### PR TITLE
Reference manager import sync backend

### DIFF
--- a/Docs/Design/2026-03-30-reference-manager-import-sync-design.md
+++ b/Docs/Design/2026-03-30-reference-manager-import-sync-design.md
@@ -1,0 +1,10 @@
+# Reference Manager Import Sync Design
+
+This is the canonical design-doc location for the reference-manager import/sync feature.
+
+The fuller working specification and implementation plan remain in:
+
+- `Docs/superpowers/specs/2026-03-30-reference-manager-import-sync-design.md`
+- `Docs/superpowers/plans/2026-03-30-reference-manager-import-sync-implementation-plan.md`
+
+The feature adds a provider-neutral reference-manager integration layer, starting with Zotero, so users can link an account, select collections as sources, and continuously import newly added references into workspace storage with metadata fidelity and non-destructive local retention.

--- a/Docs/superpowers/plans/2026-03-30-reference-manager-import-sync-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-03-30-reference-manager-import-sync-implementation-plan.md
@@ -1,0 +1,666 @@
+# Reference Manager Import Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the backend and connector API foundation for collection-linked reference-manager imports with a generic adapter seam, Zotero as the first provider, import-mode sync, strong dedupe, and normalized bibliographic metadata.
+
+**Architecture:** Extend `External_Sources` with a dedicated `ReferenceManagerAdapter` family instead of forcing scholarly-library items through the existing file-sync adapter contract. Reuse the current external account/source tables, scheduler, and Jobs worker, but add reference-item storage, Zotero normalization, and dedupe helpers specialized for bibliographic imports. This plan intentionally stops at backend/API completion because the current `/connectors` web routes are placeholders; a separate UI plan should consume the stabilized backend contract afterward.
+
+**Tech Stack:** FastAPI, Pydantic, AuthNZ DB pool, Media DB v2, APScheduler, Jobs, Loguru, pytest, httpx/TestClient, Bandit
+
+---
+
+## Scope Lock
+
+Before implementation starts, keep these planning decisions fixed:
+
+- v1 provider surface is `zotero` only
+- the abstraction is generic so `mendeley` can be added later without redesigning storage or worker flow
+- linked sources are `collection` sources only
+- v1 collection traversal is **flat, not recursive**
+- child collections must be linked separately in v1
+- sync is **import mode**
+- upstream edits or deletes do not rewrite or remove local media by default
+- annotation/highlight sync is out of scope
+- write-back is out of scope
+
+## Canonical V1 Bibliographic Field Map
+
+Every imported or dedupe-linked scholarly item should normalize into this `safe_metadata` shape:
+
+```python
+{
+    "provider": "zotero",
+    "import_mode": "reference_manager",
+    "provider_item_key": "ABCD1234",
+    "provider_library_id": "123456",
+    "collection_key": "COLL1234",
+    "collection_name": "Language Models",
+    "source_url": "https://www.zotero.org/users/123456/items/ABCD1234",
+    "doi": "10.1000/example",
+    "title": "Attention Is All You Need",
+    "authors": "Ashish Vaswani, Noam Shazeer, ...",
+    "publication_date": "2017-06-12",
+    "year": "2017",
+    "journal": "NeurIPS",
+    "abstract": "..."
+}
+```
+
+Only these fields are canonical in v1. Do not add provider-specific metadata blobs to `safe_metadata` beyond what is needed for debugging or durable identity.
+
+## File Structure
+
+- `tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py`
+  Purpose: define the provider-agnostic scholarly-library protocol used by workers and endpoints.
+- `tldw_Server_API/app/core/External_Sources/reference_manager_types.py`
+  Purpose: define normalized collection, attachment, and reference-item dataclasses for provider-neutral processing.
+- `tldw_Server_API/app/core/External_Sources/reference_manager_dedupe.py`
+  Purpose: centralize strict-first dedupe ranking and canonical metadata fingerprint generation.
+- `tldw_Server_API/app/core/External_Sources/reference_manager_import.py`
+  Purpose: orchestrate reference-item enumeration, attachment selection, dedupe decisions, and Media DB import payload generation.
+- `tldw_Server_API/app/core/External_Sources/zotero.py`
+  Purpose: implement Zotero OAuth, collection listing, flat item listing, attachment discovery, and normalized item mapping.
+- `tldw_Server_API/app/core/External_Sources/__init__.py`
+  Purpose: export the new adapter/types and register the Zotero connector.
+- `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+  Purpose: extend provider family constants, create storage for reference-item sync state, and expose helper functions used by endpoints and workers.
+- `tldw_Server_API/app/core/External_Sources/policy.py`
+  Purpose: allow org policy evaluation to reason about `zotero` as an enabled provider without assuming file-path constraints.
+- `tldw_Server_API/app/core/External_Sources/README.md`
+  Purpose: document the new reference-manager family, flat collection semantics, and import-mode behavior.
+- `tldw_Server_API/app/core/Utils/metadata_utils.py`
+  Purpose: reuse and, if needed, extend the worker-safe `normalize_safe_metadata(...)` and `update_version_safe_metadata_in_transaction(...)` helpers instead of routing metadata merges through HTTP endpoints.
+- `tldw_Server_API/app/api/v1/schemas/connectors.py`
+  Purpose: extend provider, source-type, and sync-summary schemas for reference-manager collections and duplicate/metadata-only counts.
+- `tldw_Server_API/app/api/v1/endpoints/connectors.py`
+  Purpose: expose Zotero in provider discovery, collection browsing, source creation, and source status endpoints while rejecting unsupported recursive semantics.
+- `tldw_Server_API/app/services/connectors_sync_scheduler.py`
+  Purpose: enqueue poll-based incremental sync for reference-manager sources.
+- `tldw_Server_API/app/services/connectors_worker.py`
+  Purpose: branch import jobs by provider family and execute import-mode reference-manager sync without destructive replay.
+- `tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py`
+  Purpose: lock the generic provider contract and normalized dataclass invariants.
+- `tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py`
+  Purpose: verify table creation and CRUD helpers for reference-item bindings, cursors, and result counters.
+- `tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py`
+  Purpose: verify DOI-first dedupe ranking, metadata fingerprint conservatism, and metadata enrichment guardrails.
+- `tldw_Server_API/tests/External_Sources/test_zotero_connector.py`
+  Purpose: verify collection listing, flat item listing, attachment selection, and normalized bibliographic mapping.
+- `tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py`
+  Purpose: extend the current connector API coverage for Zotero provider listing, collection source creation, and validation errors.
+- `tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py`
+  Purpose: verify scheduler enqueue behavior for poll-based Zotero sources.
+- `tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py`
+  Purpose: verify worker import-mode sync, dedupe outcomes, cursor advancement, and metadata-only skips.
+- `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py`
+  Purpose: verify end-to-end import into Media DB with stable `safe_metadata` and no destructive replay on duplicate or changed upstream items.
+
+## Stages
+
+### Stage 1: Generic Contract And Storage
+
+**Goal:** Add the provider-neutral reference-manager contract, normalized types, and storage primitives needed for collection-linked scholarly imports.
+
+**Success Criteria:** The backend can persist reference-item sync rows, expose a stable normalized item shape, and recognize `zotero` as a connector provider without yet running real imports.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py -v`
+
+**Status:** Complete
+
+### Stage 2: Zotero Adapter And Dedupe Core
+
+**Goal:** Implement the first concrete provider plus the shared dedupe logic.
+
+**Success Criteria:** Zotero collections and items can be normalized into the canonical bibliographic field map, and dedupe ranking produces deterministic match reasons.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/External_Sources/test_zotero_connector.py tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py -v`
+
+**Status:** Complete
+
+### Stage 3: Connector API Surface
+
+**Goal:** Expose Zotero through the existing connectors endpoints and source-creation flow.
+
+**Success Criteria:** Clients can discover the provider, browse collections, create flat collection sources, and retrieve source status with duplicate and metadata-only counters.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py -v`
+
+**Status:** Complete
+
+### Stage 4: Scheduled Import-Mode Sync
+
+**Goal:** Add scheduler and worker execution for reference-manager imports without destructive replay.
+
+**Success Criteria:** Poll-based jobs enumerate new reference items, dedupe them, import new attachments into Media DB, record metadata-only skips, and advance cursors.
+
+**Tests:** `python -m pytest tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py -v`
+
+**Status:** Complete
+
+### Stage 5: Documentation And Security Verification
+
+**Goal:** Document the new connector family and confirm the touched backend scope does not introduce new Bandit findings.
+
+**Success Criteria:** The README reflects Zotero-first import-mode behavior, targeted tests pass, and Bandit reports zero new findings in the touched scope.
+
+**Tests:** `python -m bandit -r tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py tldw_Server_API/app/core/External_Sources/reference_manager_types.py tldw_Server_API/app/core/External_Sources/reference_manager_dedupe.py tldw_Server_API/app/core/External_Sources/reference_manager_import.py tldw_Server_API/app/core/External_Sources/zotero.py tldw_Server_API/app/core/External_Sources/connectors_service.py tldw_Server_API/app/api/v1/endpoints/connectors.py tldw_Server_API/app/services/connectors_worker.py tldw_Server_API/app/services/connectors_sync_scheduler.py -f json -o /tmp/bandit_reference_manager_import_sync.json`
+
+**Status:** Complete
+
+## Task 1: Add The Generic Reference-Manager Contract And Sync Storage
+
+**Files:**
+- Create: `tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py`
+- Create: `tldw_Server_API/app/core/External_Sources/reference_manager_types.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/__init__.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/connectors.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py`
+
+- [x] **Step 1: Write the failing contract and storage tests**
+
+Add tests that prove:
+
+1. a `ReferenceManagerAdapter` protocol exists
+2. normalized collection and reference-item dataclasses expose the canonical v1 fields
+3. connector schemas allow `provider="zotero"` and `type="collection"`
+4. a new reference-item storage table can persist provider item identity, collection identity, match reason, and import timestamps
+5. reference-manager sources are flat by default and do not depend on recursive file traversal
+
+Use concrete assertions like:
+
+```python
+item = NormalizedReferenceItem(
+    provider="zotero",
+    provider_item_key="ABCD1234",
+    provider_library_id="123456",
+    collection_key="COLL1234",
+    collection_name="Language Models",
+    doi="10.1000/example",
+    title="Attention Is All You Need",
+    authors="Ashish Vaswani, Noam Shazeer",
+    publication_date="2017-06-12",
+    year="2017",
+    journal="NeurIPS",
+    abstract="...",
+    source_url="https://www.zotero.org/users/123456/items/ABCD1234",
+    attachments=[],
+)
+assert item.collection_name == "Language Models"
+assert item.doi == "10.1000/example"
+```
+
+```python
+payload = ConnectorSourceCreateRequest(
+    account_id=1,
+    provider="zotero",
+    remote_id="COLL1234",
+    type="collection",
+    options={},
+)
+assert payload.type == "collection"
+```
+
+- [x] **Step 2: Run the targeted tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py \
+  -v
+```
+
+Expected: FAIL because the protocol, normalized types, provider literal, and reference-item storage helpers do not exist yet.
+
+- [x] **Step 3: Implement the minimal contract and storage layer**
+
+Make the smallest backend changes that establish the new family:
+
+- define `ReferenceManagerAdapter` with collection/item/attachment methods
+- define `NormalizedReferenceCollection`, `ReferenceAttachmentCandidate`, and `NormalizedReferenceItem`
+- extend connector schema literals for `zotero` and `collection`
+- add `REFERENCE_MANAGER_PROVIDERS = frozenset({"zotero"})`
+- add a new `external_reference_items` table plus helper CRUD in `connectors_service.py`
+- keep storage provider-neutral even though only Zotero ships now
+
+Keep the storage boring and explicit:
+
+```python
+async def upsert_reference_item_binding(
+    db,
+    *,
+    source_id: int,
+    provider: str,
+    provider_item_key: str,
+    provider_library_id: str | None,
+    collection_key: str | None,
+    provider_version: str | None,
+    provider_updated_at: str | None,
+    media_id: int | None,
+    dedupe_match_reason: str | None,
+    raw_reference_metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    ...
+```
+
+- [x] **Step 4: Re-run the targeted tests**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS with the new protocol, schema support, and storage helpers in place.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py \
+  tldw_Server_API/app/core/External_Sources/reference_manager_types.py \
+  tldw_Server_API/app/core/External_Sources/__init__.py \
+  tldw_Server_API/app/core/External_Sources/connectors_service.py \
+  tldw_Server_API/app/api/v1/schemas/connectors.py \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py
+git commit -m "feat: add reference manager connector contracts"
+```
+
+## Task 2: Implement Zotero Normalization And Shared Dedupe Ranking
+
+**Files:**
+- Create: `tldw_Server_API/app/core/External_Sources/zotero.py`
+- Create: `tldw_Server_API/app/core/External_Sources/reference_manager_dedupe.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/__init__.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_zotero_connector.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py`
+
+- [x] **Step 1: Write the failing Zotero and dedupe tests**
+
+Add tests that prove:
+
+1. Zotero collection browsing returns collection records, not file-like rows
+2. Zotero item listing is flat for a selected collection in v1
+3. attachment selection prefers importable PDFs and falls back to no-attachment metadata records cleanly
+4. dedupe ranking order is `same_provider_item -> doi -> file_hash -> metadata_fingerprint`
+5. metadata fingerprint matching is conservative and does not merge similar but distinct titles
+
+Use focused assertions like:
+
+```python
+match = rank_reference_item_match(
+    normalized_item,
+    same_provider_item=None,
+    doi_match={"media_id": 77},
+    hash_match=None,
+    metadata_match={"media_id": 99},
+)
+assert match.reason == "doi"
+assert match.media_id == 77
+```
+
+```python
+item = await ZoteroConnector(...).normalize_reference_item(raw_item, raw_attachments)
+assert item.provider == "zotero"
+assert item.collection_key == "COLL1234"
+assert item.attachments[0].mime_type == "application/pdf"
+```
+
+- [x] **Step 2: Run the targeted tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/External_Sources/test_zotero_connector.py \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py \
+  -v
+```
+
+Expected: FAIL because no Zotero adapter or bibliographic dedupe helper exists yet.
+
+- [x] **Step 3: Implement the Zotero adapter and dedupe helper**
+
+Add the first real provider and its matching logic:
+
+- implement OAuth-specific Zotero connector methods
+- implement collection listing and flat collection item listing
+- map Zotero payloads into the canonical v1 field map
+- emit attachment descriptors separately from bibliographic identity
+- implement strict-first dedupe ranking and metadata fingerprint generation
+- expose a helper that returns both `match_reason` and optional `metadata_patch`
+
+Keep the fingerprint logic explicit:
+
+```python
+def build_metadata_fingerprint(
+    *,
+    title: str | None,
+    authors: str | None,
+    year: str | None,
+) -> str | None:
+    normalized_title = normalize_title(title)
+    first_author = normalize_first_author(authors)
+    if not normalized_title or not first_author or not year:
+        return None
+    return f"{normalized_title}|{first_author}|{year}"
+```
+
+- [x] **Step 4: Re-run the targeted tests**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS with deterministic normalized Zotero items and conservative dedupe ranking.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/zotero.py \
+  tldw_Server_API/app/core/External_Sources/reference_manager_dedupe.py \
+  tldw_Server_API/app/core/External_Sources/__init__.py \
+  tldw_Server_API/app/core/External_Sources/connectors_service.py \
+  tldw_Server_API/tests/External_Sources/test_zotero_connector.py \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py
+git commit -m "feat: add zotero reference manager adapter"
+```
+
+## Task 3: Expose Zotero Collection Sources Through The Connectors API
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/connectors.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/connectors.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/policy.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py`
+
+- [x] **Step 1: Write the failing connector API tests**
+
+Add tests that prove:
+
+1. `GET /api/v1/connectors/providers` includes `zotero`
+2. `POST /api/v1/connectors/providers/zotero/authorize` returns an OAuth URL and state
+3. `GET /api/v1/connectors/providers/zotero/callback` accepts a valid state and creates an account row
+4. the browse flow returns collection-shaped rows for Zotero
+5. `POST /api/v1/connectors/sources` accepts `provider="zotero"` and `type="collection"`
+6. recursive source options are rejected for Zotero with a clear 4xx message
+7. source sync summaries include reference-manager counts like `duplicate_count` and `metadata_only_count`
+
+Example assertions:
+
+```python
+response = client.get("/api/v1/connectors/providers", headers=headers)
+names = {item["name"] for item in response.json()}
+assert "zotero" in names
+```
+
+```python
+payload = {
+    "account_id": 7,
+    "provider": "zotero",
+    "remote_id": "COLL1234",
+    "type": "collection",
+    "options": {"recursive": True},
+}
+response = client.post("/api/v1/connectors/sources", json=payload, headers=headers)
+assert response.status_code == 422
+assert "flat" in response.text.lower()
+```
+
+- [x] **Step 2: Run the targeted connector API tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py \
+  tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py \
+  -v
+```
+
+Expected: FAIL because the provider catalog, browse flow, source validation, and sync summary do not yet understand Zotero collections.
+
+- [x] **Step 3: Implement the minimal endpoint and schema support**
+
+Add the smallest API surface that makes the provider usable:
+
+- include Zotero in provider discovery
+- support authorize/callback through the existing generic connector OAuth flow
+- let the existing browse flow return normalized collection rows for Zotero
+- allow source creation for `type="collection"`
+- reject `recursive=True` for Zotero with a clear validation error
+- extend sync summary models and serializers with reference-manager counters
+- keep current Drive/OneDrive behavior unchanged
+
+Be explicit about the validation rule:
+
+```python
+if provider == "zotero" and bool(options.get("recursive")):
+    raise HTTPException(
+        status_code=422,
+        detail="Zotero collection sync is flat in v1; link child collections separately.",
+    )
+```
+
+- [x] **Step 4: Re-run the targeted connector API tests**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS with a working Zotero connector contract at the API layer.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/connectors.py \
+  tldw_Server_API/app/api/v1/endpoints/connectors.py \
+  tldw_Server_API/app/core/External_Sources/policy.py \
+  tldw_Server_API/app/core/External_Sources/connectors_service.py \
+  tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py \
+  tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py
+git commit -m "feat: expose zotero collection sources in connectors api"
+```
+
+## Task 4: Add Import-Mode Reference Sync To The Scheduler And Worker
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py`
+- Create: `tldw_Server_API/app/core/External_Sources/reference_manager_import.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/zotero.py`
+- Modify: `tldw_Server_API/app/core/Utils/metadata_utils.py`
+- Modify: `tldw_Server_API/app/services/connectors_sync_scheduler.py`
+- Modify: `tldw_Server_API/app/services/connectors_worker.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_zotero_connector.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py`
+
+- [x] **Step 1: Write the failing scheduler, worker, and integration tests**
+
+Add tests that prove:
+
+1. the scheduler enqueues incremental sync for enabled Zotero collection sources
+2. the worker enumerates normalized reference items using the new provider family
+3. a new paper imports into Media DB with the canonical `safe_metadata`
+4. a DOI duplicate records a reference binding and optional metadata enrichment, but does not create a second media record
+5. metadata-only records increment `metadata_only_count`
+6. upstream edits do not rewrite local content in v1
+
+Use concrete expectations like:
+
+```python
+assert result["processed"] == 1
+assert result["duplicates"] == 1
+assert result["metadata_only"] == 1
+assert sync_state["cursor"] == "version-42"
+```
+
+```python
+latest = get_document_version(media_db, media_id, 1)
+assert latest["safe_metadata"]["provider"] == "zotero"
+assert latest["safe_metadata"]["doi"] == "10.1000/example"
+assert latest["safe_metadata"]["collection_key"] == "COLL1234"
+```
+
+- [x] **Step 2: Run the targeted sync tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py \
+  tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py \
+  -v
+```
+
+Expected: FAIL because the scheduler and worker are still hard-wired to file-centric import logic.
+
+- [x] **Step 3: Implement import-mode reference-manager sync**
+
+Build the smallest execution path that works end to end:
+
+- teach the scheduler to enqueue poll-based sync for `REFERENCE_MANAGER_PROVIDERS`
+- move reference-item enumeration and attachment selection into `reference_manager_import.py`
+- branch `_process_import_job()` by provider family
+- resolve and download selected attachments through the `ReferenceManagerAdapter` contract
+- on new item:
+  - select the best importable attachment
+  - ingest into Media DB
+  - write canonical `safe_metadata`
+  - persist the reference-item binding row
+- on duplicate:
+  - bind the provider item to the existing media record
+  - merge only missing canonical metadata fields using `normalize_safe_metadata(...)` and `update_version_safe_metadata_in_transaction(...)`
+  - do not overwrite text, title, or versions by default
+- on no attachment:
+  - persist a metadata-only result row
+  - do not fake a successful media import
+- persist cursor and source counters
+
+Keep the import-mode guard explicit:
+
+```python
+if dedupe_result.matched_media_id is not None:
+    await upsert_reference_item_binding(..., media_id=dedupe_result.matched_media_id, dedupe_match_reason=dedupe_result.reason)
+    if dedupe_result.metadata_patch:
+        await merge_missing_safe_metadata(...)
+    return "duplicate"
+```
+
+- [x] **Step 4: Re-run the targeted sync tests**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS with scheduler enqueue, worker import, duplicate linking, metadata-only skips, and non-destructive import-mode behavior.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/reference_manager_import.py \
+  tldw_Server_API/app/core/Utils/metadata_utils.py \
+  tldw_Server_API/app/services/connectors_sync_scheduler.py \
+  tldw_Server_API/app/services/connectors_worker.py \
+  tldw_Server_API/app/core/External_Sources/connectors_service.py \
+  tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py \
+  tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
+git commit -m "feat: add reference manager import sync worker"
+```
+
+## Task 5: Document The New Connector Family And Run Final Verification
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/External_Sources/README.md`
+
+- [x] **Step 1: Write the failing documentation and verification checklist**
+
+Add a short checklist section to the README update task that requires documentation to mention:
+
+1. Zotero is the only shipped provider in v1
+2. collection sync is flat
+3. import mode is non-destructive
+4. duplicate and metadata-only counts are surfaced in sync status
+
+Use a direct checklist in the plan execution notes:
+
+```markdown
+- [ ] README says child collections must be linked separately
+- [ ] README says upstream deletes do not remove local items in v1
+```
+
+- [x] **Step 2: Run the full targeted verification suite**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py \
+  tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py \
+  tldw_Server_API/tests/External_Sources/test_zotero_connector.py \
+  tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py \
+  tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py \
+  tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py \
+  tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py \
+  -v
+```
+
+Expected: PASS with the entire reference-manager backend slice green.
+
+- [x] **Step 3: Update docs and run Bandit on the touched backend scope**
+
+Document the new behavior in `External_Sources/README.md`, then run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py \
+  tldw_Server_API/app/core/External_Sources/reference_manager_types.py \
+  tldw_Server_API/app/core/External_Sources/reference_manager_dedupe.py \
+  tldw_Server_API/app/core/External_Sources/reference_manager_import.py \
+  tldw_Server_API/app/core/External_Sources/zotero.py \
+  tldw_Server_API/app/core/External_Sources/connectors_service.py \
+  tldw_Server_API/app/api/v1/endpoints/connectors.py \
+  tldw_Server_API/app/services/connectors_worker.py \
+  tldw_Server_API/app/services/connectors_sync_scheduler.py \
+  -f json -o /tmp/bandit_reference_manager_import_sync.json
+```
+
+Expected: JSON report written to `/tmp/bandit_reference_manager_import_sync.json` with zero new findings in the touched scope.
+
+- [x] **Step 4: Review the final scoped diff before closing**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: the scoped diff for the reference-manager slice matches the planned backend files, tests, and docs, even if the wider repository is already dirty.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/README.md
+git commit -m "fix: finalize reference manager import sync verification"
+```
+
+## Follow-On Plan, Not Part Of This Tranche
+
+The current `/connectors` and `/connectors/*` web routes in `apps/tldw-frontend/pages/connectors/` are placeholders. After this backend/API slice is stable, write a separate plan for:
+
+- account linking UX
+- collection picker UX
+- source status table
+- duplicate and metadata-only counters in the web client
+- workspace affordances for imported scholarly metadata

--- a/Docs/superpowers/specs/2026-03-30-reference-manager-import-sync-design.md
+++ b/Docs/superpowers/specs/2026-03-30-reference-manager-import-sync-design.md
@@ -1,0 +1,577 @@
+# Reference Manager Import Sync Design
+
+## Summary
+
+This design adds a generic reference-manager integration layer to `tldw_server2` so users can link a scholarly library account, choose collections or folders as sources, and continuously import newly added papers into a NotebookLM-style workspace.
+
+The approved v1 scope is intentionally narrow:
+
+- generic abstraction first, not a Zotero-only one-off
+- import mode, not mirror mode
+- reliable one-way sync from linked collections or folders into local workspaces
+- strong dedupe so repeated sync runs and multi-collection overlap do not create noisy duplicates
+- metadata fidelity so imported items carry DOI, authors, dates, and related bibliographic context cleanly
+- background live sync driven by the existing scheduler and job infrastructure
+
+This design explicitly excludes bidirectional repair, upstream delete propagation, and full annotation parity in the first slice.
+
+## Feasibility Verdict
+
+This feature is feasible in the current codebase and fits the existing architecture better than it would have a month earlier.
+
+The main reason it is feasible now is that the repo already has the hard operational primitives needed for a serious connector feature:
+
+- OAuth-capable account and source plumbing in `tldw_Server_API/app/api/v1/endpoints/connectors.py`
+- persistent connector account, source, and sync-state storage in `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- a recurring scheduler bridge in `tldw_Server_API/app/services/connectors_sync_scheduler.py`
+- async job workers for connector sync execution in `tldw_Server_API/app/services/connectors_worker.py`
+- DOI-aware scholarly ingestion and normalized `safe_metadata` handling in `tldw_Server_API/app/api/v1/endpoints/paper_search.py`
+
+The main reason it is not trivial is that the current connector framework is optimized for file-hosting providers. Scholarly libraries behave differently:
+
+- the primary entity is a reference item, not a file
+- bibliographic identity and attachment identity are related but not the same
+- sync must tolerate items with strong metadata but no retrievable attachment
+- dedupe decisions must prefer false negatives over false merges
+
+That means v1 should reuse the existing connector control plane and job model, but it should not pretend a Zotero library item is just another Drive file.
+
+## Goals
+
+- Let users link a reference-manager account through the existing connectors model.
+- Let users choose one or more collections or folders as linked import sources.
+- Automatically import newly discovered papers from those linked sources on a schedule.
+- Preserve bibliographic fidelity in local `safe_metadata` fields.
+- Prevent duplicate local imports across repeated syncs and overlapping collections.
+- Keep the reference manager as the source of discovery without making upstream edits or deletes destructive to local workspace content.
+- Surface clear per-source sync status, counts, and failure reasons in the existing connector UX.
+- Design the provider abstraction so Zotero can ship first while Mendeley can follow without redesigning the storage or worker contract.
+
+## Non-Goals
+
+- Propagating local edits back to Zotero, Mendeley, or another provider.
+- Rewriting or deleting local media because an upstream record changed or disappeared.
+- Full synchronization of annotations, highlights, or notes from the provider into first-class local annotation objects.
+- Building a generic citation-writing or bibliography-editing interface in v1.
+- Supporting every scholarly provider in the first delivery.
+- Replacing the existing file-sync connector architecture.
+
+## Requirements Confirmed With User
+
+- The feature is for `tldw_server2`'s own NotebookLM-style workspace, not for Google NotebookLM.
+- The abstraction should be generic from the start, even if that slows initial delivery.
+- The v1 non-negotiable outcomes are:
+  - reliable one-way sync into a workspace with dedupe
+  - metadata fidelity for DOI, authors, and date
+  - background live sync from linked collections or folders
+- The source-of-truth model for v1 is import mode:
+  - new items flow in automatically
+  - upstream edits or deletes do not rewrite or remove local items by default
+
+## Current State
+
+### What Already Exists
+
+- External accounts and sources for connectors
+- OAuth start and callback flows
+- provider registry and provider-specific source configuration
+- scheduler-driven sync job submission
+- worker execution for connector jobs
+- local media ingest and update paths
+- DOI-aware search and ingest endpoints
+- normalized `safe_metadata` storage and search in Media DB
+
+### What Does Not Exist Yet
+
+- a scholarly-library provider contract distinct from file-sync adapters
+- source models centered on collection and reference-item semantics
+- dedupe ranking specialized for bibliographic imports
+- source sync status that distinguishes metadata-only records from attachment-importable records
+- a linked-library UX in the connectors or workspace surfaces
+- provider-contract tests for scholarly library payloads
+
+## Problems To Solve
+
+### 1. The current connector model is file-centric
+
+Drive and OneDrive sync are built around remote files and file revisions. A scholarly library item may have:
+
+- metadata and an attachment
+- metadata but no attachment
+- multiple attachments
+- multiple collections pointing at the same item
+
+The first slice needs a dedicated abstraction that represents a reference item as the primary record and treats attachments as secondary import candidates.
+
+### 2. Dedupe must work across provider boundaries and collection overlap
+
+The same paper can appear:
+
+- in the same collection across multiple sync runs
+- in multiple linked collections in one provider account
+- in two different providers
+- as two local files with the same DOI but different filenames
+
+If dedupe is weak, the feature becomes a duplicate factory. If dedupe is too aggressive, it collapses distinct records and damages trust.
+
+### 3. Metadata quality is as important as file ingest
+
+Users are asking for this feature partly to avoid manual metadata cleanup. If a sync imports a PDF but drops DOI, authors, or publication date, the feature misses the core user value.
+
+### 4. Live sync must be reliable without requiring mirror semantics
+
+The user wants background import of new upstream items, not a full mirrored library. That means the system must reliably discover and ingest new items while intentionally refusing to treat local state as a mirror of the upstream library.
+
+### 5. Annotation retention is valuable but not affordable in v1
+
+The current product already has annotation-related scope boundaries in workspace flows. Pulling third-party annotations into a stable, user-trustworthy local model would materially expand the first slice and should remain out of scope.
+
+## Approaches Considered
+
+### Approach 1: Add a research-specific import feature outside the connectors framework
+
+Build a custom scholarly-library import surface under the research module and bypass the general connector machinery.
+
+Pros:
+
+- faster initial implementation
+- fewer constraints from existing connector contracts
+
+Cons:
+
+- duplicates account linking, source state, scheduling, and job status
+- makes later Mendeley support messier
+- creates another sync system in a codebase that already has one
+
+### Approach 2: Extend the connector framework with a new reference-manager adapter family
+
+Reuse accounts, sources, scheduler, and jobs, but add a separate provider contract for scholarly libraries.
+
+Pros:
+
+- strongest fit with current architecture
+- keeps OAuth, scheduling, status, and operations in one system
+- supports a generic abstraction without pretending everything is a file
+- makes phased provider rollout practical
+
+Cons:
+
+- requires more upfront design than a one-off Zotero integration
+- forces some connector storage and worker paths to become slightly more general
+
+### Approach 3: Build a full mirror-sync platform from the start
+
+Import, update, delete, annotation sync, and optional write-back all in one system.
+
+Pros:
+
+- richest end-state
+- avoids later architectural expansion
+
+Cons:
+
+- too broad for the approved v1
+- highest risk surface
+- likely to stall on edge cases around annotation fidelity and destructive sync behavior
+
+## Recommendation
+
+Use Approach 2.
+
+The first delivery should extend the connector architecture with a dedicated `ReferenceManagerAdapter` family while keeping the operational model identical to the rest of the connector system:
+
+- OAuth-based linked account
+- source rows for linked collections or folders
+- scheduled sync jobs
+- per-source status and counts
+- worker-owned import execution
+
+The feature should remain intentionally import-only in v1. The reference manager is a discovery source for new papers, not a mirrored authority that can rewrite or delete local workspace content.
+
+## Proposed Architecture
+
+### High-Level Shape
+
+Add a second connector family beside the current file-sync providers:
+
+- `FileSyncAdapter`
+  - current model for Drive and OneDrive
+- `ReferenceManagerAdapter`
+  - new model for Zotero, Mendeley, and future scholarly library providers
+
+Both families reuse:
+
+- account linking
+- external source creation
+- scheduler integration
+- job execution
+- sync status APIs
+
+They differ in how they enumerate remote entities, choose import candidates, persist remote identity, and decide dedupe.
+
+### New Provider Contract
+
+`ReferenceManagerAdapter` should define a minimal provider contract centered on collections and items rather than files.
+
+Expected capabilities:
+
+- `list_collections(account_tokens, cursor=None)`
+- `get_collection(account_tokens, collection_key)`
+- `list_items(account_tokens, collection_key, cursor=None, updated_after=None)`
+- `get_item_metadata(account_tokens, item_key)`
+- `list_item_attachments(account_tokens, item_key)`
+- `resolve_attachment_download(account_tokens, attachment_descriptor)`
+- `normalize_reference_item(raw_item, raw_attachments) -> NormalizedReferenceItem`
+- optional push-friendly methods later, but not required in v1
+
+The normalized item should include:
+
+- provider item key
+- provider library id or account-scoped remote namespace
+- collection keys
+- provider version or updated timestamp
+- item type
+- title
+- authors
+- publication date or year
+- DOI
+- journal or venue
+- abstract if available
+- source URL
+- attachment descriptors
+
+### Source Types
+
+The existing `external_sources` concept should be reused, but source options must support reference-manager semantics.
+
+New source option shape should allow:
+
+- `remote_source_type: "reference_collection"`
+- `collection_key`
+- `collection_name`
+- `import_attachments: true | false`
+- `sync_mode: "poll"`
+- optional future provider-specific knobs
+
+For v1, the linked source should be a collection or folder, not an entire account library by default. That keeps sync scope understandable and aligned with the user's request.
+
+### Storage Model
+
+Reuse the current external account and source tables, but add a dedicated reference-item sync storage layer instead of forcing everything into file-binding columns.
+
+Add a new table, or equivalent storage abstraction, conceptually shaped like:
+
+- `external_reference_items`
+  - `source_id`
+  - `provider`
+  - `provider_item_key`
+  - `provider_parent_key`
+  - `provider_version`
+  - `provider_updated_at`
+  - `attachment_status`
+  - `attachment_source_url`
+  - `media_id`
+  - `dedupe_match_reason`
+  - `raw_reference_metadata`
+  - `last_seen_at`
+  - `last_imported_at`
+  - `last_metadata_sync_at`
+
+This should be separate from file-centric binding state because one reference item may represent:
+
+- no file
+- one importable file
+- multiple candidate files
+- a duplicate of an already imported local media item
+
+### Local Metadata Contract
+
+When a media item is imported or linked by dedupe hit, the local active version should carry normalized scholarly metadata in `safe_metadata`.
+
+The normalized scholarly block should include:
+
+- `provider`
+- `provider_item_key`
+- `provider_library_id`
+- `collection_key`
+- `source_url`
+- `doi`
+- `title`
+- `authors`
+- `publication_date`
+- `journal`
+- `abstract`
+- `import_mode: "reference_manager"`
+
+The first delivery should normalize field names aggressively so downstream search, RAG, and workspace UI do not need provider-specific branching for basic bibliographic display.
+
+## Data Flow
+
+### Link Flow
+
+1. User starts OAuth flow for a reference-manager provider.
+2. OAuth callback stores account tokens in the same external-account system used by current connectors.
+3. User browses available collections or folders.
+4. User links one or more collections as import sources.
+5. Source options persist collection identity and sync configuration.
+
+### Scheduled Sync Flow
+
+1. The scheduler scans linked sources.
+2. For each eligible reference-manager source, it enqueues a sync job.
+3. The worker reserves the source and loads account tokens.
+4. The provider adapter enumerates new or updated items using cursor or updated-since semantics.
+5. Each remote item is normalized into a provider-neutral bibliographic shape.
+6. The worker resolves attachment candidates only when needed for import.
+7. The worker runs dedupe ranking.
+8. If no match exists:
+   - import the best attachment into Media DB when available
+   - or record a metadata-only skip state if the provider has no retrievable attachment
+9. If a match exists:
+   - record the remote binding against the local media item
+   - optionally fill missing normalized metadata fields
+   - do not overwrite local content, local notes, or local versions in v1
+10. Persist item-level results and advance the source cursor.
+
+### Import-Mode Semantics
+
+V1 must keep import mode explicit:
+
+- newly discovered upstream items can create or attach to local records
+- upstream edits do not automatically rewrite local records
+- upstream deletes do not remove local records
+- local users remain free to continue working on imported content without destructive upstream replay
+
+## Dedupe Strategy
+
+### Ranking Order
+
+Dedupe should be strict-first and fuzzy-last:
+
+1. existing binding on the same `provider + provider_item_key`
+2. DOI match
+3. normalized attachment hash match
+4. conservative metadata fingerprint match:
+   - normalized title
+   - first author
+   - year or publication date
+
+### Why This Order
+
+- provider item keys are best for idempotence within one provider account
+- DOI is the strongest cross-provider scholarly identity
+- attachment hash catches local duplicates where metadata differs slightly
+- title-author-year fallback is necessary, but dangerous enough that it must remain conservative
+
+### Match Outcomes
+
+Each dedupe decision should persist a match reason:
+
+- `same_provider_item`
+- `doi`
+- `file_hash`
+- `metadata_fingerprint`
+- `none`
+
+This gives the UI and debugging surfaces enough information to explain why an item was skipped or linked.
+
+### Overwrite Policy
+
+On dedupe hit, v1 may enrich missing local metadata fields if the incoming provider metadata is stronger and the local field is currently missing. It must not:
+
+- overwrite user-edited titles by default
+- replace local extracted text
+- create a new content version solely because provider metadata changed
+
+That boundary keeps v1 import-safe.
+
+## Background Live Sync
+
+The approved live-sync requirement should be implemented as scheduled polling first.
+
+Why polling first:
+
+- it matches the current scheduler and jobs model
+- it is provider-agnostic
+- it avoids making v1 dependent on webhook parity across scholarly providers
+
+Future push or streaming provider features can be layered in later where they exist, but they should feed the same source sync job path instead of creating a second execution model.
+
+## UX and Control Plane
+
+### User-Facing Shape
+
+Present the feature as a linked-library workflow inside the existing connectors and workspace surfaces, not as a one-off import wizard.
+
+The user flow should be:
+
+- connect provider
+- pick collections
+- enable background import
+- review sync status and imported items
+
+### Per-Source Status
+
+Each linked source should surface:
+
+- provider
+- collection name
+- last successful sync
+- last failed sync
+- imported count
+- skipped duplicate count
+- metadata-only or attachment-missing count
+- current state:
+  - idle
+  - queued
+  - running
+  - failed
+  - auth_expired
+
+### Failure Categories
+
+The first delivery should distinguish:
+
+- auth expired
+- rate limited
+- collection unavailable
+- item metadata incomplete
+- attachment missing
+- duplicate skipped
+- import failed
+
+These are operationally and user-meaningfully different. The UI should not collapse them into a single generic failure string.
+
+## Error Handling
+
+### Principles
+
+- keep sync jobs idempotent
+- never delete local content during v1 sync
+- preserve partial progress where possible
+- record item-level outcomes for observability
+
+### Item-Level Failures
+
+If one item fails, the job should continue unless the provider session is irrecoverable. Common per-item failures include:
+
+- malformed provider payload
+- unsupported attachment type
+- attachment download failure
+- metadata normalization failure
+- ingest failure
+
+Each failure should be recorded against the item result rather than aborting the whole collection sync immediately.
+
+### Source-Level Failures
+
+Source-level failures include:
+
+- revoked or expired OAuth credentials
+- provider API outage
+- invalid collection id
+- unrecoverable cursor corruption
+
+These should mark the source status clearly and halt further incremental advancement until the error is resolved.
+
+## Testing Strategy
+
+### Unit Tests
+
+- metadata normalization from raw provider payloads into normalized scholarly metadata
+- dedupe ranking and tie-breaking
+- source option validation
+- import-mode overwrite guards
+
+### Integration Tests
+
+- OAuth account linking and source creation through the connector API
+- scheduler enqueue of reference-manager sync jobs
+- worker execution for collection sync
+- cursor persistence and incremental replay behavior
+- duplicate handling across overlapping linked collections
+- metadata enrichment of missing local fields without destructive overwrite
+
+### Provider-Contract Tests
+
+Define provider-agnostic contract fixtures so each provider proves:
+
+- collection listing works
+- item normalization returns required fields
+- attachment resolution behavior is explicit
+- pagination or cursor advancement is correct
+
+The first provider should be Zotero, but the tests should be written against the generic contract from day one so Mendeley support does not require a design reset.
+
+## Rollout Strategy
+
+### Phase 1
+
+- add `ReferenceManagerAdapter`
+- add source options and storage for collection-linked sources
+- implement Zotero provider
+- implement scheduled import-mode sync
+- implement dedupe and normalized metadata persistence
+- surface basic linked-source status
+
+### Phase 2
+
+- add Mendeley provider against the same contract
+- improve observability and source diagnostics
+- add workspace affordances for imported scholarly metadata
+
+### Future Phases, Not V1
+
+- metadata write-back
+- annotation import and mapping
+- mirror-mode sync
+- provider push notifications where they offer real value
+
+## Risks and Mitigations
+
+### Risk: Generic abstraction becomes over-engineered before the first provider ships
+
+Mitigation:
+
+- keep the adapter contract small
+- build only the methods needed for collection-linked import mode
+- let Zotero drive the first real shape of the abstraction
+
+### Risk: Dedupe false positives merge distinct papers
+
+Mitigation:
+
+- use conservative fallback matching
+- prioritize DOI and provider item identity
+- store dedupe match reason
+- prefer duplicate leakage over destructive merge
+
+### Risk: Metadata-only items confuse users
+
+Mitigation:
+
+- record and surface attachment-missing outcomes explicitly
+- do not silently present metadata-only references as successful content imports
+
+### Risk: Mendeley parity diverges from Zotero assumptions
+
+Mitigation:
+
+- define provider-contract tests
+- keep provider-specific fields inside normalized item conversion
+- avoid embedding Zotero-specific collection or attachment assumptions into shared storage
+
+## Decision Summary
+
+The correct v1 is a generic reference-manager connector family built on the existing connector control plane and job model, with these fixed boundaries:
+
+- import mode only
+- collection-linked sources
+- polling-based live sync first
+- strict metadata normalization
+- strict-first dedupe
+- no upstream destructive replay
+- no annotation sync
+- no write-back
+
+That slice is large enough to deliver meaningful user value and small enough to plan and implement without turning into a full scholarly-library platform rewrite.

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -164,13 +164,13 @@ def _as_str_or_none(value: Any) -> str | None:
 
 
 def _derive_sync_state(sync_state: dict[str, Any] | None, active_job: dict[str, Any] | None) -> str:
-    if sync_state and sync_state.get("needs_full_rescan"):
-        return "needs_full_rescan"
     status = str((active_job or {}).get("status") or "").strip().lower()
     if status == "processing":
         return "running"
     if status == "queued":
         return "queued"
+    if sync_state and sync_state.get("needs_full_rescan"):
+        return "needs_full_rescan"
     if sync_state and sync_state.get("last_sync_failed_at"):
         return "failed"
     if sync_state and sync_state.get("last_sync_succeeded_at"):

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -5,7 +5,7 @@ import json
 import os
 import secrets
 from typing import Any, Callable
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -164,13 +164,13 @@ def _as_str_or_none(value: Any) -> str | None:
 
 
 def _derive_sync_state(sync_state: dict[str, Any] | None, active_job: dict[str, Any] | None) -> str:
+    if sync_state and sync_state.get("needs_full_rescan"):
+        return "needs_full_rescan"
     status = str((active_job or {}).get("status") or "").strip().lower()
     if status == "processing":
         return "running"
     if status == "queued":
         return "queued"
-    if sync_state and sync_state.get("needs_full_rescan"):
-        return "needs_full_rescan"
     if sync_state and sync_state.get("last_sync_failed_at"):
         return "failed"
     if sync_state and sync_state.get("last_sync_succeeded_at"):
@@ -227,6 +227,8 @@ def _build_source_sync_summary(
         active_job_id=str(sync_state.get("active_job_id") or "").strip() or None,
         tracked_item_count=int(binding_health.get("tracked_item_count") or 0),
         degraded_item_count=int(binding_health.get("degraded_item_count") or 0),
+        duplicate_count=int(binding_health.get("duplicate_count") or 0),
+        metadata_only_count=int(binding_health.get("metadata_only_count") or 0),
     )
 
 
@@ -339,11 +341,33 @@ def _manual_sync_job_type(source: dict[str, Any], sync_state: dict[str, Any] | N
 
 def _ensure_connector_provider_enabled(provider: str) -> str:
     normalized = str(provider or "").strip().lower()
-    if normalized not in {"drive", "notion", "gmail", "onedrive"}:
+    if normalized not in {"drive", "notion", "gmail", "onedrive", "zotero"}:
         raise HTTPException(status_code=404, detail=f"Unknown connector provider: {provider}")
     if normalized == "gmail" and not _gmail_connector_enabled():
         raise HTTPException(status_code=404, detail="Connector provider 'gmail' is disabled.")
     return normalized
+
+
+def _option_enabled(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return False
+
+
+def _normalize_source_options_for_provider(provider: str, options: dict[str, Any] | None) -> dict[str, Any]:
+    normalized_options = dict(options or {})
+    if provider == "zotero":
+        if _option_enabled(normalized_options.get("recursive")):
+            raise HTTPException(
+                status_code=422,
+                detail="Zotero collection sync is flat in v1; link child collections separately.",
+            )
+        normalized_options["recursive"] = False
+    return normalized_options
 
 
 @router.get("/providers", response_model=list[ConnectorProvider])
@@ -352,6 +376,7 @@ async def list_providers() -> list[ConnectorProvider]:
         ConnectorProvider(name="drive", scopes_required=["drive.readonly"], auth_type="oauth2"),
         ConnectorProvider(name="onedrive", scopes_required=["Files.Read"], auth_type="oauth2"),
         ConnectorProvider(name="notion", scopes_required=[], auth_type="oauth2"),
+        ConnectorProvider(name="zotero", scopes_required=["library_access=1", "write_access=0", "notes_access=0"], auth_type="oauth1"),
     ]
     if _gmail_connector_enabled():
         providers.append(
@@ -380,8 +405,22 @@ async def start_authorize(
         conn.redirect_base = redirect_base
     state = state or secrets.token_urlsafe(32)
     user_id = _get_user_id(principal)
-    await create_oauth_state(db, user_id, provider, state)
     scopes_list = [s for s in (scopes or "").split(",") if s]
+    oauth_state_metadata: dict[str, Any] | None = None
+    if provider == "zotero":
+        callback_params = urlencode({"state": state})
+        callback_url = f"{redirect_base}/api/v1/connectors/providers/{provider}/callback?{callback_params}" if redirect_base else ""
+        temporary_credentials = await conn.request_temporary_credential(callback_url)
+        oauth_token = str((temporary_credentials or {}).get("oauth_token") or "").strip()
+        oauth_token_secret = str((temporary_credentials or {}).get("oauth_token_secret") or "").strip()
+        if not oauth_token or not oauth_token_secret:
+            raise HTTPException(status_code=502, detail="Zotero authorization handshake failed.")
+        oauth_state_metadata = {
+            "oauth_token": oauth_token,
+            "oauth_token_secret": oauth_token_secret,
+        }
+        scopes_list = [*scopes_list, f"oauth_token={oauth_token}"]
+    await create_oauth_state(db, user_id, provider, state, metadata=oauth_state_metadata)
     url = conn.authorize_url(state=state, scopes=scopes_list or None, redirect_path=f"/api/v1/connectors/providers/{provider}/callback")
     return AuthorizeURLResponse(auth_url=url, state=state)
 
@@ -389,8 +428,10 @@ async def start_authorize(
 @router.get("/providers/{provider}/callback", response_model=ConnectorAccount)
 async def oauth_callback(
     provider: str,
-    code: str,
     request: Request,
+    code: str | None = None,
+    oauth_token: str | None = None,
+    oauth_verifier: str | None = None,
     state: str | None = None,
     db=Depends(get_db_transaction),
     principal: AuthPrincipal = Depends(get_auth_principal),
@@ -428,14 +469,14 @@ async def oauth_callback(
             default_ttl_minutes,
         )
         ttl_minutes = default_ttl_minutes
-    ok_state = await consume_oauth_state(
+    oauth_state = await consume_oauth_state(
         db,
         user_id=user_id,
         provider=provider,
         state=state,
         max_age_minutes=ttl_minutes,
     )
-    if not ok_state:
+    if not oauth_state:
         raise HTTPException(status_code=403, detail="Invalid or expired OAuth state")
 
     # Enforce org-level account linking role based on org policy; single-user
@@ -458,6 +499,26 @@ async def oauth_callback(
     # Exchange code with redirect derived from env base + this path
     base = _resolve_redirect_base(request, conn)
     redirect_uri = f"{base.rstrip('/')}/api/v1/connectors/providers/{provider}/callback" if base else ""
+    if provider == "zotero":
+        state_metadata = oauth_state if isinstance(oauth_state, dict) else {}
+        stored_oauth_token = str(state_metadata.get("oauth_token") or "").strip()
+        oauth_token_secret = str(state_metadata.get("oauth_token_secret") or "").strip()
+        if not oauth_token or not oauth_verifier:
+            raise HTTPException(status_code=400, detail="Missing Zotero OAuth callback parameters")
+        if stored_oauth_token and stored_oauth_token != oauth_token:
+            raise HTTPException(status_code=403, detail="Zotero OAuth callback token mismatch")
+        if not oauth_token_secret:
+            raise HTTPException(status_code=400, detail="Missing Zotero OAuth temporary credential")
+        code = json.dumps(
+            {
+                "oauth_token": oauth_token,
+                "oauth_token_secret": oauth_token_secret,
+                "oauth_verifier": oauth_verifier,
+            },
+            sort_keys=True,
+        )
+    elif not code:
+        raise HTTPException(status_code=400, detail="Missing OAuth code")
     tokens = await conn.exchange_code(code, redirect_uri)
     # Optional email/workspace fetch for policy enforcement
     acct_email: str | None = None
@@ -555,19 +616,30 @@ async def browse_provider_sources(
     provider = _ensure_connector_provider_enabled(provider)
     user_id = _get_user_id(principal)
     tokens = await get_account_tokens(db, user_id, account_id)
+    acct = await get_account_for_user(db, user_id, account_id) or {}
     if not tokens:
         raise HTTPException(status_code=404, detail="Account not found")
+    acct_provider = str(acct.get("provider") or "").lower()
+    if acct_provider and acct_provider != provider:
+        raise HTTPException(status_code=400, detail="Account provider mismatch")
     email = await get_account_email(db, user_id, account_id)
     conn = get_connector_by_name(provider)
+    account_payload = {**acct, "tokens": tokens, "email": email}
+    if provider == "zotero" and "provider_user_id" not in account_payload:
+        provider_user_id = str(tokens.get("provider_user_id") or tokens.get("userID") or tokens.get("user_id") or "").strip()
+        if provider_user_id:
+            account_payload["provider_user_id"] = provider_user_id
     # For Drive, parent_remote_id None implies root
     try:
         if provider == "drive":
-            items, next_cursor = await conn.list_files({"tokens": tokens, "email": email}, parent_remote_id or "root", page_size=page_size, cursor=cursor)
+            items, next_cursor = await conn.list_files(account_payload, parent_remote_id or "root", page_size=page_size, cursor=cursor)
         elif provider == "onedrive":
-            items, next_cursor = await conn.list_files({"tokens": tokens, "email": email}, parent_remote_id or "root", page_size=page_size, cursor=cursor)
+            items, next_cursor = await conn.list_files(account_payload, parent_remote_id or "root", page_size=page_size, cursor=cursor)
         elif provider == "notion":
             # Notion: treat parent_remote_id as workspace hint; we search globally for now
-            items, next_cursor = await conn.list_sources({"tokens": tokens, "email": email}, parent_remote_id=parent_remote_id, page_size=page_size, cursor=cursor)
+            items, next_cursor = await conn.list_sources(account_payload, parent_remote_id=parent_remote_id, page_size=page_size, cursor=cursor)
+        elif provider == "zotero":
+            items, next_cursor = await conn.list_collections(account_payload, cursor=cursor, page_size=page_size)
         else:
             items, next_cursor = [], None
     except Exception as e:
@@ -591,7 +663,7 @@ async def add_source(
     remote_id = str(payload.remote_id)
     type_ = str(payload.type)
     path = payload.path
-    options = payload.options or {}
+    options = _normalize_source_options_for_provider(provider, payload.options)
 
     user_id = _get_user_id(principal)
     acct = await get_account_for_user(db, user_id, account_id)
@@ -726,6 +798,12 @@ async def patch_source(
     enabled = payload.enabled
     options = payload.options
     user_id = _get_user_id(principal)
+    source = await get_source_by_id(db, user_id, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+    provider = str(source.get("provider") or "").strip().lower()
+    if options is not None:
+        options = _normalize_source_options_for_provider(provider, options)
     row = await update_source(db, user_id, source_id, enabled=enabled, options=options)
     if not row:
         raise HTTPException(status_code=404, detail="Source not found")
@@ -799,6 +877,8 @@ async def get_source_sync_status(
         active_job=_summarize_job(active_job),
         tracked_item_count=int(binding_health.get("tracked_item_count") or 0),
         degraded_item_count=int(binding_health.get("degraded_item_count") or 0),
+        duplicate_count=int(binding_health.get("duplicate_count") or 0),
+        metadata_only_count=int(binding_health.get("metadata_only_count") or 0),
     )
 
 

--- a/tldw_Server_API/app/api/v1/schemas/connectors.py
+++ b/tldw_Server_API/app/api/v1/schemas/connectors.py
@@ -2,18 +2,27 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+
+def _validate_connector_source_type(provider: str, type_: str) -> None:
+    normalized_provider = str(provider or "").strip().lower()
+    normalized_type = str(type_ or "").strip().lower()
+    if normalized_type == "collection" and normalized_provider != "zotero":
+        raise ValueError("Connector source type 'collection' is only supported for provider 'zotero'.")
+    if normalized_provider == "zotero" and normalized_type != "collection":
+        raise ValueError("Zotero sources must use type 'collection'.")
 
 
 class ConnectorProvider(BaseModel):
-    name: Literal["drive", "notion", "gmail", "onedrive"]
-    auth_type: Literal["oauth2", "token"] = "oauth2"
+    name: Literal["drive", "notion", "gmail", "onedrive", "zotero"]
+    auth_type: Literal["oauth1", "oauth2", "token"] = "oauth2"
     scopes_required: list[str] = Field(default_factory=list)
 
 
 class ConnectorAccount(BaseModel):
     id: int
-    provider: Literal["drive", "notion", "gmail", "onedrive"]
+    provider: Literal["drive", "notion", "gmail", "onedrive", "zotero"]
     display_name: str
     created_at: str | None = None
     connected: bool = True
@@ -38,19 +47,26 @@ class ConnectorSourceSyncSummary(BaseModel):
     active_job_id: str | None = None
     tracked_item_count: int = 0
     degraded_item_count: int = 0
+    duplicate_count: int = 0
+    metadata_only_count: int = 0
 
 
 class ConnectorSource(BaseModel):
     id: int
     account_id: int
-    provider: Literal["drive", "notion", "gmail", "onedrive"]
+    provider: Literal["drive", "notion", "gmail", "onedrive", "zotero"]
     remote_id: str
-    type: Literal["folder", "file", "page", "database", "link"]
+    type: Literal["folder", "file", "page", "database", "link", "collection"]
     path: str | None = None
     options: SyncOptions = Field(default_factory=SyncOptions)
     enabled: bool = True
     last_synced_at: str | None = None
     sync: ConnectorSourceSyncSummary | None = None
+
+    @model_validator(mode="after")
+    def validate_provider_type_pairing(self) -> "ConnectorSource":
+        _validate_connector_source_type(self.provider, self.type)
+        return self
 
 
 class ImportJob(BaseModel):
@@ -75,7 +91,7 @@ class ConnectorSyncJobSummary(BaseModel):
 
 class ConnectorSourceSyncStatus(BaseModel):
     source_id: int
-    provider: Literal["drive", "notion", "gmail", "onedrive"]
+    provider: Literal["drive", "notion", "gmail", "onedrive", "zotero"]
     enabled: bool = True
     state: str = "idle"
     sync_mode: str = "manual"
@@ -95,17 +111,19 @@ class ConnectorSourceSyncStatus(BaseModel):
     active_job: ConnectorSyncJobSummary | None = None
     tracked_item_count: int = 0
     degraded_item_count: int = 0
+    duplicate_count: int = 0
+    metadata_only_count: int = 0
 
 
 class ConnectorSourceSyncTriggerResponse(BaseModel):
     source_id: int
-    provider: Literal["drive", "notion", "gmail", "onedrive"]
+    provider: Literal["drive", "notion", "gmail", "onedrive", "zotero"]
     status: Literal["queued"] = "queued"
     job: ImportJob
 
 
 class ConnectorWebhookCallbackResponse(BaseModel):
-    provider: Literal["drive", "onedrive"]
+    provider: Literal["drive", "onedrive", "zotero"]
     status: Literal["queued", "duplicate", "ignored"] = "ignored"
     queued_jobs: int = 0
     duplicate_notifications: int = 0
@@ -120,7 +138,9 @@ class AuthorizeURLResponse(BaseModel):
 
 class ConnectorPolicy(BaseModel):
     org_id: int
-    enabled_providers: list[Literal["drive", "notion", "gmail", "onedrive"]] = Field(default_factory=lambda: ["drive", "notion"])
+    enabled_providers: list[Literal["drive", "notion", "gmail", "onedrive", "zotero"]] = Field(
+        default_factory=lambda: ["drive", "notion", "zotero"]
+    )
     allowed_export_formats: list[Literal["md", "txt", "pdf"]] = Field(default_factory=lambda: ["md", "txt", "pdf"])
     allowed_file_types: list[str] = Field(default_factory=list, description="Extensions or MIME prefixes")
     max_file_size_mb: int = 500
@@ -140,11 +160,16 @@ class ConnectorSourceCreateRequest(BaseModel):
     model_config = {"extra": 'forbid'}
 
     account_id: int
-    provider: Literal["drive", "notion", "gmail", "onedrive"]
+    provider: Literal["drive", "notion", "gmail", "onedrive", "zotero"]
     remote_id: str
-    type: Literal["folder", "file", "page", "database", "link"]
+    type: Literal["folder", "file", "page", "database", "link", "collection"]
     path: str | None = None
     options: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_provider_type_pairing(self) -> "ConnectorSourceCreateRequest":
+        _validate_connector_source_type(self.provider, self.type)
+        return self
 
 
 class ConnectorSourcePatchRequest(BaseModel):

--- a/tldw_Server_API/app/core/External_Sources/README.md
+++ b/tldw_Server_API/app/core/External_Sources/README.md
@@ -6,6 +6,7 @@
 - Capabilities:
   - OAuth linking, account listing/removal
   - Browsing remote sources (Drive folders/files, OneDrive folders/files, Notion pages/databases, Gmail labels/messages)
+  - Reference-manager imports for Zotero collections in v1
   - Creating sources with per-org policy enforcement; queuing import jobs
   - Source-level sync cursors, webhook state, and legacy-import rescan markers
   - Canonical remote-to-media bindings and append-only item sync events
@@ -17,6 +18,7 @@
   - Manual sync status/trigger endpoints and webhook-triggered incremental sync
   - APScheduler bridge that enqueues renewal, replay, and incremental sync jobs
   - Org policy admin: allowed providers, paths, domains, quotas
+  - Sync status summaries that surface duplicate and metadata-only reference-manager counts
 - Inputs/Outputs:
   - Inputs: OAuth code/state, provider selection, source path/IDs, policy documents
   - Outputs: accounts, sources, sync status, import/sync job descriptors; ingested content in Media DB v2
@@ -28,16 +30,29 @@
 - Related Schemas:
   - `tldw_Server_API/app/api/v1/schemas/connectors.py:1`
 
+### Reference-Manager Import Mode (v1)
+
+- Zotero is the only shipped reference-manager provider in v1.
+- Reference-manager sources are `collection` sources, not file trees.
+- Collection sync is flat in v1; child collections must be linked separately.
+- Import mode is one-way and non-destructive by default:
+  - newly discovered upstream items can create or bind local records
+  - later upstream edits do not rewrite local content or titles automatically
+  - upstream deletes do not remove local items automatically
+- Sync status surfaces `duplicate_count` and `metadata_only_count` so collection imports distinguish deduped records from metadata-only references.
+
 ## 2. Technical Details of Features
 
 - Architecture & Data Flow:
   - Provider connectors implement a small interface; file-hosting providers also implement the sync adapter contract (`list_changes`, `download_or_export`, webhook subscribe/renew/revoke)
+  - Reference-manager providers implement a separate collection/item/attachment adapter contract and keep bibliographic identity distinct from attachment identity
   - Service functions write connector account/source/binding state to AuthNZ DB tables via async pool
   - The shared sync coordinator reconciles remote change events into local `Media` and `DocumentVersions`
   - OAuth state is generated on authorize, stored in AuthNZ DB, and consumed once during callback
   - Endpoints enforce org-level policy in multi-user mode; single-user mode bypasses org checks
   - Webhook callbacks only validate, dedupe, and enqueue Jobs; they never perform ingestion inline
   - The recurring scheduler scans sources and enqueues `incremental_sync`, `subscription_renewal`, or `repair_rescan`
+  - Reference-manager imports write canonical scholarly `safe_metadata`, persist per-item bindings, and record metadata-only rows when no retrievable attachment exists
 - Key Classes/Functions:
   - Connectors service: `core/External_Sources/connectors_service.py` (DDL ensure, policy upsert/get, accounts/sources CRUD)
   - Shared reconciliation: `core/External_Sources/sync_coordinator.py`
@@ -49,6 +64,7 @@
   - External: Google Drive API, Microsoft Graph, Gmail API, Notion APIs; tokens stored via DB
 - Data Models & DB:
   - AuthNZ DB tables: `external_accounts`, `external_sources`, `external_items`, `external_source_sync_state`, `external_item_events`, `org_connector_policy`, `external_oauth_state` (SQLite/PG variants)
+  - Reference-manager bindings live in `external_reference_items`, which stores provider item identity, collection identity, dedupe reason, and raw reference metadata
   - `external_items` is the canonical remote binding row; legacy rows without `media_id` are marked for full rescan during migration
   - `external_source_sync_state` stores cursor, webhook, retry, and active-job fence state per source
   - File content versions remain in Media DB v2 `DocumentVersions`; connector tables do not duplicate content bodies
@@ -75,6 +91,7 @@
   - `External_Sources/` (provider adapters, policy), service helpers, endpoints under `/api/v1/endpoints/connectors.py`
 - Extension Points:
   - Add a provider module and wire into `get_connector_by_name`; implement browse, list, token exchange, and sync adapter methods as needed
+  - New scholarly/reference-manager providers should implement the reference-manager adapter contract instead of the file-sync contract unless they truly expose file-style deltas
 - Coding Patterns:
   - Async DB via pool; structured logs; keep endpoints thin (service owns DDL and logic)
   - File-hosting providers should keep provider-specific delta/webhook details inside the adapter and let the coordinator own reconciliation semantics
@@ -82,8 +99,14 @@
   - `tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py:1`
   - `tldw_Server_API/tests/External_Sources/test_token_refresh_envelope.py:1`
   - `tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py:1`
+  - `tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py:1`
+  - `tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py:1`
+  - `tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py:1`
+  - `tldw_Server_API/tests/External_Sources/test_zotero_connector.py:1`
   - `tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py:1`
+  - `tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py:1`
   - `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py:1`
+  - `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py:1`
 - Local Dev Tips:
   - Use TEST_MODE and mock provider modules in tests; set callback base URL via env for manual flows
 - Pitfalls & Gotchas:

--- a/tldw_Server_API/app/core/External_Sources/__init__.py
+++ b/tldw_Server_API/app/core/External_Sources/__init__.py
@@ -5,7 +5,15 @@ from .google_drive import GoogleDriveConnector
 from .notion import NotionConnector
 from .onedrive import OneDriveConnector
 from .policy import evaluate_policy_constraints, get_default_policy_from_env
+from .reference_manager_dedupe import ReferenceItemMatch, build_metadata_fingerprint, rank_reference_item_match
 from .sync_adapter import FileSyncAdapter, FileSyncChange, FileSyncWebhookSubscription
+from .reference_manager_adapter import ReferenceManagerAdapter
+from .reference_manager_types import (
+    NormalizedReferenceCollection,
+    NormalizedReferenceItem,
+    ReferenceAttachmentCandidate,
+)
+from .zotero import ZoteroConnector
 
 __all__ = [
     "BaseConnector",
@@ -14,9 +22,17 @@ __all__ = [
     "FileSyncWebhookSubscription",
     "GmailConnector",
     "GoogleDriveConnector",
+    "NormalizedReferenceCollection",
+    "NormalizedReferenceItem",
     "NotionConnector",
     "OneDriveConnector",
+    "ReferenceItemMatch",
+    "ReferenceAttachmentCandidate",
+    "ReferenceManagerAdapter",
+    "ZoteroConnector",
+    "build_metadata_fingerprint",
     "get_default_policy_from_env",
     "evaluate_policy_constraints",
     "get_connector_by_name",
+    "rank_reference_item_match",
 ]

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.core.External_Sources.google_drive import GoogleDriveCo
 from tldw_Server_API.app.core.External_Sources.notion import NotionConnector
 from tldw_Server_API.app.core.External_Sources.onedrive import OneDriveConnector
 from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncAdapter
+from tldw_Server_API.app.core.External_Sources.zotero import ZoteroConnector
 
 _CONNECTORS_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -34,6 +35,7 @@ _CONNECTORS_NONCRITICAL_EXCEPTIONS = (
 )
 
 FILE_SYNC_PROVIDERS = frozenset({"drive", "onedrive"})
+REFERENCE_MANAGER_PROVIDERS = frozenset({"zotero"})
 _SYNC_STATE_FIELDS = (
     "sync_mode",
     "cursor",
@@ -51,6 +53,16 @@ _SYNC_STATE_FIELDS = (
     "needs_full_rescan",
     "active_job_id",
     "active_job_started_at",
+)
+_REFERENCE_ITEM_BINDING_FIELDS = (
+    "provider_library_id",
+    "collection_key",
+    "collection_name",
+    "provider_version",
+    "provider_updated_at",
+    "media_id",
+    "dedupe_match_reason",
+    "raw_reference_metadata",
 )
 _EXTERNAL_ITEM_BINDING_FIELDS = (
     "name",
@@ -71,7 +83,6 @@ _EXTERNAL_ITEM_BINDING_FIELDS = (
     "access_revoked_at",
     "provider_metadata",
 )
-
 
 def _utc_now_text() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
@@ -116,6 +127,27 @@ def _json_loads(value: Any, default: Any) -> Any:
         return default
 
 
+def _provider_metadata_from_tokens(tokens: dict[str, Any] | None) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for key, value in dict(tokens or {}).items():
+        if value in (None, ""):
+            continue
+        if key in {"access_token", "refresh_token", "token_type", "expires_in", "expires_at", "scope", "email"}:
+            continue
+        metadata[str(key)] = value
+    return metadata
+
+
+def _merge_provider_metadata(target: dict[str, Any], provider_metadata: Any) -> dict[str, Any]:
+    metadata = _json_loads(provider_metadata, {})
+    if not isinstance(metadata, dict):
+        return target
+    target["provider_metadata"] = metadata
+    for key, value in metadata.items():
+        target.setdefault(str(key), value)
+    return target
+
+
 def _normalize_sync_state_row(row: Any) -> dict[str, Any] | None:
     if not row:
         return None
@@ -133,6 +165,23 @@ def _normalize_external_item_row(row: Any) -> dict[str, Any] | None:
         data["provider_metadata"] = _json_loads(data.get("provider_metadata"), {})
     if "sync_status" not in data or data.get("sync_status") is None:
         data["sync_status"] = "active"
+    return data
+
+
+def _normalize_reference_item_row(row: Any) -> dict[str, Any] | None:
+    if not row:
+        return None
+    data = _row_to_dict(row)
+    if "raw_reference_metadata" in data:
+        data["raw_reference_metadata"] = _json_loads(data.get("raw_reference_metadata"), {})
+    return data
+
+
+def _normalize_oauth_state_row(row: Any) -> dict[str, Any] | None:
+    if not row:
+        return None
+    data = _row_to_dict(row)
+    _merge_provider_metadata(data, data.get("metadata"))
     return data
 
 
@@ -258,6 +307,8 @@ def get_connector_by_name(name: str):
         return NotionConnector()
     if n == "gmail":
         return GmailConnector()
+    if n == "zotero":
+        return ZoteroConnector()
     raise ValueError(f"Unknown connector provider: {name}")
 
 
@@ -288,6 +339,7 @@ async def _ensure_tables(db) -> None:
                     refresh_token TEXT,
                     token_expires_at TIMESTAMP NULL,
                     scopes TEXT,
+                    provider_metadata JSONB,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
@@ -328,6 +380,27 @@ async def _ensure_tables(db) -> None:
             )
             await db.execute(
                 """
+                CREATE TABLE IF NOT EXISTS external_reference_items (
+                    id SERIAL PRIMARY KEY,
+                    source_id INTEGER NOT NULL REFERENCES external_sources(id) ON DELETE CASCADE,
+                    provider TEXT NOT NULL,
+                    provider_item_key TEXT NOT NULL,
+                    provider_library_id TEXT,
+                    collection_key TEXT,
+                    collection_name TEXT,
+                    provider_version TEXT,
+                    provider_updated_at TIMESTAMP NULL,
+                    media_id INTEGER,
+                    dedupe_match_reason TEXT,
+                    raw_reference_metadata JSONB,
+                    first_imported_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    last_imported_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(source_id, provider, provider_item_key)
+                )
+                """
+            )
+            await db.execute(
+                """
                 CREATE TABLE IF NOT EXISTS org_connector_policy (
                     org_id INTEGER PRIMARY KEY,
                     enabled_providers TEXT,
@@ -351,11 +424,14 @@ async def _ensure_tables(db) -> None:
                     state TEXT NOT NULL,
                     user_id INTEGER NOT NULL,
                     provider TEXT NOT NULL,
+                    metadata JSONB,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY (state, user_id)
                 )
                 """
             )
+            await db.execute("ALTER TABLE external_accounts ADD COLUMN IF NOT EXISTS provider_metadata JSONB")
+            await db.execute("ALTER TABLE external_oauth_state ADD COLUMN IF NOT EXISTS metadata JSONB")
             await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS media_id INTEGER")
             await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS sync_status TEXT")
             await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS current_version_number INTEGER")
@@ -434,6 +510,7 @@ async def _ensure_tables(db) -> None:
                     refresh_token TEXT,
                     token_expires_at TEXT,
                     scopes TEXT,
+                    provider_metadata TEXT,
                     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                     updated_at TEXT DEFAULT CURRENT_TIMESTAMP
                 )
@@ -474,6 +551,27 @@ async def _ensure_tables(db) -> None:
             )
             await db.execute(
                 """
+                CREATE TABLE IF NOT EXISTS external_reference_items (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_id INTEGER NOT NULL,
+                    provider TEXT NOT NULL,
+                    provider_item_key TEXT NOT NULL,
+                    provider_library_id TEXT,
+                    collection_key TEXT,
+                    collection_name TEXT,
+                    provider_version TEXT,
+                    provider_updated_at TEXT,
+                    media_id INTEGER,
+                    dedupe_match_reason TEXT,
+                    raw_reference_metadata TEXT,
+                    first_imported_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    last_imported_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(source_id, provider, provider_item_key)
+                )
+                """,
+            )
+            await db.execute(
+                """
                 CREATE TABLE IF NOT EXISTS org_connector_policy (
                     org_id INTEGER PRIMARY KEY,
                     enabled_providers TEXT,
@@ -497,11 +595,14 @@ async def _ensure_tables(db) -> None:
                     state TEXT NOT NULL,
                     user_id INTEGER NOT NULL,
                     provider TEXT NOT NULL,
+                    metadata TEXT,
                     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY (state, user_id)
                 )
                 """,
             )
+            await _ensure_sqlite_column(db, "external_accounts", "provider_metadata", "provider_metadata TEXT")
+            await _ensure_sqlite_column(db, "external_oauth_state", "metadata", "metadata TEXT")
             await _ensure_sqlite_column(db, "external_items", "media_id", "media_id INTEGER")
             await _ensure_sqlite_column(db, "external_items", "sync_status", "sync_status TEXT")
             await _ensure_sqlite_column(db, "external_items", "current_version_number", "current_version_number INTEGER")
@@ -703,27 +804,35 @@ def _oauth_state_cutoff(max_age_minutes: int) -> tuple[datetime, str]:
     return cutoff_dt, cutoff_str
 
 
-async def create_oauth_state(db, user_id: int, provider: str, state: str) -> None:
+async def create_oauth_state(
+    db,
+    user_id: int,
+    provider: str,
+    state: str,
+    metadata: dict[str, Any] | None = None,
+) -> None:
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
+    metadata_value = metadata or None
     if is_pg:
         await db.execute(
             """
-            INSERT INTO external_oauth_state (state, user_id, provider, created_at)
-            VALUES ($1, $2, $3, CURRENT_TIMESTAMP)
+            INSERT INTO external_oauth_state (state, user_id, provider, metadata, created_at)
+            VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)
             ON CONFLICT (state, user_id) DO UPDATE SET
                 provider = EXCLUDED.provider,
+                metadata = EXCLUDED.metadata,
                 created_at = CURRENT_TIMESTAMP
             """,
-            state, user_id, provider,
+            state, user_id, provider, metadata_value,
         )
         return
     await db.execute(
         """
-        INSERT OR REPLACE INTO external_oauth_state (state, user_id, provider, created_at)
-        VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+        INSERT OR REPLACE INTO external_oauth_state (state, user_id, provider, metadata, created_at)
+        VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
         """,
-        (state, user_id, provider),
+        (state, user_id, provider, json.dumps(metadata_value) if metadata_value is not None else None),
     )
     await getattr(db, "commit", lambda: None)()
 
@@ -735,14 +844,14 @@ async def consume_oauth_state(
     provider: str,
     state: str,
     max_age_minutes: int = 10,
-) -> bool:
+) -> dict[str, Any] | bool:
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
     cutoff_dt, cutoff_str = _oauth_state_cutoff(max_age_minutes)
     if is_pg:
         row = await db.fetchrow(
             """
-            SELECT state FROM external_oauth_state
+            SELECT state, provider, metadata, created_at FROM external_oauth_state
             WHERE state = $1 AND user_id = $2 AND provider = $3 AND created_at >= $4
             """,
             state, user_id, provider, cutoff_dt,
@@ -753,10 +862,10 @@ async def consume_oauth_state(
             "DELETE FROM external_oauth_state WHERE state = $1 AND user_id = $2",
             state, user_id,
         )
-        return True
+        return _normalize_oauth_state_row(row) or True
     cur = await db.execute(
         """
-        SELECT state FROM external_oauth_state
+        SELECT state, provider, metadata, created_at FROM external_oauth_state
         WHERE state = ? AND user_id = ? AND provider = ? AND created_at >= ?
         """,
         (state, user_id, provider, cutoff_str),
@@ -769,24 +878,18 @@ async def consume_oauth_state(
         (state, user_id),
     )
     await getattr(db, "commit", lambda: None)()
-    return True
+    return _normalize_oauth_state_row(row) or True
 
 
 async def create_account(db, user_id: int, provider: str, display_name: str, email: str | None, tokens: dict[str, Any]) -> dict[str, Any]:
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
+    provider_metadata = _provider_metadata_from_tokens(tokens)
     # Securely envelope tokens if crypto is configured; fallback to storing access token raw
     import json as _json
     try:
         from tldw_Server_API.app.core.Security.crypto import encrypt_json_blob
-        env = encrypt_json_blob({
-            "access_token": tokens.get("access_token"),
-            "refresh_token": tokens.get("refresh_token"),
-            "token_type": tokens.get("token_type"),
-            "expires_in": tokens.get("expires_in"),
-            "expires_at": tokens.get("expires_at"),
-            "scope": tokens.get("scope"),
-        })
+        env = encrypt_json_blob(dict(tokens or {}))
         access_token_store = _json.dumps(env) if env else str(tokens.get("access_token") or "")
         refresh_token_store = None  # envelope contains refresh
         tokens.get("scope") or None
@@ -798,19 +901,20 @@ async def create_account(db, user_id: int, provider: str, display_name: str, ema
     if is_pg:
         row = await db.fetchrow(
             """
-            INSERT INTO external_accounts (user_id, provider, display_name, email, access_token, refresh_token, token_expires_at, scopes)
-            VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL)
+            INSERT INTO external_accounts (user_id, provider, display_name, email, access_token, refresh_token, token_expires_at, scopes, provider_metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, $7)
             RETURNING id, user_id, provider, display_name, email, created_at
             """,
-            user_id, provider, display_name, email, access_token_store, refresh_token_store
+            user_id, provider, display_name, email, access_token_store, refresh_token_store, provider_metadata or None
         )
         return dict(row)
+    sqlite_provider_metadata = _json.dumps(provider_metadata) if provider_metadata else None
     cur = await db.execute(
         """
-        INSERT INTO external_accounts (user_id, provider, display_name, email, access_token, refresh_token, token_expires_at, scopes)
-        VALUES (?, ?, ?, ?, ?, ?, NULL, NULL)
+        INSERT INTO external_accounts (user_id, provider, display_name, email, access_token, refresh_token, token_expires_at, scopes, provider_metadata)
+        VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?)
         """,
-        (user_id, provider, display_name, email, access_token_store, refresh_token_store),
+        (user_id, provider, display_name, email, access_token_store, refresh_token_store, sqlite_provider_metadata),
     )
     await getattr(db, "commit", lambda: None)()
     rid = cur.lastrowid
@@ -826,17 +930,17 @@ async def _get_account_with_tokens(db, user_id: int, account_id: int) -> dict[st
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
     if is_pg:
-        row = await db.fetchrow("SELECT id, user_id, provider, display_name, email, access_token, refresh_token FROM external_accounts WHERE id = $1 AND user_id = $2", account_id, user_id)
+        row = await db.fetchrow("SELECT id, user_id, provider, display_name, email, access_token, refresh_token, provider_metadata FROM external_accounts WHERE id = $1 AND user_id = $2", account_id, user_id)
         if not row:
             return None
         d = dict(row)
     else:
-        cur = await db.execute("SELECT id, user_id, provider, display_name, email, access_token, refresh_token FROM external_accounts WHERE id = ? AND user_id = ?", (account_id, user_id))
+        cur = await db.execute("SELECT id, user_id, provider, display_name, email, access_token, refresh_token, provider_metadata FROM external_accounts WHERE id = ? AND user_id = ?", (account_id, user_id))
         r = await cur.fetchone()
         if not r:
             return None
         try:
-            d = {"id": r[0], "user_id": r[1], "provider": r[2], "display_name": r[3], "email": r[4], "access_token": r[5], "refresh_token": r[6]}
+            d = {"id": r[0], "user_id": r[1], "provider": r[2], "display_name": r[3], "email": r[4], "access_token": r[5], "refresh_token": r[6], "provider_metadata": r[7]}
         except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
             d = dict(r)
     # Decrypt envelope if present
@@ -855,6 +959,10 @@ async def _get_account_with_tokens(db, user_id: int, account_id: int) -> dict[st
         tokens["access_token"] = at_raw
     if not tokens.get("refresh_token") and d.get("refresh_token"):
         tokens["refresh_token"] = d.get("refresh_token")
+    _merge_provider_metadata(d, d.get("provider_metadata"))
+    if isinstance(d.get("provider_metadata"), dict):
+        for key, value in d["provider_metadata"].items():
+            tokens.setdefault(str(key), value)
     d["tokens"] = tokens
     return d
 
@@ -877,16 +985,19 @@ async def get_account_for_user(db, user_id: int, account_id: int) -> dict[str, A
     if is_pg:
         row = await db.fetchrow(
             """
-            SELECT id, user_id, provider, display_name, email, created_at
+            SELECT id, user_id, provider, display_name, email, created_at, provider_metadata
             FROM external_accounts
             WHERE id = $1 AND user_id = $2
             """,
             account_id, user_id,
         )
-        return dict(row) if row else None
+        if not row:
+            return None
+        data = dict(row)
+        return _merge_provider_metadata(data, data.get("provider_metadata"))
     cur = await db.execute(
         """
-        SELECT id, user_id, provider, display_name, email, created_at
+        SELECT id, user_id, provider, display_name, email, created_at, provider_metadata
         FROM external_accounts
         WHERE id = ? AND user_id = ?
         """,
@@ -896,16 +1007,18 @@ async def get_account_for_user(db, user_id: int, account_id: int) -> dict[str, A
     if not r:
         return None
     try:
-        return {
+        data = {
             "id": r[0],
             "user_id": r[1],
             "provider": r[2],
             "display_name": r[3],
             "email": r[4],
             "created_at": r[5],
+            "provider_metadata": r[6],
         }
     except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
-        return dict(r)
+        data = dict(r)
+    return _merge_provider_metadata(data, data.get("provider_metadata"))
 
 
 async def update_account_tokens(db, user_id: int, account_id: int, new_tokens: dict[str, Any]) -> bool:
@@ -917,23 +1030,21 @@ async def update_account_tokens(db, user_id: int, account_id: int, new_tokens: d
     is_pg = _is_postgres_connection(db)
     import json as _json
     existing_refresh: str | None = None
+    existing = await _get_account_with_tokens(db, user_id, account_id)
+    if not existing:
+        return False
+    existing_provider_metadata = dict(existing.get("provider_metadata") or {})
     if not new_tokens.get("refresh_token"):
-        existing = await _get_account_with_tokens(db, user_id, account_id)
-        if not existing:
-            return False
         existing_refresh = (existing.get("tokens") or {}).get("refresh_token")
+    provider_metadata_value = existing_provider_metadata | _provider_metadata_from_tokens(new_tokens)
     refresh_token_value = new_tokens.get("refresh_token") or existing_refresh
     # Build storage values similar to create_account
     try:
         from tldw_Server_API.app.core.Security.crypto import encrypt_json_blob
-        env = encrypt_json_blob({
-            "access_token": new_tokens.get("access_token"),
-            "refresh_token": refresh_token_value,
-            "token_type": new_tokens.get("token_type"),
-            "expires_in": new_tokens.get("expires_in"),
-            "expires_at": new_tokens.get("expires_at"),
-            "scope": new_tokens.get("scope"),
-        })
+        envelope_payload = dict(existing.get("tokens") or {})
+        envelope_payload.update(dict(new_tokens or {}))
+        envelope_payload["refresh_token"] = refresh_token_value
+        env = encrypt_json_blob(envelope_payload)
         access_token_store = _json.dumps(env) if env else str(new_tokens.get("access_token") or "")
         refresh_token_store = None
         scopes_store = new_tokens.get("scope") or None
@@ -953,19 +1064,21 @@ async def update_account_tokens(db, user_id: int, account_id: int, new_tokens: d
             SET access_token = $1,
                 refresh_token = COALESCE($2, refresh_token),
                 updated_at = CURRENT_TIMESTAMP,
-                scopes = COALESCE($3, scopes)
-            WHERE id = $4
+                scopes = COALESCE($3, scopes),
+                provider_metadata = COALESCE($4, provider_metadata)
+            WHERE id = $5
             """,
-            access_token_store, refresh_token_store, scopes_store, account_id,
+            access_token_store, refresh_token_store, scopes_store, provider_metadata_value or None, account_id,
         )
         return True
     # SQLite path
+    sqlite_provider_metadata = _json.dumps(provider_metadata_value) if provider_metadata_value else None
     cur = await db.execute("SELECT id FROM external_accounts WHERE id = ? AND user_id = ?", (account_id, user_id))
     if not await cur.fetchone():
         return False
     await db.execute(
-        "UPDATE external_accounts SET access_token = ?, refresh_token = COALESCE(?, refresh_token), scopes = COALESCE(?, scopes), updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-        (access_token_store, refresh_token_store, scopes_store, account_id),
+        "UPDATE external_accounts SET access_token = ?, refresh_token = COALESCE(?, refresh_token), scopes = COALESCE(?, scopes), provider_metadata = COALESCE(?, provider_metadata), updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+        (access_token_store, refresh_token_store, scopes_store, sqlite_provider_metadata, account_id),
     )
     await getattr(db, "commit", lambda: None)()
     return True
@@ -1418,8 +1531,10 @@ async def finish_source_sync_job(
                 SET active_job_id = NULL,
                     active_job_started_at = NULL,
                     last_sync_succeeded_at = $1,
+                    last_sync_failed_at = NULL,
                     last_error = NULL,
-                    retry_backoff_count = 0
+                    retry_backoff_count = 0,
+                    needs_full_rescan = FALSE
                 WHERE source_id = $2
                   AND (active_job_id IS NULL OR active_job_id = $3)
                 RETURNING *
@@ -1435,8 +1550,10 @@ async def finish_source_sync_job(
             SET active_job_id = NULL,
                 active_job_started_at = NULL,
                 last_sync_succeeded_at = ?,
+                last_sync_failed_at = NULL,
                 last_error = NULL,
-                retry_backoff_count = 0
+                retry_backoff_count = 0,
+                needs_full_rescan = 0
             WHERE source_id = ?
               AND (active_job_id IS NULL OR active_job_id = ?)
             """,
@@ -1550,6 +1667,56 @@ async def get_external_item_binding(
     return _normalize_external_item_row(row)
 
 
+async def get_reference_item_binding(
+    db,
+    *,
+    source_id: int,
+    provider: str,
+    provider_item_key: str,
+) -> dict[str, Any] | None:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            SELECT *
+            FROM external_reference_items
+            WHERE source_id = $1 AND provider = $2 AND provider_item_key = $3
+            """,
+            source_id,
+            provider,
+            provider_item_key,
+        )
+        return _normalize_reference_item_row(row)
+    cur = await db.execute(
+        """
+        SELECT *
+        FROM external_reference_items
+        WHERE source_id = ? AND provider = ? AND provider_item_key = ?
+        """,
+        (source_id, provider, provider_item_key),
+    )
+    row = await cur.fetchone()
+    return _normalize_reference_item_row(row)
+
+
+async def list_reference_items_for_source(db, *, source_id: int) -> list[dict[str, Any]]:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        rows = await db.fetch(
+            "SELECT * FROM external_reference_items WHERE source_id = $1 ORDER BY id ASC",
+            source_id,
+        )
+        return [_normalize_reference_item_row(row) or {} for row in rows]
+    cur = await db.execute(
+        "SELECT * FROM external_reference_items WHERE source_id = ? ORDER BY id ASC",
+        (source_id,),
+    )
+    rows = await cur.fetchall()
+    return [_normalize_reference_item_row(row) or {} for row in rows]
+
+
 async def list_external_items_for_source(db, *, source_id: int) -> list[dict[str, Any]]:
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
@@ -1571,7 +1738,7 @@ async def get_source_binding_health(db, *, source_id: int) -> dict[str, int]:
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
     if is_pg:
-        row = await db.fetchrow(
+        external_items_row = await db.fetchrow(
             """
             SELECT
                 COUNT(*) AS tracked_item_count,
@@ -1582,10 +1749,26 @@ async def get_source_binding_health(db, *, source_id: int) -> dict[str, int]:
             """,
             source_id,
         )
-        data = _row_to_dict(row)
+        reference_items_row = await db.fetchrow(
+            """
+            SELECT
+                COUNT(*) AS tracked_item_count,
+                COALESCE(SUM(CASE WHEN media_id IS NOT NULL AND dedupe_match_reason IS NOT NULL THEN 1 ELSE 0 END), 0)
+                    AS duplicate_count,
+                COALESCE(SUM(CASE WHEN media_id IS NULL AND dedupe_match_reason IS NOT NULL THEN 1 ELSE 0 END), 0)
+                    AS metadata_only_count
+            FROM external_reference_items
+            WHERE source_id = $1
+            """,
+            source_id,
+        )
+        data = _row_to_dict(external_items_row)
+        reference_data = _row_to_dict(reference_items_row)
         return {
-            "tracked_item_count": int(data.get("tracked_item_count") or 0),
+            "tracked_item_count": int(data.get("tracked_item_count") or 0) + int(reference_data.get("tracked_item_count") or 0),
             "degraded_item_count": int(data.get("degraded_item_count") or 0),
+            "duplicate_count": int(reference_data.get("duplicate_count") or 0),
+            "metadata_only_count": int(reference_data.get("metadata_only_count") or 0),
         }
 
     cur = await db.execute(
@@ -1601,9 +1784,26 @@ async def get_source_binding_health(db, *, source_id: int) -> dict[str, int]:
     )
     row = await cur.fetchone()
     data = _row_to_dict(row)
+    cur = await db.execute(
+        """
+        SELECT
+            COUNT(*) AS tracked_item_count,
+            COALESCE(SUM(CASE WHEN media_id IS NOT NULL AND dedupe_match_reason IS NOT NULL THEN 1 ELSE 0 END), 0)
+                AS duplicate_count,
+            COALESCE(SUM(CASE WHEN media_id IS NULL AND dedupe_match_reason IS NOT NULL THEN 1 ELSE 0 END), 0)
+                AS metadata_only_count
+        FROM external_reference_items
+        WHERE source_id = ?
+        """,
+        (source_id,),
+    )
+    row = await cur.fetchone()
+    reference_data = _row_to_dict(row)
     return {
-        "tracked_item_count": int(data.get("tracked_item_count") or 0),
+        "tracked_item_count": int(data.get("tracked_item_count") or 0) + int(reference_data.get("tracked_item_count") or 0),
         "degraded_item_count": int(data.get("degraded_item_count") or 0),
+        "duplicate_count": int(reference_data.get("duplicate_count") or 0),
+        "metadata_only_count": int(reference_data.get("metadata_only_count") or 0),
     }
 
 
@@ -1788,6 +1988,178 @@ async def upsert_external_item_binding(
         provider=provider,
         external_id=external_id,
     ) or {}
+
+
+async def upsert_reference_item_binding(
+    db,
+    *,
+    source_id: int,
+    provider: str,
+    provider_item_key: str,
+    provider_library_id: str | None,
+    collection_key: str | None,
+    collection_name: str | None,
+    provider_version: str | None,
+    provider_updated_at: str | None,
+    media_id: int | None,
+    dedupe_match_reason: str | None,
+    raw_reference_metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    raw_reference_metadata_value = raw_reference_metadata or None
+    collection_name_value = str(collection_name) if collection_name is not None else None
+    if collection_name_value is None and isinstance(raw_reference_metadata_value, dict):
+        collection_name_raw = raw_reference_metadata_value.get("collection_name")
+        if collection_name_raw is not None:
+            collection_name_value = str(collection_name_raw)
+    sqlite_raw_reference_metadata = (
+        json.dumps(raw_reference_metadata_value) if raw_reference_metadata_value is not None else None
+    )
+
+    if is_pg:
+        await db.execute(
+            """
+            INSERT INTO external_reference_items (
+                source_id,
+                provider,
+                provider_item_key,
+                provider_library_id,
+                collection_key,
+                collection_name,
+                provider_version,
+                provider_updated_at,
+                media_id,
+                dedupe_match_reason,
+                raw_reference_metadata,
+                first_imported_at,
+                last_imported_at
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            ON CONFLICT (source_id, provider, provider_item_key) DO UPDATE SET
+                provider_library_id = COALESCE(EXCLUDED.provider_library_id, external_reference_items.provider_library_id),
+                collection_key = COALESCE(EXCLUDED.collection_key, external_reference_items.collection_key),
+                collection_name = COALESCE(EXCLUDED.collection_name, external_reference_items.collection_name),
+                provider_version = COALESCE(EXCLUDED.provider_version, external_reference_items.provider_version),
+                provider_updated_at = COALESCE(EXCLUDED.provider_updated_at, external_reference_items.provider_updated_at),
+                media_id = COALESCE(EXCLUDED.media_id, external_reference_items.media_id),
+                dedupe_match_reason = CASE
+                    WHEN EXCLUDED.media_id IS NOT NULL AND EXCLUDED.dedupe_match_reason IS NULL THEN NULL
+                    ELSE COALESCE(EXCLUDED.dedupe_match_reason, external_reference_items.dedupe_match_reason)
+                END,
+                raw_reference_metadata = COALESCE(EXCLUDED.raw_reference_metadata, external_reference_items.raw_reference_metadata),
+                last_imported_at = CURRENT_TIMESTAMP
+            """,
+            source_id,
+            provider,
+            provider_item_key,
+            provider_library_id,
+            collection_key,
+            collection_name_value,
+            provider_version,
+            provider_updated_at,
+            media_id,
+            dedupe_match_reason,
+            raw_reference_metadata_value,
+        )
+        row = await db.fetchrow(
+            """
+            SELECT *
+            FROM external_reference_items
+            WHERE source_id = $1 AND provider = $2 AND provider_item_key = $3
+            """,
+            source_id,
+            provider,
+            provider_item_key,
+        )
+        return _normalize_reference_item_row(row) or {}
+
+    await db.execute(
+        """
+        INSERT INTO external_reference_items (
+            source_id,
+            provider,
+            provider_item_key,
+            provider_library_id,
+            collection_key,
+            collection_name,
+            provider_version,
+            provider_updated_at,
+            media_id,
+            dedupe_match_reason,
+            raw_reference_metadata,
+            first_imported_at,
+            last_imported_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        ON CONFLICT(source_id, provider, provider_item_key) DO UPDATE SET
+            provider_library_id = COALESCE(excluded.provider_library_id, external_reference_items.provider_library_id),
+            collection_key = COALESCE(excluded.collection_key, external_reference_items.collection_key),
+            collection_name = COALESCE(excluded.collection_name, external_reference_items.collection_name),
+            provider_version = COALESCE(excluded.provider_version, external_reference_items.provider_version),
+            provider_updated_at = COALESCE(excluded.provider_updated_at, external_reference_items.provider_updated_at),
+            media_id = COALESCE(excluded.media_id, external_reference_items.media_id),
+            dedupe_match_reason = CASE
+                WHEN excluded.media_id IS NOT NULL AND excluded.dedupe_match_reason IS NULL THEN NULL
+                ELSE COALESCE(excluded.dedupe_match_reason, external_reference_items.dedupe_match_reason)
+            END,
+            raw_reference_metadata = COALESCE(excluded.raw_reference_metadata, external_reference_items.raw_reference_metadata),
+            last_imported_at = CURRENT_TIMESTAMP
+        """,
+        (
+            source_id,
+            provider,
+            provider_item_key,
+            provider_library_id,
+            collection_key,
+            collection_name_value,
+            provider_version,
+            provider_updated_at,
+            media_id,
+            dedupe_match_reason,
+            sqlite_raw_reference_metadata,
+        ),
+    )
+    await getattr(db, "commit", lambda: None)()
+    return await get_reference_item_binding(
+        db,
+        source_id=source_id,
+        provider=provider,
+        provider_item_key=provider_item_key,
+    ) or {}
+
+
+async def delete_reference_item_binding(
+    db,
+    *,
+    source_id: int,
+    provider: str,
+    provider_item_key: str,
+) -> bool:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            DELETE FROM external_reference_items
+            WHERE source_id = $1 AND provider = $2 AND provider_item_key = $3
+            RETURNING id
+            """,
+            source_id,
+            provider,
+            provider_item_key,
+        )
+        return bool(row)
+
+    cur = await db.execute(
+        """
+        DELETE FROM external_reference_items
+        WHERE source_id = ? AND provider = ? AND provider_item_key = ?
+        """,
+        (source_id, provider, provider_item_key),
+    )
+    await getattr(db, "commit", lambda: None)()
+    return int(getattr(cur, "rowcount", 0) or 0) > 0
 
 
 async def record_item_event(
@@ -2104,6 +2476,15 @@ async def create_source(
 ) -> dict[str, Any]:
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
+    normalized_provider = str(provider or "").strip().lower()
+    normalized_type = str(type_ or "").strip().lower()
+    normalized_options = dict(options or {})
+    if normalized_provider in REFERENCE_MANAGER_PROVIDERS:
+        if normalized_type != "collection":
+            raise ValueError("Reference-manager sources must use type 'collection'.")
+        normalized_options["recursive"] = False
+    elif normalized_type == "collection":
+        raise ValueError("Source type 'collection' is only supported for reference-manager providers.")
     if is_pg:
         row = await db.fetchrow(
             """
@@ -2111,7 +2492,7 @@ async def create_source(
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             RETURNING id, account_id, provider, remote_id, type, path, options, enabled, last_synced_at
             """,
-            account_id, provider, remote_id, type_, path, options, enabled,
+            account_id, provider, remote_id, type_, path, normalized_options, enabled,
         )
         d = dict(row)
         return d
@@ -2120,7 +2501,7 @@ async def create_source(
         INSERT INTO external_sources (account_id, provider, remote_id, type, path, options, enabled)
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (account_id, provider, remote_id, type_, path, __import__("json").dumps(options or {}), 1 if enabled else 0),
+        (account_id, provider, remote_id, type_, path, __import__("json").dumps(normalized_options), 1 if enabled else 0),
     )
     await getattr(db, "commit", lambda: None)()
     rid = cur.lastrowid
@@ -2327,7 +2708,7 @@ async def update_source(db, user_id: int, source_id: int, *, enabled: bool | Non
     # Ensure source belongs to user via join
     if is_pg:
         row = await db.fetchrow(
-            "SELECT s.id, s.account_id FROM external_sources s JOIN external_accounts a ON s.account_id = a.id WHERE s.id = $1 AND a.user_id = $2",
+            "SELECT s.id, s.account_id, s.provider FROM external_sources s JOIN external_accounts a ON s.account_id = a.id WHERE s.id = $1 AND a.user_id = $2",
             source_id, user_id,
         )
         if not row:
@@ -2338,8 +2719,11 @@ async def update_source(db, user_id: int, source_id: int, *, enabled: bool | Non
             sets.append(f"enabled = ${len(params) + 1}")
             params.append(enabled)
         if options is not None:
+            normalized_options = dict(options or {})
+            if str(row.get("provider") or "").strip().lower() in REFERENCE_MANAGER_PROVIDERS:
+                normalized_options["recursive"] = False
             sets.append(f"options = ${len(params) + 1}")
-            params.append(options)
+            params.append(normalized_options)
         if not sets:
             pass
         else:
@@ -2353,7 +2737,7 @@ async def update_source(db, user_id: int, source_id: int, *, enabled: bool | Non
         return dict(row2)
     cur = await db.execute(
         """
-        SELECT s.id, s.account_id
+        SELECT s.id, s.account_id, s.provider
         FROM external_sources s
         JOIN external_accounts a ON s.account_id = a.id
         WHERE s.id = ? AND a.user_id = ?
@@ -2369,8 +2753,12 @@ async def update_source(db, user_id: int, source_id: int, *, enabled: bool | Non
         sets.append("enabled = ?")
         params.append(1 if enabled else 0)
     if options is not None:
+        normalized_options = dict(options or {})
+        source_provider = str(r[2] or "").strip().lower()
+        if source_provider in REFERENCE_MANAGER_PROVIDERS:
+            normalized_options["recursive"] = False
         sets.append("options = ?")
-        params.append(__import__("json").dumps(options or {}))
+        params.append(__import__("json").dumps(normalized_options))
     if sets:
         params.extend([source_id])
         set_clause = ", ".join(sets)

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -177,10 +177,42 @@ def _normalize_reference_item_row(row: Any) -> dict[str, Any] | None:
     return data
 
 
+def _protect_oauth_state_metadata(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not metadata:
+        return None
+    try:
+        from tldw_Server_API.app.core.Security.crypto import encrypt_json_blob
+
+        envelope = encrypt_json_blob(dict(metadata))
+        if envelope:
+            return envelope
+    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
+        pass
+    return dict(metadata)
+
+
+def _unprotect_oauth_state_metadata(metadata: Any) -> dict[str, Any]:
+    parsed_metadata = _json_loads(metadata, {})
+    if not isinstance(parsed_metadata, dict):
+        return {}
+    if parsed_metadata.get("_enc") != "aesgcm:v1":
+        return parsed_metadata
+    try:
+        from tldw_Server_API.app.core.Security.crypto import decrypt_json_blob
+
+        decrypted = decrypt_json_blob(parsed_metadata)
+        if isinstance(decrypted, dict):
+            return decrypted
+    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
+        pass
+    return {}
+
+
 def _normalize_oauth_state_row(row: Any) -> dict[str, Any] | None:
     if not row:
         return None
     data = _row_to_dict(row)
+    data["metadata"] = _unprotect_oauth_state_metadata(data.get("metadata"))
     _merge_provider_metadata(data, data.get("metadata"))
     return data
 
@@ -813,7 +845,7 @@ async def create_oauth_state(
 ) -> None:
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
-    metadata_value = metadata or None
+    metadata_value = _protect_oauth_state_metadata(metadata)
     if is_pg:
         await db.execute(
             """

--- a/tldw_Server_API/app/core/External_Sources/policy.py
+++ b/tldw_Server_API/app/core/External_Sources/policy.py
@@ -19,9 +19,9 @@ def _gmail_connector_enabled_from_env() -> bool:
 def get_default_policy_from_env(org_id: int) -> dict[str, Any]:
     """Return a default org policy derived from environment variables."""
     default_providers = (
-        "drive,notion,gmail"
+        "drive,notion,gmail,zotero"
         if _gmail_connector_enabled_from_env()
-        else "drive,notion"
+        else "drive,notion,zotero"
     )
     return {
         "org_id": org_id,

--- a/tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py
+++ b/tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .reference_manager_types import (
+    NormalizedReferenceCollection,
+    NormalizedReferenceItem,
+    ReferenceAttachmentCandidate,
+)
+
+
+@runtime_checkable
+class ReferenceManagerAdapter(Protocol):
+    async def list_collections(
+        self,
+        account: dict[str, Any],
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ) -> tuple[list[NormalizedReferenceCollection], str | None]: ...
+
+    async def list_collection_items(
+        self,
+        account: dict[str, Any],
+        collection_key: str,
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ) -> tuple[list[NormalizedReferenceItem], str | None]: ...
+
+    async def list_item_attachments(
+        self,
+        account: dict[str, Any],
+        provider_item_key: str,
+    ) -> list[ReferenceAttachmentCandidate]: ...
+
+    async def resolve_attachment_download(
+        self,
+        account: dict[str, Any],
+        attachment: ReferenceAttachmentCandidate,
+    ) -> bytes: ...

--- a/tldw_Server_API/app/core/External_Sources/reference_manager_dedupe.py
+++ b/tldw_Server_API/app/core/External_Sources/reference_manager_dedupe.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_Server_API.app.core.Utils.Utils import normalize_title
+
+from .reference_manager_types import NormalizedReferenceItem
+
+
+@dataclass(slots=True)
+class ReferenceItemMatch:
+    reason: str | None
+    media_id: int | None
+    metadata_patch: dict[str, Any] | None = None
+
+
+def normalize_first_author(authors: str | None) -> str | None:
+    raw_authors = str(authors or "").strip()
+    if not raw_authors:
+        return None
+    normalized_authors = re.sub(r"\s+(and|&)\s+", ", ", raw_authors, flags=re.IGNORECASE)
+    normalized_authors = normalized_authors.replace(";", ",")
+    first_author = normalized_authors.split(",", 1)[0].strip()
+    if not first_author:
+        return None
+    normalized = normalize_title(first_author).lower()
+    return normalized or None
+
+
+def build_metadata_fingerprint(
+    *,
+    title: str | None,
+    authors: str | None,
+    year: str | None,
+) -> str | None:
+    normalized_title = normalize_title(str(title or "").strip()).lower()
+    first_author = normalize_first_author(authors)
+    normalized_year = str(year or "").strip()
+    if not normalized_title or not first_author or not normalized_year:
+        return None
+    return f"{normalized_title}|{first_author}|{normalized_year}"
+
+
+def _coerce_media_id(candidate: dict[str, Any] | None) -> int | None:
+    if not candidate:
+        return None
+    raw_media_id = candidate.get("media_id")
+    if raw_media_id is None:
+        return None
+    try:
+        return int(raw_media_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_metadata_patch(item: NormalizedReferenceItem) -> dict[str, Any] | None:
+    patch = {
+        "doi": item.doi,
+        "title": item.title,
+        "authors": item.authors,
+        "publication_date": item.publication_date,
+        "year": item.year,
+        "journal": item.journal,
+        "abstract": item.abstract,
+        "source_url": item.source_url,
+    }
+    normalized_patch = {key: value for key, value in patch.items() if value not in (None, "")}
+    return normalized_patch or None
+
+
+def rank_reference_item_match(
+    item: NormalizedReferenceItem,
+    *,
+    same_provider_item: dict[str, Any] | None,
+    doi_match: dict[str, Any] | None,
+    hash_match: dict[str, Any] | None,
+    metadata_match: dict[str, Any] | None,
+) -> ReferenceItemMatch:
+    for reason, candidate in (
+        ("same_provider_item", same_provider_item),
+        ("doi", doi_match),
+        ("file_hash", hash_match),
+        ("metadata_fingerprint", metadata_match),
+    ):
+        media_id = _coerce_media_id(candidate)
+        if media_id is not None:
+            return ReferenceItemMatch(
+                reason=reason,
+                media_id=media_id,
+                metadata_patch=_build_metadata_patch(item),
+            )
+    return ReferenceItemMatch(reason=None, media_id=None, metadata_patch=None)

--- a/tldw_Server_API/app/core/External_Sources/reference_manager_import.py
+++ b/tldw_Server_API/app/core/External_Sources/reference_manager_import.py
@@ -1,3 +1,5 @@
+"""Reference-manager import helpers for attachment ingestion and metadata sync."""
+
 from __future__ import annotations
 
 import hashlib
@@ -25,10 +27,10 @@ from tldw_Server_API.app.core.External_Sources.reference_manager_types import (
     ReferenceAttachmentCandidate,
 )
 from tldw_Server_API.app.core.Utils.metadata_utils import (
-    merge_missing_safe_metadata,
     normalize_safe_metadata,
     update_version_safe_metadata_in_transaction,
 )
+from tldw_Server_API.app.core.exceptions import ReferenceImportError
 
 _REFERENCE_CANONICAL_FIELDS = (
     "provider",
@@ -46,6 +48,13 @@ _REFERENCE_CANONICAL_FIELDS = (
     "journal",
     "abstract",
 )
+
+
+def _coerce_media_id(value: Any) -> int | None:
+    try:
+        return None if value is None else int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _canonical_reference_safe_metadata(item: NormalizedReferenceItem) -> dict[str, Any]:
@@ -101,6 +110,25 @@ def _build_binding_metadata(
     return metadata
 
 
+def _carry_forward_selected_attachment(
+    binding_metadata: dict[str, Any],
+    same_provider_item: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(same_provider_item, dict):
+        return binding_metadata
+    raw_reference_metadata = same_provider_item.get("raw_reference_metadata")
+    if not isinstance(raw_reference_metadata, dict):
+        return binding_metadata
+    selected_attachment = raw_reference_metadata.get("selected_attachment")
+    if not isinstance(selected_attachment, dict) or not selected_attachment:
+        return binding_metadata
+    preserved_attachment = dict(selected_attachment)
+    if isinstance(preserved_attachment.get("metadata"), dict):
+        preserved_attachment["metadata"] = dict(preserved_attachment["metadata"])
+    binding_metadata["selected_attachment"] = preserved_attachment
+    return binding_metadata
+
+
 def _select_best_attachment(
     attachments: list[ReferenceAttachmentCandidate],
 ) -> ReferenceAttachmentCandidate | None:
@@ -127,6 +155,41 @@ def _load_safe_metadata(raw_value: Any) -> dict[str, Any]:
     except (TypeError, ValueError):
         return {}
     return dict(parsed) if isinstance(parsed, dict) else {}
+
+
+def _normalize_existing_safe_metadata_for_merge(existing_safe_metadata: dict[str, Any]) -> dict[str, Any]:
+    candidate = dict(existing_safe_metadata or {})
+    invalid_key_groups = {
+        "Invalid DOI format": ("doi", "DOI"),
+        "Invalid PMID format": ("pmid", "PMID"),
+        "Invalid PMCID format": ("pmcid", "PMCID"),
+    }
+    while True:
+        try:
+            return normalize_safe_metadata(candidate)
+        except ValueError as exc:
+            error_text = str(exc)
+            matched_group = next(
+                (
+                    keys
+                    for prefix, keys in invalid_key_groups.items()
+                    if error_text.startswith(prefix)
+                ),
+                None,
+            )
+            if not matched_group:
+                raise
+            removed = False
+            for key in matched_group:
+                if key in candidate:
+                    candidate.pop(key, None)
+                    removed = True
+            if not removed:
+                raise
+            logger.warning(
+                "Ignoring malformed legacy safe-metadata identifier while merging reference metadata: {}",
+                exc,
+            )
 
 
 def _provider_version(item: NormalizedReferenceItem) -> str | None:
@@ -213,7 +276,9 @@ def _ingest_reference_attachment(
         overwrite=False,
     )
     if media_id is None:
-        raise ValueError(f"Reference import did not return a media ID for {item.provider_item_key}")  # noqa: TRY003
+        raise ReferenceImportError(
+            f"Reference import did not return a media ID for {item.provider_item_key}"
+        )
     return int(media_id)
 
 
@@ -227,11 +292,15 @@ def _merge_missing_reference_metadata(
     if not latest_version or latest_version.get("id") is None:
         return
     existing_safe_metadata = _load_safe_metadata(latest_version.get("safe_metadata"))
-    merged_safe_metadata = merge_missing_safe_metadata(
-        existing_safe_metadata,
-        incoming_safe_metadata,
-    )
-    if merged_safe_metadata == normalize_safe_metadata(existing_safe_metadata):
+    normalized_existing_safe_metadata = _normalize_existing_safe_metadata_for_merge(existing_safe_metadata)
+    normalized_incoming_safe_metadata = normalize_safe_metadata(dict(incoming_safe_metadata or {}))
+    merged_safe_metadata = dict(normalized_existing_safe_metadata)
+    for key, value in normalized_incoming_safe_metadata.items():
+        if value in (None, ""):
+            continue
+        if merged_safe_metadata.get(key) in (None, ""):
+            merged_safe_metadata[key] = value
+    if merged_safe_metadata == normalized_existing_safe_metadata:
         return
     with media_db.transaction() as connection:
         update_version_safe_metadata_in_transaction(
@@ -283,12 +352,13 @@ async def _resolve_reference_item_match(
     *,
     item: NormalizedReferenceItem,
     same_provider_item: dict[str, Any] | None,
+    doi_match: dict[str, Any] | None,
     content_hash: str | None,
 ) -> tuple[str | None, int | None]:
     match = rank_reference_item_match(
         item,
         same_provider_item=same_provider_item,
-        doi_match=_find_doi_match(media_db, item),
+        doi_match=doi_match,
         hash_match=_find_file_hash_match(media_db, content_hash),
         metadata_match=_find_metadata_fingerprint_match(media_db, item),
     )
@@ -306,6 +376,7 @@ async def sync_reference_manager_source(
     job_id: str,
     convert_bytes_to_text: Callable[[bytes, str, str], Awaitable[str]],
 ) -> dict[str, Any]:
+    """Import one collection page and keep the cursor stable on partial failures."""
     source_id = int(source["id"])
     provider = str(source.get("provider") or "")
     collection_key = str(source.get("remote_id") or "")
@@ -329,6 +400,81 @@ async def sync_reference_manager_source(
     for item in items or []:
         try:
             safe_metadata = _canonical_reference_safe_metadata(item)
+            async with connectors_pool.transaction() as db:
+                same_provider_item = await get_reference_item_binding(
+                    db,
+                    source_id=source_id,
+                    provider=provider,
+                    provider_item_key=item.provider_item_key,
+                )
+            same_provider_media_id = _coerce_media_id(
+                None if same_provider_item is None else same_provider_item.get("media_id")
+            )
+            if same_provider_media_id is not None:
+                binding_metadata = _carry_forward_selected_attachment(
+                    _build_binding_metadata(
+                        item,
+                        selected_attachment=None,
+                        safe_metadata=safe_metadata,
+                    ),
+                    same_provider_item,
+                )
+                _merge_missing_reference_metadata(
+                    media_db,
+                    media_id=same_provider_media_id,
+                    incoming_safe_metadata=safe_metadata,
+                )
+                async with connectors_pool.transaction() as db:
+                    await upsert_reference_item_binding(
+                        db,
+                        source_id=source_id,
+                        provider=provider,
+                        provider_item_key=item.provider_item_key,
+                        provider_library_id=item.provider_library_id,
+                        collection_key=item.collection_key,
+                        collection_name=item.collection_name,
+                        provider_version=_provider_version(item),
+                        provider_updated_at=None,
+                        media_id=same_provider_media_id,
+                        dedupe_match_reason="same_provider_item",
+                        raw_reference_metadata=binding_metadata,
+                    )
+                duplicates += 1
+                processed += 1
+                continue
+
+            doi_match = _find_doi_match(media_db, item)
+            doi_media_id = _coerce_media_id(None if doi_match is None else doi_match.get("media_id"))
+            if doi_media_id is not None:
+                binding_metadata = _build_binding_metadata(
+                    item,
+                    selected_attachment=None,
+                    safe_metadata=safe_metadata,
+                )
+                _merge_missing_reference_metadata(
+                    media_db,
+                    media_id=doi_media_id,
+                    incoming_safe_metadata=safe_metadata,
+                )
+                async with connectors_pool.transaction() as db:
+                    await upsert_reference_item_binding(
+                        db,
+                        source_id=source_id,
+                        provider=provider,
+                        provider_item_key=item.provider_item_key,
+                        provider_library_id=item.provider_library_id,
+                        collection_key=item.collection_key,
+                        collection_name=item.collection_name,
+                        provider_version=_provider_version(item),
+                        provider_updated_at=None,
+                        media_id=doi_media_id,
+                        dedupe_match_reason="doi",
+                        raw_reference_metadata=binding_metadata,
+                    )
+                duplicates += 1
+                processed += 1
+                continue
+
             attachments = await _load_item_attachments(connector, account, item)
             selected_attachment = _select_best_attachment(attachments)
             content_text = ""
@@ -352,18 +498,11 @@ async def sync_reference_manager_source(
                 if content_text:
                     content_hash = hashlib.sha256(content_text.encode("utf-8")).hexdigest()
 
-            async with connectors_pool.transaction() as db:
-                same_provider_item = await get_reference_item_binding(
-                    db,
-                    source_id=source_id,
-                    provider=provider,
-                    provider_item_key=item.provider_item_key,
-                )
-
             match_reason, matched_media_id = await _resolve_reference_item_match(
                 media_db,
                 item=item,
                 same_provider_item=same_provider_item,
+                doi_match=doi_match,
                 content_hash=content_hash,
             )
             binding_metadata = _build_binding_metadata(
@@ -451,7 +590,7 @@ async def sync_reference_manager_source(
                 exc,
             )
 
-    if page_cursor not in (None, ""):
+    if failed == 0 and page_cursor not in (None, ""):
         next_cursor = page_cursor
 
     return {

--- a/tldw_Server_API/app/core/External_Sources/reference_manager_import.py
+++ b/tldw_Server_API/app/core/External_Sources/reference_manager_import.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.media_db.api import (
+    get_document_version,
+    get_media_by_hash,
+    get_media_repository,
+)
+from tldw_Server_API.app.core.External_Sources.connectors_service import (
+    get_reference_item_binding,
+    upsert_reference_item_binding,
+)
+from tldw_Server_API.app.core.External_Sources.reference_manager_dedupe import (
+    build_metadata_fingerprint,
+    rank_reference_item_match,
+)
+from tldw_Server_API.app.core.External_Sources.reference_manager_types import (
+    NormalizedReferenceItem,
+    ReferenceAttachmentCandidate,
+)
+from tldw_Server_API.app.core.Utils.metadata_utils import (
+    merge_missing_safe_metadata,
+    normalize_safe_metadata,
+    update_version_safe_metadata_in_transaction,
+)
+
+_REFERENCE_CANONICAL_FIELDS = (
+    "provider",
+    "import_mode",
+    "provider_item_key",
+    "provider_library_id",
+    "collection_key",
+    "collection_name",
+    "source_url",
+    "doi",
+    "title",
+    "authors",
+    "publication_date",
+    "year",
+    "journal",
+    "abstract",
+)
+
+
+def _canonical_reference_safe_metadata(item: NormalizedReferenceItem) -> dict[str, Any]:
+    canonical = {
+        "provider": item.provider,
+        "import_mode": item.import_mode,
+        "provider_item_key": item.provider_item_key,
+        "provider_library_id": item.provider_library_id,
+        "collection_key": item.collection_key,
+        "collection_name": item.collection_name,
+        "source_url": item.source_url,
+        "doi": item.doi,
+        "title": item.title,
+        "authors": item.authors,
+        "publication_date": item.publication_date,
+        "year": item.year,
+        "journal": item.journal,
+        "abstract": item.abstract,
+    }
+    return normalize_safe_metadata(
+        {
+            key: value
+            for key, value in canonical.items()
+            if value not in (None, "")
+        }
+    )
+
+
+def _build_binding_metadata(
+    item: NormalizedReferenceItem,
+    *,
+    selected_attachment: ReferenceAttachmentCandidate | None,
+    safe_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "provider": item.provider,
+        "safe_metadata": safe_metadata,
+    }
+    provider_version = item.metadata.get("provider_version")
+    if provider_version not in (None, ""):
+        metadata["provider_version"] = provider_version
+    if item.metadata:
+        metadata["provider_metadata"] = dict(item.metadata)
+    if selected_attachment is not None:
+        metadata["selected_attachment"] = {
+            "attachment_key": selected_attachment.attachment_key,
+            "title": selected_attachment.title,
+            "source_url": selected_attachment.source_url,
+            "mime_type": selected_attachment.mime_type,
+            "size_bytes": selected_attachment.size_bytes,
+            "metadata": dict(selected_attachment.metadata or {}),
+        }
+    return metadata
+
+
+def _select_best_attachment(
+    attachments: list[ReferenceAttachmentCandidate],
+) -> ReferenceAttachmentCandidate | None:
+    if not attachments:
+        return None
+    return max(
+        attachments,
+        key=lambda attachment: (
+            int(attachment.size_bytes or 0),
+            len(str(attachment.title or "")),
+            str(attachment.attachment_key),
+        ),
+    )
+
+
+def _load_safe_metadata(raw_value: Any) -> dict[str, Any]:
+    if isinstance(raw_value, dict):
+        return dict(raw_value)
+    raw_text = str(raw_value or "").strip()
+    if not raw_text:
+        return {}
+    try:
+        parsed = json.loads(raw_text)
+    except (TypeError, ValueError):
+        return {}
+    return dict(parsed) if isinstance(parsed, dict) else {}
+
+
+def _provider_version(item: NormalizedReferenceItem) -> str | None:
+    value = item.metadata.get("provider_version")
+    return None if value in (None, "") else str(value)
+
+
+def _metadata_fingerprint_candidate(row: dict[str, Any]) -> str | None:
+    safe_metadata = _load_safe_metadata(row.get("safe_metadata"))
+    return build_metadata_fingerprint(
+        title=safe_metadata.get("title") or row.get("title"),
+        authors=safe_metadata.get("authors"),
+        year=safe_metadata.get("year"),
+    )
+
+
+def _find_metadata_fingerprint_match(
+    media_db: Any,
+    item: NormalizedReferenceItem,
+) -> dict[str, Any] | None:
+    fingerprint = build_metadata_fingerprint(
+        title=item.title,
+        authors=item.authors,
+        year=item.year,
+    )
+    if not fingerprint or not str(item.title or "").strip():
+        return None
+    rows, _total = media_db.search_by_safe_metadata(
+        text_query=str(item.title or "").strip(),
+        per_page=25,
+        group_by_media=True,
+    )
+    for row in rows:
+        if _metadata_fingerprint_candidate(row) == fingerprint:
+            return {"media_id": row.get("media_id")}
+    return None
+
+
+def _find_doi_match(media_db: Any, item: NormalizedReferenceItem) -> dict[str, Any] | None:
+    if not item.doi:
+        return None
+    rows, _total = media_db.search_by_safe_metadata(
+        filters=[{"field": "doi", "op": "eq", "value": item.doi}],
+        per_page=1,
+        group_by_media=True,
+    )
+    if not rows:
+        return None
+    return {"media_id": rows[0].get("media_id")}
+
+
+def _find_file_hash_match(media_db: Any, content_hash: str | None) -> dict[str, Any] | None:
+    if not content_hash:
+        return None
+    row = get_media_by_hash(media_db, content_hash)
+    if not row:
+        return None
+    return {"media_id": row.get("id")}
+
+
+def _ingest_reference_attachment(
+    media_db: Any,
+    *,
+    item: NormalizedReferenceItem,
+    selected_attachment: ReferenceAttachmentCandidate,
+    content_text: str,
+    safe_metadata: dict[str, Any],
+) -> int:
+    safe_metadata_json = json.dumps(safe_metadata, ensure_ascii=False)
+    media_writer = get_media_repository(media_db)
+    media_id, _media_uuid, _message = media_writer.add_media_with_keywords(
+        url=(
+            selected_attachment.source_url
+            or item.source_url
+            or f"{item.provider}://{item.provider_item_key}/{selected_attachment.attachment_key}"
+        ),
+        title=item.title or selected_attachment.title or item.provider_item_key,
+        media_type="document",
+        content=content_text or f"[empty content for {item.provider}:{item.provider_item_key}]",
+        keywords=[],
+        safe_metadata=safe_metadata_json,
+        author=item.authors,
+        ingestion_date=item.publication_date,
+        overwrite=False,
+    )
+    if media_id is None:
+        raise ValueError(f"Reference import did not return a media ID for {item.provider_item_key}")  # noqa: TRY003
+    return int(media_id)
+
+
+def _merge_missing_reference_metadata(
+    media_db: Any,
+    *,
+    media_id: int,
+    incoming_safe_metadata: dict[str, Any],
+) -> None:
+    latest_version = get_document_version(media_db, media_id=media_id)
+    if not latest_version or latest_version.get("id") is None:
+        return
+    existing_safe_metadata = _load_safe_metadata(latest_version.get("safe_metadata"))
+    merged_safe_metadata = merge_missing_safe_metadata(
+        existing_safe_metadata,
+        incoming_safe_metadata,
+    )
+    if merged_safe_metadata == normalize_safe_metadata(existing_safe_metadata):
+        return
+    with media_db.transaction() as connection:
+        update_version_safe_metadata_in_transaction(
+            db=media_db,
+            dv_id=int(latest_version["id"]),
+            safe_metadata_json=json.dumps(merged_safe_metadata, ensure_ascii=False),
+            merged_metadata=merged_safe_metadata,
+            connection=connection,
+        )
+
+
+async def _load_item_attachments(
+    connector: Any,
+    account: dict[str, Any],
+    item: NormalizedReferenceItem,
+) -> list[ReferenceAttachmentCandidate]:
+    if item.attachments:
+        return list(item.attachments)
+    return list(
+        await connector.list_item_attachments(
+            account,
+            item.provider_item_key,
+        )
+    )
+
+
+async def _download_reference_attachment(
+    connector: Any,
+    account: dict[str, Any],
+    attachment: ReferenceAttachmentCandidate,
+) -> bytes:
+    if hasattr(connector, "resolve_attachment_download"):
+        raw_attachment = await connector.resolve_attachment_download(account, attachment)
+    else:
+        raw_attachment = await connector.download_file(
+            account,
+            attachment.attachment_key,
+            mime_type=attachment.mime_type,
+        )
+    if not raw_attachment:
+        raise ValueError(
+            f"Attachment download returned no bytes for {attachment.provider}:{attachment.attachment_key}"
+        )
+    return raw_attachment
+
+
+async def _resolve_reference_item_match(
+    media_db: Any,
+    *,
+    item: NormalizedReferenceItem,
+    same_provider_item: dict[str, Any] | None,
+    content_hash: str | None,
+) -> tuple[str | None, int | None]:
+    match = rank_reference_item_match(
+        item,
+        same_provider_item=same_provider_item,
+        doi_match=_find_doi_match(media_db, item),
+        hash_match=_find_file_hash_match(media_db, content_hash),
+        metadata_match=_find_metadata_fingerprint_match(media_db, item),
+    )
+    return match.reason, match.media_id
+
+
+async def sync_reference_manager_source(
+    *,
+    connectors_pool: Any,
+    connector: Any,
+    account: dict[str, Any],
+    source: dict[str, Any],
+    sync_state: dict[str, Any] | None,
+    media_db: Any,
+    job_id: str,
+    convert_bytes_to_text: Callable[[bytes, str, str], Awaitable[str]],
+) -> dict[str, Any]:
+    source_id = int(source["id"])
+    provider = str(source.get("provider") or "")
+    collection_key = str(source.get("remote_id") or "")
+    current_cursor = str((sync_state or {}).get("cursor") or "").strip() or None
+    next_cursor = current_cursor
+    processed = 0
+    imported = 0
+    duplicates = 0
+    metadata_only = 0
+    failed = 0
+    total = 0
+
+    items, page_cursor = await connector.list_collection_items(
+        account,
+        collection_key,
+        cursor=current_cursor,
+        page_size=100,
+    )
+    total = len(items or [])
+
+    for item in items or []:
+        try:
+            safe_metadata = _canonical_reference_safe_metadata(item)
+            attachments = await _load_item_attachments(connector, account, item)
+            selected_attachment = _select_best_attachment(attachments)
+            content_text = ""
+            content_hash = None
+            if selected_attachment is not None:
+                raw_attachment = await _download_reference_attachment(
+                    connector,
+                    account,
+                    selected_attachment,
+                )
+                attachment_name = (
+                    str(selected_attachment.metadata.get("filename") or "").strip()
+                    or selected_attachment.title
+                    or f"{item.provider_item_key}.pdf"
+                )
+                content_text = await convert_bytes_to_text(
+                    raw_attachment,
+                    attachment_name,
+                    str(selected_attachment.mime_type or "").lower(),
+                )
+                if content_text:
+                    content_hash = hashlib.sha256(content_text.encode("utf-8")).hexdigest()
+
+            async with connectors_pool.transaction() as db:
+                same_provider_item = await get_reference_item_binding(
+                    db,
+                    source_id=source_id,
+                    provider=provider,
+                    provider_item_key=item.provider_item_key,
+                )
+
+            match_reason, matched_media_id = await _resolve_reference_item_match(
+                media_db,
+                item=item,
+                same_provider_item=same_provider_item,
+                content_hash=content_hash,
+            )
+            binding_metadata = _build_binding_metadata(
+                item,
+                selected_attachment=selected_attachment,
+                safe_metadata=safe_metadata,
+            )
+
+            if matched_media_id is not None:
+                _merge_missing_reference_metadata(
+                    media_db,
+                    media_id=int(matched_media_id),
+                    incoming_safe_metadata=safe_metadata,
+                )
+                async with connectors_pool.transaction() as db:
+                    await upsert_reference_item_binding(
+                        db,
+                        source_id=source_id,
+                        provider=provider,
+                        provider_item_key=item.provider_item_key,
+                        provider_library_id=item.provider_library_id,
+                        collection_key=item.collection_key,
+                        collection_name=item.collection_name,
+                        provider_version=_provider_version(item),
+                        provider_updated_at=None,
+                        media_id=int(matched_media_id),
+                        dedupe_match_reason=match_reason,
+                        raw_reference_metadata=binding_metadata,
+                    )
+                duplicates += 1
+                processed += 1
+                continue
+
+            if selected_attachment is None:
+                async with connectors_pool.transaction() as db:
+                    await upsert_reference_item_binding(
+                        db,
+                        source_id=source_id,
+                        provider=provider,
+                        provider_item_key=item.provider_item_key,
+                        provider_library_id=item.provider_library_id,
+                        collection_key=item.collection_key,
+                        collection_name=item.collection_name,
+                        provider_version=_provider_version(item),
+                        provider_updated_at=None,
+                        media_id=None,
+                        dedupe_match_reason="metadata_only",
+                        raw_reference_metadata=binding_metadata,
+                    )
+                metadata_only += 1
+                processed += 1
+                continue
+
+            media_id = _ingest_reference_attachment(
+                media_db,
+                item=item,
+                selected_attachment=selected_attachment,
+                content_text=content_text,
+                safe_metadata=safe_metadata,
+            )
+            async with connectors_pool.transaction() as db:
+                await upsert_reference_item_binding(
+                    db,
+                    source_id=source_id,
+                    provider=provider,
+                    provider_item_key=item.provider_item_key,
+                    provider_library_id=item.provider_library_id,
+                    collection_key=item.collection_key,
+                    collection_name=item.collection_name,
+                    provider_version=_provider_version(item),
+                    provider_updated_at=None,
+                    media_id=media_id,
+                    dedupe_match_reason=None,
+                    raw_reference_metadata=binding_metadata,
+                )
+            imported += 1
+            processed += 1
+        except Exception as exc:  # pragma: no cover - defensive counter path
+            failed += 1
+            logger.warning(
+                "Reference-manager import failed for source_id={} provider={} item={}: {}",
+                source_id,
+                provider,
+                getattr(item, "provider_item_key", "unknown"),
+                exc,
+            )
+
+    if page_cursor not in (None, ""):
+        next_cursor = page_cursor
+
+    return {
+        "processed": processed,
+        "total": total,
+        "failed": failed,
+        "imported": imported,
+        "duplicates": duplicates,
+        "metadata_only": metadata_only,
+        "cursor": next_cursor,
+    }

--- a/tldw_Server_API/app/core/External_Sources/reference_manager_types.py
+++ b/tldw_Server_API/app/core/External_Sources/reference_manager_types.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ReferenceAttachmentCandidate:
+    provider: str
+    provider_item_key: str
+    attachment_key: str
+    title: str | None = None
+    source_url: str | None = None
+    mime_type: str | None = None
+    size_bytes: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class NormalizedReferenceCollection:
+    provider: str
+    import_mode: str = "reference_manager"
+    provider_library_id: str | None = None
+    collection_key: str | None = None
+    collection_name: str | None = None
+    source_url: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class NormalizedReferenceItem:
+    provider: str
+    provider_item_key: str
+    import_mode: str = "reference_manager"
+    provider_library_id: str | None = None
+    collection_key: str | None = None
+    collection_name: str | None = None
+    doi: str | None = None
+    title: str | None = None
+    authors: str | None = None
+    publication_date: str | None = None
+    year: str | None = None
+    journal: str | None = None
+    abstract: str | None = None
+    source_url: str | None = None
+    attachments: list[ReferenceAttachmentCandidate] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/tldw_Server_API/app/core/External_Sources/zotero.py
+++ b/tldw_Server_API/app/core/External_Sources/zotero.py
@@ -1,0 +1,584 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import time
+import uuid
+from typing import Any
+from urllib.parse import parse_qs, quote, urlencode
+
+from tldw_Server_API.app.core.http_client import afetch
+from tldw_Server_API.app.core.Utils.metadata_utils import normalize_safe_metadata
+
+from .connector_base import BaseConnector
+from .reference_manager_adapter import ReferenceManagerAdapter
+from .reference_manager_types import (
+    NormalizedReferenceCollection,
+    NormalizedReferenceItem,
+    ReferenceAttachmentCandidate,
+)
+
+_ZOTERO_API_BASE = "https://api.zotero.org"
+_ZOTERO_API_VERSION = "3"
+_ZOTERO_OAUTH_REQUEST_URL = "https://www.zotero.org/oauth/request"
+_ZOTERO_OAUTH_ACCESS_URL = "https://www.zotero.org/oauth/access"
+_ZOTERO_OAUTH_AUTHORIZE_URL = "https://www.zotero.org/oauth/authorize"
+_PDF_MIME_TYPES = {"application/pdf", "application/x-pdf"}
+_IMPORTABLE_ATTACHMENT_MODES = {"imported_file", "imported_url", "linked_file"}
+
+
+class ZoteroConnector(BaseConnector, ReferenceManagerAdapter):
+    name = "zotero"
+
+    def __init__(
+        self,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        redirect_base: str | None = None,
+    ):
+        super().__init__(
+            client_id=client_id or os.getenv("CONNECTOR_ZOTERO_CLIENT_ID"),
+            client_secret=client_secret or os.getenv("CONNECTOR_ZOTERO_CLIENT_SECRET"),
+            redirect_base=redirect_base or os.getenv("CONNECTOR_REDIRECT_BASE_URL"),
+        )
+
+    def authorize_url(
+        self,
+        state: str | None = None,
+        scopes: list[str] | None = None,
+        redirect_path: str = "/api/v1/connectors/providers/zotero/callback",
+    ) -> str:
+        if not self.client_id or not self.client_secret:
+            raise ValueError("Zotero authorization requires configured client credentials.")
+        oauth_token: str | None = None
+        params = {
+            "name": "tldw_server",
+            "library_access": "1",
+            "notes_access": "0",
+            "write_access": "0",
+        }
+        for scope in scopes or []:
+            if "=" not in scope:
+                continue
+            key, value = scope.split("=", 1)
+            if key == "oauth_token":
+                oauth_token = value
+            elif key:
+                params[key] = value
+        if not oauth_token:
+            raise ValueError("Zotero authorization requires an oauth_token from request_temporary_credential().")
+        params["oauth_token"] = oauth_token
+        if state:
+            params["state"] = state
+        return f"{_ZOTERO_OAUTH_AUTHORIZE_URL}?{urlencode(params)}"
+
+    async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, Any]:
+        if not self.client_id or not self.client_secret:
+            raise ValueError("Zotero OAuth exchange requires configured client credentials.")
+        token_payload = self._parse_exchange_code_payload(code)
+        oauth_token = token_payload.get("oauth_token")
+        oauth_token_secret = token_payload.get("oauth_token_secret")
+        oauth_verifier = token_payload.get("oauth_verifier")
+        if not oauth_token or not oauth_token_secret:
+            raise ValueError("Zotero OAuth exchange requires oauth_token and oauth_token_secret.")
+        headers = {
+            "Authorization": self._build_oauth_header(
+                method="POST",
+                url=_ZOTERO_OAUTH_ACCESS_URL,
+                oauth_token=oauth_token,
+                oauth_token_secret=oauth_token_secret,
+                oauth_verifier=oauth_verifier,
+            ),
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        resp = await afetch(
+            method="POST",
+            url=_ZOTERO_OAUTH_ACCESS_URL,
+            headers=headers,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            payload = self._parse_form_encoded_response(resp.content)
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        token_type = "_".join((self.name, "api", "key"))
+        return dict(
+            access_token=payload.get("oauth_token_secret"),
+            refresh_token=None,
+            token_type=token_type,
+            provider=self.name,
+            display_name="Zotero Account",
+            email=None,
+            provider_user_id=payload.get("userID"),
+            username=payload.get("username"),
+            request_token=payload.get("oauth_token"),
+            redirect_uri=redirect_uri,
+        )
+
+    @staticmethod
+    def _access_token_from_account(account: dict[str, Any]) -> str | None:
+        return (account.get("tokens") or {}).get("access_token") or account.get("access_token")
+
+    @staticmethod
+    def _provider_user_id_from_account(account: dict[str, Any]) -> str | None:
+        for key in ("provider_user_id", "userID", "user_id"):
+            value = str(account.get(key) or "").strip()
+            if value:
+                return value
+        return None
+
+    def _library_path(self, account: dict[str, Any]) -> str:
+        provider_user_id = self._provider_user_id_from_account(account)
+        if not provider_user_id:
+            raise ValueError("Zotero account is missing provider_user_id/userID.")
+        return f"users/{provider_user_id}"
+
+    @staticmethod
+    def _percent_encode(value: Any) -> str:
+        return quote(str(value), safe="~-._")
+
+    @classmethod
+    def _normalize_oauth_parameters(cls, params: dict[str, Any]) -> str:
+        pairs = []
+        for key in sorted(params):
+            pairs.append(f"{cls._percent_encode(key)}={cls._percent_encode(params[key])}")
+        return "&".join(pairs)
+
+    @classmethod
+    def _build_oauth_signature(
+        cls,
+        *,
+        method: str,
+        url: str,
+        params: dict[str, Any],
+        consumer_secret: str,
+        token_secret: str = "",
+    ) -> str:
+        base_string = "&".join(
+            [
+                method.upper(),
+                cls._percent_encode(url),
+                cls._percent_encode(cls._normalize_oauth_parameters(params)),
+            ]
+        )
+        signing_key = f"{cls._percent_encode(consumer_secret)}&{cls._percent_encode(token_secret)}"
+        digest = hmac.new(signing_key.encode("utf-8"), base_string.encode("utf-8"), hashlib.sha1).digest()
+        return base64.b64encode(digest).decode("ascii")
+
+    def _build_oauth_header(
+        self,
+        *,
+        method: str,
+        url: str,
+        oauth_token: str | None = None,
+        oauth_token_secret: str = "",
+        oauth_callback: str | None = None,
+        oauth_verifier: str | None = None,
+    ) -> str:
+        if not self.client_id or not self.client_secret:
+            raise ValueError("Zotero OAuth operations require configured client credentials.")
+        oauth_params: dict[str, Any] = {
+            "oauth_consumer_key": self.client_id,
+            "oauth_nonce": uuid.uuid4().hex,
+            "oauth_signature_method": "HMAC-SHA1",
+            "oauth_timestamp": str(int(time.time())),
+            "oauth_version": "1.0",
+        }
+        if oauth_token:
+            oauth_params["oauth_token"] = oauth_token
+        if oauth_callback:
+            oauth_params["oauth_callback"] = oauth_callback
+        if oauth_verifier:
+            oauth_params["oauth_verifier"] = oauth_verifier
+        oauth_params["oauth_signature"] = self._build_oauth_signature(
+            method=method,
+            url=url,
+            params=oauth_params,
+            consumer_secret=self.client_secret,
+            token_secret=oauth_token_secret,
+        )
+        header_parts = [
+            f'{self._percent_encode(key)}="{self._percent_encode(value)}"'
+            for key, value in sorted(oauth_params.items())
+        ]
+        return "OAuth " + ", ".join(header_parts)
+
+    @staticmethod
+    def _parse_exchange_code_payload(code: str) -> dict[str, str]:
+        raw_code = str(code or "").strip()
+        if not raw_code:
+            return {}
+        if raw_code.startswith("{"):
+            data = json.loads(raw_code)
+            return {str(key): str(value) for key, value in data.items() if value not in (None, "")}
+        parsed = parse_qs(raw_code, keep_blank_values=False)
+        return {key: values[0] for key, values in parsed.items() if values}
+
+    @staticmethod
+    def _parse_form_encoded_response(content: bytes | bytearray | str | None) -> dict[str, str]:
+        if isinstance(content, (bytes, bytearray)):
+            raw_content = content.decode("utf-8")
+        else:
+            raw_content = str(content or "")
+        parsed = parse_qs(raw_content, keep_blank_values=False)
+        return {key: values[0] for key, values in parsed.items() if values}
+
+    async def request_temporary_credential(self, callback_url: str) -> dict[str, str]:
+        headers = {
+            "Authorization": self._build_oauth_header(
+                method="POST",
+                url=_ZOTERO_OAUTH_REQUEST_URL,
+                oauth_callback=callback_url,
+            ),
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        resp = await afetch(
+            method="POST",
+            url=_ZOTERO_OAUTH_REQUEST_URL,
+            headers=headers,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            return self._parse_form_encoded_response(resp.content)
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+
+    def _build_headers(self, account: dict[str, Any]) -> dict[str, str]:
+        api_key = self._access_token_from_account(account)
+        if not api_key:
+            raise ValueError("Zotero account is missing an API key.")
+        return {
+            "Zotero-API-Version": _ZOTERO_API_VERSION,
+            "Zotero-API-Key": api_key,
+        }
+
+    @staticmethod
+    def _build_paging_params(cursor: str | None, page_size: int) -> tuple[dict[str, Any], int]:
+        start = 0
+        if cursor:
+            start = max(0, int(cursor))
+        limit = max(1, min(int(page_size), 100))
+        return {"format": "json", "limit": limit, "start": start}, start
+
+    @staticmethod
+    def _next_cursor(headers: dict[str, str], start: int, count: int) -> str | None:
+        total_results = str(headers.get("Total-Results") or "").strip()
+        if not total_results:
+            return None
+        try:
+            total = int(total_results)
+        except (TypeError, ValueError):
+            return None
+        next_start = start + count
+        if next_start >= total:
+            return None
+        return str(next_start)
+
+    @staticmethod
+    def _creator_name(creator: dict[str, Any]) -> str | None:
+        if not isinstance(creator, dict):
+            return None
+        first_name = str(creator.get("firstName") or "").strip()
+        last_name = str(creator.get("lastName") or "").strip()
+        if first_name and last_name:
+            return f"{first_name} {last_name}"
+        if last_name:
+            return last_name
+        name = str(creator.get("name") or "").strip()
+        return name or None
+
+    def _format_authors(self, raw_item: dict[str, Any]) -> str | None:
+        data = raw_item.get("data") or {}
+        creators = data.get("creators") or []
+        author_names: list[str] = []
+        for creator in creators:
+            creator_type = str((creator or {}).get("creatorType") or "").strip().lower()
+            if creator_type and creator_type != "author":
+                continue
+            name = self._creator_name(creator)
+            if name:
+                author_names.append(name)
+        if author_names:
+            return ", ".join(author_names)
+        creator_summary = str((raw_item.get("meta") or {}).get("creatorSummary") or "").strip()
+        return creator_summary or None
+
+    @staticmethod
+    def _parse_year(date_value: str | None) -> str | None:
+        if not date_value:
+            return None
+        match = re.search(r"\b(1[5-9]\d{2}|20\d{2}|21\d{2})\b", str(date_value).strip())
+        if match:
+            return match.group(1)
+        return None
+
+    @staticmethod
+    def _source_url(raw_item: dict[str, Any]) -> str | None:
+        links = raw_item.get("links") or {}
+        alternate = links.get("alternate") or {}
+        href = str(alternate.get("href") or "").strip()
+        return href or None
+
+    @staticmethod
+    def _attachment_source_url(raw_attachment: dict[str, Any]) -> str | None:
+        links = raw_attachment.get("links") or {}
+        alternate = links.get("alternate") or {}
+        href = str(alternate.get("href") or "").strip()
+        if href:
+            return href
+        data = raw_attachment.get("data") or {}
+        url = str(data.get("url") or "").strip()
+        return url or None
+
+    @staticmethod
+    def _is_attachment(raw_item: dict[str, Any]) -> bool:
+        data = raw_item.get("data") or {}
+        return str(data.get("itemType") or "").strip().lower() == "attachment"
+
+    def _normalize_attachment_candidate(
+        self,
+        raw_attachment: dict[str, Any],
+        *,
+        provider_item_key: str,
+    ) -> ReferenceAttachmentCandidate | None:
+        data = raw_attachment.get("data") or {}
+        link_mode = str(data.get("linkMode") or "").strip().lower()
+        mime_type = str(data.get("contentType") or "").strip().lower() or None
+        if link_mode not in _IMPORTABLE_ATTACHMENT_MODES:
+            return None
+        if mime_type not in _PDF_MIME_TYPES:
+            return None
+        attachment_key = str(data.get("key") or raw_attachment.get("key") or "").strip()
+        if not attachment_key:
+            return None
+        size_bytes = data.get("filesize")
+        try:
+            size_value = int(size_bytes) if size_bytes is not None else None
+        except (TypeError, ValueError):
+            size_value = None
+        return ReferenceAttachmentCandidate(
+            provider=self.name,
+            provider_item_key=provider_item_key,
+            attachment_key=attachment_key,
+            title=str(data.get("title") or "").strip() or None,
+            source_url=self._attachment_source_url(raw_attachment),
+            mime_type=mime_type,
+            size_bytes=size_value,
+            metadata={
+                "link_mode": link_mode,
+                "filename": str(data.get("filename") or "").strip() or None,
+            },
+        )
+
+    async def normalize_reference_item(
+        self,
+        raw_item: dict[str, Any],
+        raw_attachments: list[dict[str, Any]],
+        *,
+        collection_key: str | None = None,
+        collection_name: str | None = None,
+        provider_library_id: str | None = None,
+    ) -> NormalizedReferenceItem:
+        data = raw_item.get("data") or {}
+        provider_item_key = str(data.get("key") or raw_item.get("key") or "").strip()
+        if not provider_item_key:
+            raise ValueError("Zotero item is missing a key.")
+        parsed_metadata = normalize_safe_metadata({"doi": data.get("DOI") or data.get("doi")})
+        doi = parsed_metadata.get("doi")
+        item_collection_key = collection_key
+        if not item_collection_key:
+            collections = data.get("collections") or []
+            if collections:
+                item_collection_key = str(collections[0] or "").strip() or None
+        date_value = str(data.get("date") or "").strip() or None
+        attachments: list[ReferenceAttachmentCandidate] = []
+        for raw_attachment in raw_attachments:
+            candidate = self._normalize_attachment_candidate(
+                raw_attachment,
+                provider_item_key=provider_item_key,
+            )
+            if candidate is not None:
+                attachments.append(candidate)
+        return NormalizedReferenceItem(
+            provider=self.name,
+            provider_item_key=provider_item_key,
+            provider_library_id=(
+                provider_library_id
+                or self._provider_user_id_from_account(raw_item.get("account") or {})
+                or None
+            ),
+            collection_key=item_collection_key,
+            collection_name=collection_name,
+            doi=doi,
+            title=str(data.get("title") or "").strip() or None,
+            authors=self._format_authors(raw_item),
+            publication_date=date_value,
+            year=self._parse_year(date_value),
+            journal=str(data.get("publicationTitle") or "").strip() or None,
+            abstract=str(data.get("abstractNote") or "").strip() or None,
+            source_url=self._source_url(raw_item),
+            attachments=attachments,
+            metadata={
+                "provider_version": raw_item.get("version"),
+                "item_type": data.get("itemType"),
+            },
+        )
+
+    async def list_collections(
+        self,
+        account: dict[str, Any],
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ) -> tuple[list[NormalizedReferenceCollection], str | None]:
+        params, start = self._build_paging_params(cursor, page_size)
+        resp = await afetch(
+            method="GET",
+            url=f"{_ZOTERO_API_BASE}/{self._library_path(account)}/collections",
+            headers=self._build_headers(account),
+            params=params,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            payload = resp.json() or []
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+
+        collections: list[NormalizedReferenceCollection] = []
+        for raw_collection in payload:
+            if not isinstance(raw_collection, dict):
+                continue
+            data = raw_collection.get("data") or {}
+            collection_key = str(data.get("key") or raw_collection.get("key") or "").strip()
+            if not collection_key:
+                continue
+            collections.append(
+                NormalizedReferenceCollection(
+                    provider=self.name,
+                    provider_library_id=self._provider_user_id_from_account(account),
+                    collection_key=collection_key,
+                    collection_name=str(data.get("name") or "").strip() or None,
+                    source_url=self._source_url(raw_collection),
+                    metadata={
+                        "provider_version": raw_collection.get("version"),
+                        "parent_collection": data.get("parentCollection") or None,
+                    },
+                )
+            )
+        next_cursor = self._next_cursor(resp.headers, start, len(payload))
+        return collections, next_cursor
+
+    async def list_collection_items(
+        self,
+        account: dict[str, Any],
+        collection_key: str,
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ) -> tuple[list[NormalizedReferenceItem], str | None]:
+        params, start = self._build_paging_params(cursor, page_size)
+        resp = await afetch(
+            method="GET",
+            url=f"{_ZOTERO_API_BASE}/{self._library_path(account)}/collections/{collection_key}/items/top",
+            headers=self._build_headers(account),
+            params=params,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            payload = resp.json() or []
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+
+        items: list[NormalizedReferenceItem] = []
+        for raw_item in payload:
+            if not isinstance(raw_item, dict) or self._is_attachment(raw_item):
+                continue
+            normalized_item = await self.normalize_reference_item(
+                raw_item,
+                [],
+                collection_key=collection_key,
+                provider_library_id=self._provider_user_id_from_account(account),
+            )
+            items.append(normalized_item)
+        next_cursor = self._next_cursor(resp.headers, start, len(payload))
+        return items, next_cursor
+
+    async def list_item_attachments(
+        self,
+        account: dict[str, Any],
+        provider_item_key: str,
+    ) -> list[ReferenceAttachmentCandidate]:
+        resp = await afetch(
+            method="GET",
+            url=f"{_ZOTERO_API_BASE}/{self._library_path(account)}/items/{provider_item_key}/children",
+            headers=self._build_headers(account),
+            params={"format": "json"},
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            payload = resp.json() or []
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+
+        attachments: list[ReferenceAttachmentCandidate] = []
+        for raw_attachment in payload:
+            if not isinstance(raw_attachment, dict):
+                continue
+            candidate = self._normalize_attachment_candidate(
+                raw_attachment,
+                provider_item_key=provider_item_key,
+            )
+            if candidate is not None:
+                attachments.append(candidate)
+        return attachments
+
+    async def download_file(
+        self,
+        account: dict[str, Any],
+        file_id: str,
+        **kwargs: Any,
+    ) -> bytes:
+        _ = kwargs
+        resp = await afetch(
+            method="GET",
+            url=f"{_ZOTERO_API_BASE}/{self._library_path(account)}/items/{quote(file_id, safe='')}/file",
+            headers=self._build_headers(account),
+            timeout=60,
+        )
+        try:
+            resp.raise_for_status()
+            return resp.content
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+
+    async def resolve_attachment_download(
+        self,
+        account: dict[str, Any],
+        attachment: ReferenceAttachmentCandidate,
+    ) -> bytes:
+        return await self.download_file(
+            account,
+            attachment.attachment_key,
+            mime_type=attachment.mime_type,
+        )

--- a/tldw_Server_API/app/core/External_Sources/zotero.py
+++ b/tldw_Server_API/app/core/External_Sources/zotero.py
@@ -393,7 +393,10 @@ class ZoteroConnector(BaseConnector, ReferenceManagerAdapter):
         provider_item_key = str(data.get("key") or raw_item.get("key") or "").strip()
         if not provider_item_key:
             raise ValueError("Zotero item is missing a key.")
-        parsed_metadata = normalize_safe_metadata({"doi": data.get("DOI") or data.get("doi")})
+        try:
+            parsed_metadata = normalize_safe_metadata({"doi": data.get("DOI") or data.get("doi")})
+        except ValueError:
+            parsed_metadata = {}
         doi = parsed_metadata.get("doi")
         item_collection_key = collection_key
         if not item_collection_key:

--- a/tldw_Server_API/app/core/Utils/metadata_utils.py
+++ b/tldw_Server_API/app/core/Utils/metadata_utils.py
@@ -82,6 +82,24 @@ def normalize_safe_metadata(sm: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def merge_missing_safe_metadata(
+    existing: Mapping[str, Any] | None,
+    incoming: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Preserve existing metadata values and fill only missing normalized fields."""
+    normalized_existing = normalize_safe_metadata(dict(existing or {}))
+    normalized_incoming = normalize_safe_metadata(dict(incoming or {}))
+    merged = dict(normalized_existing)
+
+    for key, value in normalized_incoming.items():
+        if value in (None, ""):
+            continue
+        if merged.get(key) in (None, ""):
+            merged[key] = value
+
+    return merged
+
+
 def update_version_safe_metadata_in_transaction(
     db: Any,
     dv_id: int,

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -50,6 +50,10 @@ class IngestionSourceValidationError(ValidationError):
     """Raised when an ingestion source payload fails validation."""
 
 
+class ReferenceImportError(RuntimeError):
+    """Raised when a reference-manager item cannot be persisted correctly."""
+
+
 class StructuredOutputParseError(ValueError):
     """Base error for structured-output parsing/normalization failures.
 

--- a/tldw_Server_API/app/services/connectors_sync_scheduler.py
+++ b/tldw_Server_API/app/services/connectors_sync_scheduler.py
@@ -22,6 +22,7 @@ from loguru import logger
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.External_Sources.connectors_service import (
     FILE_SYNC_PROVIDERS,
+    REFERENCE_MANAGER_PROVIDERS,
     create_import_job,
     list_sources_for_scheduler,
     prune_webhook_receipts,
@@ -127,13 +128,19 @@ class _ConnectorsSyncScheduler:
         if not bool(source.get("enabled", True)):
             return None
         provider = str(source.get("provider") or "").strip().lower()
-        if provider not in FILE_SYNC_PROVIDERS:
+        is_file_sync_provider = provider in FILE_SYNC_PROVIDERS
+        is_reference_manager_provider = provider in REFERENCE_MANAGER_PROVIDERS
+        if not is_file_sync_provider and not is_reference_manager_provider:
             return None
         if str(source.get("active_job_id") or "").strip():
             return None
         sync_mode = str(source.get("sync_mode") or "manual").strip().lower()
         renewal_due = False
-        if source.get("webhook_status") == "active" and str(source.get("webhook_subscription_id") or "").strip():
+        if (
+            is_file_sync_provider
+            and source.get("webhook_status") == "active"
+            and str(source.get("webhook_subscription_id") or "").strip()
+        ):
             expires_at = _parse_utc_datetime(source.get("webhook_expires_at"))
             if expires_at is not None:
                 renewal_due = expires_at <= (now + timedelta(seconds=_renewal_lookahead_seconds()))
@@ -141,7 +148,7 @@ class _ConnectorsSyncScheduler:
             return "subscription_renewal"
         if sync_mode not in {"poll", "hybrid"}:
             return None
-        if bool(source.get("needs_full_rescan")):
+        if is_file_sync_provider and bool(source.get("needs_full_rescan")):
             return "repair_rescan"
         return "incremental_sync"
 

--- a/tldw_Server_API/app/services/connectors_worker.py
+++ b/tldw_Server_API/app/services/connectors_worker.py
@@ -673,7 +673,9 @@ async def _process_import_job(
     from tldw_Server_API.app.core.External_Sources import get_connector_by_name
     from tldw_Server_API.app.core.External_Sources.connectors_service import (
         FILE_SYNC_PROVIDERS,
+        REFERENCE_MANAGER_PROVIDERS,
         get_external_item_binding,
+        get_account_for_user,
         get_account_tokens,
         record_item_event,
         get_source_by_id,
@@ -694,8 +696,17 @@ async def _process_import_job(
         account_id = int(src.get("account_id"))
         options = src.get("options") or {}
         remote_id = str(src.get("remote_id"))
+        account_row = {}
+        if provider in REFERENCE_MANAGER_PROVIDERS:
+            account_row = await get_account_for_user(db, user_id, account_id) or {}
         tokens = await get_account_tokens(db, user_id, account_id)
-        acct = {"tokens": tokens, "email": src.get("email")}
+        acct = dict(account_row)
+        acct["tokens"] = dict(tokens or {})
+        acct.setdefault("email", src.get("email"))
+        for key, value in dict(tokens or {}).items():
+            if key in {"access_token", "refresh_token"} or value in (None, ""):
+                continue
+            acct.setdefault(str(key), value)
         # Load org policy for this user (best-effort)
         try:
             from tldw_Server_API.app.core.AuthNZ.orgs_teams import list_memberships_for_user
@@ -1390,6 +1401,71 @@ async def _process_import_job(
             _close_connector_media_db(mdb)
             return
         if not await _process_file_sync_changes():
+            if provider in REFERENCE_MANAGER_PROVIDERS:
+                from tldw_Server_API.app.core.External_Sources.reference_manager_import import (
+                    sync_reference_manager_source,
+                )
+
+                async with pool.transaction() as db:
+                    reference_sync_state = await get_source_sync_state(
+                        db,
+                        source_id=source_id,
+                    ) or {}
+                    await upsert_source_sync_state(
+                        db,
+                        source_id=source_id,
+                        last_sync_started_at=_utc_now_db_text(),
+                        last_error=None,
+                    )
+                try:
+                    reference_result = await sync_reference_manager_source(
+                        connectors_pool=pool,
+                        connector=conn,
+                        account=acct,
+                        source=src,
+                        sync_state=reference_sync_state,
+                        media_db=mdb,
+                        job_id=str(jid),
+                        convert_bytes_to_text=_convert_document_bytes_to_text,
+                    )
+                except _CONNECTOR_NONCRITICAL_EXCEPTIONS as exc:
+                    async with pool.transaction() as db:
+                        await upsert_source_sync_state(
+                            db,
+                            source_id=source_id,
+                            last_sync_failed_at=_utc_now_db_text(),
+                            last_error=str(exc),
+                        )
+                    raise
+
+                processed = int(reference_result.get("processed") or 0)
+                total = int(reference_result.get("total") or 0)
+                failed = int(reference_result.get("failed") or 0)
+                result_payload = {
+                    "processed": processed,
+                    "total": total,
+                    "failed": failed,
+                    "imported": int(reference_result.get("imported") or 0),
+                    "duplicates": int(reference_result.get("duplicates") or 0),
+                    "metadata_only": int(reference_result.get("metadata_only") or 0),
+                }
+                async with pool.transaction() as db:
+                    await upsert_source_sync_state(
+                        db,
+                        source_id=source_id,
+                        cursor=reference_result.get("cursor"),
+                        last_sync_succeeded_at=_utc_now_db_text(),
+                        last_error=None,
+                    )
+                jm.complete_job(
+                    jid,
+                    result=result_payload,
+                    worker_id=worker_id,
+                    lease_id=lease_id,
+                    completion_token=lease_id,
+                )
+                _close_connector_media_db(mdb)
+                return
             bootstrap_file_sync_scan = provider in FILE_SYNC_PROVIDERS
             if bootstrap_file_sync_scan:
                 async with pool.transaction() as db:

--- a/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
@@ -993,6 +993,61 @@ def test_get_source_sync_status_returns_state_and_active_job(connectors_client, 
 
 
 @pytest.mark.integration
+def test_get_source_sync_status_prefers_active_job_state_over_needs_full_rescan(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+    import tldw_Server_API.app.core.Jobs.manager as jobs_manager
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "zotero",
+            "enabled": True,
+        }
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {
+            "source_id": source_id,
+            "sync_mode": "poll",
+            "needs_full_rescan": True,
+            "active_job_id": "88",
+            "active_job_started_at": "2026-03-30 20:00:00",
+        }
+
+    async def _fake_get_source_binding_health(db, *, source_id):
+        return {
+            "tracked_item_count": 0,
+            "degraded_item_count": 0,
+            "duplicate_count": 0,
+            "metadata_only_count": 0,
+        }
+
+    class _FakeJobManager:
+        def get_job(self, job_id: int):
+            assert job_id == 88
+            return {
+                "id": job_id,
+                "job_type": "incremental_sync",
+                "status": "processing",
+                "progress_percent": 10,
+                "result": {"processed": 1, "failed": 0, "skipped": 0},
+            }
+
+    monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(ep, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(ep, "get_source_binding_health", _fake_get_source_binding_health)
+    monkeypatch.setattr(jobs_manager, "JobManager", _FakeJobManager)
+
+    response = client.get("/api/v1/connectors/sources/88/sync", headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["state"] == "running"
+    assert body["needs_full_rescan"] is True
+    assert body["active_job"]["id"] == "88"
+
+
+@pytest.mark.integration
 def test_trigger_source_sync_endpoint_queues_job(connectors_client, monkeypatch):
     client, headers = connectors_client
 

--- a/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
@@ -64,6 +64,17 @@ def test_list_providers_includes_gmail_when_feature_flag_enabled(connectors_clie
 
 
 @pytest.mark.integration
+def test_list_providers_includes_zotero(connectors_client):
+    client, headers = connectors_client
+
+    response = client.get("/api/v1/connectors/providers", headers=headers)
+    assert response.status_code == 200, response.text
+    providers = {str(item.get("name")): item for item in response.json()}
+    assert "zotero" in providers
+    assert providers["zotero"]["auth_type"] == "oauth1"
+
+
+@pytest.mark.integration
 def test_add_source_blocks_gmail_when_feature_flag_disabled(connectors_client, monkeypatch):
     client, headers = connectors_client
     import tldw_Server_API.app.api.v1.endpoints.connectors as ep
@@ -358,6 +369,19 @@ def test_add_source_forbid_extra_fields(connectors_client, monkeypatch):
 def test_patch_source_success(connectors_client, monkeypatch):
     client, headers = connectors_client
 
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "account_id": 1,
+            "provider": "notion",
+            "remote_id": "abc",
+            "type": "page",
+            "path": None,
+            "options": {"recursive": False},
+            "enabled": True,
+            "last_synced_at": None,
+        }
+
     async def _fake_update_source(db, user_id, source_id, *, enabled=None, options=None):
         return {
             "id": source_id,
@@ -372,6 +396,7 @@ def test_patch_source_success(connectors_client, monkeypatch):
         }
 
     import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+    monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
     monkeypatch.setattr(ep, "update_source", _fake_update_source)
 
     r = client.patch(
@@ -453,6 +478,8 @@ def test_get_sources_includes_sync_summary(connectors_client, monkeypatch):
         return {
             "tracked_item_count": 4,
             "degraded_item_count": 2,
+            "duplicate_count": 3,
+            "metadata_only_count": 1,
         }
 
     monkeypatch.setattr(ep, "list_sources", _fake_list_sources)
@@ -472,6 +499,8 @@ def test_get_sources_includes_sync_summary(connectors_client, monkeypatch):
     assert body[0]["sync"]["active_job_id"] == "88"
     assert body[0]["sync"]["tracked_item_count"] == 4
     assert body[0]["sync"]["degraded_item_count"] == 2
+    assert body[0]["sync"]["duplicate_count"] == 3
+    assert body[0]["sync"]["metadata_only_count"] == 1
 
 
 @pytest.mark.integration
@@ -544,6 +573,352 @@ def test_oauth_callback_accepts_valid_state(connectors_client, monkeypatch):
 
 
 @pytest.mark.integration
+def test_start_authorize_zotero_requests_temporary_credential_and_persists_state_metadata(
+    connectors_client,
+    monkeypatch,
+):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    oauth_state_calls: list[dict] = []
+    authorize_calls: list[dict] = []
+
+    async def _fake_create_oauth_state(db, user_id, provider, state, metadata=None):
+        oauth_state_calls.append(
+            {
+                "user_id": user_id,
+                "provider": provider,
+                "state": state,
+                "metadata": dict(metadata or {}),
+            }
+        )
+
+    class _FakeConn:
+        name = "zotero"
+        redirect_base = "http://ignored.example"
+
+        async def request_temporary_credential(self, callback_url):
+            authorize_calls.append({"callback_url": callback_url})
+            return {
+                "oauth_token": "temp-token",
+                "oauth_token_secret": "temp-secret",
+            }
+
+        def authorize_url(self, state=None, scopes=None, redirect_path=None):
+            authorize_calls.append(
+                {
+                    "state": state,
+                    "scopes": list(scopes or []),
+                    "redirect_path": redirect_path,
+                }
+            )
+            return "https://www.zotero.org/oauth/authorize?oauth_token=temp-token"
+
+    monkeypatch.setattr(ep, "create_oauth_state", _fake_create_oauth_state)
+    monkeypatch.setattr(ep, "get_connector_by_name", lambda provider: _FakeConn())
+
+    response = client.post("/api/v1/connectors/providers/zotero/authorize", headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["auth_url"] == "https://www.zotero.org/oauth/authorize?oauth_token=temp-token"
+    assert oauth_state_calls[0]["provider"] == "zotero"
+    assert oauth_state_calls[0]["metadata"] == {
+        "oauth_token": "temp-token",
+        "oauth_token_secret": "temp-secret",
+    }
+    assert authorize_calls[0]["callback_url"].startswith(
+        "http://testserver/api/v1/connectors/providers/zotero/callback?state="
+    )
+    assert authorize_calls[1]["scopes"] == ["oauth_token=temp-token"]
+
+
+@pytest.mark.integration
+def test_oauth_callback_accepts_zotero_oauth1_payload_and_persists_provider_identity(
+    connectors_client,
+    monkeypatch,
+):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    exchange_calls: list[dict] = []
+    account_calls: list[dict] = []
+
+    async def _fake_consume_oauth_state(db, *, user_id, provider, state, max_age_minutes=10):
+        return {
+            "state": state,
+            "provider": provider,
+            "oauth_token": "temp-token",
+            "oauth_token_secret": "temp-secret",
+        }
+
+    class _FakeConn:
+        name = "zotero"
+
+        def authorize_url(self, *a, **kw):
+            return ""
+
+        async def exchange_code(self, code, redirect_uri):
+            exchange_calls.append({"code": code, "redirect_uri": redirect_uri})
+            return {
+                "access_token": "api-key",
+                "provider": "zotero",
+                "display_name": "Zotero Account",
+                "provider_user_id": "123456",
+                "username": "alice",
+            }
+
+    async def _fake_create_account(db, user_id, provider, display_name, email, tokens):
+        account_calls.append(
+            {
+                "user_id": user_id,
+                "provider": provider,
+                "display_name": display_name,
+                "email": email,
+                "tokens": dict(tokens),
+            }
+        )
+        return {"id": 456, "display_name": display_name, "email": email, "created_at": "now"}
+
+    monkeypatch.setattr(ep, "consume_oauth_state", _fake_consume_oauth_state)
+    monkeypatch.setattr(ep, "get_connector_by_name", lambda provider: _FakeConn())
+    monkeypatch.setattr(ep, "create_account", _fake_create_account)
+    monkeypatch.setenv("ORG_CONNECTORS_ACCOUNT_LINKING_ROLE", "member")
+
+    response = client.get(
+        "/api/v1/connectors/providers/zotero/callback",
+        params={"oauth_token": "temp-token", "oauth_verifier": "verifier-1", "state": "good"},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == 456
+    assert body["provider"] == "zotero"
+    assert exchange_calls[0]["code"] == (
+        '{"oauth_token": "temp-token", "oauth_token_secret": "temp-secret", "oauth_verifier": "verifier-1"}'
+    )
+    assert account_calls[0]["tokens"]["provider_user_id"] == "123456"
+
+
+@pytest.mark.integration
+def test_browse_provider_sources_returns_zotero_collection_rows(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    class _FakeConn:
+        name = "zotero"
+
+        def authorize_url(self, *a, **kw):
+            return ""
+
+        async def exchange_code(self, *a, **kw):
+            return {}
+
+        async def list_collections(self, account, *, cursor=None, page_size=100):
+            assert account["provider_user_id"] == "123456"
+            assert account["tokens"]["access_token"] == "api-key"
+            return (
+                [
+                    {
+                        "provider": "zotero",
+                        "collection_key": "COLL1234",
+                        "collection_name": "Language Models",
+                        "source_url": "https://www.zotero.org/users/123456/collections/COLL1234",
+                    }
+                ],
+                "next-zotero-cursor",
+            )
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        assert account_id == 15
+        return {"access_token": "api-key", "provider_user_id": "123456"}
+
+    async def _fake_get_account_email(db, user_id, account_id):
+        return None
+
+    monkeypatch.setattr(ep, "get_connector_by_name", lambda provider: _FakeConn())
+    monkeypatch.setattr(ep, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(ep, "get_account_email", _fake_get_account_email)
+
+    response = client.get(
+        "/api/v1/connectors/providers/zotero/sources/browse",
+        params={"account_id": 15, "page_size": 25},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["next_cursor"] == "next-zotero-cursor"
+    assert body["items"][0]["collection_key"] == "COLL1234"
+    assert body["items"][0]["collection_name"] == "Language Models"
+
+
+@pytest.mark.integration
+def test_browse_provider_sources_rejects_account_provider_mismatch(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "api-key", "provider_user_id": "123456"}
+
+    async def _fake_get_account_for_user(db, user_id, account_id):
+        return {"id": account_id, "user_id": user_id, "provider": "drive"}
+
+    monkeypatch.setattr(ep, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(ep, "get_account_for_user", _fake_get_account_for_user)
+
+    response = client.get(
+        "/api/v1/connectors/providers/zotero/sources/browse",
+        params={"account_id": 15, "page_size": 25},
+        headers=headers,
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "Account provider mismatch"
+
+
+@pytest.mark.integration
+def test_add_zotero_source_accepts_collection_type(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    async def _fake_create_source(db, *, account_id, provider, remote_id, type_, path, options, enabled=True):
+        return {
+            "id": 202,
+            "account_id": account_id,
+            "provider": provider,
+            "remote_id": remote_id,
+            "type": type_,
+            "path": path,
+            "options": options or {},
+            "enabled": enabled,
+            "last_synced_at": None,
+        }
+
+    async def _fake_get_account_for_user(db, user_id, account_id):
+        return {"id": account_id, "user_id": user_id, "provider": "zotero"}
+
+    monkeypatch.setattr(ep, "create_source", _fake_create_source)
+    monkeypatch.setattr(ep, "get_account_for_user", _fake_get_account_for_user)
+
+    payload = {
+        "account_id": 19,
+        "provider": "zotero",
+        "remote_id": "COLL1234",
+        "type": "collection",
+        "options": {},
+    }
+    response = client.post("/api/v1/connectors/sources", json=payload, headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["provider"] == "zotero"
+    assert body["type"] == "collection"
+
+
+@pytest.mark.integration
+def test_add_zotero_source_rejects_recursive_option(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    async def _fake_get_account_for_user(db, user_id, account_id):
+        return {"id": account_id, "user_id": user_id, "provider": "zotero"}
+
+    monkeypatch.setattr(ep, "get_account_for_user", _fake_get_account_for_user)
+
+    payload = {
+        "account_id": 19,
+        "provider": "zotero",
+        "remote_id": "COLL1234",
+        "type": "collection",
+        "options": {"recursive": True},
+    }
+    response = client.post("/api/v1/connectors/sources", json=payload, headers=headers)
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == "Zotero collection sync is flat in v1; link child collections separately."
+
+
+@pytest.mark.integration
+def test_patch_zotero_source_rejects_recursive_option(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "account_id": 19,
+            "provider": "zotero",
+            "remote_id": "COLL1234",
+            "type": "collection",
+            "path": None,
+            "options": {"recursive": False},
+            "enabled": True,
+            "last_synced_at": None,
+        }
+
+    monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
+
+    response = client.patch(
+        "/api/v1/connectors/sources/19",
+        json={"options": {"recursive": True}},
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == "Zotero collection sync is flat in v1; link child collections separately."
+
+
+@pytest.mark.integration
+def test_patch_zotero_source_preserves_flat_recursive_false(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    update_calls: list[dict] = []
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "account_id": 19,
+            "provider": "zotero",
+            "remote_id": "COLL1234",
+            "type": "collection",
+            "path": None,
+            "options": {"recursive": False},
+            "enabled": True,
+            "last_synced_at": None,
+        }
+
+    async def _fake_update_source(db, user_id, source_id, *, enabled=None, options=None):
+        update_calls.append({"source_id": source_id, "enabled": enabled, "options": dict(options or {})})
+        return {
+            "id": source_id,
+            "account_id": 19,
+            "provider": "zotero",
+            "remote_id": "COLL1234",
+            "type": "collection",
+            "path": None,
+            "options": dict(options or {}),
+            "enabled": True,
+            "last_synced_at": None,
+        }
+
+    monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(ep, "update_source", _fake_update_source)
+
+    response = client.patch(
+        "/api/v1/connectors/sources/19",
+        json={"options": {}},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    assert update_calls[0]["options"]["recursive"] is False
+    assert response.json()["options"]["recursive"] is False
+
+
+@pytest.mark.integration
 def test_get_source_sync_status_returns_state_and_active_job(connectors_client, monkeypatch):
     client, headers = connectors_client
 
@@ -590,6 +965,8 @@ def test_get_source_sync_status_returns_state_and_active_job(connectors_client, 
         return {
             "tracked_item_count": 9,
             "degraded_item_count": 3,
+            "duplicate_count": 2,
+            "metadata_only_count": 5,
         }
 
     monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
@@ -611,6 +988,8 @@ def test_get_source_sync_status_returns_state_and_active_job(connectors_client, 
     assert body["active_job"]["progress_pct"] == 35
     assert body["tracked_item_count"] == 9
     assert body["degraded_item_count"] == 3
+    assert body["duplicate_count"] == 2
+    assert body["metadata_only_count"] == 5
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py
@@ -75,6 +75,17 @@ async def test_connectors_sync_scheduler_scan_enqueues_renewal_repair_and_increm
                 "webhook_subscription_id": None,
                 "webhook_expires_at": None,
             },
+            {
+                "id": 15,
+                "user_id": 5,
+                "provider": "zotero",
+                "enabled": True,
+                "sync_mode": "poll",
+                "needs_full_rescan": False,
+                "webhook_status": None,
+                "webhook_subscription_id": None,
+                "webhook_expires_at": None,
+            },
         ]
 
     queued_jobs: list[dict[str, object]] = []
@@ -129,4 +140,5 @@ async def test_connectors_sync_scheduler_scan_enqueues_renewal_repair_and_increm
         {"user_id": 1, "source_id": 11, "job_type": "subscription_renewal"},
         {"user_id": 2, "source_id": 12, "job_type": "repair_rescan"},
         {"user_id": 3, "source_id": 13, "job_type": "incremental_sync"},
+        {"user_id": 5, "source_id": 15, "job_type": "incremental_sync"},
     ]

--- a/tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py
@@ -138,7 +138,10 @@ async def test_worker_reference_manager_sync_uses_merged_account_loader_and_pers
     created_media_db = _FakeMDB()
 
     monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
-    monkeypatch.setattr(orgs, "list_memberships_for_user", lambda user_id: [])
+    async def _fake_list_memberships_for_user(user_id: int):
+        return []
+
+    monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
     monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: _FakeZoteroConnector())
     monkeypatch.setattr(svc, "get_source_by_id", _fake_get_source_by_id)
     monkeypatch.setattr(svc, "get_account_for_user", _fake_get_account_for_user, raising=False)

--- a/tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+
+
+class _FakeJM:
+    def __init__(self) -> None:
+        self.completed: dict[str, object] | None = None
+
+    def renew_job_lease(self, *args, **kwargs):
+        return None
+
+    def complete_job(
+        self,
+        jid,
+        result=None,
+        worker_id=None,
+        lease_id=None,
+        completion_token=None,
+    ) -> None:
+        self.completed = {"jid": jid, "result": result}
+
+
+class _DummyPool:
+    @asynccontextmanager
+    async def transaction(self):
+        yield object()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_reference_manager_sync_uses_merged_account_loader_and_persists_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class _FakeZoteroConnector:
+        pass
+
+    pool = _DummyPool()
+    sync_state_updates: list[dict[str, object]] = []
+    sync_calls: list[dict[str, object]] = []
+
+    async def _fake_get_db_pool():
+        return pool
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        assert user_id == 42
+        assert source_id == 99
+        return {
+            "id": source_id,
+            "provider": "zotero",
+            "account_id": 123,
+            "remote_id": "COLL1234",
+            "type": "collection",
+            "path": None,
+            "options": {"recursive": False},
+            "email": "researcher@example.com",
+        }
+
+    async def _fake_get_account_for_user(db, user_id, account_id):
+        assert user_id == 42
+        assert account_id == 123
+        return {
+            "id": account_id,
+            "user_id": user_id,
+            "provider": "zotero",
+            "provider_user_id": "123456",
+            "username": "researcher",
+            "email": "researcher@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        assert user_id == 42
+        assert account_id == 123
+        return {"access_token": "tok"}
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        assert source_id == 99
+        return {"source_id": source_id, "sync_mode": "poll", "cursor": "cursor-0"}
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    async def _fake_sync_reference_manager_source(
+        *,
+        connectors_pool,
+        connector,
+        account,
+        source,
+        sync_state,
+        media_db,
+        job_id,
+        convert_bytes_to_text,
+    ):
+        sync_calls.append(
+            {
+                "connectors_pool": connectors_pool,
+                "connector": connector,
+                "account": dict(account),
+                "source": dict(source),
+                "sync_state": dict(sync_state or {}),
+                "job_id": job_id,
+                "media_db": media_db,
+                "convert_bytes_to_text": convert_bytes_to_text,
+            }
+        )
+        assert account["tokens"]["access_token"] == "tok"
+        assert account["provider_user_id"] == "123456"
+        assert account["username"] == "researcher"
+        assert source["remote_id"] == "COLL1234"
+        assert sync_state["cursor"] == "cursor-0"
+        return {
+            "processed": 2,
+            "total": 2,
+            "failed": 0,
+            "imported": 1,
+            "duplicates": 1,
+            "metadata_only": 0,
+            "cursor": "cursor-1",
+        }
+
+    class _FakeMDB:
+        def __init__(self):
+            self.closed = False
+
+        def close_connection(self):
+            self.closed = True
+
+    created_media_db = _FakeMDB()
+
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(orgs, "list_memberships_for_user", lambda user_id: [])
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: _FakeZoteroConnector())
+    monkeypatch.setattr(svc, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc, "get_account_for_user", _fake_get_account_for_user, raising=False)
+    monkeypatch.setattr(svc, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(
+        worker,
+        "_create_connector_media_db",
+        lambda user_id: created_media_db,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        worker,
+        "_close_connector_media_db",
+        lambda media_db: media_db.close_connection(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.External_Sources.reference_manager_import.sync_reference_manager_source",
+        _fake_sync_reference_manager_source,
+        raising=False,
+    )
+
+    jm = _FakeJM()
+    await worker._process_import_job(
+        jm,
+        jid=1234,
+        lease_id="lease-1",
+        worker_id="worker-1",
+        source_id=99,
+        user_id=42,
+    )
+
+    assert len(sync_calls) == 1
+    assert sync_state_updates[0]["last_sync_started_at"] is not None
+    assert sync_state_updates[-1]["cursor"] == "cursor-1"
+    assert sync_state_updates[-1]["last_sync_succeeded_at"] is not None
+    assert jm.completed is not None
+    assert jm.completed["result"]["processed"] == 2
+    assert jm.completed["result"]["imported"] == 1
+    assert jm.completed["result"]["duplicates"] == 1
+    assert created_media_db.closed is True

--- a/tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py
+++ b/tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py
@@ -1,4 +1,5 @@
 import asyncio
+import aiosqlite
 import base64
 import json
 import os
@@ -37,6 +38,80 @@ def test_policy_fail_closed_on_error():
     ok, reason = evaluate_policy_constraints({"enabled_providers": [_BadProvider()]}, provider="drive")
     assert ok is False
     assert reason == "Policy evaluation failed"
+
+
+@pytest.mark.unit
+def test_default_connector_policy_enables_zotero_by_default(monkeypatch):
+    from tldw_Server_API.app.core.External_Sources.policy import get_default_policy_from_env
+
+    monkeypatch.delenv("ORG_CONNECTORS_ENABLED_PROVIDERS", raising=False)
+    monkeypatch.delenv("EMAIL_GMAIL_CONNECTOR_ENABLED", raising=False)
+
+    policy = get_default_policy_from_env(org_id=7)
+
+    assert policy["org_id"] == 7
+    assert policy["enabled_providers"] == ["drive", "notion", "zotero"]
+
+
+@pytest.mark.unit
+def test_connector_policy_schema_defaults_include_zotero():
+    from tldw_Server_API.app.api.v1.schemas.connectors import ConnectorPolicy
+
+    policy = ConnectorPolicy(org_id=9)
+
+    assert policy.enabled_providers == ["drive", "notion", "zotero"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_finish_source_sync_job_clears_failure_and_rescan_flags_on_success(tmp_path: Path):
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc
+
+    db = await aiosqlite.connect(tmp_path / "connectors-sync.sqlite3")
+    db.row_factory = aiosqlite.Row
+    db._is_sqlite = True
+    try:
+        account = await svc.create_account(
+            db,
+            user_id=1,
+            provider="drive",
+            display_name="Drive",
+            email="owner@example.com",
+            tokens={"access_token": "tok"},
+        )
+        source = await svc.create_source(
+            db,
+            account_id=account["id"],
+            provider="drive",
+            remote_id="root",
+            type_="folder",
+            path="/",
+            options={"recursive": True},
+        )
+        await svc.upsert_source_sync_state(
+            db,
+            source_id=source["id"],
+            sync_mode="hybrid",
+            last_sync_failed_at="2026-03-01 00:00:00",
+            last_error="cursor invalid",
+            retry_backoff_count=2,
+            needs_full_rescan=True,
+        )
+        await svc.start_source_sync_job(db, source_id=source["id"], job_id="job-1")
+
+        state = await svc.finish_source_sync_job(
+            db,
+            source_id=source["id"],
+            job_id="job-1",
+            outcome="success",
+        )
+
+        assert state["last_sync_failed_at"] is None
+        assert state["last_error"] is None
+        assert state["retry_backoff_count"] == 0
+        assert state["needs_full_rescan"] is False
+    finally:
+        await db.close()
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py
+++ b/tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py
@@ -8,12 +8,14 @@ from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.schemas.connectors import ConnectorSourceCreateRequest, SyncOptions
 from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources import reference_manager_import as ref_import
 from tldw_Server_API.app.core.External_Sources.reference_manager_adapter import ReferenceManagerAdapter
 from tldw_Server_API.app.core.External_Sources.reference_manager_types import (
     NormalizedReferenceCollection,
     NormalizedReferenceItem,
     ReferenceAttachmentCandidate,
 )
+from tldw_Server_API.app.core.exceptions import ReferenceImportError
 
 
 class _ReferenceManagerStub:
@@ -28,6 +30,11 @@ class _ReferenceManagerStub:
 
     async def resolve_attachment_download(self, account, attachment):  # pragma: no cover - contract stub
         return b""
+
+
+class _NoMediaIdRepository:
+    def add_media_with_keywords(self, **kwargs):
+        return None, None, "missing media id"
 
 
 @pytest.fixture
@@ -166,3 +173,47 @@ async def test_reference_manager_sources_are_flat_by_default(sqlite_db: aiosqlit
     assert source["options"]["recursive"] is False
     assert forced_recursive["options"]["recursive"] is False
     assert SyncOptions(recursive=True).recursive is True
+
+
+@pytest.mark.unit
+def test_ingest_reference_attachment_raises_shared_exception_when_media_id_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ref_import, "get_media_repository", lambda media_db: _NoMediaIdRepository())
+
+    item = NormalizedReferenceItem(
+        provider="zotero",
+        provider_item_key="ITEM-NO-ID",
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        doi="10.9999/example",
+        title="Item Missing Media ID",
+        authors="Author",
+        publication_date="2026-03-30",
+        year="2026",
+        journal="Journal",
+        abstract="Abstract",
+        source_url="https://example.com/item",
+        attachments=[],
+        metadata={},
+    )
+    attachment = ReferenceAttachmentCandidate(
+        provider="zotero",
+        provider_item_key="ITEM-NO-ID",
+        attachment_key="ATT-NO-ID",
+        title="Item Missing Media ID.pdf",
+        source_url="https://example.com/attachment",
+        mime_type="application/pdf",
+        size_bytes=100,
+        metadata={"filename": "missing.pdf"},
+    )
+
+    with pytest.raises(ReferenceImportError):
+        ref_import._ingest_reference_attachment(
+            object(),
+            item=item,
+            selected_attachment=attachment,
+            content_text="content",
+            safe_metadata={"doi": "10.9999/example"},
+        )

--- a/tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py
+++ b/tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import aiosqlite
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.connectors import ConnectorSourceCreateRequest, SyncOptions
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources.reference_manager_adapter import ReferenceManagerAdapter
+from tldw_Server_API.app.core.External_Sources.reference_manager_types import (
+    NormalizedReferenceCollection,
+    NormalizedReferenceItem,
+    ReferenceAttachmentCandidate,
+)
+
+
+class _ReferenceManagerStub:
+    async def list_collections(self, account, *, cursor=None, page_size=100):  # pragma: no cover - contract stub
+        return []
+
+    async def list_collection_items(self, account, collection_key, *, cursor=None, page_size=100):  # pragma: no cover - contract stub
+        return []
+
+    async def list_item_attachments(self, account, provider_item_key):  # pragma: no cover - contract stub
+        return []
+
+    async def resolve_attachment_download(self, account, attachment):  # pragma: no cover - contract stub
+        return b""
+
+
+@pytest.fixture
+async def sqlite_db(tmp_path: Path):
+    db = await aiosqlite.connect(tmp_path / "reference_manager_contract.sqlite3")
+    db.row_factory = aiosqlite.Row
+    db._is_sqlite = True
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+@pytest.mark.unit
+def test_reference_manager_adapter_protocol_accepts_collection_item_attachment_and_download_methods() -> None:
+    assert isinstance(_ReferenceManagerStub(), ReferenceManagerAdapter)
+
+
+@pytest.mark.unit
+def test_reference_manager_types_expose_canonical_v1_fields() -> None:
+    collection = NormalizedReferenceCollection(
+        provider="zotero",
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        source_url="https://www.zotero.org/users/123456/collections/COLL1234",
+    )
+    item = NormalizedReferenceItem(
+        provider="zotero",
+        provider_item_key="ABCD1234",
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        doi="10.1000/example",
+        title="Attention Is All You Need",
+        authors="Ashish Vaswani, Noam Shazeer",
+        publication_date="2017-06-12",
+        year="2017",
+        journal="NeurIPS",
+        abstract="...",
+        source_url="https://www.zotero.org/users/123456/items/ABCD1234",
+        attachments=[],
+    )
+    attachment = ReferenceAttachmentCandidate(
+        provider="zotero",
+        provider_item_key="ABCD1234",
+        attachment_key="ATTACH5678",
+        title="Supplemental PDF",
+        source_url="https://www.zotero.org/users/123456/items/ATTACH5678",
+    )
+
+    assert collection.collection_name == "Language Models"
+    assert collection.collection_key == "COLL1234"
+    assert collection.import_mode == "reference_manager"
+    assert item.collection_name == "Language Models"
+    assert item.doi == "10.1000/example"
+    assert item.import_mode == "reference_manager"
+    assert item.provider_item_key == "ABCD1234"
+    assert item.attachments == []
+    assert attachment.attachment_key == "ATTACH5678"
+    assert attachment.provider_item_key == "ABCD1234"
+
+
+@pytest.mark.unit
+def test_connector_source_request_accepts_zotero_collection_sources() -> None:
+    payload = ConnectorSourceCreateRequest(
+        account_id=1,
+        provider="zotero",
+        remote_id="COLL1234",
+        type="collection",
+        options={},
+    )
+
+    assert payload.provider == "zotero"
+    assert payload.type == "collection"
+    assert payload.options == {}
+
+
+@pytest.mark.unit
+def test_connector_source_request_rejects_invalid_provider_type_pairs() -> None:
+    with pytest.raises(ValidationError, match="only supported for provider 'zotero'"):
+        ConnectorSourceCreateRequest(
+            account_id=1,
+            provider="drive",
+            remote_id="COLL1234",
+            type="collection",
+            options={},
+        )
+
+    with pytest.raises(ValidationError, match="Zotero sources must use type 'collection'"):
+        ConnectorSourceCreateRequest(
+            account_id=1,
+            provider="zotero",
+            remote_id="ABCD1234",
+            type="folder",
+            options={},
+        )
+
+
+@pytest.mark.unit
+def test_connectors_service_recognizes_zotero_provider() -> None:
+    assert svc.get_connector_by_name("zotero").name == "zotero"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_reference_manager_sources_are_flat_by_default(sqlite_db: aiosqlite.Connection) -> None:
+    account = await svc.create_account(
+        sqlite_db,
+        user_id=7,
+        provider="zotero",
+        display_name="Zotero",
+        email="researcher@example.com",
+        tokens={"access_token": "token"},
+    )
+    source = await svc.create_source(
+        sqlite_db,
+        account_id=account["id"],
+        provider="zotero",
+        remote_id="COLL1234",
+        type_="collection",
+        path=None,
+        options={},
+    )
+    forced_recursive = await svc.create_source(
+        sqlite_db,
+        account_id=account["id"],
+        provider="zotero",
+        remote_id="COLL5678",
+        type_="collection",
+        path=None,
+        options={"recursive": True},
+    )
+
+    assert source["type"] == "collection"
+    assert source["options"]["recursive"] is False
+    assert forced_recursive["options"]["recursive"] is False
+    assert SyncOptions(recursive=True).recursive is True

--- a/tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py
+++ b/tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.External_Sources.reference_manager_dedupe import (
+    build_metadata_fingerprint,
+    rank_reference_item_match,
+)
+from tldw_Server_API.app.core.External_Sources.reference_manager_types import NormalizedReferenceItem
+
+
+def _build_item(*, doi: str | None = "10.1000/example", title: str = "Attention Is All You Need") -> NormalizedReferenceItem:
+    return NormalizedReferenceItem(
+        provider="zotero",
+        provider_item_key="ITEM1234",
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        doi=doi,
+        title=title,
+        authors="Ashish Vaswani, Noam Shazeer",
+        publication_date="2017-06-12",
+        year="2017",
+        journal="NeurIPS",
+        abstract="Transformers.",
+        source_url="https://www.zotero.org/users/123456/items/ITEM1234",
+        attachments=[],
+    )
+
+
+@pytest.mark.unit
+def test_rank_reference_item_match_prefers_same_provider_then_doi_then_file_hash_then_metadata() -> None:
+    item = _build_item()
+
+    same_provider = rank_reference_item_match(
+        item,
+        same_provider_item={"media_id": 5},
+        doi_match={"media_id": 77},
+        hash_match={"media_id": 88},
+        metadata_match={"media_id": 99},
+    )
+    doi_only = rank_reference_item_match(
+        item,
+        same_provider_item=None,
+        doi_match={"media_id": 77},
+        hash_match={"media_id": 88},
+        metadata_match={"media_id": 99},
+    )
+    hash_only = rank_reference_item_match(
+        item,
+        same_provider_item=None,
+        doi_match=None,
+        hash_match={"media_id": 88},
+        metadata_match={"media_id": 99},
+    )
+    metadata_only = rank_reference_item_match(
+        item,
+        same_provider_item=None,
+        doi_match=None,
+        hash_match=None,
+        metadata_match={"media_id": 99},
+    )
+
+    assert same_provider.reason == "same_provider_item"
+    assert same_provider.media_id == 5
+    assert doi_only.reason == "doi"
+    assert doi_only.media_id == 77
+    assert hash_only.reason == "file_hash"
+    assert hash_only.media_id == 88
+    assert metadata_only.reason == "metadata_fingerprint"
+    assert metadata_only.media_id == 99
+
+
+@pytest.mark.unit
+def test_metadata_fingerprint_matching_is_conservative_for_similar_but_distinct_titles() -> None:
+    first = build_metadata_fingerprint(
+        title="Attention Is All You Need",
+        authors="Ashish Vaswani, Noam Shazeer",
+        year="2017",
+    )
+    second = build_metadata_fingerprint(
+        title="Attention Is All You Need for Speech",
+        authors="Ashish Vaswani, Noam Shazeer",
+        year="2017",
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first != second
+
+
+@pytest.mark.unit
+def test_metadata_fingerprint_normalizes_common_author_separators() -> None:
+    comma_delimited = build_metadata_fingerprint(
+        title="Attention Is All You Need",
+        authors="Ashish Vaswani, Noam Shazeer",
+        year="2017",
+    )
+    summary_delimited = build_metadata_fingerprint(
+        title="Attention Is All You Need",
+        authors="Ashish Vaswani and Noam Shazeer",
+        year="2017",
+    )
+
+    assert comma_delimited is not None
+    assert summary_delimited is not None
+    assert comma_delimited == summary_delimited

--- a/tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py
@@ -140,3 +140,43 @@ async def test_reference_item_binding_clears_metadata_only_reason_when_item_late
     assert first["dedupe_match_reason"] == "metadata_only"
     assert second["media_id"] == 55
     assert second["dedupe_match_reason"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_oauth_state_metadata_is_encrypted_at_rest_when_crypto_enabled(
+    sqlite_db: aiosqlite.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WORKFLOWS_ARTIFACT_ENC_KEY", "reference-manager-test-key")
+
+    await svc.create_oauth_state(
+        sqlite_db,
+        user_id=7,
+        provider="zotero",
+        state="state-123",
+        metadata={
+            "oauth_token": "temp-token",
+            "oauth_token_secret": "temp-secret",
+        },
+    )
+
+    cur = await sqlite_db.execute(
+        "SELECT metadata FROM external_oauth_state WHERE state = ? AND user_id = ?",
+        ("state-123", 7),
+    )
+    row = await cur.fetchone()
+    assert row is not None
+    assert isinstance(row["metadata"], str)
+    assert "temp-secret" not in row["metadata"]
+
+    consumed = await svc.consume_oauth_state(
+        sqlite_db,
+        user_id=7,
+        provider="zotero",
+        state="state-123",
+    )
+
+    assert consumed is not False
+    assert consumed["oauth_token"] == "temp-token"
+    assert consumed["oauth_token_secret"] == "temp-secret"

--- a/tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+
+
+@pytest.fixture
+async def sqlite_db(tmp_path: Path):
+    db = await aiosqlite.connect(tmp_path / "reference_manager.sqlite3")
+    db.row_factory = aiosqlite.Row
+    db._is_sqlite = True
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+async def _create_reference_manager_source(db: aiosqlite.Connection) -> dict:
+    account = await svc.create_account(
+        db,
+        user_id=7,
+        provider="zotero",
+        display_name="Zotero",
+        email="researcher@example.com",
+        tokens={"access_token": "token"},
+    )
+    return await svc.create_source(
+        db,
+        account_id=account["id"],
+        provider="zotero",
+        remote_id="COLL1234",
+        type_="collection",
+        path=None,
+        options={},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_reference_item_binding_round_trips_provider_and_collection_identity(
+    sqlite_db: aiosqlite.Connection,
+) -> None:
+    source = await _create_reference_manager_source(sqlite_db)
+
+    first = await svc.upsert_reference_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="zotero",
+        provider_item_key="ABCD1234",
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        provider_version="1",
+        provider_updated_at="2026-03-01T00:00:00Z",
+        media_id=99,
+        dedupe_match_reason="doi",
+        raw_reference_metadata={
+            "provider": "zotero",
+            "collection_name": "Language Models",
+            "title": "Attention Is All You Need",
+        },
+    )
+    second = await svc.upsert_reference_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="zotero",
+        provider_item_key="ABCD1234",
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        provider_version="2",
+        provider_updated_at="2026-03-02T00:00:00Z",
+        media_id=99,
+        dedupe_match_reason="title",
+        raw_reference_metadata={
+            "provider": "zotero",
+            "collection_name": "Language Models",
+            "title": "Attention Is All You Need",
+        },
+    )
+
+    pragma = await sqlite_db.execute("PRAGMA table_info(external_reference_items)")
+    columns = {row["name"] for row in await pragma.fetchall()}
+
+    assert first["provider_item_key"] == "ABCD1234"
+    assert first["provider_library_id"] == "123456"
+    assert first["collection_key"] == "COLL1234"
+    assert first["collection_name"] == "Language Models"
+    assert first["dedupe_match_reason"] == "doi"
+    assert first["first_imported_at"] is not None
+    assert first["last_imported_at"] is not None
+    assert second["dedupe_match_reason"] == "title"
+    assert second["first_imported_at"] == first["first_imported_at"]
+    assert second["last_imported_at"] >= first["last_imported_at"]
+    assert second["raw_reference_metadata"]["collection_name"] == "Language Models"
+    assert {"provider_item_key", "collection_key", "dedupe_match_reason", "first_imported_at", "last_imported_at"} <= columns
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_reference_item_binding_clears_metadata_only_reason_when_item_later_imports(
+    sqlite_db: aiosqlite.Connection,
+) -> None:
+    source = await _create_reference_manager_source(sqlite_db)
+
+    first = await svc.upsert_reference_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="zotero",
+        provider_item_key="META1234",
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        provider_version="1",
+        provider_updated_at="2026-03-01T00:00:00Z",
+        media_id=None,
+        dedupe_match_reason="metadata_only",
+        raw_reference_metadata={"title": "Attachment Pending"},
+    )
+    second = await svc.upsert_reference_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="zotero",
+        provider_item_key="META1234",
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        provider_version="2",
+        provider_updated_at="2026-03-02T00:00:00Z",
+        media_id=55,
+        dedupe_match_reason=None,
+        raw_reference_metadata={"title": "Attachment Imported"},
+    )
+
+    assert first["media_id"] is None
+    assert first["dedupe_match_reason"] == "metadata_only"
+    assert second["media_id"] == 55
+    assert second["dedupe_match_reason"] is None

--- a/tldw_Server_API/tests/External_Sources/test_zotero_connector.py
+++ b/tldw_Server_API/tests/External_Sources/test_zotero_connector.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from tldw_Server_API.app.core.External_Sources.zotero import ZoteroConnector
+from tldw_Server_API.app.core.External_Sources.reference_manager_types import (
+    ReferenceAttachmentCandidate,
+)
+
+
+class _Resp:
+    def __init__(self, payload, headers: dict[str, str] | None = None, content: bytes | None = None):
+        self._payload = payload
+        self.headers = headers or {}
+        self.content = content or b""
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+    async def aclose(self):
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_zotero_collection_browsing_returns_collection_records_not_file_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [
+        {
+            "key": "COLL1234",
+            "version": 7,
+            "data": {
+                "key": "COLL1234",
+                "name": "Language Models",
+                "parentCollection": False,
+            },
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/users/123456/collections/COLL1234",
+                }
+            },
+        }
+    ]
+
+    async def _fake_afetch(*, method, url, headers=None, params=None, timeout=None):
+        assert method == "GET"
+        assert url == "https://api.zotero.org/users/123456/collections"
+        assert headers["Zotero-API-Version"] == "3"
+        assert headers["Zotero-API-Key"] == "api-key"
+        assert params == {"format": "json", "limit": 25, "start": 0}
+        return _Resp(payload)
+
+    import tldw_Server_API.app.core.External_Sources.zotero as zotero_mod
+
+    monkeypatch.setattr(zotero_mod, "afetch", _fake_afetch)
+
+    connector = ZoteroConnector(client_id="client-id", client_secret="client-secret", redirect_base="http://localhost")
+    collections, next_cursor = await connector.list_collections(
+        {
+            "provider": "zotero",
+            "provider_user_id": "123456",
+            "tokens": {"access_token": "api-key"},
+        },
+        cursor=None,
+        page_size=25,
+    )
+
+    assert next_cursor is None
+    assert len(collections) == 1
+    assert collections[0].provider == "zotero"
+    assert collections[0].collection_key == "COLL1234"
+    assert collections[0].collection_name == "Language Models"
+    assert collections[0].source_url == "https://www.zotero.org/users/123456/collections/COLL1234"
+    assert "mime_type" not in collections[0].metadata
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_zotero_collection_item_listing_is_flat_for_selected_collection_in_v1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [
+        {
+            "key": "ITEM1234",
+            "version": 11,
+            "data": {
+                "key": "ITEM1234",
+                "itemType": "journalArticle",
+                "title": "Attention Is All You Need",
+                "DOI": "10.1000/example",
+                "date": "2017-06-12",
+                "publicationTitle": "NeurIPS",
+                "abstractNote": "Transformers.",
+                "collections": ["COLL1234"],
+                "creators": [
+                    {"creatorType": "author", "firstName": "Ashish", "lastName": "Vaswani"},
+                    {"creatorType": "author", "firstName": "Noam", "lastName": "Shazeer"},
+                ],
+            },
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/users/123456/items/ITEM1234",
+                }
+            },
+        },
+        {
+            "key": "ATTACH5678",
+            "version": 12,
+            "data": {
+                "key": "ATTACH5678",
+                "itemType": "attachment",
+                "parentItem": "ITEM1234",
+                "title": "Attention Is All You Need.pdf",
+                "linkMode": "imported_file",
+                "contentType": "application/pdf",
+            },
+        },
+    ]
+
+    async def _fake_afetch(*, method, url, headers=None, params=None, timeout=None):
+        assert method == "GET"
+        assert url == "https://api.zotero.org/users/123456/collections/COLL1234/items/top"
+        assert headers["Zotero-API-Key"] == "api-key"
+        assert params == {"format": "json", "limit": 50, "start": 0}
+        return _Resp(payload)
+
+    import tldw_Server_API.app.core.External_Sources.zotero as zotero_mod
+
+    monkeypatch.setattr(zotero_mod, "afetch", _fake_afetch)
+
+    connector = ZoteroConnector(client_id="client-id", client_secret="client-secret", redirect_base="http://localhost")
+    items, next_cursor = await connector.list_collection_items(
+        {
+            "provider": "zotero",
+            "provider_user_id": "123456",
+            "tokens": {"access_token": "api-key"},
+        },
+        "COLL1234",
+        cursor=None,
+        page_size=50,
+    )
+
+    assert next_cursor is None
+    assert [item.provider_item_key for item in items] == ["ITEM1234"]
+    assert items[0].provider == "zotero"
+    assert items[0].provider_library_id == "123456"
+    assert items[0].collection_key == "COLL1234"
+    assert items[0].doi == "10.1000/example"
+    assert items[0].title == "Attention Is All You Need"
+    assert items[0].authors == "Ashish Vaswani, Noam Shazeer"
+    assert items[0].attachments == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_zotero_normalize_reference_item_prefers_importable_pdf_attachments_and_metadata_only_fallback() -> None:
+    connector = ZoteroConnector(client_id="client-id", client_secret="client-secret", redirect_base="http://localhost")
+    raw_item = {
+        "key": "ITEM1234",
+        "version": 11,
+        "data": {
+            "key": "ITEM1234",
+            "itemType": "journalArticle",
+            "title": "Attention Is All You Need",
+            "DOI": "10.1000/example",
+            "date": "2017-06-12",
+            "publicationTitle": "NeurIPS",
+            "abstractNote": "Transformers.",
+            "collections": ["COLL1234"],
+            "creators": [
+                {"creatorType": "author", "firstName": "Ashish", "lastName": "Vaswani"},
+                {"creatorType": "author", "firstName": "Noam", "lastName": "Shazeer"},
+            ],
+        },
+        "meta": {
+            "creatorSummary": "Ashish Vaswani and Noam Shazeer",
+        },
+        "links": {
+            "alternate": {
+                "href": "https://www.zotero.org/users/123456/items/ITEM1234",
+            }
+        },
+    }
+    raw_attachments = [
+        {
+            "key": "ATTACH9999",
+            "data": {
+                "key": "ATTACH9999",
+                "itemType": "attachment",
+                "title": "Landing Page",
+                "parentItem": "ITEM1234",
+                "linkMode": "linked_url",
+                "contentType": "text/html",
+                "url": "https://example.com/article",
+            },
+        },
+        {
+            "key": "ATTACH5678",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/users/123456/items/ATTACH5678",
+                }
+            },
+            "data": {
+                "key": "ATTACH5678",
+                "itemType": "attachment",
+                "title": "Attention Is All You Need.pdf",
+                "parentItem": "ITEM1234",
+                "linkMode": "imported_file",
+                "contentType": "application/pdf",
+                "filename": "attention.pdf",
+            },
+        },
+    ]
+
+    item = await connector.normalize_reference_item(raw_item, raw_attachments)
+    metadata_only_item = await connector.normalize_reference_item(raw_item, [])
+
+    assert item.provider == "zotero"
+    assert item.collection_key == "COLL1234"
+    assert item.attachments[0].attachment_key == "ATTACH5678"
+    assert item.attachments[0].mime_type == "application/pdf"
+    assert item.attachments[0].title == "Attention Is All You Need.pdf"
+    assert metadata_only_item.provider_item_key == "ITEM1234"
+    assert metadata_only_item.attachments == []
+    assert metadata_only_item.title == "Attention Is All You Need"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_zotero_normalize_reference_item_extracts_year_from_free_form_dates() -> None:
+    connector = ZoteroConnector(client_id="client-id", client_secret="client-secret", redirect_base="http://localhost")
+    raw_item = {
+        "key": "ITEM5678",
+        "data": {
+            "key": "ITEM5678",
+            "itemType": "journalArticle",
+            "title": "Scaling Laws for Neural Language Models",
+            "date": "May 2017",
+            "creators": [
+                {"creatorType": "author", "firstName": "Jared", "lastName": "Kaplan"},
+            ],
+        },
+    }
+
+    item = await connector.normalize_reference_item(raw_item, [])
+
+    assert item.publication_date == "May 2017"
+    assert item.year == "2017"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_zotero_exchange_code_parses_access_token_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_afetch(*, method, url, headers=None, params=None, timeout=None, data=None):
+        assert method == "POST"
+        assert url == "https://www.zotero.org/oauth/access"
+        assert params is None
+        assert timeout == 30
+        assert headers["Authorization"].startswith("OAuth ")
+        assert headers["Content-Type"] == "application/x-www-form-urlencoded"
+        return _Resp(
+            None,
+            content=b"oauth_token=request-token&oauth_token_secret=api-key-123&userID=123456&username=testuser",
+        )
+
+    import tldw_Server_API.app.core.External_Sources.zotero as zotero_mod
+
+    monkeypatch.setattr(zotero_mod, "afetch", _fake_afetch)
+
+    connector = ZoteroConnector(client_id="client-id", client_secret="client-secret", redirect_base="http://localhost")
+    result = await connector.exchange_code(
+        json.dumps(
+            {
+                "oauth_token": "request-token",
+                "oauth_token_secret": "temporary-secret",
+                "oauth_verifier": "verifier-123",
+            }
+        ),
+        "http://localhost/api/v1/connectors/providers/zotero/callback",
+    )
+
+    assert result["provider"] == "zotero"
+    assert result["access_token"] == "api-key-123"
+    assert result["provider_user_id"] == "123456"
+    assert result["username"] == "testuser"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_zotero_resolve_attachment_download_uses_attachment_file_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_afetch(*, method, url, headers=None, params=None, timeout=None, **kwargs):
+        assert method == "GET"
+        assert url == "https://api.zotero.org/users/123456/items/ATTACH5678/file"
+        assert headers["Zotero-API-Key"] == "api-key"
+        assert headers["Zotero-API-Version"] == "3"
+        assert params is None
+        assert timeout == 60
+        assert kwargs == {}
+        return _Resp(None, content=b"%PDF-1.7 test payload")
+
+    import tldw_Server_API.app.core.External_Sources.zotero as zotero_mod
+
+    monkeypatch.setattr(zotero_mod, "afetch", _fake_afetch)
+
+    connector = ZoteroConnector(client_id="client-id", client_secret="client-secret", redirect_base="http://localhost")
+    payload = await connector.resolve_attachment_download(
+        {
+            "provider": "zotero",
+            "provider_user_id": "123456",
+            "tokens": {"access_token": "api-key"},
+        },
+        ReferenceAttachmentCandidate(
+            provider="zotero",
+            provider_item_key="ITEM1234",
+            attachment_key="ATTACH5678",
+            title="Attention Is All You Need.pdf",
+            mime_type="application/pdf",
+        ),
+    )
+
+    assert payload == b"%PDF-1.7 test payload"
+
+
+@pytest.mark.unit
+def test_zotero_authorize_url_requires_request_token_and_builds_authorize_url() -> None:
+    connector = ZoteroConnector(client_id="client-id", client_secret="client-secret", redirect_base="http://localhost")
+
+    with pytest.raises(ValueError, match="oauth_token"):
+        connector.authorize_url(state="state-123", scopes=None)
+
+    auth_url = connector.authorize_url(
+        state="state-123",
+        scopes=["oauth_token=request-token-123", "notes_access=0"],
+    )
+    parsed = urlparse(auth_url)
+    params = parse_qs(parsed.query)
+
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "www.zotero.org"
+    assert parsed.path == "/oauth/authorize"
+    assert params["oauth_token"] == ["request-token-123"]
+    assert params["state"] == ["state-123"]

--- a/tldw_Server_API/tests/External_Sources/test_zotero_connector.py
+++ b/tldw_Server_API/tests/External_Sources/test_zotero_connector.py
@@ -258,6 +258,28 @@ async def test_zotero_normalize_reference_item_extracts_year_from_free_form_date
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_zotero_normalize_reference_item_ignores_invalid_doi() -> None:
+    connector = ZoteroConnector(client_id="client-id", client_secret="client-secret", redirect_base="http://localhost")
+    raw_item = {
+        "key": "ITEM-BAD-DOI",
+        "data": {
+            "key": "ITEM-BAD-DOI",
+            "itemType": "journalArticle",
+            "title": "Paper With Malformed DOI",
+            "DOI": "definitely-not-a-doi",
+            "date": "2024",
+        },
+    }
+
+    item = await connector.normalize_reference_item(raw_item, [])
+
+    assert item.provider_item_key == "ITEM-BAD-DOI"
+    assert item.title == "Paper With Malformed DOI"
+    assert item.doi is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_zotero_exchange_code_parses_access_token_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
@@ -1,0 +1,548 @@
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.media_db.api import get_document_version
+from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources.reference_manager_types import (
+    NormalizedReferenceItem,
+    ReferenceAttachmentCandidate,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+class _FakeJM:
+    def __init__(self) -> None:
+        self.completed: dict[str, object] | None = None
+
+    def renew_job_lease(self, *args, **kwargs):
+        return None
+
+    def complete_job(
+        self,
+        jid,
+        result=None,
+        worker_id=None,
+        lease_id=None,
+        completion_token=None,
+    ) -> None:
+        self.completed = {"jid": jid, "result": result}
+
+
+class _SqlitePool:
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self._db
+
+
+class _FakeZoteroConnector:
+    def __init__(
+        self,
+        *,
+        pages: dict[str | None, tuple[list[NormalizedReferenceItem], str | None]],
+        attachments: dict[str, list[ReferenceAttachmentCandidate]],
+        downloads: dict[str, bytes],
+    ) -> None:
+        self._pages = pages
+        self._attachments = attachments
+        self._downloads = downloads
+        self.list_collection_calls: list[str | None] = []
+        self.list_item_attachment_calls: list[str] = []
+        self.download_calls: list[str] = []
+
+    async def list_collection_items(
+        self,
+        account,
+        collection_key: str,
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ):
+        assert account["tokens"]["access_token"] == "tok"
+        assert account["provider_user_id"] == "123456"
+        assert collection_key == "COLL1234"
+        assert page_size == 100
+        self.list_collection_calls.append(cursor)
+        return self._pages.get(cursor, ([], None))
+
+    async def list_item_attachments(self, account, provider_item_key: str):
+        assert account["tokens"]["access_token"] == "tok"
+        self.list_item_attachment_calls.append(provider_item_key)
+        return list(self._attachments.get(provider_item_key, []))
+
+    async def download_file(self, account, file_id: str, **kwargs):
+        assert account["tokens"]["access_token"] == "tok"
+        self.download_calls.append(file_id)
+        return self._downloads[file_id]
+
+
+def _reference_item(
+    *,
+    provider_item_key: str,
+    doi: str | None,
+    title: str,
+    authors: str,
+    year: str,
+    journal: str,
+    abstract: str,
+    provider_version: str,
+) -> NormalizedReferenceItem:
+    return NormalizedReferenceItem(
+        provider="zotero",
+        provider_item_key=provider_item_key,
+        provider_library_id="123456",
+        collection_key="COLL1234",
+        collection_name="Language Models",
+        doi=doi,
+        title=title,
+        authors=authors,
+        publication_date=f"{year}-01-01",
+        year=year,
+        journal=journal,
+        abstract=abstract,
+        source_url=f"https://www.zotero.org/users/123456/items/{provider_item_key}",
+        attachments=[],
+        metadata={"provider_version": provider_version},
+    )
+
+
+def _attachment(*, provider_item_key: str, attachment_key: str) -> ReferenceAttachmentCandidate:
+    return ReferenceAttachmentCandidate(
+        provider="zotero",
+        provider_item_key=provider_item_key,
+        attachment_key=attachment_key,
+        title=f"{provider_item_key}.pdf",
+        source_url=f"https://www.zotero.org/users/123456/items/{attachment_key}",
+        mime_type="application/pdf",
+        size_bytes=128,
+        metadata={"filename": f"{provider_item_key}.pdf"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_reference_manager_sync_imports_new_items_merges_duplicate_metadata_and_tracks_metadata_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.db_path_utils as db_paths_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    connectors_db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    connectors_db.row_factory = aiosqlite.Row
+    connectors_db._is_sqlite = True
+
+    try:
+        media_root = tmp_path / "user_dbs"
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(media_root))
+        monkeypatch.setitem(db_paths_mod.settings, "USER_DB_BASE_DIR", str(media_root))
+        media_db_path = db_paths_mod.DatabasePaths.get_media_db_path(1)
+
+        fake_conn = _FakeZoteroConnector(
+            pages={
+                None: (
+                    [
+                        _reference_item(
+                            provider_item_key="ITEM-NEW",
+                            doi="10.1000/new",
+                            title="Attention Is All You Need",
+                            authors="Ashish Vaswani, Noam Shazeer",
+                            year="2017",
+                            journal="NeurIPS",
+                            abstract="Transformer paper.",
+                            provider_version="1",
+                        ),
+                        _reference_item(
+                            provider_item_key="ITEM-DUP",
+                            doi="10.2000/duplicate",
+                            title="Provider Duplicate Title",
+                            authors="Duplicate Author",
+                            year="2024",
+                            journal="Journal of Duplicates",
+                            abstract="Duplicate metadata should enrich only missing fields.",
+                            provider_version="4",
+                        ),
+                        _reference_item(
+                            provider_item_key="ITEM-META",
+                            doi="10.3000/metadata-only",
+                            title="Metadata Only Entry",
+                            authors="Metadata Author",
+                            year="2025",
+                            journal="Metadata Journal",
+                            abstract="No attachment available.",
+                            provider_version="2",
+                        ),
+                    ],
+                    "cursor-1",
+                ),
+            },
+            attachments={
+                "ITEM-NEW": [_attachment(provider_item_key="ITEM-NEW", attachment_key="ATT-NEW")],
+                "ITEM-DUP": [_attachment(provider_item_key="ITEM-DUP", attachment_key="ATT-DUP")],
+                "ITEM-META": [],
+            },
+            downloads={
+                "ATT-NEW": b"Imported attachment body",
+                "ATT-DUP": b"Duplicate attachment body",
+            },
+        )
+
+        pool = _SqlitePool(connectors_db)
+
+        async def _fake_get_db_pool():
+            return pool
+
+        async def _fake_list_memberships_for_user(_user_id: int):
+            return []
+
+        monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+        monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+        monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: fake_conn)
+        async def _fake_convert_document_bytes_to_text(raw, name, effective_mime):
+            return raw.decode("utf-8")
+
+        monkeypatch.setattr(
+            worker,
+            "_convert_document_bytes_to_text",
+            _fake_convert_document_bytes_to_text,
+            raising=False,
+        )
+
+        account = await svc.create_account(
+            connectors_db,
+            user_id=1,
+            provider="zotero",
+            display_name="Zotero",
+            email="researcher@example.com",
+            tokens={
+                "access_token": "tok",
+                "provider_user_id": "123456",
+                "username": "researcher",
+            },
+        )
+        source = await svc.create_source(
+            connectors_db,
+            account_id=int(account["id"]),
+            provider="zotero",
+            remote_id="COLL1234",
+            type_="collection",
+            path=None,
+            options={},
+        )
+        await svc.upsert_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+            sync_mode="poll",
+        )
+
+        media_db = MediaDatabase(db_path=str(media_db_path), client_id="1")
+        existing_media_id, _, _ = media_db.add_media_with_keywords(
+            url="seed://duplicate",
+            title="Existing Local Title",
+            media_type="document",
+            content="Existing local content",
+            keywords=[],
+            safe_metadata=json.dumps(
+                {
+                    "doi": "10.2000/duplicate",
+                    "title": "Existing Local Title",
+                }
+            ),
+            overwrite=False,
+        )
+
+        jm = _FakeJM()
+        await worker._process_import_job(
+            jm,
+            jid=9101,
+            lease_id="lease-reference",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        imported_binding = await svc.get_reference_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="zotero",
+            provider_item_key="ITEM-NEW",
+        )
+        duplicate_binding = await svc.get_reference_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="zotero",
+            provider_item_key="ITEM-DUP",
+        )
+        metadata_only_binding = await svc.get_reference_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="zotero",
+            provider_item_key="ITEM-META",
+        )
+        binding_health = await svc.get_source_binding_health(
+            connectors_db,
+            source_id=int(source["id"]),
+        )
+        sync_state = await svc.get_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+        )
+
+        assert jm.completed is not None
+        assert jm.completed["result"]["processed"] == 3
+        assert jm.completed["result"]["imported"] == 1
+        assert jm.completed["result"]["duplicates"] == 1
+        assert jm.completed["result"]["metadata_only"] == 1
+        assert fake_conn.list_collection_calls == [None]
+        assert sync_state is not None
+        assert sync_state["cursor"] == "cursor-1"
+
+        assert imported_binding is not None
+        assert imported_binding["media_id"] is not None
+        assert imported_binding["dedupe_match_reason"] is None
+        imported_version = get_document_version(
+            media_db,
+            media_id=int(imported_binding["media_id"]),
+            version_number=1,
+        )
+        imported_safe_metadata = json.loads(imported_version["safe_metadata"])
+        assert imported_version["content"] == "Imported attachment body"
+        assert imported_safe_metadata == {
+            "provider": "zotero",
+            "import_mode": "reference_manager",
+            "provider_item_key": "ITEM-NEW",
+            "provider_library_id": "123456",
+            "collection_key": "COLL1234",
+            "collection_name": "Language Models",
+            "source_url": "https://www.zotero.org/users/123456/items/ITEM-NEW",
+            "doi": "10.1000/new",
+            "title": "Attention Is All You Need",
+            "authors": "Ashish Vaswani, Noam Shazeer",
+            "publication_date": "2017-01-01",
+            "year": "2017",
+            "journal": "NeurIPS",
+            "abstract": "Transformer paper.",
+        }
+
+        assert duplicate_binding is not None
+        assert int(duplicate_binding["media_id"]) == int(existing_media_id)
+        assert duplicate_binding["dedupe_match_reason"] == "doi"
+        duplicate_version = get_document_version(
+            media_db,
+            media_id=int(existing_media_id),
+            version_number=1,
+        )
+        duplicate_safe_metadata = json.loads(duplicate_version["safe_metadata"])
+        duplicate_version_count = media_db.execute_query(
+            "SELECT COUNT(*) AS c FROM DocumentVersions WHERE media_id = ? AND deleted = 0",
+            (int(existing_media_id),),
+        ).fetchone()["c"]
+        assert duplicate_version["content"] == "Existing local content"
+        assert duplicate_version_count == 1
+        assert duplicate_safe_metadata["title"] == "Existing Local Title"
+        assert duplicate_safe_metadata["authors"] == "Duplicate Author"
+        assert duplicate_safe_metadata["journal"] == "Journal of Duplicates"
+        assert duplicate_safe_metadata["year"] == "2024"
+
+        assert metadata_only_binding is not None
+        assert metadata_only_binding["media_id"] is None
+        assert metadata_only_binding["dedupe_match_reason"] == "metadata_only"
+        assert binding_health == {
+            "tracked_item_count": 3,
+            "degraded_item_count": 0,
+            "duplicate_count": 1,
+            "metadata_only_count": 1,
+        }
+
+        media_count = media_db.execute_query(
+            "SELECT COUNT(*) AS c FROM Media WHERE deleted = 0",
+            (),
+        ).fetchone()["c"]
+        assert media_count == 2
+    finally:
+        await connectors_db.close()
+
+
+@pytest.mark.asyncio
+async def test_reference_manager_repeat_sync_keeps_existing_media_non_destructive(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.db_path_utils as db_paths_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    connectors_db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    connectors_db.row_factory = aiosqlite.Row
+    connectors_db._is_sqlite = True
+
+    try:
+        media_root = tmp_path / "user_dbs"
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(media_root))
+        monkeypatch.setitem(db_paths_mod.settings, "USER_DB_BASE_DIR", str(media_root))
+        media_db_path = db_paths_mod.DatabasePaths.get_media_db_path(1)
+
+        fake_conn = _FakeZoteroConnector(
+            pages={
+                None: (
+                    [
+                        _reference_item(
+                            provider_item_key="ITEM-NEW",
+                            doi="10.5555/reference",
+                            title="Original Imported Title",
+                            authors="First Author",
+                            year="2023",
+                            journal="Original Journal",
+                            abstract="Original abstract.",
+                            provider_version="1",
+                        ),
+                    ],
+                    "cursor-1",
+                ),
+                "cursor-1": (
+                    [
+                        _reference_item(
+                            provider_item_key="ITEM-NEW",
+                            doi="10.5555/reference",
+                            title="Changed Upstream Title",
+                            authors="Changed Author",
+                            year="2024",
+                            journal="Changed Journal",
+                            abstract="Changed abstract.",
+                            provider_version="2",
+                        ),
+                    ],
+                    "cursor-2",
+                ),
+            },
+            attachments={
+                "ITEM-NEW": [_attachment(provider_item_key="ITEM-NEW", attachment_key="ATT-NEW")],
+            },
+            downloads={
+                "ATT-NEW": b"Original imported body",
+            },
+        )
+
+        pool = _SqlitePool(connectors_db)
+
+        async def _fake_get_db_pool():
+            return pool
+
+        async def _fake_list_memberships_for_user(_user_id: int):
+            return []
+
+        monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+        monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+        monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: fake_conn)
+        async def _fake_convert_document_bytes_to_text(raw, name, effective_mime):
+            return raw.decode("utf-8")
+
+        monkeypatch.setattr(
+            worker,
+            "_convert_document_bytes_to_text",
+            _fake_convert_document_bytes_to_text,
+            raising=False,
+        )
+
+        account = await svc.create_account(
+            connectors_db,
+            user_id=1,
+            provider="zotero",
+            display_name="Zotero",
+            email="researcher@example.com",
+            tokens={
+                "access_token": "tok",
+                "provider_user_id": "123456",
+                "username": "researcher",
+            },
+        )
+        source = await svc.create_source(
+            connectors_db,
+            account_id=int(account["id"]),
+            provider="zotero",
+            remote_id="COLL1234",
+            type_="collection",
+            path=None,
+            options={},
+        )
+        await svc.upsert_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+            sync_mode="poll",
+        )
+
+        first_jm = _FakeJM()
+        await worker._process_import_job(
+            first_jm,
+            jid=9201,
+            lease_id="lease-reference-1",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        first_binding = await svc.get_reference_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="zotero",
+            provider_item_key="ITEM-NEW",
+        )
+        assert first_binding is not None
+        media_id = int(first_binding["media_id"])
+
+        second_jm = _FakeJM()
+        await worker._process_import_job(
+            second_jm,
+            jid=9202,
+            lease_id="lease-reference-2",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        media_db = MediaDatabase(db_path=str(media_db_path), client_id="1")
+        latest_version = get_document_version(media_db, media_id=media_id, version_number=1)
+        version_count = media_db.execute_query(
+            "SELECT COUNT(*) AS c FROM DocumentVersions WHERE media_id = ? AND deleted = 0",
+            (media_id,),
+        ).fetchone()["c"]
+        final_binding = await svc.get_reference_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="zotero",
+            provider_item_key="ITEM-NEW",
+        )
+        sync_state = await svc.get_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+        )
+
+        assert first_jm.completed is not None
+        assert first_jm.completed["result"]["imported"] == 1
+        assert second_jm.completed is not None
+        assert second_jm.completed["result"]["duplicates"] == 1
+        assert version_count == 1
+        assert latest_version["content"] == "Original imported body"
+        assert json.loads(latest_version["safe_metadata"])["title"] == "Original Imported Title"
+        assert final_binding is not None
+        assert final_binding["provider_version"] == "2"
+        assert final_binding["dedupe_match_reason"] == "same_provider_item"
+        assert sync_state is not None
+        assert sync_state["cursor"] == "cursor-2"
+    finally:
+        await connectors_db.close()

--- a/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
@@ -307,6 +307,8 @@ async def test_reference_manager_sync_imports_new_items_merges_duplicate_metadat
         assert jm.completed["result"]["duplicates"] == 1
         assert jm.completed["result"]["metadata_only"] == 1
         assert fake_conn.list_collection_calls == [None]
+        assert fake_conn.list_item_attachment_calls == ["ITEM-NEW", "ITEM-META"]
+        assert fake_conn.download_calls == ["ATT-NEW"]
         assert sync_state is not None
         assert sync_state["cursor"] == "cursor-1"
 
@@ -536,13 +538,291 @@ async def test_reference_manager_repeat_sync_keeps_existing_media_non_destructiv
         assert first_jm.completed["result"]["imported"] == 1
         assert second_jm.completed is not None
         assert second_jm.completed["result"]["duplicates"] == 1
+        assert fake_conn.list_item_attachment_calls == ["ITEM-NEW"]
+        assert fake_conn.download_calls == ["ATT-NEW"]
         assert version_count == 1
         assert latest_version["content"] == "Original imported body"
         assert json.loads(latest_version["safe_metadata"])["title"] == "Original Imported Title"
         assert final_binding is not None
         assert final_binding["provider_version"] == "2"
         assert final_binding["dedupe_match_reason"] == "same_provider_item"
+        assert final_binding["raw_reference_metadata"]["selected_attachment"]["attachment_key"] == "ATT-NEW"
         assert sync_state is not None
         assert sync_state["cursor"] == "cursor-2"
+    finally:
+        await connectors_db.close()
+
+
+@pytest.mark.asyncio
+async def test_reference_manager_sync_merges_metadata_even_with_legacy_invalid_identifier(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.db_path_utils as db_paths_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    connectors_db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    connectors_db.row_factory = aiosqlite.Row
+    connectors_db._is_sqlite = True
+
+    try:
+        media_root = tmp_path / "user_dbs"
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(media_root))
+        monkeypatch.setitem(db_paths_mod.settings, "USER_DB_BASE_DIR", str(media_root))
+        media_db_path = db_paths_mod.DatabasePaths.get_media_db_path(1)
+
+        fake_conn = _FakeZoteroConnector(
+            pages={
+                None: (
+                    [
+                        _reference_item(
+                            provider_item_key="ITEM-LEGACY",
+                            doi="10.5555/clean-doi",
+                            title="Legacy Imported Title",
+                            authors="Legacy Author",
+                            year="2024",
+                            journal="Legacy Journal",
+                            abstract="Updated metadata should still merge.",
+                            provider_version="2",
+                        ),
+                    ],
+                    "cursor-1",
+                ),
+            },
+            attachments={"ITEM-LEGACY": []},
+            downloads={},
+        )
+
+        pool = _SqlitePool(connectors_db)
+
+        async def _fake_get_db_pool():
+            return pool
+
+        async def _fake_list_memberships_for_user(_user_id: int):
+            return []
+
+        monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+        monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+        monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: fake_conn)
+
+        account = await svc.create_account(
+            connectors_db,
+            user_id=1,
+            provider="zotero",
+            display_name="Zotero",
+            email="researcher@example.com",
+            tokens={
+                "access_token": "tok",
+                "provider_user_id": "123456",
+                "username": "researcher",
+            },
+        )
+        source = await svc.create_source(
+            connectors_db,
+            account_id=int(account["id"]),
+            provider="zotero",
+            remote_id="COLL1234",
+            type_="collection",
+            path=None,
+            options={},
+        )
+        await svc.upsert_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+            sync_mode="poll",
+        )
+
+        media_db = MediaDatabase(db_path=str(media_db_path), client_id="1")
+        legacy_media_id, _, _ = media_db.add_media_with_keywords(
+            url="seed://legacy-invalid-doi",
+            title="Legacy Imported Title",
+            media_type="document",
+            content="Existing local content",
+            keywords=[],
+            safe_metadata=json.dumps(
+                {
+                    "doi": "not-a-real-doi",
+                    "title": "Legacy Imported Title",
+                }
+            ),
+            overwrite=False,
+        )
+
+        await svc.upsert_reference_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="zotero",
+            provider_item_key="ITEM-LEGACY",
+            provider_library_id="123456",
+            collection_key="COLL1234",
+            collection_name="Language Models",
+            provider_version="1",
+            provider_updated_at="2026-03-30T00:00:00Z",
+            media_id=int(legacy_media_id),
+            dedupe_match_reason="same_provider_item",
+            raw_reference_metadata={"title": "Legacy Imported Title"},
+        )
+
+        jm = _FakeJM()
+        await worker._process_import_job(
+            jm,
+            jid=9301,
+            lease_id="lease-reference-legacy",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        version = get_document_version(media_db, media_id=int(legacy_media_id), version_number=1)
+        safe_metadata = json.loads(version["safe_metadata"])
+
+        assert jm.completed is not None
+        assert jm.completed["result"]["duplicates"] == 1
+        assert jm.completed["result"]["failed"] == 0
+        assert safe_metadata["doi"] == "10.5555/clean-doi"
+        assert safe_metadata["authors"] == "Legacy Author"
+    finally:
+        await connectors_db.close()
+
+
+@pytest.mark.asyncio
+async def test_reference_manager_sync_does_not_advance_cursor_when_page_has_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.db_path_utils as db_paths_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    connectors_db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    connectors_db.row_factory = aiosqlite.Row
+    connectors_db._is_sqlite = True
+
+    try:
+        media_root = tmp_path / "user_dbs"
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(media_root))
+        monkeypatch.setitem(db_paths_mod.settings, "USER_DB_BASE_DIR", str(media_root))
+
+        fake_conn = _FakeZoteroConnector(
+            pages={
+                None: (
+                    [
+                        _reference_item(
+                            provider_item_key="ITEM-GOOD",
+                            doi="10.7777/good",
+                            title="Good Item",
+                            authors="Good Author",
+                            year="2024",
+                            journal="Journal",
+                            abstract="Imports cleanly.",
+                            provider_version="1",
+                        ),
+                        _reference_item(
+                            provider_item_key="ITEM-FAIL",
+                            doi="10.7777/fail",
+                            title="Failing Item",
+                            authors="Fail Author",
+                            year="2024",
+                            journal="Journal",
+                            abstract="Fails conversion.",
+                            provider_version="1",
+                        ),
+                    ],
+                    "cursor-1",
+                ),
+            },
+            attachments={
+                "ITEM-GOOD": [_attachment(provider_item_key="ITEM-GOOD", attachment_key="ATT-GOOD")],
+                "ITEM-FAIL": [_attachment(provider_item_key="ITEM-FAIL", attachment_key="ATT-FAIL")],
+            },
+            downloads={
+                "ATT-GOOD": b"good content",
+                "ATT-FAIL": b"bad content",
+            },
+        )
+
+        pool = _SqlitePool(connectors_db)
+
+        async def _fake_get_db_pool():
+            return pool
+
+        async def _fake_list_memberships_for_user(_user_id: int):
+            return []
+
+        async def _fake_convert_document_bytes_to_text(raw, name, effective_mime):
+            if name == "ITEM-FAIL.pdf":
+                raise RuntimeError("conversion failed")
+            return raw.decode("utf-8")
+
+        monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+        monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+        monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: fake_conn)
+        monkeypatch.setattr(
+            worker,
+            "_convert_document_bytes_to_text",
+            _fake_convert_document_bytes_to_text,
+            raising=False,
+        )
+
+        account = await svc.create_account(
+            connectors_db,
+            user_id=1,
+            provider="zotero",
+            display_name="Zotero",
+            email="researcher@example.com",
+            tokens={
+                "access_token": "tok",
+                "provider_user_id": "123456",
+                "username": "researcher",
+            },
+        )
+        source = await svc.create_source(
+            connectors_db,
+            account_id=int(account["id"]),
+            provider="zotero",
+            remote_id="COLL1234",
+            type_="collection",
+            path=None,
+            options={},
+        )
+        await svc.upsert_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+            sync_mode="poll",
+        )
+
+        jm = _FakeJM()
+        await worker._process_import_job(
+            jm,
+            jid=9302,
+            lease_id="lease-reference-failure",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        sync_state = await svc.get_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+        )
+        imported_binding = await svc.get_reference_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="zotero",
+            provider_item_key="ITEM-GOOD",
+        )
+
+        assert jm.completed is not None
+        assert jm.completed["result"]["processed"] == 1
+        assert jm.completed["result"]["failed"] == 1
+        assert sync_state is not None
+        assert sync_state["cursor"] is None
+        assert imported_binding is not None
+        assert imported_binding["media_id"] is not None
     finally:
         await connectors_db.close()


### PR DESCRIPTION
## Summary
- add provider-neutral reference-manager connector contracts, storage, and Zotero support
- expose Zotero collection sources through the connectors API
- add import-mode scheduler and worker sync with dedupe, metadata-only tracking, and docs

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py tldw_Server_API/tests/External_Sources/test_reference_manager_storage.py tldw_Server_API/tests/External_Sources/test_reference_manager_dedupe.py tldw_Server_API/tests/External_Sources/test_zotero_connector.py tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py -v
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py tldw_Server_API/app/core/External_Sources/reference_manager_types.py tldw_Server_API/app/core/External_Sources/reference_manager_dedupe.py tldw_Server_API/app/core/External_Sources/reference_manager_import.py tldw_Server_API/app/core/External_Sources/zotero.py tldw_Server_API/app/core/External_Sources/connectors_service.py tldw_Server_API/app/api/v1/endpoints/connectors.py tldw_Server_API/app/services/connectors_worker.py tldw_Server_API/app/services/connectors_sync_scheduler.py -f json -o /tmp/bandit_reference_manager_import_sync_pr.json