### PR TITLE
feat(tts): add pocket_tts_cpp provider

### DIFF
--- a/Docs/API-related/TTS_API.md
+++ b/Docs/API-related/TTS_API.md
@@ -6,6 +6,14 @@
 - [TTS Providers Getting Started](../User_Guides/WebUI_Extension/TTS_Getting_Started.md) — provider selection and first successful synthesis.
 - [TTS Provider Setup Guide](../User_Guides/WebUI_Extension/TTS-SETUP-GUIDE.md) — runbook index for deep provider setup/tuning.
 
+PocketTTS note:
+
+- `pocket_tts` is the Python/ONNX runtime.
+- `pocket_tts_cpp` is the compiled native runtime.
+- Both use the same public request fields and the same `/api/v1/audio/speech` route.
+- For either provider, voice cloning requests must supply either a direct base64 `voice_reference` or `voice: "custom:<voice_id>"` for a stored reference.
+- `pocket_tts_cpp` only exposes streaming when the local CLI probe proves the install is truly incremental; otherwise the adapter fails closed.
+- This page documents public request inputs only. Provider-internal `extra_params` keys are intentionally omitted.
 
 1. Client pattern (Python)
 

--- a/Docs/Getting_Started/First_Time_Audio_Setup_CPU.md
+++ b/Docs/Getting_Started/First_Time_Audio_Setup_CPU.md
@@ -21,7 +21,8 @@ For a local-first CPU setup in the current repo:
 | Goal | STT | TTS | Why |
 | --- | --- | --- | --- |
 | Recommended first local stack | `parakeet-onnx` | `supertonic` | Keeps the stack local-first and avoids mandatory voice-cloning input on every TTS request |
-| If you need local voice cloning immediately | `parakeet-onnx` | `pocket_tts` | Still local-first, but every request needs reference audio |
+| If you need local voice cloning immediately | `parakeet-onnx` | `pocket_tts` | Python/ONNX runtime; still local-first, but every request needs reference audio |
+| If you want the native compiled runtime | `parakeet-onnx` | `pocket_tts_cpp` | Separate installer and runtime layout; streaming only works when the local CLI probe proves incremental |
 | Better but more demanding | `parakeet-onnx` or `faster-whisper` | `qwen3_tts` | Strong upgrade path after the basic stack already works |
 
 Important current-repo realities:
@@ -345,19 +346,21 @@ Success means:
 - the `text` field is close to `This is the CPU audio setup smoke test`
 - the server does not silently switch to the wrong provider/model
 
-## Optional Alternative: `pocket_tts` When Voice Cloning Matters More
+## Optional Alternatives: PocketTTS Runtimes
 
-Choose `pocket_tts` instead of `supertonic` if you specifically need local voice cloning on day one.
+Choose a PocketTTS runtime instead of `supertonic` if you specifically need local voice cloning on day one.
 
 Use:
 
-- [PocketTTS Voice Cloning Guide](/Users/macbook-dev/Documents/GitHub/tldw_server2/Docs/User_Guides/WebUI_Extension/PocketTTS_Voice_Cloning_Guide.md)
+- [PocketTTS Voice Cloning Guide](/Users/macbook-dev/Documents/GitHub/tldw_server2/Docs/User_Guides/WebUI_Extension/PocketTTS_Voice_Cloning_Guide.md) for `pocket_tts` (Python/ONNX)
+- `python Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py` for `pocket_tts_cpp` (compiled native runtime)
 
-Important tradeoff:
+Important tradeoffs:
 
-- `pocket_tts` is not a better "first sound out of the box" default
-- it is a better local-first choice when cloning is mandatory
-- every request needs a reference clip or a previously prepared voice path
+- `pocket_tts` is the Python/ONNX runtime and keeps the model packaging straightforward.
+- `pocket_tts_cpp` is a separate compiled runtime with its own installer and runtime layout.
+- Both are local-first, but every request still needs either a direct `voice_reference` clip or a stored `custom:<voice_id>` voice.
+- `pocket_tts_cpp` streaming is only available when the local CLI probe proves incremental on this install; otherwise streaming requests fail closed.
 
 ## Better But More Demanding: `qwen3_tts`
 
@@ -419,4 +422,5 @@ Then come back to this guide if you want to move from the bundle defaults to:
 - `parakeet-onnx`
 - `supertonic`
 - `pocket_tts`
+- `pocket_tts_cpp`
 - `qwen3_tts`

--- a/Docs/Getting_Started/First_Time_Audio_Setup_GPU_Accelerated.md
+++ b/Docs/Getting_Started/First_Time_Audio_Setup_GPU_Accelerated.md
@@ -355,18 +355,22 @@ Success means:
 - the `text` field is close to `This is the accelerated audio setup smoke test`
 - the backend matches the path you intended
 
-## Optional Alternative: `pocket_tts`
+## Optional Alternatives: PocketTTS Runtimes
 
-Use `pocket_tts` instead of `supertonic` if local voice cloning matters more than the simplest first-run TTS path.
+Use a PocketTTS runtime instead of `supertonic` if local voice cloning matters more than the simplest first-run TTS path.
 
 Use:
 
-- [PocketTTS Voice Cloning Guide](/Users/macbook-dev/Documents/GitHub/tldw_server2/Docs/User_Guides/WebUI_Extension/PocketTTS_Voice_Cloning_Guide.md)
+- [PocketTTS Voice Cloning Guide](/Users/macbook-dev/Documents/GitHub/tldw_server2/Docs/User_Guides/WebUI_Extension/PocketTTS_Voice_Cloning_Guide.md) for `pocket_tts` (Python/ONNX)
+- `python Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py` for `pocket_tts_cpp` (compiled native runtime)
 
-Tradeoff:
+Tradeoffs:
 
-- excellent if voice cloning is the point
-- worse as the default first sound path because reference audio is mandatory
+- `pocket_tts` is the ONNX/Python runtime and is the simplest PocketTTS path to read and debug.
+- `pocket_tts_cpp` is a separate compiled runtime and uses a different installer and runtime layout.
+- Both are excellent if voice cloning is the point.
+- Both are worse than the default first-sound path because you still need either a direct `voice_reference` clip or a stored `custom:<voice_id>` voice.
+- `pocket_tts_cpp` streaming is only available when the local CLI probe proves incremental on this install; otherwise streaming requests fail closed.
 
 ## Better But More Demanding: `qwen3_tts`
 

--- a/Docs/User_Guides/WebUI_Extension/PocketTTS_Voice_Cloning_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/PocketTTS_Voice_Cloning_Guide.md
@@ -1,6 +1,8 @@
 # PocketTTS Voice Cloning Guide
 
-A step-by-step guide to installing PocketTTS, cloning a voice from a reference audio sample, and setting the cloned voice as your default TTS output.
+A step-by-step guide to installing PocketTTS (`pocket_tts`, the Python/ONNX runtime), cloning a voice from a reference audio sample, and setting the cloned voice as your default TTS output.
+
+If you want the separate compiled-native runtime, use `pocket_tts_cpp` and its installer helper instead. That provider has different runtime expectations and is documented in the general TTS guides, not in this ONNX-specific guide.
 
 ## What is PocketTTS?
 

--- a/Docs/superpowers/plans/2026-03-25-pocket-tts-cpp-provider-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-03-25-pocket-tts-cpp-provider-implementation-plan.md
@@ -8,6 +8,10 @@
 
 **Tech Stack:** Python 3, FastAPI, Pydantic, Loguru, asyncio subprocess/process management, existing TTS adapter stack, pytest, Bandit
 
+## Implementation Amendment (2026-03-26)
+
+The branch implementation deliberately narrowed the streaming scope before merge: v1 keeps the CLI probe, allows explicit streaming only when that probe succeeds on the local install, and otherwise fails closed. The adapter therefore does not advertise streaming capability for automatic provider selection yet. The loopback-only fallback server remains a deferred follow-up instead of a shipped requirement for this branch.
+
 ---
 
 ## File Map

--- a/Docs/superpowers/specs/2026-03-25-pocket-tts-cpp-provider-design.md
+++ b/Docs/superpowers/specs/2026-03-25-pocket-tts-cpp-provider-design.md
@@ -4,6 +4,10 @@ Date: 2026-03-25
 Status: Approved for planning
 Owner: Codex brainstorming session
 
+## Implementation Amendment (2026-03-26)
+
+The original design kept an internal loopback-only PocketTTS.cpp server fallback available for streaming when the CLI probe was not truly incremental. The merged v1 implementation intentionally stops short of that fallback: it probes the CLI, allows explicit streaming only when the local install proves incremental, and otherwise fails closed. To avoid over-promising in provider selection, the adapter does not advertise streaming capability for automatic selection until a real fallback transport lands.
+
 ## Summary
 
 Add `pocket_tts_cpp` as a new local TTS provider backed by [PocketTTS.cpp](https://github.com/VolgaGerm/PocketTTS.cpp), while keeping the existing `pocket_tts` Python/ONNX runtime intact.

--- a/Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py
+++ b/Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py
@@ -339,10 +339,17 @@ def build_project(build_dir: Path) -> None:
     _run_command(["cmake", "--build", str(build_dir), "--config", "Release"])
 
 
+def install_project(build_dir: Path) -> None:
+    """Install PocketTTS.cpp artifacts into the configured CMake install prefix."""
+
+    _run_command(["cmake", "--install", str(build_dir), "--config", "Release"])
+
+
 def export_runtime_artifacts(
     build_dir: Path,
     layout: PocketTTSCppRuntimeLayout,
     *,
+    install_dir: Optional[Path] = None,
     built_binary_names: Sequence[str] = ("pocket-tts", "pocket-tts.exe", "pocket_tts_cpp", "pocket_tts_cpp.exe"),
     built_tokenizer_name: str = "tokenizer.model",
 ) -> None:
@@ -352,14 +359,17 @@ def export_runtime_artifacts(
     layout.model_dir.mkdir(parents=True, exist_ok=True)
     layout.binary_path.parent.mkdir(parents=True, exist_ok=True)
 
+    candidate_roots = [root for root in (install_dir, build_dir) if root is not None]
+
     built_binary = next(
         (
             path
+            for root in candidate_roots
             for binary_name in built_binary_names
             for path in (
-                build_dir / binary_name,
-                build_dir / "Release" / binary_name,
-                build_dir / "bin" / binary_name,
+                root / binary_name,
+                root / "Release" / binary_name,
+                root / "bin" / binary_name,
             )
             if path.exists()
         ),
@@ -375,9 +385,13 @@ def export_runtime_artifacts(
         shutil.copy2(built_binary, layout.binary_path)
 
     tokenizer_candidates = [
-        build_dir / built_tokenizer_name,
-        build_dir / "assets" / built_tokenizer_name,
-        build_dir / "Release" / built_tokenizer_name,
+        candidate
+        for root in candidate_roots
+        for candidate in (
+            root / built_tokenizer_name,
+            root / "assets" / built_tokenizer_name,
+            root / "Release" / built_tokenizer_name,
+        )
     ]
     built_tokenizer = next((path for path in tokenizer_candidates if path.exists()), None)
     if built_tokenizer is not None:
@@ -386,11 +400,12 @@ def export_runtime_artifacts(
     model_source_dir = next(
         (
             path
+            for root in candidate_roots
             for path in (
-                build_dir / "onnx",
-                build_dir / "export" / "onnx",
-                build_dir / "models" / "onnx",
-                build_dir / "assets" / "onnx",
+                root / "onnx",
+                root / "export" / "onnx",
+                root / "models" / "onnx",
+                root / "assets" / "onnx",
             )
             if path.exists() and path.is_dir()
         ),
@@ -482,9 +497,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if not args.no_build:
         configure_build(source_dir=source_dir, build_dir=build_dir, install_dir=runtime_base)
         build_project(build_dir=build_dir)
+        install_project(build_dir=build_dir)
 
     if not args.no_export:
-        export_runtime_artifacts(build_dir=build_dir, layout=layout)
+        export_runtime_artifacts(build_dir=build_dir, install_dir=runtime_base, layout=layout)
 
     missing_runtime = validate_runtime_layout(layout)
     if missing_runtime:

--- a/Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py
+++ b/Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import argparse
 import shutil
-import subprocess
+import subprocess  # nosec B404
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -300,7 +300,7 @@ def _ensure_prerequisites() -> None:
 
 
 def _run_command(cmd: list[str], cwd: Optional[Path] = None) -> None:
-    subprocess.run(cmd, cwd=cwd, check=True)
+    subprocess.run(cmd, cwd=cwd, check=True)  # nosec B603
 
 
 def clone_repository(repo_url: str, clone_dir: Path, branch: Optional[str] = None) -> Path:

--- a/Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py
+++ b/Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""
+Install and configure the PocketTTS.cpp native runtime.
+
+This helper keeps `pocket_tts` (Python / ONNX) separate from `pocket_tts_cpp`
+(native compiled binary runtime). The script exposes pure helper functions for
+repo-root resolution, runtime layout construction, and config patching so they
+can be unit-tested without running clone/build steps.
+
+Expected runtime layout:
+  bin/
+    pocket-tts
+  models/pocket_tts_cpp/
+    tokenizer.model
+    onnx/
+
+The runtime build/export steps are explicit in the CLI path, but unit tests only
+exercise the pure helpers.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+from loguru import logger
+
+
+DEFAULT_REPO_URL = "https://github.com/VolgaGerm/PocketTTS.cpp"
+DEFAULT_RUNTIME_BASE = Path("models") / "pocket_tts_cpp"
+DEFAULT_BINARY_PATH = Path("bin") / "pocket-tts"
+DEFAULT_CONFIG_PATH = Path("tldw_Server_API") / "Config_Files" / "tts_providers_config.yaml"
+PROVIDER_NAME = "pocket_tts_cpp"
+INT8_MODEL_FILENAMES = (
+    "flow_lm_main_int8.onnx",
+    "flow_lm_flow_int8.onnx",
+    "mimi_decoder_int8.onnx",
+    "mimi_encoder.onnx",
+    "text_conditioner.onnx",
+)
+FP32_MODEL_FILENAMES = (
+    "flow_lm_main.onnx",
+    "flow_lm_flow.onnx",
+    "mimi_decoder.onnx",
+    "mimi_encoder.onnx",
+    "text_conditioner.onnx",
+)
+
+
+@dataclass(frozen=True)
+class PocketTTSCppRuntimeLayout:
+    """Resolved runtime paths for the native PocketTTS.cpp provider."""
+
+    provider_name: str
+    runtime_base: Path
+    binary_path: Path
+    tokenizer_path: Path
+    model_dir: Path
+    source_dir: Path
+    build_dir: Path
+
+
+def default_binary_name(platform_name: Optional[str] = None) -> str:
+    """Return the repo-local binary name for the current platform."""
+
+    platform_key = (platform_name or sys.platform).lower()
+    if platform_key.startswith("win"):
+        return "pocket-tts.exe"
+    return "pocket-tts"
+
+
+def resolve_repo_root(start: Optional[Path] = None) -> Path:
+    """Resolve the repository root from a probe path."""
+
+    probe = (start or Path(__file__)).resolve()
+    candidates = (probe,) + tuple(probe.parents)
+    for candidate in candidates:
+        if (candidate / "pyproject.toml").exists() and (candidate / "tldw_Server_API").is_dir():
+            return candidate
+    raise FileNotFoundError(f"Unable to resolve repository root from {probe}")
+
+
+def build_runtime_layout(
+    runtime_base: Path,
+    repo_root: Optional[Path] = None,
+    *,
+    platform_name: Optional[str] = None,
+) -> PocketTTSCppRuntimeLayout:
+    """Build the expected PocketTTS.cpp runtime layout."""
+
+    root = repo_root if repo_root is not None else resolve_repo_root()
+    base_candidate = runtime_base.expanduser()
+    base = base_candidate if base_candidate.is_absolute() else (root / base_candidate)
+    return PocketTTSCppRuntimeLayout(
+        provider_name=PROVIDER_NAME,
+        runtime_base=base,
+        binary_path=root / DEFAULT_BINARY_PATH.parent / default_binary_name(platform_name),
+        tokenizer_path=base / "tokenizer.model",
+        model_dir=base / "onnx",
+        source_dir=root / "external" / "PocketTTS.cpp",
+        build_dir=base / "_build",
+    )
+
+
+def _path_for_config(path: Path, repo_root: Optional[Path]) -> str:
+    if not path.is_absolute():
+        return path.as_posix()
+    if repo_root is not None:
+        try:
+            return path.relative_to(repo_root).as_posix()
+        except ValueError:
+            pass
+    return str(path)
+
+
+def _render_yaml_value(value: object, quoted: bool) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if quoted:
+        return f'"{value}"'
+    return str(value)
+
+
+def _find_provider_block(lines: list[str], provider_name: str) -> tuple[Optional[int], Optional[int], Optional[int]]:
+    in_providers = False
+    providers_indent: Optional[int] = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if not in_providers:
+            if stripped == "providers:":
+                in_providers = True
+                providers_indent = indent
+            continue
+        if providers_indent is not None and indent <= providers_indent:
+            in_providers = False
+            continue
+        if stripped.startswith(f"{provider_name}:"):
+            block_start = idx
+            block_indent = indent
+            block_end = idx + 1
+            while block_end < len(lines):
+                next_line = lines[block_end]
+                next_stripped = next_line.strip()
+                if not next_stripped or next_stripped.startswith("#"):
+                    block_end += 1
+                    continue
+                next_indent = len(next_line) - len(next_line.lstrip(" "))
+                if next_indent <= block_indent:
+                    break
+                block_end += 1
+            return block_start, block_end, block_indent
+    return None, None, None
+
+
+def _upsert_key_line(
+    lines: list[str],
+    start: int,
+    end: int,
+    key: str,
+    value: object,
+    quoted: bool,
+    key_indent: str,
+) -> int:
+    needle = f"{key}:"
+    for idx in range(start, end):
+        line = lines[idx]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not stripped.startswith(needle):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent < len(key_indent):
+            continue
+        comment = None
+        if "#" in line:
+            _, comment = line.split("#", 1)
+            comment = comment.strip()
+        new_line = f"{key_indent}{key}: {_render_yaml_value(value, quoted)}"
+        if comment:
+            new_line += f"  # {comment}"
+        lines[idx] = new_line
+        return end
+
+    lines.insert(end, f"{key_indent}{key}: {_render_yaml_value(value, quoted)}")
+    return end + 1
+
+
+def _insert_provider_block(lines: list[str], provider_name: str, block_lines: list[str]) -> list[str]:
+    block_start, block_end, block_indent = _find_provider_block(lines, provider_name)
+    if block_start is not None and block_end is not None:
+        lines[block_start:block_end] = block_lines
+        return lines
+
+    providers_start = None
+    for idx, line in enumerate(lines):
+        if line.strip() == "providers:":
+            providers_start = idx
+            break
+    if providers_start is None:
+        lines.extend(["", "providers:"])
+        providers_start = len(lines) - 1
+
+    insert_at = len(lines)
+    providers_indent = len(lines[providers_start]) - len(lines[providers_start].lstrip(" "))
+    for idx in range(providers_start + 1, len(lines)):
+        stripped = lines[idx].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(lines[idx]) - len(lines[idx].lstrip(" "))
+        if indent <= providers_indent:
+            insert_at = idx
+            break
+
+    lines[insert_at:insert_at] = block_lines
+    return lines
+
+
+def patch_tts_config(
+    config_path: Path,
+    binary_path: Path,
+    tokenizer_path: Path,
+    model_dir: Path,
+    repo_root: Optional[Path] = None,
+) -> bool:
+    """Patch the pocket_tts_cpp provider block without touching pocket_tts."""
+
+    if not config_path.exists():
+        logger.warning("Config file not found at {}; skipping update.", config_path)
+        return False
+
+    lines = config_path.read_text(encoding="utf-8").splitlines()
+    block_start, block_end, block_indent = _find_provider_block(lines, PROVIDER_NAME)
+    provider_indent = " " * (block_indent or 0)
+    key_indent = provider_indent + "  "
+
+    block_lines = [
+        f"{provider_indent}{PROVIDER_NAME}:",
+        f"{key_indent}enabled: true",
+        f'{key_indent}binary_path: "{_path_for_config(binary_path, repo_root)}"',
+        f'{key_indent}tokenizer_path: "{_path_for_config(tokenizer_path, repo_root)}"',
+        f'{key_indent}model_path: "{_path_for_config(model_dir, repo_root)}"',
+        f"{key_indent}device: cpu",
+        f"{key_indent}sample_rate: 24000",
+        f"{key_indent}enable_voice_cache: false",
+        f"{key_indent}cache_ttl_hours: 24",
+        f"{key_indent}cache_max_bytes_per_user: 1073741824",
+        f"{key_indent}persist_direct_voice_references: false",
+    ]
+
+    if block_start is None or block_end is None or block_indent is None:
+        lines = _insert_provider_block(lines, PROVIDER_NAME, block_lines)
+    else:
+        lines[block_start:block_end] = block_lines
+
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    logger.info("Updated config file: {}", config_path)
+    return True
+
+
+def missing_prerequisite_commands(
+    available_commands: Optional[Iterable[str]] = None,
+    compiler_aliases: Sequence[str] = ("c++", "clang++", "g++"),
+) -> list[str]:
+    """Return the canonical prerequisite commands that are unavailable."""
+
+    if available_commands is None:
+        available = None
+    else:
+        available = {name for name in available_commands}
+
+    missing: list[str] = []
+    for command in ("git", "cmake"):
+        if available is None:
+            if shutil.which(command) is None:
+                missing.append(command)
+        elif command not in available:
+            missing.append(command)
+
+    if available is None:
+        if not any(shutil.which(alias) for alias in compiler_aliases):
+            missing.append("c++")
+    elif not any(alias in available for alias in compiler_aliases):
+        missing.append("c++")
+
+    return missing
+
+
+def _ensure_prerequisites() -> None:
+    missing = missing_prerequisite_commands()
+    if missing:
+        raise SystemExit(f"Missing required command(s) on PATH: {', '.join(missing)}")
+
+
+def _run_command(cmd: list[str], cwd: Optional[Path] = None) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def clone_repository(repo_url: str, clone_dir: Path, branch: Optional[str] = None) -> Path:
+    """Clone the PocketTTS.cpp repository."""
+
+    clone_dir.parent.mkdir(parents=True, exist_ok=True)
+    if clone_dir.exists() and any(clone_dir.iterdir()):
+        raise SystemExit(f"Clone directory already exists and is not empty: {clone_dir}")
+
+    cmd = ["git", "clone", "--depth", "1"]
+    if branch:
+        cmd.extend(["--branch", branch])
+    cmd.extend([repo_url, str(clone_dir)])
+    _run_command(cmd)
+    return clone_dir
+
+
+def configure_build(source_dir: Path, build_dir: Path, install_dir: Path) -> None:
+    """Configure the CMake build for PocketTTS.cpp."""
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+    cmake_args = [
+        "cmake",
+        "-S",
+        str(source_dir),
+        "-B",
+        str(build_dir),
+        f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+    ]
+    _run_command(cmake_args)
+
+
+def build_project(build_dir: Path) -> None:
+    """Build the PocketTTS.cpp runtime."""
+
+    _run_command(["cmake", "--build", str(build_dir), "--config", "Release"])
+
+
+def export_runtime_artifacts(
+    build_dir: Path,
+    layout: PocketTTSCppRuntimeLayout,
+    *,
+    built_binary_names: Sequence[str] = ("pocket-tts", "pocket-tts.exe", "pocket_tts_cpp", "pocket_tts_cpp.exe"),
+    built_tokenizer_name: str = "tokenizer.model",
+) -> None:
+    """Copy the built runtime artifacts into the expected runtime layout."""
+
+    layout.runtime_base.mkdir(parents=True, exist_ok=True)
+    layout.model_dir.mkdir(parents=True, exist_ok=True)
+    layout.binary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    built_binary = next(
+        (
+            path
+            for binary_name in built_binary_names
+            for path in (
+                build_dir / binary_name,
+                build_dir / "Release" / binary_name,
+                build_dir / "bin" / binary_name,
+            )
+            if path.exists()
+        ),
+        None,
+    )
+    if built_binary is None:
+        logger.warning(
+            "Built binary not found under {}; expected one of {}",
+            build_dir,
+            ", ".join(built_binary_names),
+        )
+    else:
+        shutil.copy2(built_binary, layout.binary_path)
+
+    tokenizer_candidates = [
+        build_dir / built_tokenizer_name,
+        build_dir / "assets" / built_tokenizer_name,
+        build_dir / "Release" / built_tokenizer_name,
+    ]
+    built_tokenizer = next((path for path in tokenizer_candidates if path.exists()), None)
+    if built_tokenizer is not None:
+        shutil.copy2(built_tokenizer, layout.tokenizer_path)
+
+    model_source_dir = next(
+        (
+            path
+            for path in (
+                build_dir / "onnx",
+                build_dir / "export" / "onnx",
+                build_dir / "models" / "onnx",
+                build_dir / "assets" / "onnx",
+            )
+            if path.exists() and path.is_dir()
+        ),
+        None,
+    )
+    if model_source_dir is None:
+        logger.warning("Exported ONNX directory not found under {}", build_dir)
+    else:
+        for source in model_source_dir.iterdir():
+            target = layout.model_dir / source.name
+            if source.is_dir():
+                shutil.copytree(source, target, dirs_exist_ok=True)
+            else:
+                shutil.copy2(source, target)
+
+
+def validate_runtime_layout(layout: PocketTTSCppRuntimeLayout) -> list[str]:
+    """Return a list of missing runtime artifacts required before enabling the provider."""
+
+    missing: list[str] = []
+    if not layout.binary_path.exists():
+        missing.append(str(layout.binary_path))
+    if not layout.tokenizer_path.exists():
+        missing.append(str(layout.tokenizer_path))
+    if not layout.model_dir.exists() or not layout.model_dir.is_dir():
+        missing.append(str(layout.model_dir))
+        return missing
+
+    has_int8 = all((layout.model_dir / name).exists() for name in INT8_MODEL_FILENAMES)
+    has_fp32 = all((layout.model_dir / name).exists() for name in FP32_MODEL_FILENAMES)
+    if not has_int8 and not has_fp32:
+        missing.append(
+            f"{layout.model_dir} missing required PocketTTS.cpp ONNX exports "
+            f"(expected one full INT8 or FP32 set)"
+        )
+    return missing
+
+
+def _print_runtime_summary(layout: PocketTTSCppRuntimeLayout) -> None:
+    print("PocketTTS.cpp runtime layout:")
+    print(f"  Binary    : {layout.binary_path}")
+    print(f"  Tokenizer : {layout.tokenizer_path}")
+    print(f"  Models dir: {layout.model_dir}")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Install and configure the PocketTTS.cpp native TTS runtime."
+    )
+    parser.add_argument("--repo-url", default=DEFAULT_REPO_URL, help="PocketTTS.cpp repository URL")
+    parser.add_argument(
+        "--runtime-base",
+        default=str(DEFAULT_RUNTIME_BASE),
+        help="Base runtime directory for the compiled provider",
+    )
+    parser.add_argument(
+        "--source-dir",
+        default=None,
+        help="Optional existing PocketTTS.cpp source directory (skips clone when provided)",
+    )
+    parser.add_argument(
+        "--build-dir",
+        default=None,
+        help="Optional build directory (defaults to <runtime-base>/_build)",
+    )
+    parser.add_argument(
+        "--config-path",
+        default=None,
+        help="Path to tts_providers_config.yaml (defaults to repo copy)",
+    )
+    parser.add_argument("--branch", default=None, help="Optional git branch or tag to clone")
+    parser.add_argument("--no-config-update", action="store_true", help="Skip config patching")
+    parser.add_argument("--no-clone", action="store_true", help="Skip cloning the repository")
+    parser.add_argument("--no-build", action="store_true", help="Skip the cmake configure/build steps")
+    parser.add_argument("--no-export", action="store_true", help="Skip copying build outputs to runtime layout")
+    args = parser.parse_args(argv)
+
+    _ensure_prerequisites()
+
+    repo_root = resolve_repo_root()
+    runtime_base = Path(args.runtime_base).expanduser()
+    layout = build_runtime_layout(runtime_base, repo_root=repo_root)
+    build_dir = Path(args.build_dir).expanduser() if args.build_dir else layout.build_dir
+    source_dir = Path(args.source_dir).expanduser() if args.source_dir else layout.source_dir
+
+    if not args.no_clone and args.source_dir is None:
+        clone_repository(args.repo_url, source_dir, branch=args.branch)
+
+    if not args.no_build:
+        configure_build(source_dir=source_dir, build_dir=build_dir, install_dir=runtime_base)
+        build_project(build_dir=build_dir)
+
+    if not args.no_export:
+        export_runtime_artifacts(build_dir=build_dir, layout=layout)
+
+    missing_runtime = validate_runtime_layout(layout)
+    if missing_runtime:
+        raise SystemExit(
+            "PocketTTS.cpp runtime export incomplete: " + "; ".join(missing_runtime)
+        )
+
+    if not args.no_config_update:
+        config_path = (
+            Path(args.config_path).expanduser()
+            if args.config_path
+            else repo_root / DEFAULT_CONFIG_PATH
+        )
+        patch_tts_config(
+            config_path=config_path,
+            binary_path=layout.binary_path,
+            tokenizer_path=layout.tokenizer_path,
+            model_dir=layout.model_dir,
+            repo_root=repo_root,
+        )
+
+    _print_runtime_summary(layout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ See: `Docs/Published/RELEASE_NOTES.md` for detailed release notes.
 
 - Media ingestion & processing: video, audio, PDFs, EPUB, DOCX, HTML, Markdown, XML, MediaWiki dumps; OCR for PDFs/images; metadata extraction; configurable chunking.
 - Custom-built Chunking library, tldw_Chunker, supporting token, word, sentence, paragraph, semantic, hierarchical and template chunking approaches.
-- Audio & speech: real-time and file STT via faster_whisper, NVIDIA NeMo (Canary/Parakeet), Qwen2Audio; diarization/VAD; TTS backends — commercial: OpenAI, ElevenLabs; local: Kokoro, PocketTTS, LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, VibeVoice Realtime, NeuTTS, IndexTTS2, Supertonic, Supertonic2, Qwen3-TTS, EchoTTS; voice catalog + audio jobs queue.
+- Audio & speech: real-time and file STT via faster_whisper, NVIDIA NeMo (Canary/Parakeet), Qwen2Audio; diarization/VAD; TTS backends — commercial: OpenAI, ElevenLabs; local: Kokoro, PocketTTS (Python/ONNX), PocketTTS.cpp (native binary), LuxTTS, Higgs, Chatterbox, Dia, VibeVoice, VibeVoice Realtime, NeuTTS, IndexTTS2, Supertonic, Supertonic2, Qwen3-TTS, EchoTTS; voice catalog + audio jobs queue.
 - Audiobooks: parse + chapter detection, per-chapter voice settings, optional TTS provider overrides (alignment/subtitles Kokoro-only), and M4B packaging (API-only).
 - Search & retrieval (RAG): hybrid BM25 + vector (ChromaDB/pgvector), re-ranking, contextual retrieval, OpenAI-compatible embeddings, vector stores API, and media embeddings ingestion. 50+ optional parameters available for tuning.
 - Chat & providers: `/api/v1/chat/completions` (OpenAI-compatible), 16+ providers (commercial + self-hosted), character chat, budgets/allowlists, moderation endpoint.

--- a/tldw_Server_API/Config_Files/tts_providers_config.yaml
+++ b/tldw_Server_API/Config_Files/tts_providers_config.yaml
@@ -82,7 +82,8 @@ providers:
   # PocketTTS.cpp Configuration (local; voice cloning with cached stored voices)
   pocket_tts_cpp:
     enabled: false  # Disabled by default; enable after installing the native runtime
-    binary_path: "models/pocket_tts_cpp/pocket_tts_cpp"
+    binary_path: "bin/pocket-tts"
+    model_path: "models/pocket_tts_cpp/onnx"
     tokenizer_path: "models/pocket_tts_cpp/tokenizer.model"
     device: "cpu"
     sample_rate: 24000

--- a/tldw_Server_API/Config_Files/tts_providers_config.yaml
+++ b/tldw_Server_API/Config_Files/tts_providers_config.yaml
@@ -15,6 +15,7 @@ provider_priority:
   - dia         # Dialogue specialist
   - higgs       # Advanced multi-lingual
   - index_tts   # IndexTTS2 (local, expressive zero-shot)
+  - pocket_tts_cpp # Local PocketTTS.cpp voice cloning
   - qwen3_tts   # Qwen3-TTS (local, multilingual; disabled by default)
 
 # Provider-specific configurations
@@ -77,6 +78,18 @@ providers:
     stream_target_buffer_sec: 0.2
     stream_max_chunk_frames: 15
     sample_rate: 24000
+
+  # PocketTTS.cpp Configuration (local; voice cloning with cached stored voices)
+  pocket_tts_cpp:
+    enabled: false  # Disabled by default; enable after installing the native runtime
+    binary_path: "models/pocket_tts_cpp/pocket_tts_cpp"
+    tokenizer_path: "models/pocket_tts_cpp/tokenizer.model"
+    device: "cpu"
+    sample_rate: 24000
+    enable_voice_cache: false
+    cache_ttl_hours: 24
+    cache_max_bytes_per_user: 1073741824
+    persist_direct_voice_references: false
 
   # KittenTTS ONNX Configuration (local; English single-speaker voices)
   kitten_tts:
@@ -296,6 +309,7 @@ voice_mappings:
       chatterbox: "default"
       index_tts: "clone_required"
       pocket_tts: "clone_required"
+      pocket_tts_cpp: "clone_required"
       lux_tts: "clone_required"
     female:
       openai: "nova"
@@ -305,6 +319,7 @@ voice_mappings:
       chatterbox: "default"
       index_tts: "clone_required"
       pocket_tts: "clone_required"
+      pocket_tts_cpp: "clone_required"
       lux_tts: "clone_required"
     neutral:
       openai: "alloy"
@@ -314,6 +329,7 @@ voice_mappings:
       chatterbox: "calm"
       index_tts: "clone_required"
       pocket_tts: "clone_required"
+      pocket_tts_cpp: "clone_required"
       lux_tts: "clone_required"
 
   # Emotion-based voice selection
@@ -324,6 +340,7 @@ voice_mappings:
       chatterbox: "energetic"
       index_tts: "clone_required"
       pocket_tts: "clone_required"
+      pocket_tts_cpp: "clone_required"
       lux_tts: "clone_required"
     sad:
       openai: "shimmer"
@@ -331,6 +348,7 @@ voice_mappings:
       chatterbox: "calm"
       index_tts: "clone_required"
       pocket_tts: "clone_required"
+      pocket_tts_cpp: "clone_required"
       lux_tts: "clone_required"
     angry:
       openai: "onyx"
@@ -338,6 +356,7 @@ voice_mappings:
       chatterbox: "default"
       index_tts: "clone_required"
       pocket_tts: "clone_required"
+      pocket_tts_cpp: "clone_required"
       lux_tts: "clone_required"
     excited:
       openai: "fable"
@@ -345,6 +364,7 @@ voice_mappings:
       chatterbox: "energetic"
       index_tts: "clone_required"
       pocket_tts: "clone_required"
+      pocket_tts_cpp: "clone_required"
       lux_tts: "clone_required"
 
 # Audio format preferences by provider
@@ -358,6 +378,7 @@ format_preferences:
   neutts: ["wav", "mp3", "opus", "flac", "pcm"]
   index_tts: ["mp3", "wav"]
   pocket_tts: ["wav", "mp3", "opus", "flac", "pcm", "aac"]
+  pocket_tts_cpp: ["wav", "mp3", "opus", "flac", "pcm", "aac"]
   lux_tts: ["wav", "mp3", "opus", "flac", "pcm", "aac"]
   qwen3_tts: ["wav", "mp3", "opus", "flac", "pcm"]
 

--- a/tldw_Server_API/app/core/TTS/adapter_registry.py
+++ b/tldw_Server_API/app/core/TTS/adapter_registry.py
@@ -69,6 +69,7 @@ class TTSProvider(Enum):
     SUPERTONIC = "supertonic"
     SUPERTONIC2 = "supertonic2"
     POCKET_TTS = "pocket_tts"
+    POCKET_TTS_CPP = "pocket_tts_cpp"
     ECHO_TTS = "echo_tts"
     QWEN3_TTS = "qwen3_tts"
     LUX_TTS = "lux_tts"
@@ -141,6 +142,7 @@ class TTSAdapterRegistry:
         TTSProvider.SUPERTONIC: "tldw_Server_API.app.core.TTS.adapters.supertonic_adapter.SupertonicOnnxAdapter",
         TTSProvider.SUPERTONIC2: "tldw_Server_API.app.core.TTS.adapters.supertonic2_adapter.Supertonic2OnnxAdapter",
         TTSProvider.POCKET_TTS: "tldw_Server_API.app.core.TTS.adapters.pocket_tts_adapter.PocketTTSOnnxAdapter",
+        TTSProvider.POCKET_TTS_CPP: "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter.PocketTTSCppAdapter",
         TTSProvider.ECHO_TTS: "tldw_Server_API.app.core.TTS.adapters.echo_tts_adapter.EchoTTSAdapter",
         TTSProvider.QWEN3_TTS: "tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter.Qwen3TTSAdapter",
         TTSProvider.LUX_TTS: "tldw_Server_API.app.core.TTS.adapters.luxtts_adapter.LuxTTSAdapter",
@@ -655,6 +657,15 @@ class TTSAdapterRegistry:
                     alias('stream_first_chunk_frames', 'pocket_tts_stream_first_chunk_frames')
                     alias('stream_target_buffer_sec', 'pocket_tts_stream_target_buffer_sec')
                     alias('stream_max_chunk_frames', 'pocket_tts_stream_max_chunk_frames')
+                elif p == 'pocket_tts_cpp':
+                    alias('binary_path', 'pocket_tts_cpp_binary_path')
+                    alias('tokenizer_path', 'pocket_tts_cpp_tokenizer_path')
+                    alias('device', 'pocket_tts_cpp_device')
+                    alias('sample_rate', 'pocket_tts_cpp_sample_rate')
+                    alias('enable_voice_cache', 'pocket_tts_cpp_enable_voice_cache')
+                    alias('cache_ttl_hours', 'pocket_tts_cpp_cache_ttl_hours')
+                    alias('cache_max_bytes_per_user', 'pocket_tts_cpp_cache_max_bytes_per_user')
+                    alias('persist_direct_voice_references', 'pocket_tts_cpp_persist_direct_voice_references')
                 elif p == 'echo_tts':
                     alias('model', 'echo_tts_model')
                     alias('model_path', 'echo_tts_model_path')
@@ -726,6 +737,7 @@ class TTSAdapterRegistry:
             if provider in [TTSProvider.KOKORO, TTSProvider.KITTEN_TTS, TTSProvider.HIGGS, TTSProvider.DIA,
                            TTSProvider.CHATTERBOX, TTSProvider.VIBEVOICE, TTSProvider.VIBEVOICE_REALTIME,
                            TTSProvider.SUPERTONIC, TTSProvider.SUPERTONIC2, TTSProvider.POCKET_TTS,
+                           TTSProvider.POCKET_TTS_CPP,
                            TTSProvider.QWEN3_TTS] and enabled_flag is not True:
                 continue
 
@@ -1071,6 +1083,10 @@ class TTSAdapterFactory:
         "pockettts": TTSProvider.POCKET_TTS,
         "pockettts-onnx": TTSProvider.POCKET_TTS,
         "kevinahm/pocket-tts-onnx": TTSProvider.POCKET_TTS,
+
+        # PocketTTS.cpp models
+        "pocket_tts_cpp": TTSProvider.POCKET_TTS_CPP,
+        "pocket-tts-cpp": TTSProvider.POCKET_TTS_CPP,
 
         # Echo-TTS models
         "echo-tts": TTSProvider.ECHO_TTS,

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
@@ -307,7 +307,7 @@ class PocketTTSCppAdapter(TTSAdapter):
             supported_voices=[],
             supported_formats=self.SUPPORTED_FORMATS,
             max_text_length=self.MAX_TEXT_LENGTH,
-            supports_streaming=True,
+            supports_streaming=False,
             supports_voice_cloning=True,
             sample_rate=self.DEFAULT_SAMPLE_RATE,
             default_format=AudioFormat.WAV,

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import tempfile
 import wave
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, Optional
 
@@ -11,7 +12,7 @@ import numpy as np
 from loguru import logger
 
 from ..audio_converter import AudioConverter
-from ..streaming_audio_writer import AudioNormalizer
+from ..streaming_audio_writer import AudioNormalizer, StreamingAudioWriter
 from ..tts_exceptions import (
     TTSGenerationError,
     TTSInvalidVoiceReferenceError,
@@ -27,8 +28,11 @@ from ..utils import parse_bool
 from .base import AudioFormat, ProviderStatus, TTSAdapter, TTSCapabilities, TTSRequest, TTSResponse
 from .pocket_tts_cpp_runtime import (
     PROVIDER_KEY,
+    PROVIDER_MANAGED_VOICE_TOKEN_KEY,
     VALID_PRECISIONS,
     build_cli_command,
+    probe_cli_streaming_incremental,
+    resolve_provider_managed_voice_path,
     validate_runtime_assets,
 )
 
@@ -87,6 +91,7 @@ class PocketTTSCppAdapter(TTSAdapter):
         self.precision = str(_cfg_value("precision", "int8")).lower()
         self.timeout = _int_value("timeout", 60) or 60
         self.stream_probe_timeout = _float_value("stream_probe_timeout", 5.0) or 5.0
+        self.streaming_transport = str(_cfg_value("streaming_transport", "auto")).strip().lower() or "auto"
         self.prefer_stdout = parse_bool(_cfg_value("prefer_stdout", True), default=True)
         self.enable_voice_cache = parse_bool(_cfg_value("enable_voice_cache", True), default=True)
         self.temperature = _float_value("temperature")
@@ -99,6 +104,9 @@ class PocketTTSCppAdapter(TTSAdapter):
         self.profile = parse_bool(_cfg_value("profile", False), default=False)
 
         self._audio_normalizer = AudioNormalizer()
+        self._cli_streaming_supported: Optional[bool] = None
+        self._cli_streaming_probe_lock = asyncio.Lock()
+        self._cli_stream_probe_voice_path: Optional[Path] = None
 
     async def initialize(self) -> bool:
         if self._initialized:
@@ -109,6 +117,13 @@ class PocketTTSCppAdapter(TTSAdapter):
                 f"Invalid precision '{self.precision}' for PocketTTS.cpp",
                 provider=self.PROVIDER_KEY,
                 details={"valid_precisions": sorted(VALID_PRECISIONS)},
+            )
+
+        if self.streaming_transport not in {"auto", "cli"}:
+            raise TTSProviderInitializationError(
+                f"Invalid streaming transport '{self.streaming_transport}' for PocketTTS.cpp",
+                provider=self.PROVIDER_KEY,
+                details={"valid_transports": ["auto", "cli"]},
             )
 
         validate_runtime_assets(
@@ -137,13 +152,6 @@ class PocketTTSCppAdapter(TTSAdapter):
                 provider=self.PROVIDER_KEY,
             )
 
-        if request.stream:
-            raise TTSValidationError(
-                "PocketTTS.cpp streaming is not implemented yet",
-                provider=self.PROVIDER_KEY,
-                details={"hint": "Use stream=false until Task 4 lands"},
-            )
-
         if request.format not in self.SUPPORTED_FORMATS:
             raise TTSUnsupportedFormatError(
                 f"Format {request.format.value} not supported by PocketTTS.cpp",
@@ -161,6 +169,11 @@ class PocketTTSCppAdapter(TTSAdapter):
             ) from exc
 
         voice_path = self._resolve_voice_path(request)
+        if request.stream:
+            return await self._generate_streaming(request, voice_path)
+        return await self._generate_non_streaming(request, voice_path)
+
+    async def _generate_non_streaming(self, request: TTSRequest, voice_path: Path) -> TTSResponse:
         use_stdout = self._should_use_stdout(request)
 
         temp_output_path: Optional[Path] = None
@@ -262,6 +275,31 @@ class PocketTTSCppAdapter(TTSAdapter):
                     with contextlib.suppress(OSError):
                         path.unlink()
 
+    async def _generate_streaming(self, request: TTSRequest, voice_path: Path) -> TTSResponse:
+        use_cli_streaming = await self._get_cli_streaming_support(voice_path)
+        if not use_cli_streaming:
+            raise TTSGenerationError(
+                "PocketTTS.cpp CLI does not provide safe incremental streaming on this installation",
+                provider=self.PROVIDER_KEY,
+                details={"transport": "cli_probe_failed"},
+            )
+
+        audio_stream = self._stream_via_cli_stdout(request, voice_path)
+        transport = "stdout_stream"
+
+        logger.info("PocketTTS.cpp streaming transport selected: {}", transport)
+        return TTSResponse(
+            audio_stream=audio_stream,
+            format=request.format,
+            sample_rate=self.DEFAULT_SAMPLE_RATE,
+            channels=1,
+            text_processed=request.text,
+            voice_used=request.voice,
+            provider=self.PROVIDER_KEY,
+            model=request.model or self.PROVIDER_KEY,
+            metadata={"transport": transport},
+        )
+
     async def get_capabilities(self) -> TTSCapabilities:
         return TTSCapabilities(
             provider_name="PocketTTS.cpp",
@@ -269,7 +307,7 @@ class PocketTTSCppAdapter(TTSAdapter):
             supported_voices=[],
             supported_formats=self.SUPPORTED_FORMATS,
             max_text_length=self.MAX_TEXT_LENGTH,
-            supports_streaming=False,
+            supports_streaming=True,
             supports_voice_cloning=True,
             sample_rate=self.DEFAULT_SAMPLE_RATE,
             default_format=AudioFormat.WAV,
@@ -286,13 +324,31 @@ class PocketTTSCppAdapter(TTSAdapter):
             )
 
         voice_path = Path(str(raw_voice_path)).expanduser()
+        trust_token = extras.get(PROVIDER_MANAGED_VOICE_TOKEN_KEY)
+        if not trust_token:
+            raise TTSInvalidVoiceReferenceError(
+                "PocketTTS.cpp requires a service-issued voice trust token",
+                provider=self.PROVIDER_KEY,
+                details={"param": f"extra_params.{PROVIDER_MANAGED_VOICE_TOKEN_KEY}"},
+            )
+
         if not voice_path.exists() or not voice_path.is_file():
             raise TTSInvalidVoiceReferenceError(
                 "PocketTTS.cpp voice path does not exist",
                 provider=self.PROVIDER_KEY,
                 details={"voice_path": str(voice_path)},
             )
-        return voice_path
+
+        try:
+            resolved_voice_path = resolve_provider_managed_voice_path(str(trust_token), voice_path)
+        except (KeyError, LookupError, ValueError, OSError) as exc:
+            raise TTSInvalidVoiceReferenceError(
+                "PocketTTS.cpp voice path is not service-managed",
+                provider=self.PROVIDER_KEY,
+                details={"voice_path": str(voice_path)},
+            ) from exc
+
+        return resolved_voice_path
 
     def _should_use_stdout(self, request: TTSRequest) -> bool:
         extras = request.extra_params if isinstance(request.extra_params, dict) else {}
@@ -301,6 +357,170 @@ class PocketTTSCppAdapter(TTSAdapter):
         else:
             prefer_stdout = self.prefer_stdout
         return prefer_stdout and request.format == AudioFormat.PCM
+
+    async def _get_cli_streaming_support(self, voice_path: Path) -> bool:
+        if self._cli_streaming_supported is not None:
+            return self._cli_streaming_supported
+
+        async with self._cli_streaming_probe_lock:
+            if self._cli_streaming_supported is not None:
+                return self._cli_streaming_supported
+
+            self._cli_stream_probe_voice_path = voice_path
+            try:
+                probe_result = await self._probe_cli_streaming_support()
+                if probe_result:
+                    self._cli_streaming_supported = True
+                return probe_result
+            except Exception as exc:
+                logger.warning("PocketTTS.cpp CLI streaming probe failed: {}", exc)
+                return False
+            finally:
+                self._cli_stream_probe_voice_path = None
+
+    async def _probe_cli_streaming_support(self) -> bool:
+        voice_path = self._cli_stream_probe_voice_path
+        if voice_path is None:
+            raise TTSValidationError(
+                "PocketTTS.cpp CLI streaming probe requires a resolved voice path",
+                provider=self.PROVIDER_KEY,
+            )
+
+        return await probe_cli_streaming_incremental(
+            binary_path=self.binary_path,
+            voice_path=voice_path,
+            model_path=self.model_path,
+            tokenizer_path=self.tokenizer_path,
+            precision=self.precision,
+            timeout=self.stream_probe_timeout,
+            enable_voice_cache=self.enable_voice_cache,
+            voices_dir=self.voices_dir,
+            temperature=self.temperature,
+            lsd_steps=self.lsd_steps,
+            eos_threshold=self.eos_threshold,
+            eos_extra=self.eos_extra,
+            noise_clamp=self.noise_clamp,
+            threads=self.threads,
+            verbose=self.verbose,
+            profile=self.profile,
+        )
+
+    def _stream_via_cli_stdout(
+        self,
+        request: TTSRequest,
+        resolved_voice_path: Path,
+    ) -> AsyncGenerator[bytes, None]:
+        async def stream() -> AsyncGenerator[bytes, None]:
+            command = build_cli_command(
+                binary_path=self.binary_path,
+                text=self.preprocess_text(request.text),
+                voice_path=resolved_voice_path,
+                model_path=self.model_path,
+                tokenizer_path=self.tokenizer_path,
+                output_path=None,
+                precision=self.precision,
+                prefer_stdout=True,
+                enable_voice_cache=self.enable_voice_cache,
+                voices_dir=self.voices_dir,
+                temperature=self.temperature,
+                lsd_steps=self.lsd_steps,
+                eos_threshold=self.eos_threshold,
+                eos_extra=self.eos_extra,
+                noise_clamp=self.noise_clamp,
+                threads=self.threads,
+                verbose=self.verbose,
+                profile=self.profile,
+            )
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            writer = StreamingAudioWriter(
+                format=request.format.value,
+                sample_rate=self.DEFAULT_SAMPLE_RATE,
+                channels=1,
+            )
+            remainder = bytearray()
+            try:
+                if process.stdout is None:
+                    raise TTSGenerationError(
+                        "PocketTTS.cpp CLI stdout stream is unavailable",
+                        provider=self.PROVIDER_KEY,
+                    )
+
+                while True:
+                    try:
+                        chunk = await asyncio.wait_for(process.stdout.read(4096), timeout=self.timeout)
+                    except asyncio.TimeoutError as exc:
+                        raise TTSTimeoutError(
+                            "Timed out waiting for PocketTTS.cpp CLI stream chunk",
+                            provider=self.PROVIDER_KEY,
+                            details={"timeout_seconds": self.timeout},
+                        ) from exc
+                    if not chunk:
+                        break
+                    data = self._write_stream_chunk(chunk, remainder, writer)
+                    if data:
+                        yield data
+
+                try:
+                    _, stderr = await asyncio.wait_for(process.communicate(), timeout=self.timeout)
+                except asyncio.TimeoutError as exc:
+                    raise TTSTimeoutError(
+                        "Timed out waiting for PocketTTS.cpp CLI stream completion",
+                        provider=self.PROVIDER_KEY,
+                        details={"timeout_seconds": self.timeout},
+                    ) from exc
+
+                if process.returncode != 0:
+                    stderr_text = stderr.decode("utf-8", errors="ignore").strip()
+                    raise TTSGenerationError(
+                        "PocketTTS.cpp CLI streaming exited with an error",
+                        provider=self.PROVIDER_KEY,
+                        details={"returncode": process.returncode, "stderr": stderr_text},
+                    )
+
+                tail = writer.write_chunk(finalize=True)
+                if tail:
+                    yield tail
+            except asyncio.CancelledError:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+                raise
+            finally:
+                writer.close()
+                if process.returncode is None:
+                    with contextlib.suppress(ProcessLookupError):
+                        process.kill()
+                    with contextlib.suppress(Exception):
+                        await process.communicate()
+
+        return stream()
+
+    def _write_stream_chunk(
+        self,
+        raw_chunk: bytes,
+        remainder: bytearray,
+        writer: StreamingAudioWriter,
+    ) -> bytes:
+        if not raw_chunk:
+            return b""
+
+        remainder.extend(raw_chunk)
+        usable = len(remainder) - (len(remainder) % 4)
+        if usable <= 0:
+            return b""
+
+        pcm_bytes = bytes(remainder[:usable])
+        del remainder[:usable]
+        audio = np.frombuffer(pcm_bytes, dtype=np.dtype("<f4")).astype(np.float32, copy=False)
+
+        if audio.size == 0:
+            return b""
+
+        audio_i16 = self._audio_normalizer.normalize(audio, target_dtype=np.int16)
+        return writer.write_chunk(audio_i16) or b""
 
     async def _convert_stdout_audio(self, stdout: bytes, target_format: AudioFormat) -> bytes:
         if not stdout:

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
@@ -1,0 +1,34 @@
+# pocket_tts_cpp_adapter.py
+# Description: Placeholder PocketTTS.cpp adapter scaffold.
+#
+from __future__ import annotations
+
+from loguru import logger
+
+from .base import AudioFormat, TTSAdapter, TTSCapabilities, TTSRequest, TTSResponse
+
+
+class PocketTTSCppAdapter(TTSAdapter):
+    """Placeholder adapter for PocketTTS.cpp until the runtime lands."""
+
+    PROVIDER_KEY = "pocket_tts_cpp"
+
+    async def initialize(self) -> bool:
+        logger.warning("PocketTTS.cpp adapter is not implemented yet")
+        return False
+
+    async def generate(self, request: TTSRequest) -> TTSResponse:
+        raise RuntimeError("PocketTTS.cpp adapter is not implemented yet")
+
+    async def get_capabilities(self) -> TTSCapabilities:
+        return TTSCapabilities(
+            provider_name=self.PROVIDER_KEY,
+            supported_languages={"en"},
+            supported_voices=[],
+            supported_formats={AudioFormat.MP3, AudioFormat.WAV, AudioFormat.OPUS, AudioFormat.FLAC, AudioFormat.PCM, AudioFormat.AAC},
+            max_text_length=5000,
+            supports_streaming=False,
+            supports_voice_cloning=False,
+            sample_rate=24000,
+            default_format=AudioFormat.MP3,
+        )

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
@@ -1,34 +1,356 @@
-# pocket_tts_cpp_adapter.py
-# Description: Placeholder PocketTTS.cpp adapter scaffold.
-#
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import tempfile
+import wave
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
 from loguru import logger
 
-from .base import AudioFormat, TTSAdapter, TTSCapabilities, TTSRequest, TTSResponse
+from ..audio_converter import AudioConverter
+from ..streaming_audio_writer import AudioNormalizer
+from ..tts_exceptions import (
+    TTSGenerationError,
+    TTSInvalidVoiceReferenceError,
+    TTSModelNotFoundError,
+    TTSProviderInitializationError,
+    TTSProviderNotConfiguredError,
+    TTSTimeoutError,
+    TTSUnsupportedFormatError,
+    TTSValidationError,
+)
+from ..tts_validation import validate_tts_request
+from ..utils import parse_bool
+from .base import AudioFormat, ProviderStatus, TTSAdapter, TTSCapabilities, TTSRequest, TTSResponse
+from .pocket_tts_cpp_runtime import (
+    PROVIDER_KEY,
+    VALID_PRECISIONS,
+    build_cli_command,
+    validate_runtime_assets,
+)
 
 
 class PocketTTSCppAdapter(TTSAdapter):
-    """Placeholder adapter for PocketTTS.cpp until the runtime lands."""
+    """Adapter for the PocketTTS.cpp command-line runtime."""
 
     PROVIDER_KEY = "pocket_tts_cpp"
+    SUPPORTED_FORMATS: set[AudioFormat] = {
+        AudioFormat.MP3,
+        AudioFormat.WAV,
+        AudioFormat.OPUS,
+        AudioFormat.FLAC,
+        AudioFormat.PCM,
+        AudioFormat.AAC,
+    }
+    SUPPORTED_LANGUAGES = {"en"}
+    DEFAULT_SAMPLE_RATE = 24000
+    MAX_TEXT_LENGTH = 5000
+
+    def __init__(self, config: Optional[dict[str, Any]] = None):
+        super().__init__(config)
+        cfg = config or {}
+        extras = cfg.get("extra_params", {}) or {}
+
+        def _cfg_value(key: str, default: Any = None) -> Any:
+            value = cfg.get(key)
+            if value is None:
+                value = extras.get(key)
+            return default if value is None else value
+
+        def _float_value(key: str, default: Optional[float] = None) -> Optional[float]:
+            value = _cfg_value(key, default)
+            if value is None:
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return default
+
+        def _int_value(key: str, default: Optional[int] = None) -> Optional[int]:
+            value = _cfg_value(key, default)
+            if value is None:
+                return None
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        self.binary_path = Path(_cfg_value("binary_path", "bin/pocket-tts")).expanduser()
+        self.model_path = Path(_cfg_value("model_path", "models/pocket_tts_cpp/onnx")).expanduser()
+        self.tokenizer_path = Path(_cfg_value("tokenizer_path", "models/pocket_tts_cpp/tokenizer.model")).expanduser()
+        self.voices_dir = _cfg_value("voices_dir")
+        self.voices_dir = Path(self.voices_dir).expanduser() if self.voices_dir else None
+
+        self.precision = str(_cfg_value("precision", "int8")).lower()
+        self.timeout = _int_value("timeout", 60) or 60
+        self.stream_probe_timeout = _float_value("stream_probe_timeout", 5.0) or 5.0
+        self.prefer_stdout = parse_bool(_cfg_value("prefer_stdout", True), default=True)
+        self.enable_voice_cache = parse_bool(_cfg_value("enable_voice_cache", True), default=True)
+        self.temperature = _float_value("temperature")
+        self.lsd_steps = _int_value("lsd_steps")
+        self.eos_threshold = _float_value("eos_threshold")
+        self.eos_extra = _float_value("eos_extra")
+        self.noise_clamp = _float_value("noise_clamp")
+        self.threads = _int_value("threads")
+        self.verbose = parse_bool(_cfg_value("verbose", False), default=False)
+        self.profile = parse_bool(_cfg_value("profile", False), default=False)
+
+        self._audio_normalizer = AudioNormalizer()
 
     async def initialize(self) -> bool:
-        logger.warning("PocketTTS.cpp adapter is not implemented yet")
-        return False
+        if self._initialized:
+            return True
+
+        if self.precision not in VALID_PRECISIONS:
+            raise TTSProviderInitializationError(
+                f"Invalid precision '{self.precision}' for PocketTTS.cpp",
+                provider=self.PROVIDER_KEY,
+                details={"valid_precisions": sorted(VALID_PRECISIONS)},
+            )
+
+        validate_runtime_assets(
+            binary_path=self.binary_path,
+            model_path=self.model_path,
+            tokenizer_path=self.tokenizer_path,
+            precision=self.precision,
+        )
+
+        self._capabilities = await self.get_capabilities()
+        self._status = ProviderStatus.AVAILABLE
+        self._initialized = True
+        logger.info(
+            "PocketTTS.cpp adapter initialized (binary={}, models={}, tokenizer={}, precision={})",
+            self.binary_path,
+            self.model_path,
+            self.tokenizer_path,
+            self.precision,
+        )
+        return True
 
     async def generate(self, request: TTSRequest) -> TTSResponse:
-        raise RuntimeError("PocketTTS.cpp adapter is not implemented yet")
+        if not await self.ensure_initialized():
+            raise TTSProviderNotConfiguredError(
+                "PocketTTS.cpp adapter not initialized",
+                provider=self.PROVIDER_KEY,
+            )
+
+        if request.stream:
+            raise TTSValidationError(
+                "PocketTTS.cpp streaming is not implemented yet",
+                provider=self.PROVIDER_KEY,
+                details={"hint": "Use stream=false until Task 4 lands"},
+            )
+
+        if request.format not in self.SUPPORTED_FORMATS:
+            raise TTSUnsupportedFormatError(
+                f"Format {request.format.value} not supported by PocketTTS.cpp",
+                provider=self.PROVIDER_KEY,
+            )
+
+        try:
+            validate_tts_request(request, provider=self.PROVIDER_KEY)
+        except TTSValidationError:
+            raise
+        except Exception as exc:
+            raise TTSValidationError(
+                f"Validation failed for PocketTTS.cpp request: {exc}",
+                provider=self.PROVIDER_KEY,
+            ) from exc
+
+        voice_path = self._resolve_voice_path(request)
+        use_stdout = self._should_use_stdout(request)
+
+        temp_output_path: Optional[Path] = None
+        temp_converted_path: Optional[Path] = None
+        try:
+            if not use_stdout:
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_output:
+                    temp_output_path = Path(temp_output.name)
+
+            command = build_cli_command(
+                binary_path=self.binary_path,
+                text=self.preprocess_text(request.text),
+                voice_path=voice_path,
+                model_path=self.model_path,
+                tokenizer_path=self.tokenizer_path,
+                output_path=temp_output_path,
+                precision=self.precision,
+                prefer_stdout=use_stdout,
+                enable_voice_cache=self.enable_voice_cache,
+                voices_dir=self.voices_dir,
+                temperature=self.temperature,
+                lsd_steps=self.lsd_steps,
+                eos_threshold=self.eos_threshold,
+                eos_extra=self.eos_extra,
+                noise_clamp=self.noise_clamp,
+                threads=self.threads,
+                verbose=self.verbose,
+                profile=self.profile,
+            )
+
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self.timeout)
+            except asyncio.TimeoutError as exc:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+                with contextlib.suppress(Exception):
+                    await process.communicate()
+                raise TTSTimeoutError(
+                    "Timed out waiting for PocketTTS.cpp CLI output",
+                    provider=self.PROVIDER_KEY,
+                    details={"timeout_seconds": self.timeout},
+                ) from exc
+
+            if process.returncode != 0:
+                stderr_text = stderr.decode("utf-8", errors="ignore").strip()
+                raise TTSGenerationError(
+                    "PocketTTS.cpp CLI exited with an error",
+                    provider=self.PROVIDER_KEY,
+                    details={
+                        "returncode": process.returncode,
+                        "stderr": stderr_text,
+                    },
+                )
+
+            if use_stdout:
+                audio_bytes = await self._convert_stdout_audio(stdout, request.format)
+                transport = "stdout"
+            else:
+                if temp_output_path is None or not temp_output_path.exists():
+                    raise TTSGenerationError(
+                        "PocketTTS.cpp did not produce an output file",
+                        provider=self.PROVIDER_KEY,
+                    )
+                audio_bytes, temp_converted_path = await self._load_file_output(
+                    output_path=temp_output_path,
+                    target_format=request.format,
+                )
+                transport = "file"
+
+            return TTSResponse(
+                audio_data=audio_bytes,
+                format=request.format,
+                sample_rate=self.DEFAULT_SAMPLE_RATE,
+                channels=1,
+                text_processed=request.text,
+                voice_used=request.voice,
+                provider=self.PROVIDER_KEY,
+                model=request.model or self.PROVIDER_KEY,
+                metadata={"transport": transport},
+            )
+        except (TTSValidationError, TTSModelNotFoundError, TTSUnsupportedFormatError, TTSTimeoutError):
+            raise
+        except Exception as exc:
+            logger.error("PocketTTS.cpp generation failed: {}", exc, exc_info=True)
+            raise TTSGenerationError(
+                "PocketTTS.cpp generation failed",
+                provider=self.PROVIDER_KEY,
+                details={"error": str(exc)},
+            ) from exc
+        finally:
+            for path in (temp_output_path, temp_converted_path):
+                if path is not None:
+                    with contextlib.suppress(OSError):
+                        path.unlink()
 
     async def get_capabilities(self) -> TTSCapabilities:
         return TTSCapabilities(
-            provider_name=self.PROVIDER_KEY,
-            supported_languages={"en"},
+            provider_name="PocketTTS.cpp",
+            supported_languages=self.SUPPORTED_LANGUAGES,
             supported_voices=[],
-            supported_formats={AudioFormat.MP3, AudioFormat.WAV, AudioFormat.OPUS, AudioFormat.FLAC, AudioFormat.PCM, AudioFormat.AAC},
-            max_text_length=5000,
+            supported_formats=self.SUPPORTED_FORMATS,
+            max_text_length=self.MAX_TEXT_LENGTH,
             supports_streaming=False,
-            supports_voice_cloning=False,
-            sample_rate=24000,
-            default_format=AudioFormat.MP3,
+            supports_voice_cloning=True,
+            sample_rate=self.DEFAULT_SAMPLE_RATE,
+            default_format=AudioFormat.WAV,
         )
+
+    def _resolve_voice_path(self, request: TTSRequest) -> Path:
+        extras = request.extra_params if isinstance(request.extra_params, dict) else {}
+        raw_voice_path = extras.get("pocket_tts_cpp_voice_path")
+        if not raw_voice_path:
+            raise TTSInvalidVoiceReferenceError(
+                "PocketTTS.cpp requires a provider-managed voice path",
+                provider=self.PROVIDER_KEY,
+                details={"param": "extra_params.pocket_tts_cpp_voice_path"},
+            )
+
+        voice_path = Path(str(raw_voice_path)).expanduser()
+        if not voice_path.exists() or not voice_path.is_file():
+            raise TTSInvalidVoiceReferenceError(
+                "PocketTTS.cpp voice path does not exist",
+                provider=self.PROVIDER_KEY,
+                details={"voice_path": str(voice_path)},
+            )
+        return voice_path
+
+    def _should_use_stdout(self, request: TTSRequest) -> bool:
+        extras = request.extra_params if isinstance(request.extra_params, dict) else {}
+        if "prefer_stdout" in extras:
+            prefer_stdout = parse_bool(extras.get("prefer_stdout"), default=self.prefer_stdout)
+        else:
+            prefer_stdout = self.prefer_stdout
+        return prefer_stdout and request.format == AudioFormat.PCM
+
+    async def _convert_stdout_audio(self, stdout: bytes, target_format: AudioFormat) -> bytes:
+        if not stdout:
+            raise TTSGenerationError(
+                "PocketTTS.cpp stdout transport returned no audio",
+                provider=self.PROVIDER_KEY,
+            )
+
+        audio = np.frombuffer(stdout, dtype=np.float32)
+        if audio.size == 0:
+            raise TTSGenerationError(
+                "PocketTTS.cpp stdout transport returned empty PCM data",
+                provider=self.PROVIDER_KEY,
+            )
+
+        audio_i16 = self._audio_normalizer.normalize(audio, target_dtype=np.int16)
+        return await self.convert_audio_format(
+            audio_i16,
+            source_format=AudioFormat.PCM,
+            target_format=target_format,
+            sample_rate=self.DEFAULT_SAMPLE_RATE,
+        )
+
+    async def _load_file_output(
+        self,
+        *,
+        output_path: Path,
+        target_format: AudioFormat,
+    ) -> tuple[bytes, Optional[Path]]:
+        if target_format == AudioFormat.WAV:
+            return output_path.read_bytes(), None
+        if target_format == AudioFormat.PCM:
+            with wave.open(str(output_path), "rb") as wav_file:
+                return wav_file.readframes(wav_file.getnframes()), None
+
+        with tempfile.NamedTemporaryFile(suffix=f".{target_format.value}", delete=False) as converted_file:
+            converted_path = Path(converted_file.name)
+
+        converted = await AudioConverter.convert_format(
+            output_path,
+            converted_path,
+            target_format.value,
+            sample_rate=self.DEFAULT_SAMPLE_RATE,
+            channels=1,
+        )
+        converted_path = converted_path.with_suffix(f".{target_format.value}")
+        if not converted or not converted_path.exists():
+            raise TTSGenerationError(
+                f"Failed converting PocketTTS.cpp output to {target_format.value}",
+                provider=self.PROVIDER_KEY,
+                details={"target_format": target_format.value},
+            )
+        return converted_path.read_bytes(), converted_path

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py
@@ -41,15 +41,15 @@ class PocketTTSCppAdapter(TTSAdapter):
     """Adapter for the PocketTTS.cpp command-line runtime."""
 
     PROVIDER_KEY = "pocket_tts_cpp"
-    SUPPORTED_FORMATS: set[AudioFormat] = {
+    SUPPORTED_FORMATS: frozenset[AudioFormat] = frozenset({
         AudioFormat.MP3,
         AudioFormat.WAV,
         AudioFormat.OPUS,
         AudioFormat.FLAC,
         AudioFormat.PCM,
         AudioFormat.AAC,
-    }
-    SUPPORTED_LANGUAGES = {"en"}
+    })
+    SUPPORTED_LANGUAGES = frozenset({"en"})
     DEFAULT_SAMPLE_RATE = 24000
     MAX_TEXT_LENGTH = 5000
 
@@ -369,11 +369,11 @@ class PocketTTSCppAdapter(TTSAdapter):
             self._cli_stream_probe_voice_path = voice_path
             try:
                 probe_result = await self._probe_cli_streaming_support()
-                if probe_result:
-                    self._cli_streaming_supported = True
+                self._cli_streaming_supported = probe_result
                 return probe_result
             except Exception as exc:
                 logger.warning("PocketTTS.cpp CLI streaming probe failed: {}", exc)
+                self._cli_streaming_supported = False
                 return False
             finally:
                 self._cli_stream_probe_voice_path = None
@@ -529,7 +529,19 @@ class PocketTTSCppAdapter(TTSAdapter):
                 provider=self.PROVIDER_KEY,
             )
 
-        audio = np.frombuffer(stdout, dtype=np.float32)
+        usable = len(stdout) - (len(stdout) % 4)
+        if usable <= 0:
+            raise TTSGenerationError(
+                "PocketTTS.cpp stdout transport returned malformed PCM data",
+                provider=self.PROVIDER_KEY,
+            )
+        if usable != len(stdout):
+            logger.debug(
+                "PocketTTS.cpp stdout PCM dropped {} trailing bytes before decoding",
+                len(stdout) - usable,
+            )
+
+        audio = np.frombuffer(stdout[:usable], dtype=np.dtype("<f4")).astype(np.float32, copy=False)
         if audio.size == 0:
             raise TTSGenerationError(
                 "PocketTTS.cpp stdout transport returned empty PCM data",

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+
+
+PROVIDER_KEY = "pocket_tts_cpp"
+
+
+def get_runtime_dir(*, voice_manager, user_id: int) -> Path:
+    """Return the user-scoped PocketTTS.cpp runtime directory."""
+    voices_root = voice_manager.get_user_voices_path(user_id)
+    runtime_dir = voices_root / "providers" / PROVIDER_KEY
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    return runtime_dir
+
+
+async def materialize_custom_voice_reference(*, voice_manager, user_id: int, voice_id: str) -> Path:
+    """Materialize a stored custom voice into the provider runtime cache."""
+    runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
+    target_path = runtime_dir / f"custom_{voice_id}.wav"
+    voice_bytes = await voice_manager.load_voice_reference_audio(user_id, voice_id)
+    target_path.write_bytes(voice_bytes)
+    return target_path
+
+
+async def materialize_direct_voice_reference(
+    *,
+    voice_manager,
+    user_id: int,
+    voice_reference: bytes,
+    persist_direct_voice_references: bool,
+) -> tuple[Path, bool]:
+    """Materialize a direct voice reference into the provider runtime cache."""
+    runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
+    digest = hashlib.sha256(voice_reference).hexdigest()
+    target_path = runtime_dir / f"ref_{digest}.wav"
+    target_path.write_bytes(voice_reference)
+    return target_path, not persist_direct_voice_references
+
+
+def prune_materialized_voice_cache(
+    runtime_dir: Path,
+    *,
+    cache_ttl_hours: Optional[int],
+    cache_max_bytes: Optional[int],
+) -> list[Path]:
+    """Remove expired or oversize materialized voice files from the runtime cache."""
+    if not runtime_dir.exists():
+        return []
+
+    removed: list[Path] = []
+    files: list[tuple[Path, float, int]] = []
+    now = time.time()
+    ttl_seconds = max(0, int(cache_ttl_hours or 0)) * 3600
+
+    for path in runtime_dir.glob("*.wav"):
+        if not path.is_file():
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        mtime = float(stat.st_mtime)
+        size = int(stat.st_size)
+        if ttl_seconds and (now - mtime) > ttl_seconds:
+            try:
+                path.unlink()
+                removed.append(path)
+            except OSError as exc:
+                logger.warning("Failed pruning expired PocketTTS.cpp cache file {}: {}", path, exc)
+            continue
+        files.append((path, mtime, size))
+
+    if cache_max_bytes is None or cache_max_bytes <= 0:
+        return removed
+
+    total_bytes = sum(size for _, _, size in files)
+    if total_bytes <= cache_max_bytes:
+        return removed
+
+    for path, _, size in sorted(files, key=lambda item: item[1]):
+        if total_bytes <= cache_max_bytes:
+            break
+        try:
+            path.unlink()
+            removed.append(path)
+            total_bytes -= size
+        except OSError as exc:
+            logger.warning("Failed pruning oversized PocketTTS.cpp cache file {}: {}", path, exc)
+
+    return removed
+
+
+def cleanup_transient_voice_reference(path: Optional[Path], is_transient: bool) -> None:
+    """Delete a transient direct-reference materialization after request completion."""
+    if not is_transient or path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("Failed cleaning transient PocketTTS.cpp cache file {}: {}", path, exc)

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
@@ -34,12 +34,19 @@ async def materialize_direct_voice_reference(
     user_id: int,
     voice_reference: bytes,
     persist_direct_voice_references: bool,
+    cache_max_bytes: Optional[int] = None,
 ) -> tuple[Path, bool]:
     """Materialize a direct voice reference into the provider runtime cache."""
     runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
     digest = hashlib.sha256(voice_reference).hexdigest()
     target_path = runtime_dir / f"ref_{digest}.wav"
     target_path.write_bytes(voice_reference)
+    if persist_direct_voice_references and cache_max_bytes is not None:
+        prune_materialized_voice_cache(
+            runtime_dir,
+            cache_ttl_hours=None,
+            cache_max_bytes=cache_max_bytes,
+        )
     return target_path, not persist_direct_voice_references
 
 

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+import json
 import hashlib
 import contextlib
+import secrets
+import threading
 import time
 import tempfile
 import uuid
@@ -16,7 +20,19 @@ from tldw_Server_API.app.core.TTS.tts_exceptions import TTSModelNotFoundError
 
 
 PROVIDER_KEY = "pocket_tts_cpp"
+PROVIDER_MANAGED_VOICE_TOKEN_KEY = "_pocket_tts_cpp_voice_trust_token"  # nosec B105
+PROVIDER_MANAGED_VOICE_LEASE_DIRNAME = ".pocket_tts_cpp_leases"
+PROVIDER_MANAGED_VOICE_LEASE_SUFFIX = ".json"
 VALID_PRECISIONS = {"int8", "fp32"}
+STREAM_PROBE_TEXT = (
+    "PocketTTS.cpp streaming probe. This text is intentionally longer than a "
+    "single short sentence so the CLI has a meaningful opportunity to emit "
+    "incremental stdout before completion. If the runtime buffers everything "
+    "until the end, the probe should fail closed."
+)
+_PROVIDER_MANAGED_VOICE_TOKEN_TTL_SECONDS = 30 * 60
+_PROVIDER_MANAGED_VOICE_TOKEN_LOCK = threading.RLock()
+_PROVIDER_MANAGED_VOICE_TOKENS: dict[str, tuple[Path, float, Path]] = {}
 
 
 def get_required_model_filenames(precision: str) -> list[str]:
@@ -133,6 +149,300 @@ def build_cli_command(
     return command
 
 
+def _normalize_provider_managed_voice_path(voice_path: Path) -> Path:
+    resolved_voice_path = Path(voice_path).expanduser()
+    if not resolved_voice_path.exists() or not resolved_voice_path.is_file():
+        raise ValueError(f"PocketTTS.cpp provider-managed voice path does not exist: {resolved_voice_path}")
+    resolved_voice_path = resolved_voice_path.resolve()
+
+    provider_dir = resolved_voice_path.parent
+    if provider_dir.name != PROVIDER_KEY or provider_dir.parent.name != "providers":
+        raise ValueError(
+            "PocketTTS.cpp provider-managed voice path must be materialized under voices/providers/pocket_tts_cpp/"
+        )
+
+    return resolved_voice_path
+
+
+def _provider_managed_voice_lease_dir(runtime_dir: Path) -> Path:
+    return runtime_dir / PROVIDER_MANAGED_VOICE_LEASE_DIRNAME
+
+
+def _provider_managed_voice_lease_path(runtime_dir: Path, trust_token: str) -> Path:
+    return _provider_managed_voice_lease_dir(runtime_dir) / f"{trust_token}{PROVIDER_MANAGED_VOICE_LEASE_SUFFIX}"
+
+
+def _write_provider_managed_voice_lease(
+    lease_path: Path,
+    *,
+    trust_token: str,
+    voice_path: Path,
+    created_at: float,
+) -> None:
+    lease_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "token": trust_token,
+        "voice_path": str(voice_path),
+        "created_at": created_at,
+        "pid": os.getpid(),
+    }
+    temp_path = lease_path.with_name(f".{lease_path.name}.{uuid.uuid4().hex}.tmp")
+    temp_path.write_text(json.dumps(payload, separators=(",", ":"), sort_keys=True), encoding="utf-8")
+    temp_path.replace(lease_path)
+
+
+def _load_provider_managed_voice_lease_record(lease_path: Path) -> tuple[str, Path, float]:
+    payload = json.loads(lease_path.read_text(encoding="utf-8"))
+    token = str(payload.get("token") or "").strip()
+    voice_path = _normalize_provider_managed_voice_path(Path(str(payload.get("voice_path") or "")))
+    created_at = float(payload.get("created_at") or 0.0)
+    if not token:
+        raise ValueError("PocketTTS.cpp trust token lease is missing a token")
+    if created_at <= 0:
+        raise ValueError("PocketTTS.cpp trust token lease is missing a creation timestamp")
+    return token, voice_path, created_at
+
+
+def _purge_expired_provider_managed_voice_tokens(now: Optional[float] = None) -> None:
+    cutoff = time.time() if now is None else now
+    expired_tokens = [
+        token
+        for token, (_, created_at, _) in _PROVIDER_MANAGED_VOICE_TOKENS.items()
+        if (cutoff - created_at) > _PROVIDER_MANAGED_VOICE_TOKEN_TTL_SECONDS
+    ]
+    for token in expired_tokens:
+        _, _, lease_path = _PROVIDER_MANAGED_VOICE_TOKENS.pop(token, (None, 0.0, None))
+        if lease_path is not None:
+            with contextlib.suppress(OSError):
+                lease_path.unlink()
+
+
+def register_provider_managed_voice_path(voice_path: Path) -> str:
+    """Register a provider-managed voice path and return an unguessable trust token."""
+    resolved_voice_path = _normalize_provider_managed_voice_path(voice_path)
+    token = secrets.token_urlsafe(32)
+    created_at = time.time()
+    lease_path = _provider_managed_voice_lease_path(resolved_voice_path.parent, token)
+    _write_provider_managed_voice_lease(
+        lease_path,
+        trust_token=token,
+        voice_path=resolved_voice_path,
+        created_at=created_at,
+    )
+    with _PROVIDER_MANAGED_VOICE_TOKEN_LOCK:
+        _purge_expired_provider_managed_voice_tokens()
+        _PROVIDER_MANAGED_VOICE_TOKENS[token] = (resolved_voice_path, created_at, lease_path)
+    return token
+
+
+def resolve_provider_managed_voice_path(trust_token: str, voice_path: Path) -> Path:
+    """Return the registered path for a service-issued trust token after verifying the path."""
+    if not trust_token:
+        raise ValueError("PocketTTS.cpp trust token is required")
+
+    requested_voice_path = _normalize_provider_managed_voice_path(voice_path)
+    lease_path = _provider_managed_voice_lease_path(requested_voice_path.parent, str(trust_token))
+    if not lease_path.exists():
+        with _PROVIDER_MANAGED_VOICE_TOKEN_LOCK:
+            _PROVIDER_MANAGED_VOICE_TOKENS.pop(str(trust_token), None)
+        raise ValueError("PocketTTS.cpp trust token is not registered")
+
+    token, registered_path, created_at = _load_provider_managed_voice_lease_record(lease_path)
+    if token != str(trust_token):
+        with contextlib.suppress(OSError):
+            lease_path.unlink()
+        raise ValueError("PocketTTS.cpp trust token is not registered")
+
+    if (time.time() - created_at) > _PROVIDER_MANAGED_VOICE_TOKEN_TTL_SECONDS:
+        with contextlib.suppress(OSError):
+            lease_path.unlink()
+        with _PROVIDER_MANAGED_VOICE_TOKEN_LOCK:
+            _PROVIDER_MANAGED_VOICE_TOKENS.pop(str(trust_token), None)
+        raise ValueError("PocketTTS.cpp trust token is expired")
+
+    if registered_path != requested_voice_path:
+        raise ValueError("PocketTTS.cpp voice path does not match the registered trust token")
+
+    with _PROVIDER_MANAGED_VOICE_TOKEN_LOCK:
+        _PROVIDER_MANAGED_VOICE_TOKENS[str(trust_token)] = (registered_path, created_at, lease_path)
+    return registered_path
+
+
+def revoke_provider_managed_voice_token(trust_token: Optional[str], voice_path: Optional[Path] = None) -> None:
+    """Drop a provider-managed trust token from the in-process registry."""
+    if not trust_token:
+        return
+    lease_path: Optional[Path] = None
+    with _PROVIDER_MANAGED_VOICE_TOKEN_LOCK:
+        registered = _PROVIDER_MANAGED_VOICE_TOKENS.pop(str(trust_token), None)
+        if registered is not None:
+            lease_path = registered[2]
+    if lease_path is None and voice_path is not None:
+        try:
+            requested_voice_path = _normalize_provider_managed_voice_path(voice_path)
+            lease_path = _provider_managed_voice_lease_path(requested_voice_path.parent, str(trust_token))
+        except ValueError:
+            lease_path = None
+    if lease_path is not None:
+        with contextlib.suppress(OSError):
+            lease_path.unlink()
+
+
+def get_active_provider_managed_voice_paths(runtime_dir: Optional[Path] = None) -> set[Path]:
+    """Return the currently registered provider-managed voice paths."""
+    with _PROVIDER_MANAGED_VOICE_TOKEN_LOCK:
+        _purge_expired_provider_managed_voice_tokens()
+        if runtime_dir is None:
+            return {registered_path for registered_path, _, _ in _PROVIDER_MANAGED_VOICE_TOKENS.values()}
+
+    active_paths: set[Path] = set()
+
+    lease_dir = _provider_managed_voice_lease_dir(runtime_dir)
+    if not lease_dir.exists():
+        return active_paths
+
+    now = time.time()
+    for lease_path in lease_dir.glob(f"*{PROVIDER_MANAGED_VOICE_LEASE_SUFFIX}"):
+        if not lease_path.is_file():
+            continue
+        try:
+            token, registered_path, created_at = _load_provider_managed_voice_lease_record(lease_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            with contextlib.suppress(OSError):
+                lease_path.unlink()
+            continue
+        if lease_path.stem != token:
+            with contextlib.suppress(OSError):
+                lease_path.unlink()
+            continue
+        if (now - created_at) > _PROVIDER_MANAGED_VOICE_TOKEN_TTL_SECONDS:
+            with contextlib.suppress(OSError):
+                lease_path.unlink()
+            continue
+        active_paths.add(registered_path)
+    return active_paths
+
+
+async def probe_cli_streaming_incremental(
+    *,
+    binary_path: Path,
+    voice_path: Path,
+    model_path: Path,
+    tokenizer_path: Path,
+    precision: str,
+    timeout: float,
+    enable_voice_cache: bool,
+    voices_dir: Optional[Path] = None,
+    temperature: Optional[float] = None,
+    lsd_steps: Optional[int] = None,
+    eos_threshold: Optional[float] = None,
+    eos_extra: Optional[float] = None,
+    noise_clamp: Optional[float] = None,
+    threads: Optional[int] = None,
+    verbose: bool = False,
+    profile: bool = False,
+) -> bool:
+    """Return True when the CLI emits stdout bytes before process completion."""
+    command = build_cli_command(
+        binary_path=binary_path,
+        text=STREAM_PROBE_TEXT,
+        voice_path=voice_path,
+        model_path=model_path,
+        tokenizer_path=tokenizer_path,
+        output_path=None,
+        precision=precision,
+        prefer_stdout=True,
+        enable_voice_cache=enable_voice_cache,
+        voices_dir=voices_dir,
+        temperature=temperature,
+        lsd_steps=lsd_steps,
+        eos_threshold=eos_threshold,
+        eos_extra=eos_extra,
+        noise_clamp=noise_clamp,
+        threads=threads,
+        verbose=verbose,
+        profile=profile,
+    )
+
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    start = time.monotonic()
+    try:
+        if process.stdout is None:
+            return False
+
+        try:
+            first_chunk = await asyncio.wait_for(process.stdout.read(4096), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.info("PocketTTS.cpp CLI streaming probe timed out waiting for first chunk")
+            return False
+
+        if not first_chunk:
+            logger.info("PocketTTS.cpp CLI streaming probe produced no stdout bytes")
+            return False
+
+        first_byte_elapsed = time.monotonic() - start
+
+        drain_window = min(max(timeout * 0.05, 0.01), 0.05)
+        drain_deadline = time.monotonic() + drain_window
+        while True:
+            remaining_drain = drain_deadline - time.monotonic()
+            if remaining_drain <= 0:
+                break
+            try:
+                drain_chunk = await asyncio.wait_for(process.stdout.read(4096), timeout=remaining_drain)
+            except asyncio.TimeoutError:
+                break
+            if not drain_chunk:
+                logger.info("PocketTTS.cpp CLI streaming probe reached EOF before later stdout progress")
+                return False
+
+        observation_window = min(max(timeout * 0.25, 0.05), 0.5)
+        try:
+            later_chunk = await asyncio.wait_for(process.stdout.read(4096), timeout=observation_window)
+        except asyncio.TimeoutError:
+            logger.info("PocketTTS.cpp CLI streaming probe produced no later stdout bytes within observation window")
+            return False
+
+        if not later_chunk:
+            logger.info("PocketTTS.cpp CLI streaming probe reached EOF without later stdout progress")
+            return False
+
+        try:
+            _, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.info("PocketTTS.cpp CLI streaming probe timed out waiting for process exit")
+            return False
+
+        total_elapsed = time.monotonic() - start
+        if process.returncode != 0:
+            stderr_text = stderr.decode("utf-8", errors="ignore").strip()
+            logger.info(
+                "PocketTTS.cpp CLI streaming probe exited with returncode={} stderr={}",
+                process.returncode,
+                stderr_text,
+            )
+            return False
+
+        incremental = True
+        logger.info(
+            "PocketTTS.cpp CLI streaming probe result={} ttfb_ms={} total_ms={}",
+            incremental,
+            round(first_byte_elapsed * 1000, 2),
+            round(total_elapsed * 1000, 2),
+        )
+        return incremental
+    finally:
+        if process.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            with contextlib.suppress(Exception):
+                await process.communicate()
+
+
 def get_runtime_dir(*, voice_manager, user_id: int) -> Path:
     """Return the user-scoped PocketTTS.cpp runtime directory."""
     voices_root = voice_manager.get_user_voices_path(user_id)
@@ -210,7 +520,8 @@ async def materialize_custom_voice_reference(
     runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
     target_path = runtime_dir / f"custom_{voice_id}.wav"
     voice_bytes = await voice_manager.load_voice_reference_audio(user_id, voice_id)
-    _write_runtime_file(target_path, voice_bytes)
+    normalized_bytes = await normalize_reference_audio_to_wav(voice_bytes)
+    _write_runtime_file(target_path, normalized_bytes)
     if cache_max_bytes is not None:
         prune_materialized_voice_cache(
             runtime_dir,
@@ -266,6 +577,7 @@ def prune_materialized_voice_cache(
     protected_resolved = {
         path.resolve() for path in (protected_paths or set()) if path is not None
     }
+    protected_resolved.update(get_active_provider_managed_voice_paths(runtime_dir))
 
     for path in runtime_dir.glob("*.wav"):
         if not path.is_file():

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
@@ -67,14 +67,14 @@ def validate_runtime_assets(
             details={"binary_path": str(binary_path)},
         )
 
-    if not tokenizer_path.exists():
+    if not tokenizer_path.exists() or not tokenizer_path.is_file():
         raise TTSModelNotFoundError(
             f"PocketTTS.cpp tokenizer not found at {tokenizer_path}",
             provider=PROVIDER_KEY,
             details={"tokenizer_path": str(tokenizer_path)},
         )
 
-    if not model_path.exists():
+    if not model_path.exists() or not model_path.is_dir():
         raise TTSModelNotFoundError(
             f"PocketTTS.cpp models directory not found at {model_path}",
             provider=PROVIDER_KEY,
@@ -477,10 +477,19 @@ async def normalize_reference_audio_to_wav(
     input_fd, input_name = tempfile.mkstemp(prefix="pocket_tts_cpp_ref_", suffix=suffix)
     output_fd, output_name = tempfile.mkstemp(prefix="pocket_tts_cpp_ref_", suffix=".wav")
     try:
-        with os.fdopen(input_fd, "wb") as input_file:
-            input_file.write(audio_bytes)
-        with os.fdopen(output_fd, "wb"):
-            pass
+        def _write_input_file() -> None:
+            with os.fdopen(input_fd, "wb") as input_file:
+                input_file.write(audio_bytes)
+                input_file.flush()
+                os.fsync(input_file.fileno())
+
+        def _create_output_placeholder() -> None:
+            with os.fdopen(output_fd, "wb") as output_file:
+                output_file.flush()
+                os.fsync(output_file.fileno())
+
+        await asyncio.to_thread(_write_input_file)
+        await asyncio.to_thread(_create_output_placeholder)
 
         input_path = Path(input_name)
         output_path = Path(output_name)
@@ -493,7 +502,7 @@ async def normalize_reference_audio_to_wav(
         )
         if not converted or not output_path.exists():
             raise RuntimeError("Failed to normalize PocketTTS.cpp reference audio to WAV")
-        normalized = output_path.read_bytes()
+        normalized = await asyncio.to_thread(output_path.read_bytes)
         if normalized[:4] != b"RIFF" or normalized[8:12] != b"WAVE":
             raise RuntimeError("PocketTTS.cpp reference normalization did not produce WAV bytes")
         return normalized
@@ -503,10 +512,33 @@ async def normalize_reference_audio_to_wav(
         with contextlib.suppress(OSError):
             Path(output_name).unlink()
 
-
-def _write_runtime_file(path: Path, payload: bytes) -> None:
+def _write_runtime_file_sync(path: Path, payload: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(payload)
+    temp_fd, temp_name = tempfile.mkstemp(
+        prefix=f"{path.stem}.",
+        suffix=f"{path.suffix}.tmp",
+        dir=str(path.parent),
+    )
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(temp_fd, "wb") as temp_file:
+            temp_file.write(payload)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except Exception:
+        with contextlib.suppress(OSError):
+            temp_path.unlink()
+        raise
+
+
+async def _write_runtime_file(path: Path, payload: bytes) -> None:
+    await asyncio.to_thread(_write_runtime_file_sync, path, payload)
 
 
 async def materialize_custom_voice_reference(
@@ -521,14 +553,7 @@ async def materialize_custom_voice_reference(
     target_path = runtime_dir / f"custom_{voice_id}.wav"
     voice_bytes = await voice_manager.load_voice_reference_audio(user_id, voice_id)
     normalized_bytes = await normalize_reference_audio_to_wav(voice_bytes)
-    _write_runtime_file(target_path, normalized_bytes)
-    if cache_max_bytes is not None:
-        prune_materialized_voice_cache(
-            runtime_dir,
-            cache_ttl_hours=None,
-            cache_max_bytes=cache_max_bytes,
-            protected_paths={target_path},
-        )
+    await _write_runtime_file(target_path, normalized_bytes)
     return target_path
 
 
@@ -548,14 +573,7 @@ async def materialize_direct_voice_reference(
         target_path = runtime_dir / f"ref_{digest}.wav"
     else:
         target_path = runtime_dir / f"ref_{digest}_{uuid.uuid4().hex}.wav"
-    _write_runtime_file(target_path, normalized_bytes)
-    if cache_max_bytes is not None:
-        prune_materialized_voice_cache(
-            runtime_dir,
-            cache_ttl_hours=None,
-            cache_max_bytes=cache_max_bytes,
-            protected_paths={target_path},
-        )
+    await _write_runtime_file(target_path, normalized_bytes)
     return target_path, not persist_direct_voice_references
 
 

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import time
+import uuid
+import wave
 from pathlib import Path
 from typing import Optional
 
@@ -19,12 +22,54 @@ def get_runtime_dir(*, voice_manager, user_id: int) -> Path:
     return runtime_dir
 
 
-async def materialize_custom_voice_reference(*, voice_manager, user_id: int, voice_id: str) -> Path:
+def normalize_reference_audio_to_wav(
+    audio_bytes: bytes,
+    *,
+    sample_rate: int = 24000,
+    channels: int = 1,
+    sample_width: int = 2,
+) -> bytes:
+    """Normalize incoming reference audio bytes into a WAV-compatible payload."""
+    if audio_bytes[:4] == b"RIFF" and audio_bytes[8:12] == b"WAVE":
+        return audio_bytes
+
+    pcm_bytes = audio_bytes
+    if sample_width > 0 and len(pcm_bytes) % sample_width:
+        pcm_bytes += b"\x00" * (sample_width - (len(pcm_bytes) % sample_width))
+
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(sample_width)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm_bytes)
+    return buffer.getvalue()
+
+
+def _write_runtime_file(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+async def materialize_custom_voice_reference(
+    *,
+    voice_manager,
+    user_id: int,
+    voice_id: str,
+    cache_max_bytes: Optional[int] = None,
+) -> Path:
     """Materialize a stored custom voice into the provider runtime cache."""
     runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
     target_path = runtime_dir / f"custom_{voice_id}.wav"
     voice_bytes = await voice_manager.load_voice_reference_audio(user_id, voice_id)
-    target_path.write_bytes(voice_bytes)
+    _write_runtime_file(target_path, voice_bytes)
+    if cache_max_bytes is not None:
+        prune_materialized_voice_cache(
+            runtime_dir,
+            cache_ttl_hours=None,
+            cache_max_bytes=cache_max_bytes,
+            protected_paths={target_path},
+        )
     return target_path
 
 
@@ -38,14 +83,19 @@ async def materialize_direct_voice_reference(
 ) -> tuple[Path, bool]:
     """Materialize a direct voice reference into the provider runtime cache."""
     runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
-    digest = hashlib.sha256(voice_reference).hexdigest()
-    target_path = runtime_dir / f"ref_{digest}.wav"
-    target_path.write_bytes(voice_reference)
-    if persist_direct_voice_references and cache_max_bytes is not None:
+    normalized_bytes = normalize_reference_audio_to_wav(voice_reference)
+    digest = hashlib.sha256(normalized_bytes).hexdigest()
+    if persist_direct_voice_references:
+        target_path = runtime_dir / f"ref_{digest}.wav"
+    else:
+        target_path = runtime_dir / f"ref_{digest}_{uuid.uuid4().hex}.wav"
+    _write_runtime_file(target_path, normalized_bytes)
+    if cache_max_bytes is not None:
         prune_materialized_voice_cache(
             runtime_dir,
             cache_ttl_hours=None,
             cache_max_bytes=cache_max_bytes,
+            protected_paths={target_path},
         )
     return target_path, not persist_direct_voice_references
 
@@ -55,6 +105,7 @@ def prune_materialized_voice_cache(
     *,
     cache_ttl_hours: Optional[int],
     cache_max_bytes: Optional[int],
+    protected_paths: Optional[set[Path]] = None,
 ) -> list[Path]:
     """Remove expired or oversize materialized voice files from the runtime cache."""
     if not runtime_dir.exists():
@@ -64,17 +115,21 @@ def prune_materialized_voice_cache(
     files: list[tuple[Path, float, int]] = []
     now = time.time()
     ttl_seconds = max(0, int(cache_ttl_hours or 0)) * 3600
+    protected_resolved = {
+        path.resolve() for path in (protected_paths or set()) if path is not None
+    }
 
     for path in runtime_dir.glob("*.wav"):
         if not path.is_file():
             continue
         try:
             stat = path.stat()
+            resolved = path.resolve()
         except OSError:
             continue
         mtime = float(stat.st_mtime)
         size = int(stat.st_size)
-        if ttl_seconds and (now - mtime) > ttl_seconds:
+        if ttl_seconds and (now - mtime) > ttl_seconds and resolved not in protected_resolved:
             try:
                 path.unlink()
                 removed.append(path)
@@ -93,6 +148,12 @@ def prune_materialized_voice_cache(
     for path, _, size in sorted(files, key=lambda item: item[1]):
         if total_bytes <= cache_max_bytes:
             break
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved in protected_resolved:
+            continue
         try:
             path.unlink()
             removed.append(path)

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import hashlib
-import io
+import contextlib
 import time
+import tempfile
 import uuid
-import wave
+import os
 from pathlib import Path
 from typing import Optional
 
 from loguru import logger
+
+from tldw_Server_API.app.core.TTS.audio_converter import AudioConverter
 
 
 PROVIDER_KEY = "pocket_tts_cpp"
@@ -22,28 +25,57 @@ def get_runtime_dir(*, voice_manager, user_id: int) -> Path:
     return runtime_dir
 
 
-def normalize_reference_audio_to_wav(
+def _infer_audio_suffix(audio_bytes: bytes) -> str:
+    """Infer a likely file suffix so the shared conversion path can decode bytes correctly."""
+    if audio_bytes[:4] == b"RIFF" and audio_bytes[8:12] == b"WAVE":
+        return ".wav"
+    if audio_bytes[:3] == b"ID3" or (len(audio_bytes) > 1 and audio_bytes[0] == 0xFF and (audio_bytes[1] & 0xE0) == 0xE0):
+        return ".mp3"
+    if audio_bytes[:4] == b"fLaC":
+        return ".flac"
+    if audio_bytes[:4] == b"OggS":
+        return ".ogg"
+    if len(audio_bytes) >= 8 and audio_bytes[4:8] == b"ftyp":
+        return ".m4a"
+    return ".wav"
+
+
+async def normalize_reference_audio_to_wav(
     audio_bytes: bytes,
     *,
     sample_rate: int = 24000,
     channels: int = 1,
-    sample_width: int = 2,
 ) -> bytes:
-    """Normalize incoming reference audio bytes into a WAV-compatible payload."""
-    if audio_bytes[:4] == b"RIFF" and audio_bytes[8:12] == b"WAVE":
-        return audio_bytes
+    """Normalize incoming reference audio bytes into a provider-safe WAV payload."""
+    suffix = _infer_audio_suffix(audio_bytes)
+    input_fd, input_name = tempfile.mkstemp(prefix="pocket_tts_cpp_ref_", suffix=suffix)
+    output_fd, output_name = tempfile.mkstemp(prefix="pocket_tts_cpp_ref_", suffix=".wav")
+    try:
+        with os.fdopen(input_fd, "wb") as input_file:
+            input_file.write(audio_bytes)
+        with os.fdopen(output_fd, "wb"):
+            pass
 
-    pcm_bytes = audio_bytes
-    if sample_width > 0 and len(pcm_bytes) % sample_width:
-        pcm_bytes += b"\x00" * (sample_width - (len(pcm_bytes) % sample_width))
-
-    buffer = io.BytesIO()
-    with wave.open(buffer, "wb") as wav_file:
-        wav_file.setnchannels(channels)
-        wav_file.setsampwidth(sample_width)
-        wav_file.setframerate(sample_rate)
-        wav_file.writeframes(pcm_bytes)
-    return buffer.getvalue()
+        input_path = Path(input_name)
+        output_path = Path(output_name)
+        converted = await AudioConverter.convert_to_wav(
+            input_path,
+            output_path,
+            sample_rate=sample_rate,
+            channels=channels,
+            bit_depth=16,
+        )
+        if not converted or not output_path.exists():
+            raise RuntimeError("Failed to normalize PocketTTS.cpp reference audio to WAV")
+        normalized = output_path.read_bytes()
+        if normalized[:4] != b"RIFF" or normalized[8:12] != b"WAVE":
+            raise RuntimeError("PocketTTS.cpp reference normalization did not produce WAV bytes")
+        return normalized
+    finally:
+        with contextlib.suppress(OSError):
+            Path(input_name).unlink()
+        with contextlib.suppress(OSError):
+            Path(output_name).unlink()
 
 
 def _write_runtime_file(path: Path, payload: bytes) -> None:
@@ -83,7 +115,7 @@ async def materialize_direct_voice_reference(
 ) -> tuple[Path, bool]:
     """Materialize a direct voice reference into the provider runtime cache."""
     runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
-    normalized_bytes = normalize_reference_audio_to_wav(voice_reference)
+    normalized_bytes = await normalize_reference_audio_to_wav(voice_reference)
     digest = hashlib.sha256(normalized_bytes).hexdigest()
     if persist_direct_voice_references:
         target_path = runtime_dir / f"ref_{digest}.wav"

--- a/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_runtime.py
@@ -12,9 +12,125 @@ from typing import Optional
 from loguru import logger
 
 from tldw_Server_API.app.core.TTS.audio_converter import AudioConverter
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSModelNotFoundError
 
 
 PROVIDER_KEY = "pocket_tts_cpp"
+VALID_PRECISIONS = {"int8", "fp32"}
+
+
+def get_required_model_filenames(precision: str) -> list[str]:
+    suffix = "_int8" if precision == "int8" else ""
+    return [
+        f"flow_lm_main{suffix}.onnx",
+        f"flow_lm_flow{suffix}.onnx",
+        f"mimi_decoder{suffix}.onnx",
+        "mimi_encoder.onnx",
+        "text_conditioner.onnx",
+    ]
+
+
+def validate_runtime_assets(
+    *,
+    binary_path: Path,
+    model_path: Path,
+    tokenizer_path: Path,
+    precision: str,
+) -> None:
+    """Validate the PocketTTS.cpp runtime files needed for CLI execution."""
+    if not binary_path.exists() or not binary_path.is_file():
+        raise TTSModelNotFoundError(
+            f"PocketTTS.cpp binary not found at {binary_path}",
+            provider=PROVIDER_KEY,
+            details={"binary_path": str(binary_path)},
+        )
+    if not os.access(binary_path, os.X_OK):
+        raise TTSModelNotFoundError(
+            f"PocketTTS.cpp binary is not executable at {binary_path}",
+            provider=PROVIDER_KEY,
+            details={"binary_path": str(binary_path)},
+        )
+
+    if not tokenizer_path.exists():
+        raise TTSModelNotFoundError(
+            f"PocketTTS.cpp tokenizer not found at {tokenizer_path}",
+            provider=PROVIDER_KEY,
+            details={"tokenizer_path": str(tokenizer_path)},
+        )
+
+    if not model_path.exists():
+        raise TTSModelNotFoundError(
+            f"PocketTTS.cpp models directory not found at {model_path}",
+            provider=PROVIDER_KEY,
+            details={"model_path": str(model_path)},
+        )
+
+    missing = [name for name in get_required_model_filenames(precision) if not (model_path / name).exists()]
+    if missing:
+        raise TTSModelNotFoundError(
+            "PocketTTS.cpp exported ONNX assets missing",
+            provider=PROVIDER_KEY,
+            details={"model_path": str(model_path), "missing": missing},
+        )
+
+
+def build_cli_command(
+    *,
+    binary_path: Path,
+    text: str,
+    voice_path: Path,
+    model_path: Path,
+    tokenizer_path: Path,
+    output_path: Optional[Path],
+    precision: str,
+    prefer_stdout: bool,
+    enable_voice_cache: bool,
+    voices_dir: Optional[Path] = None,
+    temperature: Optional[float] = None,
+    lsd_steps: Optional[int] = None,
+    eos_threshold: Optional[float] = None,
+    eos_extra: Optional[float] = None,
+    noise_clamp: Optional[float] = None,
+    threads: Optional[int] = None,
+    verbose: bool = False,
+    profile: bool = False,
+) -> list[str]:
+    """Build a PocketTTS.cpp CLI invocation for a single synthesis request."""
+    command = [str(binary_path)]
+
+    if prefer_stdout:
+        command.append("--stdout")
+    if precision:
+        command.extend(["--precision", precision])
+    if temperature is not None:
+        command.extend(["--temperature", str(temperature)])
+    if lsd_steps is not None:
+        command.extend(["--lsd-steps", str(lsd_steps)])
+    if eos_threshold is not None:
+        command.extend(["--eos-threshold", str(eos_threshold)])
+    if eos_extra is not None:
+        command.extend(["--eos-extra", str(eos_extra)])
+    if noise_clamp is not None:
+        command.extend(["--noise-clamp", str(noise_clamp)])
+    if threads is not None:
+        command.extend(["--threads", str(threads)])
+    if model_path:
+        command.extend(["--models-dir", str(model_path)])
+    if tokenizer_path:
+        command.extend(["--tokenizer", str(tokenizer_path)])
+    if voices_dir is not None:
+        command.extend(["--voices-dir", str(voices_dir)])
+    if not enable_voice_cache:
+        command.append("--no-cache")
+    if verbose:
+        command.append("--verbose")
+    if profile:
+        command.append("--profile")
+
+    command.extend([text, str(voice_path)])
+    if output_path is not None:
+        command.append(str(output_path))
+    return command
 
 
 def get_runtime_dir(*, voice_manager, user_id: int) -> Path:

--- a/tldw_Server_API/app/core/TTS/tts_config.py
+++ b/tldw_Server_API/app/core/TTS/tts_config.py
@@ -45,6 +45,8 @@ class ProviderConfig(BaseModel):
     model: Optional[str] = None
     model_revision: Optional[str] = None
     model_path: Optional[str] = None
+    binary_path: Optional[str] = None
+    tokenizer_path: Optional[str] = None
     mlx_model: Optional[str] = None
     capability_override: dict[str, Any] = Field(default_factory=dict)
     device: str = "cpu"
@@ -67,6 +69,10 @@ class ProviderConfig(BaseModel):
     tokenizer_max_tokens: Optional[int] = None
     tokenizer_max_payload_mb: Optional[int] = None
     voice_clone_prompt_max_kb: Optional[int] = None
+    enable_voice_cache: bool = False
+    cache_ttl_hours: Optional[int] = None
+    cache_max_bytes_per_user: Optional[int] = None
+    persist_direct_voice_references: bool = False
     # Allow providers (esp. local ones) to declare auto-download behavior
     auto_download: bool = True
     # Optional: for HTTP/API providers like OpenAI, perform a lightweight
@@ -310,6 +316,7 @@ class TTSConfigManager:
                         'vibevoice',
                         'vibevoice_realtime',
                         'neutts',
+                        'pocket_tts_cpp',
                         'lux_tts',
                     ]:
                         if provider not in config_dict['providers']:
@@ -330,6 +337,7 @@ class TTSConfigManager:
                         'vibevoice',
                         'vibevoice_realtime',
                         'neutts',
+                        'pocket_tts_cpp',
                         'lux_tts',
                     ]:
                         config_dict['providers'].setdefault(provider, {})['auto_download'] = auto_dl

--- a/tldw_Server_API/app/core/TTS/tts_resource_manager.py
+++ b/tldw_Server_API/app/core/TTS/tts_resource_manager.py
@@ -5,6 +5,7 @@
 import asyncio
 import gc
 import os
+import sys
 import threading
 import time
 import weakref
@@ -771,8 +772,10 @@ class TTSResourceManager:
     def _cleanup_device_cache() -> None:
         """Best-effort device cleanup after model eviction."""
         gc.collect()
+        torch = sys.modules.get("torch")
+        if torch is None:
+            return
         try:
-            import torch
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
             if hasattr(torch, "mps") and torch.backends.mps.is_available():

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -2284,6 +2284,7 @@ class TTSServiceV2:
         voice_id = request.voice or ""
         is_custom_voice = isinstance(voice_id, str) and voice_id.startswith("custom:")
         raw_id = voice_id.split("custom:", 1)[-1].strip() if is_custom_voice else ""
+        provider_key = (provider_hint or "").lower()
         try:
             from tldw_Server_API.app.core.TTS.voice_manager import VoiceProcessingError, get_voice_manager
 
@@ -2302,7 +2303,6 @@ class TTSServiceV2:
                 has_ref_text = any(extras.get(key) for key in ref_text_keys)
 
                 if metadata:
-                    provider_key = (provider_hint or "").lower()
                     artifacts = metadata.provider_artifacts.get(provider_key) if provider_key else None
                     if artifacts:
                         if "ref_codes" not in extras and artifacts.get("ref_codes") is not None:
@@ -2334,6 +2334,16 @@ class TTSServiceV2:
                 extras = request.extra_params if isinstance(request.extra_params, dict) else extras
             request.extra_params = extras
         except VoiceProcessingError as e:
+            if provider_key == "pocket_tts_cpp":
+                raise TTSValidationError(
+                    "PocketTTS.cpp voice reference preparation failed",
+                    provider="pocket_tts_cpp",
+                    error_code="pocket_tts_cpp_voice_materialization_failed",
+                    details={
+                        "voice_id": raw_id or None,
+                        "reason": str(e),
+                    },
+                ) from e
             request_id, _ = self._get_tts_request_observability(request)
             logger.warning(
                 "Custom voice resolution failed for {} (request_id={}): {}",
@@ -2342,6 +2352,16 @@ class TTSServiceV2:
                 e,
             )
         except _TTS_NONCRITICAL_EXCEPTIONS as e:
+            if provider_key == "pocket_tts_cpp":
+                raise TTSGenerationError(
+                    "PocketTTS.cpp voice reference preparation failed",
+                    provider="pocket_tts_cpp",
+                    error_code="pocket_tts_cpp_voice_materialization_failed",
+                    details={
+                        "voice_id": raw_id or None,
+                        "reason": str(e),
+                    },
+                ) from e
             request_id, _ = self._get_tts_request_observability(request)
             logger.warning(
                 "Custom voice resolution error for {} (request_id={}): {}",

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -368,6 +368,7 @@ class TTSServiceV2:
                 persist_direct_voice_references=bool(
                     provider_cfg.get("persist_direct_voice_references", False)
                 ),
+                cache_max_bytes=provider_cfg.get("cache_max_bytes_per_user"),
             )
 
         if voice_path is None:
@@ -395,6 +396,55 @@ class TTSServiceV2:
         if not raw_path:
             return
         cleanup_transient_voice_reference(Path(str(raw_path)), True)
+
+    async def _prepare_generate_speech_request(
+        self,
+        *,
+        request: OpenAISpeechRequest,
+        tts_request: TTSRequest,
+        provider: Optional[str],
+        provider_hint: Optional[str],
+        provider_overrides: Optional[dict[str, Any]],
+        fallback: bool,
+        user_id: Optional[int],
+    ) -> tuple[TTSAdapter, str, TTSRequest]:
+        """Resolve provider-managed request state before execution begins."""
+        try:
+            await self._apply_custom_voice_reference(tts_request, user_id, provider_hint)
+            self._apply_token_defaults(tts_request)
+
+            validate_tts_request(
+                tts_request,
+                provider=provider_hint,
+                config=self._get_validation_config(),
+            )
+
+            adapter = await self._get_adapter(request.model, provider, overrides=provider_overrides)
+            if not adapter and fallback:
+                adapter = await self._get_fallback_adapter(tts_request)
+            if not adapter:
+                raise TTSProviderNotConfiguredError(
+                    f"No TTS adapter available for model '{request.model}'",
+                    provider=provider,
+                )
+
+            provider_key = self._resolve_provider_key(adapter)
+            try:
+                resource_mgr = await get_resource_manager()
+                resource_mgr.touch_model(provider_key, getattr(tts_request, "model", None))
+            except _TTS_NONCRITICAL_EXCEPTIONS:
+                pass
+
+            request_for_provider = self._maybe_sanitize_request(tts_request, provider_key)
+            validate_tts_request(
+                request_for_provider,
+                provider=provider_key,
+                config=self._get_validation_config(),
+            )
+            return adapter, provider_key, request_for_provider
+        except Exception:
+            self._cleanup_transient_pocket_tts_cpp_voice_path(tts_request)
+            raise
 
     def _get_tts_request_observability(
         self,
@@ -1617,12 +1667,16 @@ class TTSServiceV2:
             except _TTS_NONCRITICAL_EXCEPTIONS:
                 provider_hint = None
 
-        await self._apply_custom_voice_reference(tts_request, user_id, provider_hint)
-        self._apply_token_defaults(tts_request)
-
-        # Validate the request first
         try:
-            validate_tts_request(tts_request, provider=provider_hint, config=self._get_validation_config())
+            adapter, provider_key, request_for_provider = await self._prepare_generate_speech_request(
+                request=request,
+                tts_request=tts_request,
+                provider=provider,
+                provider_hint=provider_hint,
+                provider_overrides=provider_overrides,
+                fallback=fallback,
+                user_id=user_id,
+            )
         except TTSValidationError as e:
             logger.error(f"TTS request validation failed: {e}")
             if self._stream_errors_as_audio:
@@ -1630,31 +1684,12 @@ class TTSServiceV2:
                 return
             else:
                 raise
-
-        # Get adapter
-        adapter = await self._get_adapter(request.model, provider, overrides=provider_overrides)
-        if not adapter and fallback:
-            # Try to find any available adapter
-            adapter = await self._get_fallback_adapter(tts_request)
-
-        if not adapter:
-            error = TTSProviderNotConfiguredError(
-                f"No TTS adapter available for model '{request.model}'",
-                provider=provider,
-            )
+        except TTSProviderNotConfiguredError as error:
             logger.error(str(error))
             if self._stream_errors_as_audio:
                 yield f"ERROR: {str(error)}".encode()
                 return
             raise error
-
-        provider_key = self._resolve_provider_key(adapter)
-        # Update model usage for LRU cache tracking (best-effort)
-        try:
-            resource_mgr = await get_resource_manager()
-            resource_mgr.touch_model(provider_key, getattr(tts_request, "model", None))
-        except _TTS_NONCRITICAL_EXCEPTIONS:
-            pass
 
         # Track metrics
         start_time = time.time()
@@ -1679,19 +1714,6 @@ class TTSServiceV2:
                 tts_request.voice_to_voice_route = voice_to_voice_route_label
             except _TTS_NONCRITICAL_EXCEPTIONS:
                 pass
-
-        # Re-validate against the concrete adapter's provider (important for fallback providers)
-        try:
-            request_for_provider = tts_request
-            request_for_provider = self._maybe_sanitize_request(tts_request, provider_key)
-            validate_tts_request(request_for_provider, provider=provider_key, config=self._get_validation_config())
-        except TTSValidationError as e:
-            logger.error(f"TTS request validation failed for provider {provider_key}: {e}")
-            if self._stream_errors_as_audio:
-                yield b"ERROR: Unable to generate audio."
-                return
-            else:
-                raise
 
         def _record_voice_to_voice(provider_name: str) -> None:
             nonlocal voice_to_voice_recorded

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -345,12 +345,6 @@ class TTSServiceV2:
             extras = {}
 
         provider_cfg = self._get_provider_runtime_config("pocket_tts_cpp")
-        runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
-        prune_materialized_voice_cache(
-            runtime_dir,
-            cache_ttl_hours=provider_cfg.get("cache_ttl_hours"),
-            cache_max_bytes=provider_cfg.get("cache_max_bytes_per_user"),
-        )
 
         voice_path = None
         is_transient = False
@@ -384,6 +378,13 @@ class TTSServiceV2:
             reference_text = getattr(metadata, "reference_text", None)
 
         trust_token = register_provider_managed_voice_path(voice_path)
+        runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
+        prune_materialized_voice_cache(
+            runtime_dir,
+            cache_ttl_hours=provider_cfg.get("cache_ttl_hours"),
+            cache_max_bytes=provider_cfg.get("cache_max_bytes_per_user"),
+            protected_paths={voice_path},
+        )
         extras["pocket_tts_cpp_voice_path"] = str(voice_path)
         extras[PROVIDER_MANAGED_VOICE_TOKEN_KEY] = trust_token
         if reference_text:
@@ -448,8 +449,13 @@ class TTSServiceV2:
             try:
                 resource_mgr = await get_resource_manager()
                 resource_mgr.touch_model(provider_key, getattr(tts_request, "model", None))
-            except _TTS_NONCRITICAL_EXCEPTIONS:
-                pass
+            except _TTS_NONCRITICAL_EXCEPTIONS as exc:
+                logger.warning(
+                    "Non-critical touch_model failure for provider {} model {}: {}",
+                    provider_key,
+                    getattr(tts_request, "model", None),
+                    exc,
+                )
 
             request_for_provider = self._maybe_sanitize_request(tts_request, provider_key)
             validate_tts_request(

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -427,14 +427,13 @@ class TTSServiceV2:
         """Resolve provider-managed request state before execution begins."""
         prepared = False
         try:
-            await self._apply_custom_voice_reference(tts_request, user_id, provider_hint)
             self._apply_token_defaults(tts_request)
-
             validate_tts_request(
                 tts_request,
                 provider=provider_hint,
                 config=self._get_validation_config(),
             )
+            await self._apply_custom_voice_reference(tts_request, user_id, provider_hint)
 
             adapter = await self._get_adapter(request.model, provider, overrides=provider_overrides)
             if not adapter and fallback:

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -359,6 +359,7 @@ class TTSServiceV2:
                     voice_manager=voice_manager,
                     user_id=user_id,
                     voice_id=voice_id,
+                    cache_max_bytes=provider_cfg.get("cache_max_bytes_per_user"),
                 )
         elif request.voice_reference:
             voice_path, is_transient = await materialize_direct_voice_reference(

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -40,6 +40,9 @@ from .adapters.pocket_tts_cpp_runtime import (
     materialize_custom_voice_reference,
     materialize_direct_voice_reference,
     prune_materialized_voice_cache,
+    PROVIDER_MANAGED_VOICE_TOKEN_KEY,
+    register_provider_managed_voice_path,
+    revoke_provider_managed_voice_token,
 )
 from .audio_utils import (
     crossfade_audio,
@@ -380,7 +383,9 @@ class TTSServiceV2:
         if reference_text is None and metadata is not None:
             reference_text = getattr(metadata, "reference_text", None)
 
+        trust_token = register_provider_managed_voice_path(voice_path)
         extras["pocket_tts_cpp_voice_path"] = str(voice_path)
+        extras[PROVIDER_MANAGED_VOICE_TOKEN_KEY] = trust_token
         if reference_text:
             extras["pocket_tts_cpp_reference_text"] = reference_text
         if is_transient:
@@ -389,14 +394,24 @@ class TTSServiceV2:
             extras.pop("_pocket_tts_cpp_transient_voice_path", None)
         request.extra_params = extras
 
-    def _cleanup_transient_pocket_tts_cpp_voice_path(self, request: TTSRequest) -> None:
+    def _cleanup_transient_pocket_tts_cpp_voice_path(
+        self,
+        request: TTSRequest,
+    ) -> None:
         extras = getattr(request, "extra_params", None)
         if not isinstance(extras, dict):
             return
+        managed_voice_path_raw = extras.get("pocket_tts_cpp_voice_path")
+        trust_token = extras.pop(PROVIDER_MANAGED_VOICE_TOKEN_KEY, None)
+        revoke_provider_managed_voice_token(
+            trust_token,
+            Path(str(managed_voice_path_raw)) if managed_voice_path_raw else None,
+        )
         raw_path = extras.pop("_pocket_tts_cpp_transient_voice_path", None)
         if not raw_path:
-            return
-        cleanup_transient_voice_reference(Path(str(raw_path)), True)
+            raw_path = None
+        if raw_path:
+            cleanup_transient_voice_reference(Path(str(raw_path)), True)
 
     async def _prepare_generate_speech_request(
         self,
@@ -2004,6 +2019,7 @@ class TTSServiceV2:
                     fallback_plan[1],
                     metadata_only=True,
                     metadata_target=request,
+                    user_id=user_id,
                 ):
                     pass
                 return
@@ -2013,6 +2029,7 @@ class TTSServiceV2:
                 fallback_plan[1],
                 metadata_only=False,
                 metadata_target=request,
+                user_id=user_id,
             ):
                 yield chunk
             return
@@ -2023,14 +2040,34 @@ class TTSServiceV2:
         request: TTSRequest,
         metadata_only: bool = False,
         metadata_target: Optional[Any] = None,
+        user_id: Optional[int] = None,
     ) -> AsyncGenerator[bytes, None]:
         """Generate audio with a specific adapter"""
         provider_key = self._resolve_provider_key(adapter)
+        request_for_provider = request
+        active_requests_incremented = False
+        start_time = time.time()
+        audio_size = 0
+        success = False
+        error_message: Optional[str] = None
+        voice_metric_recorded = False
+        v2v_start: Optional[float] = None
+        v2v_route = getattr(request_for_provider, "voice_to_voice_route", "audio.speech") or "audio.speech"
         # Ensure the request is valid for the concrete adapter/provider.
         try:
+            if provider_key == "pocket_tts_cpp" and user_id is not None:
+                extras = request.extra_params if isinstance(request.extra_params, dict) else {}
+                if not (
+                    isinstance(extras, dict)
+                    and extras.get("pocket_tts_cpp_voice_path")
+                    and extras.get(PROVIDER_MANAGED_VOICE_TOKEN_KEY)
+                ):
+                    await self._apply_custom_voice_reference(request, user_id, provider_key)
             request_for_provider = self._maybe_sanitize_request(request, provider_key)
             validate_tts_request(request_for_provider, provider=provider_key, config=self._get_validation_config())
-        except TTSValidationError as e:
+        except _TTS_NONCRITICAL_EXCEPTIONS as e:
+            if provider_key == "pocket_tts_cpp":
+                self._cleanup_transient_pocket_tts_cpp_voice_path(request)
             logger.error(f"TTS request validation failed for provider {provider_key}: {e}")
             if self._stream_errors_as_audio:
                 yield b"ERROR: Unable to generate audio."
@@ -2039,12 +2076,8 @@ class TTSServiceV2:
                 raise
 
         await self._increment_active_requests(provider_key)
+        active_requests_incremented = True
         start_time = time.time()
-        audio_size = 0
-        success = False
-        error_message: Optional[str] = None
-        voice_metric_recorded = False
-        v2v_start: Optional[float] = None
         try:
             raw = getattr(request_for_provider, "voice_to_voice_start", None)
             if raw is not None:
@@ -2053,7 +2086,6 @@ class TTSServiceV2:
                     v2v_start = parsed
         except _TTS_NONCRITICAL_EXCEPTIONS:
             v2v_start = None
-        v2v_route = getattr(request_for_provider, "voice_to_voice_route", "audio.speech") or "audio.speech"
 
         def _record_voice_to_voice() -> None:
             nonlocal voice_metric_recorded
@@ -2139,23 +2171,24 @@ class TTSServiceV2:
             raise TTSGenerationError(f"All providers failed - {str(e)}") from e
         finally:
             self._cleanup_transient_pocket_tts_cpp_voice_path(request_for_provider)
-            with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
-                await self._decrement_active_requests(provider_key)
-            try:
-                duration = time.time() - start_time
-                self._record_tts_metrics(
-                    provider=provider_key,
-                    model=getattr(request_for_provider, "model", None) or provider_key,
-                    voice=request_for_provider.voice or "default",
-                    format=request_for_provider.format.value,
-                    text_length=len(request_for_provider.text),
-                    audio_size=audio_size,
-                    duration=duration if duration >= 0 else 0.0,
-                    success=success,
-                    error=error_message if not success else None
-                )
-            except _TTS_NONCRITICAL_EXCEPTIONS:
-                pass
+            if active_requests_incremented:
+                with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
+                    await self._decrement_active_requests(provider_key)
+                try:
+                    duration = time.time() - start_time
+                    self._record_tts_metrics(
+                        provider=provider_key,
+                        model=getattr(request_for_provider, "model", None) or provider_key,
+                        voice=request_for_provider.voice or "default",
+                        format=request_for_provider.format.value,
+                        text_length=len(request_for_provider.text),
+                        audio_size=audio_size,
+                        duration=duration if duration >= 0 else 0.0,
+                        success=success,
+                        error=error_message if not success else None
+                    )
+                except _TTS_NONCRITICAL_EXCEPTIONS:
+                    pass
 
     def _convert_request(self, request: OpenAISpeechRequest) -> TTSRequest:
         """Convert OpenAI request to unified TTS request"""
@@ -2774,6 +2807,7 @@ class TTSServiceV2:
         *,
         metadata_only: bool = False,
         metadata_target: Optional[Any] = None,
+        user_id: Optional[int] = None,
     ) -> AsyncGenerator[bytes, None]:
         """
         Try fallback providers in priority order.
@@ -2804,9 +2838,10 @@ class TTSServiceV2:
                         fallback_adapter,
                         request,
                         metadata_only=metadata_only,
-                            metadata_target=metadata_target,
-                        ):
-                            yield chunk
+                        metadata_target=metadata_target,
+                        user_id=user_id,
+                    ):
+                        yield chunk
                 finally:
                     request.model = original_model
                 logger.info(f"Successfully fell back to {fallback_provider_key}")
@@ -2852,6 +2887,7 @@ class TTSServiceV2:
                                     request,
                                     metadata_only=metadata_only,
                                     metadata_target=metadata_target,
+                                    user_id=user_id,
                                 ):
                                     yield chunk
                             finally:

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -409,6 +409,7 @@ class TTSServiceV2:
         user_id: Optional[int],
     ) -> tuple[TTSAdapter, str, TTSRequest]:
         """Resolve provider-managed request state before execution begins."""
+        prepared = False
         try:
             await self._apply_custom_voice_reference(tts_request, user_id, provider_hint)
             self._apply_token_defaults(tts_request)
@@ -441,10 +442,11 @@ class TTSServiceV2:
                 provider=provider_key,
                 config=self._get_validation_config(),
             )
+            prepared = True
             return adapter, provider_key, request_for_provider
-        except Exception:
-            self._cleanup_transient_pocket_tts_cpp_voice_path(tts_request)
-            raise
+        finally:
+            if not prepared:
+                self._cleanup_transient_pocket_tts_cpp_voice_path(tts_request)
 
     def _get_tts_request_observability(
         self,

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -11,6 +11,7 @@ import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, suppress
 from dataclasses import replace
+from pathlib import Path
 from typing import Any, Optional
 
 #
@@ -33,6 +34,13 @@ from .adapter_registry import (
     get_tts_factory,
 )
 from .adapters.base import AudioFormat, TTSAdapter, TTSCapabilities, TTSRequest, TTSResponse
+from .adapters.pocket_tts_cpp_runtime import (
+    cleanup_transient_voice_reference,
+    get_runtime_dir,
+    materialize_custom_voice_reference,
+    materialize_direct_voice_reference,
+    prune_materialized_voice_cache,
+)
 from .audio_utils import (
     crossfade_audio,
     evaluate_audio_quality,
@@ -264,6 +272,129 @@ class TTSServiceV2:
             ("correlation_id", "x_correlation_id", "x-correlation-id"),
         )
         return request_id, correlation_id
+
+    def _get_provider_runtime_config(self, provider_key: str) -> dict[str, Any]:
+        """Best-effort provider config lookup for runtime materialization settings."""
+        config_source = None
+        for factory in (self.factory, self._factory):
+            registry = getattr(factory, "registry", None) if factory is not None else None
+            if registry is None:
+                continue
+            config_source = getattr(registry, "config", None)
+            if config_source is not None:
+                break
+
+        if config_source is None:
+            return {}
+
+        if hasattr(config_source, "model_dump"):
+            config_source = config_source.model_dump()
+        elif hasattr(config_source, "dict"):
+            config_source = config_source.dict()
+
+        providers_cfg = None
+        if isinstance(config_source, dict):
+            providers_cfg = config_source.get("providers")
+        else:
+            providers_cfg = getattr(config_source, "providers", None)
+
+        if providers_cfg is None:
+            return {}
+
+        provider_cfg = providers_cfg.get(provider_key) if isinstance(providers_cfg, dict) else getattr(providers_cfg, provider_key, None)
+        if provider_cfg is None:
+            return {}
+        if hasattr(provider_cfg, "model_dump"):
+            provider_cfg = provider_cfg.model_dump()
+        elif hasattr(provider_cfg, "dict"):
+            provider_cfg = provider_cfg.dict()
+        return provider_cfg if isinstance(provider_cfg, dict) else {}
+
+    @staticmethod
+    def _extract_reference_text_from_extras(extras: dict[str, Any]) -> Optional[str]:
+        for key in (
+            "pocket_tts_cpp_reference_text",
+            "reference_text",
+            "ref_text",
+            "voice_reference_text",
+        ):
+            value = extras.get(key)
+            if value is None:
+                continue
+            try:
+                parsed = str(value).strip()
+            except _TTS_NONCRITICAL_EXCEPTIONS:
+                continue
+            if parsed:
+                return parsed
+        return None
+
+    async def _apply_pocket_tts_cpp_runtime_materialization(
+        self,
+        request: TTSRequest,
+        *,
+        user_id: int,
+        voice_manager: Any,
+        metadata: Optional[Any],
+    ) -> None:
+        extras = request.extra_params or {}
+        if not isinstance(extras, dict):
+            extras = {}
+
+        provider_cfg = self._get_provider_runtime_config("pocket_tts_cpp")
+        runtime_dir = get_runtime_dir(voice_manager=voice_manager, user_id=user_id)
+        prune_materialized_voice_cache(
+            runtime_dir,
+            cache_ttl_hours=provider_cfg.get("cache_ttl_hours"),
+            cache_max_bytes=provider_cfg.get("cache_max_bytes_per_user"),
+        )
+
+        voice_path = None
+        is_transient = False
+        voice_name = request.voice or ""
+        if isinstance(voice_name, str) and voice_name.startswith("custom:"):
+            voice_id = voice_name.split("custom:", 1)[-1].strip()
+            if voice_id:
+                voice_path = await materialize_custom_voice_reference(
+                    voice_manager=voice_manager,
+                    user_id=user_id,
+                    voice_id=voice_id,
+                )
+        elif request.voice_reference:
+            voice_path, is_transient = await materialize_direct_voice_reference(
+                voice_manager=voice_manager,
+                user_id=user_id,
+                voice_reference=request.voice_reference,
+                persist_direct_voice_references=bool(
+                    provider_cfg.get("persist_direct_voice_references", False)
+                ),
+            )
+
+        if voice_path is None:
+            request.extra_params = extras
+            return
+
+        reference_text = self._extract_reference_text_from_extras(extras)
+        if reference_text is None and metadata is not None:
+            reference_text = getattr(metadata, "reference_text", None)
+
+        extras["pocket_tts_cpp_voice_path"] = str(voice_path)
+        if reference_text:
+            extras["pocket_tts_cpp_reference_text"] = reference_text
+        if is_transient:
+            extras["_pocket_tts_cpp_transient_voice_path"] = str(voice_path)
+        else:
+            extras.pop("_pocket_tts_cpp_transient_voice_path", None)
+        request.extra_params = extras
+
+    def _cleanup_transient_pocket_tts_cpp_voice_path(self, request: TTSRequest) -> None:
+        extras = getattr(request, "extra_params", None)
+        if not isinstance(extras, dict):
+            return
+        raw_path = extras.pop("_pocket_tts_cpp_transient_voice_path", None)
+        if not raw_path:
+            return
+        cleanup_transient_voice_reference(Path(str(raw_path)), True)
 
     def _get_tts_request_observability(
         self,
@@ -1009,8 +1140,10 @@ class TTSServiceV2:
             # Ignore resource check errors in legacy path
             pass
 
-        # Delegate to adapter.generate and return its response
-        return await adapter.generate(request)  # type: ignore[union-attr]
+        try:
+            return await adapter.generate(request)  # type: ignore[union-attr]
+        finally:
+            self._cleanup_transient_pocket_tts_cpp_voice_path(request)
 
     async def generate_stream(self, request: TTSRequest) -> AsyncGenerator[bytes, None]:
         """Legacy streaming wrapper expected by unit tests."""
@@ -1037,10 +1170,12 @@ class TTSServiceV2:
         except _TTS_NONCRITICAL_EXCEPTIONS:
             pass
 
-        # Adapter is expected to expose `generate_stream` in legacy tests
-        stream = await adapter.generate_stream(request)  # type: ignore[attr-defined]
-        async for chunk in stream:
-            yield chunk
+        try:
+            stream = await adapter.generate_stream(request)  # type: ignore[attr-defined]
+            async for chunk in stream:
+                yield chunk
+        finally:
+            self._cleanup_transient_pocket_tts_cpp_voice_path(request)
 
     async def list_providers(self) -> list[str]:
         """Legacy provider listing wrapper."""
@@ -1829,6 +1964,7 @@ class TTSServiceV2:
                 else:
                     raise tts_error from e
         finally:
+            self._cleanup_transient_pocket_tts_cpp_voice_path(request_for_provider)
             try:
                 if not released_active_slot:
                     await self._decrement_active_requests(provider_key)
@@ -1977,6 +2113,7 @@ class TTSServiceV2:
                 yield f"ERROR: All providers failed - {str(e)}".encode()
             raise TTSGenerationError(f"All providers failed - {str(e)}") from e
         finally:
+            self._cleanup_transient_pocket_tts_cpp_voice_path(request_for_provider)
             with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
                 await self._decrement_active_requests(provider_key)
             try:
@@ -2120,55 +2257,62 @@ class TTSServiceV2:
         if not user_id:
             return
         voice_id = request.voice or ""
-        if not isinstance(voice_id, str) or not voice_id.startswith("custom:"):
-            return
-        raw_id = voice_id.split("custom:", 1)[-1].strip()
-        if not raw_id:
-            return
+        is_custom_voice = isinstance(voice_id, str) and voice_id.startswith("custom:")
+        raw_id = voice_id.split("custom:", 1)[-1].strip() if is_custom_voice else ""
         try:
             from tldw_Server_API.app.core.TTS.voice_manager import VoiceProcessingError, get_voice_manager
 
             voice_manager = get_voice_manager()
-            if request.voice_reference is None:
+            metadata = None
+            if is_custom_voice and raw_id and request.voice_reference is None:
                 request.voice_reference = await voice_manager.load_voice_reference_audio(user_id, raw_id)
 
-            metadata = await voice_manager.load_reference_metadata(user_id, raw_id)
             extras = request.extra_params or {}
             if not isinstance(extras, dict):
                 extras = {}
 
-            ref_text_keys = ("reference_text", "ref_text", "voice_reference_text")
-            has_ref_text = any(extras.get(key) for key in ref_text_keys)
+            if is_custom_voice and raw_id:
+                metadata = await voice_manager.load_reference_metadata(user_id, raw_id)
+                ref_text_keys = ("reference_text", "ref_text", "voice_reference_text")
+                has_ref_text = any(extras.get(key) for key in ref_text_keys)
 
-            if metadata:
-                provider_key = (provider_hint or "").lower()
-                artifacts = metadata.provider_artifacts.get(provider_key) if provider_key else None
-                if artifacts:
-                    if "ref_codes" not in extras and artifacts.get("ref_codes") is not None:
-                        extras["ref_codes"] = artifacts.get("ref_codes")
-                    if not has_ref_text:
-                        extras["reference_text"] = (
-                            artifacts.get("reference_text") or metadata.reference_text
-                        )
-                elif not has_ref_text and metadata.reference_text:
-                    extras["reference_text"] = metadata.reference_text
+                if metadata:
+                    provider_key = (provider_hint or "").lower()
+                    artifacts = metadata.provider_artifacts.get(provider_key) if provider_key else None
+                    if artifacts:
+                        if "ref_codes" not in extras and artifacts.get("ref_codes") is not None:
+                            extras["ref_codes"] = artifacts.get("ref_codes")
+                        if not has_ref_text:
+                            extras["reference_text"] = (
+                                artifacts.get("reference_text") or metadata.reference_text
+                            )
+                    elif not has_ref_text and metadata.reference_text:
+                        extras["reference_text"] = metadata.reference_text
 
-                if provider_key == "qwen3_tts" and "voice_clone_prompt" not in extras:
-                    if metadata.voice_clone_prompt_b64:
-                        if metadata.voice_clone_prompt_format:
-                            extras["voice_clone_prompt"] = {
-                                "format": metadata.voice_clone_prompt_format,
-                                "data_b64": metadata.voice_clone_prompt_b64,
-                            }
-                        else:
-                            extras["voice_clone_prompt"] = metadata.voice_clone_prompt_b64
+                    if provider_key == "qwen3_tts" and "voice_clone_prompt" not in extras:
+                        if metadata.voice_clone_prompt_b64:
+                            if metadata.voice_clone_prompt_format:
+                                extras["voice_clone_prompt"] = {
+                                    "format": metadata.voice_clone_prompt_format,
+                                    "data_b64": metadata.voice_clone_prompt_b64,
+                                }
+                            else:
+                                extras["voice_clone_prompt"] = metadata.voice_clone_prompt_b64
 
+            if (provider_hint or "").lower() == "pocket_tts_cpp":
+                await self._apply_pocket_tts_cpp_runtime_materialization(
+                    request,
+                    user_id=user_id,
+                    voice_manager=voice_manager,
+                    metadata=metadata,
+                )
+                extras = request.extra_params if isinstance(request.extra_params, dict) else extras
             request.extra_params = extras
         except VoiceProcessingError as e:
             request_id, _ = self._get_tts_request_observability(request)
             logger.warning(
                 "Custom voice resolution failed for {} (request_id={}): {}",
-                raw_id,
+                raw_id or "direct-reference",
                 request_id or "unknown",
                 e,
             )
@@ -2176,7 +2320,7 @@ class TTSServiceV2:
             request_id, _ = self._get_tts_request_observability(request)
             logger.warning(
                 "Custom voice resolution error for {} (request_id={}): {}",
-                raw_id,
+                raw_id or "direct-reference",
                 request_id or "unknown",
                 e,
             )

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -414,6 +414,14 @@ class TTSServiceV2:
         if raw_path:
             cleanup_transient_voice_reference(Path(str(raw_path)), True)
 
+    async def _close_response_audio_stream(self, response: Optional[TTSResponse]) -> None:
+        if response is None:
+            return
+        audio_stream = getattr(response, "audio_stream", None)
+        if audio_stream and hasattr(audio_stream, "aclose"):
+            with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
+                await audio_stream.aclose()
+
     async def _prepare_generate_speech_request(
         self,
         *,
@@ -1723,6 +1731,7 @@ class TTSServiceV2:
         voice_to_voice_recorded = False
         voice_to_voice_route_label = voice_to_voice_route or "audio.speech"
         voice_to_voice_start_ts: Optional[float] = None
+        response: Optional[TTSResponse] = None
         try:
             if voice_to_voice_start is not None:
                 start_val = float(voice_to_voice_start)
@@ -1766,9 +1775,6 @@ class TTSServiceV2:
                     if self.circuit_manager:
                         breaker_provider_key = self._resolve_circuit_breaker_key(provider_key, adapter)
                         circuit_breaker = await self.circuit_manager.get_breaker(breaker_provider_key)
-
-                    # Generate response (with or without circuit breaker)
-                    response: Optional[TTSResponse] = None
 
                     async def _generate_with_adapter() -> TTSResponse:
                         should_chunk, target_chars, max_chars, min_chars, crossfade_ms = self._should_service_chunk(
@@ -1823,9 +1829,7 @@ class TTSServiceV2:
                             request_for_provider,
                         )
                         if metadata_only:
-                            if response.audio_stream and hasattr(response.audio_stream, "aclose"):
-                                with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
-                                    await response.audio_stream.aclose()
+                            await self._close_response_audio_stream(response)
                             with suppress(_TTS_NONCRITICAL_EXCEPTIONS):
                                 self._record_tts_metrics(
                                     provider=provider_key,
@@ -2009,6 +2013,7 @@ class TTSServiceV2:
                 else:
                     raise tts_error from e
         finally:
+            await self._close_response_audio_stream(response)
             self._cleanup_transient_pocket_tts_cpp_voice_path(request_for_provider)
             try:
                 if not released_active_slot:
@@ -2058,6 +2063,7 @@ class TTSServiceV2:
         voice_metric_recorded = False
         v2v_start: Optional[float] = None
         v2v_route = getattr(request_for_provider, "voice_to_voice_route", "audio.speech") or "audio.speech"
+        response: Optional[TTSResponse] = None
         # Ensure the request is valid for the concrete adapter/provider.
         try:
             if provider_key == "pocket_tts_cpp" and user_id is not None:
@@ -2175,6 +2181,7 @@ class TTSServiceV2:
                 yield f"ERROR: All providers failed - {str(e)}".encode()
             raise TTSGenerationError(f"All providers failed - {str(e)}") from e
         finally:
+            await self._close_response_audio_stream(response)
             self._cleanup_transient_pocket_tts_cpp_voice_path(request_for_provider)
             if active_requests_incremented:
                 with suppress(_TTS_NONCRITICAL_EXCEPTIONS):

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -26,6 +26,7 @@ from .tts_exceptions import (
     TTSVoiceNotFoundError,
 )
 from .utils import parse_bool, resolve_qwen3_runtime_name
+from .voice_manager import PROVIDER_REQUIREMENTS
 
 #
 #######################################################################################################################
@@ -567,6 +568,7 @@ class TTSInputValidator:
                 self._validate_voice(request.voice, provider)
 
             min_duration = None
+            max_duration = None
             if isinstance(request.extra_params, dict):
                 min_duration = self._coerce_float(request.extra_params.get("reference_duration_min"))
 
@@ -641,6 +643,10 @@ class TTSInputValidator:
                         "PocketTTS.cpp requires a direct voice_reference or a stored custom: voice",
                         provider=provider,
                     )
+                duration_limits = PROVIDER_REQUIREMENTS.get("pocket_tts_cpp", {}).get("duration", {})
+                if min_duration is None:
+                    min_duration = self._coerce_float(duration_limits.get("min"))
+                max_duration = self._coerce_float(duration_limits.get("max"))
 
             # Validate parameters (provider-aware)
             self._validate_parameters(request, provider)
@@ -654,7 +660,11 @@ class TTSInputValidator:
 
             # Validate voice reference if provided
             if request.voice_reference:
-                self._validate_voice_reference(request.voice_reference, min_duration=min_duration)
+                self._validate_voice_reference(
+                    request.voice_reference,
+                    min_duration=min_duration,
+                    max_duration=max_duration,
+                )
 
             return True, None
 
@@ -870,7 +880,12 @@ class TTSInputValidator:
             if voice_clone_prompt is not None:
                 self._validate_voice_clone_prompt(voice_clone_prompt, provider)
 
-    def _validate_voice_reference(self, voice_ref_data: bytes, min_duration: Optional[float] = None):
+    def _validate_voice_reference(
+        self,
+        voice_ref_data: bytes,
+        min_duration: Optional[float] = None,
+        max_duration: Optional[float] = None,
+    ):
         """Validate voice reference audio for cloning"""
         if len(voice_ref_data) == 0:
             raise TTSInvalidVoiceReferenceError("Voice reference data is empty")
@@ -887,7 +902,7 @@ class TTSInputValidator:
                 "Voice reference file is not a valid audio format"
             )
 
-        if min_duration is not None and min_duration > 0:
+        if (min_duration is not None and min_duration > 0) or (max_duration is not None and max_duration > 0):
             try:
                 import io
 
@@ -905,10 +920,15 @@ class TTSInputValidator:
                     "Unable to read voice reference audio for duration validation",
                     details={"error": str(exc)},
                 ) from exc
-            if duration < min_duration:
+            if min_duration is not None and duration < min_duration:
                 raise TTSInvalidVoiceReferenceError(
                     f"Voice reference audio too short: {duration:.2f}s (min {min_duration}s)",
                     details={"duration_seconds": duration, "min_seconds": min_duration},
+                )
+            if max_duration is not None and duration > max_duration:
+                raise TTSInvalidVoiceReferenceError(
+                    f"Voice reference audio too long: {duration:.2f}s (max {max_duration}s)",
+                    details={"duration_seconds": duration, "max_seconds": max_duration},
                 )
 
     def _sanitize_html(self, text: str) -> str:

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -121,6 +121,13 @@ class ProviderLimits:
             "min_speed": 0.25,
             "max_speed": 4.0
         },
+        "pocket_tts_cpp": {
+            "max_text_length": 5000,
+            "languages": ["en"],
+            "valid_formats": {"mp3", "wav", "opus", "flac", "pcm", "aac"},
+            "min_speed": 0.25,
+            "max_speed": 4.0
+        },
         "kitten_tts": {
             "max_text_length": 5000,
             "languages": ["en"],
@@ -239,6 +246,7 @@ class TTSInputValidator:
         "supertonic": 15000,
         "supertonic2": 15000,
         "pocket_tts": 5000,
+        "pocket_tts_cpp": 5000,
         "kitten_tts": 5000,
         "echo_tts": 768,
         "lux_tts": 5000,
@@ -272,6 +280,7 @@ class TTSInputValidator:
         "supertonic": {"en"},
         "supertonic2": {"en", "ko", "es", "pt", "fr"},
         "pocket_tts": {"en"},
+        "pocket_tts_cpp": {"en"},
         "kitten_tts": {"en"},
         "echo_tts": {"en"},
         "lux_tts": {"en"},
@@ -293,6 +302,7 @@ class TTSInputValidator:
         "supertonic": {AudioFormat.MP3, AudioFormat.WAV},
         "supertonic2": {AudioFormat.MP3, AudioFormat.WAV},
         "pocket_tts": {AudioFormat.MP3, AudioFormat.WAV, AudioFormat.OPUS, AudioFormat.FLAC, AudioFormat.PCM, AudioFormat.AAC},
+        "pocket_tts_cpp": {AudioFormat.MP3, AudioFormat.WAV, AudioFormat.OPUS, AudioFormat.FLAC, AudioFormat.PCM, AudioFormat.AAC},
         "kitten_tts": {AudioFormat.MP3, AudioFormat.WAV, AudioFormat.PCM},
         "echo_tts": {AudioFormat.MP3, AudioFormat.WAV, AudioFormat.FLAC, AudioFormat.OPUS, AudioFormat.AAC, AudioFormat.PCM},
         "lux_tts": {AudioFormat.MP3, AudioFormat.WAV, AudioFormat.FLAC, AudioFormat.OPUS, AudioFormat.AAC, AudioFormat.PCM},
@@ -624,6 +634,13 @@ class TTSInputValidator:
                         )
                     if min_duration is None:
                         min_duration = 3.0
+            elif provider == "pocket_tts_cpp":
+                voice = (request.voice or "").strip()
+                if not request.voice_reference and not voice.startswith("custom:"):
+                    raise TTSInvalidVoiceReferenceError(
+                        "PocketTTS.cpp requires a direct voice_reference or a stored custom: voice",
+                        provider=provider,
+                    )
 
             # Validate parameters (provider-aware)
             self._validate_parameters(request, provider)
@@ -920,7 +937,7 @@ class TTSInputValidator:
         elif provider == "elevenlabs":
             # ElevenLabs specific rules
             return text
-        elif provider in ["kokoro", "kitten_tts", "higgs", "dia", "chatterbox", "vibevoice", "pocket_tts", "lux_tts"]:
+        elif provider in ["kokoro", "kitten_tts", "higgs", "dia", "chatterbox", "vibevoice", "pocket_tts", "pocket_tts_cpp", "lux_tts"]:
             # Local model specific rules - more conservative
             # Remove URLs and email addresses
             text = re.sub(r'https?://\S+', '[URL]', text)

--- a/tldw_Server_API/app/core/TTS/voice_manager.py
+++ b/tldw_Server_API/app/core/TTS/voice_manager.py
@@ -90,6 +90,13 @@ PROVIDER_REQUIREMENTS = {
         "sample_rate": 24000,
         "convert_to": "wav"
     },
+    "pocket_tts_cpp": {
+        "formats": [".wav", ".mp3", ".flac", ".ogg", ".m4a"],
+        "max_size_mb": 20,
+        "duration": {"min": 1, "max": 60},
+        "sample_rate": 24000,
+        "convert_to": "wav"
+    },
     "qwen3_tts": {
         "formats": [".wav", ".mp3", ".flac", ".ogg", ".m4a", ".opus"],
         "max_size_mb": 50,
@@ -943,9 +950,23 @@ class VoiceManager:
             return False, f"Rate limit exceeded: {VOICE_RATE_LIMITS['upload_per_hour']} uploads per hour"
 
         # Check total storage
-        total_size = sum(
-            f.stat().st_size for f in voices_path.rglob("*") if f.is_file()
-        )
+        provider_cache_root = (voices_path / "providers").resolve()
+        total_size = 0
+        for file_path in voices_path.rglob("*"):
+            if not file_path.is_file():
+                continue
+            try:
+                resolved = file_path.resolve()
+                resolved.relative_to(provider_cache_root)
+                continue
+            except ValueError:
+                pass
+            except _VOICE_IO_EXCEPTIONS:
+                continue
+            try:
+                total_size += file_path.stat().st_size
+            except _VOICE_IO_EXCEPTIONS:
+                continue
 
         max_storage = VOICE_RATE_LIMITS["total_storage_mb"] * 1024 * 1024
         if total_size > max_storage:

--- a/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_integration.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_integration.py
@@ -1,0 +1,75 @@
+# test_pocket_tts_cpp_adapter_integration.py
+# Description: Opt-in integration test skeleton for PocketTTS.cpp CLI adapter
+#
+import os
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter import PocketTTSCppAdapter
+
+
+pytestmark = pytest.mark.integration
+RUN_TTS_CPP_INTEGRATION = os.getenv("RUN_TTS_CPP_INTEGRATION") == "1"
+
+if not RUN_TTS_CPP_INTEGRATION:
+    pytest.skip(
+        "PocketTTS.cpp integration tests are disabled by default. Set RUN_TTS_CPP_INTEGRATION=1 to enable.",
+        allow_module_level=True,
+    )
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _resolve_assets() -> tuple[Path, Path, Path] | None:
+    root = _repo_root()
+    binary_path = root / "bin" / "pocket-tts"
+    model_path = root / "models" / "pocket_tts_cpp" / "onnx"
+    tokenizer_path = root / "models" / "pocket_tts_cpp" / "tokenizer.model"
+
+    if not binary_path.exists() or not model_path.exists() or not tokenizer_path.exists():
+        return None
+
+    return binary_path, model_path, tokenizer_path
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_initialize_and_synthesize_short_request():
+    assets = _resolve_assets()
+    if assets is None:
+        pytest.skip("PocketTTS.cpp binary or models are not available")
+
+    binary_path, model_path, tokenizer_path = assets
+    sample_voice = _repo_root() / "Helper_Scripts" / "Audio" / "Sample_Voices" / "Sample_Voice_1.wav"
+    if not sample_voice.exists():
+        pytest.skip("PocketTTS.cpp sample voice file is not available")
+
+    adapter = PocketTTSCppAdapter(
+        {
+            "binary_path": str(binary_path),
+            "model_path": str(model_path),
+            "tokenizer_path": str(tokenizer_path),
+            "timeout": 60,
+            "prefer_stdout": True,
+        }
+    )
+
+    assert await adapter.initialize() is True
+
+    request = TTSRequest(
+        text="Hi.",
+        voice="custom:sample",
+        format=AudioFormat.PCM,
+        stream=False,
+        voice_reference=sample_voice.read_bytes(),
+        extra_params={"pocket_tts_cpp_voice_path": str(sample_voice)},
+    )
+
+    response = await adapter.generate(request)
+
+    assert response.audio_data is not None
+    assert len(response.audio_data) > 0
+    assert response.metadata.get("transport") in {"stdout", "file"}

--- a/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_integration.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_integration.py
@@ -8,6 +8,10 @@ import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter import PocketTTSCppAdapter
+from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+    PROVIDER_MANAGED_VOICE_TOKEN_KEY,
+    register_provider_managed_voice_path,
+)
 
 
 pytestmark = pytest.mark.integration
@@ -37,7 +41,7 @@ def _resolve_assets() -> tuple[Path, Path, Path] | None:
 
 
 @pytest.mark.asyncio
-async def test_pocket_tts_cpp_initialize_and_synthesize_short_request():
+async def test_pocket_tts_cpp_initialize_and_synthesize_short_request(tmp_path):
     assets = _resolve_assets()
     if assets is None:
         pytest.skip("PocketTTS.cpp binary or models are not available")
@@ -46,6 +50,11 @@ async def test_pocket_tts_cpp_initialize_and_synthesize_short_request():
     sample_voice = _repo_root() / "Helper_Scripts" / "Audio" / "Sample_Voices" / "Sample_Voice_1.wav"
     if not sample_voice.exists():
         pytest.skip("PocketTTS.cpp sample voice file is not available")
+
+    provider_root = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
+    provider_root.mkdir(parents=True, exist_ok=True)
+    managed_voice = provider_root / sample_voice.name
+    managed_voice.write_bytes(sample_voice.read_bytes())
 
     adapter = PocketTTSCppAdapter(
         {
@@ -64,8 +73,11 @@ async def test_pocket_tts_cpp_initialize_and_synthesize_short_request():
         voice="custom:sample",
         format=AudioFormat.PCM,
         stream=False,
-        voice_reference=sample_voice.read_bytes(),
-        extra_params={"pocket_tts_cpp_voice_path": str(sample_voice)},
+        voice_reference=managed_voice.read_bytes(),
+        extra_params={
+            "pocket_tts_cpp_voice_path": str(managed_voice),
+            PROVIDER_MANAGED_VOICE_TOKEN_KEY: register_provider_managed_voice_path(managed_voice),
+        },
     )
 
     response = await adapter.generate(request)

--- a/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
@@ -89,6 +89,15 @@ def _provider_managed_extras(voice_path: Path) -> dict[str, str]:
 
 
 @pytest.mark.asyncio
+async def test_capabilities_do_not_advertise_streaming_for_provider_selection(tmp_path):
+    adapter = _build_adapter(tmp_path)
+
+    capabilities = await adapter.get_capabilities()
+
+    assert capabilities.supports_streaming is False
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "missing_path",
     ["binary", "tokenizer", "onnx"],

--- a/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
@@ -1,0 +1,235 @@
+# test_pocket_tts_cpp_adapter_mock.py
+# Description: Mock/unit tests for PocketTTS.cpp CLI adapter
+#
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, ProviderStatus, TTSRequest
+from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter import PocketTTSCppAdapter
+from tldw_Server_API.app.core.TTS.tts_exceptions import (
+    TTSInvalidVoiceReferenceError,
+    TTSModelNotFoundError,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_wav_bytes(*, sample_rate: int = 24000, channels: int = 1) -> bytes:
+    import io
+    import wave
+
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\x00\x00" * 32)
+    return buffer.getvalue()
+
+
+def _write_cpp_assets(root: Path) -> tuple[Path, Path, Path]:
+    binary_path = root / "bin" / "pocket-tts"
+    model_path = root / "models" / "pocket_tts_cpp" / "onnx"
+    tokenizer_path = root / "models" / "pocket_tts_cpp" / "tokenizer.model"
+
+    binary_path.parent.mkdir(parents=True, exist_ok=True)
+    model_path.mkdir(parents=True, exist_ok=True)
+    tokenizer_path.parent.mkdir(parents=True, exist_ok=True)
+
+    binary_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary_path.chmod(0o755)
+    tokenizer_path.write_bytes(b"tokenizer")
+    for name in [
+        "flow_lm_main_int8.onnx",
+        "flow_lm_flow_int8.onnx",
+        "mimi_decoder_int8.onnx",
+        "mimi_encoder.onnx",
+        "text_conditioner.onnx",
+    ]:
+        (model_path / name).write_bytes(b"")
+
+    return binary_path, model_path, tokenizer_path
+
+
+def _build_adapter(root: Path, *, prefer_stdout: bool = True) -> PocketTTSCppAdapter:
+    binary_path, model_path, tokenizer_path = _write_cpp_assets(root)
+    return PocketTTSCppAdapter(
+        {
+            "binary_path": str(binary_path),
+            "model_path": str(model_path),
+            "tokenizer_path": str(tokenizer_path),
+            "timeout": 30,
+            "prefer_stdout": prefer_stdout,
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "missing_path",
+    ["binary", "tokenizer", "onnx"],
+)
+async def test_initialize_requires_binary_tokenizer_and_onnx_assets(tmp_path, missing_path):
+    adapter = _build_adapter(tmp_path)
+
+    if missing_path == "binary":
+        Path(adapter.binary_path).unlink()
+    elif missing_path == "tokenizer":
+        Path(adapter.tokenizer_path).unlink()
+    else:
+        (Path(adapter.model_path) / "mimi_decoder_int8.onnx").unlink()
+
+    with pytest.raises(TTSModelNotFoundError):
+        await adapter.initialize()
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_generation_uses_provider_voice_path_and_stdout_for_pcm(tmp_path, monkeypatch):
+    adapter = _build_adapter(tmp_path, prefer_stdout=True)
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    voice_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-1.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(_make_wav_bytes())
+
+    stdout_pcm = np.array([0.0, 0.5, -0.5], dtype=np.float32).tobytes()
+    captured: dict[str, tuple[str, ...]] = {}
+
+    class _FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return stdout_pcm, b""
+
+    async def _fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = tuple(str(part) for part in cmd)
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter.tempfile.NamedTemporaryFile",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("stdout transport should not create a temp output file")),
+        raising=True,
+    )
+
+    request = TTSRequest(
+        text="hello world",
+        voice="custom:voice-1",
+        format=AudioFormat.PCM,
+        stream=False,
+        extra_params={"pocket_tts_cpp_voice_path": str(voice_path)},
+    )
+
+    response = await adapter.generate(request)
+
+    assert response.audio_data is not None
+    assert response.audio_data != stdout_pcm
+    assert response.metadata["transport"] == "stdout"
+    assert "--stdout" in captured["cmd"]
+    assert str(voice_path) in captured["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_generation_requires_provider_managed_voice_path(tmp_path):
+    adapter = _build_adapter(tmp_path)
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    request = TTSRequest(
+        text="hello world",
+        voice="custom:voice-1",
+        format=AudioFormat.WAV,
+        stream=False,
+        voice_reference=_make_wav_bytes(),
+        extra_params={},
+    )
+
+    with pytest.raises(TTSInvalidVoiceReferenceError):
+        await adapter.generate(request)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target_format",
+    [AudioFormat.WAV, AudioFormat.MP3, AudioFormat.OPUS, AudioFormat.FLAC, AudioFormat.PCM, AudioFormat.AAC],
+)
+async def test_non_streaming_generation_normalizes_file_output_to_requested_format(tmp_path, monkeypatch, target_format):
+    adapter = _build_adapter(tmp_path, prefer_stdout=False)
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    voice_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-2.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(_make_wav_bytes())
+
+    recorded: dict[str, object] = {}
+    target_bytes = b"normalized-" + target_format.value.encode("utf-8")
+    wav_bytes = _make_wav_bytes()
+
+    class _FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            output_path = Path(str(recorded["output_path"]))
+            output_path.write_bytes(wav_bytes)
+            return b"", b""
+
+    async def _fake_create_subprocess_exec(*cmd, **kwargs):
+        recorded["cmd"] = tuple(str(part) for part in cmd)
+        recorded["output_path"] = cmd[-1]
+        return _FakeProcess()
+
+    async def _fake_convert_format(input_path: Path, output_path: Path, target_format_arg: str, **kwargs):
+        recorded["convert"] = (Path(input_path), Path(output_path), target_format_arg, kwargs)
+        Path(output_path).write_bytes(target_bytes)
+        return True
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter.AudioConverter.convert_format",
+        _fake_convert_format,
+        raising=True,
+    )
+
+    request = TTSRequest(
+        text="hello world",
+        voice="custom:voice-2",
+        format=target_format,
+        stream=False,
+        extra_params={"pocket_tts_cpp_voice_path": str(voice_path)},
+    )
+
+    response = await adapter.generate(request)
+
+    if target_format == AudioFormat.WAV:
+        expected_bytes = wav_bytes
+    elif target_format == AudioFormat.PCM:
+        import io
+        import wave
+
+        with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
+            expected_bytes = wav_file.readframes(wav_file.getnframes())
+    else:
+        expected_bytes = target_bytes
+    assert response.audio_data == expected_bytes
+    assert response.metadata["transport"] == "file"
+    assert "--stdout" not in recorded["cmd"]
+    assert str(voice_path) in recorded["cmd"]
+    if target_format in {AudioFormat.WAV, AudioFormat.PCM}:
+        assert "convert" not in recorded
+    else:
+        assert recorded["convert"][2] == target_format.value

--- a/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
@@ -33,7 +33,7 @@ def _make_wav_bytes(*, sample_rate: int = 24000, channels: int = 1) -> bytes:
         wav_file.setnchannels(channels)
         wav_file.setsampwidth(2)
         wav_file.setframerate(sample_rate)
-        wav_file.writeframes(b"\x00\x00" * 32)
+        wav_file.writeframes(b"\x00\x00" * sample_rate)
     return buffer.getvalue()
 
 
@@ -333,13 +333,12 @@ async def test_streaming_generation_retries_probe_after_non_incremental_result(t
     voice_path.parent.mkdir(parents=True, exist_ok=True)
     voice_path.write_bytes(_make_wav_bytes())
 
-    probe_results = iter([False, True])
     probe_calls = 0
 
     async def _fake_probe() -> bool:
         nonlocal probe_calls
         probe_calls += 1
-        return next(probe_results)
+        return False
 
     async def _fake_cli_stream(request: TTSRequest, resolved_voice_path: Path):
         assert resolved_voice_path == voice_path
@@ -361,10 +360,34 @@ async def test_streaming_generation_retries_probe_after_non_incremental_result(t
     with pytest.raises(TTSGenerationError):
         await adapter.generate(request)
 
-    response = await adapter.generate(request)
-    assert response.metadata["transport"] == "stdout_stream"
-    assert [chunk async for chunk in response.audio_stream] == [b"cli-retry-1", b"cli-retry-2"]
-    assert probe_calls == 2
+    with pytest.raises(TTSGenerationError):
+        await adapter.generate(request)
+    assert probe_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_convert_stdout_audio_trims_partial_float_frame_before_decoding(tmp_path, monkeypatch):
+    adapter = _build_adapter(tmp_path)
+
+    captured: dict[str, object] = {}
+
+    async def _fake_convert(audio_data, source_format, target_format, sample_rate):
+        captured["audio_data"] = audio_data
+        captured["source_format"] = source_format
+        captured["target_format"] = target_format
+        captured["sample_rate"] = sample_rate
+        return b"converted"
+
+    monkeypatch.setattr(adapter, "convert_audio_format", _fake_convert)
+
+    stdout = np.array([0.0, 0.5, -0.5], dtype=np.dtype("<f4")).tobytes() + b"\xff"
+    output = await adapter._convert_stdout_audio(stdout, AudioFormat.WAV)
+
+    assert output == b"converted"
+    assert captured["source_format"] == AudioFormat.PCM
+    assert captured["target_format"] == AudioFormat.WAV
+    assert captured["sample_rate"] == adapter.DEFAULT_SAMPLE_RATE
+    assert list(captured["audio_data"]) == [0, 16383, -16383]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
@@ -3,14 +3,19 @@
 #
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import numpy as np
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, ProviderStatus, TTSRequest
 from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter import PocketTTSCppAdapter
+from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+    PROVIDER_MANAGED_VOICE_TOKEN_KEY,
+    register_provider_managed_voice_path,
+)
 from tldw_Server_API.app.core.TTS.tts_exceptions import (
+    TTSGenerationError,
     TTSInvalidVoiceReferenceError,
     TTSModelNotFoundError,
 )
@@ -56,7 +61,12 @@ def _write_cpp_assets(root: Path) -> tuple[Path, Path, Path]:
     return binary_path, model_path, tokenizer_path
 
 
-def _build_adapter(root: Path, *, prefer_stdout: bool = True) -> PocketTTSCppAdapter:
+def _build_adapter(
+    root: Path,
+    *,
+    prefer_stdout: bool = True,
+    streaming_transport: str = "auto",
+) -> PocketTTSCppAdapter:
     binary_path, model_path, tokenizer_path = _write_cpp_assets(root)
     return PocketTTSCppAdapter(
         {
@@ -65,8 +75,17 @@ def _build_adapter(root: Path, *, prefer_stdout: bool = True) -> PocketTTSCppAda
             "tokenizer_path": str(tokenizer_path),
             "timeout": 30,
             "prefer_stdout": prefer_stdout,
+            "streaming_transport": streaming_transport,
         }
     )
+
+
+def _provider_managed_extras(voice_path: Path) -> dict[str, str]:
+    token = register_provider_managed_voice_path(voice_path)
+    return {
+        "pocket_tts_cpp_voice_path": str(voice_path),
+        PROVIDER_MANAGED_VOICE_TOKEN_KEY: token,
+    }
 
 
 @pytest.mark.asyncio
@@ -127,7 +146,7 @@ async def test_non_streaming_generation_uses_provider_voice_path_and_stdout_for_
         voice="custom:voice-1",
         format=AudioFormat.PCM,
         stream=False,
-        extra_params={"pocket_tts_cpp_voice_path": str(voice_path)},
+        extra_params=_provider_managed_extras(voice_path),
     )
 
     response = await adapter.generate(request)
@@ -227,7 +246,7 @@ async def test_non_streaming_generation_normalizes_file_output_to_requested_form
         voice="custom:voice-2",
         format=target_format,
         stream=False,
-        extra_params={"pocket_tts_cpp_voice_path": str(voice_path)},
+        extra_params=_provider_managed_extras(voice_path),
     )
 
     response = await adapter.generate(request)
@@ -250,3 +269,181 @@ async def test_non_streaming_generation_normalizes_file_output_to_requested_form
         assert "convert" not in recorded
     else:
         assert recorded["convert"][2] == target_format.value
+
+
+@pytest.mark.asyncio
+async def test_streaming_generation_probes_cli_once_and_returns_stdout_stream(tmp_path, monkeypatch):
+    adapter = _build_adapter(tmp_path, prefer_stdout=True)
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    voice_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-stream.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(_make_wav_bytes())
+
+    probe_calls = 0
+
+    async def _fake_probe() -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        return True
+
+    async def _fake_cli_stream(request: TTSRequest, resolved_voice_path: Path):
+        assert request.stream is True
+        assert resolved_voice_path == voice_path
+        for chunk in [b"cli-chunk-1", b"cli-chunk-2"]:
+            yield chunk
+
+    monkeypatch.setattr(adapter, "_probe_cli_streaming_support", _fake_probe)
+    monkeypatch.setattr(adapter, "_stream_via_cli_stdout", _fake_cli_stream)
+
+    request = TTSRequest(
+        text="stream this",
+        voice="custom:voice-stream",
+        format=AudioFormat.PCM,
+        stream=True,
+        extra_params=_provider_managed_extras(voice_path),
+    )
+
+    response_one = await adapter.generate(request)
+    assert response_one.metadata["transport"] == "stdout_stream"
+    assert [chunk async for chunk in response_one.audio_stream] == [b"cli-chunk-1", b"cli-chunk-2"]
+
+    response_two = await adapter.generate(request)
+    assert [chunk async for chunk in response_two.audio_stream] == [b"cli-chunk-1", b"cli-chunk-2"]
+    assert probe_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_generation_retries_probe_after_non_incremental_result(tmp_path, monkeypatch):
+    adapter = _build_adapter(tmp_path, prefer_stdout=True)
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    voice_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-retry.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(_make_wav_bytes())
+
+    probe_results = iter([False, True])
+    probe_calls = 0
+
+    async def _fake_probe() -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        return next(probe_results)
+
+    async def _fake_cli_stream(request: TTSRequest, resolved_voice_path: Path):
+        assert resolved_voice_path == voice_path
+        assert request.stream is True
+        for chunk in [b"cli-retry-1", b"cli-retry-2"]:
+            yield chunk
+
+    monkeypatch.setattr(adapter, "_probe_cli_streaming_support", _fake_probe)
+    monkeypatch.setattr(adapter, "_stream_via_cli_stdout", _fake_cli_stream)
+
+    request = TTSRequest(
+        text="retry stream",
+        voice="custom:voice-retry",
+        format=AudioFormat.PCM,
+        stream=True,
+        extra_params=_provider_managed_extras(voice_path),
+    )
+
+    with pytest.raises(TTSGenerationError):
+        await adapter.generate(request)
+
+    response = await adapter.generate(request)
+    assert response.metadata["transport"] == "stdout_stream"
+    assert [chunk async for chunk in response.audio_stream] == [b"cli-retry-1", b"cli-retry-2"]
+    assert probe_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_streaming_generation_forced_cli_still_probes_feasibility(tmp_path, monkeypatch):
+    adapter = _build_adapter(tmp_path, prefer_stdout=True, streaming_transport="cli")
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    voice_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-forced-cli.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(_make_wav_bytes())
+
+    probe_calls = 0
+
+    async def _fake_probe() -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        return False
+
+    monkeypatch.setattr(adapter, "_probe_cli_streaming_support", _fake_probe)
+
+    request = TTSRequest(
+        text="forced cli probe",
+        voice="custom:voice-forced-cli",
+        format=AudioFormat.PCM,
+        stream=True,
+        extra_params=_provider_managed_extras(voice_path),
+    )
+
+    with pytest.raises(TTSGenerationError):
+        await adapter.generate(request)
+
+    assert probe_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_generation_rejects_arbitrary_existing_voice_path_without_provider_root(
+    tmp_path,
+):
+    adapter = _build_adapter(tmp_path)
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    unmanaged_voice_path = tmp_path / "unmanaged" / "voice.wav"
+    unmanaged_voice_path.parent.mkdir(parents=True, exist_ok=True)
+    unmanaged_voice_path.write_bytes(_make_wav_bytes())
+
+    request = TTSRequest(
+        text="hello world",
+        voice="custom:voice-unmanaged",
+        format=AudioFormat.WAV,
+        stream=False,
+        extra_params={
+            "pocket_tts_cpp_voice_path": str(unmanaged_voice_path),
+            PROVIDER_MANAGED_VOICE_TOKEN_KEY: "forged-token",
+        },
+    )
+
+    with pytest.raises(TTSInvalidVoiceReferenceError):
+        await adapter.generate(request)
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_generation_rejects_voice_path_outside_provider_managed_root(
+    tmp_path,
+):
+    adapter = _build_adapter(tmp_path)
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    provider_root = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
+    provider_root.mkdir(parents=True, exist_ok=True)
+    voice_path = tmp_path / "shared" / "voice.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(_make_wav_bytes())
+    managed_voice_path = provider_root / "managed.wav"
+    managed_voice_path.write_bytes(_make_wav_bytes())
+
+    request = TTSRequest(
+        text="hello world",
+        voice="custom:voice-outside-root",
+        format=AudioFormat.WAV,
+        stream=False,
+        extra_params={
+            "pocket_tts_cpp_voice_path": str(voice_path),
+            PROVIDER_MANAGED_VOICE_TOKEN_KEY: register_provider_managed_voice_path(managed_voice_path),
+        },
+    )
+
+    with pytest.raises(TTSInvalidVoiceReferenceError):
+        await adapter.generate(request)

--- a/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py
@@ -140,7 +140,7 @@ async def test_non_streaming_generation_uses_provider_voice_path_and_stdout_for_
 
 
 @pytest.mark.asyncio
-async def test_non_streaming_generation_requires_provider_managed_voice_path(tmp_path):
+async def test_non_streaming_generation_requires_provider_managed_voice_path_for_custom_voice(tmp_path):
     adapter = _build_adapter(tmp_path)
     adapter._initialized = True
     adapter._status = ProviderStatus.AVAILABLE
@@ -148,6 +148,23 @@ async def test_non_streaming_generation_requires_provider_managed_voice_path(tmp
     request = TTSRequest(
         text="hello world",
         voice="custom:voice-1",
+        format=AudioFormat.WAV,
+        stream=False,
+        extra_params={},
+    )
+
+    with pytest.raises(TTSInvalidVoiceReferenceError):
+        await adapter.generate(request)
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_generation_requires_provider_managed_voice_path_for_direct_reference(tmp_path):
+    adapter = _build_adapter(tmp_path)
+    adapter._initialized = True
+    adapter._status = ProviderStatus.AVAILABLE
+
+    request = TTSRequest(
+        text="hello world",
         format=AudioFormat.WAV,
         stream=False,
         voice_reference=_make_wav_bytes(),

--- a/tldw_Server_API/tests/TTS/test_tts_resource_manager.py
+++ b/tldw_Server_API/tests/TTS/test_tts_resource_manager.py
@@ -4,6 +4,8 @@
 # Imports
 import pytest
 import asyncio
+import builtins
+import sys
 from unittest.mock import Mock, AsyncMock, MagicMock, patch
 from typing import Dict, Any
 import psutil
@@ -386,6 +388,26 @@ class TestTTSResourceManager:
         cleanup_a.assert_called_once()
         assert "a" not in manager._registered_models
         assert "b" in manager._registered_models
+
+    def test_cleanup_device_cache_does_not_import_torch_when_unloaded(self, monkeypatch):
+        """Device-cache cleanup should not import torch just to check for caches."""
+        manager = TTSResourceManager({})
+        monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+        original_import = builtins.__import__
+        torch_import_attempts: list[str] = []
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "torch":
+                torch_import_attempts.append(name)
+                raise ImportError("torch should not be imported during best-effort cleanup")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+        manager._cleanup_device_cache()
+
+        assert torch_import_attempts == []
 
     @pytest.mark.asyncio
     async def test_unregister_model(self, resource_manager):

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_custom_voice_resolution.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_custom_voice_resolution.py
@@ -1,4 +1,6 @@
 import os
+import wave
+from io import BytesIO
 from pathlib import Path
 import pytest
 from unittest.mock import AsyncMock
@@ -9,8 +11,27 @@ from tldw_Server_API.app.api.v1.endpoints.audio.audio import router as audio_rou
 from tldw_Server_API.app.api.v1.endpoints import audio as audio_endpoints
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 from tldw_Server_API.app.core.TTS.adapters.base import TTSResponse
+from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+    PROVIDER_MANAGED_VOICE_TOKEN_KEY,
+)
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 from tldw_Server_API.app.core.TTS.voice_manager import VoiceReferenceMetadata
+
+
+def _make_wav_bytes(
+    payload: bytes = b"\x00\x01" * 8,
+    *,
+    sample_rate: int = 24000,
+    channels: int = 1,
+    sample_width: int = 2,
+) -> bytes:
+    buffer = BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(sample_width)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(payload)
+    return buffer.getvalue()
 
 
 @pytest.fixture
@@ -106,6 +127,7 @@ def test_pocket_tts_cpp_custom_voice_resolution_uses_stable_path_and_reference_t
     client, monkeypatch, tmp_path
 ):
     voices_root = tmp_path / "voices"
+    expected_wav = _make_wav_bytes(b"\x02\x03" * 8)
 
     class _FakeVoiceManager:
         def get_user_voices_path(self, user_id):
@@ -116,7 +138,7 @@ def test_pocket_tts_cpp_custom_voice_resolution_uses_stable_path_and_reference_t
         async def load_voice_reference_audio(self, user_id, voice_id):
             assert str(user_id) == "1"
             assert voice_id == "voice-1"
-            return b"RIFF" + b"\x00" * 1000
+            return expected_wav
 
         async def load_reference_metadata(self, user_id, voice_id):
             return VoiceReferenceMetadata(
@@ -133,7 +155,12 @@ def test_pocket_tts_cpp_custom_voice_resolution_uses_stable_path_and_reference_t
             assert voice_path is not None
             assert voice_path.endswith("/voices/providers/pocket_tts_cpp/custom_voice-1.wav")
             assert Path(voice_path).exists()
-            assert Path(voice_path).read_bytes() == b"RIFF" + b"\x00" * 1000
+            assert Path(voice_path).read_bytes()[:4] == b"RIFF"
+            with wave.open(str(voice_path), "rb") as wav_file:
+                assert wav_file.getnchannels() == 1
+                assert wav_file.getsampwidth() == 2
+                assert wav_file.getframerate() == 24000
+            assert request.extra_params.get(PROVIDER_MANAGED_VOICE_TOKEN_KEY)
             assert request.extra_params.get("pocket_tts_cpp_reference_text") == "stored text"
             return TTSResponse(audio_data=b"ok", format=request.format, sample_rate=24000)
 

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_custom_voice_resolution.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_custom_voice_resolution.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pytest
 from unittest.mock import AsyncMock
 from fastapi import FastAPI
@@ -84,6 +85,88 @@ def test_custom_voice_resolution_populates_reference(client, monkeypatch):
 
     payload = {
         "model": "neutts-air",
+        "input": "Hello world",
+        "voice": "custom:voice-1",
+        "response_format": "pcm",
+        "stream": False,
+    }
+    try:
+        r = client.post(
+            "/api/v1/audio/speech",
+            json=payload,
+            headers={"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]},
+        )
+        assert r.status_code == 200, r.text
+        assert r.content == b"ok"
+    finally:
+        client.app.dependency_overrides.pop(audio_endpoints.get_tts_service, None)
+
+
+def test_pocket_tts_cpp_custom_voice_resolution_uses_stable_path_and_reference_text(
+    client, monkeypatch, tmp_path
+):
+    voices_root = tmp_path / "voices"
+
+    class _FakeVoiceManager:
+        def get_user_voices_path(self, user_id):
+            assert str(user_id) == "1"
+            voices_root.mkdir(parents=True, exist_ok=True)
+            return voices_root
+
+        async def load_voice_reference_audio(self, user_id, voice_id):
+            assert str(user_id) == "1"
+            assert voice_id == "voice-1"
+            return b"RIFF" + b"\x00" * 1000
+
+        async def load_reference_metadata(self, user_id, voice_id):
+            return VoiceReferenceMetadata(
+                voice_id=voice_id,
+                reference_text="stored text",
+            )
+
+    class _FakeAdapter:
+        provider_name = "pocket_tts_cpp"
+        provider_key = "pocket_tts_cpp"
+
+        async def generate(self, request):
+            voice_path = request.extra_params.get("pocket_tts_cpp_voice_path")
+            assert voice_path is not None
+            assert voice_path.endswith("/voices/providers/pocket_tts_cpp/custom_voice-1.wav")
+            assert Path(voice_path).exists()
+            assert Path(voice_path).read_bytes() == b"RIFF" + b"\x00" * 1000
+            assert request.extra_params.get("pocket_tts_cpp_reference_text") == "stored text"
+            return TTSResponse(audio_data=b"ok", format=request.format, sample_rate=24000)
+
+    def _fake_get_voice_manager():
+        return _FakeVoiceManager()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        _fake_get_voice_manager,
+        raising=True,
+    )
+
+    class _FakeFactory:
+        def get_provider_for_model(self, _model):
+            return "pocket_tts_cpp"
+
+    service = TTSServiceV2()
+    service._ensure_factory = AsyncMock(return_value=_FakeFactory())
+    service._get_adapter = AsyncMock(return_value=_FakeAdapter())
+
+    async def _fake_get_tts_service_v2():
+        return service
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.tts_service_v2.get_tts_service_v2",
+        _fake_get_tts_service_v2,
+        raising=True,
+    )
+
+    client.app.dependency_overrides[audio_endpoints.get_tts_service] = _fake_get_tts_service_v2
+
+    payload = {
+        "model": "pocket_tts_cpp",
         "input": "Hello world",
         "voice": "custom:voice-1",
         "response_format": "pcm",

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_tts_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_tts_endpoints.py
@@ -9,6 +9,8 @@ import contextlib
 import json
 import base64
 import tempfile
+import wave
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +23,7 @@ from tldw_Server_API.app.api.v1.endpoints.audio import audio_jobs
 from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 from tldw_Server_API.app.core.TTS.tts_jobs_worker import _handle_tts_job
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
@@ -384,6 +387,201 @@ class TestTTSStreamingEndpoint:
             except Exception:
                 # Some Starlette versions propagate generator errors; accept as handled for test purposes
                 assert True
+
+    @pytest.mark.streaming
+    async def test_streaming_pocket_tts_cpp_custom_voice_request(self, test_client, auth_headers):
+        """PocketTTS.cpp custom voices should reach the streaming path with PCM headers."""
+        seen_requests: list[Any] = []
+
+        async def mock_stream(request_obj, *args, **kwargs):  # noqa: ARG001
+            request_obj._tts_metadata = {"sample_rate": 24000}
+            seen_requests.append(request_obj)
+            yield b"chunk-a"
+            yield b"chunk-b"
+
+        with patch("tldw_Server_API.app.core.TTS.tts_service_v2.TTSServiceV2.generate_speech") as mock_stream_gen:
+            mock_stream_gen.side_effect = mock_stream
+
+            response = test_client.post(
+                "/api/v1/audio/speech",
+                json={
+                    "input": "Stream PocketTTS.cpp custom voice",
+                    "voice": "custom:voice-1",
+                    "model": "pocket_tts_cpp",
+                    "response_format": "pcm",
+                    "stream": True,
+                },
+                headers=auth_headers,
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.headers.get("X-Audio-Sample-Rate") == "24000"
+            assert "audio/L16; rate=24000; channels=1" in response.headers.get("content-type", "")
+            assert b"".join(response.iter_bytes()) == b"chunk-achunk-b"
+            assert seen_requests
+            assert seen_requests[0].model == "pocket_tts_cpp"
+            assert seen_requests[0].voice == "custom:voice-1"
+            assert seen_requests[0].stream is True
+
+    @pytest.mark.streaming
+    async def test_streaming_pocket_tts_cpp_direct_reference_request(self, test_client, auth_headers):
+        """PocketTTS.cpp direct references should also reach the streaming path."""
+        seen_requests: list[Any] = []
+        voice_reference = base64.b64encode(b"RIFF\x24\x00\x00\x00WAVEfmt ").decode("ascii")
+
+        async def mock_stream(request_obj, *args, **kwargs):  # noqa: ARG001
+            request_obj._tts_metadata = {"sample_rate": 24000}
+            seen_requests.append(request_obj)
+            yield b"direct-ref-chunk"
+
+        with patch("tldw_Server_API.app.core.TTS.tts_service_v2.TTSServiceV2.generate_speech") as mock_stream_gen:
+            mock_stream_gen.side_effect = mock_stream
+
+            response = test_client.post(
+                "/api/v1/audio/speech",
+                json={
+                    "input": "Stream PocketTTS.cpp direct reference",
+                    "voice": "clone",
+                    "model": "pocket_tts_cpp",
+                    "response_format": "pcm",
+                    "stream": True,
+                    "voice_reference": voice_reference,
+                },
+                headers=auth_headers,
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.headers.get("X-Audio-Sample-Rate") == "24000"
+            assert "audio/L16; rate=24000; channels=1" in response.headers.get("content-type", "")
+            assert b"".join(response.iter_bytes()) == b"direct-ref-chunk"
+            assert seen_requests
+            assert seen_requests[0].model == "pocket_tts_cpp"
+            assert seen_requests[0].voice_reference == voice_reference
+            assert seen_requests[0].stream is True
+
+    @pytest.mark.streaming
+    async def test_streaming_pocket_tts_cpp_real_service_and_adapter_path(self, test_client, auth_headers, monkeypatch, tmp_path):
+        """PocketTTS.cpp streaming should flow through the real service and adapter gating."""
+        from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_adapter import PocketTTSCppAdapter
+        from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+            PROVIDER_MANAGED_VOICE_TOKEN_KEY,
+            resolve_provider_managed_voice_path,
+        )
+        from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+        from tldw_Server_API.app.core.TTS import audio_converter as audio_converter_module
+
+        voices_root = tmp_path / "voices"
+        managed_voice = voices_root / "providers" / "pocket_tts_cpp" / "custom_voice-1.wav"
+        managed_voice.parent.mkdir(parents=True, exist_ok=True)
+        managed_voice.write_bytes(b"RIFF" + b"\x00" * 1000)
+        wav_buffer = BytesIO()
+        with wave.open(wav_buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(24000)
+            wav_file.writeframes(b"\x02\x03" * 8)
+        converted_wav = wav_buffer.getvalue()
+
+        class _FakeVoiceManager:
+            def get_user_voices_path(self, user_id):
+                assert str(user_id) == "1"
+                voices_root.mkdir(parents=True, exist_ok=True)
+                return voices_root
+
+            async def load_voice_reference_audio(self, user_id, voice_id):
+                assert str(user_id) == "1"
+                assert voice_id == "voice-1"
+                return b"RIFF" + b"\x00" * 1000
+
+            async def load_reference_metadata(self, user_id, voice_id):
+                return None
+
+        adapter = PocketTTSCppAdapter({})
+        adapter._initialized = True
+        adapter._status = None
+
+        seen: dict[str, str] = {}
+
+        async def _fake_probe():
+            return True
+
+        async def _fake_stream(request_obj, resolved_voice_path):  # noqa: ARG001
+            token = request_obj.extra_params[PROVIDER_MANAGED_VOICE_TOKEN_KEY]
+            voice_path = Path(request_obj.extra_params["pocket_tts_cpp_voice_path"])
+            seen["token"] = token
+            seen["voice_path"] = str(voice_path)
+            assert resolve_provider_managed_voice_path(token, voice_path) == voice_path.resolve()
+            request_obj._tts_metadata = {"sample_rate": 24000}
+            yield b"chunk-a"
+            yield b"chunk-b"
+
+        monkeypatch.setattr(adapter, "_probe_cli_streaming_support", _fake_probe)
+        monkeypatch.setattr(adapter, "_stream_via_cli_stdout", _fake_stream)
+
+        async def _fake_convert(input_path, output_path, sample_rate, channels, bit_depth):
+            output_path.write_bytes(converted_wav)
+            return True
+
+        monkeypatch.setattr(
+            runtime_module.AudioConverter,
+            "convert_to_wav",
+            _fake_convert,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            audio_converter_module.AudioConverter,
+            "convert_to_wav",
+            _fake_convert,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+            lambda: _FakeVoiceManager(),
+            raising=True,
+        )
+
+        service = TTSServiceV2()
+
+        class _Factory:
+            def get_provider_for_model(self, _model):
+                return "pocket_tts_cpp"
+
+        service._ensure_factory = AsyncMock(return_value=_Factory())
+        service._get_adapter = AsyncMock(return_value=adapter)
+
+        async def _fake_get_tts_service_v2():
+            return service
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.TTS.tts_service_v2.get_tts_service_v2",
+            _fake_get_tts_service_v2,
+            raising=True,
+        )
+        test_client.app.dependency_overrides[audio_endpoints.get_tts_service] = _fake_get_tts_service_v2
+
+        try:
+            response = test_client.post(
+                "/api/v1/audio/speech",
+                json={
+                    "input": "Stream PocketTTS.cpp via real service",
+                    "voice": "custom:voice-1",
+                    "model": "pocket_tts_cpp",
+                    "response_format": "pcm",
+                    "stream": True,
+                },
+                headers=auth_headers,
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.headers.get("X-Audio-Sample-Rate") == "24000"
+            assert "audio/L16; rate=24000; channels=1" in response.headers.get("content-type", "")
+            assert b"".join(response.iter_bytes()) == b"chunk-achunk-b"
+            assert seen["voice_path"].endswith("/voices/providers/pocket_tts_cpp/custom_voice-1.wav")
+            assert seen["token"]
+            with pytest.raises(ValueError):
+                resolve_provider_managed_voice_path(seen["token"], Path(seen["voice_path"]))
+        finally:
+            test_client.app.dependency_overrides.pop(audio_endpoints.get_tts_service, None)
 
     @pytest.mark.streaming
     async def test_streaming_failure_writes_history(self, test_client, auth_headers, monkeypatch, tmp_path):

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_echo_tts_audio_loading.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_echo_tts_audio_loading.py
@@ -7,46 +7,63 @@ from tldw_Server_API.app.core.TTS.adapters.echo_tts_adapter import EchoTTSAdapte
 
 
 @pytest.mark.unit
-def test_load_reference_audio_prefers_torchaudio_for_wav_path():
-    adapter = EchoTTSAdapter(config={})
-    expected_audio = object()
+@pytest.mark.asyncio
+async def test_compute_speaker_latent_loads_reference_audio_via_inference(tmp_path):
+    adapter = EchoTTSAdapter(config={"max_reference_seconds": 120})
+    temp_path = tmp_path / "reference.wav"
+    temp_path.write_bytes(b"wav")
+
+    speaker_audio = Mock()
+    speaker_audio.to = Mock(return_value="speaker-audio")
     inference = SimpleNamespace(
-        load_audio=Mock(side_effect=AssertionError("inference.load_audio should not be called for WAV")),
+        load_audio=Mock(return_value=speaker_audio),
+        get_speaker_latent_and_mask=Mock(return_value=("latent", "mask")),
     )
-    wav_loader = Mock(return_value=expected_audio)
-    adapter._load_wav_with_torchaudio = wav_loader
+    adapter._echo_inference = inference
+    adapter._model = SimpleNamespace(device="cpu")
+    adapter._fish_ae = SimpleNamespace(dtype="float32")
+    adapter._pca_state = object()
+    adapter._write_temp_audio = Mock(return_value=str(temp_path))
 
-    result = adapter._load_reference_audio(inference, "ref.WAV", 120)
+    latent, mask = await adapter._compute_speaker_latent(b"voice-bytes")
 
-    assert result is expected_audio
-    wav_loader.assert_called_once_with("ref.WAV", max_duration=120)
-
-
-@pytest.mark.unit
-def test_load_reference_audio_falls_back_when_torchaudio_path_errors():
-    adapter = EchoTTSAdapter(config={})
-    expected_audio = object()
-    inference = SimpleNamespace(load_audio=Mock(return_value=expected_audio))
-    wav_loader = Mock(side_effect=ImportError("torchaudio unavailable"))
-    adapter._load_wav_with_torchaudio = wav_loader
-
-    result = adapter._load_reference_audio(inference, "ref.wav", 90)
-
-    assert result is expected_audio
-    wav_loader.assert_called_once_with("ref.wav", max_duration=90)
-    inference.load_audio.assert_called_once_with("ref.wav", 90)
+    assert (latent, mask) == ("latent", "mask")
+    adapter._write_temp_audio.assert_called_once_with(b"voice-bytes")
+    inference.load_audio.assert_called_once_with(str(temp_path), 120)
+    speaker_audio.to.assert_called_once_with(device="cpu", dtype="float32")
+    inference.get_speaker_latent_and_mask.assert_called_once_with(
+        adapter._fish_ae,
+        adapter._pca_state,
+        "speaker-audio",
+    )
+    assert not temp_path.exists()
 
 
 @pytest.mark.unit
-def test_load_reference_audio_uses_inference_loader_for_non_wav():
+@pytest.mark.asyncio
+async def test_compute_speaker_latent_removes_temp_audio_when_loader_fails(tmp_path):
     adapter = EchoTTSAdapter(config={})
-    expected_audio = object()
-    inference = SimpleNamespace(load_audio=Mock(return_value=expected_audio))
-    wav_loader = Mock()
-    adapter._load_wav_with_torchaudio = wav_loader
+    temp_path = tmp_path / "reference.wav"
+    temp_path.write_bytes(b"wav")
 
-    result = adapter._load_reference_audio(inference, "ref.mp3", 45)
+    inference = SimpleNamespace(load_audio=Mock(side_effect=RuntimeError("bad audio")))
+    adapter._echo_inference = inference
+    adapter._write_temp_audio = Mock(return_value=str(temp_path))
+    adapter._model = SimpleNamespace(device="cpu")
+    adapter._fish_ae = SimpleNamespace(dtype="float32")
+    adapter._pca_state = object()
 
-    assert result is expected_audio
-    wav_loader.assert_not_called()
-    inference.load_audio.assert_called_once_with("ref.mp3", 45)
+    with pytest.raises(RuntimeError, match="bad audio"):
+        await adapter._compute_speaker_latent(b"voice-bytes")
+
+    assert not temp_path.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_compute_speaker_latent_raises_when_inference_missing():
+    adapter = EchoTTSAdapter(config={})
+    adapter._echo_inference = None
+
+    with pytest.raises(Exception, match="inference module not loaded"):
+        await adapter._compute_speaker_latent(b"voice-bytes")

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_echo_tts_audio_loading.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_echo_tts_audio_loading.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.echo_tts_adapter import EchoTTSAdapter
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSModelLoadError
 
 
 @pytest.mark.unit
@@ -65,5 +66,5 @@ async def test_compute_speaker_latent_raises_when_inference_missing():
     adapter = EchoTTSAdapter(config={})
     adapter._echo_inference = None
 
-    with pytest.raises(Exception, match="inference module not loaded"):
+    with pytest.raises(TTSModelLoadError, match="inference module not loaded"):
         await adapter._compute_speaker_latent(b"voice-bytes")

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_tts_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_tts_adapter.py
@@ -100,7 +100,6 @@ def fake_qwen_model_module(monkeypatch):
 @pytest.mark.asyncio
 async def test_auto_model_selects_customvoice_cpu(fake_qwen_module):
     adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
-    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     request = TTSRequest(
@@ -136,7 +135,6 @@ def test_provider_style_model_aliases_resolve_to_canonical_model(model_alias):
 @pytest.mark.asyncio
 async def test_voice_design_requires_instruct(fake_qwen_module):
     adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
-    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     request = TTSRequest(
@@ -156,7 +154,6 @@ async def test_voice_design_requires_instruct(fake_qwen_module):
 @pytest.mark.asyncio
 async def test_voice_clone_maps_reference_and_prompt(fake_qwen_module):
     adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
-    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     voice_bytes = b"VOICE_BYTES"
@@ -195,7 +192,6 @@ async def test_voice_clone_maps_reference_and_prompt(fake_qwen_module):
 @pytest.mark.asyncio
 async def test_streaming_transcode_fallback_buffers_output(fake_qwen_module, monkeypatch):
     adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
-    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     async def fake_generate_pcm(_request, _model_id):

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_tts_adapter.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_tts_adapter.py
@@ -99,7 +99,8 @@ def fake_qwen_model_module(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_auto_model_selects_customvoice_cpu(fake_qwen_module):
-    adapter = Qwen3TTSAdapter({"device": "cpu", "model": "auto"})
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
+    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     request = TTSRequest(
@@ -134,7 +135,8 @@ def test_provider_style_model_aliases_resolve_to_canonical_model(model_alias):
 
 @pytest.mark.asyncio
 async def test_voice_design_requires_instruct(fake_qwen_module):
-    adapter = Qwen3TTSAdapter({"device": "cpu", "model": "auto"})
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
+    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     request = TTSRequest(
@@ -153,7 +155,8 @@ async def test_voice_design_requires_instruct(fake_qwen_module):
 
 @pytest.mark.asyncio
 async def test_voice_clone_maps_reference_and_prompt(fake_qwen_module):
-    adapter = Qwen3TTSAdapter({"device": "cpu", "model": "auto"})
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
+    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     voice_bytes = b"VOICE_BYTES"
@@ -191,7 +194,8 @@ async def test_voice_clone_maps_reference_and_prompt(fake_qwen_module):
 
 @pytest.mark.asyncio
 async def test_streaming_transcode_fallback_buffers_output(fake_qwen_module, monkeypatch):
-    adapter = Qwen3TTSAdapter({"device": "cpu", "model": "auto"})
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
+    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     async def fake_generate_pcm(_request, _model_id):
@@ -225,7 +229,8 @@ async def test_streaming_transcode_fallback_buffers_output(fake_qwen_module, mon
 
 @pytest.mark.asyncio
 async def test_voice_clone_requires_reference_even_with_x_vector_only(fake_qwen_module):
-    adapter = Qwen3TTSAdapter({"device": "cpu", "model": "auto"})
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
+    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     request = TTSRequest(
@@ -244,7 +249,8 @@ async def test_voice_clone_requires_reference_even_with_x_vector_only(fake_qwen_
 
 @pytest.mark.asyncio
 async def test_voice_clone_requires_reference_text_unless_x_vector_only(fake_qwen_module):
-    adapter = Qwen3TTSAdapter({"device": "cpu", "model": "auto"})
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
+    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     request = TTSRequest(
@@ -264,7 +270,8 @@ async def test_voice_clone_requires_reference_text_unless_x_vector_only(fake_qwe
 
 @pytest.mark.asyncio
 async def test_builder_discovers_qwen3_tts_model(fake_qwen_model_module):
-    adapter = Qwen3TTSAdapter({"device": "cpu", "model": "auto"})
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
+    adapter._resolve_torch_dtype = lambda: "float32"
     await adapter.ensure_initialized()
 
     request = TTSRequest(

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_installer.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_installer.py
@@ -1,0 +1,158 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_installer_resolves_repo_root_from_nested_path():
+    from Helper_Scripts.TTS_Installers.install_tts_pocket_tts_cpp import resolve_repo_root
+
+    repo_root = Path(__file__).resolve().parents[4]
+    probe = repo_root / "tldw_Server_API" / "tests" / "TTS_NEW" / "unit" / "nested" / "probe.py"
+
+    assert resolve_repo_root(probe) == repo_root
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_installer_builds_separate_runtime_layout():
+    from Helper_Scripts.TTS_Installers.install_tts_pocket_tts_cpp import build_runtime_layout
+
+    repo_root = Path(__file__).resolve().parents[4]
+    layout = build_runtime_layout(Path("models") / "pocket_tts_cpp", repo_root=repo_root)
+
+    assert layout.binary_path.relative_to(repo_root).as_posix() == "bin/pocket-tts"
+    assert layout.tokenizer_path.relative_to(repo_root).as_posix() == "models/pocket_tts_cpp/tokenizer.model"
+    assert layout.model_dir.relative_to(repo_root).as_posix() == "models/pocket_tts_cpp/onnx"
+    assert layout.provider_name == "pocket_tts_cpp"
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_installer_updates_only_cpp_provider_block(tmp_path):
+    from Helper_Scripts.TTS_Installers.install_tts_pocket_tts_cpp import patch_tts_config
+
+    config_path = tmp_path / "tts_providers_config.yaml"
+    config_path.write_text(
+        """
+providers:
+  pocket_tts:
+    enabled: false
+    model_path: "models/pocket_tts_onnx/onnx"
+    tokenizer_path: "models/pocket_tts_onnx/tokenizer.model"
+    module_path: "models/pocket_tts_onnx"
+
+  pocket_tts_cpp:
+    enabled: false
+    binary_path: "models/pocket_tts_cpp/pocket_tts_cpp"
+    tokenizer_path: "models/pocket_tts_cpp/tokenizer.model"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    changed = patch_tts_config(
+        config_path=config_path,
+        binary_path=Path("bin") / "pocket-tts",
+        tokenizer_path=Path("models") / "pocket_tts_cpp" / "tokenizer.model",
+        model_dir=Path("models") / "pocket_tts_cpp" / "onnx",
+        repo_root=tmp_path,
+    )
+
+    content = config_path.read_text(encoding="utf-8")
+    assert changed is True
+    assert "pocket_tts:\n    enabled: false" in content
+    assert "pocket_tts_cpp:\n    enabled: true" in content
+    assert 'binary_path: "bin/pocket-tts"' in content
+    assert 'model_path: "models/pocket_tts_cpp/onnx"' in content
+    assert 'tokenizer_path: "models/pocket_tts_cpp/tokenizer.model"' in content
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_installer_reports_missing_prerequisite_commands_without_running_them():
+    from Helper_Scripts.TTS_Installers.install_tts_pocket_tts_cpp import missing_prerequisite_commands
+
+    missing = missing_prerequisite_commands(available_commands={"git", "cmake"})
+
+    assert missing == ["c++"]
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_installer_exports_binary_tokenizer_and_onnx_layout(tmp_path):
+    from Helper_Scripts.TTS_Installers.install_tts_pocket_tts_cpp import (
+        build_runtime_layout,
+        export_runtime_artifacts,
+    )
+
+    repo_root = tmp_path / "repo"
+    runtime_base = repo_root / "models" / "pocket_tts_cpp"
+    build_dir = tmp_path / "build"
+    layout = build_runtime_layout(runtime_base, repo_root=repo_root)
+
+    (build_dir / "bin").mkdir(parents=True, exist_ok=True)
+    (build_dir / "assets").mkdir(parents=True, exist_ok=True)
+    (build_dir / "onnx").mkdir(parents=True, exist_ok=True)
+    (build_dir / "bin" / "pocket_tts_cpp").write_text("binary", encoding="utf-8")
+    (build_dir / "assets" / "tokenizer.model").write_text("tokenizer", encoding="utf-8")
+    (build_dir / "onnx" / "flow_lm_main_int8.onnx").write_text("model", encoding="utf-8")
+
+    export_runtime_artifacts(build_dir=build_dir, layout=layout)
+
+    assert layout.binary_path.read_text(encoding="utf-8") == "binary"
+    assert layout.tokenizer_path.read_text(encoding="utf-8") == "tokenizer"
+    assert (layout.model_dir / "flow_lm_main_int8.onnx").read_text(encoding="utf-8") == "model"
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_installer_builds_windows_binary_layout():
+    from Helper_Scripts.TTS_Installers.install_tts_pocket_tts_cpp import build_runtime_layout
+
+    repo_root = Path(__file__).resolve().parents[4]
+    layout = build_runtime_layout(
+        Path("models") / "pocket_tts_cpp",
+        repo_root=repo_root,
+        platform_name="win32",
+    )
+
+    assert layout.binary_path.relative_to(repo_root).as_posix() == "bin/pocket-tts.exe"
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_installer_aborts_before_config_patch_when_runtime_is_incomplete(
+    tmp_path,
+    monkeypatch,
+):
+    from Helper_Scripts.TTS_Installers import install_tts_pocket_tts_cpp as installer
+
+    repo_root = tmp_path / "repo"
+    runtime_base = repo_root / "models" / "pocket_tts_cpp"
+    build_dir = tmp_path / "empty_build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(installer, "_ensure_prerequisites", lambda: None, raising=True)
+    monkeypatch.setattr(installer, "resolve_repo_root", lambda start=None: repo_root, raising=True)
+    monkeypatch.setattr(installer, "clone_repository", lambda *args, **kwargs: None, raising=True)
+    monkeypatch.setattr(installer, "configure_build", lambda *args, **kwargs: None, raising=True)
+    monkeypatch.setattr(installer, "build_project", lambda *args, **kwargs: None, raising=True)
+
+    patch_calls: list[object] = []
+
+    def _record_patch(*args, **kwargs):
+        patch_calls.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(installer, "patch_tts_config", _record_patch, raising=True)
+
+    with pytest.raises(SystemExit, match="runtime export incomplete"):
+        installer.main(
+            [
+                "--runtime-base",
+                str(runtime_base),
+                "--build-dir",
+                str(build_dir),
+                "--config-path",
+                str(tmp_path / "tts_providers_config.yaml"),
+                "--no-clone",
+                "--no-build",
+            ]
+        )
+
+    assert patch_calls == []

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_installer.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_installer.py
@@ -102,6 +102,32 @@ def test_pocket_tts_cpp_installer_exports_binary_tokenizer_and_onnx_layout(tmp_p
 
 
 @pytest.mark.unit
+def test_pocket_tts_cpp_installer_exports_from_install_layout_when_build_tree_is_incomplete(tmp_path):
+    from Helper_Scripts.TTS_Installers.install_tts_pocket_tts_cpp import (
+        build_runtime_layout,
+        export_runtime_artifacts,
+    )
+
+    repo_root = tmp_path / "repo"
+    runtime_base = repo_root / "models" / "pocket_tts_cpp"
+    build_dir = tmp_path / "build"
+    install_dir = tmp_path / "install"
+    layout = build_runtime_layout(runtime_base, repo_root=repo_root)
+
+    (install_dir / "bin").mkdir(parents=True, exist_ok=True)
+    (install_dir / "onnx").mkdir(parents=True, exist_ok=True)
+    (install_dir / "bin" / "pocket-tts").write_text("installed-binary", encoding="utf-8")
+    (install_dir / "tokenizer.model").write_text("installed-tokenizer", encoding="utf-8")
+    (install_dir / "onnx" / "flow_lm_main_int8.onnx").write_text("installed-model", encoding="utf-8")
+
+    export_runtime_artifacts(build_dir=build_dir, install_dir=install_dir, layout=layout)
+
+    assert layout.binary_path.read_text(encoding="utf-8") == "installed-binary"
+    assert layout.tokenizer_path.read_text(encoding="utf-8") == "installed-tokenizer"
+    assert (layout.model_dir / "flow_lm_main_int8.onnx").read_text(encoding="utf-8") == "installed-model"
+
+
+@pytest.mark.unit
 def test_pocket_tts_cpp_installer_builds_windows_binary_layout():
     from Helper_Scripts.TTS_Installers.install_tts_pocket_tts_cpp import build_runtime_layout
 
@@ -113,6 +139,69 @@ def test_pocket_tts_cpp_installer_builds_windows_binary_layout():
     )
 
     assert layout.binary_path.relative_to(repo_root).as_posix() == "bin/pocket-tts.exe"
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_installer_runs_install_step_before_export(tmp_path, monkeypatch):
+    from Helper_Scripts.TTS_Installers import install_tts_pocket_tts_cpp as installer
+
+    repo_root = tmp_path / "repo"
+    runtime_base = repo_root / "models" / "pocket_tts_cpp"
+    build_dir = tmp_path / "build"
+    source_dir = tmp_path / "src"
+    calls: list[tuple] = []
+
+    monkeypatch.setattr(installer, "_ensure_prerequisites", lambda: None, raising=True)
+    monkeypatch.setattr(installer, "resolve_repo_root", lambda start=None: repo_root, raising=True)
+    monkeypatch.setattr(
+        installer,
+        "configure_build",
+        lambda source_dir, build_dir, install_dir: calls.append(("configure", source_dir, build_dir, install_dir)),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        installer,
+        "build_project",
+        lambda build_dir: calls.append(("build", build_dir)),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        installer,
+        "install_project",
+        lambda build_dir: calls.append(("install", build_dir)),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        installer,
+        "export_runtime_artifacts",
+        lambda *, build_dir, install_dir, layout: calls.append(("export", build_dir, install_dir, layout.binary_path)),
+        raising=True,
+    )
+    monkeypatch.setattr(installer, "validate_runtime_layout", lambda layout: [], raising=True)
+    monkeypatch.setattr(installer, "patch_tts_config", lambda **kwargs: True, raising=True)
+
+    exit_code = installer.main(
+        [
+            "--runtime-base",
+            str(runtime_base),
+            "--build-dir",
+            str(build_dir),
+            "--source-dir",
+            str(source_dir),
+            "--config-path",
+            str(tmp_path / "tts_providers_config.yaml"),
+            "--no-clone",
+        ]
+    )
+
+    assert exit_code == 0
+    assert [entry[0] for entry in calls] == ["configure", "build", "install", "export"]
+    assert calls[0][1] == source_dir
+    assert calls[0][2] == build_dir
+    assert calls[0][3] == runtime_base
+    assert calls[2][1] == build_dir
+    assert calls[3][1] == build_dir
+    assert calls[3][2] == runtime_base
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_registry.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_registry.py
@@ -38,3 +38,22 @@ def test_pocket_tts_cpp_config_round_trip_preserves_explicit_fields():
     assert provider_dict["cache_ttl_hours"] == 12
     assert provider_dict["cache_max_bytes_per_user"] == 2048
     assert provider_dict["persist_direct_voice_references"] is True
+
+
+@pytest.mark.asyncio
+async def test_enabled_pocket_tts_cpp_returns_unavailable_instead_of_import_error():
+    factory = TTSAdapterFactory(
+        {
+            "providers": {
+                "pocket_tts_cpp": {
+                    "enabled": True,
+                    "binary_path": "models/pocket_tts_cpp/pocket_tts_cpp",
+                    "tokenizer_path": "models/pocket_tts_cpp/tokenizer.model",
+                }
+            }
+        }
+    )
+
+    adapter = await factory.registry.get_adapter(TTSProvider.POCKET_TTS_CPP)
+
+    assert adapter is None

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_registry.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_registry.py
@@ -1,0 +1,40 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapter_registry import TTSAdapterFactory, TTSProvider
+from tldw_Server_API.app.core.TTS.tts_config import ProviderConfig, TTSConfig, TTSConfigManager
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_model_aliases_resolve_to_new_provider():
+    factory = TTSAdapterFactory({})
+
+    assert factory.get_provider_for_model("pocket_tts_cpp") == TTSProvider.POCKET_TTS_CPP
+    assert factory.get_provider_for_model("pocket-tts-cpp") == TTSProvider.POCKET_TTS_CPP
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_config_round_trip_preserves_explicit_fields():
+    manager = TTSConfigManager.__new__(TTSConfigManager)
+    manager._config = TTSConfig(
+        providers={
+            "pocket_tts_cpp": ProviderConfig(
+                binary_path="models/pocket_tts_cpp/pocket_tts_cpp",
+                tokenizer_path="models/pocket_tts_cpp/tokenizer.model",
+                enable_voice_cache=True,
+                cache_ttl_hours=12,
+                cache_max_bytes_per_user=2048,
+                persist_direct_voice_references=True,
+            )
+        }
+    )
+    manager._sources = {}
+
+    config_dict = manager.to_dict()
+    provider_dict = config_dict["providers"]["pocket_tts_cpp"]
+
+    assert provider_dict["binary_path"] == "models/pocket_tts_cpp/pocket_tts_cpp"
+    assert provider_dict["tokenizer_path"] == "models/pocket_tts_cpp/tokenizer.model"
+    assert provider_dict["enable_voice_cache"] is True
+    assert provider_dict["cache_ttl_hours"] == 12
+    assert provider_dict["cache_max_bytes_per_user"] == 2048
+    assert provider_dict["persist_direct_voice_references"] is True

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import time
+import wave
 from pathlib import Path
 
 import pytest
@@ -48,11 +49,13 @@ async def test_pocket_tts_cpp_materializes_stored_voice_to_stable_custom_path(tm
 async def test_pocket_tts_cpp_materializes_direct_reference_to_deterministic_ref_path(tmp_path):
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         materialize_direct_voice_reference,
+        normalize_reference_audio_to_wav,
     )
 
     voice_reference = b"RIFF" + b"\x01" * 32
     runtime_root = tmp_path / "voices"
     manager = _RuntimeVoiceManager(runtime_root)
+    normalized = normalize_reference_audio_to_wav(voice_reference)
 
     materialized, is_transient = await materialize_direct_voice_reference(
         voice_manager=manager,
@@ -61,11 +64,70 @@ async def test_pocket_tts_cpp_materializes_direct_reference_to_deterministic_ref
         persist_direct_voice_references=True,
     )
 
-    expected_name = f"ref_{hashlib.sha256(voice_reference).hexdigest()}.wav"
+    expected_name = f"ref_{hashlib.sha256(normalized).hexdigest()}.wav"
     assert materialized == runtime_root / "providers" / "pocket_tts_cpp" / expected_name
     assert materialized.exists()
-    assert materialized.read_bytes() == voice_reference
+    assert materialized.read_bytes() == normalized
     assert is_transient is False
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_normalizes_non_wav_direct_reference_before_materialization(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        materialize_direct_voice_reference,
+        normalize_reference_audio_to_wav,
+    )
+
+    runtime_root = tmp_path / "voices"
+    manager = _RuntimeVoiceManager(runtime_root)
+    mp3_like_bytes = b"ID3" + b"\x04" * 17
+    normalized = normalize_reference_audio_to_wav(mp3_like_bytes)
+
+    materialized, is_transient = await materialize_direct_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_reference=mp3_like_bytes,
+        persist_direct_voice_references=True,
+    )
+
+    expected_name = f"ref_{hashlib.sha256(normalized).hexdigest()}.wav"
+    assert materialized == runtime_root / "providers" / "pocket_tts_cpp" / expected_name
+    assert is_transient is False
+    assert materialized.read_bytes() == normalized
+    with wave.open(str(materialized), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == 24000
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_transient_direct_references_use_unique_request_scoped_paths(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        materialize_direct_voice_reference,
+    )
+
+    runtime_root = tmp_path / "voices"
+    manager = _RuntimeVoiceManager(runtime_root)
+    voice_reference = b"RIFF" + b"\x07" * 32
+
+    first_path, first_transient = await materialize_direct_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_reference=voice_reference,
+        persist_direct_voice_references=False,
+    )
+    second_path, second_transient = await materialize_direct_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_reference=voice_reference,
+        persist_direct_voice_references=False,
+    )
+
+    assert first_transient is True
+    assert second_transient is True
+    assert first_path != second_path
+    assert first_path.exists()
+    assert second_path.exists()
 
 
 @pytest.mark.asyncio
@@ -94,7 +156,60 @@ async def test_pocket_tts_cpp_materialized_direct_reference_enforces_max_bytes_i
     assert not old_file.exists()
     remaining_files = list(runtime_dir.glob("*.wav"))
     assert remaining_files == [materialized]
-    assert sum(path.stat().st_size for path in remaining_files) <= 12
+    assert sum(path.stat().st_size for path in remaining_files) == materialized.stat().st_size
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_post_write_pruning_never_returns_deleted_active_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        materialize_direct_voice_reference,
+    )
+
+    runtime_root = tmp_path / "voices"
+    manager = _RuntimeVoiceManager(runtime_root)
+    runtime_dir = runtime_root / "providers" / "pocket_tts_cpp"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    stale_file = runtime_dir / "ref_stale.wav"
+    stale_file.write_bytes(b"old-old-old-old")
+
+    materialized, is_transient = await materialize_direct_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_reference=b"RIFF" + b"\x09" * 20,
+        persist_direct_voice_references=True,
+        cache_max_bytes=8,
+    )
+
+    assert is_transient is False
+    assert materialized.exists()
+    assert not stale_file.exists()
+    assert materialized in runtime_dir.glob("*.wav")
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_custom_voice_materialization_enforces_max_bytes_immediately(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        materialize_custom_voice_reference,
+    )
+
+    runtime_root = tmp_path / "voices"
+    manager = _RuntimeVoiceManager(runtime_root, voice_bytes=b"RIFF" + b"\x05" * 12)
+    runtime_dir = runtime_root / "providers" / "pocket_tts_cpp"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    old_file = runtime_dir / "ref_old.wav"
+    old_file.write_bytes(b"old-old")
+
+    materialized = await materialize_custom_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_id="voice-123",
+        cache_max_bytes=20,
+    )
+
+    assert materialized.exists()
+    assert not old_file.exists()
+    assert materialized in runtime_dir.glob("*.wav")
+    assert sum(path.stat().st_size for path in runtime_dir.glob("*.wav")) <= 20 or list(runtime_dir.glob("*.wav")) == [materialized]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import os
 import time
@@ -42,24 +43,268 @@ def _make_wav_bytes(
     return buffer.getvalue()
 
 
+class _TimedProbeStdout:
+    def __init__(self, chunks: list[tuple[float, bytes]]):
+        self._chunks = chunks
+        self._read_calls = 0
+
+    async def read(self, _n: int) -> bytes:
+        if self._read_calls >= len(self._chunks):
+            return b""
+
+        delay, chunk = self._chunks[self._read_calls]
+        if delay:
+            await asyncio.sleep(delay)
+        self._read_calls += 1
+        return chunk
+
+
+class _TimedProbeProcess:
+    def __init__(
+        self,
+        *,
+        chunks: list[tuple[float, bytes]],
+        returncode: int = 0,
+        stderr_bytes: bytes = b"",
+    ):
+        self.stdout = _TimedProbeStdout(chunks)
+        self.stderr_bytes = stderr_bytes
+        self.returncode = None
+        self._returncode = returncode
+
+    async def communicate(self):
+        self.returncode = self._returncode
+        return b"", self.stderr_bytes
+
+    def kill(self):
+        self.returncode = -9
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_probe_accepts_only_when_later_stdout_progress_arrives(
+    monkeypatch,
+):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import probe_cli_streaming_incremental
+
+    fake_process = _TimedProbeProcess(
+        chunks=[
+            (0.0, b"probe-bytes"),
+            (0.03, b"later-bytes"),
+        ]
+    )
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):  # noqa: ARG001
+        return fake_process
+
+    monkeypatch.setattr(runtime_module.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec, raising=True)
+
+    result = await probe_cli_streaming_incremental(
+        binary_path=Path("/tmp/pocket-tts"),
+        voice_path=Path("/tmp/voice.wav"),
+        model_path=Path("/tmp/models"),
+        tokenizer_path=Path("/tmp/tokenizer.model"),
+        precision="int8",
+        timeout=0.1,
+        enable_voice_cache=True,
+    )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_probe_rejects_stdout_bytes_when_process_exits_immediately_after_first_output(
+    monkeypatch,
+):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import probe_cli_streaming_incremental
+
+    fake_process = _TimedProbeProcess(
+        chunks=[
+            (0.0, b"probe-bytes"),
+        ]
+    )
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):  # noqa: ARG001
+        return fake_process
+
+    monkeypatch.setattr(runtime_module.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec, raising=True)
+
+    result = await probe_cli_streaming_incremental(
+        binary_path=Path("/tmp/pocket-tts"),
+        voice_path=Path("/tmp/voice.wav"),
+        model_path=Path("/tmp/models"),
+        tokenizer_path=Path("/tmp/tokenizer.model"),
+        precision="int8",
+        timeout=0.1,
+        enable_voice_cache=True,
+    )
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_probe_rejects_early_burst_without_later_stdout_progress(
+    monkeypatch,
+):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import probe_cli_streaming_incremental
+
+    fake_process = _TimedProbeProcess(
+        chunks=[
+            (0.0, b"probe-bytes"),
+            (0.0, b"burst-bytes"),
+        ],
+    )
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):  # noqa: ARG001
+        return fake_process
+
+    monkeypatch.setattr(runtime_module.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec, raising=True)
+
+    result = await probe_cli_streaming_incremental(
+        binary_path=Path("/tmp/pocket-tts"),
+        voice_path=Path("/tmp/voice.wav"),
+        model_path=Path("/tmp/models"),
+        tokenizer_path=Path("/tmp/tokenizer.model"),
+        precision="int8",
+        timeout=0.1,
+        enable_voice_cache=True,
+    )
+
+    assert result is False
+
+
+def test_pocket_tts_cpp_trust_token_binds_to_registered_voice_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        PROVIDER_MANAGED_VOICE_TOKEN_KEY,
+        register_provider_managed_voice_path,
+        resolve_provider_managed_voice_path,
+        revoke_provider_managed_voice_token,
+    )
+
+    voice_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "voice.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(b"RIFF" + b"\x00" * 32)
+
+    token = register_provider_managed_voice_path(voice_path)
+    assert token
+    assert isinstance(token, str)
+    assert token != str(voice_path)
+    assert len(token) > 16
+    assert PROVIDER_MANAGED_VOICE_TOKEN_KEY.startswith("_")
+
+    resolved = resolve_provider_managed_voice_path(token, voice_path)
+    assert resolved == voice_path.resolve()
+
+    revoke_provider_managed_voice_token(token)
+
+    with pytest.raises(ValueError):
+        resolve_provider_managed_voice_path(token, voice_path)
+
+
+def test_pocket_tts_cpp_trust_token_rejects_forged_voice_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        register_provider_managed_voice_path,
+        resolve_provider_managed_voice_path,
+        revoke_provider_managed_voice_token,
+    )
+
+    managed_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "managed.wav"
+    forged_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "forged.wav"
+    managed_path.parent.mkdir(parents=True, exist_ok=True)
+    managed_path.write_bytes(b"RIFF" + b"\x00" * 32)
+    forged_path.write_bytes(b"RIFF" + b"\x01" * 32)
+
+    token = register_provider_managed_voice_path(managed_path)
+
+    with pytest.raises(ValueError):
+        resolve_provider_managed_voice_path(token, forged_path)
+
+    revoke_provider_managed_voice_token(token)
+
+
+def test_pocket_tts_cpp_trust_token_rejects_paths_outside_provider_runtime_dir(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        register_provider_managed_voice_path,
+    )
+
+    unmanaged_path = tmp_path / "voices" / "shared" / "voice.wav"
+    unmanaged_path.parent.mkdir(parents=True, exist_ok=True)
+    unmanaged_path.write_bytes(b"RIFF" + b"\x00" * 32)
+
+    with pytest.raises(ValueError):
+        register_provider_managed_voice_path(unmanaged_path)
+
+
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_materializes_stored_voice_to_stable_custom_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         materialize_custom_voice_reference,
     )
 
     runtime_root = tmp_path / "voices"
     manager = _RuntimeVoiceManager(runtime_root)
+    normalized = _make_wav_bytes(b"\x00\x01" * 8)
 
-    materialized = await materialize_custom_voice_reference(
-        voice_manager=manager,
-        user_id=7,
-        voice_id="voice-123",
-    )
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        assert input_path.read_bytes() == manager.voice_bytes
+        assert sample_rate == 24000
+        assert channels == 1
+        assert bit_depth == 16
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
+    try:
+        materialized = await materialize_custom_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_id="voice-123",
+        )
+    finally:
+        monkeypatch.undo()
 
     assert materialized == runtime_root / "providers" / "pocket_tts_cpp" / "custom_voice-123.wav"
     assert materialized.exists()
-    assert materialized.read_bytes() == manager.voice_bytes
+    assert materialized.read_bytes() == normalized
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_normalizes_stored_custom_voice_before_materialization(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        materialize_custom_voice_reference,
+    )
+
+    runtime_root = tmp_path / "voices"
+    stored_bytes = b"ID3" + b"\x06" * 20
+    manager = _RuntimeVoiceManager(runtime_root, voice_bytes=stored_bytes)
+    normalized = _make_wav_bytes(b"\x06\x07" * 8)
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        assert input_path.read_bytes() == stored_bytes
+        assert sample_rate == 24000
+        assert channels == 1
+        assert bit_depth == 16
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
+    try:
+        materialized = await materialize_custom_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_id="voice-123",
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert materialized.exists()
+    assert materialized.read_bytes() == normalized
 
 
 @pytest.mark.asyncio
@@ -267,6 +512,7 @@ async def test_pocket_tts_cpp_post_write_pruning_never_returns_deleted_active_pa
 
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_custom_voice_materialization_enforces_max_bytes_immediately(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         materialize_custom_voice_reference,
     )
@@ -277,17 +523,29 @@ async def test_pocket_tts_cpp_custom_voice_materialization_enforces_max_bytes_im
     runtime_dir.mkdir(parents=True, exist_ok=True)
     old_file = runtime_dir / "ref_old.wav"
     old_file.write_bytes(b"old-old")
+    normalized = _make_wav_bytes(b"\x05\x06" * 8)
 
-    materialized = await materialize_custom_voice_reference(
-        voice_manager=manager,
-        user_id=7,
-        voice_id="voice-123",
-        cache_max_bytes=20,
-    )
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        assert input_path.read_bytes() == manager.voice_bytes
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
+    try:
+        materialized = await materialize_custom_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_id="voice-123",
+            cache_max_bytes=20,
+        )
+    finally:
+        monkeypatch.undo()
 
     assert materialized.exists()
     assert not old_file.exists()
     assert materialized in runtime_dir.glob("*.wav")
+    assert materialized.read_bytes() == normalized
     assert sum(path.stat().st_size for path in runtime_dir.glob("*.wav")) <= 20 or list(runtime_dir.glob("*.wav")) == [materialized]
 
 
@@ -356,6 +614,48 @@ def test_pocket_tts_cpp_prunes_provider_cache_for_ttl_and_oversize_files(tmp_pat
     assert not expired.exists()
     assert not oldest.exists()
     assert newest.exists()
+
+
+def test_pocket_tts_cpp_prune_keeps_active_registered_voice_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        PROVIDER_MANAGED_VOICE_LEASE_DIRNAME,
+        prune_materialized_voice_cache,
+        resolve_provider_managed_voice_path,
+        register_provider_managed_voice_path,
+    )
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+
+    runtime_dir = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+
+    active = runtime_dir / "active.wav"
+    stale = runtime_dir / "stale.wav"
+    active.write_bytes(b"a" * 7)
+    stale.write_bytes(b"b" * 7)
+
+    now = time.time()
+    os.utime(active, (now - 120, now - 120))
+    os.utime(stale, (now - 60, now - 60))
+
+    token = register_provider_managed_voice_path(active)
+    runtime_module._PROVIDER_MANAGED_VOICE_TOKENS.clear()
+
+    assert resolve_provider_managed_voice_path(token, active) == active.resolve()
+
+    runtime_module._PROVIDER_MANAGED_VOICE_TOKENS.clear()
+    removed = prune_materialized_voice_cache(
+        runtime_dir,
+        cache_ttl_hours=None,
+        cache_max_bytes=8,
+    )
+
+    removed_names = {path.name for path in removed}
+    assert removed_names == {"stale.wav"}
+    assert active.exists()
+    assert not stale.exists()
+    lease_files = list((runtime_dir / PROVIDER_MANAGED_VOICE_LEASE_DIRNAME).glob("*.json"))
+    assert len(lease_files) == 1
+    assert lease_files[0].stem == token
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
@@ -1,0 +1,154 @@
+import hashlib
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.voice_manager import VoiceManager, VOICE_RATE_LIMITS
+
+
+class _RuntimeVoiceManager:
+    def __init__(self, root: Path, voice_bytes: bytes = b"RIFF" + b"\x00" * 64):
+        self.root = root
+        self.voice_bytes = voice_bytes
+
+    def get_user_voices_path(self, user_id: int) -> Path:
+        assert user_id == 7
+        self.root.mkdir(parents=True, exist_ok=True)
+        return self.root
+
+    async def load_voice_reference_audio(self, user_id: int, voice_id: str) -> bytes:
+        assert user_id == 7
+        assert voice_id == "voice-123"
+        return self.voice_bytes
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_materializes_stored_voice_to_stable_custom_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        materialize_custom_voice_reference,
+    )
+
+    runtime_root = tmp_path / "voices"
+    manager = _RuntimeVoiceManager(runtime_root)
+
+    materialized = await materialize_custom_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_id="voice-123",
+    )
+
+    assert materialized == runtime_root / "providers" / "pocket_tts_cpp" / "custom_voice-123.wav"
+    assert materialized.exists()
+    assert materialized.read_bytes() == manager.voice_bytes
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_materializes_direct_reference_to_deterministic_ref_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        materialize_direct_voice_reference,
+    )
+
+    voice_reference = b"RIFF" + b"\x01" * 32
+    runtime_root = tmp_path / "voices"
+    manager = _RuntimeVoiceManager(runtime_root)
+
+    materialized, is_transient = await materialize_direct_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_reference=voice_reference,
+        persist_direct_voice_references=True,
+    )
+
+    expected_name = f"ref_{hashlib.sha256(voice_reference).hexdigest()}.wav"
+    assert materialized == runtime_root / "providers" / "pocket_tts_cpp" / expected_name
+    assert materialized.exists()
+    assert materialized.read_bytes() == voice_reference
+    assert is_transient is False
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_deletes_transient_direct_reference_when_persistence_disabled(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        cleanup_transient_voice_reference,
+        materialize_direct_voice_reference,
+    )
+
+    runtime_root = tmp_path / "voices"
+    manager = _RuntimeVoiceManager(runtime_root)
+    materialized, is_transient = await materialize_direct_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_reference=b"RIFF" + b"\x02" * 16,
+        persist_direct_voice_references=False,
+    )
+
+    assert is_transient is True
+    assert materialized.exists()
+
+    cleanup_transient_voice_reference(materialized, is_transient)
+
+    assert not materialized.exists()
+
+
+def test_pocket_tts_cpp_prunes_provider_cache_for_ttl_and_oversize_files(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        prune_materialized_voice_cache,
+    )
+
+    runtime_dir = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+
+    expired = runtime_dir / "expired.wav"
+    oldest = runtime_dir / "oldest.wav"
+    newest = runtime_dir / "newest.wav"
+    expired.write_bytes(b"x" * 4)
+    oldest.write_bytes(b"y" * 7)
+    newest.write_bytes(b"z" * 7)
+
+    now = time.time()
+    os.utime(expired, (now - 7200, now - 7200))
+    os.utime(oldest, (now - 60, now - 60))
+    os.utime(newest, (now - 5, now - 5))
+
+    removed = prune_materialized_voice_cache(
+        runtime_dir,
+        cache_ttl_hours=1,
+        cache_max_bytes=10,
+    )
+
+    removed_names = {path.name for path in removed}
+    assert removed_names == {"expired.wav", "oldest.wav"}
+    assert not expired.exists()
+    assert not oldest.exists()
+    assert newest.exists()
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_provider_cache_is_excluded_from_uploaded_voice_quota(tmp_path, monkeypatch):
+    manager = VoiceManager()
+    voices_root = tmp_path / "voices"
+    processed_dir = voices_root / "processed"
+    provider_dir = voices_root / "providers" / "pocket_tts_cpp"
+    processed_dir.mkdir(parents=True, exist_ok=True)
+    provider_dir.mkdir(parents=True, exist_ok=True)
+
+    processed_file = processed_dir / "user_voice.wav"
+    provider_file = provider_dir / "ref_cache.wav"
+    processed_file.write_bytes(b"a" * 512)
+    provider_file.write_bytes(b"b" * 4096)
+
+    monkeypatch.setattr(manager, "get_user_voices_path", lambda user_id: voices_root, raising=False)
+    monkeypatch.setitem(VOICE_RATE_LIMITS, "total_storage_mb", 0.001)
+    monkeypatch.setitem(VOICE_RATE_LIMITS, "max_voices_per_user", 10)
+
+    async def _fake_duration(_path: Path) -> float:
+        return 1.0
+
+    monkeypatch.setattr(manager, "_get_audio_duration", _fake_duration, raising=False)
+
+    allowed, message = await manager.check_rate_limits(99)
+
+    assert allowed is True
+    assert message == ""

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import time
 import wave
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,22 @@ class _RuntimeVoiceManager:
         assert user_id == 7
         assert voice_id == "voice-123"
         return self.voice_bytes
+
+
+def _make_wav_bytes(
+    payload: bytes = b"\x00\x01" * 8,
+    *,
+    sample_rate: int = 24000,
+    channels: int = 1,
+    sample_width: int = 2,
+) -> bytes:
+    buffer = BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(sample_width)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(payload)
+    return buffer.getvalue()
 
 
 @pytest.mark.asyncio
@@ -47,22 +64,35 @@ async def test_pocket_tts_cpp_materializes_stored_voice_to_stable_custom_path(tm
 
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_materializes_direct_reference_to_deterministic_ref_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         materialize_direct_voice_reference,
-        normalize_reference_audio_to_wav,
     )
 
     voice_reference = b"RIFF" + b"\x01" * 32
     runtime_root = tmp_path / "voices"
     manager = _RuntimeVoiceManager(runtime_root)
-    normalized = normalize_reference_audio_to_wav(voice_reference)
+    normalized = _make_wav_bytes(b"\x01\x02" * 8)
 
-    materialized, is_transient = await materialize_direct_voice_reference(
-        voice_manager=manager,
-        user_id=7,
-        voice_reference=voice_reference,
-        persist_direct_voice_references=True,
-    )
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        assert input_path.read_bytes() == voice_reference
+        assert sample_rate == 24000
+        assert channels == 1
+        assert bit_depth == 16
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
+    try:
+        materialized, is_transient = await materialize_direct_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_reference=voice_reference,
+            persist_direct_voice_references=True,
+        )
+    finally:
+        monkeypatch.undo()
 
     expected_name = f"ref_{hashlib.sha256(normalized).hexdigest()}.wav"
     assert materialized == runtime_root / "providers" / "pocket_tts_cpp" / expected_name
@@ -73,26 +103,42 @@ async def test_pocket_tts_cpp_materializes_direct_reference_to_deterministic_ref
 
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_normalizes_non_wav_direct_reference_before_materialization(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         materialize_direct_voice_reference,
-        normalize_reference_audio_to_wav,
     )
 
     runtime_root = tmp_path / "voices"
     manager = _RuntimeVoiceManager(runtime_root)
     mp3_like_bytes = b"ID3" + b"\x04" * 17
-    normalized = normalize_reference_audio_to_wav(mp3_like_bytes)
+    normalized = _make_wav_bytes(b"\x04\x05" * 12)
+    converter_calls: list[tuple[Path, Path]] = []
 
-    materialized, is_transient = await materialize_direct_voice_reference(
-        voice_manager=manager,
-        user_id=7,
-        voice_reference=mp3_like_bytes,
-        persist_direct_voice_references=True,
-    )
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        converter_calls.append((input_path, output_path))
+        assert input_path.read_bytes() == mp3_like_bytes
+        assert sample_rate == 24000
+        assert channels == 1
+        assert bit_depth == 16
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
+    try:
+        materialized, is_transient = await materialize_direct_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_reference=mp3_like_bytes,
+            persist_direct_voice_references=True,
+        )
+    finally:
+        monkeypatch.undo()
 
     expected_name = f"ref_{hashlib.sha256(normalized).hexdigest()}.wav"
     assert materialized == runtime_root / "providers" / "pocket_tts_cpp" / expected_name
     assert is_transient is False
+    assert len(converter_calls) == 1
     assert materialized.read_bytes() == normalized
     with wave.open(str(materialized), "rb") as wav_file:
         assert wav_file.getnchannels() == 1
@@ -102,6 +148,7 @@ async def test_pocket_tts_cpp_normalizes_non_wav_direct_reference_before_materia
 
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_transient_direct_references_use_unique_request_scoped_paths(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         materialize_direct_voice_reference,
     )
@@ -109,19 +156,29 @@ async def test_pocket_tts_cpp_transient_direct_references_use_unique_request_sco
     runtime_root = tmp_path / "voices"
     manager = _RuntimeVoiceManager(runtime_root)
     voice_reference = b"RIFF" + b"\x07" * 32
+    normalized = _make_wav_bytes(b"\x07\x08" * 10)
 
-    first_path, first_transient = await materialize_direct_voice_reference(
-        voice_manager=manager,
-        user_id=7,
-        voice_reference=voice_reference,
-        persist_direct_voice_references=False,
-    )
-    second_path, second_transient = await materialize_direct_voice_reference(
-        voice_manager=manager,
-        user_id=7,
-        voice_reference=voice_reference,
-        persist_direct_voice_references=False,
-    )
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
+    try:
+        first_path, first_transient = await materialize_direct_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_reference=voice_reference,
+            persist_direct_voice_references=False,
+        )
+        second_path, second_transient = await materialize_direct_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_reference=voice_reference,
+            persist_direct_voice_references=False,
+        )
+    finally:
+        monkeypatch.undo()
 
     assert first_transient is True
     assert second_transient is True
@@ -132,6 +189,7 @@ async def test_pocket_tts_cpp_transient_direct_references_use_unique_request_sco
 
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_materialized_direct_reference_enforces_max_bytes_immediately(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         materialize_direct_voice_reference,
     )
@@ -142,14 +200,24 @@ async def test_pocket_tts_cpp_materialized_direct_reference_enforces_max_bytes_i
     runtime_dir.mkdir(parents=True, exist_ok=True)
     old_file = runtime_dir / "ref_old.wav"
     old_file.write_bytes(b"old-old")
+    normalized = _make_wav_bytes(b"\x03\x03")
 
-    materialized, is_transient = await materialize_direct_voice_reference(
-        voice_manager=manager,
-        user_id=7,
-        voice_reference=b"RIFF" + b"\x03" * 8,
-        persist_direct_voice_references=True,
-        cache_max_bytes=12,
-    )
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
+    try:
+        materialized, is_transient = await materialize_direct_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_reference=b"RIFF" + b"\x03" * 8,
+            persist_direct_voice_references=True,
+            cache_max_bytes=12,
+        )
+    finally:
+        monkeypatch.undo()
 
     assert is_transient is False
     assert materialized.exists()
@@ -161,6 +229,7 @@ async def test_pocket_tts_cpp_materialized_direct_reference_enforces_max_bytes_i
 
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_post_write_pruning_never_returns_deleted_active_path(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         materialize_direct_voice_reference,
     )
@@ -171,14 +240,24 @@ async def test_pocket_tts_cpp_post_write_pruning_never_returns_deleted_active_pa
     runtime_dir.mkdir(parents=True, exist_ok=True)
     stale_file = runtime_dir / "ref_stale.wav"
     stale_file.write_bytes(b"old-old-old-old")
+    normalized = _make_wav_bytes(b"\x09\x09" * 2)
 
-    materialized, is_transient = await materialize_direct_voice_reference(
-        voice_manager=manager,
-        user_id=7,
-        voice_reference=b"RIFF" + b"\x09" * 20,
-        persist_direct_voice_references=True,
-        cache_max_bytes=8,
-    )
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
+    try:
+        materialized, is_transient = await materialize_direct_voice_reference(
+            voice_manager=manager,
+            user_id=7,
+            voice_reference=b"RIFF" + b"\x09" * 20,
+            persist_direct_voice_references=True,
+            cache_max_bytes=8,
+        )
+    finally:
+        monkeypatch.undo()
 
     assert is_transient is False
     assert materialized.exists()
@@ -214,6 +293,7 @@ async def test_pocket_tts_cpp_custom_voice_materialization_enforces_max_bytes_im
 
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_deletes_transient_direct_reference_when_persistence_disabled(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         cleanup_transient_voice_reference,
         materialize_direct_voice_reference,
@@ -221,12 +301,21 @@ async def test_pocket_tts_cpp_deletes_transient_direct_reference_when_persistenc
 
     runtime_root = tmp_path / "voices"
     manager = _RuntimeVoiceManager(runtime_root)
+    normalized = _make_wav_bytes(b"\x02\x02" * 8)
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(normalized)
+        return True
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_module.AudioConverter, "convert_to_wav", _fake_convert)
     materialized, is_transient = await materialize_direct_voice_reference(
         voice_manager=manager,
         user_id=7,
         voice_reference=b"RIFF" + b"\x02" * 16,
         persist_direct_voice_references=False,
     )
+    monkeypatch.undo()
 
     assert is_transient is True
     assert materialized.exists()

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
@@ -69,6 +69,35 @@ async def test_pocket_tts_cpp_materializes_direct_reference_to_deterministic_ref
 
 
 @pytest.mark.asyncio
+async def test_pocket_tts_cpp_materialized_direct_reference_enforces_max_bytes_immediately(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+        materialize_direct_voice_reference,
+    )
+
+    runtime_root = tmp_path / "voices"
+    manager = _RuntimeVoiceManager(runtime_root)
+    runtime_dir = runtime_root / "providers" / "pocket_tts_cpp"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    old_file = runtime_dir / "ref_old.wav"
+    old_file.write_bytes(b"old-old")
+
+    materialized, is_transient = await materialize_direct_voice_reference(
+        voice_manager=manager,
+        user_id=7,
+        voice_reference=b"RIFF" + b"\x03" * 8,
+        persist_direct_voice_references=True,
+        cache_max_bytes=12,
+    )
+
+    assert is_transient is False
+    assert materialized.exists()
+    assert not old_file.exists()
+    remaining_files = list(runtime_dir.glob("*.wav"))
+    assert remaining_files == [materialized]
+    assert sum(path.stat().st_size for path in remaining_files) <= 12
+
+
+@pytest.mark.asyncio
 async def test_pocket_tts_cpp_deletes_transient_direct_reference_when_persistence_disabled(tmp_path):
     from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
         cleanup_transient_voice_reference,

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py
@@ -237,6 +237,59 @@ def test_pocket_tts_cpp_trust_token_rejects_paths_outside_provider_runtime_dir(t
         register_provider_managed_voice_path(unmanaged_path)
 
 
+def test_pocket_tts_cpp_validate_runtime_assets_requires_tokenizer_file_and_model_directory(tmp_path):
+    from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import validate_runtime_assets
+    from tldw_Server_API.app.core.TTS.tts_exceptions import TTSModelNotFoundError
+
+    binary_path = tmp_path / "bin" / "pocket-tts"
+    tokenizer_path = tmp_path / "models" / "pocket_tts_cpp" / "tokenizer.model"
+    model_path = tmp_path / "models" / "pocket_tts_cpp" / "onnx"
+
+    binary_path.parent.mkdir(parents=True, exist_ok=True)
+    binary_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary_path.chmod(0o755)
+    tokenizer_path.mkdir(parents=True, exist_ok=True)
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    model_path.write_bytes(b"not-a-directory")
+
+    with pytest.raises(TTSModelNotFoundError, match="tokenizer"):
+        validate_runtime_assets(
+            binary_path=binary_path,
+            model_path=model_path,
+            tokenizer_path=tokenizer_path,
+            precision="int8",
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_runtime_file_writes_via_atomic_replace(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+
+    target_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "voice.wav"
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_bytes(b"old-bytes")
+    replace_calls: list[tuple[Path, Path, bytes, bytes]] = []
+
+    def _fake_replace(src: str, dst: str) -> None:
+        src_path = Path(src)
+        dst_path = Path(dst)
+        replace_calls.append((src_path, dst_path, src_path.read_bytes(), dst_path.read_bytes()))
+        os.unlink(dst_path)
+        os.rename(src_path, dst_path)
+
+    monkeypatch.setattr(runtime_module.os, "replace", _fake_replace, raising=True)
+
+    await runtime_module._write_runtime_file(target_path, b"new-bytes")
+
+    assert replace_calls
+    src_path, dst_path, temp_bytes, old_bytes = replace_calls[0]
+    assert src_path != target_path
+    assert dst_path == target_path
+    assert temp_bytes == b"new-bytes"
+    assert old_bytes == b"old-bytes"
+    assert target_path.read_bytes() == b"new-bytes"
+
+
 @pytest.mark.asyncio
 async def test_pocket_tts_cpp_materializes_stored_voice_to_stable_custom_path(tmp_path):
     from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
@@ -466,10 +519,12 @@ async def test_pocket_tts_cpp_materialized_direct_reference_enforces_max_bytes_i
 
     assert is_transient is False
     assert materialized.exists()
-    assert not old_file.exists()
-    remaining_files = list(runtime_dir.glob("*.wav"))
-    assert remaining_files == [materialized]
-    assert sum(path.stat().st_size for path in remaining_files) == materialized.stat().st_size
+    assert old_file.exists()
+    remaining_files = sorted(runtime_dir.glob("*.wav"))
+    assert remaining_files == sorted([materialized, old_file])
+    assert sum(path.stat().st_size for path in remaining_files) == (
+        materialized.stat().st_size + old_file.stat().st_size
+    )
 
 
 @pytest.mark.asyncio
@@ -506,7 +561,7 @@ async def test_pocket_tts_cpp_post_write_pruning_never_returns_deleted_active_pa
 
     assert is_transient is False
     assert materialized.exists()
-    assert not stale_file.exists()
+    assert stale_file.exists()
     assert materialized in runtime_dir.glob("*.wav")
 
 
@@ -543,10 +598,9 @@ async def test_pocket_tts_cpp_custom_voice_materialization_enforces_max_bytes_im
         monkeypatch.undo()
 
     assert materialized.exists()
-    assert not old_file.exists()
+    assert old_file.exists()
     assert materialized in runtime_dir.glob("*.wav")
     assert materialized.read_bytes() == normalized
-    assert sum(path.stat().st_size for path in runtime_dir.glob("*.wav")) <= 20 or list(runtime_dir.glob("*.wav")) == [materialized]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -1,4 +1,6 @@
 import asyncio
+import wave
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -9,6 +11,22 @@ from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 from tldw_Server_API.app.core.TTS.voice_manager import VoiceReferenceMetadata
+
+
+def _make_wav_bytes(
+    payload: bytes = b"\x00\x01" * 8,
+    *,
+    sample_rate: int = 24000,
+    channels: int = 1,
+    sample_width: int = 2,
+) -> bytes:
+    buffer = BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(sample_width)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(payload)
+    return buffer.getvalue()
 
 
 class _ServiceVoiceManager:
@@ -83,13 +101,23 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_direct_voice_refer
             return None
 
     from tldw_Server_API.app.core.TTS import voice_manager as voice_manager_module
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+
+    converted_wav = _make_wav_bytes(b"\x01\x02" * 8)
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(converted_wav)
+        return True
 
     original_get_voice_manager = voice_manager_module.get_voice_manager
     voice_manager_module.get_voice_manager = lambda: _DirectReferenceVoiceManager()
+    original_convert = runtime_module.AudioConverter.convert_to_wav
+    runtime_module.AudioConverter.convert_to_wav = _fake_convert
     try:
         await service._apply_custom_voice_reference(request, user_id=1, provider_hint="pocket_tts_cpp")
     finally:
         voice_manager_module.get_voice_manager = original_get_voice_manager
+        runtime_module.AudioConverter.convert_to_wav = original_convert
 
     voice_path = Path(request.extra_params["pocket_tts_cpp_voice_path"])
     assert voice_path.parent == tmp_path / "voices" / "providers" / "pocket_tts_cpp"
@@ -141,6 +169,11 @@ async def test_pocket_tts_cpp_validation_failure_cleans_transient_direct_referen
 
     service._ensure_factory = AsyncMock(return_value=_FactoryWithPocketRuntimeConfig())
     service._get_adapter = AsyncMock()
+    converted_wav = _make_wav_bytes(b"\x02\x03" * 8)
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(converted_wav)
+        return True
 
     def _raise_validation(*args, **kwargs):
         raise TTSValidationError("synthetic validation failure", provider="pocket_tts_cpp")
@@ -148,6 +181,11 @@ async def test_pocket_tts_cpp_validation_failure_cleans_transient_direct_referen
     monkeypatch.setattr(
         "tldw_Server_API.app.core.TTS.tts_service_v2.validate_tts_request",
         _raise_validation,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime.AudioConverter.convert_to_wav",
+        _fake_convert,
         raising=True,
     )
 
@@ -213,11 +251,21 @@ async def test_pocket_tts_cpp_cancellation_during_adapter_acquisition_cleans_tra
             return "pocket_tts_cpp"
 
     service._ensure_factory = AsyncMock(return_value=_FactoryWithPocketRuntimeConfig())
+    converted_wav = _make_wav_bytes(b"\x04\x05" * 8)
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(converted_wav)
+        return True
 
     async def _cancel_adapter(*args, **kwargs):
         raise asyncio.CancelledError()
 
     service._get_adapter = AsyncMock(side_effect=_cancel_adapter)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime.AudioConverter.convert_to_wav",
+        _fake_convert,
+        raising=True,
+    )
 
     request = OpenAISpeechRequest(
         model="pocket_tts_cpp",

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
+from tldw_Server_API.app.core.TTS.voice_manager import VoiceReferenceMetadata
+
+
+class _ServiceVoiceManager:
+    def __init__(self, root: Path):
+        self.root = root
+
+    def get_user_voices_path(self, user_id: int) -> Path:
+        assert user_id == 1
+        self.root.mkdir(parents=True, exist_ok=True)
+        return self.root
+
+    async def load_voice_reference_audio(self, user_id: int, voice_id: str) -> bytes:
+        assert user_id == 1
+        assert voice_id == "voice-1"
+        return b"RIFF" + b"\x00" * 32
+
+    async def load_reference_metadata(self, user_id: int, voice_id: str):
+        assert user_id == 1
+        assert voice_id == "voice-1"
+        return VoiceReferenceMetadata(
+            voice_id=voice_id,
+            reference_text="stored reference text",
+        )
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_service_injects_stable_path_for_custom_voice(tmp_path, monkeypatch):
+    service = TTSServiceV2()
+    manager = _ServiceVoiceManager(tmp_path / "voices")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: manager,
+        raising=True,
+    )
+
+    request = TTSRequest(
+        text="hello",
+        voice="custom:voice-1",
+        format=AudioFormat.WAV,
+        extra_params={},
+    )
+
+    await service._apply_custom_voice_reference(request, user_id=1, provider_hint="pocket_tts_cpp")
+
+    expected = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-1.wav"
+    assert request.voice_reference == b"RIFF" + b"\x00" * 32
+    assert request.extra_params["pocket_tts_cpp_voice_path"] == str(expected)
+    assert request.extra_params["pocket_tts_cpp_reference_text"] == "stored reference text"
+    assert expected.exists()
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_service_injects_stable_path_for_direct_voice_reference(tmp_path):
+    service = TTSServiceV2()
+    request = TTSRequest(
+        text="hello",
+        voice="alloy",
+        format=AudioFormat.WAV,
+        voice_reference=b"RIFF" + b"\x01" * 24,
+        extra_params={"reference_text": "direct reference text"},
+    )
+
+    class _DirectReferenceVoiceManager:
+        def get_user_voices_path(self, user_id: int) -> Path:
+            assert user_id == 1
+            root = tmp_path / "voices"
+            root.mkdir(parents=True, exist_ok=True)
+            return root
+
+        async def load_reference_metadata(self, user_id: int, voice_id: str):
+            return None
+
+    from tldw_Server_API.app.core.TTS import voice_manager as voice_manager_module
+
+    original_get_voice_manager = voice_manager_module.get_voice_manager
+    voice_manager_module.get_voice_manager = lambda: _DirectReferenceVoiceManager()
+    try:
+        await service._apply_custom_voice_reference(request, user_id=1, provider_hint="pocket_tts_cpp")
+    finally:
+        voice_manager_module.get_voice_manager = original_get_voice_manager
+
+    voice_path = Path(request.extra_params["pocket_tts_cpp_voice_path"])
+    assert voice_path.parent == tmp_path / "voices" / "providers" / "pocket_tts_cpp"
+    assert voice_path.name.startswith("ref_")
+    assert voice_path.suffix == ".wav"
+    assert request.extra_params["pocket_tts_cpp_reference_text"] == "direct reference text"
+    assert voice_path.exists()

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -12,6 +12,7 @@ from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest, 
 from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
     PROVIDER_MANAGED_VOICE_LEASE_DIRNAME,
     PROVIDER_MANAGED_VOICE_TOKEN_KEY,
+    register_provider_managed_voice_path,
     resolve_provider_managed_voice_path,
 )
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSTimeoutError, TTSGenerationError, TTSValidationError
@@ -282,6 +283,132 @@ async def test_pocket_tts_cpp_service_cleans_trust_token_after_generation(tmp_pa
             seen_tokens[0],
             Path(tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-1.wav"),
         )
+
+
+@pytest.mark.asyncio
+async def test_generate_speech_closes_stream_before_pocket_tts_cpp_cleanup(tmp_path, monkeypatch):
+    service = TTSServiceV2()
+    events: list[tuple[str, bool] | str] = []
+    stream_closed = False
+
+    voice_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-stream.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(_make_wav_bytes())
+    token = register_provider_managed_voice_path(voice_path)
+    provider_request = TTSRequest(
+        text="hello",
+        voice="custom:voice-stream",
+        format=AudioFormat.WAV,
+        stream=True,
+        extra_params={
+            "pocket_tts_cpp_voice_path": str(voice_path),
+            PROVIDER_MANAGED_VOICE_TOKEN_KEY: token,
+            "_pocket_tts_cpp_transient_voice_path": str(voice_path),
+        },
+    )
+
+    class _StreamingAdapter:
+        provider_name = "pocket_tts_cpp"
+        provider_key = "pocket_tts_cpp"
+
+        async def generate(self, request):  # noqa: ARG002
+            async def _stream():
+                nonlocal stream_closed
+                try:
+                    yield b"chunk-1"
+                    yield b"chunk-2"
+                finally:
+                    stream_closed = True
+                    events.append("stream_closed")
+
+            return TTSResponse(audio_stream=_stream(), format=AudioFormat.WAV, sample_rate=24000)
+
+    service._prepare_generate_speech_request = AsyncMock(
+        return_value=(_StreamingAdapter(), "pocket_tts_cpp", provider_request)
+    )
+
+    def _record_cleanup(request):
+        assert request is provider_request
+        events.append(("cleanup", stream_closed))
+
+    monkeypatch.setattr(
+        service,
+        "_cleanup_transient_pocket_tts_cpp_voice_path",
+        _record_cleanup,
+        raising=True,
+    )
+
+    request = OpenAISpeechRequest(
+        model="pocket_tts_cpp",
+        input="hello",
+        voice="custom:voice-stream",
+        response_format="wav",
+        stream=True,
+    )
+
+    generator = service.generate_speech(request, user_id=1, fallback=False)
+
+    assert await anext(generator) == b"chunk-1"
+    await generator.aclose()
+
+    assert events == ["stream_closed", ("cleanup", True)]
+
+
+@pytest.mark.asyncio
+async def test_generate_with_adapter_closes_stream_before_pocket_tts_cpp_cleanup(tmp_path, monkeypatch):
+    service = TTSServiceV2()
+    events: list[tuple[str, bool] | str] = []
+    stream_closed = False
+
+    voice_path = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-helper.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(_make_wav_bytes())
+    token = register_provider_managed_voice_path(voice_path)
+    request = TTSRequest(
+        text="hello",
+        voice="custom:voice-helper",
+        format=AudioFormat.WAV,
+        stream=True,
+        extra_params={
+            "pocket_tts_cpp_voice_path": str(voice_path),
+            PROVIDER_MANAGED_VOICE_TOKEN_KEY: token,
+            "_pocket_tts_cpp_transient_voice_path": str(voice_path),
+        },
+    )
+
+    class _StreamingAdapter:
+        provider_name = "pocket_tts_cpp"
+        provider_key = "pocket_tts_cpp"
+
+        async def generate(self, stream_request):  # noqa: ARG002
+            async def _stream():
+                nonlocal stream_closed
+                try:
+                    yield b"chunk-1"
+                    yield b"chunk-2"
+                finally:
+                    stream_closed = True
+                    events.append("stream_closed")
+
+            return TTSResponse(audio_stream=_stream(), format=AudioFormat.WAV, sample_rate=24000)
+
+    def _record_cleanup(cleanup_request):
+        assert cleanup_request is request
+        events.append(("cleanup", stream_closed))
+
+    monkeypatch.setattr(
+        service,
+        "_cleanup_transient_pocket_tts_cpp_voice_path",
+        _record_cleanup,
+        raising=True,
+    )
+
+    generator = service._generate_with_adapter(_StreamingAdapter(), request, user_id=1)
+
+    assert await anext(generator) == b"chunk-1"
+    await generator.aclose()
+
+    assert events == ["stream_closed", ("cleanup", True)]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import wave
 from io import BytesIO
 from pathlib import Path
@@ -25,6 +26,11 @@ def _make_wav_bytes(
     channels: int = 1,
     sample_width: int = 2,
 ) -> bytes:
+    frame_width = max(channels * sample_width, 1)
+    min_payload_len = sample_rate * frame_width
+    if len(payload) < min_payload_len:
+        repeats = (min_payload_len + len(payload) - 1) // len(payload)
+        payload = (payload * repeats)[:min_payload_len]
     buffer = BytesIO()
     with wave.open(buffer, "wb") as wav_file:
         wav_file.setnchannels(channels)
@@ -32,6 +38,10 @@ def _make_wav_bytes(
         wav_file.setframerate(sample_rate)
         wav_file.writeframes(payload)
     return buffer.getvalue()
+
+
+def _make_wav_base64(payload: bytes = b"\x00\x01" * 8) -> str:
+    return base64.b64encode(_make_wav_bytes(payload)).decode("ascii")
 
 
 class _ServiceVoiceManager:
@@ -46,7 +56,7 @@ class _ServiceVoiceManager:
     async def load_voice_reference_audio(self, user_id: int, voice_id: str) -> bytes:
         assert user_id == 1
         assert voice_id == "voice-1"
-        return b"RIFF" + b"\x00" * 32
+        return _make_wav_bytes()
 
     async def load_reference_metadata(self, user_id: int, voice_id: str):
         assert user_id == 1
@@ -63,6 +73,7 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_custom_voice(tmp_p
     manager = _ServiceVoiceManager(tmp_path / "voices")
     from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
 
+    source_wav = _make_wav_bytes()
     converted_wav = _make_wav_bytes(b"\x00\x01" * 8)
 
     monkeypatch.setattr(
@@ -72,7 +83,7 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_custom_voice(tmp_p
     )
 
     async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
-        assert input_path.read_bytes() == b"RIFF" + b"\x00" * 32
+        assert input_path.read_bytes() == source_wav
         output_path.write_bytes(converted_wav)
         return True
 
@@ -93,7 +104,7 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_custom_voice(tmp_p
     await service._apply_custom_voice_reference(request, user_id=1, provider_hint="pocket_tts_cpp")
 
     expected = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-1.wav"
-    assert request.voice_reference == b"RIFF" + b"\x00" * 32
+    assert request.voice_reference == source_wav
     assert request.extra_params["pocket_tts_cpp_voice_path"] == str(expected)
     assert request.extra_params[PROVIDER_MANAGED_VOICE_TOKEN_KEY]
     assert request.extra_params["pocket_tts_cpp_reference_text"] == "stored reference text"
@@ -108,7 +119,7 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_direct_voice_refer
         text="hello",
         voice="alloy",
         format=AudioFormat.WAV,
-        voice_reference=b"RIFF" + b"\x01" * 24,
+        voice_reference=_make_wav_bytes(b"\x01\x02" * 8),
         extra_params={"reference_text": "direct reference text"},
     )
 
@@ -208,7 +219,7 @@ async def test_pocket_tts_cpp_service_cleans_trust_token_after_generation(tmp_pa
         async def load_voice_reference_audio(self, user_id: int, voice_id: str) -> bytes:
             assert user_id == 1
             assert voice_id == "voice-1"
-            return b"RIFF" + b"\x00" * 32
+            return _make_wav_bytes()
 
         async def load_reference_metadata(self, user_id: int, voice_id: str):
             return None
@@ -278,7 +289,7 @@ async def test_pocket_tts_cpp_service_cleans_trust_token_after_generation(tmp_pa
     "voice,voice_reference,expected_fragment",
     [
         ("custom:voice-1", None, "custom_voice-1.wav"),
-        ("alloy", "UklGRgMDAwMDAwM=", "ref_"),
+        ("alloy", _make_wav_base64(b"\x01\x02" * 8), "ref_"),
     ],
 )
 async def test_pocket_tts_cpp_fallback_materializes_voice_for_fallback_adapter(
@@ -483,7 +494,7 @@ async def test_pocket_tts_cpp_validation_failure_cleans_transient_direct_referen
         voice="alloy",
         response_format="wav",
         stream=False,
-        voice_reference="UklGRgMDAwMDAwM=",
+        voice_reference=_make_wav_base64(b"\x02\x03" * 8),
         extra_params={"reference_text": "direct reference text"},
     )
 
@@ -561,7 +572,7 @@ async def test_pocket_tts_cpp_cancellation_during_adapter_acquisition_cleans_tra
         voice="alloy",
         response_format="wav",
         stream=False,
-        voice_reference="UklGRgMDAwMDAwM=",
+        voice_reference=_make_wav_base64(b"\x04\x05" * 8),
         extra_params={"reference_text": "direct reference text"},
     )
 
@@ -631,7 +642,7 @@ async def test_pocket_tts_cpp_materialization_failure_surfaces_explicit_error(tm
         voice="alloy",
         response_format="wav",
         stream=False,
-        voice_reference="UklGRgMDAwMDAwM=",
+        voice_reference=_make_wav_base64(b"\x06\x07" * 8),
         extra_params={"reference_text": "direct reference text"},
     )
 
@@ -643,3 +654,57 @@ async def test_pocket_tts_cpp_materialization_failure_surfaces_explicit_error(tm
     assert exc_info.value.error_code == "pocket_tts_cpp_voice_materialization_failed"
     assert "ffmpeg missing" in exc_info.value.details["reason"]
     service._get_adapter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prepare_generate_speech_request_logs_noncritical_touch_model_failure(monkeypatch):
+    service = TTSServiceV2()
+    warnings: list[str] = []
+
+    class _Adapter:
+        provider_name = "pocket_tts_cpp"
+        provider_key = "pocket_tts_cpp"
+
+    class _ResourceManager:
+        def touch_model(self, provider_key, model_name):
+            raise RuntimeError(f"cache miss for {provider_key}:{model_name}")
+
+    request = OpenAISpeechRequest(
+        model="pocket_tts_cpp",
+        input="hello",
+        voice="custom:voice-1",
+        response_format="wav",
+        stream=False,
+    )
+    tts_request = TTSRequest(
+        text="hello",
+        voice="custom:voice-1",
+        format=AudioFormat.WAV,
+        extra_params={},
+    )
+
+    monkeypatch.setattr(service, "_apply_custom_voice_reference", AsyncMock(), raising=True)
+    monkeypatch.setattr(service, "_get_adapter", AsyncMock(return_value=_Adapter()), raising=True)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.tts_service_v2.get_resource_manager",
+        AsyncMock(return_value=_ResourceManager()),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.tts_service_v2.logger.warning",
+        lambda message, *args: warnings.append(message.format(*args)),
+        raising=True,
+    )
+
+    await service._prepare_generate_speech_request(
+        request=request,
+        tts_request=tts_request,
+        provider="pocket_tts_cpp",
+        provider_hint="pocket_tts_cpp",
+        provider_overrides=None,
+        fallback=False,
+        user_id=1,
+    )
+
+    assert warnings
+    assert "touch_model" in warnings[0]

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -8,7 +8,7 @@ import pytest
 
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
-from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSGenerationError, TTSValidationError
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 from tldw_Server_API.app.core.TTS.voice_manager import VoiceReferenceMetadata
 
@@ -283,3 +283,75 @@ async def test_pocket_tts_cpp_cancellation_during_adapter_acquisition_cleans_tra
 
     runtime_dir = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
     assert list(runtime_dir.glob("ref_*.wav")) == []
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_materialization_failure_surfaces_explicit_error(tmp_path, monkeypatch):
+    service = TTSServiceV2()
+
+    class _DirectReferenceVoiceManager:
+        def get_user_voices_path(self, user_id: int) -> Path:
+            assert user_id == 1
+            root = tmp_path / "voices"
+            root.mkdir(parents=True, exist_ok=True)
+            return root
+
+        async def load_reference_metadata(self, user_id: int, voice_id: str):
+            return None
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _DirectReferenceVoiceManager(),
+        raising=True,
+    )
+
+    class _FactoryWithPocketRuntimeConfig:
+        registry = type(
+            "_Registry",
+            (),
+            {
+                "config": {
+                    "providers": {
+                        "pocket_tts_cpp": {
+                            "persist_direct_voice_references": False,
+                            "cache_ttl_hours": None,
+                            "cache_max_bytes_per_user": None,
+                        }
+                    }
+                }
+            },
+        )()
+
+        def get_provider_for_model(self, _model):
+            return "pocket_tts_cpp"
+
+    service._ensure_factory = AsyncMock(return_value=_FactoryWithPocketRuntimeConfig())
+    service._get_adapter = AsyncMock()
+
+    async def _raise_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        raise RuntimeError("ffmpeg missing")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime.AudioConverter.convert_to_wav",
+        _raise_convert,
+        raising=True,
+    )
+
+    request = OpenAISpeechRequest(
+        model="pocket_tts_cpp",
+        input="hello",
+        voice="alloy",
+        response_format="wav",
+        stream=False,
+        voice_reference="UklGRgMDAwMDAwM=",
+        extra_params={"reference_text": "direct reference text"},
+    )
+
+    with pytest.raises(TTSGenerationError) as exc_info:
+        async for _ in service.generate_speech(request, user_id=1, fallback=False):
+            pass
+
+    assert exc_info.value.provider == "pocket_tts_cpp"
+    assert exc_info.value.error_code == "pocket_tts_cpp_voice_materialization_failed"
+    assert "ffmpeg missing" in exc_info.value.details["reason"]
+    service._get_adapter.assert_not_called()

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -7,8 +7,13 @@ from unittest.mock import AsyncMock
 import pytest
 
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
-from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
-from tldw_Server_API.app.core.TTS.tts_exceptions import TTSGenerationError, TTSValidationError
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest, TTSResponse
+from tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime import (
+    PROVIDER_MANAGED_VOICE_LEASE_DIRNAME,
+    PROVIDER_MANAGED_VOICE_TOKEN_KEY,
+    resolve_provider_managed_voice_path,
+)
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSTimeoutError, TTSGenerationError, TTSValidationError
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 from tldw_Server_API.app.core.TTS.voice_manager import VoiceReferenceMetadata
 
@@ -56,10 +61,25 @@ class _ServiceVoiceManager:
 async def test_pocket_tts_cpp_service_injects_stable_path_for_custom_voice(tmp_path, monkeypatch):
     service = TTSServiceV2()
     manager = _ServiceVoiceManager(tmp_path / "voices")
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+
+    converted_wav = _make_wav_bytes(b"\x00\x01" * 8)
 
     monkeypatch.setattr(
         "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
         lambda: manager,
+        raising=True,
+    )
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        assert input_path.read_bytes() == b"RIFF" + b"\x00" * 32
+        output_path.write_bytes(converted_wav)
+        return True
+
+    monkeypatch.setattr(
+        runtime_module.AudioConverter,
+        "convert_to_wav",
+        _fake_convert,
         raising=True,
     )
 
@@ -75,8 +95,10 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_custom_voice(tmp_p
     expected = tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-1.wav"
     assert request.voice_reference == b"RIFF" + b"\x00" * 32
     assert request.extra_params["pocket_tts_cpp_voice_path"] == str(expected)
+    assert request.extra_params[PROVIDER_MANAGED_VOICE_TOKEN_KEY]
     assert request.extra_params["pocket_tts_cpp_reference_text"] == "stored reference text"
     assert expected.exists()
+    assert expected.read_bytes() == converted_wav
 
 
 @pytest.mark.asyncio
@@ -123,8 +145,234 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_direct_voice_refer
     assert voice_path.parent == tmp_path / "voices" / "providers" / "pocket_tts_cpp"
     assert voice_path.name.startswith("ref_")
     assert voice_path.suffix == ".wav"
+    assert request.extra_params[PROVIDER_MANAGED_VOICE_TOKEN_KEY]
     assert request.extra_params["pocket_tts_cpp_reference_text"] == "direct reference text"
     assert voice_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_service_cleans_trust_token_after_generation(tmp_path):
+    service = TTSServiceV2()
+    seen_tokens: list[str] = []
+    from tldw_Server_API.app.core.TTS.adapters import pocket_tts_cpp_runtime as runtime_module
+
+    converted_wav = _make_wav_bytes(b"\x00\x01" * 8)
+
+    class _FakeVoiceManager:
+        def get_user_voices_path(self, user_id: int) -> Path:
+            assert user_id == 1
+            root = tmp_path / "voices"
+            root.mkdir(parents=True, exist_ok=True)
+            return root
+
+        async def load_voice_reference_audio(self, user_id: int, voice_id: str) -> bytes:
+            assert user_id == 1
+            assert voice_id == "voice-1"
+            return b"RIFF" + b"\x00" * 32
+
+        async def load_reference_metadata(self, user_id: int, voice_id: str):
+            return None
+
+    class _FakeAdapter:
+        provider_name = "pocket_tts_cpp"
+        provider_key = "pocket_tts_cpp"
+
+        async def generate(self, request):
+            token = request.extra_params[PROVIDER_MANAGED_VOICE_TOKEN_KEY]
+            seen_tokens.append(token)
+            voice_path = Path(request.extra_params["pocket_tts_cpp_voice_path"])
+            assert resolve_provider_managed_voice_path(token, voice_path) == voice_path.resolve()
+            return TTSResponse(audio_data=b"ok", format=request.format, sample_rate=24000)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _FakeVoiceManager(),
+        raising=True,
+    )
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(converted_wav)
+        return True
+
+    monkeypatch.setattr(
+        runtime_module.AudioConverter,
+        "convert_to_wav",
+        _fake_convert,
+        raising=True,
+    )
+
+    class _Factory:
+        def get_provider_for_model(self, _model):
+            return "pocket_tts_cpp"
+
+    service._ensure_factory = AsyncMock(return_value=_Factory())
+    service._get_adapter = AsyncMock(return_value=_FakeAdapter())
+
+    request = OpenAISpeechRequest(
+        model="pocket_tts_cpp",
+        input="hello",
+        voice="custom:voice-1",
+        response_format="wav",
+        stream=False,
+    )
+
+    try:
+        chunks = []
+        async for chunk in service.generate_speech(request, user_id=1, fallback=False):
+            chunks.append(chunk)
+    finally:
+        monkeypatch.undo()
+
+    assert b"".join(chunks) == b"ok"
+    assert seen_tokens
+    with pytest.raises(ValueError):
+        resolve_provider_managed_voice_path(
+            seen_tokens[0],
+            Path(tmp_path / "voices" / "providers" / "pocket_tts_cpp" / "custom_voice-1.wav"),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "voice,voice_reference,expected_fragment",
+    [
+        ("custom:voice-1", None, "custom_voice-1.wav"),
+        ("alloy", "UklGRgMDAwMDAwM=", "ref_"),
+    ],
+)
+async def test_pocket_tts_cpp_fallback_materializes_voice_for_fallback_adapter(
+    tmp_path,
+    monkeypatch,
+    voice,
+    voice_reference,
+    expected_fragment,
+):
+    service = TTSServiceV2()
+    seen: dict[str, str] = {}
+    converted_wav = _make_wav_bytes(b"\x01\x02" * 8)
+
+    class _FailingAdapter:
+        provider_name = "openai"
+        provider_key = "openai"
+
+        async def generate(self, request):
+            raise TTSTimeoutError("primary provider failed", provider="openai")
+
+    class _FallbackFactory:
+        def get_provider_for_model(self, _model):
+            return "openai"
+
+    class _FallbackAdapter:
+        provider_name = "pocket_tts_cpp"
+        provider_key = "pocket_tts_cpp"
+
+        async def generate(self, request):
+            token = request.extra_params[PROVIDER_MANAGED_VOICE_TOKEN_KEY]
+            voice_path = Path(request.extra_params["pocket_tts_cpp_voice_path"])
+            seen["token"] = token
+            seen["voice_path"] = str(voice_path)
+            assert resolve_provider_managed_voice_path(token, voice_path) == voice_path.resolve()
+            return TTSResponse(audio_data=b"fallback", format=request.format, sample_rate=24000)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _ServiceVoiceManager(tmp_path / "voices"),
+        raising=True,
+    )
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(converted_wav)
+        return True
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime.AudioConverter.convert_to_wav",
+        _fake_convert,
+        raising=True,
+    )
+
+    service._ensure_factory = AsyncMock(return_value=_FallbackFactory())
+    service._get_adapter = AsyncMock(return_value=_FailingAdapter())
+    service._get_fallback_adapter = AsyncMock(return_value=_FallbackAdapter())
+
+    request = OpenAISpeechRequest(
+        model="openai",
+        input="hello",
+        voice=voice,
+        response_format="wav",
+        stream=False,
+        voice_reference=voice_reference,
+        extra_params={"reference_text": "fallback reference text"},
+    )
+
+    chunks = []
+    async for chunk in service.generate_speech(request, user_id=1, fallback=True):
+        chunks.append(chunk)
+
+    assert b"".join(chunks) == b"fallback"
+    assert "/voices/providers/pocket_tts_cpp/" in seen["voice_path"]
+    assert expected_fragment in seen["voice_path"]
+    with pytest.raises(ValueError):
+        resolve_provider_managed_voice_path(seen["token"], Path(seen["voice_path"]))
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_fallback_validation_failure_revokes_lease_but_keeps_stable_materialized_voice(
+    tmp_path,
+    monkeypatch,
+):
+    service = TTSServiceV2()
+    seen: dict[str, str] = {}
+    converted_wav = _make_wav_bytes(b"\x05\x06" * 8)
+
+    class _PocketAdapter:
+        provider_name = "pocket_tts_cpp"
+        provider_key = "pocket_tts_cpp"
+
+        async def generate(self, request):  # noqa: ARG002
+            raise AssertionError("adapter.generate should not be reached on validation failure")
+
+    async def _fake_convert(input_path: Path, output_path: Path, sample_rate: int, channels: int, bit_depth: int) -> bool:
+        output_path.write_bytes(converted_wav)
+        return True
+
+    def _raise_validation(request, provider_key):  # noqa: ARG001
+        extras = request.extra_params if isinstance(request.extra_params, dict) else {}
+        seen["token"] = extras.get(PROVIDER_MANAGED_VOICE_TOKEN_KEY)
+        seen["voice_path"] = extras.get("pocket_tts_cpp_voice_path")
+        raise TTSValidationError("synthetic validation failure", provider="pocket_tts_cpp")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _ServiceVoiceManager(tmp_path / "voices"),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.adapters.pocket_tts_cpp_runtime.AudioConverter.convert_to_wav",
+        _fake_convert,
+        raising=True,
+    )
+    monkeypatch.setattr(service, "_maybe_sanitize_request", _raise_validation, raising=True)
+
+    request = TTSRequest(
+        text="hello",
+        voice="custom:voice-1",
+        format=AudioFormat.WAV,
+        stream=False,
+        extra_params={"reference_text": "fallback reference text"},
+    )
+
+    with pytest.raises(TTSValidationError):
+        async for _ in service._generate_with_adapter(_PocketAdapter(), request, user_id=1):
+            pass
+
+    runtime_dir = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
+    assert seen["token"]
+    assert seen["voice_path"].endswith("custom_voice-1.wav")
+    assert (runtime_dir / "custom_voice-1.wav").exists()
+    assert not list((runtime_dir / PROVIDER_MANAGED_VOICE_LEASE_DIRNAME).glob("*.json"))
+    with pytest.raises(ValueError):
+        resolve_provider_managed_voice_path(seen["token"], Path(seen["voice_path"]))
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -151,6 +151,46 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_direct_voice_refer
 
 
 @pytest.mark.asyncio
+async def test_pocket_tts_cpp_invalid_direct_voice_reference_is_rejected_before_materialization(monkeypatch):
+    service = TTSServiceV2()
+    request = OpenAISpeechRequest(
+        model="pocket_tts_cpp",
+        input="hello",
+        voice="alloy",
+        response_format="wav",
+        stream=False,
+    )
+    tts_request = TTSRequest(
+        text="hello",
+        voice="alloy",
+        format=AudioFormat.WAV,
+        voice_reference=b"not-audio",
+        extra_params={},
+    )
+    materialization_calls = 0
+
+    async def _unexpected_materialization(*args, **kwargs):
+        nonlocal materialization_calls
+        materialization_calls += 1
+        raise AssertionError("invalid voice_reference should be rejected before materialization")
+
+    monkeypatch.setattr(service, "_apply_custom_voice_reference", _unexpected_materialization, raising=True)
+
+    with pytest.raises(TTSValidationError, match="Voice reference file is not a valid audio format"):
+        await service._prepare_generate_speech_request(
+            request=request,
+            tts_request=tts_request,
+            provider="pocket_tts_cpp",
+            provider_hint="pocket_tts_cpp",
+            provider_overrides=None,
+            fallback=False,
+            user_id=1,
+        )
+
+    assert materialization_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_pocket_tts_cpp_service_cleans_trust_token_after_generation(tmp_path):
     service = TTSServiceV2()
     seen_tokens: list[str] = []

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -167,3 +168,70 @@ async def test_pocket_tts_cpp_validation_failure_cleans_transient_direct_referen
     runtime_dir = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
     assert list(runtime_dir.glob("ref_*.wav")) == []
     service._get_adapter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_cancellation_during_adapter_acquisition_cleans_transient_direct_reference(
+    tmp_path, monkeypatch
+):
+    service = TTSServiceV2()
+
+    class _DirectReferenceVoiceManager:
+        def get_user_voices_path(self, user_id: int) -> Path:
+            assert user_id == 1
+            root = tmp_path / "voices"
+            root.mkdir(parents=True, exist_ok=True)
+            return root
+
+        async def load_reference_metadata(self, user_id: int, voice_id: str):
+            return None
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _DirectReferenceVoiceManager(),
+        raising=True,
+    )
+
+    class _FactoryWithPocketRuntimeConfig:
+        registry = type(
+            "_Registry",
+            (),
+            {
+                "config": {
+                    "providers": {
+                        "pocket_tts_cpp": {
+                            "persist_direct_voice_references": False,
+                            "cache_ttl_hours": None,
+                            "cache_max_bytes_per_user": None,
+                        }
+                    }
+                }
+            },
+        )()
+
+        def get_provider_for_model(self, _model):
+            return "pocket_tts_cpp"
+
+    service._ensure_factory = AsyncMock(return_value=_FactoryWithPocketRuntimeConfig())
+
+    async def _cancel_adapter(*args, **kwargs):
+        raise asyncio.CancelledError()
+
+    service._get_adapter = AsyncMock(side_effect=_cancel_adapter)
+
+    request = OpenAISpeechRequest(
+        model="pocket_tts_cpp",
+        input="hello",
+        voice="alloy",
+        response_format="wav",
+        stream=False,
+        voice_reference="UklGRgMDAwMDAwM=",
+        extra_params={"reference_text": "direct reference text"},
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in service.generate_speech(request, user_id=1, fallback=False):
+            pass
+
+    runtime_dir = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
+    assert list(runtime_dir.glob("ref_*.wav")) == []

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py
@@ -1,8 +1,11 @@
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
+from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 from tldw_Server_API.app.core.TTS.voice_manager import VoiceReferenceMetadata
 
@@ -93,3 +96,74 @@ async def test_pocket_tts_cpp_service_injects_stable_path_for_direct_voice_refer
     assert voice_path.suffix == ".wav"
     assert request.extra_params["pocket_tts_cpp_reference_text"] == "direct reference text"
     assert voice_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_pocket_tts_cpp_validation_failure_cleans_transient_direct_reference(tmp_path, monkeypatch):
+    service = TTSServiceV2()
+
+    class _DirectReferenceVoiceManager:
+        def get_user_voices_path(self, user_id: int) -> Path:
+            assert user_id == 1
+            root = tmp_path / "voices"
+            root.mkdir(parents=True, exist_ok=True)
+            return root
+
+        async def load_reference_metadata(self, user_id: int, voice_id: str):
+            return None
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.voice_manager.get_voice_manager",
+        lambda: _DirectReferenceVoiceManager(),
+        raising=True,
+    )
+
+    class _FactoryWithPocketRuntimeConfig:
+        registry = type(
+            "_Registry",
+            (),
+            {
+                "config": {
+                    "providers": {
+                        "pocket_tts_cpp": {
+                            "persist_direct_voice_references": False,
+                            "cache_ttl_hours": None,
+                            "cache_max_bytes_per_user": None,
+                        }
+                    }
+                }
+            },
+        )()
+
+        def get_provider_for_model(self, _model):
+            return "pocket_tts_cpp"
+
+    service._ensure_factory = AsyncMock(return_value=_FactoryWithPocketRuntimeConfig())
+    service._get_adapter = AsyncMock()
+
+    def _raise_validation(*args, **kwargs):
+        raise TTSValidationError("synthetic validation failure", provider="pocket_tts_cpp")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.TTS.tts_service_v2.validate_tts_request",
+        _raise_validation,
+        raising=True,
+    )
+
+    request = OpenAISpeechRequest(
+        model="pocket_tts_cpp",
+        input="hello",
+        voice="alloy",
+        response_format="wav",
+        stream=False,
+        voice_reference="UklGRgMDAwMDAwM=",
+        extra_params={"reference_text": "direct reference text"},
+    )
+
+    with pytest.raises(TTSValidationError):
+        async for _ in service.generate_speech(request, user_id=1, fallback=False):
+            pass
+
+    runtime_dir = tmp_path / "voices" / "providers" / "pocket_tts_cpp"
+    assert list(runtime_dir.glob("ref_*.wav")) == []
+    service._get_adapter.assert_not_called()

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tokenizer_service_qwen3.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tokenizer_service_qwen3.py
@@ -30,8 +30,8 @@ def _install_fake_tokenizer_module(monkeypatch):
     return FakeTokenizer
 
 
-def test_serialize_audio_output_wav_wraps_raw_pcm_bytes():
-    pcm = np.array([0, 1000, -1000, 0], dtype=np.int16).tobytes()
+def test_serialize_audio_output_wav_wraps_numpy_audio():
+    pcm = np.array([0, 1000, -1000, 0], dtype=np.int16)
     wav_bytes = tokenizer_service._serialize_audio_output(pcm, 24000, "wav")
     assert wav_bytes[:4] == b"RIFF"
     decoded, sample_rate = sf.read(io.BytesIO(wav_bytes), dtype="int16")
@@ -47,30 +47,34 @@ def test_serialize_audio_output_wav_passthrough():
     assert output == wav_bytes
 
 
-def test_load_qwen3_tokenizer_patches_chunked_decode(monkeypatch):
+def test_load_qwen3_tokenizer_instantiates_fake_backend(monkeypatch):
     tokenizer_cls = _install_fake_tokenizer_module(monkeypatch)
-    original_fn = tokenizer_cls.chunked_decode
 
     tokenizer = tokenizer_service._load_qwen3_tokenizer(
         "Qwen/Qwen3-TTS-Tokenizer-12Hz/",
         allow_download=False,
-        patch_chunked_decode=True,
     )
+    assert isinstance(tokenizer, tokenizer_cls)
+    assert tokenizer.model == "Qwen/Qwen3-TTS-Tokenizer-12Hz/"
+
+
+def test_load_qwen3_tokenizer_uses_from_pretrained_when_available(monkeypatch):
+    module = types.ModuleType("qwen_tts")
+
+    class FakeTokenizer:
+        @classmethod
+        def from_pretrained(cls, model_id, local_files_only=True):
+            instance = cls()
+            instance.model = model_id
+            instance.local_files_only = local_files_only
+            return instance
+
+    module.Qwen3TTSTokenizer = FakeTokenizer
+    monkeypatch.setitem(sys.modules, "qwen_tts", module)
+
+    tokenizer = tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=False)
     assert tokenizer.model == "Qwen/Qwen3-TTS-Tokenizer-12Hz"
-    assert tokenizer.__class__.chunked_decode is not original_fn
-
-
-def test_load_qwen3_tokenizer_patch_toggle_off(monkeypatch):
-    tokenizer_cls = _install_fake_tokenizer_module(monkeypatch)
-    original_fn = tokenizer_cls.chunked_decode
-
-    tokenizer = tokenizer_service._load_qwen3_tokenizer(
-        "Qwen/Qwen3-TTS-Tokenizer-12Hz/",
-        allow_download=False,
-        patch_chunked_decode=False,
-    )
-    assert tokenizer.model == "Qwen/Qwen3-TTS-Tokenizer-12Hz"
-    assert tokenizer.__class__.chunked_decode is original_fn
+    assert tokenizer.local_files_only is True
 
 
 def test_load_qwen3_tokenizer_maps_model_path_error(monkeypatch):
@@ -84,9 +88,8 @@ def test_load_qwen3_tokenizer_maps_model_path_error(monkeypatch):
     module.Qwen3TTSTokenizer = BadTokenizer
     monkeypatch.setitem(sys.modules, "qwen_tts", module)
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(RuntimeError, match="Repo id must be in the form 'repo_name'"):
         tokenizer_service._load_qwen3_tokenizer("Qwen/Bad-Tokenizer/", allow_download=False)
-    assert getattr(exc_info.value, "status_code", None) == 400
 
 
 def test_load_qwen3_tokenizer_maps_rope_compat_error(monkeypatch):
@@ -100,6 +103,5 @@ def test_load_qwen3_tokenizer_maps_rope_compat_error(monkeypatch):
     module.Qwen3TTSTokenizer = BadTokenizer
     monkeypatch.setitem(sys.modules, "qwen_tts", module)
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(RuntimeError, match="KeyError: 'default' while setting rope"):
         tokenizer_service._load_qwen3_tokenizer("Qwen/Tokenizer", allow_download=False)
-    assert getattr(exc_info.value, "status_code", None) == 500

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tokenizer_service_qwen3.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tokenizer_service_qwen3.py
@@ -63,7 +63,7 @@ def test_load_qwen3_tokenizer_uses_from_pretrained_when_available(monkeypatch):
 
     class FakeTokenizer:
         @classmethod
-        def from_pretrained(cls, model_id, local_files_only=True):
+        def from_pretrained(cls, model_id, local_files_only=False):
             instance = cls()
             instance.model = model_id
             instance.local_files_only = local_files_only
@@ -75,6 +75,10 @@ def test_load_qwen3_tokenizer_uses_from_pretrained_when_available(monkeypatch):
     tokenizer = tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=False)
     assert tokenizer.model == "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     assert tokenizer.local_files_only is True
+
+    tokenizer = tokenizer_service._load_qwen3_tokenizer("Qwen/Qwen3-TTS-Tokenizer-12Hz", allow_download=True)
+    assert tokenizer.model == "Qwen/Qwen3-TTS-Tokenizer-12Hz"
+    assert tokenizer.local_files_only is False
 
 
 def test_load_qwen3_tokenizer_maps_model_path_error(monkeypatch):

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py
@@ -445,6 +445,7 @@ class TestMetricsCollection:
             *,
             metadata_only: bool = False,
             metadata_target=None,
+            user_id=None,
         ):
             yield b"fallback-audio"
 
@@ -532,6 +533,7 @@ class TestMetricsCollection:
             *,
             metadata_only: bool = False,
             metadata_target=None,
+            user_id=None,
         ):
             service._record_fallback_event(
                 from_provider=from_provider or "unknown",

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_pocket_tts_cpp.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_pocket_tts_cpp.py
@@ -1,0 +1,23 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
+from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_accepts_custom_voice_without_raw_reference():
+    request = TTSRequest(text="hello", voice="custom:voice-1", format=AudioFormat.MP3)
+
+    validate_tts_request(request, provider="pocket_tts_cpp")
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_rejects_requests_without_reference_or_custom_voice():
+    request = TTSRequest(text="hello", voice="narrator", format=AudioFormat.MP3)
+
+    with pytest.raises(TTSValidationError) as exc:
+        validate_tts_request(request, provider="pocket_tts_cpp")
+
+    message = str(exc.value).lower()
+    assert "voice_reference" in message or "custom" in message

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_pocket_tts_cpp.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_pocket_tts_cpp.py
@@ -1,8 +1,20 @@
 import pytest
+import wave
+from io import BytesIO
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
 from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
+
+
+def _make_wav_bytes(*, seconds: int, sample_rate: int = 8000) -> bytes:
+    buffer = BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\x00\x00" * (seconds * sample_rate))
+    return buffer.getvalue()
 
 
 @pytest.mark.unit
@@ -21,3 +33,18 @@ def test_pocket_tts_cpp_rejects_requests_without_reference_or_custom_voice():
 
     message = str(exc.value).lower()
     assert "voice_reference" in message or "custom" in message
+
+
+@pytest.mark.unit
+def test_pocket_tts_cpp_rejects_voice_reference_longer_than_provider_limit():
+    request = TTSRequest(
+        text="hello",
+        voice="alloy",
+        format=AudioFormat.MP3,
+        voice_reference=_make_wav_bytes(seconds=61),
+    )
+
+    with pytest.raises(TTSValidationError) as exc:
+        validate_tts_request(request, provider="pocket_tts_cpp")
+
+    assert "too long" in str(exc.value).lower() or "max" in str(exc.value).lower()


### PR DESCRIPTION
## Summary
- add a separate `pocket_tts_cpp` provider with runtime helper, deterministic provider-managed voice materialization, installer, config wiring, and docs
- preserve the existing `pocket_tts` provider while fixing the legacy torch-import cleanup abort in the shared TTS resource manager
- address review findings by validating direct `voice_reference` inputs before materialization, making streaming capability selection honest for v1, and teaching the installer to run/install/export from an installed layout

## Testing
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/TTS_NEW/unit tldw_Server_API/tests/TTS_NEW/integration/test_audio_auth.py tldw_Server_API/tests/TTS_NEW/integration/test_custom_voice_resolution.py tldw_Server_API/tests/TTS_NEW/integration/test_tokenizer_endpoints.py tldw_Server_API/tests/TTS_NEW/integration/test_transcription_auth.py tldw_Server_API/tests/TTS_NEW/integration/test_tts_endpoints.py tldw_Server_API/tests/TTS_NEW/integration/test_tts_history_artifact_purge.py tldw_Server_API/tests/TTS_NEW/integration/test_tts_history_perf_sanity.py tldw_Server_API/tests/TTS_NEW/integration/test_voice_encode_endpoint.py tldw_Server_API/tests/TTS_NEW/integration/test_voice_routes_rate_limit.py`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/TTS_NEW/unit/test_tts_service.py tldw_Server_API/tests/TTS_NEW/integration/test_custom_voice_resolution.py`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_registry.py tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_pocket_tts_cpp.py tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_runtime.py tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_installer.py tldw_Server_API/tests/TTS_NEW/integration/test_custom_voice_resolution.py tldw_Server_API/tests/TTS_NEW/integration/test_tts_endpoints.py -k pocket_tts_cpp tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -s B101 tldw_Server_API/app/core/TTS/tts_service_v2.py tldw_Server_API/app/core/TTS/adapters/pocket_tts_cpp_adapter.py Helper_Scripts/TTS_Installers/install_tts_pocket_tts_cpp.py tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_service.py tldw_Server_API/tests/TTS/adapters/test_pocket_tts_cpp_adapter_mock.py tldw_Server_API/tests/TTS_NEW/unit/test_pocket_tts_cpp_installer.py`