### PR TITLE
feat(ui): add MCP Hub navigation parity

### DIFF
--- a/.github/workflows/frontend-e2e-tiers.yml
+++ b/.github/workflows/frontend-e2e-tiers.yml
@@ -56,6 +56,8 @@ jobs:
       TLDW_WEB_URL: http://localhost:8080
       TLDW_SERVER_URL: http://127.0.0.1:8000
       TLDW_API_KEY: test-api-key-for-e2e-testing-12345
+      NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: advanced
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:8000
       PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -146,6 +148,8 @@ jobs:
       TLDW_WEB_URL: http://localhost:8080
       TLDW_SERVER_URL: http://127.0.0.1:8000
       TLDW_API_KEY: test-api-key-for-e2e-testing-12345
+      NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: advanced
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:8000
       PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -228,6 +232,8 @@ jobs:
       TLDW_WEB_URL: http://localhost:8080
       TLDW_SERVER_URL: http://127.0.0.1:8000
       TLDW_API_KEY: test-api-key-for-e2e-testing-12345
+      NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: advanced
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:8000
       PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/frontend-ux-gates.yml
+++ b/.github/workflows/frontend-ux-gates.yml
@@ -34,6 +34,8 @@ jobs:
       TLDW_API_KEY: smoke-ci-key-12345
       TLDW_WEB_URL: http://localhost:8080
       TLDW_WEB_AUTOSTART: 'true'
+      NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: advanced
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:8000
       TLDW_WEB_CMD: 'env NEXT_DISABLE_MEM_OVERRIDE=1 NODE_OPTIONS=--max-old-space-size=5120 bun run dev -- --webpack -p 8080'
       TLDW_ONBOARDING_EVIDENCE_TAG: ci-${{ github.run_id }}-${{ github.run_attempt }}
 
@@ -140,6 +142,8 @@ jobs:
       TLDW_API_KEY: smoke-ci-key-12345
       TLDW_WEB_URL: http://localhost:8080
       TLDW_WEB_AUTOSTART: 'true'
+      NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: advanced
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:8000
       TLDW_WEB_CMD: 'env NODE_OPTIONS=--max-old-space-size=4096 bun run start -- -p 8080'
       TLDW_SMOKE_HARD_GATE: '1'
 

--- a/apps/bun.lock
+++ b/apps/bun.lock
@@ -144,7 +144,7 @@
         "cytoscape-dagre": "^2.0.0",
         "dayjs": "^1.0.0",
         "dexie": "^4.0.0",
-        "dexie-react-hooks": ">=1.0.0",
+        "dexie-react-hooks": ">=1.0.0 <2.0.0",
         "dompurify": "^3.0.0",
         "epubjs": "^0.3.93",
         "gpt-tokenizer": "^3.4.0",
@@ -154,11 +154,11 @@
         "jszip": "^3.10.1",
         "katex": "^0.16.0",
         "lucide-react": "^0.500.0",
-        "marked": ">=15.0.0",
+        "marked": ">=15.0.0 <16.0.0",
         "mermaid": "^10.0.0",
         "pdfjs-dist": "^4.0.0",
         "prism-react-renderer": "^2.0.0",
-        "property-information": ">=6.0.0",
+        "property-information": ">=6.0.0 <7.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-i18next": "^16.0.0",
@@ -167,7 +167,7 @@
         "react-markdown": "^10.1.0",
         "react-pdf": "^9.0.0",
         "react-router-dom": "^6.0.0",
-        "react-toastify": ">=10.0.0",
+        "react-toastify": ">=10.0.0 <11.0.0",
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
@@ -175,7 +175,7 @@
         "wxt": "^0.20.0",
         "xlsx": "^0.18.0",
         "xterm": "^5.3.0",
-        "zustand": ">=4.0.0",
+        "zustand": ">=4.0.0 <5.0.0",
       },
     },
     "packages/voice-assistant-sdk": {
@@ -1703,7 +1703,7 @@
 
     "dexie": ["dexie@4.2.1", "", {}, "sha512-Ckej0NS6jxQ4Po3OrSQBFddayRhTCic2DoCAG5zacOfOVB9P2Q5Xc5uL/nVa7ZVs+HdMnvUPzLFCB/JwpB6Csg=="],
 
-    "dexie-react-hooks": ["dexie-react-hooks@4.2.0", "", { "peerDependencies": { "@types/react": ">=16", "dexie": ">=4.2.0-alpha.1 <5.0.0", "react": ">=16" } }, "sha512-u7KqTX9JpBQK8+tEyA9X0yMGXlSCsbm5AU64N6gjvGk/IutYDpLBInMYEAEC83s3qhIvryFS+W+sqLZUBEvePQ=="],
+    "dexie-react-hooks": ["dexie-react-hooks@1.1.7", "", { "peerDependencies": { "@types/react": ">=16", "dexie": "^3.2 || ^4.0.1-alpha", "react": ">=16" } }, "sha512-Lwv5W0Hk+uOW3kGnsU9GZoR1er1B7WQ5DSdonoNG+focTNeJbHW6vi6nBoX534VKI3/uwHebYzSw1fwY6a7mTw=="],
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
@@ -2327,7 +2327,7 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
-    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "marks-pane": ["marks-pane@1.0.9", "", {}, "sha512-Ahs4oeG90tbdPWwAJkAAoHg2lRR8lAs9mZXETNPO9hYg3AkjUJBKi1NQ4aaIQZVGrig7c/3NUV1jANl8rFTeMg=="],
 
@@ -2679,7 +2679,7 @@
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
-    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+    "property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
@@ -2753,7 +2753,7 @@
 
     "react-syntax-highlighter": ["react-syntax-highlighter@16.1.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "highlight.js": "^10.4.1", "highlightjs-vue": "^1.0.0", "lowlight": "^1.17.0", "prismjs": "^1.30.0", "refractor": "^5.0.0" }, "peerDependencies": { "react": ">= 0.14.0" } }, "sha512-E40/hBiP5rCNwkeBN1vRP+xow1X0pndinO+z3h7HLsHyjztbyjfzNWNKuAsJj+7DLam9iT4AaaOZnueCU+Nplg=="],
 
-    "react-toastify": ["react-toastify@11.0.5", "", { "dependencies": { "clsx": "^2.1.1" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA=="],
+    "react-toastify": ["react-toastify@10.0.6", "", { "dependencies": { "clsx": "^2.1.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
@@ -3279,7 +3279,7 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
-    "zustand": ["zustand@5.0.10", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg=="],
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -3338,8 +3338,6 @@
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vue/devtools-kit/perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
-
-    "@xyflow/react/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -3432,6 +3430,14 @@
     "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "hast-util-from-html-isomorphic/hast-util-from-dom": ["hast-util-from-dom@5.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hastscript": "^9.0.0", "web-namespaces": "^2.0.0" } }, "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q=="],
+
+    "hast-util-from-parse5/property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "hast-util-to-html/property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "hast-util-to-jsx-runtime/property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "hastscript/property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "html-encoding-sniffer/@exodus/bytes": ["@exodus/bytes@1.9.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-lagqsvnk09NKogQaN/XrtlWeUF8SRhT12odMvbTIIaVObqzwAogL6jhR4DAp0gPuKoM1AOVrKUshJpRdpMFrww=="],
 
@@ -3563,33 +3569,33 @@
 
     "tldw-assistant/@types/react-dom": ["@types/react-dom@18.2.18", "", { "dependencies": { "@types/react": "*" } }, "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw=="],
 
-    "tldw-assistant/dexie-react-hooks": ["dexie-react-hooks@1.1.7", "", { "peerDependencies": { "@types/react": ">=16", "dexie": "^3.2 || ^4.0.1-alpha", "react": ">=16" } }, "sha512-Lwv5W0Hk+uOW3kGnsU9GZoR1er1B7WQ5DSdonoNG+focTNeJbHW6vi6nBoX534VKI3/uwHebYzSw1fwY6a7mTw=="],
-
     "tldw-assistant/lucide-react": ["lucide-react@0.561.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Y59gMY38tl4/i0qewcqohPdEbieBy7SovpBL9IFebhc2mDd8x4PZSOsiFRkpPcOq6bj1r/mjH/Rk73gSlIJP2A=="],
-
-    "tldw-assistant/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
-
-    "tldw-assistant/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
 
     "tldw-assistant/react": ["react@18.2.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="],
 
     "tldw-assistant/react-dom": ["react-dom@18.2.0", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g=="],
 
-    "tldw-assistant/react-toastify": ["react-toastify@10.0.6", "", { "dependencies": { "clsx": "^2.1.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A=="],
-
-    "tldw-assistant/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
-
     "tldw-frontend/@ant-design/icons": ["@ant-design/icons@5.6.1", "", { "dependencies": { "@ant-design/colors": "^7.0.0", "@ant-design/icons-svg": "^4.4.0", "@babel/runtime": "^7.24.8", "classnames": "^2.2.6", "rc-util": "^5.31.1" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg=="],
 
     "tldw-frontend/d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
 
+    "tldw-frontend/dexie-react-hooks": ["dexie-react-hooks@4.2.0", "", { "peerDependencies": { "@types/react": ">=16", "dexie": ">=4.2.0-alpha.1 <5.0.0", "react": ">=16" } }, "sha512-u7KqTX9JpBQK8+tEyA9X0yMGXlSCsbm5AU64N6gjvGk/IutYDpLBInMYEAEC83s3qhIvryFS+W+sqLZUBEvePQ=="],
+
     "tldw-frontend/jsdom": ["jsdom@27.4.0", "", { "dependencies": { "@acemir/cssom": "^0.9.28", "@asamuzakjp/dom-selector": "^6.7.6", "@exodus/bytes": "^1.6.0", "cssstyle": "^5.3.4", "data-urls": "^6.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.0", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^15.1.0", "ws": "^8.18.3", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ=="],
 
+    "tldw-frontend/marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
     "tldw-frontend/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "tldw-frontend/property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "tldw-frontend/react-toastify": ["react-toastify@11.0.5", "", { "dependencies": { "clsx": "^2.1.1" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA=="],
 
     "tldw-frontend/rehype-mathjax": ["rehype-mathjax@7.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mathjax": "^0.0.40", "hast-util-to-text": "^4.0.0", "hastscript": "^9.0.0", "mathjax-full": "^3.0.0", "unified": "^11.0.0", "unist-util-visit-parents": "^6.0.0", "vfile": "^6.0.0" } }, "sha512-mJHNpoqCC5UZ24OKx0wNjlzV18qeJz/Q/LtEjxXzt8vqrZ1Z3GxQnVrHcF5/PogcXUK8cWwJ4U/LWOQWEiABHw=="],
 
     "tldw-frontend/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "tldw-frontend/zustand": ["zustand@5.0.10", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
@@ -3682,8 +3688,6 @@
     "hast-util-from-dom/hastscript/@types/hast": ["@types/hast@2.3.10", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw=="],
 
     "hast-util-from-dom/hastscript/hast-util-parse-selector": ["hast-util-parse-selector@3.1.1", "", { "dependencies": { "@types/hast": "^2.0.0" } }, "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA=="],
-
-    "hast-util-from-dom/hastscript/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
 
     "html-to-text/htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 

--- a/apps/packages/ui/src/components/Common/CommandPalette.tsx
+++ b/apps/packages/ui/src/components/Common/CommandPalette.tsx
@@ -474,6 +474,11 @@ export function CommandPalette({
       }
 
       const existingCommand = dedupedCommands[existingIndex]
+      if (existingCommand.category === "setting" && command.category === "setting") {
+        dedupedCommands.push(command)
+        continue
+      }
+
       if (existingCommand.category === "setting" && command.category !== "setting") {
         dedupedCommands[existingIndex] = command
       }

--- a/apps/packages/ui/src/components/Common/CommandPalette.tsx
+++ b/apps/packages/ui/src/components/Common/CommandPalette.tsx
@@ -29,7 +29,7 @@ import {
 import { useShortcutConfig } from "@/hooks/keyboard/useShortcutConfig"
 import type { KeyboardShortcut as ConfiguredKeyboardShortcut } from "@/hooks/keyboard/useKeyboardShortcuts"
 import { WORKSPACE_PLAYGROUND_PATH } from "@/routes/route-paths"
-import { searchSettings, type SettingDefinition } from "@/data/settings-index"
+import { searchSettings } from "@/data/settings-index"
 import { cn } from "@/libs/utils"
 
 type CommandShortcut = { key: string; modifiers: ShortcutModifier[] }
@@ -63,6 +63,7 @@ export interface CommandItem {
   icon: React.ReactNode
   shortcut?: CommandShortcut
   action: () => void
+  targetPath?: string
   category: "navigation" | "action" | "setting" | "recent" | "prompt"
   keywords?: string[]
 }
@@ -162,6 +163,7 @@ export function CommandPalette({
         label: t("common:commandPalette.goToChat", "Go to Chat"),
         icon: <MessageSquare className="size-4" />,
         action: () => { navigate("/"); setOpen(false) },
+        targetPath: "/",
         category: "navigation",
         keywords: ["playground", "conversation"],
       },
@@ -171,6 +173,7 @@ export function CommandPalette({
           label: t("common:commandPalette.goToKnowledge", "Go to Knowledge QA"),
           icon: <CombineIcon className="size-4" />,
           action: () => { navigate("/knowledge"); setOpen(false) },
+          targetPath: "/knowledge",
           category: "navigation" as const,
           keywords: ["knowledge", "qa", "rag", "search"],
         },
@@ -179,6 +182,7 @@ export function CommandPalette({
           label: t("common:commandPalette.goToMedia", "Go to Media"),
           icon: <BookText className="size-4" />,
           action: () => { navigate("/media"); setOpen(false) },
+          targetPath: "/media",
           category: "navigation" as const,
           keywords: ["documents", "files", "library"],
         },
@@ -187,6 +191,7 @@ export function CommandPalette({
           label: t("common:commandPalette.goToNotes", "Go to Notes"),
           icon: <StickyNote className="size-4" />,
           action: () => { navigate("/notes"); setOpen(false) },
+          targetPath: "/notes",
           category: "navigation" as const,
           keywords: ["notes", "notebook"],
         },
@@ -195,6 +200,7 @@ export function CommandPalette({
           label: t("common:commandPalette.goToPrompts", "Go to Prompts"),
           icon: <NotebookPen className="size-4" />,
           action: () => { navigate("/prompts"); setOpen(false) },
+          targetPath: "/prompts",
           category: "navigation" as const,
           keywords: ["prompts", "template", "studio"],
         },
@@ -203,6 +209,7 @@ export function CommandPalette({
           label: t("common:commandPalette.goToFlashcards", "Go to Flashcards"),
           icon: <Layers className="size-4" />,
           action: () => { navigate("/flashcards"); setOpen(false) },
+          targetPath: "/flashcards",
           category: "navigation" as const,
           keywords: ["study", "cards", "learn"],
         },
@@ -214,6 +221,7 @@ export function CommandPalette({
           ),
           icon: <BookOpen className="size-4" />,
           action: () => { navigate("/documentation"); setOpen(false) },
+          targetPath: "/documentation",
           category: "navigation" as const,
           keywords: ["docs", "documentation", "guide", "help", "reference"],
         },
@@ -223,8 +231,18 @@ export function CommandPalette({
         label: t("common:commandPalette.goToSettings", "Go to Settings"),
         icon: <Settings className="size-4" />,
         action: () => { navigate("/settings"); setOpen(false) },
+        targetPath: "/settings",
         category: "navigation",
         keywords: ["preferences", "config", "options"],
+      },
+      {
+        id: "nav-mcp-hub",
+        label: t("common:commandPalette.goToMcpHub", "Go to MCP Hub"),
+        icon: <Settings className="size-4" />,
+        action: () => { navigate("/settings/mcp-hub"); setOpen(false) },
+        targetPath: "/settings/mcp-hub",
+        category: "navigation",
+        keywords: ["mcp", "hub", "acp", "policy", "server"],
       },
       ...(!isSidepanel ? ([
         {
@@ -235,6 +253,7 @@ export function CommandPalette({
           ),
           icon: <Activity className="size-4" />,
           action: () => { navigate("/settings/health"); setOpen(false) },
+          targetPath: "/settings/health",
           category: "navigation" as const,
           keywords: ["status", "connection", "diagnostic"],
         }
@@ -426,6 +445,7 @@ export function CommandPalette({
         : setting.defaultDescription,
       icon: <Settings className="size-4" />,
       action: () => { navigate(setting.route); setOpen(false) },
+      targetPath: setting.route,
       category: "setting" as const,
       keywords: setting.keywords,
     }))
@@ -436,21 +456,51 @@ export function CommandPalette({
     return [...defaultCommands, ...additionalCommands, ...settingCommands]
   }, [defaultCommands, additionalCommands, settingCommands])
 
+  const dedupeByTargetPath = useCallback((commands: CommandItem[]) => {
+    const dedupedCommands: CommandItem[] = []
+    const targetPathIndex = new Map<string, number>()
+
+    for (const command of commands) {
+      if (!command.targetPath) {
+        dedupedCommands.push(command)
+        continue
+      }
+
+      const existingIndex = targetPathIndex.get(command.targetPath)
+      if (existingIndex === undefined) {
+        targetPathIndex.set(command.targetPath, dedupedCommands.length)
+        dedupedCommands.push(command)
+        continue
+      }
+
+      const existingCommand = dedupedCommands[existingIndex]
+      if (existingCommand.category === "setting" && command.category !== "setting") {
+        dedupedCommands[existingIndex] = command
+      }
+    }
+
+    return dedupedCommands
+  }, [])
+
   // Filter commands based on query
   const filteredCommands = useMemo(() => {
+    let commands: CommandItem[]
+
     if (!query) {
       // Show all non-setting commands when no query
-      return allCommands.filter(c => c.category !== "setting")
+      commands = allCommands.filter(c => c.category !== "setting")
+      return dedupeByTargetPath(commands)
     }
 
     const q = query.toLowerCase()
-    return allCommands.filter((cmd) => {
+    commands = allCommands.filter((cmd) => {
       const labelMatch = cmd.label.toLowerCase().includes(q)
       const descMatch = cmd.description?.toLowerCase().includes(q)
       const keywordMatch = cmd.keywords?.some((kw) => kw.toLowerCase().includes(q))
       return labelMatch || descMatch || keywordMatch
     })
-  }, [allCommands, query])
+    return dedupeByTargetPath(commands)
+  }, [allCommands, dedupeByTargetPath, query])
 
   // Clamp selection when filtered commands change
   useEffect(() => {

--- a/apps/packages/ui/src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx
@@ -1,0 +1,66 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+
+import { CommandPalette } from "../CommandPalette"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string) => defaultValue ?? key,
+  }),
+}))
+
+describe("CommandPalette MCP Hub discoverability", () => {
+  it("shows Go to MCP Hub when the palette opens with an empty query", async () => {
+    render(
+      <MemoryRouter>
+        <CommandPalette />
+      </MemoryRouter>
+    )
+
+    window.dispatchEvent(new CustomEvent("tldw:open-command-palette"))
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    expect(
+      screen.getByRole("option", { name: /Go to MCP Hub/i })
+    ).toBeInTheDocument()
+  })
+
+  it("shows only one MCP Hub route result when searching for mcp", async () => {
+    render(
+      <MemoryRouter>
+        <CommandPalette />
+      </MemoryRouter>
+    )
+
+    window.dispatchEvent(new CustomEvent("tldw:open-command-palette"))
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+
+    const searchInput = screen.getByPlaceholderText(/Type a command or search/i)
+    fireEvent.change(searchInput, { target: { value: "mcp" } })
+
+    expect(screen.getAllByRole("option", { name: /MCP Hub/i })).toHaveLength(1)
+  })
+
+  it("keeps the specific Theme setting when searching a shared settings route", async () => {
+    render(
+      <MemoryRouter>
+        <CommandPalette />
+      </MemoryRouter>
+    )
+
+    window.dispatchEvent(new CustomEvent("tldw:open-command-palette"))
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+
+    const searchInput = screen.getByPlaceholderText(/Type a command or search/i)
+    fireEvent.change(searchInput, { target: { value: "theme" } })
+
+    expect(screen.getByRole("option", { name: /Theme/i })).toBeInTheDocument()
+    expect(
+      screen.queryByRole("option", { name: /Go to Settings/i })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx
@@ -63,4 +63,24 @@ describe("CommandPalette MCP Hub discoverability", () => {
       screen.queryByRole("option", { name: /Go to Settings/i })
     ).not.toBeInTheDocument()
   })
+
+  it("keeps multiple settings that intentionally share the same route", async () => {
+    render(
+      <MemoryRouter>
+        <CommandPalette />
+      </MemoryRouter>
+    )
+
+    window.dispatchEvent(new CustomEvent("tldw:open-command-palette"))
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+
+    const searchInput = screen.getByPlaceholderText(/Type a command or search/i)
+    fireEvent.change(searchInput, { target: { value: "language" } })
+
+    expect(screen.getAllByRole("option")).toHaveLength(3)
+    expect(screen.getByText("Language")).toBeInTheDocument()
+    expect(screen.getByText("OCR language")).toBeInTheDocument()
+    expect(screen.getByText("Speech recognition language")).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/routes/__tests__/mcp-hub-route.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/mcp-hub-route.test.tsx
@@ -1,25 +1,91 @@
-import { existsSync, readFileSync } from "node:fs"
-import { describe, expect, it } from "vitest"
+// @vitest-environment jsdom
+import React, { Suspense } from "react"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const routeRegistryPathCandidates = [
-  "src/routes/route-registry.tsx",
-  "../packages/ui/src/routes/route-registry.tsx",
-  "apps/packages/ui/src/routes/route-registry.tsx"
-]
+const routeMocks = vi.hoisted(() => ({
+  standaloneMcpHub: vi.fn(() => (
+    <div data-testid="standalone-mcp-hub">Standalone MCP Hub</div>
+  )),
+  settingsMcpHub: vi.fn(() => (
+    <div data-testid="settings-mcp-hub">Settings MCP Hub</div>
+  ))
+}))
 
-const routeRegistryPath = routeRegistryPathCandidates.find((candidate) =>
-  existsSync(candidate)
-)
+vi.mock("../option-mcp-hub", () => ({
+  __esModule: true,
+  default: routeMocks.standaloneMcpHub
+}))
 
-if (!routeRegistryPath) {
-  throw new Error("Unable to locate route-registry.tsx for MCP Hub route test")
-}
+vi.mock("../option-settings-mcp-hub", () => ({
+  __esModule: true,
+  default: routeMocks.settingsMcpHub
+}))
 
-const routeRegistrySource = readFileSync(routeRegistryPath, "utf8")
+vi.mock("../option-index", () => ({
+  __esModule: true,
+  default: () => <div data-testid="option-index" />
+}))
+
+vi.mock("../settings-route", () => ({
+  __esModule: true,
+  createSettingsRoute: () => () => <div data-testid="settings-route-stub" />,
+  SettingsRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+import { ROUTE_DEFINITIONS } from "../route-registry"
+import { optionSettingsRoutes } from "../option-settings-route-registry"
+
+const renderRoute = (element: React.ReactElement, path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Suspense fallback={<div data-testid="route-fallback" />}>
+        <Routes>
+          <Route path="*" element={element} />
+        </Routes>
+      </Suspense>
+    </MemoryRouter>
+  )
 
 describe("mcp hub route wiring", () => {
-  it("registers mcp hub in route registry for both workspace and settings entry", () => {
-    expect(routeRegistrySource).toMatch(/path:\s*"\/mcp-hub"/)
-    expect(routeRegistrySource).toMatch(/path:\s*"\/settings\/mcp-hub"/)
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the standalone MCP hub route from the main registry", async () => {
+    const route = ROUTE_DEFINITIONS.find((candidate) => candidate.path === "/mcp-hub")
+
+    expect(route).toBeDefined()
+    renderRoute(route!.element, "/mcp-hub")
+
+    expect(await screen.findByTestId("standalone-mcp-hub")).toBeVisible()
+    expect(screen.queryByTestId("settings-mcp-hub")).not.toBeInTheDocument()
+  })
+
+  it("renders the settings MCP hub route from the main registry", async () => {
+    const mainRoute = ROUTE_DEFINITIONS.find(
+      (candidate) => candidate.path === "/settings/mcp-hub"
+    )
+
+    expect(mainRoute).toBeDefined()
+    renderRoute(mainRoute!.element, "/settings/mcp-hub")
+
+    expect(await screen.findByTestId("settings-mcp-hub")).toBeVisible()
+    expect(routeMocks.settingsMcpHub).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId("standalone-mcp-hub")).not.toBeInTheDocument()
+  })
+
+  it("renders the settings MCP hub route from the settings registry", async () => {
+    const settingsRoute = optionSettingsRoutes.find(
+      (candidate) => candidate.path === "/settings/mcp-hub"
+    )
+
+    expect(settingsRoute).toBeDefined()
+    renderRoute(settingsRoute!.element, "/settings/mcp-hub")
+
+    expect(await screen.findByTestId("settings-mcp-hub")).toBeVisible()
+    expect(routeMocks.settingsMcpHub).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId("standalone-mcp-hub")).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/routes/__tests__/option-settings-mcp-hub.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-settings-mcp-hub.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import React from "react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      fallbackOrOptions?: string | { defaultValue?: string }
+    ) => {
+      if (typeof fallbackOrOptions === "string") {
+        return fallbackOrOptions
+      }
+
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        return fallbackOrOptions.defaultValue ?? ""
+      }
+
+      return ""
+    },
+    i18n: {
+      language: "en",
+      resolvedLanguage: "en"
+    }
+  })
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    loading: false,
+    capabilities: {
+      hasMcpHub: true
+    }
+  })
+}))
+
+vi.mock("@/components/Option/MCPHub", () => ({
+  McpHubPage: () => <h1>MCP Hub</h1>
+}))
+vi.mock("~/components/Layouts/Layout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+import { OptionSettingsMcpHub } from "../option-settings-mcp-hub"
+
+describe("OptionSettingsMcpHub", () => {
+  it("renders the MCP Hub page inside the shared settings shell", () => {
+    render(
+      <MemoryRouter initialEntries={["/settings/mcp-hub"]}>
+        <Routes>
+          <Route path="*" element={<OptionSettingsMcpHub />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId("settings-navigation")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: /mcp hub/i })).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/routes/option-settings-mcp-hub.tsx
+++ b/apps/packages/ui/src/routes/option-settings-mcp-hub.tsx
@@ -1,0 +1,14 @@
+import { PageShell } from "@/components/Common/PageShell"
+import { McpHubPage } from "@/components/Option/MCPHub"
+
+import { SettingsRoute } from "./settings-route"
+
+export const OptionSettingsMcpHub = () => (
+  <SettingsRoute>
+    <PageShell className="flex-1 min-h-0" maxWidthClassName="max-w-full">
+      <McpHubPage />
+    </PageShell>
+  </SettingsRoute>
+)
+
+export default OptionSettingsMcpHub

--- a/apps/packages/ui/src/routes/option-settings-route-registry.tsx
+++ b/apps/packages/ui/src/routes/option-settings-route-registry.tsx
@@ -58,7 +58,7 @@ const OptionSettingsPromptStudio = createSettingsRoute(
   () => import("~/components/Option/Settings/prompt-studio"),
   "PromptStudioSettings"
 )
-const OptionMcpHub = lazy(() => import("./option-mcp-hub"))
+const OptionSettingsMcpHub = lazy(() => import("./option-settings-mcp-hub"))
 const OptionChatSettings = createSettingsRoute(
   () => import("~/components/Option/Settings/ChatSettings"),
   "ChatSettings"
@@ -114,7 +114,7 @@ export const optionSettingsRoutes: RouteDefinition[] = [
   {
     kind: "options",
     path: "/settings/mcp-hub",
-    element: <OptionMcpHub />,
+    element: <OptionSettingsMcpHub />,
   },
   {
     kind: "options",

--- a/apps/packages/ui/src/routes/route-registry.tsx
+++ b/apps/packages/ui/src/routes/route-registry.tsx
@@ -161,6 +161,7 @@ const OptionACPPlayground = lazy(() => import("./option-acp-playground"))
 const OptionAgents = lazy(() => import("./option-agents"))
 const OptionAgentTasks = lazy(() => import("./option-agent-tasks"))
 const OptionMcpHub = lazy(() => import("./option-mcp-hub"))
+const OptionSettingsMcpHub = lazy(() => import("./option-settings-mcp-hub"))
 const OptionSkills = lazy(() => import("./option-skills"))
 const OptionRepo2Txt = lazy(() => import("./option-repo2txt"))
 const OptionSetup = lazy(() => import("./option-setup"))
@@ -196,7 +197,7 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
   {
     kind: "options",
     path: "/settings/mcp-hub",
-    element: <OptionMcpHub />,
+    element: <OptionSettingsMcpHub />,
   },
   {
     kind: "options",

--- a/apps/tldw-frontend/__tests__/extension/route-registry.mcp-hub.test.ts
+++ b/apps/tldw-frontend/__tests__/extension/route-registry.mcp-hub.test.ts
@@ -1,33 +1,78 @@
-import { existsSync, readFileSync } from "node:fs"
-import { describe, expect, it } from "vitest"
+// @vitest-environment jsdom
+import React, { Suspense } from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const extensionRouteRegistryPathCandidates = [
-  "extension/routes/route-registry.tsx",
-  "apps/tldw-frontend/extension/routes/route-registry.tsx"
-]
+const routeMocks = vi.hoisted(() => ({
+  standaloneMcpHub: vi.fn(() =>
+    React.createElement(
+      "div",
+      { "data-testid": "standalone-mcp-hub" },
+      "Standalone MCP Hub Wrapper"
+    )
+  ),
+  settingsMcpHub: vi.fn(() =>
+    React.createElement(
+      "div",
+      { "data-testid": "settings-mcp-hub" },
+      "Settings MCP Hub Wrapper"
+    )
+  )
+}))
 
-const extensionRouteRegistryPath = extensionRouteRegistryPathCandidates.find(
-  (candidate) => existsSync(candidate)
-)
+vi.mock("../../extension/routes/option-mcp-hub", () => ({
+  __esModule: true,
+  default: routeMocks.standaloneMcpHub
+}))
 
-if (!extensionRouteRegistryPath) {
-  throw new Error("Unable to locate extension route-registry.tsx for MCP Hub parity test")
-}
+vi.mock("../../extension/routes/option-settings-mcp-hub", () => ({
+  __esModule: true,
+  default: routeMocks.settingsMcpHub
+}))
 
-const extensionRouteRegistrySource = readFileSync(
-  extensionRouteRegistryPath,
-  "utf8"
-)
+const renderRoute = (element: React.ReactElement) =>
+  render(
+    React.createElement(
+      Suspense,
+      { fallback: React.createElement("div", { "data-testid": "route-fallback" }) },
+      element
+    )
+  )
 
 describe("extension route registry MCP Hub parity", () => {
-  it("registers the settings MCP Hub route", () => {
-    expect(extensionRouteRegistrySource).toMatch(/path:\s*"\/settings\/mcp-hub"/)
-    expect(extensionRouteRegistrySource).toMatch(
-      /labelToken:\s*"settings:mcpHubNav"/
-    )
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it("registers the standalone MCP Hub route", () => {
-    expect(extensionRouteRegistrySource).toMatch(/path:\s*"\/mcp-hub"/)
+  it("renders the standalone MCP Hub route from the extension registry", async () => {
+    const { ROUTE_DEFINITIONS } = await import(
+      "../../extension/routes/route-registry"
+    )
+    const route = ROUTE_DEFINITIONS.find((candidate) => candidate.path === "/mcp-hub")
+
+    expect(route).toBeDefined()
+    renderRoute(route!.element)
+
+    expect(await screen.findByTestId("standalone-mcp-hub")).toBeVisible()
+    expect(screen.queryByTestId("settings-mcp-hub")).not.toBeInTheDocument()
+  })
+
+  it("renders the settings MCP Hub route from the extension registry", async () => {
+    const { ROUTE_DEFINITIONS } = await import(
+      "../../extension/routes/route-registry"
+    )
+    const route = ROUTE_DEFINITIONS.find(
+      (candidate) => candidate.path === "/settings/mcp-hub"
+    )
+
+    expect(route).toBeDefined()
+    expect(route?.nav).toBeDefined()
+    expect(route?.nav?.group).toBe("server")
+    expect(route?.nav?.labelToken).toBe("settings:mcpHubNav")
+    renderRoute(route!.element)
+
+    expect(await screen.findByTestId("settings-mcp-hub")).toBeVisible()
+    expect(routeMocks.settingsMcpHub).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId("standalone-mcp-hub")).not.toBeInTheDocument()
   })
 })

--- a/apps/tldw-frontend/__tests__/extension/route-registry.mcp-hub.test.ts
+++ b/apps/tldw-frontend/__tests__/extension/route-registry.mcp-hub.test.ts
@@ -2,6 +2,12 @@
 import React, { Suspense } from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation
+} from "react-router-dom"
 
 const routeMocks = vi.hoisted(() => ({
   standaloneMcpHub: vi.fn(() =>
@@ -39,6 +45,16 @@ const renderRoute = (element: React.ReactElement) =>
     )
   )
 
+const RedirectLocationProbe = () => {
+  const location = useLocation()
+
+  return React.createElement(
+    "div",
+    { "data-testid": "redirect-location" },
+    `${location.pathname}${location.search}`
+  )
+}
+
 describe("extension route registry MCP Hub parity", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -74,5 +90,39 @@ describe("extension route registry MCP Hub parity", () => {
     expect(await screen.findByTestId("settings-mcp-hub")).toBeVisible()
     expect(routeMocks.settingsMcpHub).toHaveBeenCalledTimes(1)
     expect(screen.queryByTestId("standalone-mcp-hub")).not.toBeInTheDocument()
+  })
+
+  it("uses react-router redirects for legacy extension routes", async () => {
+    const { ROUTE_DEFINITIONS } = await import(
+      "../../extension/routes/route-registry"
+    )
+    const route = ROUTE_DEFINITIONS.find(
+      (candidate) => candidate.path === "/prompt-studio"
+    )
+
+    expect(route).toBeDefined()
+
+    render(
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: ["/prompt-studio"] },
+        React.createElement(
+          Routes,
+          null,
+          React.createElement(Route, {
+            path: "/prompt-studio",
+            element: route!.element
+          }),
+          React.createElement(Route, {
+            path: "/prompts",
+            element: React.createElement(RedirectLocationProbe)
+          })
+        )
+      )
+    )
+
+    expect(await screen.findByTestId("redirect-location")).toHaveTextContent(
+      "/prompts?tab=studio"
+    )
   })
 })

--- a/apps/tldw-frontend/__tests__/frontend-ci-networking-workflows.test.ts
+++ b/apps/tldw-frontend/__tests__/frontend-ci-networking-workflows.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const appDir = path.resolve(__dirname, "..")
+const repoRoot = path.resolve(appDir, "..", "..")
+const workflowsDir = path.join(repoRoot, ".github", "workflows")
+
+const readWorkflow = (fileName: string) =>
+  readFileSync(path.join(workflowsDir, fileName), "utf8")
+
+const getJobBlock = (workflow: string, jobId: string) => {
+  const lines = workflow.split("\n")
+  const startIndex = lines.findIndex((line) => line === `  ${jobId}:`)
+
+  if (startIndex === -1) {
+    throw new Error(`Unable to locate job "${jobId}" in workflow`)
+  }
+
+  const bodyLines: string[] = []
+
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+
+    if (/^  [a-z0-9-]+:$/.test(line)) {
+      break
+    }
+
+    bodyLines.push(line)
+  }
+
+  return bodyLines.join("\n")
+}
+
+describe("frontend CI workflow networking", () => {
+  it("pins advanced-mode browser API settings for the frontend UX gates", () => {
+    const workflow = readWorkflow("frontend-ux-gates.yml")
+
+    for (const jobId of ["onboarding-gate", "smoke-gate"]) {
+      const jobBlock = getJobBlock(workflow, jobId)
+
+      expect(jobBlock).toContain("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: advanced")
+      expect(jobBlock).toContain("NEXT_PUBLIC_API_URL: http://127.0.0.1:8000")
+    }
+  })
+
+  it("pins advanced-mode browser API settings for the frontend E2E tiers", () => {
+    const workflow = readWorkflow("frontend-e2e-tiers.yml")
+
+    for (const jobId of ["critical", "features", "admin"]) {
+      const jobBlock = getJobBlock(workflow, jobId)
+
+      expect(jobBlock).toContain("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE: advanced")
+      expect(jobBlock).toContain("NEXT_PUBLIC_API_URL: http://127.0.0.1:8000")
+    }
+  })
+})

--- a/apps/tldw-frontend/extension/routes/option-mcp-hub.tsx
+++ b/apps/tldw-frontend/extension/routes/option-mcp-hub.tsx
@@ -1,0 +1,15 @@
+import OptionLayout from "@web/components/layout/WebLayout"
+import { PageShell } from "@/components/Common/PageShell"
+import { McpHubPage } from "@/components/Option/MCPHub"
+
+const OptionMcpHub = () => {
+  return (
+    <OptionLayout>
+      <PageShell className="flex-1 min-h-0" maxWidthClassName="max-w-full">
+        <McpHubPage />
+      </PageShell>
+    </OptionLayout>
+  )
+}
+
+export default OptionMcpHub

--- a/apps/tldw-frontend/extension/routes/option-settings-mcp-hub.tsx
+++ b/apps/tldw-frontend/extension/routes/option-settings-mcp-hub.tsx
@@ -1,0 +1,14 @@
+import { PageShell } from "@/components/Common/PageShell"
+import { McpHubPage } from "@/components/Option/MCPHub"
+
+import { SettingsRoute } from "./settings-route"
+
+export const OptionSettingsMcpHub = () => (
+  <SettingsRoute>
+    <PageShell className="flex-1 min-h-0" maxWidthClassName="max-w-full">
+      <McpHubPage />
+    </PageShell>
+  </SettingsRoute>
+)
+
+export default OptionSettingsMcpHub

--- a/apps/tldw-frontend/extension/routes/route-registry.tsx
+++ b/apps/tldw-frontend/extension/routes/route-registry.tsx
@@ -33,9 +33,9 @@ import {
   PenLine,
   ShieldCheck
 } from "lucide-react"
+import { Navigate } from "react-router-dom"
 import { ALL_TARGETS, type PlatformTarget } from "@/config/platform"
 import { createSettingsRoute } from "./settings-route"
-import { Navigate } from "../shims/react-router-dom"
 
 export type RouteKind = "options" | "sidepanel"
 

--- a/apps/tldw-frontend/extension/routes/route-registry.tsx
+++ b/apps/tldw-frontend/extension/routes/route-registry.tsx
@@ -35,7 +35,7 @@ import {
 } from "lucide-react"
 import { ALL_TARGETS, type PlatformTarget } from "@/config/platform"
 import { createSettingsRoute } from "./settings-route"
-import { Navigate } from "react-router-dom"
+import { Navigate } from "../shims/react-router-dom"
 
 export type RouteKind = "options" | "sidepanel"
 
@@ -168,6 +168,8 @@ const OptionQuickIngestSettings = createSettingsRoute(
 const OptionQuickChatPopout = lazy(() => import("./option-quick-chat-popout"))
 const OptionContentReview = lazy(() => import("./option-content-review"))
 const OptionACPPlayground = lazy(() => import("./option-acp-playground"))
+const OptionMcpHub = lazy(() => import("./option-mcp-hub"))
+const OptionSettingsMcpHub = lazy(() => import("./option-settings-mcp-hub"))
 const OptionChunkingPlayground = lazy(() => import("./option-chunking-playground"))
 const OptionDocumentation = lazy(() => import("./option-documentation"))
 const OptionQuiz = lazy(() => import("./option-quiz"))
@@ -376,6 +378,18 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
       labelToken: "settings:promptStudio.nav",
       icon: Microscope,
       order: 10,
+      beta: true
+    }
+  },
+  {
+    kind: "options",
+    path: "/settings/mcp-hub",
+    element: <OptionSettingsMcpHub />,
+    nav: {
+      group: "server",
+      labelToken: "settings:mcpHubNav",
+      icon: ServerIcon,
+      order: 11.1,
       beta: true
     }
   },
@@ -691,6 +705,7 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
       beta: true
     }
   },
+  { kind: "options", path: "/mcp-hub", element: <OptionMcpHub /> },
   {
     kind: "options",
     path: "/admin/server",

--- a/apps/tldw-frontend/vitest.config.ts
+++ b/apps/tldw-frontend/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
       '@': path.resolve(__dirname, '../packages/ui/src'),
       '~': path.resolve(__dirname, '../packages/ui/src'),
       '@web': path.resolve(__dirname, '.'),
+      'react-router-dom': path.resolve(
+        __dirname,
+        '../packages/ui/node_modules/react-router-dom'
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- route shared `/settings/mcp-hub` through a dedicated settings shell while preserving standalone `/mcp-hub`
- expose MCP Hub in the command palette without duplicate route results and keep specific setting searches intact
- add extension parity for `/settings/mcp-hub` and `/mcp-hub` with explicit nav metadata and route tests

## Test Plan
- bunx vitest run ../packages/ui/src/routes/__tests__/option-settings-mcp-hub.test.tsx ../packages/ui/src/routes/__tests__/mcp-hub-route.test.tsx ../packages/ui/src/components/Common/__tests__/CommandPalette.shortcuts.test.tsx ../packages/ui/src/components/Common/__tests__/CommandPalette.mcp-hub.test.tsx --reporter=verbose
- bunx vitest run __tests__/extension/route-registry.persona.test.ts __tests__/extension/route-registry.acp.test.ts __tests__/extension/route-registry.mcp-hub.test.ts --reporter=verbose
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r apps/packages/ui/src/routes apps/packages/ui/src/components/Common apps/tldw-frontend/extension/routes apps/tldw-frontend/__tests__/extension -f json -o /tmp/bandit_mcp_hub_navigation.json