### PR TITLE
feat(mcp): add virtual CLI run tool phase 1

### DIFF
--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -1172,7 +1172,7 @@ async def upsert_source_sync_state(db, *, source_id: int, **updates: Any) -> dic
     existing = await get_source_sync_state(db, source_id=source_id) or {}
     data = {"source_id": source_id, "sync_mode": "manual", **existing}
     for field in _SYNC_STATE_FIELDS:
-        if field in updates and updates[field] is not None:
+        if field in updates:
             data[field] = updates[field]
 
     is_pg = _is_postgres_connection(db)

--- a/tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py
+++ b/tldw_Server_API/app/core/External_Sources/reference_manager_adapter.py
@@ -24,6 +24,7 @@ class ReferenceManagerAdapter(Protocol):
         account: dict[str, Any],
         collection_key: str,
         *,
+        collection_name: str | None = None,
         cursor: str | None = None,
         page_size: int = 100,
     ) -> tuple[list[NormalizedReferenceItem], str | None]: ...

--- a/tldw_Server_API/app/core/External_Sources/reference_manager_import.py
+++ b/tldw_Server_API/app/core/External_Sources/reference_manager_import.py
@@ -388,10 +388,12 @@ async def sync_reference_manager_source(
     metadata_only = 0
     failed = 0
     total = 0
+    collection_name = str(source.get("path") or "").strip() or None
 
     items, page_cursor = await connector.list_collection_items(
         account,
         collection_key,
+        collection_name=collection_name,
         cursor=current_cursor,
         page_size=100,
     )

--- a/tldw_Server_API/app/core/External_Sources/reference_manager_import.py
+++ b/tldw_Server_API/app/core/External_Sources/reference_manager_import.py
@@ -590,8 +590,11 @@ async def sync_reference_manager_source(
                 exc,
             )
 
-    if failed == 0 and page_cursor not in (None, ""):
-        next_cursor = page_cursor
+    if failed == 0:
+        if page_cursor in (None, ""):
+            next_cursor = None
+        else:
+            next_cursor = str(page_cursor).strip() or None
 
     return {
         "processed": processed,

--- a/tldw_Server_API/app/core/External_Sources/zotero.py
+++ b/tldw_Server_API/app/core/External_Sources/zotero.py
@@ -489,6 +489,7 @@ class ZoteroConnector(BaseConnector, ReferenceManagerAdapter):
         account: dict[str, Any],
         collection_key: str,
         *,
+        collection_name: str | None = None,
         cursor: str | None = None,
         page_size: int = 100,
     ) -> tuple[list[NormalizedReferenceItem], str | None]:
@@ -516,6 +517,7 @@ class ZoteroConnector(BaseConnector, ReferenceManagerAdapter):
                 raw_item,
                 [],
                 collection_key=collection_key,
+                collection_name=collection_name,
                 provider_library_id=self._provider_user_id_from_account(account),
             )
             items.append(normalized_item)

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import difflib
 import hashlib
 import json
+from collections.abc import Iterator
 from collections import deque
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable, Mapping
 
 from .models import CommandChain, CommandSpillReference, CommandStepResult
@@ -101,6 +103,8 @@ def visible_command_registry(
 class PhaseOneCommandAdapters:
     """Adapter layer that separates pure transforms from governed MCP tool calls."""
 
+    _PURE_GREP_MAX_OUTPUT_BYTES = 1_000_000
+
     def __init__(self, context: AdapterContext) -> None:
         self.context = context
         self._preflighted: dict[str, deque[_PreparedStep]] = {}
@@ -121,6 +125,7 @@ class PhaseOneCommandAdapters:
     async def preflight_chain(self, chain: CommandChain) -> None:
         """Prepare all governed steps before execution starts."""
 
+        handled_exceptions = self._handled_governed_exceptions()
         step_index = 0
         for segment in chain.segments:
             for invocation in segment.commands:
@@ -141,15 +146,20 @@ class PhaseOneCommandAdapters:
                     raise PreflightCommandError(
                         CommandStepResult(stderr=plan_or_error.message, exit_code=plan_or_error.exit_code)
                     )
-                prepared = await self.context.protocol.prepare_tool_call(
-                    params={"name": plan_or_error.tool_name, "arguments": dict(plan_or_error.arguments)},
-                    context=self.context.request_context,
-                    idempotency_key=derive_step_idempotency_key(
-                        self.context.parent_idempotency_key,
-                        argv,
-                        step_index,
-                    ),
-                )
+                try:
+                    prepared = await self.context.protocol.prepare_tool_call(
+                        params={"name": plan_or_error.tool_name, "arguments": dict(plan_or_error.arguments)},
+                        context=self.context.request_context,
+                        idempotency_key=derive_step_idempotency_key(
+                            self.context.parent_idempotency_key,
+                            argv,
+                            step_index,
+                        ),
+                    )
+                except handled_exceptions as exc:
+                    if self._is_passthrough_governed_exception(exc):
+                        raise
+                    raise PreflightCommandError(self._governed_error_result(exc)) from exc
                 signature = normalize_step_content(argv)
                 bucket = self._preflighted.setdefault(signature, deque())
                 bucket.append(_PreparedStep(prepared=prepared, plan=plan_or_error))
@@ -175,25 +185,32 @@ class PhaseOneCommandAdapters:
     async def _execute_governed(self, argv: list[str], step_index: int) -> CommandStepResult:
         signature = normalize_step_content(argv)
         bucket = self._preflighted.get(signature)
-        if bucket:
-            prepared_step = bucket.popleft()
-        else:
-            plan_or_error = self._governed_plan(argv)
-            if isinstance(plan_or_error, _UsageError):
-                return CommandStepResult(stderr=plan_or_error.message, exit_code=plan_or_error.exit_code)
-            prepared = await self.context.protocol.prepare_tool_call(
-                params={"name": plan_or_error.tool_name, "arguments": dict(plan_or_error.arguments)},
-                context=self.context.request_context,
-                idempotency_key=derive_step_idempotency_key(
-                    self.context.parent_idempotency_key,
-                    argv,
-                    step_index,
-                ),
-            )
-            prepared_step = _PreparedStep(prepared=prepared, plan=plan_or_error)
+        handled_exceptions = self._handled_governed_exceptions()
+        try:
+            if bucket:
+                prepared_step = bucket.popleft()
+            else:
+                plan_or_error = self._governed_plan(argv)
+                if isinstance(plan_or_error, _UsageError):
+                    return CommandStepResult(stderr=plan_or_error.message, exit_code=plan_or_error.exit_code)
+                prepared = await self.context.protocol.prepare_tool_call(
+                    params={"name": plan_or_error.tool_name, "arguments": dict(plan_or_error.arguments)},
+                    context=self.context.request_context,
+                    idempotency_key=derive_step_idempotency_key(
+                        self.context.parent_idempotency_key,
+                        argv,
+                        step_index,
+                    ),
+                )
+                prepared_step = _PreparedStep(prepared=prepared, plan=plan_or_error)
 
-        payload = await self.context.protocol.execute_prepared_tool_call(prepared_step.prepared)
-        rendered = prepared_step.plan.renderer(payload)
+            payload = await self.context.protocol.execute_prepared_tool_call(prepared_step.prepared)
+            rendered = prepared_step.plan.renderer(payload)
+        except handled_exceptions as exc:
+            if self._is_passthrough_governed_exception(exc):
+                raise
+            return self._governed_error_result(exc)
+
         return CommandStepResult(stdout=rendered, stderr="", exit_code=0)
 
     def _execute_pure_transform(self, argv: list[str], stdin: Any) -> CommandStepResult:
@@ -328,18 +345,25 @@ class PhaseOneCommandAdapters:
         if unsupported_flags:
             return CommandStepResult(stderr="usage: grep <pattern> [-i|--ignore-case]", exit_code=2)
 
-        text = self._stdin_text(stdin)
-        lines = text.splitlines()
         ignore_case = "-i" in flags or "--ignore-case" in flags
         needle = pattern.lower() if ignore_case else pattern
         matched: list[str] = []
-        for line in lines:
+        matched_byte_count = 0
+        for line in self._iter_stdin_lines(stdin):
             haystack = line.lower() if ignore_case else line
             if needle in haystack:
+                encoded = line.encode("utf-8")
+                if matched_byte_count + len(encoded) > self._PURE_GREP_MAX_OUTPUT_BYTES:
+                    return CommandStepResult(
+                        stderr=(
+                            "grep: matched output exceeds "
+                            f"{self._PURE_GREP_MAX_OUTPUT_BYTES} bytes; refine the pattern or narrow the pipeline"
+                        ),
+                        exit_code=2,
+                    )
                 matched.append(line)
-        output = "\n".join(matched)
-        if matched and text.endswith("\n"):
-            output += "\n"
+                matched_byte_count += len(encoded)
+        output = "".join(matched)
         return CommandStepResult(stdout=output, stderr="", exit_code=0 if matched else 1)
 
     def _pure_head(self, argv: list[str], stdin: Any) -> CommandStepResult:
@@ -467,6 +491,20 @@ class PhaseOneCommandAdapters:
         return str(stdin)
 
     @staticmethod
+    def _iter_stdin_lines(stdin: Any) -> Iterator[str]:
+        if isinstance(stdin, CommandSpillReference):
+            try:
+                with Path(stdin.path).open("r", encoding=stdin.encoding) as handle:
+                    yield from handle
+            except OSError:
+                return
+            return
+        text = PhaseOneCommandAdapters._stdin_text(stdin)
+        if not text:
+            return
+        yield from text.splitlines(keepends=True)
+
+    @staticmethod
     def _extract_json_content(payload: Any) -> Any:
         if not isinstance(payload, dict):
             return payload
@@ -510,6 +548,8 @@ class PhaseOneCommandAdapters:
         decoded = self._extract_json_content(payload)
         if isinstance(decoded, dict):
             text = decoded.get("text")
+            if text is None:
+                text = decoded.get("content")
             return str(text or "")
         return str(decoded or "")
 
@@ -532,6 +572,41 @@ class PhaseOneCommandAdapters:
             return json.dumps(decoded, ensure_ascii=False, indent=2, sort_keys=True)
         except TypeError:
             return str(decoded)
+
+    @staticmethod
+    def _handled_governed_exceptions() -> tuple[type[BaseException], ...]:
+        exceptions: list[type[BaseException]] = [OSError, ValueError]
+        try:
+            from ..protocol import InvalidParamsException
+        except ImportError:
+            InvalidParamsException = None
+        if InvalidParamsException is not None:
+            exceptions.append(InvalidParamsException)
+        return tuple(exceptions)
+
+    @classmethod
+    def _governed_error_result(cls, exc: BaseException) -> CommandStepResult:
+        exit_code = 2 if cls._is_usage_like_exception(exc) else 1
+        message = str(exc).strip() or exc.__class__.__name__
+        return CommandStepResult(stderr=message, exit_code=exit_code)
+
+    @staticmethod
+    def _is_usage_like_exception(exc: BaseException) -> bool:
+        if isinstance(exc, ValueError):
+            return True
+        try:
+            from ..protocol import InvalidParamsException
+        except ImportError:
+            InvalidParamsException = None
+        return InvalidParamsException is not None and isinstance(exc, InvalidParamsException)
+
+    @staticmethod
+    def _is_passthrough_governed_exception(exc: BaseException) -> bool:
+        try:
+            from ..protocol import ApprovalRequiredError, GovernanceDeniedError
+        except ImportError:
+            return False
+        return isinstance(exc, (ApprovalRequiredError, GovernanceDeniedError))
 
     def _unknown_command_result(self, command: str) -> CommandStepResult:
         return CommandStepResult(stderr=self._unknown_command_message(command), exit_code=127)

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/adapters.py
@@ -6,11 +6,11 @@ import difflib
 import hashlib
 import json
 from collections.abc import Iterator
-from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
+from .executor import HandlerInvocationContext
 from .models import CommandChain, CommandSpillReference, CommandStepResult
 from .registry import CommandDescriptor
 
@@ -107,7 +107,7 @@ class PhaseOneCommandAdapters:
 
     def __init__(self, context: AdapterContext) -> None:
         self.context = context
-        self._preflighted: dict[str, deque[_PreparedStep]] = {}
+        self._preflighted: dict[tuple[str, int], _PreparedStep] = {}
         self._next_step_index = 0
 
     def requires_whole_chain_preflight(self, chain: CommandChain) -> bool:
@@ -160,19 +160,22 @@ class PhaseOneCommandAdapters:
                     if self._is_passthrough_governed_exception(exc):
                         raise
                     raise PreflightCommandError(self._governed_error_result(exc)) from exc
-                signature = normalize_step_content(argv)
-                bucket = self._preflighted.setdefault(signature, deque())
-                bucket.append(_PreparedStep(prepared=prepared, plan=plan_or_error))
+                prepared_key = (normalize_step_content(argv), step_index)
+                self._preflighted[prepared_key] = _PreparedStep(prepared=prepared, plan=plan_or_error)
                 step_index += 1
 
-    async def execute(self, argv: list[str], stdin: Any) -> CommandStepResult:
+    async def execute(
+        self,
+        argv: list[str],
+        stdin: Any,
+        handler_context: Any | None = None,
+    ) -> CommandStepResult:
         """Execute one command invocation for the runtime backend."""
 
         if not argv:
             return CommandStepResult(stderr="Missing command", exit_code=127)
 
-        step_index = self._next_step_index
-        self._next_step_index += 1
+        step_index = self._resolve_step_index(handler_context)
         descriptor = self.context.visible_commands.get(argv[0])
         if descriptor is None:
             return self._unknown_command_result(argv[0])
@@ -184,12 +187,11 @@ class PhaseOneCommandAdapters:
 
     async def _execute_governed(self, argv: list[str], step_index: int) -> CommandStepResult:
         signature = normalize_step_content(argv)
-        bucket = self._preflighted.get(signature)
         handled_exceptions = self._handled_governed_exceptions()
         try:
-            if bucket:
-                prepared_step = bucket.popleft()
-            else:
+            prepared_key = (signature, step_index)
+            prepared_step = self._preflighted.pop(prepared_key, None)
+            if prepared_step is None:
                 plan_or_error = self._governed_plan(argv)
                 if isinstance(plan_or_error, _UsageError):
                     return CommandStepResult(stderr=plan_or_error.message, exit_code=plan_or_error.exit_code)
@@ -212,6 +214,13 @@ class PhaseOneCommandAdapters:
             return self._governed_error_result(exc)
 
         return CommandStepResult(stdout=rendered, stderr="", exit_code=0)
+
+    def _resolve_step_index(self, handler_context: Any | None) -> int:
+        if isinstance(handler_context, HandlerInvocationContext):
+            return int(handler_context.lexical_step_index)
+        step_index = self._next_step_index
+        self._next_step_index += 1
+        return step_index
 
     def _execute_pure_transform(self, argv: list[str], stdin: Any) -> CommandStepResult:
         command = argv[0]

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/executor.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/executor.py
@@ -257,13 +257,7 @@ class CommandRuntimeExecutor:
         spill_root = self._resolve_spill_root()
         self._prune_stale_spills(spill_root)
         digest = hashlib.sha256(payload).hexdigest()[:16]
-        path = self._ensure_spill_file(
-            spill_root / f"mcp-command-{kind}-{digest}.txt",
-            payload,
-            spill_root=spill_root,
-            kind=kind,
-            digest=digest,
-        )
+        path = self._write_unique_spill(payload, spill_root=spill_root, kind=kind, digest=digest)
         try:
             os.utime(path, None)
         except OSError:

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/executor.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/executor.py
@@ -29,12 +29,27 @@ _DEFAULT_SPILL_ROOT_PRUNE_INTERVAL_SECONDS = 300.0
 class CommandBackend(Protocol):
     """Backend contract used by the raw runtime executor."""
 
-    async def execute(self, argv: list[str], stdin: Any) -> CommandStepResult:
+    async def execute(
+        self,
+        argv: list[str],
+        stdin: Any,
+        handler_context: Any | None = None,
+    ) -> CommandStepResult:
         """Execute one command and return its raw stdout/stderr and exit code.
 
         Backends may receive raw text/bytes or a CommandSpillReference when a
         previous pipeline stage spilled oversized stdin to disk.
         """
+
+
+@dataclass(frozen=True, slots=True)
+class HandlerInvocationContext:
+    """Execution metadata for one lexical command step."""
+
+    runtime_context: Any | None = None
+    segment_index: int = 0
+    command_index: int = 0
+    lexical_step_index: int = 0
 
 
 @dataclass(slots=True)
@@ -54,6 +69,7 @@ class CommandRuntimeExecutor:
         """Run a parsed command chain and preserve raw stream semantics."""
 
         start = time.perf_counter()
+        step_indices = self._build_step_indices(chain)
         last_exit_code = 0
         last_stdout: Any = ""
         last_stderr: Any = ""
@@ -90,7 +106,15 @@ class CommandRuntimeExecutor:
             for command_index, command in enumerate(segment.commands):
                 step_started = time.perf_counter()
                 step_stdin = pipeline_stdin
-                step_result = await self.backend.execute(list(command.argv), step_stdin)
+                step_result = await self.backend.execute(
+                    list(command.argv),
+                    step_stdin,
+                    HandlerInvocationContext(
+                        segment_index=segment_index,
+                        command_index=command_index,
+                        lexical_step_index=step_indices[(segment_index, command_index)],
+                    ),
+                )
                 step_stdout, step_stdout_binary = self._classify_stream(step_result.stdout)
                 step_stderr, step_stderr_binary = self._classify_stream(step_result.stderr)
                 step_stderr_contains_binary = step_stderr_binary
@@ -184,6 +208,16 @@ class CommandRuntimeExecutor:
             stderr_is_binary=last_stderr_binary,
             stderr_contains_binary=aggregate_stderr_binary,
         )
+
+    @staticmethod
+    def _build_step_indices(chain: CommandChain) -> dict[tuple[int, int], int]:
+        indices: dict[tuple[int, int], int] = {}
+        step_index = 0
+        for segment_index, segment in enumerate(chain.segments):
+            for command_index, _command in enumerate(segment.commands):
+                indices[(segment_index, command_index)] = step_index
+                step_index += 1
+        return indices
 
     async def _spill_payload_async(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/command_runtime/presentation.py
+++ b/tldw_Server_API/app/core/MCP_unified/command_runtime/presentation.py
@@ -85,14 +85,16 @@ def _render_stdout(
     active_spill = spill
     if active_spill is not None:
         preview, truncated = _preview_spill_text(active_spill, byte_limit=byte_limit, line_limit=line_limit, fallback=stdout_text)
+        line_count = active_spill.line_count
+        byte_count = active_spill.bytes_written
     else:
         preview, truncated = _truncate_text(stdout_text, byte_limit=byte_limit, line_limit=line_limit)
-    if truncated and active_spill is None:
-        active_spill = _materialize_spill_reference(stdout_text, "stdout", spill_dir=spill_dir)
-    if active_spill is not None and truncated:
+        line_count = _count_lines(stdout_text)
+        byte_count = len(stdout_text.encode("utf-8"))
+    if truncated:
         if preview:
-            return "\n".join([preview, "", _overflow_notice("stdout", active_spill)])
-        return _overflow_notice("stdout", active_spill)
+            return "\n".join([preview, "", _overflow_notice("stdout", line_count=line_count, byte_count=byte_count)])
+        return _overflow_notice("stdout", line_count=line_count, byte_count=byte_count)
     return preview
 
 
@@ -106,6 +108,8 @@ def _render_stderr(
     active_spills = list(spills)
     if stderr_text:
         preview, truncated = _truncate_text(stderr_text, byte_limit=byte_limit, line_limit=line_limit)
+        line_count = _count_lines(stderr_text)
+        byte_count = len(stderr_text.encode("utf-8"))
     elif active_spills:
         preview, truncated = _preview_spill_text(
             active_spills[0],
@@ -113,20 +117,23 @@ def _render_stderr(
             line_limit=line_limit,
             fallback=active_spills[0].preview,
         )
+        line_count = active_spills[0].line_count
+        byte_count = active_spills[0].bytes_written
     else:
         preview, truncated = "", False
-    if truncated and stderr_text:
-        inline_spill = _materialize_spill_reference(stderr_text, "stderr", spill_dir=spill_dir)
-        if all(spill.path != inline_spill.path for spill in active_spills):
-            active_spills.append(inline_spill)
+        line_count = 0
+        byte_count = 0
     show_overflow = truncated or len(active_spills) > 1 or bool(stderr_text and active_spills)
     if active_spills and show_overflow:
         lines = [preview] if preview else []
-        for spill in active_spills:
-            if lines:
-                lines.append("")
-            lines.append(_overflow_notice("stderr", spill))
+        if lines:
+            lines.append("")
+        lines.append(_overflow_notice("stderr", line_count=line_count, byte_count=byte_count))
         return "\n".join(lines)
+    if truncated:
+        if preview:
+            return "\n".join([preview, "", _overflow_notice("stderr", line_count=line_count, byte_count=byte_count)])
+        return _overflow_notice("stderr", line_count=line_count, byte_count=byte_count)
     return preview
 
 
@@ -155,16 +162,12 @@ def _render_stderr_block(
     return lines
 
 
-def _overflow_notice(stream_name: str, spill: CommandSpillReference) -> str:
-    line_count = spill.line_count
-    quoted_path = shlex.quote(spill.path)
+def _overflow_notice(stream_name: str, *, line_count: int, byte_count: int) -> str:
     return "\n".join(
         [
-            f"--- {stream_name} truncated ({line_count} lines, {spill.bytes_written} bytes) ---",
-            f"Full {stream_name} spilled to {spill.path}",
-            "If workspace-accessible:",
-            f"  cat {quoted_path} | grep <pattern>",
-            f"  cat {quoted_path} | tail 100",
+            f"--- {stream_name} truncated ({line_count} lines, {byte_count} bytes) ---",
+            f"Full {stream_name} was stored internally because it exceeded the preview limit.",
+            "Refine and rerun with: | grep <pattern>, | head <n>, or | tail <n>",
         ]
     )
 
@@ -173,7 +176,7 @@ def _binary_spill_notice(stream_name: str, spill: CommandSpillReference) -> str:
     return "\n".join(
         [
             f"--- binary {stream_name} omitted ({spill.bytes_written} bytes) ---",
-            f"Binary {stream_name} spill: {spill.path}",
+            f"Binary {stream_name} was stored internally.",
             "Use a binary-safe inspection command or text-rendering subcommand.",
         ]
     )

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py
@@ -35,6 +35,8 @@ def _first_nonempty(*values: Any) -> str | None:
 class FilesystemModule(BaseModule):
     """Workspace-scoped text filesystem primitives."""
 
+    _DEFAULT_MAX_READ_BYTES = 1_000_000
+
     def __init__(
         self,
         config: ModuleConfig,
@@ -130,7 +132,7 @@ class FilesystemModule(BaseModule):
 
         if tool_name == "fs.read_text":
             target = self._resolve_workspace_path(workspace_root, str(args.get("path")))
-            read_result = await asyncio.to_thread(self._read_text_file, target)
+            read_result = await asyncio.to_thread(self._read_text_file, target, self._max_read_bytes())
             return {
                 "path": self._to_workspace_relative_path(workspace_root, target),
                 "text": read_result["text"],
@@ -153,6 +155,14 @@ class FilesystemModule(BaseModule):
             limit = int(raw_limit)
         except (TypeError, ValueError):
             limit = 1000
+        return max(1, limit)
+
+    def _max_read_bytes(self) -> int:
+        raw_limit = self.config.settings.get("max_read_bytes", self._DEFAULT_MAX_READ_BYTES)
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            limit = self._DEFAULT_MAX_READ_BYTES
         return max(1, limit)
 
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
@@ -272,11 +282,17 @@ class FilesystemModule(BaseModule):
         return rel_text if rel_text not in {"", "."} else "."
 
     @staticmethod
-    def _read_text_file(target: Path) -> dict[str, Any]:
+    def _read_text_file(target: Path, max_read_bytes: int) -> dict[str, Any]:
         if not target.exists():
             raise FileNotFoundError(f"path not found: {target}")
         if not target.is_file():
             raise ValueError(f"path is not a file: {target}")
+
+        file_size = target.stat().st_size
+        if file_size > max_read_bytes:
+            raise ValueError(
+                f"file exceeds fs.read_text limit ({file_size} bytes > {max_read_bytes} bytes)"
+            )
 
         payload = target.read_bytes()
         if b"\x00" in payload:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from pathlib import Path
@@ -137,19 +138,24 @@ class RunCommandModule(BaseModule):
                 exit_code=exc.result.exit_code,
                 duration_ms=max(0.0, (time.perf_counter() - start) * 1000.0),
             )
-        except ValueError as exc:
+        except (OSError, ValueError) as exc:
+            if self._is_passthrough_runtime_exception(exc):
+                raise
             result = CommandExecutionResult(
                 stdout="",
                 stderr=str(exc),
-                exit_code=2,
+                exit_code=2 if isinstance(exc, ValueError) else 1,
                 duration_ms=max(0.0, (time.perf_counter() - start) * 1000.0),
             )
-        return present_command_execution_result(
-            result,
-            spill_dir=spill_dir,
-            byte_limit=preview_byte_limit,
-            line_limit=preview_line_limit,
-        )
+        try:
+            return present_command_execution_result(
+                result,
+                spill_dir=spill_dir,
+                byte_limit=preview_byte_limit,
+                line_limit=preview_line_limit,
+            )
+        finally:
+            await self._cleanup_spill_artifacts(result)
 
     def validate_tool_arguments(self, tool_name: str, arguments: dict[str, Any]) -> None:
         if tool_name != "run":
@@ -221,11 +227,10 @@ class RunCommandModule(BaseModule):
         from ...protocol import MCPProtocol
         from ...server import get_mcp_server
 
-        try:
-            return get_mcp_server().protocol
-        except Exception as exc:
-            logger.warning("Falling back to a standalone MCPProtocol for run module: {}", exc)
+        protocol = get_mcp_server().protocol
+        if protocol is None:
             return MCPProtocol()
+        return protocol
 
     async def _visible_commands_for_context(self, context: Any | None) -> Mapping[str, CommandDescriptor]:
         protocol = await self._resolve_protocol()
@@ -414,3 +419,41 @@ class RunCommandModule(BaseModule):
             if isinstance(value, str) and value.strip():
                 return value.strip()
         return None
+
+    @staticmethod
+    async def _cleanup_spill_artifacts(result: CommandExecutionResult) -> None:
+        spill_paths: set[Path] = set()
+
+        def _record(spill: Any) -> None:
+            path_value = getattr(spill, "path", None)
+            if isinstance(path_value, str) and path_value.strip():
+                spill_paths.add(Path(path_value))
+
+        _record(result.stdout_spill)
+        _record(result.stderr_spill)
+        for spill in result.stderr_spills:
+            _record(spill)
+        for step in result.steps:
+            _record(step.stdout_spill)
+            _record(step.stderr_spill)
+
+        if not spill_paths:
+            return
+
+        await asyncio.to_thread(RunCommandModule._unlink_spills, spill_paths)
+
+    @staticmethod
+    def _unlink_spills(spill_paths: set[Path]) -> None:
+        for spill_path in spill_paths:
+            try:
+                spill_path.unlink(missing_ok=True)
+            except OSError:
+                continue
+
+    @staticmethod
+    def _is_passthrough_runtime_exception(exc: BaseException) -> bool:
+        try:
+            from ...protocol import ApprovalRequiredError, GovernanceDeniedError
+        except ImportError:
+            return False
+        return isinstance(exc, (ApprovalRequiredError, GovernanceDeniedError))

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py
@@ -33,8 +33,13 @@ class _AdapterBackend(CommandBackend):
     def __init__(self, adapters: PhaseOneCommandAdapters) -> None:
         self._adapters = adapters
 
-    async def execute(self, argv: list[str], stdin: Any) -> CommandStepResult:
-        return await self._adapters.execute(argv, stdin)
+    async def execute(
+        self,
+        argv: list[str],
+        stdin: Any,
+        handler_context: Any | None = None,
+    ) -> CommandStepResult:
+        return await self._adapters.execute(argv, stdin, handler_context)
 
 
 class RunCommandModule(BaseModule):

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -906,6 +906,12 @@ class MCPProtocol:
             raw_idempotency_key = params.get("idempotencyKey")
             if raw_idempotency_key is None:
                 raw_idempotency_key = params.get("idempotency_key")
+        if raw_idempotency_key is None:
+            arguments = params.get("arguments")
+            if isinstance(arguments, dict):
+                raw_idempotency_key = arguments.get("idempotencyKey")
+                if raw_idempotency_key is None:
+                    raw_idempotency_key = arguments.get("idempotency_key")
 
         if raw_idempotency_key is None:
             return None

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py
@@ -20,7 +20,13 @@ class _FakeBackend:
         self.handlers = handlers
         self.calls: list[tuple[list[str], str]] = []
 
-    async def execute(self, argv: list[str], stdin: str) -> CommandStepResult:
+    async def execute(
+        self,
+        argv: list[str],
+        stdin: str,
+        handler_context=None,  # noqa: ANN001
+    ) -> CommandStepResult:
+        del handler_context
         self.calls.append((list(argv), stdin))
         handler = self.handlers[argv[0]]
         return handler(argv, stdin)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py
@@ -318,7 +318,7 @@ async def test_execution_counts_newline_terminated_spill_lines_correctly(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_execution_reuses_matching_spill_file_for_identical_payloads(tmp_path):
+async def test_execution_uses_unique_spill_files_for_identical_payloads(tmp_path):
     big_output = "reuse" * 32
     backend = _FakeBackend(
         {
@@ -337,8 +337,9 @@ async def test_execution_reuses_matching_spill_file_for_identical_payloads(tmp_p
 
     assert first.stdout_spill is not None
     assert second.stdout_spill is not None
-    assert first.stdout_spill.path == second.stdout_spill.path
+    assert first.stdout_spill.path != second.stdout_spill.path
     assert Path(first.stdout_spill.path).read_text(encoding="utf-8") == big_output
+    assert Path(second.stdout_spill.path).read_text(encoding="utf-8") == big_output
 
 
 @pytest.mark.asyncio
@@ -575,7 +576,8 @@ async def test_execution_keeps_recently_reused_default_root_from_being_pruned(tm
 
     reused = await first.execute(parse_command("big"))
     assert reused.stdout_spill is not None
-    assert Path(reused.stdout_spill.path) == first_spill
+    assert Path(reused.stdout_spill.path) != first_spill
+    assert Path(reused.stdout_spill.path).parent == first_root
 
     second = CommandRuntimeExecutor(
         backend=backend,
@@ -586,3 +588,4 @@ async def test_execution_keeps_recently_reused_default_root_from_being_pruned(tm
 
     assert first_root.exists()
     assert first_spill.exists()
+    assert Path(reused.stdout_spill.path).exists()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_parser.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_parser.py
@@ -65,5 +65,8 @@ def test_parser_handles_semicolon_and_or_operator():
     ],
 )
 def test_parser_rejects_malformed_input(command: str):
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="operator cannot appear here|dangling operator|unterminated",
+    ):
         parse_command(command)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py
@@ -214,7 +214,8 @@ def test_presentation_keeps_textual_stderr_visible_when_binary_fragments_exist()
 @pytest.mark.asyncio
 async def test_presentation_keeps_pipe_abort_explanation_alongside_binary_stderr_notice(tmp_path: Path) -> None:
     class _Backend:
-        async def execute(self, argv, stdin):  # noqa: ANN001
+        async def execute(self, argv, stdin, handler_context=None):  # noqa: ANN001
+            del handler_context
             if argv[0] == "first":
                 return CommandStepResult(stdout=b"\xff\xfeout", stderr=b"\xff\xfeerr", exit_code=0)
             return CommandStepResult(stdout="should-not-run", stderr="", exit_code=0)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import os
-import re
-import stat
 from pathlib import Path
 
 import pytest
@@ -12,8 +8,8 @@ from tldw_Server_API.app.core.MCP_unified.command_runtime.executor import Comman
 from tldw_Server_API.app.core.MCP_unified.command_runtime.models import (
     CommandExecutionResult,
     CommandExecutionStep,
-    CommandStepResult,
     CommandSpillReference,
+    CommandStepResult,
 )
 from tldw_Server_API.app.core.MCP_unified.command_runtime.parser import parse_command
 from tldw_Server_API.app.core.MCP_unified.command_runtime.presentation import (
@@ -21,7 +17,7 @@ from tldw_Server_API.app.core.MCP_unified.command_runtime.presentation import (
 )
 
 
-def test_presentation_guards_binary_stdout():
+def test_presentation_guards_binary_stdout() -> None:
     result = CommandExecutionResult(
         stdout=b"\x00\x01binary",
         stderr="",
@@ -37,7 +33,7 @@ def test_presentation_guards_binary_stdout():
     assert "[exit:0 | 8ms]" in rendered
 
 
-def test_presentation_renders_utf8_bytes_stdout_as_text():
+def test_presentation_renders_utf8_bytes_stdout_as_text() -> None:
     result = CommandExecutionResult(
         stdout=b"hello\n",
         stderr=b"",
@@ -52,7 +48,7 @@ def test_presentation_renders_utf8_bytes_stdout_as_text():
     assert "[binary output omitted]" not in rendered
 
 
-def test_presentation_mentions_spill_file_when_stdout_is_truncated():
+def test_presentation_mentions_internal_storage_when_stdout_is_truncated() -> None:
     spill = CommandSpillReference(path="/tmp/spill-output.txt", bytes_written=128, line_count=1, preview="abcd")
     result = CommandExecutionResult(stdout="x" * 128, stderr="", exit_code=0, duration_ms=1.0, stdout_spill=spill)
 
@@ -60,13 +56,13 @@ def test_presentation_mentions_spill_file_when_stdout_is_truncated():
 
     assert "xxxx" in rendered
     assert "--- stdout truncated (1 lines, 128 bytes) ---" in rendered
-    assert "/tmp/spill-output.txt" in rendered
-    assert "spill" in rendered.lower()
+    assert "stored internally" in rendered
+    assert "/tmp/spill-output.txt" not in rendered
+    assert "Refine and rerun with:" in rendered
     assert "[exit:0 | 1ms]" in rendered
-    assert "x" * 16 not in rendered
 
 
-def test_presentation_reads_spilled_stdout_from_disk_instead_of_executor_preview(tmp_path):
+def test_presentation_reads_spilled_stdout_from_disk_instead_of_executor_preview(tmp_path: Path) -> None:
     spill_path = tmp_path / "stdout-spill.txt"
     spill_path.write_text("0123456789ABCDEFG", encoding="utf-8")
     spill = CommandSpillReference(
@@ -83,7 +79,7 @@ def test_presentation_reads_spilled_stdout_from_disk_instead_of_executor_preview
     assert "0123\n\n--- stdout truncated" not in rendered
 
 
-def test_presentation_does_not_claim_truncation_when_spilled_output_fits_preview_limits(tmp_path):
+def test_presentation_does_not_claim_truncation_when_spilled_output_fits_preview_limits(tmp_path: Path) -> None:
     text = "x" * 128
     spill_path = tmp_path / "stdout-spill.txt"
     spill_path.write_text(text, encoding="utf-8")
@@ -101,7 +97,7 @@ def test_presentation_does_not_claim_truncation_when_spilled_output_fits_preview
     assert "--- stdout truncated" not in rendered
 
 
-def test_presentation_truncates_utf8_output_on_byte_boundary():
+def test_presentation_truncates_utf8_output_on_byte_boundary() -> None:
     rendered = present_command_execution_result(
         CommandExecutionResult(stdout="ééé", stderr="", exit_code=0, duration_ms=2.0),
         preview_limit=3,
@@ -113,7 +109,7 @@ def test_presentation_truncates_utf8_output_on_byte_boundary():
     assert "[exit:0 | 2ms]" in rendered
 
 
-def test_presentation_truncates_when_line_limit_is_exceeded_under_byte_cap():
+def test_presentation_truncates_when_line_limit_is_exceeded_under_byte_cap() -> None:
     result = CommandExecutionResult(stdout="a\n" * 4, stderr="", exit_code=0, duration_ms=2.0)
 
     rendered = present_command_execution_result(result, byte_limit=128, line_limit=2)
@@ -122,7 +118,7 @@ def test_presentation_truncates_when_line_limit_is_exceeded_under_byte_cap():
     assert "--- stdout truncated (4 lines, 8 bytes) ---" in rendered
 
 
-def test_presentation_attaches_stderr_on_failure():
+def test_presentation_attaches_stderr_on_failure() -> None:
     result = CommandExecutionResult(stdout="ok", stderr="boom", exit_code=3, duration_ms=12.0)
 
     rendered = present_command_execution_result(result)
@@ -133,7 +129,7 @@ def test_presentation_attaches_stderr_on_failure():
     assert "[exit:3 | 12ms]" in rendered
 
 
-def test_presentation_omits_leading_blank_lines_for_stderr_only_failures():
+def test_presentation_omits_leading_blank_lines_for_stderr_only_failures() -> None:
     result = CommandExecutionResult(stdout="", stderr="boom", exit_code=3, duration_ms=12.0)
 
     rendered = present_command_execution_result(result)
@@ -141,7 +137,7 @@ def test_presentation_omits_leading_blank_lines_for_stderr_only_failures():
     assert rendered.startswith("stderr:\nboom")
 
 
-def test_presentation_guards_binary_stderr_on_failure():
+def test_presentation_guards_binary_stderr_on_failure_without_path_leak() -> None:
     result = CommandExecutionResult(
         stdout="ok",
         stderr=b"\xff\xfebad",
@@ -154,51 +150,13 @@ def test_presentation_guards_binary_stderr_on_failure():
 
     assert "ok" in rendered
     assert "binary stderr omitted" in rendered.lower()
+    assert "stored internally" not in rendered.lower() or "binary stderr was stored internally" in rendered
+    assert "/tmp/" not in rendered
     assert "\ufffd" not in rendered
     assert "[exit:2 | 6ms]" in rendered
 
 
-def test_presentation_spill_guidance_uses_cli_surface():
-    spill = CommandSpillReference(path="/tmp/spill-output.txt", bytes_written=128, line_count=1, preview="abcd")
-    result = CommandExecutionResult(stdout="x" * 128, stderr="", exit_code=0, duration_ms=1.0, stdout_spill=spill)
-
-    rendered = present_command_execution_result(result, preview_limit=4)
-
-    assert "If workspace-accessible:" in rendered
-    assert "cat /tmp/spill-output.txt | grep <pattern>" in rendered
-    assert "cat /tmp/spill-output.txt | tail 100" in rendered
-
-
-def test_presentation_creates_spill_guidance_for_truncated_stdout_without_spill_ref():
-    result = CommandExecutionResult(stdout="é" * 16, stderr="", exit_code=0, duration_ms=1.0)
-
-    rendered = present_command_execution_result(result, preview_limit=4)
-
-    match = re.search(r"Full stdout spilled to (.+)", rendered)
-    assert match is not None
-    spill_path = match.group(1)
-    assert "If workspace-accessible:" in rendered
-    assert f"cat {spill_path} | grep <pattern>" in rendered
-    assert f"cat {spill_path} | tail 100" in rendered
-    assert "grep <pattern>" in rendered
-    assert "tail 100" in rendered
-    assert "[exit:0 | 1ms]" in rendered
-
-
-def test_presentation_creates_spill_guidance_for_truncated_stderr_without_spill_ref():
-    result = CommandExecutionResult(stdout="ok", stderr="ß" * 16, exit_code=2, duration_ms=1.0)
-
-    rendered = present_command_execution_result(result, preview_limit=4)
-
-    assert "stderr" in rendered.lower()
-    assert "--- stderr truncated (" in rendered
-    assert "Full stderr spilled to " in rendered
-    assert "If workspace-accessible:" in rendered
-    assert "grep <pattern>" in rendered
-    assert "tail 100" in rendered
-
-
-def test_presentation_attaches_spilled_text_stderr_on_failure():
+def test_presentation_attaches_spilled_text_stderr_on_failure_without_path_leak() -> None:
     spill = CommandSpillReference(path="/tmp/stderr-spill.txt", bytes_written=128, line_count=1, preview="warn")
     result = CommandExecutionResult(stdout="ok", stderr="", stderr_spill=spill, exit_code=2, duration_ms=5.0)
 
@@ -207,58 +165,12 @@ def test_presentation_attaches_spilled_text_stderr_on_failure():
     assert "stderr" in rendered.lower()
     assert "warn" in rendered
     assert "--- stderr truncated (1 lines, 128 bytes) ---" in rendered
-    assert "/tmp/stderr-spill.txt" in rendered
-    assert "grep <pattern>" in rendered
+    assert "stored internally" in rendered
+    assert "/tmp/stderr-spill.txt" not in rendered
     assert "[exit:2 | 5ms]" in rendered
 
 
-def test_presentation_attaches_spilled_text_stderr_when_stdout_is_binary():
-    spill = CommandSpillReference(path="/tmp/stderr-spill.txt", bytes_written=128, line_count=1, preview="warn")
-    result = CommandExecutionResult(
-        stdout=b"\x00\x01binary",
-        stdout_is_binary=True,
-        stderr="",
-        stderr_spill=spill,
-        exit_code=2,
-        duration_ms=5.0,
-    )
-
-    rendered = present_command_execution_result(result, preview_limit=4)
-
-    assert "[binary output omitted]" in rendered
-    assert "stderr" in rendered.lower()
-    assert "warn" in rendered
-    assert "/tmp/stderr-spill.txt" in rendered
-    assert "tail 100" in rendered
-
-
-def test_presentation_preserves_inline_and_spilled_stderr_together():
-    spill = CommandSpillReference(path="/tmp/stderr-spill.txt", bytes_written=128, line_count=1, preview="warn")
-    result = CommandExecutionResult(
-        stdout="ok",
-        stderr="tail",
-        stderr_spill=spill,
-        stderr_spills=[spill],
-        exit_code=2,
-        duration_ms=5.0,
-    )
-
-    rendered = present_command_execution_result(result, preview_limit=16)
-
-    assert "tail" in rendered
-    assert "--- stderr truncated (1 lines, 128 bytes) ---" in rendered
-    assert "/tmp/stderr-spill.txt" in rendered
-
-
-def test_presentation_reports_exact_line_count_for_newline_terminated_output():
-    result = CommandExecutionResult(stdout="line\n" * 3, stderr="", exit_code=0, duration_ms=1.0)
-
-    rendered = present_command_execution_result(result, preview_limit=4)
-
-    assert "--- stdout truncated (3 lines," in rendered
-
-
-def test_presentation_uses_binary_safe_spill_notice_for_binary_stderr():
+def test_presentation_uses_binary_safe_notice_for_binary_stderr_without_path_leak() -> None:
     spill = CommandSpillReference(path="/tmp/binary-stderr.bin", bytes_written=128, line_count=0, preview="")
     result = CommandExecutionResult(
         stdout="ok",
@@ -274,12 +186,12 @@ def test_presentation_uses_binary_safe_spill_notice_for_binary_stderr():
     rendered = present_command_execution_result(result, preview_limit=16)
 
     assert "[binary stderr omitted]" in rendered
-    assert "Binary stderr spill: /tmp/binary-stderr.bin" in rendered
+    assert "Binary stderr was stored internally." in rendered
+    assert "/tmp/binary-stderr.bin" not in rendered
     assert "grep <pattern>" not in rendered
-    assert "tail 100" not in rendered
 
 
-def test_presentation_keeps_textual_stderr_visible_when_binary_fragments_exist():
+def test_presentation_keeps_textual_stderr_visible_when_binary_fragments_exist() -> None:
     result = CommandExecutionResult(
         stdout="ok",
         stderr=b"\xff\xfebadtail",
@@ -300,9 +212,9 @@ def test_presentation_keeps_textual_stderr_visible_when_binary_fragments_exist()
 
 
 @pytest.mark.asyncio
-async def test_presentation_keeps_pipe_abort_explanation_alongside_binary_stderr_spill(tmp_path):
+async def test_presentation_keeps_pipe_abort_explanation_alongside_binary_stderr_notice(tmp_path: Path) -> None:
     class _Backend:
-        async def execute(self, argv, stdin):
+        async def execute(self, argv, stdin):  # noqa: ANN001
             if argv[0] == "first":
                 return CommandStepResult(stdout=b"\xff\xfeout", stderr=b"\xff\xfeerr", exit_code=0)
             return CommandStepResult(stdout="should-not-run", stderr="", exit_code=0)
@@ -314,163 +226,4 @@ async def test_presentation_keeps_pipe_abort_explanation_alongside_binary_stderr
 
     assert "Pipe payloads must be UTF-8 text" in rendered
     assert "[binary stderr omitted]" in rendered
-    assert "Binary stderr spill:" in rendered
-
-
-def test_presentation_treats_fallback_mixed_stderr_spills_as_binary():
-    spill = CommandSpillReference(path="/tmp/binary-stderr.bin", bytes_written=128, line_count=0, preview="")
-    result = CommandExecutionResult(
-        stdout="ok",
-        stderr="tail",
-        stderr_spill=spill,
-        stderr_spills=[spill],
-        stderr_contains_binary=True,
-        exit_code=2,
-        duration_ms=5.0,
-    )
-
-    rendered = present_command_execution_result(result, preview_limit=16)
-
-    assert "tail" in rendered
-    assert "[binary stderr omitted]" in rendered
-    assert "Binary stderr spill: /tmp/binary-stderr.bin" in rendered
-    assert "grep <pattern>" not in rendered
-
-
-
-def test_presentation_materializes_spill_for_oversized_inline_stderr_even_with_existing_spills():
-    existing_spill = CommandSpillReference(path="/tmp/existing-stderr.txt", bytes_written=128, line_count=1, preview="warn")
-    result = CommandExecutionResult(
-        stdout="ok",
-        stderr="z" * 64,
-        stderr_spill=existing_spill,
-        stderr_spills=[existing_spill],
-        exit_code=2,
-        duration_ms=5.0,
-    )
-
-    rendered = present_command_execution_result(result, preview_limit=8)
-
-    paths = re.findall(r"Full stderr spilled to (.+)", rendered)
-    assert "/tmp/existing-stderr.txt" in paths
-    assert len(paths) == 2
-
-
-def test_presentation_reuses_same_materialized_spill_path_for_repeated_renders():
-    result = CommandExecutionResult(stdout="line\n" * 8, stderr="", exit_code=0, duration_ms=1.0)
-
-    first = present_command_execution_result(result, preview_limit=4)
-    second = present_command_execution_result(result, preview_limit=4)
-
-    first_path = re.search(r"Full stdout spilled to (.+)", first)
-    second_path = re.search(r"Full stdout spilled to (.+)", second)
-    assert first_path is not None
-    assert second_path is not None
-    assert first_path.group(1) == second_path.group(1)
-
-
-def test_presentation_materialized_spill_uses_requested_dir_and_restricted_permissions(tmp_path):
-    result = CommandExecutionResult(stdout="line\n" * 8, stderr="", exit_code=0, duration_ms=1.0)
-    spill_dir = tmp_path / "spill"
-    spill_dir.mkdir(mode=0o700)
-
-    rendered = present_command_execution_result(result, preview_limit=4, spill_dir=spill_dir)
-
-    match = re.search(r"Full stdout spilled to (.+)", rendered)
-    assert match is not None
-    spill_path = Path(match.group(1))
-    assert spill_path.parent == spill_dir
-    assert stat.S_IMODE(spill_path.stat().st_mode) == 0o600
-
-
-def test_presentation_materialized_spill_refuses_to_reuse_tampered_deterministic_file(tmp_path):
-    text = "line\n" * 8
-    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
-    compromised_path = tmp_path / f"stdout-{digest}.txt"
-    compromised_path.write_text("tampered", encoding="utf-8")
-    result = CommandExecutionResult(stdout=text, stderr="", exit_code=0, duration_ms=1.0)
-
-    rendered = present_command_execution_result(result, preview_limit=4, spill_dir=tmp_path)
-
-    match = re.search(r"Full stdout spilled to (.+)", rendered)
-    assert match is not None
-    spill_path = Path(match.group(1))
-    assert spill_path.read_text(encoding="utf-8") == text
-    assert spill_path != compromised_path
-
-
-def test_presentation_materialized_spill_refuses_to_reuse_symlinked_deterministic_file(tmp_path):
-    text = "line\n" * 8
-    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
-    deterministic_path = tmp_path / f"stdout-{digest}.txt"
-    external_path = tmp_path / "external.txt"
-    external_path.write_text(text, encoding="utf-8")
-    deterministic_path.symlink_to(external_path)
-    result = CommandExecutionResult(stdout=text, stderr="", exit_code=0, duration_ms=1.0)
-
-    rendered = present_command_execution_result(result, preview_limit=4, spill_dir=tmp_path)
-
-    match = re.search(r"Full stdout spilled to (.+)", rendered)
-    assert match is not None
-    spill_path = Path(match.group(1))
-    assert spill_path.read_text(encoding="utf-8") == text
-    assert spill_path != deterministic_path
-
-
-def test_presentation_shell_quotes_spill_paths_in_explore_guidance():
-    spill = CommandSpillReference(
-        path="/tmp/path with spaces/stdout.txt",
-        bytes_written=128,
-        line_count=1,
-        preview="abcd",
-    )
-    result = CommandExecutionResult(stdout="x" * 128, stderr="", exit_code=0, duration_ms=1.0, stdout_spill=spill)
-
-    rendered = present_command_execution_result(result, preview_limit=4)
-
-    assert "Full stdout spilled to /tmp/path with spaces/stdout.txt" in rendered
-    assert "cat '/tmp/path with spaces/stdout.txt' | grep <pattern>" in rendered
-    assert "cat '/tmp/path with spaces/stdout.txt' | tail 100" in rendered
-
-
-def test_presentation_rejects_symlinked_spill_dir(tmp_path):
-    target = tmp_path / "target"
-    target.mkdir()
-    symlink = tmp_path / "spill-link"
-    symlink.symlink_to(target, target_is_directory=True)
-    result = CommandExecutionResult(stdout="line\n" * 8, stderr="", exit_code=0, duration_ms=1.0)
-
-    with pytest.raises(PermissionError, match="symlink"):
-        present_command_execution_result(result, preview_limit=4, spill_dir=symlink)
-
-
-@pytest.mark.skipif(os.name == "nt", reason="POSIX permission test")
-def test_presentation_rejects_non_private_existing_spill_dir(tmp_path):
-    spill_dir = tmp_path / "spill"
-    spill_dir.mkdir(mode=0o755)
-    result = CommandExecutionResult(stdout="line\n" * 8, stderr="", exit_code=0, duration_ms=1.0)
-
-    with pytest.raises(PermissionError, match="non-private permissions"):
-        present_command_execution_result(result, preview_limit=4, spill_dir=spill_dir)
-
-
-def test_presentation_tolerates_raced_spill_root_creation(tmp_path, monkeypatch):
-    spill_dir = tmp_path / "spill"
-    original_mkdir = Path.mkdir
-    injected_race = False
-    result = CommandExecutionResult(stdout="line\n" * 8, stderr="", exit_code=0, duration_ms=1.0)
-
-    def racing_mkdir(self: Path, *args, **kwargs):
-        nonlocal injected_race
-        if self == spill_dir and not injected_race:
-            injected_race = True
-            original_mkdir(self, *args, **kwargs)
-            raise FileExistsError()
-        return original_mkdir(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "mkdir", racing_mkdir)
-
-    rendered = present_command_execution_result(result, preview_limit=4, spill_dir=spill_dir)
-
-    assert injected_race is True
-    assert f"Full stdout spilled to {spill_dir}" in rendered
+    assert "Binary stderr was stored internally." in rendered

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py
@@ -238,6 +238,40 @@ async def test_filesystem_read_text_rejects_binary_payload(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_filesystem_read_text_rejects_files_over_size_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    large_path = workspace_root / "large.txt"
+    large_path.write_text("x" * 32, encoding="utf-8")
+
+    resolver = _FakeWorkspaceRootResolver(
+        {
+            "workspace_root": str(workspace_root),
+            "workspace_id": "workspace-1",
+            "source": "sandbox_workspace_lookup",
+            "reason": None,
+        }
+    )
+    mod = FilesystemModule(
+        ModuleConfig(name="filesystem", settings={"max_read_bytes": 8}),
+        workspace_root_resolver=resolver,
+    )
+    context = RequestContext(
+        request_id="req-filesystem-large-read",
+        user_id="7",
+        metadata={"workspace_id": "workspace-1"},
+    )
+
+    def _fail_read_bytes(self):  # noqa: ANN001
+        raise AssertionError("unexpected full file read")
+
+    monkeypatch.setattr(Path, "read_bytes", _fail_read_bytes)
+
+    with pytest.raises(ValueError, match="exceeds fs.read_text limit"):
+        await mod.execute_tool("fs.read_text", {"path": "large.txt"}, context=context)
+
+
+@pytest.mark.asyncio
 async def test_filesystem_write_text_rejects_path_escape(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py
@@ -349,3 +349,37 @@ async def test_protocol_idempotency_key_is_forwarded_to_run_nested_steps(monkeyp
         ["write", "notes.txt", "hi"],
         0,
     )
+
+
+@pytest.mark.asyncio
+async def test_prepare_tool_call_accepts_run_idempotency_key_inside_arguments(monkeypatch, tmp_path):
+    monkeypatch.setenv("MCP_DISABLE_WRITE_TOOLS", "false")
+    monkeypatch.setenv("MCP_AUDIT_LOG_FILE", str(tmp_path / "audit.log"))
+    try:
+        get_config.cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    registry = get_module_registry()
+    await registry.register_module(
+        "run_nested_argument_idempotency",
+        RunCommandModule,
+        ModuleConfig(name="run_nested_argument_idempotency"),
+    )
+
+    proto = MCPProtocol()
+    proto.rbac_policy = AllowAllRBAC()
+    ctx = RequestContext(request_id="run-idem-args", user_id="u1", client_id="c1")
+
+    prepared = await proto.prepare_tool_call(
+        params={
+            "name": "run",
+            "arguments": {
+                "command": "write notes.txt hi",
+                "idempotencyKey": "demo-args-1",
+            },
+        },
+        context=ctx,
+    )
+
+    assert prepared.normalized_idempotency_key == "demo-args-1"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-import re
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -14,7 +14,11 @@ from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.run_command_module import (
     RunCommandModule,
 )
-from tldw_Server_API.app.core.MCP_unified.protocol import MCPProtocol, RequestContext
+from tldw_Server_API.app.core.MCP_unified.protocol import (
+    ApprovalRequiredError,
+    MCPProtocol,
+    RequestContext,
+)
 
 
 @dataclass
@@ -28,9 +32,12 @@ class _ProtocolStub:
         self.prepare_calls: list[_PreparedCall] = []
         self.execute_calls: list[_PreparedCall] = []
         self.tools_list_calls = 0
-        self.raise_on_prepare_for_tool: str | None = None
+        self.prepare_errors: dict[str, BaseException] = {}
+        self.execute_errors: dict[str, BaseException] = {}
+        self.read_text_content = "hello"
 
     async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+        del params, context
         self.tools_list_calls += 1
         return {
             "tools": [
@@ -47,15 +54,21 @@ class _ProtocolStub:
         context: RequestContext,
         idempotency_key: str | None = None,
     ) -> _PreparedCall:
+        del context
         prepared = _PreparedCall(params=dict(params), idempotency_key=idempotency_key)
         self.prepare_calls.append(prepared)
-        if self.raise_on_prepare_for_tool and params.get("name") == self.raise_on_prepare_for_tool:
-            raise PermissionError("blocked by policy")
+        tool_name = str(params.get("name") or "")
+        error = self.prepare_errors.get(tool_name)
+        if error is not None:
+            raise error
         return prepared
 
     async def execute_prepared_tool_call(self, prepared: _PreparedCall) -> dict[str, Any]:
         self.execute_calls.append(prepared)
-        tool_name = prepared.params.get("name")
+        tool_name = str(prepared.params.get("name") or "")
+        error = self.execute_errors.get(tool_name)
+        if error is not None:
+            raise error
         if tool_name == "fs.list":
             return {
                 "content": [
@@ -79,7 +92,7 @@ class _ProtocolStub:
             }
         if tool_name == "fs.read_text":
             return {
-                "content": [{"type": "json", "json": {"path": "notes.txt", "text": "hello"}}],
+                "content": [{"type": "json", "json": {"path": "notes.txt", "text": self.read_text_content}}],
                 "tool": tool_name,
             }
         raise AssertionError(f"Unexpected tool execution: {tool_name}")
@@ -142,13 +155,14 @@ async def test_run_cat_without_path_returns_usage() -> None:
 @pytest.mark.asyncio
 async def test_run_preflights_write_chain_before_executing_first_step() -> None:
     protocol = _ProtocolStub()
-    protocol.raise_on_prepare_for_tool = "fs.write_text"
+    protocol.prepare_errors["fs.write_text"] = PermissionError("blocked by policy")
     module = _build_module(protocol)
     context = RequestContext(request_id="run-preflight", user_id="1", client_id="unit")
 
-    with pytest.raises(PermissionError, match="blocked by policy"):
-        await module.execute_tool("run", {"command": "ls ; write notes.txt hello"}, context=context)
+    rendered = await module.execute_tool("run", {"command": "ls ; write notes.txt hello"}, context=context)
 
+    assert "blocked by policy" in rendered
+    assert "[exit:1 |" in rendered
     assert [call.params["name"] for call in protocol.prepare_calls] == ["fs.list", "fs.write_text"]
     assert protocol.execute_calls == []
 
@@ -183,9 +197,37 @@ async def test_run_derives_step_idempotency_from_parent_key() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_converts_governed_file_errors_into_cli_result() -> None:
+    protocol = _ProtocolStub()
+    protocol.execute_errors["fs.read_text"] = FileNotFoundError("Path not found: notes.txt")
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-cat-missing", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "cat notes.txt"}, context=context)
+
+    assert "Path not found: notes.txt" in rendered
+    assert "[exit:1 |" in rendered
+
+
+@pytest.mark.asyncio
+async def test_run_preserves_approval_required_errors() -> None:
+    protocol = _ProtocolStub()
+    protocol.prepare_errors["fs.write_text"] = ApprovalRequiredError(
+        "approval required",
+        approval={"reason": "path_outside_current_folder_scope"},
+    )
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-approval", user_id="1", client_id="unit")
+
+    with pytest.raises(ApprovalRequiredError, match="approval required"):
+        await module.execute_tool("run", {"command": "write notes.txt hello"}, context=context)
+
+
+@pytest.mark.asyncio
 async def test_run_help_keeps_argument_sensitive_allowed_commands_visible() -> None:
     class _PatternProtocolStub:
         async def _handle_tools_list(self, params: dict[str, Any], context: RequestContext) -> dict[str, Any]:
+            del params, context
             return {
                 "tools": [
                     {"name": "sandbox.run", "module": "sandbox", "canExecute": True},
@@ -193,9 +235,11 @@ async def test_run_help_keeps_argument_sensitive_allowed_commands_visible() -> N
             }
 
         def _extract_allowed_tools(self, context: RequestContext) -> list[str]:
+            del context
             return ["sandbox.run(ls *)"]
 
         async def _resolve_effective_tool_policy(self, context: RequestContext) -> dict[str, Any]:
+            del context
             return {
                 "enabled": True,
                 "allowed_tools": ["sandbox.run(ls *)"],
@@ -203,6 +247,7 @@ async def test_run_help_keeps_argument_sensitive_allowed_commands_visible() -> N
             }
 
         def _is_tool_allowed_by_context(self, tool_name: str, tool_args: dict[str, Any], context: RequestContext) -> bool:
+            del tool_name, tool_args, context
             return False
 
         def _is_tool_allowed_by_effective_policy(
@@ -211,6 +256,7 @@ async def test_run_help_keeps_argument_sensitive_allowed_commands_visible() -> N
             tool_args: dict[str, Any],
             policy: dict[str, Any],
         ) -> bool:
+            del tool_name, tool_args, policy
             return False
 
     module = RunCommandModule(
@@ -230,25 +276,10 @@ async def test_run_help_keeps_argument_sensitive_allowed_commands_visible() -> N
 
 @pytest.mark.asyncio
 async def test_run_uses_configured_spill_settings_and_workspace_relative_spill_dir(tmp_path: Path) -> None:
-    class _SpillProtocolStub(_ProtocolStub):
-        async def execute_prepared_tool_call(self, prepared: _PreparedCall) -> dict[str, Any]:
-            self.execute_calls.append(prepared)
-            return {
-                "content": [
-                    {
-                        "type": "json",
-                        "json": {
-                            "path": "notes.txt",
-                            "text": "line one\nline two\nline three\n",
-                        },
-                    }
-                ],
-                "tool": prepared.params.get("name"),
-            }
-
+    protocol = _ProtocolStub()
+    protocol.read_text_content = "line one\nline two\nline three\n"
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir(parents=True, exist_ok=True)
-    protocol = _SpillProtocolStub()
     resolver = _WorkspaceRootResolverStub(workspace_root)
     module = RunCommandModule(
         ModuleConfig(
@@ -272,13 +303,39 @@ async def test_run_uses_configured_spill_settings_and_workspace_relative_spill_d
 
     rendered = await module.execute_tool("run", {"command": "cat notes.txt"}, context=context)
 
-    match = re.search(r"Full stdout spilled to (.+)", rendered)
-    assert match is not None
-    spill_path = Path(match.group(1))
-    assert spill_path.parent == workspace_root / ".mcp" / "spills"
+    spill_root = workspace_root / ".mcp" / "spills"
+    assert spill_root.exists()
+    assert list(spill_root.iterdir()) == []
     assert "line one" in rendered
     assert "line two" not in rendered
+    assert "stored internally" in rendered
+    assert str(spill_root) not in rendered
     assert resolver.calls
+
+
+@pytest.mark.asyncio
+async def test_run_cleans_up_internal_spill_files_after_rendering(tmp_path: Path) -> None:
+    protocol = _ProtocolStub()
+    protocol.read_text_content = "line\n" * 500
+    spill_root = tmp_path / "spills"
+    module = RunCommandModule(
+        ModuleConfig(
+            name="run",
+            settings={
+                "protocol": protocol,
+                "spill_dir": spill_root,
+                "spill_threshold_bytes": 32,
+            },
+        )
+    )
+    context = RequestContext(request_id="run-spill-cleanup", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool("run", {"command": "cat notes.txt"}, context=context)
+
+    assert "--- stdout truncated" in rendered
+    assert "stored internally" in rendered
+    assert spill_root.exists()
+    assert list(spill_root.iterdir()) == []
 
 
 @pytest.mark.asyncio
@@ -314,25 +371,15 @@ async def test_run_supports_json_paths_with_escaped_dots() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_resolve_protocol_logs_before_falling_back(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_run_resolve_protocol_uses_standalone_protocol_when_server_protocol_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from tldw_Server_API.app.core.MCP_unified import server as server_module
-    from tldw_Server_API.app.core.MCP_unified.modules.implementations import run_command_module as run_module_impl
 
-    warnings: list[str] = []
-
-    def _boom() -> Any:
-        raise RuntimeError("missing server")
-
-    monkeypatch.setattr(server_module, "get_mcp_server", _boom)
-    monkeypatch.setattr(
-        run_module_impl.logger,
-        "warning",
-        lambda message, *args: warnings.append(str(message).format(*args)),
-    )
+    monkeypatch.setattr(server_module, "get_mcp_server", lambda: SimpleNamespace(protocol=None))
 
     module = RunCommandModule(ModuleConfig(name="run"))
 
     protocol = await module._resolve_protocol()
 
     assert isinstance(protocol, MCPProtocol)
-    assert warnings

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py
@@ -184,8 +184,9 @@ async def test_run_derives_step_idempotency_from_parent_key() -> None:
         context=context,
     )
 
-    assert first == second
+    assert first.split("\n[exit:0 |", 1)[0] == second.split("\n[exit:0 |", 1)[0]
     assert "[exit:0 |" in first
+    assert "[exit:0 |" in second
     assert len(protocol.prepare_calls) == 2
     assert protocol.prepare_calls[0].params["name"] == "fs.write_text"
     assert protocol.prepare_calls[0].idempotency_key == derive_step_idempotency_key(
@@ -194,6 +195,39 @@ async def test_run_derives_step_idempotency_from_parent_key() -> None:
         0,
     )
     assert protocol.prepare_calls[0].idempotency_key == protocol.prepare_calls[1].idempotency_key
+
+
+@pytest.mark.asyncio
+async def test_run_uses_lexical_preflighted_step_for_identical_command_after_skipped_branch() -> None:
+    protocol = _ProtocolStub()
+    protocol.execute_errors["fs.read_text"] = FileNotFoundError("Path not found: missing.txt")
+    module = _build_module(protocol)
+    context = RequestContext(request_id="run-skipped-branch", user_id="1", client_id="unit")
+
+    rendered = await module.execute_tool(
+        "run",
+        {
+            "command": "cat missing.txt && write notes.txt hi ; write notes.txt hi",
+            "idempotencyKey": "parent-idem-skip-1",
+        },
+        context=context,
+    )
+
+    assert "[exit:0 |" in rendered
+    assert [call.params["name"] for call in protocol.prepare_calls] == [
+        "fs.read_text",
+        "fs.write_text",
+        "fs.write_text",
+    ]
+    assert [call.params["name"] for call in protocol.execute_calls] == [
+        "fs.read_text",
+        "fs.write_text",
+    ]
+    assert protocol.execute_calls[1].idempotency_key == derive_step_idempotency_key(
+        "parent-idem-skip-1",
+        ["write", "notes.txt", "hi"],
+        2,
+    )
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/app/services/connectors_worker.py
+++ b/tldw_Server_API/app/services/connectors_worker.py
@@ -770,6 +770,26 @@ async def _process_import_job(
             except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
                 raise
 
+    async def _renew_reference_manager_lease_until_stopped(stop_event: asyncio.Event) -> None:
+        if not lease_id:
+            return
+
+        while not stop_event.is_set():
+            try:
+                jm.renew_job_lease(
+                    jid,
+                    seconds=120,
+                    worker_id=worker_id,
+                    lease_id=lease_id,
+                )
+            except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
+                pass
+
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=30)
+            except TimeoutError:
+                continue
+
     # Prepare DB instance
     mdb = _create_connector_media_db(user_id)
 
@@ -1417,6 +1437,10 @@ async def _process_import_job(
                         last_sync_started_at=_utc_now_db_text(),
                         last_error=None,
                     )
+                heartbeat_stop = asyncio.Event()
+                heartbeat_task = asyncio.create_task(
+                    _renew_reference_manager_lease_until_stopped(heartbeat_stop)
+                )
                 try:
                     reference_result = await sync_reference_manager_source(
                         connectors_pool=pool,
@@ -1437,10 +1461,18 @@ async def _process_import_job(
                             last_error=str(exc),
                         )
                     raise
+                finally:
+                    heartbeat_stop.set()
+                    await heartbeat_task
 
                 processed = int(reference_result.get("processed") or 0)
                 total = int(reference_result.get("total") or 0)
                 failed = int(reference_result.get("failed") or 0)
+                if "cursor" in reference_result:
+                    cursor_value = reference_result.get("cursor")
+                else:
+                    cursor_value = reference_sync_state.get("cursor")
+                final_cursor = str(cursor_value).strip() or None if cursor_value is not None else None
                 result_payload = {
                     "processed": processed,
                     "total": total,
@@ -1453,7 +1485,7 @@ async def _process_import_job(
                     await upsert_source_sync_state(
                         db,
                         source_id=source_id,
-                        cursor=reference_result.get("cursor"),
+                        cursor=final_cursor,
                         last_sync_succeeded_at=_utc_now_db_text(),
                         last_error=None,
                     )

--- a/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
@@ -738,7 +738,12 @@ def test_browse_provider_sources_returns_zotero_collection_rows(connectors_clien
     async def _fake_get_account_email(db, user_id, account_id):
         return None
 
+    async def _fake_get_account_for_user(db, user_id, account_id):
+        assert account_id == 15
+        return {"id": account_id, "user_id": user_id, "provider": "zotero"}
+
     monkeypatch.setattr(ep, "get_connector_by_name", lambda provider: _FakeConn())
+    monkeypatch.setattr(ep, "get_account_for_user", _fake_get_account_for_user)
     monkeypatch.setattr(ep, "get_account_tokens", _fake_get_account_tokens)
     monkeypatch.setattr(ep, "get_account_email", _fake_get_account_email)
 

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
@@ -238,6 +238,37 @@ async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_upsert_source_sync_state_allows_explicit_none_to_clear_nullable_fields(
+    sqlite_db: aiosqlite.Connection,
+) -> None:
+    _, source = await _create_account_and_source(sqlite_db)
+
+    seeded = await svc.upsert_source_sync_state(
+        sqlite_db,
+        source_id=source["id"],
+        sync_mode="hybrid",
+        cursor="delta-token",
+        last_error="boom",
+        active_job_id="job-123",
+    )
+    cleared = await svc.upsert_source_sync_state(
+        sqlite_db,
+        source_id=source["id"],
+        cursor=None,
+        last_error=None,
+        active_job_id=None,
+    )
+
+    assert seeded["cursor"] == "delta-token"
+    assert seeded["last_error"] == "boom"
+    assert seeded["active_job_id"] == "job-123"
+    assert cleared["cursor"] is None
+    assert cleared["last_error"] is None
+    assert cleared["active_job_id"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_get_source_binding_health_counts_tracked_and_degraded_items(
     sqlite_db: aiosqlite.Connection,
 ) -> None:

--- a/tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_worker_reference_sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 
 import pytest
@@ -8,8 +9,10 @@ import pytest
 class _FakeJM:
     def __init__(self) -> None:
         self.completed: dict[str, object] | None = None
+        self.renew_calls: list[dict[str, object]] = []
 
     def renew_job_lease(self, *args, **kwargs):
+        self.renew_calls.append({"args": args, "kwargs": dict(kwargs)})
         return None
 
     def complete_job(
@@ -113,6 +116,7 @@ async def test_worker_reference_manager_sync_uses_merged_account_loader_and_pers
                 "convert_bytes_to_text": convert_bytes_to_text,
             }
         )
+        await asyncio.sleep(0)
         assert account["tokens"]["access_token"] == "tok"
         assert account["provider_user_id"] == "123456"
         assert account["username"] == "researcher"
@@ -177,6 +181,7 @@ async def test_worker_reference_manager_sync_uses_merged_account_loader_and_pers
     )
 
     assert len(sync_calls) == 1
+    assert jm.renew_calls
     assert sync_state_updates[0]["last_sync_started_at"] is not None
     assert sync_state_updates[-1]["cursor"] == "cursor-1"
     assert sync_state_updates[-1]["last_sync_succeeded_at"] is not None
@@ -185,3 +190,99 @@ async def test_worker_reference_manager_sync_uses_merged_account_loader_and_pers
     assert jm.completed["result"]["imported"] == 1
     assert jm.completed["result"]["duplicates"] == 1
     assert created_media_db.closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_reference_manager_sync_preserves_existing_cursor_when_importer_omits_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class _FakeZoteroConnector:
+        pass
+
+    pool = _DummyPool()
+    sync_state_updates: list[dict[str, object]] = []
+
+    async def _fake_get_db_pool():
+        return pool
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "zotero",
+            "account_id": 123,
+            "remote_id": "COLL1234",
+            "type": "collection",
+            "path": None,
+            "options": {"recursive": False},
+            "email": "researcher@example.com",
+        }
+
+    async def _fake_get_account_for_user(db, user_id, account_id):
+        return {
+            "id": account_id,
+            "user_id": user_id,
+            "provider": "zotero",
+            "provider_user_id": "123456",
+            "username": "researcher",
+            "email": "researcher@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {"source_id": source_id, "sync_mode": "poll", "cursor": "cursor-0"}
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    async def _fake_sync_reference_manager_source(**kwargs):
+        return {
+            "processed": 1,
+            "total": 1,
+            "failed": 0,
+            "imported": 0,
+            "duplicates": 1,
+            "metadata_only": 0,
+        }
+
+    class _FakeMDB:
+        def close_connection(self):
+            return None
+
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(orgs, "list_memberships_for_user", lambda user_id: [])
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: _FakeZoteroConnector())
+    monkeypatch.setattr(svc, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc, "get_account_for_user", _fake_get_account_for_user, raising=False)
+    monkeypatch.setattr(svc, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(worker, "_create_connector_media_db", lambda user_id: _FakeMDB(), raising=False)
+    monkeypatch.setattr(worker, "_close_connector_media_db", lambda media_db: None, raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.External_Sources.reference_manager_import.sync_reference_manager_source",
+        _fake_sync_reference_manager_source,
+        raising=False,
+    )
+
+    jm = _FakeJM()
+    await worker._process_import_job(
+        jm,
+        jid=1234,
+        lease_id="lease-1",
+        worker_id="worker-1",
+        source_id=99,
+        user_id=42,
+    )
+
+    assert sync_state_updates[-1]["cursor"] == "cursor-0"

--- a/tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py
+++ b/tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py
@@ -20,10 +20,10 @@ from tldw_Server_API.app.core.exceptions import ReferenceImportError
 
 class _ReferenceManagerStub:
     async def list_collections(self, account, *, cursor=None, page_size=100):  # pragma: no cover - contract stub
-        return []
+        return [], None
 
     async def list_collection_items(self, account, collection_key, *, cursor=None, page_size=100):  # pragma: no cover - contract stub
-        return []
+        return [], None
 
     async def list_item_attachments(self, account, provider_item_key):  # pragma: no cover - contract stub
         return []
@@ -48,9 +48,20 @@ async def sqlite_db(tmp_path: Path):
         await db.close()
 
 
+@pytest.mark.asyncio
 @pytest.mark.unit
-def test_reference_manager_adapter_protocol_accepts_collection_item_attachment_and_download_methods() -> None:
-    assert isinstance(_ReferenceManagerStub(), ReferenceManagerAdapter)
+async def test_reference_manager_adapter_protocol_accepts_collection_item_attachment_and_download_methods() -> None:
+    stub = _ReferenceManagerStub()
+
+    assert isinstance(stub, ReferenceManagerAdapter)
+
+    collections, collections_cursor = await stub.list_collections({})
+    items, items_cursor = await stub.list_collection_items({}, "COLL1234")
+
+    assert collections == []
+    assert items == []
+    assert collections_cursor is None
+    assert items_cursor is None
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py
+++ b/tldw_Server_API/tests/External_Sources/test_reference_manager_contract.py
@@ -22,7 +22,15 @@ class _ReferenceManagerStub:
     async def list_collections(self, account, *, cursor=None, page_size=100):  # pragma: no cover - contract stub
         return [], None
 
-    async def list_collection_items(self, account, collection_key, *, cursor=None, page_size=100):  # pragma: no cover - contract stub
+    async def list_collection_items(
+        self,
+        account,
+        collection_key,
+        *,
+        collection_name=None,
+        cursor=None,
+        page_size=100,
+    ):  # pragma: no cover - contract stub
         return [], None
 
     async def list_item_attachments(self, account, provider_item_key):  # pragma: no cover - contract stub

--- a/tldw_Server_API/tests/External_Sources/test_zotero_connector.py
+++ b/tldw_Server_API/tests/External_Sources/test_zotero_connector.py
@@ -143,6 +143,7 @@ async def test_zotero_collection_item_listing_is_flat_for_selected_collection_in
             "tokens": {"access_token": "api-key"},
         },
         "COLL1234",
+        collection_name="Language Models",
         cursor=None,
         page_size=50,
     )
@@ -152,6 +153,7 @@ async def test_zotero_collection_item_listing_is_flat_for_selected_collection_in
     assert items[0].provider == "zotero"
     assert items[0].provider_library_id == "123456"
     assert items[0].collection_key == "COLL1234"
+    assert items[0].collection_name == "Language Models"
     assert items[0].doi == "10.1000/example"
     assert items[0].title == "Attention Is All You Need"
     assert items[0].authors == "Ashish Vaswani, Noam Shazeer"

--- a/tldw_Server_API/tests/MCP/test_mcp_tools_execute_authz.py
+++ b/tldw_Server_API/tests/MCP/test_mcp_tools_execute_authz.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import asyncio
 import pytest
@@ -197,3 +198,103 @@ def test_tools_execute_with_api_key_and_role_permission_allows_200(tmp_path, mon
     assert run_response.status_code == 200, run_response.text
     run_body = run_response.json()
     assert "[exit:0 |" in run_body["result"]
+
+
+def test_tools_execute_with_api_key_can_run_virtual_cli_help(tmp_path):
+    from tldw_Server_API.app.core.MCP_unified.config import get_config
+    from tldw_Server_API.app.core.MCP_unified.server import get_mcp_server, reset_mcp_server
+
+    db_file = tmp_path / "mcp_run_help.sqlite"
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_file}"
+    os.environ["AUTH_MODE"] = "single_user"
+    os.environ.pop("MCP_MODULES", None)
+    os.environ.pop("MCP_MODULES_CONFIG", None)
+
+    _run(reset_db_pool())
+    reset_settings()
+    with contextlib.suppress(AttributeError):
+        get_config.cache_clear()  # type: ignore[attr-defined]
+    _run(reset_mcp_server())
+
+    ensure_authnz_tables(Path(db_file))
+    pool = _run(get_db_pool())
+
+    async def _insert_user():
+        async with pool.transaction() as conn:
+            if hasattr(conn, 'fetchval'):
+                uid = await conn.fetchval(
+                    "INSERT INTO users (username, email, password_hash, is_active, role, is_verified) VALUES ($1,$2,$3,$4,$5,$6) RETURNING id",
+                    "run_user", "run@test.local", "dummyhash", True, "user", True
+                )
+                return uid
+            else:
+                cur = await conn.execute(
+                    "INSERT INTO users (username, email, password_hash, is_active, role, is_verified) VALUES (?,?,?,?,?,?)",
+                    ("run_user", "run@test.local", "dummyhash", 1, "user", 1)
+                )
+                uid = cur.lastrowid
+                await conn.commit()
+                return uid
+
+    user_id = _run(_insert_user())
+    api_mgr = _run(get_api_key_manager())
+    key_data = _run(api_mgr.create_api_key(user_id=user_id, name="run-key"))
+    api_key = key_data["key"]
+
+    async def _seed():
+        async with pool.transaction() as conn:
+            if not hasattr(conn, 'fetchval'):
+                await conn.execute("CREATE TABLE IF NOT EXISTS roles (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, description TEXT, is_system INTEGER DEFAULT 0)")
+                await conn.execute("CREATE TABLE IF NOT EXISTS permissions (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, description TEXT, category TEXT)")
+                await conn.execute("CREATE TABLE IF NOT EXISTS role_permissions (role_id INTEGER NOT NULL, permission_id INTEGER NOT NULL, PRIMARY KEY(role_id, permission_id))")
+                await conn.execute("CREATE TABLE IF NOT EXISTS user_roles (user_id INTEGER NOT NULL, role_id INTEGER NOT NULL, PRIMARY KEY(user_id, role_id))")
+            if hasattr(conn, 'fetchval'):
+                pid = await conn.fetchval(
+                    "INSERT INTO permissions (name, description, category) VALUES ($1,$2,$3) ON CONFLICT (name) DO NOTHING RETURNING id",
+                    "tools.execute:*", "Wildcard tool execution", "tools"
+                )
+                if not pid:
+                    pid = await conn.fetchval("SELECT id FROM permissions WHERE name = $1", "tools.execute:*")
+                rid = await conn.fetchval(
+                    "INSERT INTO roles (name, description, is_system) VALUES ($1,$2,$3) RETURNING id",
+                    "run_tool_role", "Role for run tool exec", False
+                )
+                await conn.execute("INSERT INTO role_permissions (role_id, permission_id) VALUES ($1,$2) ON CONFLICT DO NOTHING", rid, pid)
+                await conn.execute("INSERT INTO user_roles (user_id, role_id) VALUES ($1,$2) ON CONFLICT DO NOTHING", user_id, rid)
+            else:
+                cur = await conn.execute("SELECT id FROM permissions WHERE name = ?", ("tools.execute:*",))
+                row = await cur.fetchone()
+                if row:
+                    pid = row[0]
+                else:
+                    cur = await conn.execute(
+                        "INSERT INTO permissions (name, description, category) VALUES (?,?,?)",
+                        ("tools.execute:*", "Wildcard tool execution", "tools")
+                    )
+                    pid = cur.lastrowid
+                cur = await conn.execute(
+                    "INSERT INTO roles (name, description, is_system) VALUES (?,?,?)",
+                    ("run_tool_role", "Role for run tool exec", 0)
+                )
+                rid = cur.lastrowid
+                await conn.execute("INSERT INTO role_permissions (role_id, permission_id) VALUES (?,?)", (rid, pid))
+                await conn.execute("INSERT INTO user_roles (user_id, role_id) VALUES (?,?)", (user_id, rid))
+                await conn.commit()
+
+    _run(_seed())
+
+    payload = {"tool_name": "run", "arguments": {"command": "help"}}
+    r = client.post(
+        "/api/v1/mcp/tools/execute",
+        json=payload,
+        headers={"X-API-KEY": api_key},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["module"] == "run_command"
+    assert isinstance(body["result"], str)
+    assert "Virtual CLI commands available in this context" in body["result"]
+    assert "[exit:0 |" in body["result"]
+
+    module_ids = set(_run(get_mcp_server().module_registry.get_all_modules()).keys())
+    assert {"filesystem", "knowledge", "run_command"}.issubset(module_ids)

--- a/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
@@ -66,9 +66,11 @@ class _FakeZoteroConnector:
         account,
         collection_key: str,
         *,
+        collection_name: str | None = None,
         cursor: str | None = None,
         page_size: int = 100,
     ):
+        del collection_name
         assert account["tokens"]["access_token"] == "tok"
         assert account["provider_user_id"] == "123456"
         assert collection_key == "COLL1234"

--- a/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_reference_import_integration.py
@@ -379,6 +379,138 @@ async def test_reference_manager_sync_imports_new_items_merges_duplicate_metadat
 
 
 @pytest.mark.asyncio
+async def test_reference_manager_terminal_page_clears_stored_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.db_path_utils as db_paths_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    connectors_db = await aiosqlite.connect(tmp_path / "connectors-terminal.sqlite3")
+    connectors_db.row_factory = aiosqlite.Row
+    connectors_db._is_sqlite = True
+
+    try:
+        media_root = tmp_path / "user_dbs"
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(media_root))
+        monkeypatch.setitem(db_paths_mod.settings, "USER_DB_BASE_DIR", str(media_root))
+        _media_db_path = db_paths_mod.DatabasePaths.get_media_db_path(1)
+
+        fake_conn = _FakeZoteroConnector(
+            pages={
+                "cursor-0": (
+                    [
+                        _reference_item(
+                            provider_item_key="ITEM-NEW",
+                            doi="10.1000/new",
+                            title="Attention Is All You Need",
+                            authors="Ashish Vaswani, Noam Shazeer",
+                            year="2017",
+                            journal="NeurIPS",
+                            abstract="Transformer paper.",
+                            provider_version="1",
+                        )
+                    ],
+                    "cursor-1",
+                ),
+                "cursor-1": ([], None),
+            },
+            attachments={
+                "ITEM-NEW": [_attachment(provider_item_key="ITEM-NEW", attachment_key="ATT-NEW")],
+            },
+            downloads={
+                "ATT-NEW": b"Imported attachment body",
+            },
+        )
+
+        pool = _SqlitePool(connectors_db)
+
+        async def _fake_get_db_pool():
+            return pool
+
+        async def _fake_list_memberships_for_user(_user_id: int):
+            return []
+
+        async def _fake_convert_document_bytes_to_text(raw, name, effective_mime):
+            return raw.decode("utf-8")
+
+        monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+        monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+        monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: fake_conn)
+        monkeypatch.setattr(
+            worker,
+            "_convert_document_bytes_to_text",
+            _fake_convert_document_bytes_to_text,
+            raising=False,
+        )
+
+        account = await svc.create_account(
+            connectors_db,
+            user_id=1,
+            provider="zotero",
+            display_name="Zotero",
+            email="researcher@example.com",
+            tokens={
+                "access_token": "tok",
+                "provider_user_id": "123456",
+                "username": "researcher",
+            },
+        )
+        source = await svc.create_source(
+            connectors_db,
+            account_id=int(account["id"]),
+            provider="zotero",
+            remote_id="COLL1234",
+            type_="collection",
+            path=None,
+            options={},
+        )
+        await svc.upsert_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+            sync_mode="poll",
+            cursor="cursor-0",
+        )
+
+        first_jm = _FakeJM()
+        await worker._process_import_job(
+            first_jm,
+            jid=9301,
+            lease_id="lease-reference-1",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+        second_jm = _FakeJM()
+        await worker._process_import_job(
+            second_jm,
+            jid=9302,
+            lease_id="lease-reference-2",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        sync_state = await svc.get_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+        )
+
+        assert first_jm.completed is not None
+        assert first_jm.completed["result"]["imported"] == 1
+        assert second_jm.completed is not None
+        assert second_jm.completed["result"]["processed"] == 0
+        assert fake_conn.list_collection_calls == ["cursor-0", "cursor-1"]
+        assert sync_state is not None
+        assert sync_state["cursor"] is None
+    finally:
+        await connectors_db.close()
+
+
+@pytest.mark.asyncio
 async def test_reference_manager_repeat_sync_keeps_existing_media_non_destructive(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- add workspace-bounded MCP filesystem tools and register the phase-1 default module inventory
- add the virtual CLI parser, registry, execution/presentation layers, and governed `run` MCP tool
- add documentation plus idempotency, auth, and path-scope integration coverage for the new command surface

## Test Plan
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/app/core/MCP_unified/tests/test_protocol_preexec_validation.py tldw_Server_API/app/core/MCP_unified/tests/test_filesystem_module.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_parser.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_registry.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_execution.py tldw_Server_API/app/core/MCP_unified/tests/test_command_runtime_presentation.py tldw_Server_API/app/core/MCP_unified/tests/test_run_command_module.py tldw_Server_API/app/core/MCP_unified/tests/test_idempotency_and_category.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py tldw_Server_API/tests/MCP/test_mcp_tools_execute_authz.py tldw_Server_API/tests/MCP_unified/test_mcp_protocol_path_scope.py -v`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/MCP_unified/command_runtime tldw_Server_API/app/core/MCP_unified/modules/implementations/filesystem_module.py tldw_Server_API/app/core/MCP_unified/modules/implementations/run_command_module.py`
