### PR TITLE
feat: add NotebookLM presentation style catalog support

### DIFF
--- a/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioPage.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioPage.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { useNavigate } from "react-router-dom"
 
 import { ProjectWorkspace } from "./ProjectWorkspace"
+import { VisualStylePicker } from "./VisualStylePicker"
 import { VisualStyleManager } from "./VisualStyleManager"
 import {
   buildPresentationVisualStyleSnapshot,
@@ -63,6 +64,19 @@ const getDefaultVisualStyleValue = (styles: VisualStyleRecord[]): string => {
   return preferred ? encodeVisualStyleValue(preferred.id, preferred.scope) : ""
 }
 
+const resolveThemeFromVisualStyle = (
+  style: VisualStyleRecord | null,
+  fallbackTheme: string
+): string => {
+  if (style?.scope !== "builtin") {
+    return fallbackTheme
+  }
+  const resolvedTheme = style.appearance_defaults?.theme
+  return typeof resolvedTheme === "string" && resolvedTheme.trim().length > 0
+    ? resolvedTheme.trim()
+    : fallbackTheme
+}
+
 export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
   mode = "index",
   projectId = null
@@ -74,6 +88,7 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
   const title = usePresentationStudioStore((state) => state.title)
   const slides = usePresentationStudioStore((state) => state.slides)
   const currentProjectId = usePresentationStudioStore((state) => state.projectId)
+  const theme = usePresentationStudioStore((state) => state.theme)
   const visualStyleId = usePresentationStudioStore((state) => state.visualStyleId)
   const visualStyleScope = usePresentationStudioStore((state) => state.visualStyleScope)
   const visualStyleName = usePresentationStudioStore((state) => state.visualStyleName)
@@ -183,6 +198,10 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
         scope: visualStyleScope,
         name: visualStyleName || `${visualStyleScope}:${visualStyleId}`,
         description: "This style is no longer available, but this deck still retains its snapshot.",
+        category: null,
+        guide_number: null,
+        tags: [],
+        best_for: [],
         generation_rules: {},
         artifact_preferences: [],
         appearance_defaults: {},
@@ -193,23 +212,15 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
     return options
   }, [availableStyles, visualStyleId, visualStyleName, visualStyleScope])
 
-  const groupedStyleOptions = React.useMemo(
-    () => ({
-      builtin: styleOptions.filter((style) => style.scope === "builtin"),
-      user: styleOptions.filter((style) => style.scope !== "builtin")
-    }),
-    [styleOptions]
-  )
-
   const selectedDraftStyle = React.useMemo(() => {
     const { visualStyleId: nextStyleId, visualStyleScope: nextStyleScope } =
       parseVisualStyleValue(draftVisualStyleValue)
     return (
-      availableStyles.find(
+      styleOptions.find(
         (style) => style.id === nextStyleId && style.scope === nextStyleScope
       ) || null
     )
-  }, [availableStyles, draftVisualStyleValue])
+  }, [draftVisualStyleValue, styleOptions])
 
   const selectedPresentationStyle = React.useMemo(
     () =>
@@ -241,6 +252,10 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
     },
     [mode, updateProjectMeta]
   )
+
+  const handleDraftStyleChange = React.useCallback((nextValue: string) => {
+    setDraftVisualStyleValue(nextValue)
+  }, [])
 
   const handleCreateProject = React.useCallback(async () => {
     if (isCreatingProject) {
@@ -305,14 +320,14 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
   }, [draftTitle, draftVisualStyleValue, isCreatingProject, loadProject, navigate, styleOptions])
 
   const handleDetailStyleChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLSelectElement>) => {
-      const nextValue = event.target.value
+    (nextValue: string) => {
       const { visualStyleId: nextStyleId, visualStyleScope: nextStyleScope } =
         parseVisualStyleValue(nextValue)
       const selectedStyle =
         styleOptions.find(
           (style) => style.id === nextStyleId && style.scope === nextStyleScope
         ) || null
+      const nextTheme = resolveThemeFromVisualStyle(selectedStyle, theme)
       updateProjectMeta({
         visualStyleId: nextStyleId,
         visualStyleScope: nextStyleScope,
@@ -320,10 +335,11 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
         visualStyleVersion: selectedStyle?.version ?? null,
         visualStyleSnapshot: selectedStyle
           ? buildPresentationVisualStyleSnapshot(selectedStyle)
-          : null
+          : null,
+        theme: selectedStyle?.scope === "builtin" ? nextTheme : undefined
       })
     },
-    [styleOptions, updateProjectMeta]
+    [styleOptions, theme, updateProjectMeta]
   )
 
   if (!isOnline) {
@@ -393,59 +409,15 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
               </div>
 
               <div>
-                <label
-                  className="mb-1 block text-sm font-medium text-slate-700"
-                  htmlFor="presentation-studio-visual-style"
-                >
-                  Choose visual style
-                </label>
-                <select
-                  id="presentation-studio-visual-style"
-                  aria-label="Choose visual style"
+                <VisualStylePicker
+                  label="Choose visual style"
                   value={draftVisualStyleValue}
-                  onChange={(event) => setDraftVisualStyleValue(event.target.value)}
+                  styles={styleOptions}
+                  onChange={handleDraftStyleChange}
                   disabled={stylesLoading || isCreatingProject}
-                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none transition focus:border-sky-500 focus:ring-2 focus:ring-sky-100 disabled:bg-slate-100"
-                >
-                  <option value="">No visual style preset</option>
-                  {groupedStyleOptions.builtin.length > 0 && (
-                    <optgroup label="Built-in styles">
-                      {groupedStyleOptions.builtin.map((style) => (
-                        <option
-                          key={`${style.scope}:${style.id}`}
-                          value={encodeVisualStyleValue(style.id, style.scope)}
-                        >
-                          {style.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                  {groupedStyleOptions.user.length > 0 && (
-                    <optgroup label="Custom styles">
-                      {groupedStyleOptions.user.map((style) => (
-                        <option
-                          key={`${style.scope}:${style.id}`}
-                          value={encodeVisualStyleValue(style.id, style.scope)}
-                        >
-                          {style.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                </select>
-              </div>
-
-              <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-                <p className="text-sm font-medium text-slate-900">
-                  {selectedDraftStyle?.name || "Manual deck defaults"}
-                </p>
-                <p className="mt-1 text-sm text-slate-600">
-                  {selectedDraftStyle?.description ||
-                    "No preset selected. The deck starts with standard manual settings."}
-                </p>
-                <p className="mt-3 text-xs uppercase tracking-wide text-slate-500">
-                  Applies to future generated slides. Existing slides stay unchanged.
-                </p>
+                  loading={stylesLoading}
+                  description="Built-ins stay read-only. Updates deck appearance defaults and future generated slides. Existing slide content stays unchanged. Custom styles stay editable below."
+                />
               </div>
 
               {stylesError && <p className="text-sm text-rose-600">{stylesError}</p>}
@@ -516,50 +488,15 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
             </p>
           </div>
           <div className="min-w-[240px] flex-1 sm:max-w-sm">
-            <label
-              className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500"
-              htmlFor="presentation-studio-detail-visual-style"
-            >
-              Choose visual style
-            </label>
-            <select
-              id="presentation-studio-detail-visual-style"
-              aria-label="Choose visual style"
+            <VisualStylePicker
+              label="Choose visual style"
               value={encodeVisualStyleValue(visualStyleId, visualStyleScope)}
+              styles={styleOptions}
               onChange={handleDetailStyleChange}
               disabled={stylesLoading}
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none transition focus:border-sky-500 focus:ring-2 focus:ring-sky-100 disabled:bg-slate-100"
-            >
-              <option value="">No visual style preset</option>
-              {groupedStyleOptions.builtin.length > 0 && (
-                <optgroup label="Built-in styles">
-                  {groupedStyleOptions.builtin.map((style) => (
-                    <option
-                      key={`${style.scope}:${style.id}`}
-                      value={encodeVisualStyleValue(style.id, style.scope)}
-                    >
-                      {style.name}
-                    </option>
-                  ))}
-                </optgroup>
-              )}
-              {groupedStyleOptions.user.length > 0 && (
-                <optgroup label="Custom styles">
-                  {groupedStyleOptions.user.map((style) => (
-                    <option
-                      key={`${style.scope}:${style.id}`}
-                      value={encodeVisualStyleValue(style.id, style.scope)}
-                    >
-                      {style.name}
-                    </option>
-                  ))}
-                </optgroup>
-              )}
-            </select>
-            <p className="mt-1 text-xs text-slate-500">
-              {selectedPresentationStyle?.description ||
-                "Applies to future generated slides. Existing slides are unchanged."}
-            </p>
+              loading={stylesLoading}
+              description="Updates deck appearance defaults and future generated slides. Existing slide content stays unchanged."
+            />
           </div>
         </div>
       </header>

--- a/apps/packages/ui/src/components/Option/PresentationStudio/VisualStylePicker.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/VisualStylePicker.tsx
@@ -333,6 +333,7 @@ export const VisualStylePicker: React.FC<VisualStylePickerProps> = ({
                       const isSelected =
                         selectedValue.visualStyleId === style.id &&
                         selectedValue.visualStyleScope === style.scope
+                      const bestForText = describeBestFor(style)
                       return (
                         <button
                           type="button"
@@ -361,12 +362,12 @@ export const VisualStylePicker: React.FC<VisualStylePickerProps> = ({
                             ) : null}
                           </div>
                           <div className="mt-3 flex flex-wrap gap-2">{renderChips(style)}</div>
-                          {describeBestFor(style) ? (
+                          {bestForText ? (
                             <p className="mt-3 text-xs text-slate-500">
                               <span className="font-semibold uppercase tracking-wide">
                                 Best for
                               </span>{" "}
-                              {describeBestFor(style)}
+                              {bestForText}
                             </p>
                           ) : null}
                         </button>

--- a/apps/packages/ui/src/components/Option/PresentationStudio/VisualStylePicker.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/VisualStylePicker.tsx
@@ -1,0 +1,371 @@
+import React from "react"
+
+import type { VisualStyleRecord } from "@/services/tldw/TldwApiClient"
+
+type VisualStylePickerProps = {
+  label: string
+  value: string
+  styles: VisualStyleRecord[]
+  onChange: (value: string) => void
+  disabled?: boolean
+  loading?: boolean
+  description?: string
+}
+
+type ParsedStyleValue = {
+  visualStyleId: string | null
+  visualStyleScope: string | null
+}
+
+const encodeVisualStyleValue = (styleId: string | null, styleScope: string | null): string =>
+  styleId && styleScope ? `${styleScope}::${styleId}` : ""
+
+const parseVisualStyleValue = (value: string): ParsedStyleValue => {
+  if (!value) {
+    return { visualStyleId: null, visualStyleScope: null }
+  }
+  const separatorIndex = value.indexOf("::")
+  if (separatorIndex === -1) {
+    return { visualStyleId: null, visualStyleScope: null }
+  }
+  const visualStyleScope = value.slice(0, separatorIndex).trim()
+  const visualStyleId = value.slice(separatorIndex + 2).trim()
+  if (!visualStyleScope || !visualStyleId) {
+    return { visualStyleId: null, visualStyleScope: null }
+  }
+  return { visualStyleId, visualStyleScope }
+}
+
+const normalizeSearchText = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value.trim().toLowerCase()
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value).toLowerCase()
+  }
+  return ""
+}
+
+const buildSearchText = (style: VisualStyleRecord): string => {
+  const pieces = [
+    style.id,
+    style.name,
+    style.scope,
+    style.description || "",
+    style.category || "",
+    style.guide_number ?? "",
+    ...(style.tags || []),
+    ...(style.best_for || [])
+  ]
+  return pieces.map(normalizeSearchText).filter(Boolean).join(" ")
+}
+
+const describeBestFor = (style: VisualStyleRecord): string | null => {
+  if (!style.best_for?.length) {
+    return null
+  }
+  return style.best_for.join(", ")
+}
+
+const renderChips = (style: VisualStyleRecord): React.ReactNode => {
+  const chips: Array<{ key: string; label: string }> = []
+  if (style.scope === "builtin") {
+    chips.push({ key: "scope", label: "Built-in" })
+  } else {
+    chips.push({ key: "scope", label: "Custom" })
+  }
+  if (style.scope === "builtin" && style.category) {
+    chips.push({ key: "category", label: style.category })
+  }
+  if (style.scope === "builtin" && typeof style.guide_number === "number") {
+    chips.push({ key: "guide_number", label: `Guide ${style.guide_number}` })
+  }
+  for (const tag of (style.tags || []).slice(0, 3)) {
+    chips.push({ key: `tag:${tag}`, label: tag })
+  }
+  return chips.map((chip) => (
+    <span
+      key={chip.key}
+      className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-medium text-slate-600"
+    >
+      {chip.label}
+    </span>
+  ))
+}
+
+const groupBuiltInStyles = (styles: VisualStyleRecord[]): Array<[string, VisualStyleRecord[]]> => {
+  const groups = new Map<string, VisualStyleRecord[]>()
+  for (const style of styles) {
+    const category = style.category?.trim() || "Built-in styles"
+    const entries = groups.get(category) || []
+    entries.push(style)
+    groups.set(category, entries)
+  }
+
+  return [...groups.entries()]
+    .map(([category, entries]) => [
+      category,
+      [...entries].sort((left, right) => {
+        const leftGuide = typeof left.guide_number === "number" ? left.guide_number : Number.POSITIVE_INFINITY
+        const rightGuide = typeof right.guide_number === "number" ? right.guide_number : Number.POSITIVE_INFINITY
+        if (leftGuide !== rightGuide) {
+          return leftGuide - rightGuide
+        }
+        return left.name.localeCompare(right.name)
+      })
+    ] as [string, VisualStyleRecord[]])
+    .sort(([leftCategory], [rightCategory]) => leftCategory.localeCompare(rightCategory))
+}
+
+const toDomIdFragment = (value: string): string =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "style-group"
+
+export const VisualStylePicker: React.FC<VisualStylePickerProps> = ({
+  label,
+  value,
+  styles,
+  onChange,
+  disabled = false,
+  loading = false,
+  description
+}) => {
+  const [searchTerm, setSearchTerm] = React.useState("")
+  const deferredSearchTerm = React.useDeferredValue(searchTerm)
+
+  const selectedValue = React.useMemo(() => parseVisualStyleValue(value), [value])
+  const selectedStyle = React.useMemo(
+    () =>
+      styles.find(
+        (style) =>
+          style.id === selectedValue.visualStyleId &&
+          style.scope === selectedValue.visualStyleScope
+      ) || null,
+    [selectedValue.visualStyleId, selectedValue.visualStyleScope, styles]
+  )
+
+  const filteredStyles = React.useMemo(() => {
+    const query = deferredSearchTerm.trim().toLowerCase()
+    if (!query) {
+      return styles
+    }
+    return styles.filter((style) => buildSearchText(style).includes(query))
+  }, [deferredSearchTerm, styles])
+
+  const builtInStyles = React.useMemo(
+    () => filteredStyles.filter((style) => style.scope === "builtin"),
+    [filteredStyles]
+  )
+  const customStyles = React.useMemo(
+    () => filteredStyles.filter((style) => style.scope !== "builtin"),
+    [filteredStyles]
+  )
+
+  const groupedBuiltInStyles = React.useMemo(() => groupBuiltInStyles(builtInStyles), [builtInStyles])
+
+  const handleChange = React.useCallback(
+    (nextValue: string) => {
+      if (disabled || loading) {
+        return
+      }
+      onChange(nextValue)
+    },
+    [disabled, loading, onChange]
+  )
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label
+          className="mb-1 block text-sm font-medium text-slate-700"
+          htmlFor="presentation-studio-visual-style-search"
+        >
+          {label}
+        </label>
+        {description ? <p className="text-sm text-slate-600">{description}</p> : null}
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white">
+        <div className="border-b border-slate-200 px-4 py-3">
+          <label className="sr-only" htmlFor="presentation-studio-visual-style-search">
+            Search visual styles
+          </label>
+          <input
+            id="presentation-studio-visual-style-search"
+            type="search"
+            role="searchbox"
+            aria-label="Search visual styles"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Search by name, category, tags, or best-for"
+            disabled={disabled || loading}
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-2 focus:ring-sky-100 disabled:bg-slate-100"
+          />
+        </div>
+
+        <div className="border-b border-slate-200 px-4 py-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Selected preset
+              </p>
+              <p className="mt-1 text-sm font-medium text-slate-900">
+                {selectedStyle?.name || "No visual style preset"}
+              </p>
+              <p className="mt-1 text-sm text-slate-600">
+                {selectedStyle?.description ||
+                  "Select a built-in or custom style to update deck appearance defaults and future generated slides."}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => handleChange("")}
+              disabled={disabled || loading}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              No visual style preset
+            </button>
+          </div>
+        </div>
+
+        <div className="max-h-[34rem] space-y-5 overflow-y-auto px-4 py-4">
+          {loading ? (
+            <p className="text-sm text-slate-600">Loading visual styles…</p>
+          ) : filteredStyles.length === 0 ? (
+            <p className="text-sm text-slate-600">
+              No visual styles match “{deferredSearchTerm.trim()}”.
+            </p>
+          ) : (
+            <>
+              {groupedBuiltInStyles.map(([category, categoryStyles]) => (
+                <section
+                  key={category}
+                  role="region"
+                  aria-labelledby={`visual-style-picker-${toDomIdFragment(category)}`}
+                  className="space-y-3"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <h3
+                      id={`visual-style-picker-${toDomIdFragment(category)}`}
+                      className="text-sm font-semibold text-slate-900"
+                    >
+                      {category}
+                    </h3>
+                    <span className="text-xs uppercase tracking-wide text-slate-500">
+                      {categoryStyles.length} style{categoryStyles.length === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {categoryStyles.map((style) => {
+                      const isSelected =
+                        selectedValue.visualStyleId === style.id &&
+                        selectedValue.visualStyleScope === style.scope
+                      return (
+                        <button
+                          type="button"
+                          key={`${style.scope}:${style.id}`}
+                          aria-pressed={isSelected}
+                          disabled={disabled || loading}
+                          onClick={() => handleChange(encodeVisualStyleValue(style.id, style.scope))}
+                          className={`rounded-xl border p-4 text-left transition outline-none focus-visible:ring-2 focus-visible:ring-sky-200 disabled:cursor-not-allowed disabled:opacity-60 ${
+                            isSelected
+                              ? "border-sky-400 bg-sky-50 shadow-sm"
+                              : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50"
+                          }`}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="text-sm font-semibold text-slate-900">{style.name}</p>
+                              <p className="mt-1 text-sm text-slate-600">
+                                {style.description ||
+                                  "No description was provided for this preset."}
+                              </p>
+                            </div>
+                            {isSelected ? (
+                              <span className="rounded-full bg-sky-600 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white">
+                                Selected
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="mt-3 flex flex-wrap gap-2">{renderChips(style)}</div>
+                          {describeBestFor(style) ? (
+                            <p className="mt-3 text-xs text-slate-500">
+                              <span className="font-semibold uppercase tracking-wide">
+                                Best for
+                              </span>{" "}
+                              {describeBestFor(style)}
+                            </p>
+                          ) : null}
+                        </button>
+                      )
+                    })}
+                  </div>
+                </section>
+              ))}
+
+              {customStyles.length > 0 ? (
+                <section
+                  role="region"
+                  aria-labelledby="visual-style-picker-custom"
+                  className="space-y-3"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <h3
+                      id="visual-style-picker-custom"
+                      className="text-sm font-semibold text-slate-900"
+                    >
+                      Custom styles
+                    </h3>
+                    <span className="text-xs uppercase tracking-wide text-slate-500">
+                      {customStyles.length} style{customStyles.length === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {customStyles.map((style) => {
+                      const isSelected =
+                        selectedValue.visualStyleId === style.id &&
+                        selectedValue.visualStyleScope === style.scope
+                      return (
+                        <button
+                          type="button"
+                          key={`${style.scope}:${style.id}`}
+                          aria-pressed={isSelected}
+                          disabled={disabled || loading}
+                          onClick={() => handleChange(encodeVisualStyleValue(style.id, style.scope))}
+                          className={`rounded-xl border p-4 text-left transition outline-none focus-visible:ring-2 focus-visible:ring-sky-200 disabled:cursor-not-allowed disabled:opacity-60 ${
+                            isSelected
+                              ? "border-sky-400 bg-sky-50 shadow-sm"
+                              : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50"
+                          }`}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="text-sm font-semibold text-slate-900">{style.name}</p>
+                              <p className="mt-1 text-sm text-slate-600">
+                                {style.description ||
+                                  "No description was provided for this preset."}
+                              </p>
+                            </div>
+                            {isSelected ? (
+                              <span className="rounded-full bg-sky-600 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white">
+                                Selected
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="mt-3 flex flex-wrap gap-2">{renderChips(style)}</div>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </section>
+              ) : null}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/PresentationStudio/VisualStylePicker.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/VisualStylePicker.tsx
@@ -17,6 +17,24 @@ type ParsedStyleValue = {
   visualStyleScope: string | null
 }
 
+const BUILTIN_CATEGORY_ORDER = [
+  "legacy",
+  "educational",
+  "technical",
+  "narrative",
+  "playful",
+  "nostalgic"
+] as const
+
+const BUILTIN_CATEGORY_LABELS: Record<(typeof BUILTIN_CATEGORY_ORDER)[number], string> = {
+  legacy: "Existing built-ins",
+  educational: "Educational and Explainer",
+  technical: "Technical and Engineering",
+  narrative: "Narrative and Strategic",
+  playful: "Playful and Tactile",
+  nostalgic: "Nostalgic and Artistic"
+}
+
 const encodeVisualStyleValue = (styleId: string | null, styleScope: string | null): string =>
   styleId && styleScope ? `${styleScope}::${styleId}` : ""
 
@@ -46,6 +64,36 @@ const normalizeSearchText = (value: unknown): string => {
   return ""
 }
 
+const normalizeCategoryKey = (value: string | null | undefined): string | null => {
+  if (typeof value !== "string") {
+    return null
+  }
+  const normalized = value.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+const getBuiltInCategoryLabel = (category: string | null | undefined): string => {
+  const normalized = normalizeCategoryKey(category)
+  if (!normalized) {
+    return "Built-in styles"
+  }
+  return (
+    BUILTIN_CATEGORY_LABELS[normalized as keyof typeof BUILTIN_CATEGORY_LABELS] ||
+    (typeof category === "string" ? category.trim() : "Built-in styles")
+  )
+}
+
+const getBuiltInCategoryOrder = (category: string | null | undefined): number => {
+  const normalized = normalizeCategoryKey(category)
+  if (!normalized) {
+    return BUILTIN_CATEGORY_ORDER.length
+  }
+  const index = BUILTIN_CATEGORY_ORDER.indexOf(
+    normalized as (typeof BUILTIN_CATEGORY_ORDER)[number]
+  )
+  return index === -1 ? BUILTIN_CATEGORY_ORDER.length : index
+}
+
 const buildSearchText = (style: VisualStyleRecord): string => {
   const pieces = [
     style.id,
@@ -53,6 +101,7 @@ const buildSearchText = (style: VisualStyleRecord): string => {
     style.scope,
     style.description || "",
     style.category || "",
+    style.scope === "builtin" ? getBuiltInCategoryLabel(style.category) : "",
     style.guide_number ?? "",
     ...(style.tags || []),
     ...(style.best_for || [])
@@ -75,7 +124,7 @@ const renderChips = (style: VisualStyleRecord): React.ReactNode => {
     chips.push({ key: "scope", label: "Custom" })
   }
   if (style.scope === "builtin" && style.category) {
-    chips.push({ key: "category", label: style.category })
+    chips.push({ key: "category", label: getBuiltInCategoryLabel(style.category) })
   }
   if (style.scope === "builtin" && typeof style.guide_number === "number") {
     chips.push({ key: "guide_number", label: `Guide ${style.guide_number}` })
@@ -93,19 +142,33 @@ const renderChips = (style: VisualStyleRecord): React.ReactNode => {
   ))
 }
 
-const groupBuiltInStyles = (styles: VisualStyleRecord[]): Array<[string, VisualStyleRecord[]]> => {
-  const groups = new Map<string, VisualStyleRecord[]>()
+type BuiltInStyleGroup = {
+  categoryKey: string | null
+  label: string
+  styles: VisualStyleRecord[]
+}
+
+const groupBuiltInStyles = (styles: VisualStyleRecord[]): BuiltInStyleGroup[] => {
+  const groups = new Map<string, BuiltInStyleGroup>()
   for (const style of styles) {
-    const category = style.category?.trim() || "Built-in styles"
-    const entries = groups.get(category) || []
-    entries.push(style)
-    groups.set(category, entries)
+    const categoryKey = normalizeCategoryKey(style.category)
+    const groupKey = categoryKey || "__uncategorized__"
+    const existingGroup = groups.get(groupKey)
+    if (existingGroup) {
+      existingGroup.styles.push(style)
+      continue
+    }
+    groups.set(groupKey, {
+      categoryKey,
+      label: getBuiltInCategoryLabel(style.category),
+      styles: [style]
+    })
   }
 
-  return [...groups.entries()]
-    .map(([category, entries]) => [
-      category,
-      [...entries].sort((left, right) => {
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      styles: [...group.styles].sort((left, right) => {
         const leftGuide = typeof left.guide_number === "number" ? left.guide_number : Number.POSITIVE_INFINITY
         const rightGuide = typeof right.guide_number === "number" ? right.guide_number : Number.POSITIVE_INFINITY
         if (leftGuide !== rightGuide) {
@@ -113,8 +176,15 @@ const groupBuiltInStyles = (styles: VisualStyleRecord[]): Array<[string, VisualS
         }
         return left.name.localeCompare(right.name)
       })
-    ] as [string, VisualStyleRecord[]])
-    .sort(([leftCategory], [rightCategory]) => leftCategory.localeCompare(rightCategory))
+    }))
+    .sort((leftGroup, rightGroup) => {
+      const orderDelta =
+        getBuiltInCategoryOrder(leftGroup.categoryKey) - getBuiltInCategoryOrder(rightGroup.categoryKey)
+      if (orderDelta !== 0) {
+        return orderDelta
+      }
+      return leftGroup.label.localeCompare(rightGroup.label)
+    })
 }
 
 const toDomIdFragment = (value: string): string =>
@@ -240,26 +310,26 @@ export const VisualStylePicker: React.FC<VisualStylePickerProps> = ({
             </p>
           ) : (
             <>
-              {groupedBuiltInStyles.map(([category, categoryStyles]) => (
+              {groupedBuiltInStyles.map((group) => (
                 <section
-                  key={category}
+                  key={group.categoryKey || group.label}
                   role="region"
-                  aria-labelledby={`visual-style-picker-${toDomIdFragment(category)}`}
+                  aria-labelledby={`visual-style-picker-${toDomIdFragment(group.label)}`}
                   className="space-y-3"
                 >
                   <div className="flex items-center justify-between gap-3">
                     <h3
-                      id={`visual-style-picker-${toDomIdFragment(category)}`}
+                      id={`visual-style-picker-${toDomIdFragment(group.label)}`}
                       className="text-sm font-semibold text-slate-900"
                     >
-                      {category}
+                      {group.label}
                     </h3>
                     <span className="text-xs uppercase tracking-wide text-slate-500">
-                      {categoryStyles.length} style{categoryStyles.length === 1 ? "" : "s"}
+                      {group.styles.length} style{group.styles.length === 1 ? "" : "s"}
                     </span>
                   </div>
                   <div className="grid gap-3 md:grid-cols-2">
-                    {categoryStyles.map((style) => {
+                    {group.styles.map((style) => {
                       const isSelected =
                         selectedValue.visualStyleId === style.id &&
                         selectedValue.visualStyleScope === style.scope

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioPage.test.tsx
@@ -151,7 +151,9 @@ describe("PresentationStudioPage", () => {
       expect(clientMocks.listVisualStyles).toHaveBeenCalledTimes(1)
     })
     expect(
-      screen.getByText("Applies to future generated slides. Existing slides stay unchanged.")
+      screen.getByText(
+        /Updates deck appearance defaults and future generated slides\. Existing slide content stays unchanged\./
+      )
     ).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId("presentation-studio-create-button"))
@@ -316,9 +318,11 @@ describe("PresentationStudioPage", () => {
       expect(screen.getByTestId("presentation-studio-slide-rail")).toBeInTheDocument()
     })
     expect(screen.queryByText("Loading presentation…")).not.toBeInTheDocument()
-    expect(
-      (screen.getByLabelText("Choose visual style") as HTMLSelectElement).value
-    ).toBe("builtin::minimal-academic")
+    fireEvent.click(screen.getByRole("button", { name: /Timeline/ }))
+
+    await waitFor(() => {
+      expect(usePresentationStudioStore.getState().theme).toBe("beige")
+    })
   })
 
   it("updates the deck visual style preference on the detail page without mutating slides", async () => {
@@ -363,17 +367,15 @@ describe("PresentationStudioPage", () => {
 
     render(<PresentationStudioPage mode="detail" projectId="presentation-style" />)
 
-    const styleSelect = await screen.findByLabelText("Choose visual style")
-    fireEvent.change(styleSelect, {
-      target: { value: "builtin::timeline" }
-    })
+    await screen.findByText("Timeline")
+    fireEvent.click(screen.getByRole("button", { name: /Timeline/ }))
 
     const state = usePresentationStudioStore.getState()
     expect(state.visualStyleId).toBe("timeline")
     expect(state.visualStyleScope).toBe("builtin")
     expect(state.visualStyleName).toBe("Timeline")
     expect(state.slides).toHaveLength(1)
-    expect(state.theme).toBe("black")
+    expect(state.theme).toBe("beige")
   })
 
   it("creates a custom visual style and selects it in new mode", async () => {
@@ -454,9 +456,10 @@ describe("PresentationStudioPage", () => {
       )
     })
     await waitFor(() => {
-      expect(
-        (screen.getByLabelText("Choose visual style") as HTMLSelectElement).value
-      ).toBe("user::style-user-1")
+      expect(screen.getByRole("button", { name: /CGPSC Sprint/ })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      )
     })
   })
 

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/VisualStylePicker.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/VisualStylePicker.test.tsx
@@ -1,0 +1,91 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { VisualStylePicker } from "../VisualStylePicker"
+
+const styles = [
+  {
+    id: "minimal-academic",
+    scope: "builtin",
+    name: "Minimal Academic",
+    description: "Structured, restrained, study-first slides.",
+    category: "Educational and Explainer",
+    guide_number: 1,
+    tags: ["study", "notes"],
+    best_for: ["exam prep", "course notes"],
+    generation_rules: {},
+    artifact_preferences: [],
+    appearance_defaults: { theme: "white" },
+    fallback_policy: {},
+    version: 1
+  },
+  {
+    id: "blueprint-lab",
+    scope: "user",
+    name: "Blueprint Lab",
+    description: "A custom technical deck style.",
+    generation_rules: {},
+    artifact_preferences: [],
+    appearance_defaults: { theme: "night" },
+    fallback_policy: {},
+    version: 2
+  }
+]
+
+describe("VisualStylePicker", () => {
+  it("groups, searches, and preserves selection for built-in and custom styles", () => {
+    const onChange = vi.fn()
+
+    render(
+      <VisualStylePicker
+        label="Visual style"
+        value="builtin::minimal-academic"
+        styles={styles as any}
+        onChange={onChange}
+      />
+    )
+
+    expect(screen.getByRole("searchbox", { name: "Search visual styles" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Educational and Explainer" })).toBeInTheDocument()
+    expect(screen.getByText("Guide 1")).toBeInTheDocument()
+    expect(screen.getByText("Best for")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Custom styles" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /Minimal Academic/ })
+    ).toHaveAttribute("aria-pressed", "true")
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search visual styles" }), {
+      target: { value: "blueprint" }
+    })
+
+    expect(screen.queryByRole("button", { name: /Minimal Academic/ })).toBeNull()
+    expect(screen.getByText("Blueprint Lab")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /Blueprint Lab/ }))
+
+    expect(onChange).toHaveBeenCalledWith("user::blueprint-lab")
+    expect(screen.queryByRole("region", { name: "Educational and Explainer" })).toBeNull()
+  })
+
+  it("disables both the search box and style actions when disabled", () => {
+    const onChange = vi.fn()
+
+    render(
+      <VisualStylePicker
+        label="Visual style"
+        value="builtin::minimal-academic"
+        styles={styles as any}
+        onChange={onChange}
+        disabled
+      />
+    )
+
+    expect(screen.getByRole("searchbox", { name: "Search visual styles" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /Minimal Academic/ })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole("button", { name: /Blueprint Lab/ }))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/VisualStylePicker.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/VisualStylePicker.test.tsx
@@ -10,13 +10,28 @@ const styles = [
     scope: "builtin",
     name: "Minimal Academic",
     description: "Structured, restrained, study-first slides.",
-    category: "Educational and Explainer",
+    category: "educational",
     guide_number: 1,
     tags: ["study", "notes"],
     best_for: ["exam prep", "course notes"],
     generation_rules: {},
     artifact_preferences: [],
     appearance_defaults: { theme: "white" },
+    fallback_policy: {},
+    version: 1
+  },
+  {
+    id: "notebooklm-blueprint",
+    scope: "builtin",
+    name: "Blueprint",
+    description: "Technical diagrams and systems breakdowns.",
+    category: "technical",
+    guide_number: 12,
+    tags: ["architecture", "systems"],
+    best_for: ["engineering review"],
+    generation_rules: {},
+    artifact_preferences: [],
+    appearance_defaults: { theme: "night" },
     fallback_policy: {},
     version: 1
   },
@@ -47,10 +62,13 @@ describe("VisualStylePicker", () => {
     )
 
     expect(screen.getByRole("searchbox", { name: "Search visual styles" })).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Educational and Explainer" })).toBeInTheDocument()
+    expect(screen.getAllByRole("heading").map((node) => node.textContent)).toEqual([
+      "Educational and Explainer",
+      "Technical and Engineering",
+      "Custom styles"
+    ])
     expect(screen.getByText("Guide 1")).toBeInTheDocument()
-    expect(screen.getByText("Best for")).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Custom styles" })).toBeInTheDocument()
+    expect(screen.getAllByText("Best for")).toHaveLength(2)
     expect(
       screen.getByRole("button", { name: /Minimal Academic/ })
     ).toHaveAttribute("aria-pressed", "true")

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentation-studio.store.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentation-studio.store.test.tsx
@@ -21,6 +21,10 @@ const sampleProject = {
     id: "minimal-academic",
     scope: "builtin",
     name: "Minimal Academic",
+    category: "Educational and Explainer",
+    guide_number: 1,
+    tags: ["study", "notes"],
+    best_for: ["exam prep", "course notes"],
     appearance_defaults: { theme: "white" }
   },
   settings: null,
@@ -137,7 +141,11 @@ describe("presentation studio store", () => {
     expect(state.visualStyleSnapshot).toEqual(
       expect.objectContaining({
         id: "minimal-academic",
-        name: "Minimal Academic"
+        name: "Minimal Academic",
+        category: "Educational and Explainer",
+        guide_number: 1,
+        tags: ["study", "notes"],
+        best_for: ["exam prep", "course notes"]
       })
     )
 

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.presentations-normalization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.presentations-normalization.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bgRequest: vi.fn(),
+  bgUpload: vi.fn(),
+  bgStream: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: (...args: unknown[]) => mocks.bgRequest(...args),
+  bgUpload: (...args: unknown[]) => mocks.bgUpload(...args),
+  bgStream: (...args: unknown[]) => mocks.bgStream(...args)
+}))
+
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => ({
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    remove: vi.fn(async () => undefined)
+  }),
+  safeStorageSerde: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value
+  }
+}))
+
+import {
+  presentationsMethods,
+  type TldwApiClientCore
+} from "@/services/tldw/domains/presentations"
+
+describe("TldwApiClient presentations normalization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("trims and filters array-based visual style metadata fields", async () => {
+    const client: TldwApiClientCore = {
+      ensureConfigForRequest: vi.fn(async () => ({})),
+      request: vi.fn(async () => ({
+        styles: [
+          {
+            id: "notebooklm-blueprint",
+            name: "Blueprint",
+            scope: "builtin",
+            tags: [" technical ", " ", "technical_grid"],
+            best_for: [" systems explanation ", "", "architecture walkthrough "],
+            artifact_preferences: [" timeline ", "comparison_matrix", ""],
+            appearance_defaults: { theme: "night" },
+            generation_rules: {},
+            fallback_policy: {}
+          }
+        ],
+        total_count: 1
+      })),
+      resolveApiPath: vi.fn(),
+      fillPathParams: vi.fn()
+    }
+
+    const styles = await presentationsMethods.listVisualStyles.call(client)
+
+    expect(styles).toHaveLength(1)
+    expect(styles[0]?.tags).toEqual(["technical", "technical_grid"])
+    expect(styles[0]?.best_for).toEqual(["systems explanation", "architecture walkthrough"])
+    expect(styles[0]?.artifact_preferences).toEqual(["timeline", "comparison_matrix"])
+  })
+})

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -11,6 +11,7 @@ import { appendPathQuery } from "@/services/tldw/path-utils"
 import { inferUploadMediaTypeFromUrl } from "@/services/tldw/media-routing"
 import { captureChatRequestDebugSnapshot } from "@/services/tldw/chat-request-debug"
 import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
+import { toTrimmedStringArray } from "@/services/tldw/client-utils"
 import {
   DEFAULT_CHARACTER_PROFILE_PREFERENCE_KEY,
   normalizeDefaultCharacterPreferenceId
@@ -177,18 +178,6 @@ const toOptionalNumber = (value: unknown): number | null => {
     }
   }
   return null
-}
-
-const toStringArray = (value: unknown): string[] => {
-  if (Array.isArray(value)) {
-    return value
-      .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
-      .map((entry) => entry.trim())
-  }
-  if (typeof value === "string" && value.trim().length > 0) {
-    return [value.trim()]
-  }
-  return []
 }
 
 export const normalizeIngestionSourceSyncSummary = (
@@ -589,10 +578,10 @@ const normalizeVisualStyleSnapshot = (
     description: toOptionalString(snapshot.description),
     category: toOptionalString(snapshot.category),
     guide_number: toOptionalNumber(snapshot.guide_number),
-    tags: toStringArray(snapshot.tags),
-    best_for: toStringArray(snapshot.best_for),
+    tags: toTrimmedStringArray(snapshot.tags),
+    best_for: toTrimmedStringArray(snapshot.best_for),
     generation_rules: toRecord(snapshot.generation_rules),
-    artifact_preferences: toStringArray(snapshot.artifact_preferences),
+    artifact_preferences: toTrimmedStringArray(snapshot.artifact_preferences),
     appearance_defaults: toRecord(snapshot.appearance_defaults),
     fallback_policy: toRecord(snapshot.fallback_policy),
     version: toOptionalNumber(snapshot.version)
@@ -610,10 +599,10 @@ const normalizeVisualStyleRecord = (style: unknown): VisualStyleRecord => {
     description: toOptionalString(record.description),
     category: toOptionalString(record.category),
     guide_number: toOptionalNumber(record.guide_number),
-    tags: toStringArray(record.tags),
-    best_for: toStringArray(record.best_for),
+    tags: toTrimmedStringArray(record.tags),
+    best_for: toTrimmedStringArray(record.best_for),
     generation_rules: toRecord(record.generation_rules),
-    artifact_preferences: toStringArray(record.artifact_preferences),
+    artifact_preferences: toTrimmedStringArray(record.artifact_preferences),
     appearance_defaults: toRecord(record.appearance_defaults),
     fallback_policy: toRecord(record.fallback_policy),
     version: toOptionalNumber(record.version),

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -180,12 +180,15 @@ const toOptionalNumber = (value: unknown): number | null => {
 }
 
 const toStringArray = (value: unknown): string[] => {
-  if (!Array.isArray(value)) {
-    return []
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      .map((entry) => entry.trim())
   }
-  return value
-    .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
-    .map((entry) => entry.trim())
+  if (typeof value === "string" && value.trim().length > 0) {
+    return [value.trim()]
+  }
+  return []
 }
 
 export const normalizeIngestionSourceSyncSummary = (
@@ -388,6 +391,10 @@ export type PresentationVisualStyleSnapshot = {
   scope: string
   name: string
   description?: string | null
+  category?: string | null
+  guide_number?: number | null
+  tags?: string[]
+  best_for?: string[]
   generation_rules?: Record<string, any>
   artifact_preferences?: string[]
   appearance_defaults?: Record<string, any>
@@ -400,6 +407,10 @@ export type VisualStyleRecord = {
   name: string
   scope: string
   description?: string | null
+  category?: string | null
+  guide_number?: number | null
+  tags: string[]
+  best_for: string[]
   generation_rules: Record<string, any>
   artifact_preferences: string[]
   appearance_defaults: Record<string, any>
@@ -458,6 +469,10 @@ export const clonePresentationVisualStyleSnapshot = (
     scope: snapshot.scope,
     name: snapshot.name,
     description: snapshot.description ?? null,
+    category: snapshot.category ?? null,
+    guide_number: snapshot.guide_number ?? null,
+    tags: [...(snapshot.tags || [])],
+    best_for: [...(snapshot.best_for || [])],
     generation_rules: cloneVisualStyleObject(snapshot.generation_rules),
     artifact_preferences: [...(snapshot.artifact_preferences || [])],
     appearance_defaults: cloneVisualStyleObject(snapshot.appearance_defaults),
@@ -473,6 +488,10 @@ export const buildPresentationVisualStyleSnapshot = (
     | "scope"
     | "name"
     | "description"
+    | "category"
+    | "guide_number"
+    | "tags"
+    | "best_for"
     | "generation_rules"
     | "artifact_preferences"
     | "appearance_defaults"
@@ -485,6 +504,10 @@ export const buildPresentationVisualStyleSnapshot = (
     scope: style.scope,
     name: style.name,
     description: style.description ?? null,
+    category: style.category ?? null,
+    guide_number: style.guide_number ?? null,
+    tags: [...(style.tags || [])],
+    best_for: [...(style.best_for || [])],
     generation_rules: cloneVisualStyleObject(style.generation_rules),
     artifact_preferences: [...(style.artifact_preferences || [])],
     appearance_defaults: cloneVisualStyleObject(style.appearance_defaults),
@@ -564,6 +587,10 @@ const normalizeVisualStyleSnapshot = (
     scope,
     name,
     description: toOptionalString(snapshot.description),
+    category: toOptionalString(snapshot.category),
+    guide_number: toOptionalNumber(snapshot.guide_number),
+    tags: toStringArray(snapshot.tags),
+    best_for: toStringArray(snapshot.best_for),
     generation_rules: toRecord(snapshot.generation_rules),
     artifact_preferences: toStringArray(snapshot.artifact_preferences),
     appearance_defaults: toRecord(snapshot.appearance_defaults),
@@ -581,6 +608,10 @@ const normalizeVisualStyleRecord = (style: unknown): VisualStyleRecord => {
     name: String(record.name ?? ""),
     scope: String(record.scope ?? ""),
     description: toOptionalString(record.description),
+    category: toOptionalString(record.category),
+    guide_number: toOptionalNumber(record.guide_number),
+    tags: toStringArray(record.tags),
+    best_for: toStringArray(record.best_for),
     generation_rules: toRecord(record.generation_rules),
     artifact_preferences: toStringArray(record.artifact_preferences),
     appearance_defaults: toRecord(record.appearance_defaults),

--- a/apps/packages/ui/src/services/tldw/__tests__/client-utils.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/client-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { toTrimmedStringArray } from "@/services/tldw/client-utils"
+
+describe("toTrimmedStringArray", () => {
+  it("trims and filters array entries", () => {
+    expect(toTrimmedStringArray([" one ", "", "two", 3, "   "])).toEqual([
+      "one",
+      "two"
+    ])
+  })
+
+  it("normalizes a scalar string into a one-item array", () => {
+    expect(toTrimmedStringArray("  single value ")).toEqual(["single value"])
+    expect(toTrimmedStringArray("   ")).toEqual([])
+    expect(toTrimmedStringArray(null)).toEqual([])
+  })
+})

--- a/apps/packages/ui/src/services/tldw/client-utils.ts
+++ b/apps/packages/ui/src/services/tldw/client-utils.ts
@@ -22,3 +22,15 @@ export function buildQuery(params?: Record<string, any>): string {
   const query = search.toString()
   return query ? `?${query}` : ''
 }
+
+export function toTrimmedStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      .map((entry) => entry.trim())
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return [value.trim()]
+  }
+  return []
+}

--- a/apps/packages/ui/src/services/tldw/domains/presentations.ts
+++ b/apps/packages/ui/src/services/tldw/domains/presentations.ts
@@ -53,7 +53,11 @@ const toFiniteNumber = (value: unknown, fallback = 0): number => {
 }
 
 const toStringArray = (value: unknown): string[] => {
-  if (Array.isArray(value)) return value.filter((v) => typeof v === "string").map(String)
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      .map((entry) => entry.trim())
+  }
   if (typeof value === "string" && value.trim().length > 0) return [value.trim()]
   return []
 }

--- a/apps/packages/ui/src/services/tldw/domains/presentations.ts
+++ b/apps/packages/ui/src/services/tldw/domains/presentations.ts
@@ -53,8 +53,9 @@ const toFiniteNumber = (value: unknown, fallback = 0): number => {
 }
 
 const toStringArray = (value: unknown): string[] => {
-  if (!Array.isArray(value)) return []
-  return value.filter((v) => typeof v === "string").map(String)
+  if (Array.isArray(value)) return value.filter((v) => typeof v === "string").map(String)
+  if (typeof value === "string" && value.trim().length > 0) return [value.trim()]
+  return []
 }
 
 const normalizeVisualStyleSnapshot = (
@@ -75,6 +76,10 @@ const normalizeVisualStyleSnapshot = (
     scope,
     name,
     description: toOptionalString(snapshot.description),
+    category: toOptionalString(snapshot.category),
+    guide_number: toOptionalNumber(snapshot.guide_number),
+    tags: toStringArray(snapshot.tags),
+    best_for: toStringArray(snapshot.best_for),
     generation_rules: toRecord(snapshot.generation_rules),
     artifact_preferences: toStringArray(snapshot.artifact_preferences),
     appearance_defaults: toRecord(snapshot.appearance_defaults),
@@ -92,6 +97,10 @@ const normalizeVisualStyleRecord = (style: unknown): VisualStyleRecord => {
     name: String(record.name ?? ""),
     scope: String(record.scope ?? ""),
     description: toOptionalString(record.description),
+    category: toOptionalString(record.category),
+    guide_number: toOptionalNumber(record.guide_number),
+    tags: toStringArray(record.tags),
+    best_for: toStringArray(record.best_for),
     generation_rules: toRecord(record.generation_rules),
     artifact_preferences: toStringArray(record.artifact_preferences),
     appearance_defaults: toRecord(record.appearance_defaults),

--- a/apps/packages/ui/src/services/tldw/domains/presentations.ts
+++ b/apps/packages/ui/src/services/tldw/domains/presentations.ts
@@ -1,5 +1,5 @@
 import { bgRequest } from "@/services/background-proxy"
-import { buildQuery } from "../client-utils"
+import { buildQuery, toTrimmedStringArray } from "../client-utils"
 import type {
   PresentationStudioSlide,
   PresentationVisualStyleSnapshot,
@@ -14,12 +14,6 @@ import type {
 import {
   clonePresentationVisualStyleSnapshot,
 } from "../TldwApiClient"
-
-// Re-use the file-level normalizers from TldwApiClient.
-// They are module-scoped `const` functions, so we must
-// import the helpers they depend on and replicate them here
-// (they are not exported from TldwApiClient).
-// These inline versions mirror the originals exactly.
 
 const toOptionalString = (value: unknown): string | null => {
   if (typeof value !== "string") return null
@@ -52,16 +46,6 @@ const toFiniteNumber = (value: unknown, fallback = 0): number => {
   return fallback
 }
 
-const toStringArray = (value: unknown): string[] => {
-  if (Array.isArray(value)) {
-    return value
-      .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
-      .map((entry) => entry.trim())
-  }
-  if (typeof value === "string" && value.trim().length > 0) return [value.trim()]
-  return []
-}
-
 const normalizeVisualStyleSnapshot = (
   value: unknown
 ): PresentationVisualStyleSnapshot | null => {
@@ -82,10 +66,10 @@ const normalizeVisualStyleSnapshot = (
     description: toOptionalString(snapshot.description),
     category: toOptionalString(snapshot.category),
     guide_number: toOptionalNumber(snapshot.guide_number),
-    tags: toStringArray(snapshot.tags),
-    best_for: toStringArray(snapshot.best_for),
+    tags: toTrimmedStringArray(snapshot.tags),
+    best_for: toTrimmedStringArray(snapshot.best_for),
     generation_rules: toRecord(snapshot.generation_rules),
-    artifact_preferences: toStringArray(snapshot.artifact_preferences),
+    artifact_preferences: toTrimmedStringArray(snapshot.artifact_preferences),
     appearance_defaults: toRecord(snapshot.appearance_defaults),
     fallback_policy: toRecord(snapshot.fallback_policy),
     version: toOptionalNumber(snapshot.version)
@@ -103,10 +87,10 @@ const normalizeVisualStyleRecord = (style: unknown): VisualStyleRecord => {
     description: toOptionalString(record.description),
     category: toOptionalString(record.category),
     guide_number: toOptionalNumber(record.guide_number),
-    tags: toStringArray(record.tags),
-    best_for: toStringArray(record.best_for),
+    tags: toTrimmedStringArray(record.tags),
+    best_for: toTrimmedStringArray(record.best_for),
     generation_rules: toRecord(record.generation_rules),
-    artifact_preferences: toStringArray(record.artifact_preferences),
+    artifact_preferences: toTrimmedStringArray(record.artifact_preferences),
     appearance_defaults: toRecord(record.appearance_defaults),
     fallback_policy: toRecord(record.fallback_policy),
     version: toOptionalNumber(record.version),

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -9,6 +9,8 @@ import json
 import os
 import re
 import time
+from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -98,9 +100,12 @@ from tldw_Server_API.app.core.Slides.slides_templates import (
     list_slide_templates,
 )
 from tldw_Server_API.app.core.Slides.visual_styles import (
-    VisualStylePreset,
     get_builtin_visual_style,
     list_builtin_visual_styles,
+)
+from tldw_Server_API.app.core.Slides.visual_style_resolver import (
+    ResolvedBuiltinVisualStyle,
+    resolve_builtin_visual_style,
 )
 from tldw_Server_API.app.core.testing import is_truthy
 
@@ -162,6 +167,18 @@ _SLIDES_NONCRITICAL_EXCEPTIONS = (
 
 _PRESENTATION_STUDIO_TRANSITIONS = {"fade", "cut", "wipe", "zoom"}
 _PRESENTATION_STUDIO_TIMING_MODES = {"auto", "manual"}
+
+
+@dataclass(frozen=True)
+class PresentationVisualStyleApplication:
+    """Resolved visual-style application data for presentation writes."""
+
+    style_id: str
+    scope: str
+    name: str
+    version: int | None
+    snapshot: dict[str, Any]
+    appearance_defaults: dict[str, Any]
 
 
 def _parse_etag(raw: str | None) -> int:
@@ -458,36 +475,82 @@ def _resolve_template(template_id: str | None) -> SlidesTemplate | None:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
+def _compact_visual_style_appearance_defaults(appearance_defaults: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact, response-safe copy of visual-style appearance defaults."""
+
+    compact = deepcopy(appearance_defaults)
+    if isinstance(compact, dict):
+        compact.pop("custom_css", None)
+    return compact
+
+
+def _visual_style_application_from_builtin(
+    resolved: ResolvedBuiltinVisualStyle,
+) -> PresentationVisualStyleApplication:
+    appearance_defaults = _validate_visual_style_appearance_defaults(resolved.appearance)
+    return PresentationVisualStyleApplication(
+        style_id=resolved.definition.style_id,
+        scope="builtin",
+        name=resolved.definition.name,
+        version=resolved.definition.version,
+        snapshot=deepcopy(resolved.snapshot),
+        appearance_defaults=appearance_defaults,
+    )
+
+
+def _visual_style_application_from_row(row: VisualStyleRow) -> PresentationVisualStyleApplication:
+    payload = _deserialize_visual_style_payload(row.style_payload)
+    appearance_defaults_raw = payload.get("appearance_defaults") if isinstance(payload.get("appearance_defaults"), dict) else {}
+    appearance_defaults = _validate_visual_style_appearance_defaults(appearance_defaults_raw)
+    generation_rules = payload.get("generation_rules") if isinstance(payload.get("generation_rules"), dict) else {}
+    fallback_policy = payload.get("fallback_policy") if isinstance(payload.get("fallback_policy"), dict) else {}
+    artifact_preferences_raw = payload.get("artifact_preferences")
+    artifact_preferences = artifact_preferences_raw if isinstance(artifact_preferences_raw, list) else []
+    version = payload.get("version")
+    response = VisualStyleResponse(
+        id=row.id,
+        name=row.name,
+        scope=row.scope,
+        description=payload.get("description") if isinstance(payload.get("description"), str) else None,
+        version=version if isinstance(version, int) else None,
+        generation_rules=generation_rules,
+        artifact_preferences=[str(item) for item in artifact_preferences],
+        appearance_defaults=appearance_defaults,
+        fallback_policy=fallback_policy,
+        created_at=_normalize_dt(row.created_at),
+        updated_at=_normalize_dt(row.updated_at),
+    )
+    return PresentationVisualStyleApplication(
+        style_id=response.id,
+        scope=response.scope,
+        name=response.name,
+        version=response.version,
+        snapshot=_visual_style_snapshot_from_response(response),
+        appearance_defaults=response.appearance_defaults,
+    )
+
+
 def _apply_template_defaults(
     *,
     request: Any,
     template: SlidesTemplate | None,
-    visual_style_snapshot: dict[str, Any] | None = None,
+    visual_style_application: PresentationVisualStyleApplication | None = None,
 ) -> tuple[str, str | None, dict[str, Any] | None, str | None]:
-    theme = request.theme if _field_was_set(request, "theme") else None
-    marp_theme = request.marp_theme if _field_was_set(request, "marp_theme") else None
-    settings = request.settings if _field_was_set(request, "settings") else None
-    custom_css = _validate_custom_css(request.custom_css) if _field_was_set(request, "custom_css") else None
-
     appearance_defaults = (
-        visual_style_snapshot.get("appearance_defaults")
-        if isinstance(visual_style_snapshot, dict) and isinstance(visual_style_snapshot.get("appearance_defaults"), dict)
-        else {}
+        visual_style_application.appearance_defaults if visual_style_application is not None else {}
     )
-    if "custom_css" in appearance_defaults:
-        appearance_defaults = dict(appearance_defaults)
-        appearance_defaults["custom_css"] = _validate_custom_css(
-            appearance_defaults.get("custom_css"),
-            detail="invalid_visual_style_custom_css",
-        )
-    if theme is None:
-        theme = appearance_defaults.get("theme")
-    if marp_theme is None:
-        marp_theme = appearance_defaults.get("marp_theme")
-    if settings is None:
-        settings = appearance_defaults.get("settings")
-    if custom_css is None:
-        custom_css = appearance_defaults.get("custom_css")
+    theme = appearance_defaults.get("theme")
+    marp_theme = appearance_defaults.get("marp_theme")
+    settings = appearance_defaults.get("settings")
+    custom_css = appearance_defaults.get("custom_css")
+    if _field_was_set(request, "theme"):
+        theme = request.theme
+    if _field_was_set(request, "marp_theme"):
+        marp_theme = request.marp_theme
+    if _field_was_set(request, "settings"):
+        settings = request.settings
+    if _field_was_set(request, "custom_css"):
+        custom_css = _validate_custom_css(request.custom_css)
 
     if template:
         if theme is None:
@@ -573,17 +636,23 @@ def _serialize_visual_style_payload(
     return json.dumps(payload, ensure_ascii=True)
 
 
-def _visual_style_response_from_builtin(style: VisualStylePreset) -> VisualStyleResponse:
+def _visual_style_response_from_builtin(
+    resolved: ResolvedBuiltinVisualStyle,
+) -> VisualStyleResponse:
     return VisualStyleResponse(
-        id=style.style_id,
-        name=style.name,
+        id=resolved.definition.style_id,
+        name=resolved.definition.name,
         scope="builtin",
-        description=style.description,
-        version=style.version,
-        generation_rules=style.generation_rules,
-        artifact_preferences=list(style.artifact_preferences),
-        appearance_defaults=style.appearance_defaults,
-        fallback_policy=style.fallback_policy,
+        category=resolved.definition.category,
+        guide_number=resolved.definition.guide_number,
+        tags=list(resolved.definition.tags),
+        best_for=list(resolved.definition.best_for),
+        description=resolved.definition.description,
+        version=resolved.definition.version,
+        generation_rules=deepcopy(resolved.definition.generation_rules),
+        artifact_preferences=list(resolved.definition.artifact_preferences),
+        appearance_defaults=_compact_visual_style_appearance_defaults(resolved.appearance),
+        fallback_policy=deepcopy(resolved.definition.fallback_policy),
         created_at=None,
         updated_at=None,
     )
@@ -614,9 +683,9 @@ def _visual_style_response_from_row(row: VisualStyleRow) -> VisualStyleResponse:
 
 
 def _resolve_visual_style_response(style_id: str, db: SlidesDatabase) -> VisualStyleResponse:
-    builtin = get_builtin_visual_style(style_id)
-    if builtin is not None:
-        return _visual_style_response_from_builtin(builtin)
+    resolved_builtin = resolve_builtin_visual_style(style_id)
+    if resolved_builtin is not None:
+        return _visual_style_response_from_builtin(resolved_builtin)
     try:
         row = db.get_visual_style_by_id(style_id)
     except KeyError:
@@ -624,28 +693,35 @@ def _resolve_visual_style_response(style_id: str, db: SlidesDatabase) -> VisualS
     return _visual_style_response_from_row(row)
 
 
-def _visual_style_snapshot_from_response(style: VisualStyleResponse) -> dict[str, Any]:
-    return {
+def _visual_style_snapshot_from_response(
+    style: VisualStyleResponse,
+    *,
+    compact_resolution: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    snapshot = {
         "id": style.id,
         "scope": style.scope,
         "name": style.name,
         "version": style.version,
         "description": style.description,
-        "generation_rules": style.generation_rules,
-        "artifact_preferences": style.artifact_preferences,
-        "appearance_defaults": style.appearance_defaults,
-        "fallback_policy": style.fallback_policy,
+        "generation_rules": deepcopy(style.generation_rules),
+        "artifact_preferences": list(style.artifact_preferences),
+        "appearance_defaults": deepcopy(style.appearance_defaults),
+        "fallback_policy": deepcopy(style.fallback_policy),
     }
+    if compact_resolution is not None:
+        snapshot["resolution"] = deepcopy(compact_resolution)
+    return snapshot
 
 
-def _resolve_presentation_visual_style(
+def _resolve_presentation_visual_style_application(
     *,
     visual_style_id: str | None,
     visual_style_scope: str | None,
     db: SlidesDatabase,
-) -> tuple[str | None, str | None, str | None, int | None, str | None]:
+) -> PresentationVisualStyleApplication | None:
     if visual_style_id is None and visual_style_scope is None:
-        return None, None, None, None, None
+        return None
     if visual_style_id is None:
         raise HTTPException(status_code=422, detail="visual_style_id_required")
     if visual_style_scope is None:
@@ -657,26 +733,18 @@ def _resolve_presentation_visual_style(
 
     resolved_scope = visual_style_scope.strip().lower()
     if resolved_scope == "builtin":
-        builtin = get_builtin_visual_style(resolved_id)
-        if builtin is None:
+        resolved_builtin = resolve_builtin_visual_style(resolved_id)
+        if resolved_builtin is None:
             raise HTTPException(status_code=404, detail="visual_style_not_found")
-        style = _visual_style_response_from_builtin(builtin)
+        return _visual_style_application_from_builtin(resolved_builtin)
     elif resolved_scope == "user":
         try:
             row = db.get_visual_style_by_id(resolved_id)
         except KeyError:
             raise HTTPException(status_code=404, detail="visual_style_not_found") from None
-        style = _visual_style_response_from_row(row)
+        return _visual_style_application_from_row(row)
     else:
         raise HTTPException(status_code=422, detail="invalid_visual_style_scope")
-
-    return (
-        style.id,
-        style.scope,
-        style.name,
-        style.version,
-        _serialize_visual_style_snapshot(_visual_style_snapshot_from_response(style)),
-    )
 
 
 def _normalize_template_slides(slides_payload: list[Any]) -> list[Slide]:
@@ -927,19 +995,17 @@ def _generate_presentation(
     source_ref: Any | None,
     source_query: str | None,
 ) -> PresentationResponse:
-    visual_style_id, visual_style_scope, visual_style_name, visual_style_version, visual_style_snapshot = (
-        _resolve_presentation_visual_style(
-            visual_style_id=getattr(request, "visual_style_id", None),
-            visual_style_scope=getattr(request, "visual_style_scope", None),
-            db=db,
-        )
+    visual_style_application = _resolve_presentation_visual_style_application(
+        visual_style_id=getattr(request, "visual_style_id", None),
+        visual_style_scope=getattr(request, "visual_style_scope", None),
+        db=db,
     )
-    visual_style_snapshot_dict = _deserialize_visual_style_snapshot(visual_style_snapshot)
+    visual_style_snapshot_dict = visual_style_application.snapshot if visual_style_application else None
     template = _resolve_template(getattr(request, "template_id", None))
     theme, marp_theme, settings, custom_css = _apply_template_defaults(
         request=request,
         template=template,
-        visual_style_snapshot=visual_style_snapshot_dict,
+        visual_style_application=visual_style_application,
     )
     _validate_theme(theme)
     marp_theme = _validate_marp_theme(marp_theme)
@@ -1015,11 +1081,11 @@ def _generate_presentation(
         theme=theme,
         marp_theme=marp_theme,
         template_id=template.template_id if template else None,
-        visual_style_id=visual_style_id,
-        visual_style_scope=visual_style_scope,
-        visual_style_name=visual_style_name,
-        visual_style_version=visual_style_version,
-        visual_style_snapshot=visual_style_snapshot,
+        visual_style_id=visual_style_application.style_id if visual_style_application else None,
+        visual_style_scope=visual_style_application.scope if visual_style_application else None,
+        visual_style_name=visual_style_application.name if visual_style_application else None,
+        visual_style_version=visual_style_application.version if visual_style_application else None,
+        visual_style_snapshot=_serialize_visual_style_snapshot(visual_style_snapshot_dict),
         settings=_serialize_settings(settings),
         studio_data=None,
         slides=json.dumps([slide.model_dump() if hasattr(slide, "model_dump") else slide.dict() for slide in slides]),
@@ -1058,19 +1124,17 @@ async def create_presentation(
     title = request.title.strip()
     if not title:
         raise HTTPException(status_code=422, detail="title_required")
-    visual_style_id, visual_style_scope, visual_style_name, visual_style_version, visual_style_snapshot = (
-        _resolve_presentation_visual_style(
-            visual_style_id=request.visual_style_id,
-            visual_style_scope=request.visual_style_scope,
-            db=db,
-        )
+    visual_style_application = _resolve_presentation_visual_style_application(
+        visual_style_id=request.visual_style_id,
+        visual_style_scope=request.visual_style_scope,
+        db=db,
     )
-    visual_style_snapshot_dict = _deserialize_visual_style_snapshot(visual_style_snapshot)
+    visual_style_snapshot_dict = visual_style_application.snapshot if visual_style_application else None
     template = _resolve_template(request.template_id)
     theme, marp_theme, settings, custom_css = _apply_template_defaults(
         request=request,
         template=template,
-        visual_style_snapshot=visual_style_snapshot_dict,
+        visual_style_application=visual_style_application,
     )
     _validate_theme(theme)
     marp_theme = _validate_marp_theme(marp_theme)
@@ -1087,11 +1151,11 @@ async def create_presentation(
         theme=theme,
         marp_theme=marp_theme,
         template_id=template.template_id if template else None,
-        visual_style_id=visual_style_id,
-        visual_style_scope=visual_style_scope,
-        visual_style_name=visual_style_name,
-        visual_style_version=visual_style_version,
-        visual_style_snapshot=visual_style_snapshot,
+        visual_style_id=visual_style_application.style_id if visual_style_application else None,
+        visual_style_scope=visual_style_application.scope if visual_style_application else None,
+        visual_style_name=visual_style_application.name if visual_style_application else None,
+        visual_style_version=visual_style_application.version if visual_style_application else None,
+        visual_style_snapshot=_serialize_visual_style_snapshot(visual_style_snapshot_dict),
         settings=_serialize_settings(settings),
         studio_data=_serialize_studio_data(request.studio_data),
         slides=json.dumps([slide.model_dump() if hasattr(slide, "model_dump") else slide.dict() for slide in slides]),
@@ -1195,19 +1259,17 @@ async def update_presentation(
     title = request.title.strip()
     if not title:
         raise HTTPException(status_code=422, detail="title_required")
-    visual_style_id, visual_style_scope, visual_style_name, visual_style_version, visual_style_snapshot = (
-        _resolve_presentation_visual_style(
-            visual_style_id=request.visual_style_id,
-            visual_style_scope=request.visual_style_scope,
-            db=db,
-        )
+    visual_style_application = _resolve_presentation_visual_style_application(
+        visual_style_id=request.visual_style_id,
+        visual_style_scope=request.visual_style_scope,
+        db=db,
     )
-    visual_style_snapshot_dict = _deserialize_visual_style_snapshot(visual_style_snapshot)
+    visual_style_snapshot_dict = visual_style_application.snapshot if visual_style_application else None
     template = _resolve_template(request.template_id)
     theme, marp_theme, settings, custom_css = _apply_template_defaults(
         request=request,
         template=template,
-        visual_style_snapshot=visual_style_snapshot_dict,
+        visual_style_application=visual_style_application,
     )
     _validate_theme(theme)
     marp_theme = _validate_marp_theme(marp_theme)
@@ -1226,11 +1288,11 @@ async def update_presentation(
                 "theme": theme,
                 "marp_theme": marp_theme,
                 "template_id": template.template_id if template else None,
-                "visual_style_id": visual_style_id,
-                "visual_style_scope": visual_style_scope,
-                "visual_style_name": visual_style_name,
-                "visual_style_version": visual_style_version,
-                "visual_style_snapshot": visual_style_snapshot,
+                "visual_style_id": visual_style_application.style_id if visual_style_application else None,
+                "visual_style_scope": visual_style_application.scope if visual_style_application else None,
+                "visual_style_name": visual_style_application.name if visual_style_application else None,
+                "visual_style_version": visual_style_application.version if visual_style_application else None,
+                "visual_style_snapshot": _serialize_visual_style_snapshot(visual_style_snapshot_dict),
                 "settings": _serialize_settings(settings),
                 "studio_data": _serialize_studio_data(request.studio_data),
                 "slides": json.dumps([slide.model_dump() if hasattr(slide, "model_dump") else slide.dict() for slide in slides]),
@@ -1265,6 +1327,11 @@ async def patch_presentation(
 ) -> PresentationResponse:
     expected_version = _parse_etag(if_match)
     update_fields: dict[str, Any] = {}
+    builtin_appearance_defaults: dict[str, Any] | None = None
+    theme_was_set = _field_was_set(request, "theme")
+    marp_theme_was_set = _field_was_set(request, "marp_theme")
+    settings_was_set = _field_was_set(request, "settings")
+    custom_css_was_set = _field_was_set(request, "custom_css")
     if request.title is not None:
         title = request.title.strip()
         if not title:
@@ -1275,7 +1342,7 @@ async def patch_presentation(
     if request.theme is not None:
         _validate_theme(request.theme)
         update_fields["theme"] = request.theme
-    if request.marp_theme is not None:
+    if marp_theme_was_set:
         update_fields["marp_theme"] = _validate_marp_theme(request.marp_theme)
     if _field_was_set(request, "template_id"):
         template = _resolve_template(request.template_id)
@@ -1288,19 +1355,36 @@ async def patch_presentation(
             update_fields["visual_style_version"] = None
             update_fields["visual_style_snapshot"] = None
         else:
-            visual_style_id, visual_style_scope, visual_style_name, visual_style_version, visual_style_snapshot = (
-                _resolve_presentation_visual_style(
-                    visual_style_id=request.visual_style_id,
-                    visual_style_scope=request.visual_style_scope,
-                    db=db,
-                )
+            visual_style_application = _resolve_presentation_visual_style_application(
+                visual_style_id=request.visual_style_id,
+                visual_style_scope=request.visual_style_scope,
+                db=db,
             )
-            update_fields["visual_style_id"] = visual_style_id
-            update_fields["visual_style_scope"] = visual_style_scope
-            update_fields["visual_style_name"] = visual_style_name
-            update_fields["visual_style_version"] = visual_style_version
-            update_fields["visual_style_snapshot"] = visual_style_snapshot
-    if request.settings is not None:
+            if visual_style_application is None:
+                update_fields["visual_style_id"] = None
+                update_fields["visual_style_scope"] = None
+                update_fields["visual_style_name"] = None
+                update_fields["visual_style_version"] = None
+                update_fields["visual_style_snapshot"] = None
+            else:
+                update_fields["visual_style_id"] = visual_style_application.style_id
+                update_fields["visual_style_scope"] = visual_style_application.scope
+                update_fields["visual_style_name"] = visual_style_application.name
+                update_fields["visual_style_version"] = visual_style_application.version
+                update_fields["visual_style_snapshot"] = _serialize_visual_style_snapshot(
+                    visual_style_application.snapshot
+                )
+                if visual_style_application.scope == "builtin":
+                    builtin_appearance_defaults = visual_style_application.appearance_defaults
+                    if not theme_was_set and "theme" not in update_fields:
+                        update_fields["theme"] = builtin_appearance_defaults.get("theme") or "black"
+                    if not marp_theme_was_set and "marp_theme" not in update_fields:
+                        update_fields["marp_theme"] = builtin_appearance_defaults.get("marp_theme")
+                    if not settings_was_set and "settings" not in update_fields:
+                        update_fields["settings"] = _serialize_settings(builtin_appearance_defaults.get("settings"))
+                    if not custom_css_was_set and "custom_css" not in update_fields:
+                        update_fields["custom_css"] = builtin_appearance_defaults.get("custom_css")
+    if settings_was_set:
         settings = _validate_settings(request.settings)
         update_fields["settings"] = _serialize_settings(settings)
     if _field_was_set(request, "studio_data"):
@@ -1309,8 +1393,8 @@ async def patch_presentation(
         slides = _normalize_slides([_slide_from_obj(s) for s in request.slides])
         update_fields["slides"] = json.dumps([slide.model_dump() if hasattr(slide, "model_dump") else slide.dict() for slide in slides])
         update_fields["slides_text"] = _flatten_slides_text(slides)
-    if request.custom_css is not None:
-        update_fields["custom_css"] = request.custom_css
+    if custom_css_was_set:
+        update_fields["custom_css"] = _validate_custom_css(request.custom_css)
     if not update_fields:
         raise HTTPException(status_code=400, detail="no_fields_to_update")
     try:
@@ -1487,7 +1571,11 @@ async def list_visual_styles(
         user_rows, _ = db.list_visual_styles(limit=remaining, offset=user_offset)
     total_count = builtin_total + db.count_visual_styles()
     styles = [
-        *(_visual_style_response_from_builtin(style) for style in builtin_slice),
+        *(
+            _visual_style_response_from_builtin(resolved)
+            for resolved in (resolve_builtin_visual_style(style.style_id) for style in builtin_slice)
+            if resolved is not None
+        ),
         *(_visual_style_response_from_row(row) for row in user_rows),
     ]
     return VisualStyleListResponse(styles=styles, total_count=total_count, limit=limit, offset=offset)

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -753,7 +753,7 @@ def _resolve_presentation_visual_style_application(
         if resolved_builtin is None:
             raise HTTPException(status_code=404, detail="visual_style_not_found")
         return _visual_style_application_from_builtin(resolved_builtin)
-    elif resolved_scope == "user":
+    if resolved_scope == "user":
         try:
             row = db.get_visual_style_by_id(resolved_id)
         except KeyError:
@@ -1393,6 +1393,8 @@ async def patch_presentation(
                     visual_style_application.snapshot
                 )
                 if visual_style_application.scope == "builtin":
+                    # Built-in presets provide deck-wide appearance defaults unless the caller
+                    # overrides a specific field in this patch request.
                     builtin_appearance_defaults = visual_style_application.appearance_defaults
                     if not theme_was_set and "theme" not in update_fields:
                         update_fields["theme"] = builtin_appearance_defaults.get("theme") or "black"

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -2205,6 +2205,9 @@ async def export_presentation(
     slides = [_slide_from_obj(item) for item in slides_raw]
     slides = _normalize_slides(slides)
     settings = _deserialize_settings(row.settings)
+    visual_style_snapshot = _deserialize_visual_style_snapshot(
+        getattr(row, "visual_style_snapshot", None)
+    )
     try:
         user_id = int(db.client_id)
     except (TypeError, ValueError) as exc:
@@ -2277,6 +2280,7 @@ async def export_presentation(
                 theme=row.theme,
                 settings=settings,
                 custom_css=row.custom_css,
+                visual_style_snapshot=visual_style_snapshot,
                 pdf_options=pdf_options,
                 asset_resolver=_asset_resolver,
             )
@@ -2307,6 +2311,7 @@ async def export_presentation(
                 theme=row.theme,
                 settings=settings,
                 custom_css=row.custom_css,
+                visual_style_snapshot=visual_style_snapshot,
                 asset_resolver=_asset_resolver,
             )
         except SlidesAssetsMissingError as exc:

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -458,6 +458,8 @@ def _serialize_source_ref(value: Any | None) -> str | None:
 
 
 def _field_was_set(model: Any, field_name: str) -> bool:
+    """Return whether a Pydantic model received an explicit value for a field."""
+
     fields_set = getattr(model, "model_fields_set", None)
     if isinstance(fields_set, set):
         return field_name in fields_set
@@ -465,6 +467,8 @@ def _field_was_set(model: Any, field_name: str) -> bool:
 
 
 def _resolve_template(template_id: str | None) -> SlidesTemplate | None:
+    """Resolve a template id into a template object or raise the appropriate API error."""
+
     if not template_id:
         return None
     try:
@@ -487,6 +491,8 @@ def _compact_visual_style_appearance_defaults(appearance_defaults: dict[str, Any
 def _visual_style_application_from_builtin(
     resolved: ResolvedBuiltinVisualStyle,
 ) -> PresentationVisualStyleApplication:
+    """Convert a resolved builtin style into the presentation write-model shape."""
+
     appearance_defaults = _validate_visual_style_appearance_defaults(resolved.appearance)
     return PresentationVisualStyleApplication(
         style_id=resolved.definition.style_id,
@@ -499,6 +505,8 @@ def _visual_style_application_from_builtin(
 
 
 def _visual_style_application_from_row(row: VisualStyleRow) -> PresentationVisualStyleApplication:
+    """Convert a stored user visual-style row into the presentation write-model shape."""
+
     payload = _deserialize_visual_style_payload(row.style_payload)
     appearance_defaults_raw = payload.get("appearance_defaults") if isinstance(payload.get("appearance_defaults"), dict) else {}
     appearance_defaults = _validate_visual_style_appearance_defaults(appearance_defaults_raw)
@@ -536,6 +544,8 @@ def _apply_template_defaults(
     template: SlidesTemplate | None,
     visual_style_application: PresentationVisualStyleApplication | None = None,
 ) -> tuple[str, str | None, dict[str, Any] | None, str | None]:
+    """Merge request values with visual-style and template defaults."""
+
     appearance_defaults = (
         visual_style_application.appearance_defaults if visual_style_application is not None else {}
     )
@@ -639,6 +649,8 @@ def _serialize_visual_style_payload(
 def _visual_style_response_from_builtin(
     resolved: ResolvedBuiltinVisualStyle,
 ) -> VisualStyleResponse:
+    """Convert a resolved builtin style into the public API response shape."""
+
     return VisualStyleResponse(
         id=resolved.definition.style_id,
         name=resolved.definition.name,
@@ -683,7 +695,9 @@ def _visual_style_response_from_row(row: VisualStyleRow) -> VisualStyleResponse:
 
 
 def _resolve_visual_style_response(style_id: str, db: SlidesDatabase) -> VisualStyleResponse:
-    resolved_builtin = resolve_builtin_visual_style(style_id)
+    """Resolve either a builtin or stored style into the public API response shape."""
+
+    resolved_builtin = resolve_builtin_visual_style(style_id, include_custom_css=False)
     if resolved_builtin is not None:
         return _visual_style_response_from_builtin(resolved_builtin)
     try:
@@ -720,6 +734,8 @@ def _resolve_presentation_visual_style_application(
     visual_style_scope: str | None,
     db: SlidesDatabase,
 ) -> PresentationVisualStyleApplication | None:
+    """Resolve a presentation-level visual-style selection into an application payload."""
+
     if visual_style_id is None and visual_style_scope is None:
         return None
     if visual_style_id is None:
@@ -1339,6 +1355,8 @@ async def patch_presentation(
         update_fields["title"] = title
     if request.description is not None:
         update_fields["description"] = request.description
+    if theme_was_set and request.theme is None:
+        raise HTTPException(status_code=422, detail="invalid_theme")
     if request.theme is not None:
         _validate_theme(request.theme)
         update_fields["theme"] = request.theme
@@ -1573,7 +1591,10 @@ async def list_visual_styles(
     styles = [
         *(
             _visual_style_response_from_builtin(resolved)
-            for resolved in (resolve_builtin_visual_style(style.style_id) for style in builtin_slice)
+            for resolved in (
+                resolve_builtin_visual_style(style.style_id, include_custom_css=False)
+                for style in builtin_slice
+            )
             if resolved is not None
         ),
         *(_visual_style_response_from_row(row) for row in user_rows),

--- a/tldw_Server_API/app/api/v1/schemas/slides_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/slides_schemas.py
@@ -190,6 +190,10 @@ class VisualStyleResponse(VisualStyleBase):
 
     id: str
     scope: str
+    category: str | None = None
+    guide_number: int | None = None
+    tags: list[str] | None = None
+    best_for: list[str] | None = None
     version: int | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/slides_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/slides_module.py
@@ -1461,6 +1461,9 @@ class SlidesModule(BaseModule):
             pres_dict = self._presentation_to_dict(pres)
             slides = self._parse_slides_for_export(pres)
             settings = self._parse_settings(pres.settings)
+            visual_style_snapshot = self._parse_visual_style_snapshot(
+                getattr(pres, "visual_style_snapshot", None)
+            )
 
             if fmt == "json":
                 content = export_presentation_json(pres_dict)
@@ -1486,6 +1489,7 @@ class SlidesModule(BaseModule):
                         theme=pres.theme,
                         settings=settings,
                         custom_css=pres.custom_css,
+                        visual_style_snapshot=visual_style_snapshot,
                     )
                 except SlidesAssetsMissingError as exc:
                     raise ValueError("slides_assets_missing") from exc
@@ -1500,6 +1504,7 @@ class SlidesModule(BaseModule):
                         theme=pres.theme,
                         settings=settings,
                         custom_css=pres.custom_css,
+                        visual_style_snapshot=visual_style_snapshot,
                     )
                 except (SlidesExportInputError, SlidesExportError) as exc:
                     raise ValueError(str(exc)) from exc
@@ -1551,6 +1556,19 @@ class SlidesModule(BaseModule):
         if isinstance(settings, str):
             try:
                 parsed = json.loads(settings)
+                return parsed if isinstance(parsed, dict) else None
+            except json.JSONDecodeError:
+                return None
+        return None
+
+    def _parse_visual_style_snapshot(self, snapshot: Any) -> Optional[dict[str, Any]]:
+        if snapshot is None:
+            return None
+        if isinstance(snapshot, dict):
+            return snapshot
+        if isinstance(snapshot, str):
+            try:
+                parsed = json.loads(snapshot)
                 return parsed if isinstance(parsed, dict) else None
             except json.JSONDecodeError:
                 return None

--- a/tldw_Server_API/app/core/Slides/slides_export.py
+++ b/tldw_Server_API/app/core/Slides/slides_export.py
@@ -45,6 +45,7 @@ from tldw_Server_API.app.core.Slides.slides_assets import (
     resolve_slide_asset,
 )
 from tldw_Server_API.app.core.Slides.slides_images import SlidesImageError, validate_images_payload
+from tldw_Server_API.app.core.Slides.visual_style_packs import render_pack_custom_css
 from tldw_Server_API.app.core.testing import is_truthy
 
 
@@ -117,12 +118,24 @@ _ALLOWED_HTML_ATTRS = {
 _ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
 
 _ALLOWED_CSS_PROPERTIES = [
+    "--accent",
+    "--border",
+    "--glow",
+    "--grid",
+    "--pixel",
+    "--rule",
+    "--shadow",
+    "--surface",
+    "--text",
+    "--visual-style-pack",
     "align-content",
     "align-items",
     "align-self",
     "background",
     "background-color",
+    "backdrop-filter",
     "border",
+    "border-collapse",
     "border-color",
     "border-radius",
     "border-style",
@@ -435,6 +448,319 @@ def _sanitize_custom_css(css_text: str | None) -> str | None:
     return cleaned or None
 
 
+def _normalize_text_block(text: str | None) -> str:
+    if not text:
+        return ""
+    lines = [" ".join(line.split()) for line in str(text).splitlines()]
+    normalized = "\n".join(line for line in lines if line)
+    return normalized.strip()
+
+
+def _extract_visual_blocks(slide: Any) -> list[dict[str, Any]]:
+    metadata = _get_slide_value(slide, "metadata", {}) or {}
+    if not isinstance(metadata, dict):
+        return []
+    blocks = metadata.get("visual_blocks")
+    if not isinstance(blocks, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for block in blocks:
+        if isinstance(block, dict):
+            normalized.append(dict(block))
+    return normalized
+
+
+def _compile_visual_block_fallback(block: dict[str, Any]) -> list[str]:
+    block_type = str(block.get("type") or "").strip()
+    if block_type == "timeline":
+        items = block.get("items")
+        if not isinstance(items, list):
+            return []
+        lines: list[str] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            label = str(item.get("label") or item.get("date") or item.get("year") or "").strip()
+            title = str(item.get("title") or item.get("name") or "").strip()
+            description = str(item.get("description") or item.get("summary") or "").strip()
+            headline = ": ".join(part for part in (label, title) if part)
+            if not headline:
+                headline = "Timeline event"
+            line = f"- {headline}"
+            if description:
+                line += f" - {description}"
+            lines.append(line)
+        return lines
+    if block_type == "comparison_matrix":
+        rows = block.get("rows")
+        if not isinstance(rows, list):
+            return []
+        lines = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            label = str(row.get("label") or row.get("name") or row.get("topic") or "").strip()
+            values = row.get("values")
+            summary = str(row.get("summary") or row.get("description") or "").strip()
+            value_text = ", ".join(str(item) for item in values) if isinstance(values, list) else ""
+            details = summary or value_text
+            headline = label or "Comparison"
+            line = f"- {headline}"
+            if details:
+                line += f": {details}"
+            lines.append(line)
+        return lines
+    if block_type == "process_flow":
+        steps = block.get("steps")
+        if not isinstance(steps, list):
+            return []
+        lines = []
+        for index, step in enumerate(steps, start=1):
+            if not isinstance(step, dict):
+                continue
+            title = str(step.get("title") or step.get("name") or f"Step {index}").strip()
+            description = str(step.get("description") or step.get("summary") or "").strip()
+            line = f"{index}. {title}"
+            if description:
+                line += f" - {description}"
+            lines.append(line)
+        return lines
+    if block_type == "stat_group":
+        items = block.get("items")
+        if not isinstance(items, list):
+            return []
+        lines = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            label = str(item.get("label") or item.get("name") or "Metric").strip()
+            value = str(item.get("value") or item.get("stat") or "").strip()
+            context = str(item.get("context") or item.get("description") or "").strip()
+            line = f"- {label}"
+            if value:
+                line += f": {value}"
+            if context:
+                line += f" - {context}"
+            lines.append(line)
+        return lines
+    return []
+
+
+def _render_timeline_block(block: dict[str, Any]) -> str:
+    items = block.get("items")
+    if not isinstance(items, list):
+        return ""
+    rendered_items: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        label = escape(str(item.get("label") or item.get("date") or item.get("year") or "").strip())
+        title = escape(str(item.get("title") or item.get("name") or "").strip())
+        description = escape(str(item.get("description") or item.get("summary") or "").strip())
+        if not (label or title or description):
+            continue
+        parts = ['<li class="visual-block-item">']
+        if label:
+            parts.append(f'<p class="visual-block-label">{label}</p>')
+        if title:
+            parts.append(f"<h3>{title}</h3>")
+        if description:
+            parts.append(f"<p>{description}</p>")
+        parts.append("</li>")
+        rendered_items.append("".join(parts))
+    if not rendered_items:
+        return ""
+    return (
+        '<div class="visual-block visual-block--timeline" data-visual-block-type="timeline">'
+        '<ol class="visual-block-list">'
+        + "".join(rendered_items)
+        + "</ol></div>"
+    )
+
+
+def _render_comparison_matrix_block(block: dict[str, Any]) -> str:
+    rows = block.get("rows")
+    if not isinstance(rows, list):
+        return ""
+    rendered_rows: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        label = escape(str(row.get("label") or row.get("name") or row.get("topic") or "").strip())
+        values = row.get("values")
+        summary = escape(str(row.get("summary") or row.get("description") or "").strip())
+        value_cells = []
+        if isinstance(values, list):
+            value_cells = [f"<td>{escape(str(value).strip())}</td>" for value in values if str(value).strip()]
+        if summary:
+            value_cells.append(f"<td>{summary}</td>")
+        if not label and not value_cells:
+            continue
+        heading = f"<th>{label or 'Comparison'}</th>"
+        rendered_rows.append(f"<tr>{heading}{''.join(value_cells)}</tr>")
+    if not rendered_rows:
+        return ""
+    return (
+        '<div class="visual-block visual-block--comparison" data-visual-block-type="comparison_matrix">'
+        '<table class="visual-block-table"><tbody>'
+        + "".join(rendered_rows)
+        + "</tbody></table></div>"
+    )
+
+
+def _render_process_flow_block(block: dict[str, Any]) -> str:
+    steps = block.get("steps")
+    if not isinstance(steps, list):
+        return ""
+    rendered_steps: list[str] = []
+    for index, step in enumerate(steps, start=1):
+        if not isinstance(step, dict):
+            continue
+        title = escape(str(step.get("title") or step.get("name") or f"Step {index}").strip())
+        description = escape(str(step.get("description") or step.get("summary") or "").strip())
+        parts = ['<li class="visual-block-item">', f"<h3>{title}</h3>"]
+        if description:
+            parts.append(f"<p>{description}</p>")
+        parts.append("</li>")
+        rendered_steps.append("".join(parts))
+    if not rendered_steps:
+        return ""
+    return (
+        '<div class="visual-block visual-block--process" data-visual-block-type="process_flow">'
+        '<ol class="visual-block-list">'
+        + "".join(rendered_steps)
+        + "</ol></div>"
+    )
+
+
+def _render_stat_group_block(block: dict[str, Any]) -> str:
+    items = block.get("items")
+    if not isinstance(items, list):
+        return ""
+    rendered_items: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        label = escape(str(item.get("label") or item.get("name") or "Metric").strip())
+        value = escape(str(item.get("value") or item.get("stat") or "").strip())
+        context = escape(str(item.get("context") or item.get("description") or "").strip())
+        if not (label or value or context):
+            continue
+        parts = ['<div class="visual-block-item">']
+        if label:
+            parts.append(f"<dt>{label}</dt>")
+        if value:
+            parts.append(f"<dd>{value}</dd>")
+        if context:
+            parts.append(f"<p>{context}</p>")
+        parts.append("</div>")
+        rendered_items.append("".join(parts))
+    if not rendered_items:
+        return ""
+    return (
+        '<div class="visual-block visual-block--stats" data-visual-block-type="stat_group">'
+        '<dl class="visual-block-stats">'
+        + "".join(rendered_items)
+        + "</dl></div>"
+    )
+
+
+def _render_visual_blocks_html(blocks: list[dict[str, Any]]) -> tuple[str, bool, str]:
+    if not blocks:
+        return "", False, ""
+    rendered_html: list[str] = []
+    fallback_lines: list[str] = []
+    rendered_count = 0
+    for block in blocks:
+        fallback_lines.extend(_compile_visual_block_fallback(block))
+        block_type = str(block.get("type") or "").strip()
+        if block_type == "timeline":
+            html = _render_timeline_block(block)
+        elif block_type == "comparison_matrix":
+            html = _render_comparison_matrix_block(block)
+        elif block_type == "process_flow":
+            html = _render_process_flow_block(block)
+        elif block_type == "stat_group":
+            html = _render_stat_group_block(block)
+        else:
+            html = ""
+        if html:
+            rendered_html.append(html)
+            rendered_count += 1
+    return "\n".join(rendered_html), rendered_count == len(blocks) and bool(rendered_html), "\n".join(fallback_lines)
+
+
+def _content_is_structured_fallback(content: Any, fallback_text: str) -> bool:
+    normalized_content = _normalize_text_block(str(content or ""))
+    normalized_fallback = _normalize_text_block(fallback_text)
+    if not normalized_fallback:
+        return False
+    return normalized_content == normalized_fallback
+
+
+def _render_style_shell_attrs(visual_style_snapshot: dict[str, Any] | None) -> str:
+    if not isinstance(visual_style_snapshot, dict):
+        return ""
+    resolution = visual_style_snapshot.get("resolution")
+    if not isinstance(resolution, dict):
+        return ""
+    style_id = str(visual_style_snapshot.get("id") or "").strip()
+    style_pack = str(resolution.get("style_pack") or "").strip()
+    attrs: list[str] = []
+    if style_id:
+        attrs.append(f'data-visual-style="{escape(style_id)}"')
+    if style_pack:
+        attrs.append(f'data-style-pack="{escape(style_pack)}"')
+    if not attrs:
+        return ""
+    return " " + " ".join(attrs)
+
+
+def _compose_export_css(
+    *,
+    custom_css: str | None,
+    visual_style_snapshot: dict[str, Any] | None,
+) -> str | None:
+    built_in_css = None
+    if isinstance(visual_style_snapshot, dict):
+        resolution = visual_style_snapshot.get("resolution")
+        if isinstance(resolution, dict):
+            style_id = str(visual_style_snapshot.get("id") or "").strip()
+            style_pack = str(resolution.get("style_pack") or "").strip()
+            token_overrides = resolution.get("token_overrides")
+            if style_id and style_pack and isinstance(token_overrides, dict):
+                built_in_css = render_pack_custom_css(
+                    style_id=style_id,
+                    pack_id=style_pack,
+                    token_overrides=token_overrides,
+                )
+
+    shared_css = """
+.reveal .content > * + * { margin-top: 1rem; }
+.reveal .visual-block { margin-top: 1rem; padding: 1rem; border: 1px solid rgba(148, 163, 184, 0.35); border-radius: 1rem; }
+.reveal .visual-block-table { width: 100%; }
+.reveal .visual-block-table th,
+.reveal .visual-block-table td { padding: 0.6rem; border: 1px solid rgba(148, 163, 184, 0.25); text-align: left; }
+.reveal .visual-block-list { margin: 0; padding-left: 1.25rem; }
+.reveal .visual-block-item + .visual-block-item { margin-top: 0.75rem; }
+.reveal .visual-block-item h3,
+.reveal .visual-block-item p,
+.reveal .visual-block-label,
+.reveal .visual-block-stats dt,
+.reveal .visual-block-stats dd { margin: 0; }
+.reveal .visual-block-stats .visual-block-item + .visual-block-item { margin-top: 0.75rem; }
+.reveal .visual-block-stats dd { font-weight: 700; }
+""".strip()
+
+    parts = [shared_css]
+    if built_in_css and not (custom_css and built_in_css.strip() in custom_css):
+        parts.append(built_in_css)
+    if custom_css:
+        parts.append(custom_css)
+    merged = "\n\n".join(part.strip() for part in parts if part and part.strip())
+    return merged or None
+
+
 def _resolve_assets_dir(assets_dir: Path | str | None) -> Path:
     if assets_dir:
         return Path(assets_dir).expanduser().resolve()
@@ -502,11 +828,14 @@ def _render_sections(
         content = _get_slide_value(slide, "content", "")
         notes = _get_slide_value(slide, "speaker_notes")
         images = _extract_images(slide, asset_resolver=asset_resolver)
+        visual_blocks = _extract_visual_blocks(slide)
         images_html = _render_images_html(images)
+        visual_blocks_html, rendered_all_blocks, fallback_text = _render_visual_blocks_html(visual_blocks)
 
         title_html = f"<h2>{escape(str(title))}</h2>" if title else ""
-        content_html = _sanitize_markdown(str(content or "")) if content else ""
-        body_html = f"{content_html}{images_html}" if content_html or images_html else ""
+        suppress_content = rendered_all_blocks and _content_is_structured_fallback(content, fallback_text)
+        content_html = _sanitize_markdown(str(content or "")) if content and not suppress_content else ""
+        body_html = "".join(part for part in (content_html, visual_blocks_html, images_html) if part)
         notes_html = f"<aside class=\"notes\">{escape(str(notes))}</aside>" if notes else ""
 
         section = (
@@ -527,11 +856,13 @@ def _render_index_html(
     theme: str,
     settings_json: str,
     include_custom_css: bool,
+    visual_style_snapshot: dict[str, Any] | None = None,
     asset_resolver: SlideAssetResolver | None = None,
 ) -> str:
     css_link = "  <link rel=\"stylesheet\" href=\"assets/custom.css\">\n" if include_custom_css else ""
     title_html = escape(title or "Presentation")
     sections_html = _render_sections(slides, asset_resolver=asset_resolver)
+    reveal_attrs = _render_style_shell_attrs(visual_style_snapshot)
     return (
         "<!DOCTYPE html>\n"
         "<html>\n"
@@ -543,7 +874,7 @@ def _render_index_html(
         f"{css_link}"
         "</head>\n"
         "<body>\n"
-        "  <div class=\"reveal\">\n"
+        f"  <div class=\"reveal\"{reveal_attrs}>\n"
         "    <div class=\"slides\">\n"
         f"{sections_html}\n"
         "    </div>\n"
@@ -567,19 +898,23 @@ def export_presentation_bundle(
     theme: str,
     settings: dict[str, Any] | None,
     custom_css: str | None,
+    visual_style_snapshot: dict[str, Any] | None = None,
     assets_dir: Path | str | None = None,
     asset_resolver: SlideAssetResolver | None = None,
 ) -> bytes:
     resolved_assets = _resolve_assets_dir(assets_dir)
     _validate_reveal_assets(resolved_assets, theme)
     settings_json = json.dumps(settings or {}, ensure_ascii=True)
-    sanitized_css = _sanitize_custom_css(custom_css)
+    sanitized_css = _sanitize_custom_css(
+        _compose_export_css(custom_css=custom_css, visual_style_snapshot=visual_style_snapshot)
+    )
     index_html = _render_index_html(
         title=title,
         slides=slides,
         theme=theme,
         settings_json=settings_json,
         include_custom_css=bool(sanitized_css),
+        visual_style_snapshot=visual_style_snapshot,
         asset_resolver=asset_resolver,
     )
 
@@ -661,6 +996,7 @@ def export_presentation_pdf(
     theme: str,
     settings: dict[str, Any] | None,
     custom_css: str | None,
+    visual_style_snapshot: dict[str, Any] | None = None,
     assets_dir: Path | str | None = None,
     pdf_options: dict[str, Any] | None = None,
     asset_resolver: SlideAssetResolver | None = None,
@@ -673,13 +1009,16 @@ def export_presentation_pdf(
     resolved_assets = _resolve_assets_dir(assets_dir)
     _validate_reveal_assets(resolved_assets, theme)
     settings_json = json.dumps(settings or {}, ensure_ascii=True)
-    sanitized_css = _sanitize_custom_css(custom_css)
+    sanitized_css = _sanitize_custom_css(
+        _compose_export_css(custom_css=custom_css, visual_style_snapshot=visual_style_snapshot)
+    )
     index_html = _render_index_html(
         title=title,
         slides=slides_list,
         theme=theme,
         settings_json=settings_json,
         include_custom_css=bool(sanitized_css),
+        visual_style_snapshot=visual_style_snapshot,
         asset_resolver=asset_resolver,
     )
     if max_html_bytes and len(index_html.encode("utf-8")) > max_html_bytes:

--- a/tldw_Server_API/app/core/Slides/slides_export.py
+++ b/tldw_Server_API/app/core/Slides/slides_export.py
@@ -449,6 +449,8 @@ def _sanitize_custom_css(css_text: str | None) -> str | None:
 
 
 def _normalize_text_block(text: str | None) -> str:
+    """Collapse a text block into comparable normalized lines."""
+
     if not text:
         return ""
     lines = [" ".join(line.split()) for line in str(text).splitlines()]
@@ -457,6 +459,8 @@ def _normalize_text_block(text: str | None) -> str:
 
 
 def _extract_visual_blocks(slide: Any) -> list[dict[str, Any]]:
+    """Extract normalized visual block metadata from a slide payload."""
+
     metadata = _get_slide_value(slide, "metadata", {}) or {}
     if not isinstance(metadata, dict):
         return []
@@ -471,6 +475,8 @@ def _extract_visual_blocks(slide: Any) -> list[dict[str, Any]]:
 
 
 def _compile_visual_block_fallback(block: dict[str, Any]) -> list[str]:
+    """Compile a visual block into plain-text fallback lines for markdown exports."""
+
     block_type = str(block.get("type") or "").strip()
     if block_type == "timeline":
         items = block.get("items")
@@ -547,6 +553,8 @@ def _compile_visual_block_fallback(block: dict[str, Any]) -> list[str]:
 
 
 def _render_timeline_block(block: dict[str, Any]) -> str:
+    """Render timeline metadata into HTML for Reveal exports."""
+
     items = block.get("items")
     if not isinstance(items, list):
         return ""
@@ -579,6 +587,8 @@ def _render_timeline_block(block: dict[str, Any]) -> str:
 
 
 def _render_comparison_matrix_block(block: dict[str, Any]) -> str:
+    """Render comparison matrix metadata into HTML for Reveal exports."""
+
     rows = block.get("rows")
     if not isinstance(rows, list):
         return ""
@@ -609,6 +619,8 @@ def _render_comparison_matrix_block(block: dict[str, Any]) -> str:
 
 
 def _render_process_flow_block(block: dict[str, Any]) -> str:
+    """Render process flow metadata into HTML for Reveal exports."""
+
     steps = block.get("steps")
     if not isinstance(steps, list):
         return ""
@@ -634,6 +646,8 @@ def _render_process_flow_block(block: dict[str, Any]) -> str:
 
 
 def _render_stat_group_block(block: dict[str, Any]) -> str:
+    """Render stat group metadata into HTML for Reveal exports."""
+
     items = block.get("items")
     if not isinstance(items, list):
         return ""
@@ -666,6 +680,8 @@ def _render_stat_group_block(block: dict[str, Any]) -> str:
 
 
 def _render_visual_blocks_html(blocks: list[dict[str, Any]]) -> tuple[str, bool, str]:
+    """Render all supported visual blocks and return HTML plus fallback metadata."""
+
     if not blocks:
         return "", False, ""
     rendered_html: list[str] = []
@@ -691,6 +707,8 @@ def _render_visual_blocks_html(blocks: list[dict[str, Any]]) -> tuple[str, bool,
 
 
 def _content_is_structured_fallback(content: Any, fallback_text: str) -> bool:
+    """Return whether slide content already matches the generated block fallback text."""
+
     normalized_content = _normalize_text_block(str(content or ""))
     normalized_fallback = _normalize_text_block(fallback_text)
     if not normalized_fallback:
@@ -699,6 +717,8 @@ def _content_is_structured_fallback(content: Any, fallback_text: str) -> bool:
 
 
 def _render_style_shell_attrs(visual_style_snapshot: dict[str, Any] | None) -> str:
+    """Render shell-level data attributes for built-in visual style hooks."""
+
     if not isinstance(visual_style_snapshot, dict):
         return ""
     resolution = visual_style_snapshot.get("resolution")
@@ -721,6 +741,8 @@ def _compose_export_css(
     custom_css: str | None,
     visual_style_snapshot: dict[str, Any] | None,
 ) -> str | None:
+    """Compose shared export CSS with builtin pack CSS and custom deck CSS."""
+
     built_in_css = None
     if isinstance(visual_style_snapshot, dict):
         resolution = visual_style_snapshot.get("resolution")

--- a/tldw_Server_API/app/core/Slides/style_packs/brutalist_editorial.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/brutalist_editorial.css
@@ -1,0 +1,11 @@
+.reveal[data-style-pack="brutalist_editorial"] {
+  background-color: var(--surface, #f5f5f5);
+  color: var(--text, #000000);
+  font-family: "Helvetica Neue", "Arial Narrow", sans-serif;
+  text-transform: uppercase;
+}
+
+.reveal[data-style-pack="brutalist_editorial"] .slides section {
+  border: 4px solid var(--border, #000000);
+  box-shadow: 12px 12px 0 rgba(0, 0, 0, 0.12);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/dashboard_glass.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/dashboard_glass.css
@@ -1,6 +1,6 @@
 .reveal[data-style-pack="dashboard_glass"] {
   background-color: #0f172a;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.98), rgba(30, 41, 59, 0.92));
+  background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.98), rgba(30, 41, 59, 0.92));
   color: var(--text, #f8fafc);
   font-family: "IBM Plex Sans", "Helvetica Neue", sans-serif;
 }

--- a/tldw_Server_API/app/core/Slides/style_packs/dashboard_glass.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/dashboard_glass.css
@@ -1,0 +1,15 @@
+.reveal[data-style-pack="dashboard_glass"] {
+  background-color: #0f172a;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.98), rgba(30, 41, 59, 0.92));
+  color: var(--text, #f8fafc);
+  font-family: "IBM Plex Sans", "Helvetica Neue", sans-serif;
+}
+
+.reveal[data-style-pack="dashboard_glass"] .slides section,
+.reveal[data-style-pack="dashboard_glass"] .visual-block {
+  background-color: var(--surface, rgba(15, 23, 42, 0.72));
+  border: 1px solid rgba(103, 232, 249, 0.28);
+  border-radius: 20px;
+  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.35);
+  backdrop-filter: blur(18px);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/editorial_print.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/editorial_print.css
@@ -1,0 +1,10 @@
+.reveal[data-style-pack="editorial_print"] {
+  background-color: var(--surface, #ffffff);
+  color: var(--text, #111111);
+  font-family: "Iowan Old Style", "Times New Roman", serif;
+}
+
+.reveal[data-style-pack="editorial_print"] .slides section {
+  border-top: 4px solid var(--rule, #d4d4d8);
+  border-bottom: 1px solid var(--rule, #d4d4d8);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/hand_drawn_surface.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/hand_drawn_surface.css
@@ -1,0 +1,13 @@
+.reveal[data-style-pack="hand_drawn_surface"] {
+  background-color: var(--surface, #101418);
+  color: var(--text, #f8f2c8);
+  font-family: "Patrick Hand", "Comic Sans MS", "Marker Felt", cursive;
+}
+
+.reveal[data-style-pack="hand_drawn_surface"] .slides section {
+  background-color: var(--surface, #101418);
+  color: var(--text, #f8f2c8);
+  border: 3px solid var(--border, #f8f2c8);
+  border-radius: 24px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.3);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/heritage_formal.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/heritage_formal.css
@@ -1,10 +1,11 @@
 .reveal[data-style-pack="heritage_formal"] {
   background-color: var(--surface, #fffbf5);
   color: var(--text, #3f2a14);
-  font-family: "Baskerville", "Times New Roman", serif;
+  font-family: Baskerville, "Times New Roman", serif;
 }
 
 .reveal[data-style-pack="heritage_formal"] .slides section {
   border-top: 5px solid var(--rule, #b45309);
-  border-bottom: 1px solid rgba(107, 79, 42, 0.2);
+  border-bottom: 1px solid var(--accent, #6b4f2a);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent, #6b4f2a) 20%, transparent);
 }

--- a/tldw_Server_API/app/core/Slides/style_packs/heritage_formal.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/heritage_formal.css
@@ -1,0 +1,10 @@
+.reveal[data-style-pack="heritage_formal"] {
+  background-color: var(--surface, #fffbf5);
+  color: var(--text, #3f2a14);
+  font-family: "Baskerville", "Times New Roman", serif;
+}
+
+.reveal[data-style-pack="heritage_formal"] .slides section {
+  border-top: 5px solid var(--rule, #b45309);
+  border-bottom: 1px solid rgba(107, 79, 42, 0.2);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/isometric_clean.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/isometric_clean.css
@@ -1,0 +1,12 @@
+.reveal[data-style-pack="isometric_clean"] {
+  background-color: var(--surface, #ffffff);
+  color: var(--text, #0f172a);
+  font-family: "Avenir Next", "Helvetica Neue", sans-serif;
+}
+
+.reveal[data-style-pack="isometric_clean"] .slides section {
+  background-color: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 20px;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/isometric_dark.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/isometric_dark.css
@@ -1,0 +1,12 @@
+.reveal[data-style-pack="isometric_dark"] {
+  background-color: var(--surface, #111827);
+  color: var(--text, #e5e7eb);
+  font-family: "Avenir Next", "Helvetica Neue", sans-serif;
+}
+
+.reveal[data-style-pack="isometric_dark"] .slides section {
+  background-color: rgba(17, 24, 39, 0.92);
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.4);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/neon_cinematic.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/neon_cinematic.css
@@ -1,0 +1,11 @@
+.reveal[data-style-pack="neon_cinematic"] {
+  background-color: var(--surface, #020617);
+  color: var(--text, #f8fafc);
+  font-family: "Neue Haas Grotesk", "Helvetica Neue", sans-serif;
+}
+
+.reveal[data-style-pack="neon_cinematic"] .slides section {
+  border: 1px solid rgba(103, 232, 249, 0.24);
+  box-shadow: 0 0 28px rgba(103, 232, 249, 0.22), 0 0 56px rgba(249, 115, 22, 0.12);
+  text-shadow: 0 0 18px rgba(103, 232, 249, 0.2);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/pastel_character.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/pastel_character.css
@@ -1,0 +1,12 @@
+.reveal[data-style-pack="pastel_character"] {
+  background-color: var(--surface, #fff1f2);
+  color: var(--text, #1f2937);
+  font-family: "Baloo 2", "Trebuchet MS", sans-serif;
+}
+
+.reveal[data-style-pack="pastel_character"] .slides section {
+  background-color: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(251, 113, 133, 0.26);
+  border-radius: 28px;
+  box-shadow: 0 18px 38px var(--shadow, rgba(244, 114, 182, 0.2));
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/retro_pixel.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/retro_pixel.css
@@ -1,0 +1,10 @@
+.reveal[data-style-pack="retro_pixel"] {
+  background-color: var(--surface, #111827);
+  color: var(--text, #f9fafb);
+  font-family: "Press Start 2P", "Courier New", monospace;
+}
+
+.reveal[data-style-pack="retro_pixel"] .slides section {
+  border: 4px solid var(--accent, #22c55e);
+  box-shadow: 0 0 0 var(--pixel, 4px) rgba(34, 197, 94, 0.12);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/tactile_soft.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/tactile_soft.css
@@ -1,0 +1,12 @@
+.reveal[data-style-pack="tactile_soft"] {
+  background-color: var(--surface, #faf5ff);
+  color: var(--text, #1f2937);
+  font-family: "Sofia Pro", "Avenir Next", sans-serif;
+}
+
+.reveal[data-style-pack="tactile_soft"] .slides section {
+  background-color: rgba(255, 255, 255, 0.84);
+  border: 1px solid rgba(192, 132, 252, 0.2);
+  border-radius: 24px;
+  box-shadow: 0 18px 40px var(--shadow, rgba(15, 23, 42, 0.12));
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/technical_grid.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/technical_grid.css
@@ -1,0 +1,13 @@
+.reveal[data-style-pack="technical_grid"] {
+  background-color: var(--surface, #0f172a);
+  background: linear-gradient(90deg, var(--grid, rgba(125, 211, 252, 0.16)) 1px, transparent 1px),
+    linear-gradient(var(--grid, rgba(125, 211, 252, 0.16)) 1px, transparent 1px),
+    var(--surface, #0f172a);
+  color: var(--text, #f8fafc);
+  font-family: "IBM Plex Sans", "Helvetica Neue", sans-serif;
+}
+
+.reveal[data-style-pack="technical_grid"] .slides section {
+  border: 1px solid var(--accent, #7dd3fc);
+  box-shadow: 0 12px 28px rgba(2, 6, 23, 0.35);
+}

--- a/tldw_Server_API/app/core/Slides/style_packs/technical_grid.css
+++ b/tldw_Server_API/app/core/Slides/style_packs/technical_grid.css
@@ -1,5 +1,4 @@
 .reveal[data-style-pack="technical_grid"] {
-  background-color: var(--surface, #0f172a);
   background: linear-gradient(90deg, var(--grid, rgba(125, 211, 252, 0.16)) 1px, transparent 1px),
     linear-gradient(var(--grid, rgba(125, 211, 252, 0.16)) 1px, transparent 1px),
     var(--surface, #0f172a);

--- a/tldw_Server_API/app/core/Slides/visual_style_catalog.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_catalog.py
@@ -25,6 +25,7 @@ class BuiltinVisualStyleDefinition:
     generation_rules: dict[str, Any] = field(default_factory=dict)
     artifact_preferences: tuple[str, ...] = field(default_factory=tuple)
     fallback_policy: dict[str, Any] = field(default_factory=dict)
+    prompt_notes: tuple[str, ...] = field(default_factory=tuple)
     appearance_overrides: dict[str, Any] = field(default_factory=dict)
     tags: tuple[str, ...] = field(default_factory=tuple)
     best_for: tuple[str, ...] = field(default_factory=tuple)
@@ -80,6 +81,10 @@ def _legacy_style_specs() -> tuple[dict[str, Any], ...]:
             "generation_rules": {"density": "high", "bullet_bias": "high", "exam_focus": True},
             "artifact_preferences": ("stat_group", "comparison_matrix"),
             "fallback_policy": {"mode": "key-points", "preserve_key_stats": True},
+            "prompt_notes": (
+                "Prefer concise, high-yield bullets over narrative paragraphs.",
+                "Optimize for recall, revision, and fast scanning.",
+            ),
         },
         {
             "style_id": "diagram-map-based",
@@ -93,6 +98,10 @@ def _legacy_style_specs() -> tuple[dict[str, Any], ...]:
             "generation_rules": {"density": "medium", "bullet_bias": "low", "spatial_reasoning": "high"},
             "artifact_preferences": ("process_flow", "comparison_matrix"),
             "fallback_policy": {"mode": "labeled-outline", "preserve_key_stats": True},
+            "prompt_notes": (
+                "Emphasize relationships, flows, regions, and conceptual structure.",
+                "Use process or comparison blocks when they improve comprehension.",
+            ),
         },
         {
             "style_id": "timeline",
@@ -106,6 +115,7 @@ def _legacy_style_specs() -> tuple[dict[str, Any], ...]:
             "generation_rules": {"density": "medium", "bullet_bias": "medium", "chronology_bias": "high"},
             "artifact_preferences": ("timeline", "stat_group"),
             "fallback_policy": {"mode": "ordered-bullets", "preserve_key_stats": True},
+            "prompt_notes": ("Favor chronology, causality, and milestone sequencing.",),
         },
         {
             "style_id": "data-visualization",
@@ -119,6 +129,10 @@ def _legacy_style_specs() -> tuple[dict[str, Any], ...]:
             "generation_rules": {"density": "medium", "bullet_bias": "low", "quant_focus": "high"},
             "artifact_preferences": ("stat_group", "comparison_matrix"),
             "fallback_policy": {"mode": "metric-summary", "preserve_key_stats": True},
+            "prompt_notes": (
+                "Highlight metrics, trends, comparisons, and quantitative takeaways.",
+                "Prefer stat groups or comparison blocks over decorative prose.",
+            ),
         },
         {
             "style_id": "storytelling",
@@ -132,6 +146,10 @@ def _legacy_style_specs() -> tuple[dict[str, Any], ...]:
             "generation_rules": {"density": "medium", "bullet_bias": "low", "narrative_bias": "high"},
             "artifact_preferences": ("timeline", "process_flow"),
             "fallback_policy": {"mode": "narrative-outline", "preserve_key_stats": False},
+            "prompt_notes": (
+                "Use a narrative arc with setup, development, and payoff.",
+                "Keep slides concise while preserving story progression.",
+            ),
         },
         {
             "style_id": "high-contrast-revision",
@@ -663,6 +681,7 @@ def _build_definition(spec: dict[str, Any], *, sort_order: int) -> BuiltinVisual
         generation_rules=deepcopy(spec.get("generation_rules") or {}),
         artifact_preferences=tuple(str(item) for item in spec.get("artifact_preferences") or ()),
         fallback_policy=deepcopy(spec.get("fallback_policy") or {}),
+        prompt_notes=tuple(str(item) for item in spec.get("prompt_notes") or ()),
         appearance_overrides=deepcopy(spec.get("appearance_overrides") or {}),
         tags=(
             category,
@@ -699,6 +718,7 @@ def _clone_definition(definition: BuiltinVisualStyleDefinition) -> BuiltinVisual
         generation_rules=deepcopy(definition.generation_rules),
         artifact_preferences=tuple(definition.artifact_preferences),
         fallback_policy=deepcopy(definition.fallback_policy),
+        prompt_notes=tuple(definition.prompt_notes),
         appearance_overrides=deepcopy(definition.appearance_overrides),
         tags=tuple(definition.tags),
         best_for=tuple(definition.best_for),

--- a/tldw_Server_API/app/core/Slides/visual_style_catalog.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_catalog.py
@@ -1,0 +1,750 @@
+"""Structured built-in visual style catalog for slide generation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BuiltinVisualStyleDefinition:
+    """Structured catalog entry for a built-in slide visual style."""
+
+    style_id: str
+    name: str
+    description: str
+    category: str
+    guide_number: int | None
+    sort_order: int
+    version: int
+    prompt_profile: str
+    style_pack: str
+    style_pack_version: int
+    base_theme: str
+    generation_rules: dict[str, Any] = field(default_factory=dict)
+    artifact_preferences: tuple[str, ...] = field(default_factory=tuple)
+    fallback_policy: dict[str, Any] = field(default_factory=dict)
+    appearance_overrides: dict[str, Any] = field(default_factory=dict)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    best_for: tuple[str, ...] = field(default_factory=tuple)
+
+
+_CATEGORY_BEST_FOR: dict[str, tuple[str, ...]] = {
+    "legacy": ("general slide generation",),
+    "educational": ("teaching", "study notes"),
+    "technical": ("systems explanation", "architecture walkthrough"),
+    "narrative": ("story-led decks", "executive summaries"),
+    "playful": ("lightweight explainer decks", "creative prompts"),
+    "nostalgic": ("themed decks", "high-contrast storytelling"),
+}
+
+
+def _legacy_style_specs() -> tuple[dict[str, Any], ...]:
+    return (
+        {
+            "style_id": "infographic",
+            "name": "Infographic",
+            "description": "Digest-heavy slides with visual callouts and synthesis-first framing.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "corporate_strategy",
+            "style_pack": "editorial_print",
+            "base_theme": "white",
+            "generation_rules": {"density": "medium", "bullet_bias": "low", "visual_callouts": "high"},
+            "artifact_preferences": ("stat_group", "comparison_matrix", "process_flow"),
+            "fallback_policy": {"mode": "textual-summary", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "minimal-academic",
+            "name": "Minimal Academic",
+            "description": "Calm, low-noise academic slides with restrained text and careful structure.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "design_editorial",
+            "style_pack": "editorial_print",
+            "base_theme": "white",
+            "generation_rules": {"density": "low", "bullet_bias": "medium", "citation_bias": "high"},
+            "artifact_preferences": ("comparison_matrix", "timeline"),
+            "fallback_policy": {"mode": "outline", "preserve_key_stats": False},
+        },
+        {
+            "style_id": "exam-focused-bullet",
+            "name": "Exam-Focused Bullet",
+            "description": "Recall-first slides optimized for high-yield revision and exam prep.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "technical_precision",
+            "style_pack": "brutalist_editorial",
+            "base_theme": "black",
+            "generation_rules": {"density": "high", "bullet_bias": "high", "exam_focus": True},
+            "artifact_preferences": ("stat_group", "comparison_matrix"),
+            "fallback_policy": {"mode": "key-points", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "diagram-map-based",
+            "name": "Diagram / Map-Based",
+            "description": "Spatial and relationship-first slides with process and place emphasis.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "technical_precision",
+            "style_pack": "technical_grid",
+            "base_theme": "league",
+            "generation_rules": {"density": "medium", "bullet_bias": "low", "spatial_reasoning": "high"},
+            "artifact_preferences": ("process_flow", "comparison_matrix"),
+            "fallback_policy": {"mode": "labeled-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "timeline",
+            "name": "Timeline",
+            "description": "Chronology-first slides focused on sequence, causality, and milestones.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "narrative_journey",
+            "style_pack": "editorial_print",
+            "base_theme": "beige",
+            "generation_rules": {"density": "medium", "bullet_bias": "medium", "chronology_bias": "high"},
+            "artifact_preferences": ("timeline", "stat_group"),
+            "fallback_policy": {"mode": "ordered-bullets", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "data-visualization",
+            "name": "Data Visualization",
+            "description": "Trend and comparison slides that foreground metrics, ratios, and patterns.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "metric_first",
+            "style_pack": "dashboard_glass",
+            "base_theme": "night",
+            "generation_rules": {"density": "medium", "bullet_bias": "low", "quant_focus": "high"},
+            "artifact_preferences": ("stat_group", "comparison_matrix"),
+            "fallback_policy": {"mode": "metric-summary", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "storytelling",
+            "name": "Storytelling",
+            "description": "Narrative slides with setup, tension, and payoff across the deck.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "narrative_journey",
+            "style_pack": "editorial_print",
+            "base_theme": "moon",
+            "generation_rules": {"density": "medium", "bullet_bias": "low", "narrative_bias": "high"},
+            "artifact_preferences": ("timeline", "process_flow"),
+            "fallback_policy": {"mode": "narrative-outline", "preserve_key_stats": False},
+        },
+        {
+            "style_id": "high-contrast-revision",
+            "name": "High-Contrast Revision",
+            "description": "Fast-scan revision slides using strong contrast and concise anchors.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "high_energy_marketing",
+            "style_pack": "brutalist_editorial",
+            "base_theme": "black",
+            "generation_rules": {"density": "high", "bullet_bias": "high", "scanability": "high"},
+            "artifact_preferences": ("stat_group", "process_flow"),
+            "fallback_policy": {"mode": "flashcard-points", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "comparative-matrix",
+            "name": "Comparative Matrix",
+            "description": "Comparison-driven slides for similarities, differences, and tradeoffs.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "design_editorial",
+            "style_pack": "editorial_print",
+            "base_theme": "white",
+            "generation_rules": {"density": "medium", "bullet_bias": "medium", "comparison_bias": "high"},
+            "artifact_preferences": ("comparison_matrix", "stat_group"),
+            "fallback_policy": {"mode": "two-column-summary", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "policy-case-brief",
+            "name": "Policy / Case Brief",
+            "description": "Issue, context, analysis, and takeaway framing for policy or case-study decks.",
+            "category": "legacy",
+            "guide_number": None,
+            "prompt_profile": "corporate_strategy",
+            "style_pack": "heritage_formal",
+            "base_theme": "simple",
+            "generation_rules": {"density": "medium", "bullet_bias": "medium", "argument_bias": "high"},
+            "artifact_preferences": ("comparison_matrix", "timeline"),
+            "fallback_policy": {"mode": "brief-outline", "preserve_key_stats": True},
+        },
+    )
+
+
+def _notebooklm_style_specs() -> tuple[dict[str, Any], ...]:
+    return (
+        {
+            "style_id": "notebooklm-chalkboard",
+            "name": "Chalkboard",
+            "description": "Dark slate chalk style with instructional contrast.",
+            "category": "educational",
+            "guide_number": 1,
+            "prompt_profile": "instructional_hand_drawn",
+            "style_pack": "hand_drawn_surface",
+            "base_theme": "black",
+            "generation_rules": {"bullet_bias": "medium", "instructional_bias": "high"},
+            "artifact_preferences": ("process_flow", "stat_group"),
+            "appearance_overrides": {
+                "token_overrides": {
+                    "surface": "#0f172a",
+                    "text": "#f8f2c8",
+                    "accent": "#fef08a",
+                    "border": "#f8f2c8",
+                }
+            },
+            "fallback_policy": {"mode": "chalk-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-whiteboard",
+            "name": "Whiteboard",
+            "description": "Bright whiteboard framing with marker-like emphasis.",
+            "category": "educational",
+            "guide_number": 2,
+            "prompt_profile": "instructional_hand_drawn",
+            "style_pack": "hand_drawn_surface",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "medium", "instructional_bias": "high"},
+            "artifact_preferences": ("process_flow", "comparison_matrix"),
+            "appearance_overrides": {
+                "token_overrides": {
+                    "surface": "#fdfdfb",
+                    "text": "#0f172a",
+                    "accent": "#0f766e",
+                    "border": "#d1d5db",
+                }
+            },
+            "fallback_policy": {"mode": "marker-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-sketch-noting",
+            "name": "Sketch Noting",
+            "description": "Workshop synthesis style with loose annotated structure.",
+            "category": "educational",
+            "guide_number": 3,
+            "prompt_profile": "instructional_hand_drawn",
+            "style_pack": "hand_drawn_surface",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "medium", "instructional_bias": "high"},
+            "artifact_preferences": ("process_flow", "comparison_matrix"),
+            "appearance_overrides": {
+                "token_overrides": {
+                    "surface": "#fffaf0",
+                    "text": "#374151",
+                    "accent": "#d97706",
+                    "border": "#fbbf24",
+                }
+            },
+            "fallback_policy": {"mode": "sketch-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-graphite-charcoal",
+            "name": "Graphite and Charcoal Realism",
+            "description": "Monochrome realism with a restrained editorial mood.",
+            "category": "educational",
+            "guide_number": 4,
+            "prompt_profile": "fine_art_human",
+            "style_pack": "editorial_print",
+            "base_theme": "serif",
+            "generation_rules": {"bullet_bias": "low", "artful_recall": True},
+            "artifact_preferences": ("timeline",),
+            "fallback_policy": {"mode": "monochrome-outline", "preserve_key_stats": False},
+        },
+        {
+            "style_id": "notebooklm-claymation",
+            "name": "Claymation",
+            "description": "Tactile, playful framing with soft dimensionality.",
+            "category": "educational",
+            "guide_number": 5,
+            "prompt_profile": "tactile_playful",
+            "style_pack": "tactile_soft",
+            "base_theme": "beige",
+            "generation_rules": {"bullet_bias": "medium", "playful_bias": True},
+            "artifact_preferences": ("process_flow", "stat_group"),
+            "fallback_policy": {"mode": "soft-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-exploded-view",
+            "name": "Exploded View Diagram",
+            "description": "Orthographic, assembly-first technical framing.",
+            "category": "technical",
+            "guide_number": 6,
+            "prompt_profile": "technical_precision",
+            "style_pack": "technical_grid",
+            "base_theme": "simple",
+            "generation_rules": {"bullet_bias": "low", "technical_bias": "high"},
+            "artifact_preferences": ("process_flow", "comparison_matrix"),
+            "fallback_policy": {"mode": "technical-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-blueprint",
+            "name": "Blueprint",
+            "description": "Cyan grid blueprint treatment with technical linework.",
+            "category": "technical",
+            "guide_number": 7,
+            "prompt_profile": "technical_precision",
+            "style_pack": "technical_grid",
+            "base_theme": "night",
+            "generation_rules": {"bullet_bias": "low", "technical_bias": "high"},
+            "artifact_preferences": ("process_flow", "timeline"),
+            "fallback_policy": {"mode": "technical-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-isometric-3d",
+            "name": "Isometric 3D Illustration",
+            "description": "Clean spatial framing with a corporate polish.",
+            "category": "technical",
+            "guide_number": 8,
+            "prompt_profile": "technical_precision",
+            "style_pack": "isometric_clean",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "low", "technical_bias": "high"},
+            "artifact_preferences": ("process_flow", "stat_group"),
+            "fallback_policy": {"mode": "spatial-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-minimalist-data-viz",
+            "name": "Minimalist 2D Data-Viz",
+            "description": "Flat quantitative clarity with editorial restraint.",
+            "category": "technical",
+            "guide_number": 9,
+            "prompt_profile": "metric_first",
+            "style_pack": "editorial_print",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "low", "quant_focus": "high"},
+            "artifact_preferences": ("stat_group", "comparison_matrix"),
+            "fallback_policy": {"mode": "metric-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-dark-saas-isometric",
+            "name": "Dark-Mode SaaS Isometric",
+            "description": "Dark module treatment with neon edges and product polish.",
+            "category": "technical",
+            "guide_number": 10,
+            "prompt_profile": "technical_precision",
+            "style_pack": "isometric_dark",
+            "base_theme": "night",
+            "generation_rules": {"bullet_bias": "low", "technical_bias": "high"},
+            "artifact_preferences": ("process_flow", "stat_group"),
+            "fallback_policy": {"mode": "spatial-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-professional-futuristic",
+            "name": "Professional Futuristic",
+            "description": "Premium future-tech framing with a dashboard feel.",
+            "category": "technical",
+            "guide_number": 11,
+            "prompt_profile": "corporate_strategy",
+            "style_pack": "dashboard_glass",
+            "base_theme": "moon",
+            "generation_rules": {"bullet_bias": "low", "quant_focus": "high"},
+            "artifact_preferences": ("stat_group", "comparison_matrix"),
+            "fallback_policy": {"mode": "futuristic-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-neumorphic",
+            "name": "Neumorphic",
+            "description": "Low-contrast tactile chrome with soft surfaces.",
+            "category": "technical",
+            "guide_number": 12,
+            "prompt_profile": "corporate_strategy",
+            "style_pack": "tactile_soft",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "low", "quant_focus": "medium"},
+            "artifact_preferences": ("stat_group",),
+            "fallback_policy": {"mode": "soft-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-high-contrast-monospace",
+            "name": "High-Contrast Monospace",
+            "description": "Terminal-style emphasis with bold contrast.",
+            "category": "technical",
+            "guide_number": 13,
+            "prompt_profile": "technical_precision",
+            "style_pack": "neon_cinematic",
+            "base_theme": "black",
+            "generation_rules": {"bullet_bias": "low", "scanability": "high"},
+            "artifact_preferences": ("stat_group", "comparison_matrix"),
+            "fallback_policy": {"mode": "terminal-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-journey-map",
+            "name": "Conceptual Journey Map",
+            "description": "Roadmap metaphor with a left-to-right narrative arc.",
+            "category": "narrative",
+            "guide_number": 14,
+            "prompt_profile": "narrative_journey",
+            "style_pack": "editorial_print",
+            "base_theme": "beige",
+            "generation_rules": {"bullet_bias": "medium", "narrative_bias": "high"},
+            "artifact_preferences": ("timeline", "process_flow"),
+            "fallback_policy": {"mode": "journey-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-strategic-infographic",
+            "name": "Strategic Infographic",
+            "description": "Problem-solution-impact framing for executive decks.",
+            "category": "narrative",
+            "guide_number": 15,
+            "prompt_profile": "corporate_strategy",
+            "style_pack": "editorial_print",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "low", "argument_bias": "high"},
+            "artifact_preferences": ("stat_group", "comparison_matrix"),
+            "fallback_policy": {"mode": "brief-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-executive-dashboard",
+            "name": "Executive Dashboard",
+            "description": "Dense KPI treatment with a dashboard cadence.",
+            "category": "narrative",
+            "guide_number": 16,
+            "prompt_profile": "metric_first",
+            "style_pack": "dashboard_glass",
+            "base_theme": "night",
+            "generation_rules": {"bullet_bias": "low", "quant_focus": "high"},
+            "artifact_preferences": ("stat_group", "comparison_matrix"),
+            "fallback_policy": {"mode": "dashboard-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-watercolour",
+            "name": "Watercolour",
+            "description": "Soft atmospheric palette for reflective storytelling.",
+            "category": "narrative",
+            "guide_number": 17,
+            "prompt_profile": "narrative_journey",
+            "style_pack": "editorial_print",
+            "base_theme": "beige",
+            "generation_rules": {"bullet_bias": "medium", "narrative_bias": "high"},
+            "artifact_preferences": ("timeline",),
+            "fallback_policy": {"mode": "soft-narrative-outline", "preserve_key_stats": False},
+        },
+        {
+            "style_id": "notebooklm-heritage",
+            "name": "Heritage",
+            "description": "Formal institutional tone with historical gravity.",
+            "category": "narrative",
+            "guide_number": 18,
+            "prompt_profile": "corporate_strategy",
+            "style_pack": "heritage_formal",
+            "base_theme": "serif",
+            "generation_rules": {"bullet_bias": "medium", "argument_bias": "high"},
+            "artifact_preferences": ("timeline", "comparison_matrix"),
+            "fallback_policy": {"mode": "formal-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-swiss-design",
+            "name": "Swiss Design",
+            "description": "Strict grid and whitespace with editorial control.",
+            "category": "narrative",
+            "guide_number": 19,
+            "prompt_profile": "design_editorial",
+            "style_pack": "editorial_print",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "medium", "argument_bias": "high"},
+            "artifact_preferences": ("comparison_matrix", "stat_group"),
+            "fallback_policy": {"mode": "grid-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-glassmorphic-ui",
+            "name": "Glass-morphic UI",
+            "description": "Frosted panel treatment within sanitizer limits.",
+            "category": "narrative",
+            "guide_number": 20,
+            "prompt_profile": "corporate_strategy",
+            "style_pack": "dashboard_glass",
+            "base_theme": "moon",
+            "generation_rules": {"bullet_bias": "low", "quant_focus": "medium"},
+            "artifact_preferences": ("stat_group",),
+            "fallback_policy": {"mode": "glass-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-corporate-memphis",
+            "name": "Corporate Memphis",
+            "description": "Approachable startup tone with soft character framing.",
+            "category": "narrative",
+            "guide_number": 21,
+            "prompt_profile": "playful_approachable",
+            "style_pack": "pastel_character",
+            "base_theme": "sky",
+            "generation_rules": {"bullet_bias": "medium", "playful_bias": True},
+            "artifact_preferences": ("process_flow", "stat_group"),
+            "fallback_policy": {"mode": "approachable-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-papercraft",
+            "name": "Papercraft",
+            "description": "Layered shadows and paper-like depth.",
+            "category": "playful",
+            "guide_number": 22,
+            "prompt_profile": "tactile_playful",
+            "style_pack": "tactile_soft",
+            "base_theme": "beige",
+            "generation_rules": {"bullet_bias": "medium", "playful_bias": True},
+            "artifact_preferences": ("process_flow",),
+            "fallback_policy": {"mode": "paper-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-tactile-3d",
+            "name": "Tactile 3D",
+            "description": "Soft inflated UI style with tactile depth.",
+            "category": "playful",
+            "guide_number": 23,
+            "prompt_profile": "tactile_playful",
+            "style_pack": "tactile_soft",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "medium", "playful_bias": True},
+            "artifact_preferences": ("stat_group",),
+            "fallback_policy": {"mode": "soft-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-miniature-world",
+            "name": "Miniature World",
+            "description": "Toy-like overview framing with isometric cues.",
+            "category": "playful",
+            "guide_number": 24,
+            "prompt_profile": "tactile_playful",
+            "style_pack": "isometric_clean",
+            "base_theme": "sky",
+            "generation_rules": {"bullet_bias": "medium", "playful_bias": True},
+            "artifact_preferences": ("process_flow", "timeline"),
+            "fallback_policy": {"mode": "miniature-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-kawaii",
+            "name": "Kawaii",
+            "description": "Pastel rounded friendliness with a light narrative tone.",
+            "category": "playful",
+            "guide_number": 25,
+            "prompt_profile": "playful_approachable",
+            "style_pack": "pastel_character",
+            "base_theme": "sky",
+            "generation_rules": {"bullet_bias": "medium", "playful_bias": True},
+            "artifact_preferences": ("process_flow", "stat_group"),
+            "fallback_policy": {"mode": "cute-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-pop-art",
+            "name": "Pop Art",
+            "description": "High-contrast editorial framing with a bold commercial pulse.",
+            "category": "nostalgic",
+            "guide_number": 26,
+            "prompt_profile": "high_energy_marketing",
+            "style_pack": "editorial_print",
+            "base_theme": "white",
+            "generation_rules": {"bullet_bias": "medium", "energy_bias": "high"},
+            "artifact_preferences": ("stat_group",),
+            "fallback_policy": {"mode": "pop-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-risograph-print",
+            "name": "Risograph Print",
+            "description": "Grainy spot-color editorial look.",
+            "category": "nostalgic",
+            "guide_number": 27,
+            "prompt_profile": "design_editorial",
+            "style_pack": "editorial_print",
+            "base_theme": "beige",
+            "generation_rules": {"bullet_bias": "medium", "energy_bias": "medium"},
+            "artifact_preferences": ("comparison_matrix", "stat_group"),
+            "fallback_policy": {"mode": "print-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-retro-90s-gaming",
+            "name": "Retro 90s Gaming",
+            "description": "Chunky UI and low-poly flavor with a retro synthetic tone.",
+            "category": "nostalgic",
+            "guide_number": 28,
+            "prompt_profile": "retro_synthetic",
+            "style_pack": "retro_pixel",
+            "base_theme": "black",
+            "generation_rules": {"bullet_bias": "medium", "retro_bias": "high"},
+            "artifact_preferences": ("process_flow", "stat_group"),
+            "fallback_policy": {"mode": "retro-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-oregon-trail",
+            "name": "Oregon Trail",
+            "description": "8-bit frontier journey framing.",
+            "category": "nostalgic",
+            "guide_number": 29,
+            "prompt_profile": "retro_synthetic",
+            "style_pack": "retro_pixel",
+            "base_theme": "simple",
+            "generation_rules": {"bullet_bias": "medium", "retro_bias": "high"},
+            "artifact_preferences": ("timeline", "process_flow"),
+            "fallback_policy": {"mode": "journey-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-cyberpunk",
+            "name": "Cyberpunk",
+            "description": "Neon, gritty, and atmospheric with strong contrast.",
+            "category": "nostalgic",
+            "guide_number": 30,
+            "prompt_profile": "high_energy_marketing",
+            "style_pack": "neon_cinematic",
+            "base_theme": "blood",
+            "generation_rules": {"bullet_bias": "low", "energy_bias": "high"},
+            "artifact_preferences": ("stat_group", "comparison_matrix"),
+            "fallback_policy": {"mode": "neon-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-anime-battle",
+            "name": "Anime Battle",
+            "description": "High-energy launch and competition framing.",
+            "category": "nostalgic",
+            "guide_number": 31,
+            "prompt_profile": "high_energy_marketing",
+            "style_pack": "neon_cinematic",
+            "base_theme": "moon",
+            "generation_rules": {"bullet_bias": "medium", "energy_bias": "high"},
+            "artifact_preferences": ("process_flow", "stat_group"),
+            "fallback_policy": {"mode": "battle-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-anime",
+            "name": "Anime",
+            "description": "Bright cinematic narrative tone with approachable energy.",
+            "category": "nostalgic",
+            "guide_number": 32,
+            "prompt_profile": "playful_approachable",
+            "style_pack": "pastel_character",
+            "base_theme": "sky",
+            "generation_rules": {"bullet_bias": "medium", "energy_bias": "medium"},
+            "artifact_preferences": ("timeline", "process_flow"),
+            "fallback_policy": {"mode": "cinematic-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-retro-print",
+            "name": "Retro Print",
+            "description": "Archive or newspaper tone with editorial restraint.",
+            "category": "nostalgic",
+            "guide_number": 33,
+            "prompt_profile": "design_editorial",
+            "style_pack": "editorial_print",
+            "base_theme": "beige",
+            "generation_rules": {"bullet_bias": "medium", "energy_bias": "medium"},
+            "artifact_preferences": ("timeline", "comparison_matrix"),
+            "fallback_policy": {"mode": "archive-outline", "preserve_key_stats": True},
+        },
+        {
+            "style_id": "notebooklm-brutalist-design",
+            "name": "Brutalist Design",
+            "description": "Harsh contrast and oversized type with editorial edge.",
+            "category": "nostalgic",
+            "guide_number": 34,
+            "prompt_profile": "design_editorial",
+            "style_pack": "brutalist_editorial",
+            "base_theme": "simple",
+            "generation_rules": {"bullet_bias": "medium", "energy_bias": "high"},
+            "artifact_preferences": ("comparison_matrix", "stat_group"),
+            "fallback_policy": {"mode": "brutalist-outline", "preserve_key_stats": True},
+        },
+    )
+
+
+def _build_definition(spec: dict[str, Any], *, sort_order: int) -> BuiltinVisualStyleDefinition:
+    category = str(spec["category"])
+    return BuiltinVisualStyleDefinition(
+        style_id=str(spec["style_id"]),
+        name=str(spec["name"]),
+        description=str(spec["description"]),
+        category=category,
+        guide_number=spec.get("guide_number"),
+        sort_order=sort_order,
+        version=1,
+        prompt_profile=str(spec["prompt_profile"]),
+        style_pack=str(spec["style_pack"]),
+        style_pack_version=1,
+        base_theme=str(spec["base_theme"]),
+        generation_rules=deepcopy(spec.get("generation_rules") or {}),
+        artifact_preferences=tuple(str(item) for item in spec.get("artifact_preferences") or ()),
+        fallback_policy=deepcopy(spec.get("fallback_policy") or {}),
+        appearance_overrides=deepcopy(spec.get("appearance_overrides") or {}),
+        tags=(
+            category,
+            str(spec["style_pack"]),
+            str(spec["prompt_profile"]),
+        ),
+        best_for=_CATEGORY_BEST_FOR.get(category, ("slide generation",)),
+    )
+
+
+_BUILTIN_STYLE_DEFINITIONS: tuple[BuiltinVisualStyleDefinition, ...] = tuple(
+    _build_definition(spec, sort_order=index)
+    for index, spec in enumerate((*_legacy_style_specs(), *_notebooklm_style_specs()), start=1)
+)
+
+_BUILTIN_STYLE_DEFINITIONS_BY_ID = {definition.style_id: definition for definition in _BUILTIN_STYLE_DEFINITIONS}
+
+
+def _clone_definition(definition: BuiltinVisualStyleDefinition) -> BuiltinVisualStyleDefinition:
+    """Return a defensive copy of a built-in style definition."""
+
+    return BuiltinVisualStyleDefinition(
+        style_id=definition.style_id,
+        name=definition.name,
+        description=definition.description,
+        category=definition.category,
+        guide_number=definition.guide_number,
+        sort_order=definition.sort_order,
+        version=definition.version,
+        prompt_profile=definition.prompt_profile,
+        style_pack=definition.style_pack,
+        style_pack_version=definition.style_pack_version,
+        base_theme=definition.base_theme,
+        generation_rules=deepcopy(definition.generation_rules),
+        artifact_preferences=tuple(definition.artifact_preferences),
+        fallback_policy=deepcopy(definition.fallback_policy),
+        appearance_overrides=deepcopy(definition.appearance_overrides),
+        tags=tuple(definition.tags),
+        best_for=tuple(definition.best_for),
+    )
+
+
+def _validate_registry_integrity() -> None:
+    """Ensure catalog entries reference valid profile and pack identifiers."""
+
+    from tldw_Server_API.app.core.Slides.visual_style_packs import get_visual_style_pack
+    from tldw_Server_API.app.core.Slides.visual_style_profiles import get_visual_style_profile
+
+    missing_profiles = sorted(
+        {
+            definition.prompt_profile
+            for definition in _BUILTIN_STYLE_DEFINITIONS
+            if get_visual_style_profile(definition.prompt_profile) is None
+        }
+    )
+    missing_packs = sorted(
+        {
+            definition.style_pack
+            for definition in _BUILTIN_STYLE_DEFINITIONS
+            if get_visual_style_pack(definition.style_pack) is None
+        }
+    )
+    if missing_profiles or missing_packs:
+        problems: list[str] = []
+        if missing_profiles:
+            problems.append(f"missing prompt profiles: {', '.join(missing_profiles)}")
+        if missing_packs:
+            problems.append(f"missing style packs: {', '.join(missing_packs)}")
+        raise RuntimeError("invalid visual style registry: " + "; ".join(problems))
+
+
+def list_builtin_visual_style_definitions() -> list[BuiltinVisualStyleDefinition]:
+    """Return all built-in style definitions in registry order."""
+
+    return [_clone_definition(definition) for definition in _BUILTIN_STYLE_DEFINITIONS]
+
+
+def get_builtin_visual_style_definition(style_id: str) -> BuiltinVisualStyleDefinition | None:
+    """Look up a built-in style definition by identifier."""
+
+    definition = _BUILTIN_STYLE_DEFINITIONS_BY_ID.get(style_id)
+    return _clone_definition(definition) if definition is not None else None
+
+
+_validate_registry_integrity()

--- a/tldw_Server_API/app/core/Slides/visual_style_generation.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_generation.py
@@ -22,12 +22,16 @@ _SUPPORTED_VISUAL_BLOCK_TYPES: tuple[str, ...] = (
 
 
 def _coerce_dict(value: Any) -> dict[str, Any]:
+    """Return a shallow dict copy when the incoming value is dict-like."""
+
     if isinstance(value, dict):
         return dict(value)
     return {}
 
 
 def _coerce_string_tuple(value: Any) -> tuple[str, ...]:
+    """Normalize a list-like value into a trimmed tuple of strings."""
+
     if isinstance(value, (list, tuple)):
         return tuple(str(item).strip() for item in value if str(item).strip())
     return ()
@@ -36,6 +40,8 @@ def _coerce_string_tuple(value: Any) -> tuple[str, ...]:
 def _resolve_visual_style_prompt_source(
     visual_style_snapshot: dict[str, Any],
 ) -> dict[str, Any]:
+    """Resolve prompt-driving style metadata from a snapshot or builtin catalog entry."""
+
     style_id = str(visual_style_snapshot.get("id") or "").strip()
     style_scope = str(visual_style_snapshot.get("scope") or "").strip().lower()
     style_name = str(visual_style_snapshot.get("name") or style_id or "selected").strip()
@@ -73,6 +79,8 @@ def _resolve_visual_style_prompt_source(
 
 
 def _format_fallback_policy(fallback_policy: dict[str, Any]) -> str:
+    """Format fallback policy metadata into a compact prompt line."""
+
     if not fallback_policy:
         return "Keep slides readable in plain markdown if a structured block does not fit."
 
@@ -94,6 +102,8 @@ def _format_fallback_policy(fallback_policy: dict[str, Any]) -> str:
 
 
 def _build_prompt_sections(visual_style_snapshot: dict[str, Any]) -> list[str]:
+    """Build the prompt sections that steer slide generation toward the selected style."""
+
     source = _resolve_visual_style_prompt_source(visual_style_snapshot)
 
     lines = [
@@ -177,6 +187,8 @@ def apply_visual_block_fallback(slide: dict[str, Any]) -> dict[str, Any]:
 
 
 def _compile_block_fallback(block: dict[str, Any]) -> list[str]:
+    """Compile a structured visual block into readable markdown fallback lines."""
+
     block_type = block.get("type")
     if block_type == "timeline":
         return _compile_timeline(block)
@@ -190,6 +202,8 @@ def _compile_block_fallback(block: dict[str, Any]) -> list[str]:
 
 
 def _compile_timeline(block: dict[str, Any]) -> list[str]:
+    """Compile a timeline block into ordered markdown bullets."""
+
     items = block.get("items")
     if not isinstance(items, list):
         return _compile_generic_block(block)
@@ -211,6 +225,8 @@ def _compile_timeline(block: dict[str, Any]) -> list[str]:
 
 
 def _compile_comparison_matrix(block: dict[str, Any]) -> list[str]:
+    """Compile a comparison matrix block into readable comparison bullets."""
+
     rows = block.get("rows")
     if not isinstance(rows, list):
         return _compile_generic_block(block)
@@ -232,6 +248,8 @@ def _compile_comparison_matrix(block: dict[str, Any]) -> list[str]:
 
 
 def _compile_process_flow(block: dict[str, Any]) -> list[str]:
+    """Compile a process flow block into numbered markdown steps."""
+
     steps = block.get("steps")
     if not isinstance(steps, list):
         return _compile_generic_block(block)
@@ -249,6 +267,8 @@ def _compile_process_flow(block: dict[str, Any]) -> list[str]:
 
 
 def _compile_stat_group(block: dict[str, Any]) -> list[str]:
+    """Compile a stat group block into metric bullets."""
+
     items = block.get("items")
     if not isinstance(items, list):
         return _compile_generic_block(block)
@@ -269,6 +289,8 @@ def _compile_stat_group(block: dict[str, Any]) -> list[str]:
 
 
 def _compile_generic_block(block: dict[str, Any]) -> list[str]:
+    """Compile an unknown block into a generic markdown fallback."""
+
     title = str(block.get("title") or block.get("name") or "").strip()
     description = str(block.get("description") or block.get("summary") or "").strip()
     if title and description:

--- a/tldw_Server_API/app/core/Slides/visual_style_generation.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_generation.py
@@ -90,9 +90,7 @@ def _format_fallback_policy(fallback_policy: dict[str, Any]) -> str:
     if "preserve_key_stats" in fallback_policy:
         parts.append(f"preserve_key_stats={fallback_policy['preserve_key_stats']}")
 
-    extra_keys = sorted(
-        key for key in fallback_policy.keys() if key not in {"mode", "preserve_key_stats"}
-    )
+    extra_keys = sorted(key for key in fallback_policy if key not in {"mode", "preserve_key_stats"})
     for key in extra_keys:
         value = fallback_policy.get(key)
         if isinstance(value, (str, int, float, bool)) and str(value).strip():

--- a/tldw_Server_API/app/core/Slides/visual_style_generation.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_generation.py
@@ -5,68 +5,129 @@ from __future__ import annotations
 import json
 from typing import Any
 
-
-_STYLE_PROMPT_HINTS: dict[str, tuple[str, ...]] = {
-    "timeline": (
-        "Favor chronology, causality, and milestone sequencing.",
-        "When helpful, emit timeline visual blocks with dated events and short explanations.",
-    ),
-    "exam-focused-bullet": (
-        "Prefer concise, high-yield bullets over narrative paragraphs.",
-        "Optimize for recall, revision, and fast scanning.",
-    ),
-    "diagram-map-based": (
-        "Emphasize relationships, flows, regions, and conceptual structure.",
-        "Use process or comparison blocks when they improve comprehension.",
-    ),
-    "data-visualization": (
-        "Highlight metrics, trends, comparisons, and quantitative takeaways.",
-        "Prefer stat groups or comparison blocks over decorative prose.",
-    ),
-    "storytelling": (
-        "Use a narrative arc with setup, development, and payoff.",
-        "Keep slides concise while preserving story progression.",
-    ),
-}
+from tldw_Server_API.app.core.Slides.visual_style_catalog import (
+    get_builtin_visual_style_definition,
+)
+from tldw_Server_API.app.core.Slides.visual_style_profiles import (
+    build_prompt_profile_prompt_lines,
+)
 
 
-def build_visual_style_generation_prompt(visual_style_snapshot: dict[str, Any] | None) -> str:
-    """Return style-specific prompt guidance for slide generation."""
+_SUPPORTED_VISUAL_BLOCK_TYPES: tuple[str, ...] = (
+    "timeline",
+    "comparison_matrix",
+    "process_flow",
+    "stat_group",
+)
 
-    if not isinstance(visual_style_snapshot, dict) or not visual_style_snapshot:
-        return ""
 
+def _coerce_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+def _coerce_string_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    return ()
+
+
+def _resolve_visual_style_prompt_source(
+    visual_style_snapshot: dict[str, Any],
+) -> dict[str, Any]:
     style_id = str(visual_style_snapshot.get("id") or "").strip()
+    style_scope = str(visual_style_snapshot.get("scope") or "").strip().lower()
     style_name = str(visual_style_snapshot.get("name") or style_id or "selected").strip()
-    generation_rules = (
-        visual_style_snapshot.get("generation_rules")
-        if isinstance(visual_style_snapshot.get("generation_rules"), dict)
-        else {}
+    resolved = {
+        "id": style_id,
+        "scope": style_scope,
+        "name": style_name,
+        "description": str(visual_style_snapshot.get("description") or "").strip(),
+        "prompt_profile": str(visual_style_snapshot.get("prompt_profile") or "").strip(),
+        "generation_rules": _coerce_dict(visual_style_snapshot.get("generation_rules")),
+        "artifact_preferences": _coerce_string_tuple(
+            visual_style_snapshot.get("artifact_preferences")
+        ),
+        "fallback_policy": _coerce_dict(visual_style_snapshot.get("fallback_policy")),
+        "prompt_notes": _coerce_string_tuple(visual_style_snapshot.get("prompt_notes")),
+        "builtin": False,
+    }
+
+    if style_scope == "builtin" and style_id:
+        definition = get_builtin_visual_style_definition(style_id)
+        if definition is not None:
+            resolved.update(
+                {
+                    "name": definition.name,
+                    "description": definition.description,
+                    "prompt_profile": definition.prompt_profile,
+                    "generation_rules": dict(definition.generation_rules),
+                    "artifact_preferences": tuple(definition.artifact_preferences),
+                    "fallback_policy": dict(definition.fallback_policy),
+                    "prompt_notes": tuple(definition.prompt_notes),
+                    "builtin": True,
+                }
+            )
+    return resolved
+
+
+def _format_fallback_policy(fallback_policy: dict[str, Any]) -> str:
+    if not fallback_policy:
+        return "Keep slides readable in plain markdown if a structured block does not fit."
+
+    parts: list[str] = []
+    if "mode" in fallback_policy and str(fallback_policy["mode"]).strip():
+        parts.append(f"mode={fallback_policy['mode']}")
+    if "preserve_key_stats" in fallback_policy:
+        parts.append(f"preserve_key_stats={fallback_policy['preserve_key_stats']}")
+
+    extra_keys = sorted(
+        key for key in fallback_policy.keys() if key not in {"mode", "preserve_key_stats"}
     )
-    artifact_preferences = (
-        visual_style_snapshot.get("artifact_preferences")
-        if isinstance(visual_style_snapshot.get("artifact_preferences"), list)
-        else []
-    )
+    for key in extra_keys:
+        value = fallback_policy.get(key)
+        if isinstance(value, (str, int, float, bool)) and str(value).strip():
+            parts.append(f"{key}={value}")
+
+    return "; ".join(parts) if parts else "Keep slides readable in plain markdown."
+
+
+def _build_prompt_sections(visual_style_snapshot: dict[str, Any]) -> list[str]:
+    source = _resolve_visual_style_prompt_source(visual_style_snapshot)
 
     lines = [
-        f"Visual style preset: {style_name}.",
+        f"Visual style preset: {source['name']}.",
         "Adapt slide structure and emphasis to this preset instead of using a generic deck pattern.",
     ]
-    lines.extend(_STYLE_PROMPT_HINTS.get(style_id, ()))
-    if generation_rules:
+
+    if source["description"]:
+        lines.append(f"Style description: {source['description']}")
+
+    if source["prompt_notes"]:
+        lines.append("Style notes:")
+        lines.extend(f"- {note}" for note in source["prompt_notes"])
+
+    profile_lines = build_prompt_profile_prompt_lines(str(source["prompt_profile"]))
+    if profile_lines:
+        lines.extend(profile_lines)
+
+    if source["generation_rules"]:
         lines.append(
             "Generation rules: "
-            + json.dumps(generation_rules, ensure_ascii=True, sort_keys=True)
+            + json.dumps(source["generation_rules"], ensure_ascii=True, sort_keys=True)
         )
-    if artifact_preferences:
+    if source["artifact_preferences"]:
         lines.append(
             "Preferred visual block types: "
-            + ", ".join(str(item) for item in artifact_preferences)
+            + ", ".join(str(item) for item in source["artifact_preferences"])
         )
+
+    lines.append("Fallback instructions: " + _format_fallback_policy(source["fallback_policy"]))
     lines.append(
         "You may include metadata.visual_blocks on slides using these supported types: "
-        "timeline, comparison_matrix, process_flow, stat_group."
+        + ", ".join(_SUPPORTED_VISUAL_BLOCK_TYPES)
+        + "."
     )
     lines.append(
         "Every slide must remain valid in plain markdown or reveal exports, so provide meaningful content "
@@ -75,7 +136,15 @@ def build_visual_style_generation_prompt(visual_style_snapshot: dict[str, Any] |
     lines.append(
         'Example timeline block: {"type":"timeline","items":[{"label":"1776","title":"Event","description":"Why it matters"}]}'
     )
-    return "\n".join(lines)
+    return lines
+
+
+def build_visual_style_generation_prompt(visual_style_snapshot: dict[str, Any] | None) -> str:
+    """Return style-specific prompt guidance for slide generation."""
+
+    if not isinstance(visual_style_snapshot, dict) or not visual_style_snapshot:
+        return ""
+    return "\n".join(_build_prompt_sections(visual_style_snapshot))
 
 
 def apply_visual_block_fallback(slide: dict[str, Any]) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/Slides/visual_style_packs.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_packs.py
@@ -1,0 +1,233 @@
+"""Reusable resolved appearance packs for built-in slide visual styles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class VisualStylePack:
+    """Reusable deck-appearance pack."""
+
+    pack_id: str
+    version: int
+    default_token_overrides: dict[str, Any]
+    default_resolved_settings: dict[str, Any]
+
+
+_VISUAL_STYLE_PACKS: tuple[VisualStylePack, ...] = (
+    VisualStylePack(
+        pack_id="hand_drawn_surface",
+        version=1,
+        default_token_overrides={
+            "surface": "#101418",
+            "text": "#f8f2c8",
+            "accent": "#fef08a",
+            "border": "#f8f2c8",
+        },
+        default_resolved_settings={"controls": True, "progress": False},
+    ),
+    VisualStylePack(
+        pack_id="technical_grid",
+        version=1,
+        default_token_overrides={
+            "surface": "#0f172a",
+            "text": "#f8fafc",
+            "accent": "#7dd3fc",
+            "grid": "rgba(125, 211, 252, 0.16)",
+        },
+        default_resolved_settings={"controls": True, "progress": True},
+    ),
+    VisualStylePack(
+        pack_id="isometric_clean",
+        version=1,
+        default_token_overrides={
+            "surface": "#ffffff",
+            "text": "#0f172a",
+            "accent": "#2563eb",
+        },
+        default_resolved_settings={"controls": True, "progress": True},
+    ),
+    VisualStylePack(
+        pack_id="isometric_dark",
+        version=1,
+        default_token_overrides={
+            "surface": "#111827",
+            "text": "#e5e7eb",
+            "accent": "#7dd3fc",
+        },
+        default_resolved_settings={"controls": True, "progress": True, "backgroundTransition": "fade"},
+    ),
+    VisualStylePack(
+        pack_id="dashboard_glass",
+        version=1,
+        default_token_overrides={
+            "surface": "rgba(15, 23, 42, 0.72)",
+            "text": "#f8fafc",
+            "accent": "#38bdf8",
+            "glow": "#67e8f9",
+        },
+        default_resolved_settings={"controls": True, "progress": True, "transition": "slide"},
+    ),
+    VisualStylePack(
+        pack_id="editorial_print",
+        version=1,
+        default_token_overrides={
+            "surface": "#ffffff",
+            "text": "#111111",
+            "accent": "#111111",
+            "rule": "#d4d4d8",
+        },
+        default_resolved_settings={"controls": False, "progress": False},
+    ),
+    VisualStylePack(
+        pack_id="tactile_soft",
+        version=1,
+        default_token_overrides={
+            "surface": "#faf5ff",
+            "text": "#1f2937",
+            "accent": "#c084fc",
+            "shadow": "rgba(15, 23, 42, 0.12)",
+        },
+        default_resolved_settings={"controls": True, "progress": True},
+    ),
+    VisualStylePack(
+        pack_id="retro_pixel",
+        version=1,
+        default_token_overrides={
+            "surface": "#111827",
+            "text": "#f9fafb",
+            "accent": "#22c55e",
+            "pixel": "4px",
+        },
+        default_resolved_settings={"controls": True, "progress": True, "transition": "convex"},
+    ),
+    VisualStylePack(
+        pack_id="neon_cinematic",
+        version=1,
+        default_token_overrides={
+            "surface": "#020617",
+            "text": "#f8fafc",
+            "accent": "#f97316",
+            "glow": "#67e8f9",
+        },
+        default_resolved_settings={"controls": True, "progress": True},
+    ),
+    VisualStylePack(
+        pack_id="brutalist_editorial",
+        version=1,
+        default_token_overrides={
+            "surface": "#f5f5f5",
+            "text": "#000000",
+            "accent": "#000000",
+            "border": "#000000",
+        },
+        default_resolved_settings={"controls": True, "progress": False, "transition": "none"},
+    ),
+    VisualStylePack(
+        pack_id="heritage_formal",
+        version=1,
+        default_token_overrides={
+            "surface": "#fffbf5",
+            "text": "#3f2a14",
+            "accent": "#6b4f2a",
+            "rule": "#b45309",
+        },
+        default_resolved_settings={"controls": False, "progress": False},
+    ),
+    VisualStylePack(
+        pack_id="pastel_character",
+        version=1,
+        default_token_overrides={
+            "surface": "#fff1f2",
+            "text": "#1f2937",
+            "accent": "#fb7185",
+            "shadow": "rgba(244, 114, 182, 0.2)",
+        },
+        default_resolved_settings={"controls": True, "progress": True},
+    ),
+)
+
+_VISUAL_STYLE_PACKS_BY_ID = {pack.pack_id: pack for pack in _VISUAL_STYLE_PACKS}
+
+
+def _clone_pack(pack: VisualStylePack) -> VisualStylePack:
+    """Return a defensive copy of a style pack."""
+
+    return VisualStylePack(
+        pack_id=pack.pack_id,
+        version=pack.version,
+        default_token_overrides=dict(pack.default_token_overrides),
+        default_resolved_settings=dict(pack.default_resolved_settings),
+    )
+
+
+def list_visual_style_packs() -> list[VisualStylePack]:
+    """Return all reusable style packs."""
+
+    return [_clone_pack(pack) for pack in _VISUAL_STYLE_PACKS]
+
+
+def get_visual_style_pack(pack_id: str) -> VisualStylePack | None:
+    """Look up a style pack by identifier."""
+
+    pack = _VISUAL_STYLE_PACKS_BY_ID.get(pack_id)
+    return _clone_pack(pack) if pack is not None else None
+
+
+def resolve_pack_token_overrides(
+    pack_id: str,
+    *,
+    token_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Merge pack defaults with optional style-specific token overrides."""
+
+    pack = _VISUAL_STYLE_PACKS_BY_ID.get(pack_id)
+    if pack is None:
+        return dict(token_overrides or {})
+    resolved = dict(pack.default_token_overrides)
+    if token_overrides:
+        resolved.update(token_overrides)
+    return resolved
+
+
+def resolve_pack_settings(
+    pack_id: str,
+    *,
+    settings_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Merge pack defaults with optional style-specific settings overrides."""
+
+    pack = _VISUAL_STYLE_PACKS_BY_ID.get(pack_id)
+    if pack is None:
+        return dict(settings_overrides or {})
+    resolved = dict(pack.default_resolved_settings)
+    if settings_overrides:
+        resolved.update(settings_overrides)
+    return resolved
+
+
+def render_pack_custom_css(
+    *,
+    style_id: str,
+    pack_id: str,
+    token_overrides: dict[str, Any],
+) -> str:
+    """Render safe CSS for a built-in style pack."""
+
+    lines = [
+        f'.reveal[data-visual-style="{style_id}"] {{',
+        f"  --visual-style-pack: {pack_id};",
+    ]
+    for key in sorted(token_overrides):
+        value = token_overrides[key]
+        if value is None:
+            continue
+        css_key = str(key).replace("_", "-")
+        css_value = str(value).replace("\n", " ").strip()
+        if not css_value:
+            continue
+        lines.append(f"  --{css_key}: {css_value};")
+    lines.append("}")
+    return "\n".join(lines)

--- a/tldw_Server_API/app/core/Slides/visual_style_packs.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_packs.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 
@@ -150,6 +152,7 @@ _VISUAL_STYLE_PACKS: tuple[VisualStylePack, ...] = (
 )
 
 _VISUAL_STYLE_PACKS_BY_ID = {pack.pack_id: pack for pack in _VISUAL_STYLE_PACKS}
+_STYLE_PACKS_DIR = Path(__file__).resolve().parent / "style_packs"
 
 
 def _clone_pack(pack: VisualStylePack) -> VisualStylePack:
@@ -208,16 +211,24 @@ def resolve_pack_settings(
     return resolved
 
 
-def render_pack_custom_css(
+@lru_cache(maxsize=None)
+def _load_pack_css(pack_id: str) -> str:
+    """Read the static stylesheet for a built-in pack."""
+
+    css_path = _STYLE_PACKS_DIR / f"{pack_id}.css"
+    if not css_path.exists():
+        return ""
+    return css_path.read_text(encoding="utf-8").strip()
+
+
+def _render_token_block(
     *,
-    style_id: str,
+    selector: str,
     pack_id: str,
     token_overrides: dict[str, Any],
 ) -> str:
-    """Render safe CSS for a built-in style pack."""
-
     lines = [
-        f'.reveal[data-visual-style="{style_id}"] {{',
+        f"{selector} {{",
         f"  --visual-style-pack: {pack_id};",
     ]
     for key in sorted(token_overrides):
@@ -231,3 +242,27 @@ def render_pack_custom_css(
         lines.append(f"  --{css_key}: {css_value};")
     lines.append("}")
     return "\n".join(lines)
+
+
+def render_pack_custom_css(
+    *,
+    style_id: str,
+    pack_id: str,
+    token_overrides: dict[str, Any],
+) -> str:
+    """Render safe CSS for a built-in style pack."""
+
+    parts = [
+        _load_pack_css(pack_id),
+        _render_token_block(
+            selector=f'.reveal[data-style-pack="{pack_id}"]',
+            pack_id=pack_id,
+            token_overrides=token_overrides,
+        ),
+        _render_token_block(
+            selector=f'.reveal[data-visual-style="{style_id}"]',
+            pack_id=pack_id,
+            token_overrides=token_overrides,
+        ),
+    ]
+    return "\n\n".join(part for part in parts if part.strip())

--- a/tldw_Server_API/app/core/Slides/visual_style_packs.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_packs.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import cache
+import re
 from pathlib import Path
 from typing import Any
 
@@ -153,6 +154,8 @@ _VISUAL_STYLE_PACKS: tuple[VisualStylePack, ...] = (
 
 _VISUAL_STYLE_PACKS_BY_ID = {pack.pack_id: pack for pack in _VISUAL_STYLE_PACKS}
 _STYLE_PACKS_DIR = Path(__file__).resolve().parent / "style_packs"
+_SAFE_TOKEN_KEY_PATTERN = re.compile(r"^[a-z0-9-]+$")
+_SAFE_TOKEN_VALUE_PATTERN = re.compile(r"^[a-zA-Z0-9\s#(),.%'\"_/-]+$")
 
 
 def _clone_pack(pack: VisualStylePack) -> VisualStylePack:
@@ -211,14 +214,55 @@ def resolve_pack_settings(
     return resolved
 
 
-@lru_cache(maxsize=None)
+def _normalize_pack_id(pack_id: str) -> str | None:
+    """Return a known pack identifier or ``None`` when the value is invalid."""
+
+    normalized = str(pack_id).strip()
+    if not normalized:
+        return None
+    if normalized not in _VISUAL_STYLE_PACKS_BY_ID:
+        return None
+    return normalized
+
+
+@cache
 def _load_pack_css(pack_id: str) -> str:
     """Read the static stylesheet for a built-in pack."""
 
-    css_path = _STYLE_PACKS_DIR / f"{pack_id}.css"
+    normalized_pack_id = _normalize_pack_id(pack_id)
+    if normalized_pack_id is None:
+        return ""
+
+    packs_dir = _STYLE_PACKS_DIR.resolve()
+    css_path = (packs_dir / f"{normalized_pack_id}.css").resolve()
+    if css_path.parent != packs_dir:
+        return ""
     if not css_path.exists():
         return ""
     return css_path.read_text(encoding="utf-8").strip()
+
+
+def _normalize_token_key(value: Any) -> str | None:
+    """Return a safe CSS custom property suffix or ``None`` when invalid."""
+
+    normalized = str(value).strip().replace("_", "-").lower()
+    if not normalized or not _SAFE_TOKEN_KEY_PATTERN.fullmatch(normalized):
+        return None
+    return normalized
+
+
+def _normalize_token_value(value: Any) -> str | None:
+    """Return a safe CSS token value or ``None`` when it contains unsafe syntax."""
+
+    normalized = str(value).replace("\n", " ").strip()
+    if not normalized:
+        return None
+    lowered = normalized.lower()
+    if "url(" in lowered or "@import" in lowered or "expression(" in lowered:
+        return None
+    if not _SAFE_TOKEN_VALUE_PATTERN.fullmatch(normalized):
+        return None
+    return normalized
 
 
 def _render_token_block(
@@ -235,9 +279,9 @@ def _render_token_block(
         value = token_overrides[key]
         if value is None:
             continue
-        css_key = str(key).replace("_", "-")
-        css_value = str(value).replace("\n", " ").strip()
-        if not css_value:
+        css_key = _normalize_token_key(key)
+        css_value = _normalize_token_value(value)
+        if css_key is None or css_value is None:
             continue
         lines.append(f"  --{css_key}: {css_value};")
     lines.append("}")
@@ -252,16 +296,20 @@ def render_pack_custom_css(
 ) -> str:
     """Render safe CSS for a built-in style pack."""
 
+    normalized_pack_id = _normalize_pack_id(pack_id)
+    if normalized_pack_id is None:
+        return ""
+
     parts = [
-        _load_pack_css(pack_id),
+        _load_pack_css(normalized_pack_id),
         _render_token_block(
-            selector=f'.reveal[data-style-pack="{pack_id}"]',
-            pack_id=pack_id,
+            selector=f'.reveal[data-style-pack="{normalized_pack_id}"]',
+            pack_id=normalized_pack_id,
             token_overrides=token_overrides,
         ),
         _render_token_block(
             selector=f'.reveal[data-visual-style="{style_id}"]',
-            pack_id=pack_id,
+            pack_id=normalized_pack_id,
             token_overrides=token_overrides,
         ),
     ]

--- a/tldw_Server_API/app/core/Slides/visual_style_profiles.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_profiles.py
@@ -1,0 +1,167 @@
+"""Prompt profile definitions for built-in slide visual styles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VisualStyleProfile:
+    """Reusable prompt guidance for a family of visual styles."""
+
+    profile_id: str
+    name: str
+    guidance: tuple[str, ...]
+    avoid: tuple[str, ...] = ()
+    artifact_bias: tuple[str, ...] = ()
+
+
+_VISUAL_STYLE_PROFILES: tuple[VisualStyleProfile, ...] = (
+    VisualStyleProfile(
+        profile_id="instructional_hand_drawn",
+        name="Instructional Hand Drawn",
+        guidance=(
+            "prioritize pedagogical clarity",
+            "use approachable explainer language",
+            "keep the layout loose but readable",
+        ),
+        avoid=("overly polished corporate framing",),
+        artifact_bias=("process_flow", "comparison_matrix"),
+    ),
+    VisualStyleProfile(
+        profile_id="fine_art_human",
+        name="Fine Art Human",
+        guidance=(
+            "lean into human texture and restraint",
+            "use measured pacing and reflective language",
+        ),
+        avoid=("overly literal art direction",),
+        artifact_bias=("timeline",),
+    ),
+    VisualStyleProfile(
+        profile_id="tactile_playful",
+        name="Tactile Playful",
+        guidance=(
+            "emphasize soft dimensionality and playful tactility",
+            "keep the content grounded and easy to scan",
+        ),
+        avoid=("sharp technical jargon without explanation",),
+        artifact_bias=("process_flow", "stat_group"),
+    ),
+    VisualStyleProfile(
+        profile_id="technical_precision",
+        name="Technical Precision",
+        guidance=(
+            "prefer exact sequencing and component naming",
+            "foreground systems relationships over decoration",
+        ),
+        avoid=("decorative narrative filler",),
+        artifact_bias=("process_flow", "comparison_matrix"),
+    ),
+    VisualStyleProfile(
+        profile_id="metric_first",
+        name="Metric First",
+        guidance=(
+            "foreground numbers, ratios, comparisons, and takeaways",
+            "prefer concise analytical framing",
+        ),
+        avoid=("vague inspirational language",),
+        artifact_bias=("stat_group", "comparison_matrix"),
+    ),
+    VisualStyleProfile(
+        profile_id="narrative_journey",
+        name="Narrative Journey",
+        guidance=(
+            "use a clear beginning, middle, and end",
+            "treat the deck like a guided story arc",
+        ),
+        avoid=("disconnected bullet dumps",),
+        artifact_bias=("timeline", "process_flow"),
+    ),
+    VisualStyleProfile(
+        profile_id="corporate_strategy",
+        name="Corporate Strategy",
+        guidance=(
+            "use concise executive framing",
+            "connect problem, solution, and impact clearly",
+        ),
+        avoid=("fluffy brand language",),
+        artifact_bias=("stat_group", "comparison_matrix"),
+    ),
+    VisualStyleProfile(
+        profile_id="design_editorial",
+        name="Design Editorial",
+        guidance=(
+            "use controlled whitespace and high-signal titles",
+            "keep the language concise and considered",
+        ),
+        avoid=("bullet bloat",),
+        artifact_bias=("comparison_matrix", "stat_group"),
+    ),
+    VisualStyleProfile(
+        profile_id="playful_approachable",
+        name="Playful Approachable",
+        guidance=(
+            "keep the tone friendly and accessible",
+            "prefer warm, readable framing",
+        ),
+        avoid=("cold institutional wording",),
+        artifact_bias=("process_flow", "stat_group"),
+    ),
+    VisualStyleProfile(
+        profile_id="retro_synthetic",
+        name="Retro Synthetic",
+        guidance=(
+            "use stylized framing language and strong section labels",
+            "keep the content readable despite the theme",
+        ),
+        avoid=("overly modern corporate phrasing",),
+        artifact_bias=("timeline", "process_flow"),
+    ),
+    VisualStyleProfile(
+        profile_id="high_energy_marketing",
+        name="High Energy Marketing",
+        guidance=(
+            "use sharp hooks and energetic pacing",
+            "make the main takeaway obvious fast",
+        ),
+        avoid=("flat academic tone",),
+        artifact_bias=("stat_group", "comparison_matrix"),
+    ),
+)
+
+_VISUAL_STYLE_PROFILES_BY_ID = {profile.profile_id: profile for profile in _VISUAL_STYLE_PROFILES}
+
+
+def _clone_profile(profile: VisualStyleProfile) -> VisualStyleProfile:
+    """Return a defensive copy of a prompt profile."""
+
+    return VisualStyleProfile(
+        profile_id=profile.profile_id,
+        name=profile.name,
+        guidance=tuple(profile.guidance),
+        avoid=tuple(profile.avoid),
+        artifact_bias=tuple(profile.artifact_bias),
+    )
+
+
+def list_visual_style_profiles() -> list[VisualStyleProfile]:
+    """Return all prompt profiles in catalog order."""
+
+    return [_clone_profile(profile) for profile in _VISUAL_STYLE_PROFILES]
+
+
+def get_visual_style_profile(profile_id: str) -> VisualStyleProfile | None:
+    """Look up a prompt profile by identifier."""
+
+    profile = _VISUAL_STYLE_PROFILES_BY_ID.get(profile_id)
+    return _clone_profile(profile) if profile is not None else None
+
+
+def build_prompt_profile_guidance(profile_id: str) -> tuple[str, ...]:
+    """Return the guidance lines for a prompt profile."""
+
+    profile = get_visual_style_profile(profile_id)
+    if profile is None:
+        return ()
+    return profile.guidance

--- a/tldw_Server_API/app/core/Slides/visual_style_profiles.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_profiles.py
@@ -165,3 +165,23 @@ def build_prompt_profile_guidance(profile_id: str) -> tuple[str, ...]:
     if profile is None:
         return ()
     return profile.guidance
+
+
+def build_prompt_profile_prompt_lines(profile_id: str) -> tuple[str, ...]:
+    """Return prompt-ready lines describing a profile."""
+
+    profile = get_visual_style_profile(profile_id)
+    if profile is None:
+        return ()
+
+    lines = [f"Prompt profile: {profile.name}."]
+    if profile.guidance:
+        lines.append("Profile guidance:")
+        lines.extend(f"- {item}" for item in profile.guidance)
+    if profile.avoid:
+        lines.append("Profile avoid:")
+        lines.extend(f"- {item}" for item in profile.avoid)
+    if profile.artifact_bias:
+        lines.append("Profile artifact bias:")
+        lines.extend(f"- {item}" for item in profile.artifact_bias)
+    return tuple(lines)

--- a/tldw_Server_API/app/core/Slides/visual_style_profiles.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_profiles.py
@@ -130,7 +130,26 @@ _VISUAL_STYLE_PROFILES: tuple[VisualStyleProfile, ...] = (
     ),
 )
 
-_VISUAL_STYLE_PROFILES_BY_ID = {profile.profile_id: profile for profile in _VISUAL_STYLE_PROFILES}
+
+def _index_visual_style_profiles(
+    profiles: tuple[VisualStyleProfile, ...],
+) -> dict[str, VisualStyleProfile]:
+    """Build a profile lookup table and fail fast on duplicate identifiers."""
+
+    indexed: dict[str, VisualStyleProfile] = {}
+    duplicate_ids: list[str] = []
+    for profile in profiles:
+        if profile.profile_id in indexed:
+            duplicate_ids.append(profile.profile_id)
+            continue
+        indexed[profile.profile_id] = profile
+    if duplicate_ids:
+        duplicates = ", ".join(sorted(set(duplicate_ids)))
+        raise ValueError(f"Duplicate visual style profile IDs: {duplicates}")
+    return indexed
+
+
+_VISUAL_STYLE_PROFILES_BY_ID = _index_visual_style_profiles(_VISUAL_STYLE_PROFILES)
 
 
 def _clone_profile(profile: VisualStyleProfile) -> VisualStyleProfile:

--- a/tldw_Server_API/app/core/Slides/visual_style_resolver.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_resolver.py
@@ -1,0 +1,118 @@
+"""Resolve built-in visual style catalog entries into snapshots and appearance."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_Server_API.app.core.Slides.visual_style_catalog import (
+    BuiltinVisualStyleDefinition,
+    get_builtin_visual_style_definition,
+)
+from tldw_Server_API.app.core.Slides.visual_style_packs import (
+    get_visual_style_pack,
+    render_pack_custom_css,
+    resolve_pack_settings,
+    resolve_pack_token_overrides,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedBuiltinVisualStyle:
+    """Resolved built-in style payload."""
+
+    definition: BuiltinVisualStyleDefinition
+    snapshot: dict[str, Any]
+    appearance: dict[str, Any]
+
+
+def _build_snapshot(
+    definition: BuiltinVisualStyleDefinition,
+    *,
+    token_overrides: dict[str, Any],
+    resolved_settings: dict[str, Any],
+    resolved_theme: str,
+    resolved_marp_theme: str | None,
+) -> dict[str, Any]:
+    return {
+        "id": definition.style_id,
+        "scope": "builtin",
+        "name": definition.name,
+        "version": definition.version,
+        "description": definition.description,
+        "category": definition.category,
+        "guide_number": definition.guide_number,
+        "sort_order": definition.sort_order,
+        "prompt_profile": definition.prompt_profile,
+        "style_pack": definition.style_pack,
+        "style_pack_version": definition.style_pack_version,
+        "base_theme": definition.base_theme,
+        "generation_rules": deepcopy(definition.generation_rules),
+        "artifact_preferences": list(definition.artifact_preferences),
+        "fallback_policy": deepcopy(definition.fallback_policy),
+        "tags": list(definition.tags),
+        "best_for": list(definition.best_for),
+        "resolution": {
+            "base_theme": definition.base_theme,
+            "resolved_theme": resolved_theme,
+            "resolved_marp_theme": resolved_marp_theme,
+            "style_pack": definition.style_pack,
+            "style_pack_version": definition.style_pack_version,
+            "token_overrides": deepcopy(token_overrides),
+            "resolved_settings": deepcopy(resolved_settings),
+        },
+    }
+
+
+def resolve_builtin_visual_style(style_id: str) -> ResolvedBuiltinVisualStyle | None:
+    """Resolve a built-in style id into compact snapshot metadata and appearance."""
+
+    definition = get_builtin_visual_style_definition(style_id)
+    if definition is None:
+        return None
+
+    pack = get_visual_style_pack(definition.style_pack)
+    appearance_overrides = (
+        dict(definition.appearance_overrides)
+        if isinstance(definition.appearance_overrides, dict)
+        else {}
+    )
+    style_token_overrides = appearance_overrides.get("token_overrides")
+    token_overrides = resolve_pack_token_overrides(
+        definition.style_pack,
+        token_overrides=style_token_overrides if isinstance(style_token_overrides, dict) else None,
+    )
+    settings_overrides = appearance_overrides.get("settings")
+    resolved_settings = resolve_pack_settings(
+        definition.style_pack,
+        settings_overrides=settings_overrides if isinstance(settings_overrides, dict) else None,
+    )
+
+    resolved_theme = str(appearance_overrides.get("theme") or definition.base_theme)
+    resolved_marp_theme_value = appearance_overrides.get("marp_theme")
+    resolved_marp_theme = str(resolved_marp_theme_value) if isinstance(resolved_marp_theme_value, str) else None
+    custom_css = render_pack_custom_css(
+        style_id=definition.style_id,
+        pack_id=pack.pack_id if pack is not None else definition.style_pack,
+        token_overrides=token_overrides,
+    )
+
+    snapshot = _build_snapshot(
+        definition,
+        token_overrides=token_overrides,
+        resolved_settings=resolved_settings,
+        resolved_theme=resolved_theme,
+        resolved_marp_theme=resolved_marp_theme,
+    )
+    appearance = {
+        "theme": resolved_theme,
+        "marp_theme": resolved_marp_theme,
+        "settings": deepcopy(resolved_settings),
+        "custom_css": custom_css,
+    }
+    return ResolvedBuiltinVisualStyle(
+        definition=definition,
+        snapshot=snapshot,
+        appearance=appearance,
+    )

--- a/tldw_Server_API/app/core/Slides/visual_style_resolver.py
+++ b/tldw_Server_API/app/core/Slides/visual_style_resolver.py
@@ -35,6 +35,8 @@ def _build_snapshot(
     resolved_theme: str,
     resolved_marp_theme: str | None,
 ) -> dict[str, Any]:
+    """Build the compact persisted snapshot for a resolved built-in style."""
+
     return {
         "id": definition.style_id,
         "scope": "builtin",
@@ -64,8 +66,11 @@ def _build_snapshot(
         },
     }
 
-
-def resolve_builtin_visual_style(style_id: str) -> ResolvedBuiltinVisualStyle | None:
+def resolve_builtin_visual_style(
+    style_id: str,
+    *,
+    include_custom_css: bool = True,
+) -> ResolvedBuiltinVisualStyle | None:
     """Resolve a built-in style id into compact snapshot metadata and appearance."""
 
     definition = get_builtin_visual_style_definition(style_id)
@@ -92,11 +97,13 @@ def resolve_builtin_visual_style(style_id: str) -> ResolvedBuiltinVisualStyle | 
     resolved_theme = str(appearance_overrides.get("theme") or definition.base_theme)
     resolved_marp_theme_value = appearance_overrides.get("marp_theme")
     resolved_marp_theme = str(resolved_marp_theme_value) if isinstance(resolved_marp_theme_value, str) else None
-    custom_css = render_pack_custom_css(
-        style_id=definition.style_id,
-        pack_id=pack.pack_id if pack is not None else definition.style_pack,
-        token_overrides=token_overrides,
-    )
+    custom_css = None
+    if include_custom_css:
+        custom_css = render_pack_custom_css(
+            style_id=definition.style_id,
+            pack_id=pack.pack_id if pack is not None else definition.style_pack,
+            token_overrides=token_overrides,
+        )
 
     snapshot = _build_snapshot(
         definition,

--- a/tldw_Server_API/app/core/Slides/visual_styles.py
+++ b/tldw_Server_API/app/core/Slides/visual_styles.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from tldw_Server_API.app.core.Slides.visual_style_catalog import (
+    BuiltinVisualStyleDefinition,
     get_builtin_visual_style_definition,
     list_builtin_visual_style_definitions,
 )
@@ -25,7 +26,9 @@ class VisualStylePreset:
     fallback_policy: dict[str, Any]
 
 
-def _project_definition(definition) -> VisualStylePreset:
+def _project_definition(definition: BuiltinVisualStyleDefinition) -> VisualStylePreset:
+    """Project a catalog definition into the legacy preset compatibility shape."""
+
     return VisualStylePreset(
         style_id=definition.style_id,
         name=definition.name,

--- a/tldw_Server_API/app/core/Slides/visual_styles.py
+++ b/tldw_Server_API/app/core/Slides/visual_styles.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from tldw_Server_API.app.core.Slides.visual_style_catalog import (
+    get_builtin_visual_style_definition,
+    list_builtin_visual_style_definitions,
+)
+
 
 @dataclass(frozen=True)
 class VisualStylePreset:
-    """Resolved built-in visual style definition."""
+    """Resolved built-in visual style definition for compatibility callers."""
 
     style_id: str
     name: str
@@ -20,121 +25,29 @@ class VisualStylePreset:
     fallback_policy: dict[str, Any]
 
 
-_BUILTIN_VISUAL_STYLES: tuple[VisualStylePreset, ...] = (
-    VisualStylePreset(
-        style_id="infographic",
-        name="Infographic",
-        description="Digest-heavy slides with visual callouts and synthesis-first framing.",
-        version=1,
-        generation_rules={"density": "medium", "bullet_bias": "low", "visual_callouts": "high"},
-        artifact_preferences=("stat_group", "comparison_matrix", "process_flow"),
-        appearance_defaults={"theme": "white"},
-        fallback_policy={"mode": "textual-summary", "preserve_key_stats": True},
-    ),
-    VisualStylePreset(
-        style_id="minimal-academic",
-        name="Minimal Academic",
-        description="Calm, low-noise academic slides with restrained text and careful structure.",
-        version=1,
-        generation_rules={"density": "low", "bullet_bias": "medium", "citation_bias": "high"},
-        artifact_preferences=("comparison_matrix", "timeline"),
-        appearance_defaults={"theme": "white"},
-        fallback_policy={"mode": "outline", "preserve_key_stats": False},
-    ),
-    VisualStylePreset(
-        style_id="exam-focused-bullet",
-        name="Exam-Focused Bullet",
-        description="Recall-first slides optimized for high-yield revision and exam prep.",
-        version=1,
-        generation_rules={"density": "high", "bullet_bias": "high", "exam_focus": True},
-        artifact_preferences=("stat_group", "comparison_matrix"),
-        appearance_defaults={"theme": "black"},
-        fallback_policy={"mode": "key-points", "preserve_key_stats": True},
-    ),
-    VisualStylePreset(
-        style_id="diagram-map-based",
-        name="Diagram / Map-Based",
-        description="Spatial and relationship-first slides with process and place emphasis.",
-        version=1,
-        generation_rules={"density": "medium", "bullet_bias": "low", "spatial_reasoning": "high"},
-        artifact_preferences=("process_flow", "comparison_matrix"),
-        appearance_defaults={"theme": "league"},
-        fallback_policy={"mode": "labeled-outline", "preserve_key_stats": True},
-    ),
-    VisualStylePreset(
-        style_id="timeline",
-        name="Timeline",
-        description="Chronology-first slides focused on sequence, causality, and milestones.",
-        version=1,
-        generation_rules={"density": "medium", "bullet_bias": "medium", "chronology_bias": "high"},
-        artifact_preferences=("timeline", "stat_group"),
-        appearance_defaults={"theme": "beige"},
-        fallback_policy={"mode": "ordered-bullets", "preserve_key_stats": True},
-    ),
-    VisualStylePreset(
-        style_id="data-visualization",
-        name="Data Visualization",
-        description="Trend and comparison slides that foreground metrics, ratios, and patterns.",
-        version=1,
-        generation_rules={"density": "medium", "bullet_bias": "low", "quant_focus": "high"},
-        artifact_preferences=("stat_group", "comparison_matrix"),
-        appearance_defaults={"theme": "night"},
-        fallback_policy={"mode": "metric-summary", "preserve_key_stats": True},
-    ),
-    VisualStylePreset(
-        style_id="storytelling",
-        name="Storytelling",
-        description="Narrative slides with setup, tension, and payoff across the deck.",
-        version=1,
-        generation_rules={"density": "medium", "bullet_bias": "low", "narrative_bias": "high"},
-        artifact_preferences=("timeline", "process_flow"),
-        appearance_defaults={"theme": "moon"},
-        fallback_policy={"mode": "narrative-outline", "preserve_key_stats": False},
-    ),
-    VisualStylePreset(
-        style_id="high-contrast-revision",
-        name="High-Contrast Revision",
-        description="Fast-scan revision slides using strong contrast and concise anchors.",
-        version=1,
-        generation_rules={"density": "high", "bullet_bias": "high", "scanability": "high"},
-        artifact_preferences=("stat_group", "process_flow"),
-        appearance_defaults={"theme": "black"},
-        fallback_policy={"mode": "flashcard-points", "preserve_key_stats": True},
-    ),
-    VisualStylePreset(
-        style_id="comparative-matrix",
-        name="Comparative Matrix",
-        description="Comparison-driven slides for similarities, differences, and tradeoffs.",
-        version=1,
-        generation_rules={"density": "medium", "bullet_bias": "medium", "comparison_bias": "high"},
-        artifact_preferences=("comparison_matrix", "stat_group"),
-        appearance_defaults={"theme": "white"},
-        fallback_policy={"mode": "two-column-summary", "preserve_key_stats": True},
-    ),
-    VisualStylePreset(
-        style_id="policy-case-brief",
-        name="Policy / Case Brief",
-        description="Issue, context, analysis, and takeaway framing for policy or case-study decks.",
-        version=1,
-        generation_rules={"density": "medium", "bullet_bias": "medium", "argument_bias": "high"},
-        artifact_preferences=("comparison_matrix", "timeline"),
-        appearance_defaults={"theme": "simple"},
-        fallback_policy={"mode": "brief-outline", "preserve_key_stats": True},
-    ),
-)
-
-_BUILTIN_VISUAL_STYLES_BY_ID: dict[str, VisualStylePreset] = {
-    style.style_id: style for style in _BUILTIN_VISUAL_STYLES
-}
+def _project_definition(definition) -> VisualStylePreset:
+    return VisualStylePreset(
+        style_id=definition.style_id,
+        name=definition.name,
+        description=definition.description,
+        version=definition.version,
+        generation_rules=dict(definition.generation_rules),
+        artifact_preferences=tuple(definition.artifact_preferences),
+        appearance_defaults={"theme": definition.base_theme},
+        fallback_policy=dict(definition.fallback_policy),
+    )
 
 
 def list_builtin_visual_styles() -> list[VisualStylePreset]:
     """Return all built-in visual style presets."""
 
-    return list(_BUILTIN_VISUAL_STYLES)
+    return [_project_definition(definition) for definition in list_builtin_visual_style_definitions()]
 
 
 def get_builtin_visual_style(style_id: str) -> VisualStylePreset | None:
     """Look up a built-in visual style by identifier."""
 
-    return _BUILTIN_VISUAL_STYLES_BY_ID.get(style_id)
+    definition = get_builtin_visual_style_definition(style_id)
+    if definition is None:
+        return None
+    return _project_definition(definition)

--- a/tldw_Server_API/tests/MCP_unified/test_slides_module_exports.py
+++ b/tldw_Server_API/tests/MCP_unified/test_slides_module_exports.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.slides_module import SlidesModule
+
+
+class _FakeSlidesDb:
+    def __init__(self, presentation: SimpleNamespace) -> None:
+        self._presentation = presentation
+        self.closed = False
+
+    def get_presentation_by_id(self, presentation_id: str):
+        assert presentation_id == "pres-1"
+        return self._presentation
+
+    def close_connection(self) -> None:
+        self.closed = True
+
+
+def _build_presentation_row() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="pres-1",
+        title="Styled Deck",
+        description=None,
+        theme="night",
+        marp_theme=None,
+        template_id=None,
+        settings=json.dumps({"controls": True}),
+        studio_data=None,
+        slides=json.dumps(
+            [
+                {
+                    "order": 0,
+                    "layout": "title",
+                    "title": "Deck",
+                    "content": "",
+                    "speaker_notes": None,
+                    "metadata": {},
+                }
+            ]
+        ),
+        slides_text="",
+        source_type="manual",
+        source_ref=None,
+        source_query=None,
+        custom_css=".reveal { color: red; }",
+        visual_style_snapshot=json.dumps(
+            {
+                "id": "notebooklm-blueprint",
+                "scope": "builtin",
+                "name": "Blueprint",
+                "resolution": {
+                    "style_pack": "technical_grid",
+                    "resolved_theme": "night",
+                },
+            }
+        ),
+        created_at="2026-03-29T00:00:00Z",
+        last_modified="2026-03-29T00:00:00Z",
+        deleted=False,
+        client_id="test-client",
+        version=1,
+    )
+
+
+@pytest.mark.parametrize(
+    ("fmt", "export_path", "payload", "expected_mime_type"),
+    [
+        (
+            "reveal",
+            "tldw_Server_API.app.core.Slides.slides_export.export_presentation_bundle",
+            b"PK\x03\x04stub",
+            "application/zip",
+        ),
+        (
+            "pdf",
+            "tldw_Server_API.app.core.Slides.slides_export.export_presentation_pdf",
+            b"%PDF-1.4\n%stub",
+            "application/pdf",
+        ),
+    ],
+)
+def test_slides_module_export_passes_visual_style_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    fmt: str,
+    export_path: str,
+    payload: bytes,
+    expected_mime_type: str,
+) -> None:
+    presentation = _build_presentation_row()
+    fake_db = _FakeSlidesDb(presentation)
+    module = SlidesModule(ModuleConfig(name="slides"))
+    monkeypatch.setattr(module, "_open_db", lambda context: fake_db)
+
+    captured: dict[str, object] = {}
+
+    def _stub_export(**kwargs):
+        captured["visual_style_snapshot"] = kwargs.get("visual_style_snapshot")
+        return payload
+
+    monkeypatch.setattr(export_path, _stub_export)
+
+    result = module._export_presentation_sync(
+        context=SimpleNamespace(),
+        args={"presentation_id": "pres-1", "format": fmt},
+    )
+
+    assert captured["visual_style_snapshot"] == {
+        "id": "notebooklm-blueprint",
+        "scope": "builtin",
+        "name": "Blueprint",
+        "resolution": {
+            "style_pack": "technical_grid",
+            "resolved_theme": "night",
+        },
+    }
+    assert result["mime_type"] == expected_mime_type
+    assert base64.b64decode(result["content_base64"]) == payload
+    assert result["success"] is True
+    assert fake_db.closed is True

--- a/tldw_Server_API/tests/Slides/test_presentation_rendering.py
+++ b/tldw_Server_API/tests/Slides/test_presentation_rendering.py
@@ -1,5 +1,7 @@
+import json
 from pathlib import Path
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image, ImageChops
@@ -8,6 +10,7 @@ from tldw_Server_API.app.core.Slides.presentation_rendering import (
     PresentationRenderError,
     _TRANSITION_DURATION_SECONDS,
     _build_transition_video_command,
+    load_presentation_render_snapshot,
     _probe_media_duration_seconds,
     _resolve_effective_slide_duration_seconds,
     _resolve_ffmpeg_timeout_seconds,
@@ -40,6 +43,52 @@ def test_render_slide_frame_draws_slide_text_content(tmp_path):
     background = Image.new("RGB", rendered.size, "#0f172a")
 
     assert ImageChops.difference(rendered, background).getbbox() is not None
+
+
+def test_load_presentation_render_snapshot_accepts_richer_style_snapshot_metadata():
+    db = SimpleNamespace(
+        get_presentation_version=lambda **kwargs: SimpleNamespace(
+            payload_json=json.dumps(
+                {
+                    "title": "Deck",
+                    "theme": "night",
+                    "slides": [{"order": 0, "layout": "content", "title": "Slide", "content": "Hello"}],
+                    "visual_style_snapshot": {
+                        "id": "notebooklm-blueprint",
+                        "scope": "builtin",
+                        "resolution": {
+                            "style_pack": "technical_grid",
+                            "style_pack_version": 1,
+                            "token_overrides": {"surface": "#0f172a"},
+                            "resolved_settings": {"controls": True},
+                        },
+                    },
+                    "studio_data": {
+                        "resolution": {
+                            "style_pack": "technical_grid",
+                            "resolved_theme": "night",
+                        }
+                    },
+                }
+            )
+        )
+    )
+
+    snapshot = load_presentation_render_snapshot(
+        db,
+        presentation_id="pres_123",
+        presentation_version=4,
+    )
+
+    assert snapshot.title == "Deck"
+    assert snapshot.theme == "night"
+    assert snapshot.slides[0]["content"] == "Hello"
+    assert snapshot.studio_data == {
+        "resolution": {
+            "style_pack": "technical_grid",
+            "resolved_theme": "night",
+        }
+    }
 
 
 def test_resolve_slide_audio_duration_prefers_metadata_and_probes_asset_when_needed(monkeypatch, tmp_path):

--- a/tldw_Server_API/tests/Slides/test_slides_api.py
+++ b/tldw_Server_API/tests/Slides/test_slides_api.py
@@ -267,6 +267,17 @@ def _setup_rag_too_large(monkeypatch, fake_notes, fake_media):
     )
 
 
+def _assert_compact_builtin_snapshot(snapshot: dict) -> None:
+    assert snapshot["id"] == "notebooklm-blueprint"
+    assert snapshot["scope"] == "builtin"
+    assert snapshot["resolution"]["base_theme"] == "night"
+    assert snapshot["resolution"]["resolved_theme"] == "night"
+    assert snapshot["resolution"]["style_pack"] == "technical_grid"
+    assert snapshot["resolution"]["style_pack_version"] == 1
+    assert "custom_css" not in snapshot
+    assert "custom_css" not in snapshot["resolution"]
+
+
 _TOO_LARGE_CASES = [
     {
         "id": "prompt",
@@ -692,11 +703,31 @@ def test_slides_styles_list_returns_builtin_and_user_styles(slides_client):
     payload = list_resp.json()
     styles = payload["styles"]
 
-    assert any(item["scope"] == "builtin" and item["id"] == "timeline" for item in styles)
+    builtin = next(item for item in styles if item["id"] == "notebooklm-blueprint")
+    assert builtin["scope"] == "builtin"
+    assert builtin["category"] == "technical"
+    assert builtin["guide_number"] == 7
+    assert builtin["tags"] == ["technical", "technical_grid", "technical_precision"]
+    assert builtin["best_for"] == ["systems explanation", "architecture walkthrough"]
+    assert builtin["appearance_defaults"]["theme"] == "night"
+    assert "custom_css" not in builtin["appearance_defaults"]
     assert any(item["scope"] == "user" and item["id"] == created_id for item in styles)
     assert payload["total_count"] >= len(styles)
     assert payload["limit"] == 50
     assert payload["offset"] == 0
+
+
+def test_slides_builtin_style_detail_exposes_catalog_metadata_and_compact_defaults(slides_client):
+    resp = slides_client.get("/api/v1/slides/styles/notebooklm-blueprint")
+    assert resp.status_code == 200, resp.text
+    style = resp.json()
+    assert style["scope"] == "builtin"
+    assert style["category"] == "technical"
+    assert style["guide_number"] == 7
+    assert style["tags"] == ["technical", "technical_grid", "technical_precision"]
+    assert style["best_for"] == ["systems explanation", "architecture walkthrough"]
+    assert style["appearance_defaults"]["theme"] == "night"
+    assert "custom_css" not in style["appearance_defaults"]
 
 
 def test_slides_styles_list_supports_pagination(slides_client):
@@ -954,7 +985,7 @@ def test_slides_create_persists_visual_style_snapshot(slides_client):
         "/api/v1/slides/presentations",
         json={
             "title": "History Deck",
-            "visual_style_id": "timeline",
+            "visual_style_id": "notebooklm-blueprint",
             "visual_style_scope": "builtin",
             "slides": [
                 {
@@ -970,12 +1001,126 @@ def test_slides_create_persists_visual_style_snapshot(slides_client):
     )
     assert resp.status_code == 201, resp.text
     payload = resp.json()
-    assert payload["visual_style_id"] == "timeline"
+    assert payload["visual_style_id"] == "notebooklm-blueprint"
     assert payload["visual_style_scope"] == "builtin"
-    assert payload["visual_style_name"] == "Timeline"
+    assert payload["visual_style_name"] == "Blueprint"
     assert payload["visual_style_version"] == 1
-    assert payload["visual_style_snapshot"]["id"] == "timeline"
-    assert payload["visual_style_snapshot"]["scope"] == "builtin"
+    assert payload["theme"] == "night"
+    assert payload["settings"] == {"controls": True, "progress": True}
+    assert payload["custom_css"]
+    _assert_compact_builtin_snapshot(payload["visual_style_snapshot"])
+    assert payload["visual_style_snapshot"]["resolution"]["resolved_settings"] == payload["settings"]
+
+
+def test_slides_create_with_builtin_style_preserves_explicit_appearance_overrides(slides_client):
+    resp = slides_client.post(
+        "/api/v1/slides/presentations",
+        json={
+            "title": "History Deck",
+            "theme": "white",
+            "marp_theme": "gaia",
+            "settings": {"controls": False, "progress": False},
+            "custom_css": ".reveal { font-size: 42px; }",
+            "visual_style_id": "notebooklm-blueprint",
+            "visual_style_scope": "builtin",
+            "slides": [
+                {
+                    "order": 0,
+                    "layout": "title",
+                    "title": "History",
+                    "content": "",
+                    "speaker_notes": None,
+                    "metadata": {},
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    payload = resp.json()
+    assert payload["theme"] == "white"
+    assert payload["marp_theme"] == "gaia"
+    assert payload["settings"] == {"controls": False, "progress": False}
+    assert payload["custom_css"] == ".reveal { font-size: 42px; }"
+    _assert_compact_builtin_snapshot(payload["visual_style_snapshot"])
+    assert payload["visual_style_snapshot"]["resolution"]["resolved_theme"] == "night"
+    assert payload["visual_style_snapshot"]["resolution"]["resolved_settings"] == {
+        "controls": True,
+        "progress": True,
+    }
+
+
+def test_slides_create_with_builtin_style_rejects_invalid_theme(slides_client):
+    resp = slides_client.post(
+        "/api/v1/slides/presentations",
+        json={
+            "title": "History Deck",
+            "theme": "ultraviolet",
+            "visual_style_id": "notebooklm-blueprint",
+            "visual_style_scope": "builtin",
+            "slides": [
+                {
+                    "order": 0,
+                    "layout": "title",
+                    "title": "History",
+                    "content": "",
+                    "speaker_notes": None,
+                    "metadata": {},
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "invalid_theme"
+
+
+def test_slides_put_applies_builtin_visual_style_atomically(slides_client):
+    create_resp = slides_client.post(
+        "/api/v1/slides/presentations",
+        json={
+            "title": "History Deck",
+            "slides": [
+                {
+                    "order": 0,
+                    "layout": "title",
+                    "title": "History",
+                    "content": "",
+                    "speaker_notes": None,
+                    "metadata": {},
+                }
+            ],
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    presentation_id = create_resp.json()["id"]
+
+    put_resp = slides_client.put(
+        f"/api/v1/slides/presentations/{presentation_id}",
+        json={
+            "title": "History Deck Updated",
+            "description": None,
+            "visual_style_id": "notebooklm-blueprint",
+            "visual_style_scope": "builtin",
+            "slides": [
+                {
+                    "order": 0,
+                    "layout": "title",
+                    "title": "History",
+                    "content": "",
+                    "speaker_notes": None,
+                    "metadata": {},
+                }
+            ],
+        },
+        headers={"If-Match": create_resp.headers["ETag"]},
+    )
+    assert put_resp.status_code == 200, put_resp.text
+    payload = put_resp.json()
+    assert payload["title"] == "History Deck Updated"
+    assert payload["visual_style_id"] == "notebooklm-blueprint"
+    assert payload["theme"] == "night"
+    assert payload["settings"] == {"controls": True, "progress": True}
+    assert payload["custom_css"]
+    _assert_compact_builtin_snapshot(payload["visual_style_snapshot"])
 
 
 def test_slides_patch_updates_visual_style_snapshot(slides_client):
@@ -1000,16 +1145,75 @@ def test_slides_patch_updates_visual_style_snapshot(slides_client):
     patch_resp = slides_client.patch(
         f"/api/v1/slides/presentations/{presentation_id}",
         json={
-            "visual_style_id": "timeline",
+            "theme": "white",
+            "marp_theme": "gaia",
+            "settings": {"controls": False, "progress": False},
+            "custom_css": ".reveal { font-size: 42px; }",
+            "visual_style_id": "notebooklm-blueprint",
             "visual_style_scope": "builtin",
         },
         headers={"If-Match": create_resp.headers["ETag"]},
     )
     assert patch_resp.status_code == 200, patch_resp.text
     payload = patch_resp.json()
-    assert payload["visual_style_id"] == "timeline"
+    assert payload["visual_style_id"] == "notebooklm-blueprint"
     assert payload["visual_style_scope"] == "builtin"
-    assert payload["visual_style_snapshot"]["id"] == "timeline"
+    assert payload["theme"] == "white"
+    assert payload["marp_theme"] == "gaia"
+    assert payload["settings"] == {"controls": False, "progress": False}
+    assert payload["custom_css"] == ".reveal { font-size: 42px; }"
+    _assert_compact_builtin_snapshot(payload["visual_style_snapshot"])
+    assert payload["visual_style_snapshot"]["resolution"]["resolved_theme"] == "night"
+    assert payload["visual_style_snapshot"]["resolution"]["resolved_settings"] == {
+        "controls": True,
+        "progress": True,
+    }
+
+
+def test_slides_patch_with_builtin_style_preserves_explicit_null_appearance_overrides(slides_client):
+    create_resp = slides_client.post(
+        "/api/v1/slides/presentations",
+        json={
+            "title": "History Deck",
+            "slides": [
+                {
+                    "order": 0,
+                    "layout": "title",
+                    "title": "History",
+                    "content": "",
+                    "speaker_notes": None,
+                    "metadata": {},
+                }
+            ],
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    presentation_id = create_resp.json()["id"]
+    patch_resp = slides_client.patch(
+        f"/api/v1/slides/presentations/{presentation_id}",
+        json={
+            "visual_style_id": "notebooklm-blueprint",
+            "visual_style_scope": "builtin",
+            "marp_theme": None,
+            "settings": None,
+            "custom_css": None,
+        },
+        headers={"If-Match": create_resp.headers["ETag"]},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    payload = patch_resp.json()
+    assert payload["visual_style_id"] == "notebooklm-blueprint"
+    assert payload["visual_style_scope"] == "builtin"
+    assert payload["theme"] == "night"
+    assert payload["marp_theme"] is None
+    assert payload["settings"] is None
+    assert payload["custom_css"] is None
+    _assert_compact_builtin_snapshot(payload["visual_style_snapshot"])
+    assert payload["visual_style_snapshot"]["resolution"]["resolved_theme"] == "night"
+    assert payload["visual_style_snapshot"]["resolution"]["resolved_settings"] == {
+        "controls": True,
+        "progress": True,
+    }
 
 
 def test_slides_generate_with_template_defaults(slides_client, tmp_path, monkeypatch):
@@ -1045,16 +1249,18 @@ def test_slides_generate_with_visual_style_snapshot(slides_client, monkeypatch):
         json={
             "title_hint": "Generated History Deck",
             "prompt": "Summarize key history milestones.",
-            "visual_style_id": "timeline",
+            "visual_style_id": "notebooklm-blueprint",
             "visual_style_scope": "builtin",
         },
     )
     assert resp.status_code == 200, resp.text
     data = resp.json()
-    assert data["visual_style_id"] == "timeline"
+    assert data["visual_style_id"] == "notebooklm-blueprint"
     assert data["visual_style_scope"] == "builtin"
-    assert data["visual_style_snapshot"]["id"] == "timeline"
-    assert data["theme"] == "beige"
+    assert data["theme"] == "night"
+    assert data["settings"] == {"controls": True, "progress": True}
+    assert data["custom_css"]
+    _assert_compact_builtin_snapshot(data["visual_style_snapshot"])
 
 
 def test_slides_reorder(slides_client):

--- a/tldw_Server_API/tests/Slides/test_slides_api.py
+++ b/tldw_Server_API/tests/Slides/test_slides_api.py
@@ -797,6 +797,51 @@ def test_slides_builtin_style_detail_exposes_catalog_metadata_and_compact_defaul
     assert "custom_css" not in style["appearance_defaults"]
 
 
+def test_slides_builtin_style_list_skips_custom_css_rendering(slides_client, monkeypatch):
+    from tldw_Server_API.app.core.Slides.visual_style_resolver import (
+        resolve_builtin_visual_style as real_resolve_builtin_visual_style,
+    )
+
+    captured: list[bool] = []
+
+    def _recorded_resolve(style_id: str, *, include_custom_css: bool):
+        captured.append(include_custom_css)
+        return real_resolve_builtin_visual_style(style_id, include_custom_css=include_custom_css)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.slides.resolve_builtin_visual_style",
+        _recorded_resolve,
+    )
+
+    resp = slides_client.get("/api/v1/slides/styles")
+
+    assert resp.status_code == 200, resp.text
+    assert captured
+    assert set(captured) == {False}
+
+
+def test_slides_builtin_style_detail_skips_custom_css_rendering(slides_client, monkeypatch):
+    from tldw_Server_API.app.core.Slides.visual_style_resolver import (
+        resolve_builtin_visual_style as real_resolve_builtin_visual_style,
+    )
+
+    captured: list[bool] = []
+
+    def _recorded_resolve(style_id: str, *, include_custom_css: bool):
+        captured.append(include_custom_css)
+        return real_resolve_builtin_visual_style(style_id, include_custom_css=include_custom_css)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.slides.resolve_builtin_visual_style",
+        _recorded_resolve,
+    )
+
+    resp = slides_client.get("/api/v1/slides/styles/notebooklm-blueprint")
+
+    assert resp.status_code == 200, resp.text
+    assert captured == [False]
+
+
 def test_slides_styles_list_supports_pagination(slides_client):
     create_resp = slides_client.post(
         "/api/v1/slides/styles",
@@ -1281,6 +1326,40 @@ def test_slides_patch_with_builtin_style_preserves_explicit_null_appearance_over
         "controls": True,
         "progress": True,
     }
+
+
+def test_slides_patch_rejects_explicit_null_theme(slides_client):
+    create_resp = slides_client.post(
+        "/api/v1/slides/presentations",
+        json={
+            "title": "History Deck",
+            "slides": [
+                {
+                    "order": 0,
+                    "layout": "title",
+                    "title": "History",
+                    "content": "",
+                    "speaker_notes": None,
+                    "metadata": {},
+                }
+            ],
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    presentation_id = create_resp.json()["id"]
+
+    patch_resp = slides_client.patch(
+        f"/api/v1/slides/presentations/{presentation_id}",
+        json={
+            "theme": None,
+            "visual_style_id": "notebooklm-blueprint",
+            "visual_style_scope": "builtin",
+        },
+        headers={"If-Match": create_resp.headers["ETag"]},
+    )
+
+    assert patch_resp.status_code == 422
+    assert patch_resp.json()["detail"] == "invalid_theme"
 
 
 def test_slides_generate_with_template_defaults(slides_client, tmp_path, monkeypatch):

--- a/tldw_Server_API/tests/Slides/test_slides_api.py
+++ b/tldw_Server_API/tests/Slides/test_slides_api.py
@@ -574,6 +574,41 @@ def test_slides_export_reveal(slides_client, tmp_path, monkeypatch):
         assert "alt=\"Logo\"" in index_html
 
 
+def test_slides_export_reveal_passes_visual_style_snapshot(slides_client, monkeypatch):
+    captured = {}
+
+    def _stub_export(**kwargs):
+        captured["visual_style_snapshot"] = kwargs.get("visual_style_snapshot")
+        return b"PK\x03\x04stub"
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.slides.export_presentation_bundle",
+        _stub_export,
+    )
+    payload = {
+        "title": "Styled Deck",
+        "description": None,
+        "theme": "black",
+        "visual_style_id": "notebooklm-blueprint",
+        "visual_style_scope": "builtin",
+        "slides": [
+            {"order": 0, "layout": "title", "title": "Deck", "content": "", "speaker_notes": None, "metadata": {}},
+        ],
+        "custom_css": None,
+    }
+    resp = slides_client.post("/api/v1/slides/presentations", json=payload)
+    assert resp.status_code == 201, resp.text
+
+    presentation_id = resp.json()["id"]
+    export_resp = slides_client.get(
+        f"/api/v1/slides/presentations/{presentation_id}/export?format=revealjs"
+    )
+
+    assert export_resp.status_code == 200, export_resp.text
+    assert captured["visual_style_snapshot"]["id"] == "notebooklm-blueprint"
+    assert captured["visual_style_snapshot"]["resolution"]["style_pack"] == "technical_grid"
+
+
 def test_slides_export_markdown_marp_override(slides_client):
     payload = {
         "title": "Deck",
@@ -624,6 +659,38 @@ def test_slides_export_pdf(slides_client, monkeypatch):
     assert options.get("format") == "Letter"
     assert options.get("landscape") is True
     assert (options.get("margin") or {}).get("top") == "0.2in"
+
+
+def test_slides_export_pdf_passes_visual_style_snapshot(slides_client, monkeypatch):
+    captured = {}
+
+    def _stub_export(**kwargs):
+        captured["visual_style_snapshot"] = kwargs.get("visual_style_snapshot")
+        return b"%PDF-1.4\n%stub"
+
+    monkeypatch.setattr("tldw_Server_API.app.api.v1.endpoints.slides.export_presentation_pdf", _stub_export)
+    payload = {
+        "title": "Styled Deck",
+        "description": None,
+        "theme": "black",
+        "visual_style_id": "notebooklm-blueprint",
+        "visual_style_scope": "builtin",
+        "slides": [
+            {"order": 0, "layout": "title", "title": "Deck", "content": "", "speaker_notes": None, "metadata": {}},
+        ],
+        "custom_css": None,
+    }
+    resp = slides_client.post("/api/v1/slides/presentations", json=payload)
+    assert resp.status_code == 201, resp.text
+
+    presentation_id = resp.json()["id"]
+    export_resp = slides_client.get(
+        f"/api/v1/slides/presentations/{presentation_id}/export?format=pdf"
+    )
+
+    assert export_resp.status_code == 200, export_resp.text
+    assert captured["visual_style_snapshot"]["id"] == "notebooklm-blueprint"
+    assert captured["visual_style_snapshot"]["resolution"]["style_pack"] == "technical_grid"
 
 
 def test_slides_export_pdf_input_error(slides_client, monkeypatch):

--- a/tldw_Server_API/tests/Slides/test_slides_db.py
+++ b/tldw_Server_API/tests/Slides/test_slides_db.py
@@ -36,8 +36,16 @@ def _sample_visual_style_snapshot() -> str:
             "description": "Chronology-first slides",
             "generation_rules": {"chronology_bias": "high"},
             "artifact_preferences": ["timeline", "stat_group"],
-            "appearance_defaults": {"theme": "beige"},
             "fallback_policy": {"mode": "ordered-bullets"},
+            "resolution": {
+                "base_theme": "beige",
+                "resolved_theme": "beige",
+                "resolved_marp_theme": None,
+                "style_pack": "editorial_print",
+                "style_pack_version": 1,
+                "token_overrides": {"surface": "#f5efe6"},
+                "resolved_settings": {"controls": False, "progress": False},
+            },
         }
     )
 
@@ -120,7 +128,10 @@ def test_slides_db_visual_style_snapshot_round_trip(tmp_path):
     assert fetched.visual_style_scope == "builtin"
     assert fetched.visual_style_name == "Timeline"
     assert fetched.visual_style_version == 1
-    assert json.loads(fetched.visual_style_snapshot)["id"] == "timeline"
+    snapshot = json.loads(fetched.visual_style_snapshot)
+    assert snapshot["id"] == "timeline"
+    assert "custom_css" not in snapshot
+    assert snapshot["resolution"]["resolved_theme"] == "beige"
     db.close_connection()
 
 
@@ -238,7 +249,10 @@ def test_slides_db_version_snapshots(tmp_path):
     assert payload["title"] == "Deck"
     assert json.loads(payload["studio_data"]) == json.loads(_sample_studio_data())
     assert payload["visual_style_id"] == "timeline"
-    assert json.loads(payload["visual_style_snapshot"])["id"] == "timeline"
+    payload_snapshot = json.loads(payload["visual_style_snapshot"])
+    assert payload_snapshot["id"] == "timeline"
+    assert "custom_css" not in payload_snapshot
+    assert payload_snapshot["resolution"]["resolved_theme"] == "beige"
 
     updated = db.update_presentation(
         presentation_id=row.id,
@@ -255,6 +269,15 @@ def test_slides_db_version_snapshots(tmp_path):
                     "scope": "builtin",
                     "name": "Exam-Focused Bullet",
                     "version": 1,
+                    "resolution": {
+                        "base_theme": "black",
+                        "resolved_theme": "black",
+                        "resolved_marp_theme": None,
+                        "style_pack": "brutalist_editorial",
+                        "style_pack_version": 1,
+                        "token_overrides": {"surface": "#000000"},
+                        "resolved_settings": {"controls": True, "progress": True},
+                    },
                 }
             ),
         },
@@ -266,7 +289,10 @@ def test_slides_db_version_snapshots(tmp_path):
     latest_payload = json.loads(versions[0].payload_json)
     assert json.loads(latest_payload["studio_data"]) == {"origin": "workspace_playground"}
     assert latest_payload["visual_style_id"] == "exam-focused-bullet"
-    assert json.loads(latest_payload["visual_style_snapshot"])["id"] == "exam-focused-bullet"
+    latest_snapshot = json.loads(latest_payload["visual_style_snapshot"])
+    assert latest_snapshot["id"] == "exam-focused-bullet"
+    assert "custom_css" not in latest_snapshot
+    assert latest_snapshot["resolution"]["resolved_theme"] == "black"
     db.close_connection()
 
 

--- a/tldw_Server_API/tests/Slides/test_slides_export.py
+++ b/tldw_Server_API/tests/Slides/test_slides_export.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.Slides.slides_export import (
     export_presentation_bundle,
     export_presentation_markdown,
 )
+from tldw_Server_API.app.core.Slides.visual_style_resolver import resolve_builtin_visual_style
 
 _SAMPLE_PNG_B64 = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAn8B9XgU1b0AAAAASUVORK5CYII="
@@ -24,6 +25,7 @@ def _build_assets(tmp_path):
     (assets_dir / "reveal.css").write_text("/* reveal.css */", encoding="utf-8")
     (assets_dir / "plugin" / "notes" / "notes.js").write_text("// notes", encoding="utf-8")
     (assets_dir / "theme" / "black.css").write_text("/* theme */", encoding="utf-8")
+    (assets_dir / "theme" / "night.css").write_text("/* theme */", encoding="utf-8")
     (assets_dir / "LICENSE.revealjs.txt").write_text("license", encoding="utf-8")
     return assets_dir
 
@@ -79,6 +81,42 @@ def test_export_bundle_includes_assets(tmp_path):
         assert "assets/custom.css" in index_html
         assert "data:image/png;base64," in index_html
         assert "alt=\"Logo\"" in index_html
+
+
+@pytest.mark.unit
+def test_export_bundle_stamps_style_hooks_and_includes_builtin_pack_css(tmp_path):
+    assets_dir = _build_assets(tmp_path)
+    resolved_style = resolve_builtin_visual_style("notebooklm-blueprint")
+    assert resolved_style is not None
+
+    bundle = export_presentation_bundle(
+        title="Deck",
+        slides=[
+            {
+                "order": 0,
+                "layout": "content",
+                "title": "Styled",
+                "content": "Blueprint summary",
+                "speaker_notes": None,
+                "metadata": {},
+            }
+        ],
+        theme="night",
+        settings=resolved_style.snapshot["resolution"]["resolved_settings"],
+        custom_css=resolved_style.appearance["custom_css"],
+        visual_style_snapshot=resolved_style.snapshot,
+        assets_dir=assets_dir,
+    )
+
+    with zipfile.ZipFile(io.BytesIO(bundle)) as zf:
+        index_html = zf.read("index.html").decode("utf-8")
+        custom_css = zf.read("assets/custom.css").decode("utf-8")
+
+    assert 'data-visual-style="notebooklm-blueprint"' in index_html
+    assert 'data-style-pack="technical_grid"' in index_html
+    assert '[data-style-pack="technical_grid"]' in custom_css
+    assert '--surface: #0f172a;' in custom_css
+    assert 'url(' not in custom_css.lower()
 
 
 def test_export_bundle_missing_assets(tmp_path):
@@ -149,6 +187,89 @@ def test_export_markdown_includes_images():
 
 
 @pytest.mark.unit
+def test_export_bundle_renders_structured_visual_blocks_without_duplicate_text_fallback(tmp_path):
+    assets_dir = _build_assets(tmp_path)
+    fallback_lines = [
+        "- 1776: Declaration - American independence declared",
+        "- Scope: federal, state",
+        "1. Capture - Gather evidence",
+        "- Revenue: $5M - FY2025",
+    ]
+
+    bundle = export_presentation_bundle(
+        title="Deck",
+        slides=[
+            {
+                "order": 0,
+                "layout": "content",
+                "title": "Structured",
+                "content": "\n".join(fallback_lines),
+                "speaker_notes": None,
+                "metadata": {
+                    "visual_blocks": [
+                        {
+                            "type": "timeline",
+                            "items": [
+                                {
+                                    "label": "1776",
+                                    "title": "Declaration",
+                                    "description": "American independence declared",
+                                }
+                            ],
+                        },
+                        {
+                            "type": "comparison_matrix",
+                            "rows": [
+                                {
+                                    "label": "Scope",
+                                    "values": ["federal", "state"],
+                                }
+                            ],
+                        },
+                        {
+                            "type": "process_flow",
+                            "steps": [
+                                {
+                                    "title": "Capture",
+                                    "description": "Gather evidence",
+                                }
+                            ],
+                        },
+                        {
+                            "type": "stat_group",
+                            "items": [
+                                {
+                                    "label": "Revenue",
+                                    "value": "$5M",
+                                    "context": "FY2025",
+                                }
+                            ],
+                        },
+                    ]
+                },
+            }
+        ],
+        theme="black",
+        settings=None,
+        custom_css=None,
+        assets_dir=assets_dir,
+    )
+
+    with zipfile.ZipFile(io.BytesIO(bundle)) as zf:
+        index_html = zf.read("index.html").decode("utf-8")
+
+    assert 'data-visual-block-type="timeline"' in index_html
+    assert 'data-visual-block-type="comparison_matrix"' in index_html
+    assert 'data-visual-block-type="process_flow"' in index_html
+    assert 'data-visual-block-type="stat_group"' in index_html
+    assert "1776" in index_html
+    assert "Declaration" in index_html
+    assert "Revenue" in index_html
+    for line in fallback_lines:
+        assert line not in index_html
+
+
+@pytest.mark.unit
 def test_export_markdown_preserves_text_fallback_for_visual_blocks():
     slides = [
         {
@@ -178,6 +299,58 @@ def test_export_markdown_preserves_text_fallback_for_visual_blocks():
 
     assert "1776" in md
     assert "American independence declared" in md
+
+
+@pytest.mark.unit
+def test_export_markdown_keeps_text_fallback_for_supported_visual_blocks():
+    slide_content = "\n".join(
+        [
+            "- 1776: Declaration - American independence declared",
+            "- Scope: federal, state",
+            "1. Capture - Gather evidence",
+            "- Revenue: $5M - FY2025",
+        ]
+    )
+    slides = [
+        {
+            "order": 0,
+            "layout": "content",
+            "title": "Structured",
+            "content": slide_content,
+            "speaker_notes": None,
+            "metadata": {
+                "visual_blocks": [
+                    {
+                        "type": "timeline",
+                        "items": [
+                            {
+                                "label": "1776",
+                                "title": "Declaration",
+                                "description": "American independence declared",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "comparison_matrix",
+                        "rows": [{"label": "Scope", "values": ["federal", "state"]}],
+                    },
+                    {
+                        "type": "process_flow",
+                        "steps": [{"title": "Capture", "description": "Gather evidence"}],
+                    },
+                    {
+                        "type": "stat_group",
+                        "items": [{"label": "Revenue", "value": "$5M", "context": "FY2025"}],
+                    },
+                ]
+            },
+        }
+    ]
+
+    md = export_presentation_markdown(title="Deck", slides=slides, theme="black")
+
+    assert slide_content in md
+    assert 'data-visual-block-type="' not in md
 
 
 def test_export_bundle_resolves_output_asset_ref(tmp_path, monkeypatch):

--- a/tldw_Server_API/tests/Slides/test_slides_generator.py
+++ b/tldw_Server_API/tests/Slides/test_slides_generator.py
@@ -25,6 +25,17 @@ def _stub_llm_call(api_provider=None, messages=None, **kwargs):
     return {"choices": [{"message": {"content": json.dumps(payload)}}]}
 
 
+def _make_prompt_capture_llm(payload: dict[str, object], captured: dict[str, str]):
+    def _llm_call(api_provider=None, messages=None, **kwargs):
+        del api_provider, kwargs
+        if messages:
+            captured["system_prompt"] = str(messages[0].get("content", ""))
+            captured["user_prompt"] = str(messages[-1].get("content", ""))
+        return {"choices": [{"message": {"content": json.dumps(payload)}}]}
+
+    return _llm_call
+
+
 def test_generate_rejects_large_input_without_chunking():
     generator = SlidesGenerator(llm_call=_stub_llm_call)
     with pytest.raises(SlidesSourceTooLargeError):
@@ -44,7 +55,11 @@ def test_generate_rejects_large_input_without_chunking():
         )
 
 
-def test_generate_parses_json_response():
+def test_generate_parses_json_response(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",
+        lambda: False,
+    )
     generator = SlidesGenerator(llm_call=_stub_llm_call)
     result = generator.generate_from_text(
         source_text="Content",
@@ -64,7 +79,11 @@ def test_generate_parses_json_response():
     assert len(result["slides"]) == 2
 
 
-def test_generate_handles_invalid_json():
+def test_generate_handles_invalid_json(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",
+        lambda: False,
+    )
     def bad_llm_call(api_provider=None, messages=None, **kwargs):
         return {"choices": [{"message": {"content": "not json"}}]}
 
@@ -86,7 +105,11 @@ def test_generate_handles_invalid_json():
         )
 
 
-def test_timeline_style_generates_visual_block_and_text_fallback():
+def test_timeline_style_generates_visual_block_and_text_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",
+        lambda: False,
+    )
     captured: dict[str, str] = {}
 
     def timeline_llm_call(
@@ -151,13 +174,161 @@ def test_timeline_style_generates_visual_block_and_text_fallback():
         visual_style_snapshot={
             "id": "timeline",
             "name": "Timeline",
-            "generation_rules": {"chronology_bias": "high"},
-            "artifact_preferences": ["timeline"],
+            "scope": "builtin",
         },
     )
 
     slide = result["slides"][1]
-    assert "timeline" in captured["system_prompt"].lower() or "chronology" in captured["system_prompt"].lower()
+    assert (
+        "Style description: Chronology-first slides focused on sequence, causality, and milestones."
+        in captured["system_prompt"]
+    )
+    assert "Favor chronology, causality, and milestone sequencing." in captured["system_prompt"]
     assert slide["metadata"]["visual_blocks"][0]["type"] == "timeline"
     assert "1776" in slide["content"]
     assert "1947" in slide["content"]
+
+
+def test_builtin_blueprint_prompt_uses_profile_guidance_and_artifact_preferences(
+    monkeypatch,
+):
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",
+        lambda: False,
+    )
+    generator = SlidesGenerator(
+        llm_call=_make_prompt_capture_llm(
+            {
+                "title": "Blueprint Deck",
+                "slides": [
+                    {"layout": "title", "title": "Blueprint Deck", "content": "", "order": 0},
+                ],
+            },
+            captured,
+        )
+    )
+
+    generator.generate_from_text(
+        source_text="Blueprint source",
+        title_hint="Blueprint",
+        provider="openai",
+        model=None,
+        api_key=None,
+        temperature=None,
+        max_tokens=None,
+        max_source_tokens=None,
+        max_source_chars=None,
+        enable_chunking=False,
+        chunk_size_tokens=None,
+        summary_tokens=None,
+        visual_style_snapshot={
+            "id": "notebooklm-blueprint",
+            "scope": "builtin",
+        },
+    )
+
+    system_prompt = captured["system_prompt"]
+    assert "Visual style preset: Blueprint." in system_prompt
+    assert "Cyan grid blueprint treatment with technical linework." in system_prompt
+    assert "Prompt profile: Technical Precision." in system_prompt
+    assert "prefer exact sequencing and component naming" in system_prompt
+    assert "Preferred visual block types: process_flow, timeline" in system_prompt
+    assert "Fallback instructions:" in system_prompt
+
+
+def test_timeline_style_prompts_chronology_first_behavior(monkeypatch):
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",
+        lambda: False,
+    )
+    generator = SlidesGenerator(
+        llm_call=_make_prompt_capture_llm(
+            {
+                "title": "Timeline Deck",
+                "slides": [
+                    {"layout": "title", "title": "Timeline Deck", "content": "", "order": 0},
+                ],
+            },
+            captured,
+        )
+    )
+
+    generator.generate_from_text(
+        source_text="1776, 1947",
+        title_hint="History",
+        provider="openai",
+        model=None,
+        api_key=None,
+        temperature=None,
+        max_tokens=None,
+        max_source_tokens=None,
+        max_source_chars=None,
+        enable_chunking=False,
+        chunk_size_tokens=None,
+        summary_tokens=None,
+        visual_style_snapshot={
+            "id": "timeline",
+            "scope": "builtin",
+        },
+    )
+
+    system_prompt = captured["system_prompt"]
+    assert "Visual style preset: Timeline." in system_prompt
+    assert "Chronology-first slides focused on sequence, causality, and milestones." in system_prompt
+    assert "Favor chronology, causality, and milestone sequencing." in system_prompt
+    assert '"chronology_bias": "high"' in system_prompt
+    assert "Preferred visual block types: timeline, stat_group" in system_prompt
+
+
+def test_user_style_snapshot_uses_raw_generation_rules_and_artifact_preferences(
+    monkeypatch,
+):
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.slides_generator.is_test_mode",
+        lambda: False,
+    )
+    generator = SlidesGenerator(
+        llm_call=_make_prompt_capture_llm(
+            {
+                "title": "Custom Deck",
+                "slides": [
+                    {"layout": "title", "title": "Custom Deck", "content": "", "order": 0},
+                ],
+            },
+            captured,
+        )
+    )
+
+    generator.generate_from_text(
+        source_text="Custom source",
+        title_hint="Custom",
+        provider="openai",
+        model=None,
+        api_key=None,
+        temperature=None,
+        max_tokens=None,
+        max_source_tokens=None,
+        max_source_chars=None,
+        enable_chunking=False,
+        chunk_size_tokens=None,
+        summary_tokens=None,
+        visual_style_snapshot={
+            "id": "notebooklm-blueprint",
+            "scope": "user",
+            "name": "User Blueprint",
+            "description": "User supplied blueprint style",
+            "generation_rules": {"custom_bias": "high"},
+            "artifact_preferences": ["stat_group"],
+            "fallback_policy": {"mode": "custom-outline", "preserve_key_stats": False},
+        },
+    )
+
+    system_prompt = captured["system_prompt"]
+    assert "User supplied blueprint style" in system_prompt
+    assert '"custom_bias": "high"' in system_prompt
+    assert "Preferred visual block types: stat_group" in system_prompt
+    assert "custom-outline" in system_prompt
+    assert "Cyan grid blueprint treatment with technical linework." not in system_prompt

--- a/tldw_Server_API/tests/Slides/test_visual_style_packs.py
+++ b/tldw_Server_API/tests/Slides/test_visual_style_packs.py
@@ -1,0 +1,43 @@
+import pytest
+
+from tldw_Server_API.app.core.Slides.visual_style_packs import (
+    _load_pack_css,
+    render_pack_custom_css,
+)
+
+
+@pytest.mark.unit
+def test_load_pack_css_rejects_path_traversal(monkeypatch, tmp_path):
+    packs_dir = tmp_path / "style_packs"
+    packs_dir.mkdir()
+    (tmp_path / "secret.css").write_text("body { color: red; }", encoding="utf-8")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.visual_style_packs._STYLE_PACKS_DIR",
+        packs_dir,
+    )
+    _load_pack_css.cache_clear()
+
+    try:
+        assert _load_pack_css("../secret") == ""
+    finally:
+        _load_pack_css.cache_clear()
+
+
+@pytest.mark.unit
+def test_render_pack_custom_css_omits_unsafe_token_entries():
+    css = render_pack_custom_css(
+        style_id="notebooklm-blueprint",
+        pack_id="technical_grid",
+        token_overrides={
+            "accent": "#7dd3fc",
+            "safe_value": "rgba(125, 211, 252, 0.16)",
+            "surface; color:red": "#ffffff",
+            "glow": "#67e8f9;\nbackground:url(https://example.com)",
+        },
+    )
+
+    assert "--accent: #7dd3fc;" in css
+    assert "--safe-value: rgba(125, 211, 252, 0.16);" in css
+    assert "--surface;" not in css
+    assert "background:url(" not in css
+    assert "https://example.com" not in css

--- a/tldw_Server_API/tests/Slides/test_visual_style_resolver.py
+++ b/tldw_Server_API/tests/Slides/test_visual_style_resolver.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tldw_Server_API.app.core.Slides.visual_style_resolver import resolve_builtin_visual_style
 
 
@@ -36,3 +38,19 @@ def test_resolver_uses_style_specific_token_overrides_for_hand_drawn_styles():
     assert whiteboard.appearance["custom_css"] != sketch_noting.appearance["custom_css"]
     assert chalkboard.appearance["theme"] == "black"
     assert whiteboard.appearance["theme"] == "white"
+
+
+def test_resolver_can_skip_custom_css_rendering(monkeypatch):
+    def _unexpected_render(**kwargs):
+        raise AssertionError("custom_css should not be rendered")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.visual_style_resolver.render_pack_custom_css",
+        _unexpected_render,
+    )
+
+    resolved = resolve_builtin_visual_style("notebooklm-blueprint", include_custom_css=False)
+
+    assert resolved is not None
+    assert resolved.appearance["theme"] == "night"
+    assert resolved.appearance["custom_css"] is None

--- a/tldw_Server_API/tests/Slides/test_visual_style_resolver.py
+++ b/tldw_Server_API/tests/Slides/test_visual_style_resolver.py
@@ -1,0 +1,38 @@
+from tldw_Server_API.app.core.Slides.visual_style_resolver import resolve_builtin_visual_style
+
+
+def test_resolver_returns_compact_snapshot_without_inline_css():
+    resolved = resolve_builtin_visual_style("notebooklm-blueprint")
+
+    assert resolved.snapshot["id"] == "notebooklm-blueprint"
+    assert resolved.snapshot["resolution"]["base_theme"] == "night"
+    assert resolved.snapshot["resolution"]["style_pack"] == "technical_grid"
+    assert resolved.snapshot["resolution"]["style_pack_version"] == 1
+    assert resolved.snapshot["resolution"]["token_overrides"]
+    assert resolved.snapshot["resolution"]["resolved_settings"]
+    assert "custom_css" not in resolved.snapshot
+    assert "custom_css" not in resolved.snapshot["resolution"]
+
+    assert resolved.appearance["theme"] == "night"
+    assert resolved.appearance["settings"]
+    assert resolved.appearance["custom_css"]
+
+
+def test_resolver_uses_style_specific_token_overrides_for_hand_drawn_styles():
+    chalkboard = resolve_builtin_visual_style("notebooklm-chalkboard")
+    whiteboard = resolve_builtin_visual_style("notebooklm-whiteboard")
+    sketch_noting = resolve_builtin_visual_style("notebooklm-sketch-noting")
+
+    assert chalkboard is not None
+    assert whiteboard is not None
+    assert sketch_noting is not None
+
+    assert chalkboard.snapshot["resolution"]["token_overrides"]["surface"] == "#0f172a"
+    assert whiteboard.snapshot["resolution"]["token_overrides"]["surface"] == "#fdfdfb"
+    assert sketch_noting.snapshot["resolution"]["token_overrides"]["surface"] == "#fffaf0"
+
+    assert chalkboard.appearance["custom_css"] != whiteboard.appearance["custom_css"]
+    assert chalkboard.appearance["custom_css"] != sketch_noting.appearance["custom_css"]
+    assert whiteboard.appearance["custom_css"] != sketch_noting.appearance["custom_css"]
+    assert chalkboard.appearance["theme"] == "black"
+    assert whiteboard.appearance["theme"] == "white"

--- a/tldw_Server_API/tests/Slides/test_visual_styles.py
+++ b/tldw_Server_API/tests/Slides/test_visual_styles.py
@@ -9,6 +9,10 @@ from tldw_Server_API.app.core.Slides.visual_style_catalog import (
     list_builtin_visual_style_definitions,
 )
 from tldw_Server_API.app.core.Slides.visual_style_packs import get_visual_style_pack
+from tldw_Server_API.app.core.Slides.visual_style_profiles import (
+    VisualStyleProfile,
+    _index_visual_style_profiles,
+)
 
 
 def test_slides_db_initializes_visual_styles_table(tmp_path):
@@ -77,6 +81,16 @@ def test_visual_style_registry_references_are_valid():
             "retro_synthetic",
             "high_energy_marketing",
         }
+
+
+def test_visual_style_profiles_reject_duplicate_ids():
+    with pytest.raises(ValueError, match="Duplicate visual style profile IDs: duplicate"):
+        _index_visual_style_profiles(
+            (
+                VisualStyleProfile(profile_id="duplicate", name="One", guidance=("a",)),
+                VisualStyleProfile(profile_id="duplicate", name="Two", guidance=("b",)),
+            )
+        )
 
 
 def test_slides_db_visual_style_crud(tmp_path):

--- a/tldw_Server_API/tests/Slides/test_visual_styles.py
+++ b/tldw_Server_API/tests/Slides/test_visual_styles.py
@@ -4,6 +4,11 @@ import pytest
 
 from tldw_Server_API.app.core.Slides.slides_db import ConflictError, SlidesDatabase
 from tldw_Server_API.app.core.Slides.visual_styles import list_builtin_visual_styles
+from tldw_Server_API.app.core.Slides.visual_style_catalog import (
+    get_builtin_visual_style_definition,
+    list_builtin_visual_style_definitions,
+)
+from tldw_Server_API.app.core.Slides.visual_style_packs import get_visual_style_pack
 
 
 def test_slides_db_initializes_visual_styles_table(tmp_path):
@@ -25,10 +30,53 @@ def test_visual_style_registry_includes_expected_builtins():
     styles = list_builtin_visual_styles()
     style_ids = [style.style_id for style in styles]
 
-    assert len(styles) >= 8
+    assert len(styles) == 44
     assert len(style_ids) == len(set(style_ids))
     assert "timeline" in style_ids
     assert "exam-focused-bullet" in style_ids
+    assert "notebooklm-chalkboard" in style_ids
+    assert "notebooklm-blueprint" in style_ids
+    assert "notebooklm-swiss-design" in style_ids
+    assert "notebooklm-brutalist-design" in style_ids
+
+
+def test_visual_style_registry_returns_defensive_copies():
+    definition = get_builtin_visual_style_definition("notebooklm-whiteboard")
+    assert definition is not None
+    definition.appearance_overrides["token_overrides"]["surface"] = "#000000"
+    definition.generation_rules["instructional_bias"] = "low"
+
+    pack = get_visual_style_pack("hand_drawn_surface")
+    assert pack is not None
+    pack.default_token_overrides["surface"] = "#000000"
+
+    fresh_definition = get_builtin_visual_style_definition("notebooklm-whiteboard")
+    fresh_pack = get_visual_style_pack("hand_drawn_surface")
+    assert fresh_definition is not None
+    assert fresh_pack is not None
+    assert fresh_definition.appearance_overrides["token_overrides"]["surface"] == "#fdfdfb"
+    assert fresh_definition.generation_rules["instructional_bias"] == "high"
+    assert fresh_pack.default_token_overrides["surface"] == "#101418"
+
+
+def test_visual_style_registry_references_are_valid():
+    definitions = list_builtin_visual_style_definitions()
+    assert len(definitions) == 44
+    for definition in definitions:
+        assert get_visual_style_pack(definition.style_pack) is not None
+        assert definition.prompt_profile in {
+            "instructional_hand_drawn",
+            "fine_art_human",
+            "tactile_playful",
+            "technical_precision",
+            "metric_first",
+            "narrative_journey",
+            "corporate_strategy",
+            "design_editorial",
+            "playful_approachable",
+            "retro_synthetic",
+            "high_energy_marketing",
+        }
 
 
 def test_slides_db_visual_style_crud(tmp_path):


### PR DESCRIPTION
## Summary
- add a built-in NotebookLM visual style catalog with resolver-backed metadata, prompt profiles, and reusable style packs
- apply built-in style resolution at the slides API boundary and extend Reveal export rendering with namespaced style CSS and richer visual-block HTML
- add the Presentation Studio visual style picker, client metadata support, and built-in theme synchronization for deck appearance defaults

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_visual_styles.py tldw_Server_API/tests/Slides/test_visual_style_resolver.py tldw_Server_API/tests/Slides/test_slides_api.py tldw_Server_API/tests/Slides/test_slides_db.py tldw_Server_API/tests/Slides/test_slides_generator.py tldw_Server_API/tests/Slides/test_slides_export.py tldw_Server_API/tests/Slides/test_presentation_rendering.py -q
- bunx vitest run src/components/Option/PresentationStudio/__tests__/VisualStylePicker.test.tsx src/components/Option/PresentationStudio/__tests__/PresentationStudioPage.test.tsx src/components/Option/PresentationStudio/__tests__/PresentationStudioCreatePayload.test.tsx src/components/Option/PresentationStudio/__tests__/PresentationStudioBootstrap.test.tsx src/components/Option/PresentationStudio/__tests__/presentation-studio.store.test.tsx
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Slides/visual_styles.py tldw_Server_API/app/core/Slides/visual_style_catalog.py tldw_Server_API/app/core/Slides/visual_style_profiles.py tldw_Server_API/app/core/Slides/visual_style_packs.py tldw_Server_API/app/core/Slides/visual_style_resolver.py tldw_Server_API/app/core/Slides/visual_style_generation.py tldw_Server_API/app/core/Slides/slides_export.py tldw_Server_API/app/api/v1/endpoints/slides.py tldw_Server_API/app/api/v1/schemas/slides_schemas.py -f json -o /tmp/bandit_notebooklm_style_catalog.json