### PR TITLE
fix(chat): hide mood badge by default

### DIFF
--- a/apps/packages/ui/src/components/Common/Playground/Message.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/Message.tsx
@@ -12,6 +12,7 @@ import {
 import { EditMessageForm } from "./EditMessageForm"
 import { useTranslation } from "react-i18next"
 import { useTTS, type TtsClipMeta } from "@/hooks/useTTS"
+import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference"
 import { tagColors } from "@/utils/color"
 import { removeModelSuffix } from "@/db/dexie/models"
 import { parseReasoning } from "@/libs/reasoning"
@@ -292,7 +293,7 @@ export const PlaygroundMessage = (props: Props) => {
   const [assistantTextSize] = useStorage("chatAssistantTextSize", "md")
   const [userDisplayName] = useStorage("chatUserDisplayName", "")
   const [showCharacterPortraits] = useStorage("chatShowCharacterPortraits", true)
-  const [showMoodBadge] = useStorage("chatShowMoodBadge", true)
+  const [showMoodBadge] = useChatMoodBadgePreference()
   const moodConfidenceDefault =
     Boolean(props.characterIdentityEnabled) && Boolean(props.characterIdentity?.id)
   const [showMoodConfidence] = useStorage(
@@ -1049,12 +1050,15 @@ export const PlaygroundMessage = (props: Props) => {
     setSavingKnowledge(makeFlashcard ? "flashcard" : "note")
     try {
       await tldwClient.initialize().catch(() => null)
-      await tldwClient.saveChatKnowledge({
-        conversation_id: props.serverChatId,
-        message_id: props.serverMessageId,
-        snippet,
-        make_flashcard: makeFlashcard
-      })
+      await tldwClient.saveChatKnowledge(
+        {
+          conversation_id: props.serverChatId,
+          message_id: props.serverMessageId,
+          snippet,
+          make_flashcard: makeFlashcard
+        },
+        props.scope ? { scope: props.scope } : undefined
+      )
       message.success(
         makeFlashcard
           ? t("savedToFlashcards", "Saved to Flashcards")

--- a/apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
+++ b/apps/packages/ui/src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx
@@ -56,6 +56,16 @@ vi.mock("@plasmohq/storage/hook", () => ({
   ]
 }))
 
+vi.mock("@/hooks/useChatMoodBadgePreference", () => ({
+  useChatMoodBadgePreference: () => [
+    storageOverrides.has("chatShowMoodBadge")
+      ? Boolean(storageOverrides.get("chatShowMoodBadge"))
+      : false,
+    vi.fn(),
+    { isLoading: false, setRenderValue: vi.fn() }
+  ]
+}))
+
 vi.mock("@/components/Common/Markdown", () => ({
   default: ({ message }: { message: string }) => (
     <div data-testid="mock-markdown">{message}</div>
@@ -350,6 +360,12 @@ describe("PlaygroundMessage routing fallback integration", () => {
     expect(screen.queryByTestId("message-mood-indicator")).toBeNull()
   })
 
+  it("hides mood badge by default", () => {
+    render(<PlaygroundMessage {...baseProps} />)
+
+    expect(screen.queryByTestId("message-mood-indicator")).toBeNull()
+  })
+
   it("shows mood badge when chat mood visibility is enabled", () => {
     storageOverrides.set("chatShowMoodBadge", true)
 
@@ -360,6 +376,8 @@ describe("PlaygroundMessage routing fallback integration", () => {
   })
 
   it("defaults mood confidence to off for non-character chats", () => {
+    storageOverrides.set("chatShowMoodBadge", true)
+
     render(
       <PlaygroundMessage
         {...baseProps}

--- a/apps/packages/ui/src/components/Common/Playground/useMessageState.ts
+++ b/apps/packages/ui/src/components/Common/Playground/useMessageState.ts
@@ -1,6 +1,7 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { useStorage } from "@plasmohq/storage/hook"
+import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference"
 import { useTTS, type TtsClipMeta } from "@/hooks/useTTS"
 import { useTldwAudioStatus } from "@/hooks/useTldwAudioStatus"
 import { useFeedback } from "@/hooks/useFeedback"
@@ -246,7 +247,7 @@ export function useMessageState(props: MessageStateProps) {
   const [assistantTextSize] = useStorage("chatAssistantTextSize", "md")
   const [userDisplayName] = useStorage("chatUserDisplayName", "")
   const [showCharacterPortraits] = useStorage("chatShowCharacterPortraits", true)
-  const [showMoodBadge] = useStorage("chatShowMoodBadge", true)
+  const [showMoodBadge] = useChatMoodBadgePreference()
   const moodConfidenceDefault =
     Boolean(props.characterIdentityEnabled) && Boolean(props.characterIdentity?.id)
   const [showMoodConfidence] = useStorage(

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -33,6 +33,7 @@ import { isFirefoxTarget } from "@/config/platform"
 import { handleChatInputKeyDown } from "@/utils/key-down"
 import { getProviderDisplayName } from "@/utils/provider-registry"
 import { useStorage } from "@plasmohq/storage/hook"
+import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference"
 import { useTabMentions } from "~/hooks/useTabMentions"
 import { useFocusShortcuts } from "~/hooks/keyboard"
 // isMac moved to PlaygroundSendControl
@@ -401,10 +402,7 @@ export const PlaygroundForm = ({
     "allowExternalImages",
     DEFAULT_CHAT_SETTINGS.allowExternalImages
   )
-  const [showMoodBadge, setShowMoodBadge] = useStorage(
-    "chatShowMoodBadge",
-    true
-  )
+  const [showMoodBadge, setShowMoodBadge] = useChatMoodBadgePreference()
   const researchContext = React.useMemo(
     () =>
       attachedResearchContext
@@ -735,6 +733,15 @@ export const PlaygroundForm = ({
     ]
   )
   const voiceChatAvailable = voiceConversationAvailability.available
+  const voiceChatUnavailableReason = React.useMemo(() => {
+    const fallback = t(
+      "playground:voiceChat.unavailableBody",
+      "Connect to a tldw server with audio chat streaming enabled."
+    )
+    return voiceConversationAvailability.message
+      ? t(voiceConversationAvailability.message, fallback)
+      : fallback
+  }, [t, voiceConversationAvailability.message])
   const voiceChat = useVoiceChatStream({
     active: voiceChatEnabled && voiceChatAvailable,
     onTranscript: (text) => {
@@ -3505,6 +3512,7 @@ export const PlaygroundForm = ({
       onToggleKnowledgePanel={toggleKnowledgePanel}
       voiceChatEnabled={voiceChatEnabled}
       voiceChatAvailable={voiceChatAvailable}
+      voiceChatUnavailableReason={voiceChatUnavailableReason}
       isSending={isSending}
       onVoiceChatToggle={handleVoiceChatToggle}
       webSearch={webSearch}
@@ -3800,6 +3808,7 @@ export const PlaygroundForm = ({
       onOpenRawRequest={openRawRequestModal}
       voiceChatAvailable={voiceChatAvailable}
       voiceChatEnabled={voiceChatEnabled}
+      voiceChatUnavailableReason={voiceChatUnavailableReason}
       voiceChatState={voiceChat.state}
       voiceChatStatusLabel={voiceChatStatusLabel}
       onVoiceChatToggle={handleVoiceChatToggle}

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.voice-visibility.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.voice-visibility.integration.test.tsx
@@ -798,17 +798,11 @@ vi.mock("react-router-dom", () => ({
 import { PlaygroundForm } from "../PlaygroundForm"
 
 describe("PlaygroundForm voice visibility", () => {
-  it("keeps the main voice button rendered but disabled when voice transport is missing", () => {
+  it("hides the main voice button but forwards the shared unavailable reason when voice transport is missing", () => {
     capturedModeLauncherProps = null
     render(<PlaygroundForm droppedFiles={[]} />)
 
-    const voiceButton = screen.getByTestId("voice-chat-button")
-
-    expect(voiceButton).toBeDisabled()
-    expect(voiceButton).toHaveAttribute(
-      "title",
-      "This server does not advertise voice conversation streaming."
-    )
+    expect(screen.queryByTestId("voice-chat-button")).toBeNull()
     expect(capturedModeLauncherProps?.voiceChatUnavailableReason).toBe(
       "This server does not advertise voice conversation streaming."
     )

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ControlRow.tsx
@@ -16,6 +16,7 @@ import { ModelSelect } from "@/components/Common/ModelSelect"
 import { PromptSelect } from "@/components/Common/PromptSelect"
 import { FeatureHint, useFeatureHintSeen } from "@/components/Common/FeatureHint"
 import { CharacterSelect } from "./CharacterSelect"
+import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { useMcpTools } from "@/hooks/useMcpTools"
 import { browser } from "wxt/browser"
@@ -99,10 +100,7 @@ const ControlRowBase: React.FC<ControlRowProps> = ({
     "allowExternalImages",
     DEFAULT_CHAT_SETTINGS.allowExternalImages
   )
-  const [showMoodBadge, setShowMoodBadge] = useStorage(
-    "chatShowMoodBadge",
-    true
-  )
+  const [showMoodBadge, setShowMoodBadge] = useChatMoodBadgePreference()
   const [showMoodConfidence, setShowMoodConfidence] = useStorage(
     "chatShowMoodConfidence",
     Boolean(selectedCharacterId)

--- a/apps/packages/ui/src/hooks/__tests__/useChatMoodBadgePreference.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useChatMoodBadgePreference.test.tsx
@@ -1,0 +1,137 @@
+import React from "react"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => {
+  const values = new Map<string, unknown>()
+  const storage = {
+    get: vi.fn(async (key: string) => (values.has(key) ? values.get(key) : undefined)),
+    set: vi.fn(async (key: string, value: unknown) => {
+      values.set(key, value)
+    }),
+    remove: vi.fn(async (key: string) => {
+      values.delete(key)
+    })
+  }
+
+  return {
+    values,
+    storage
+  }
+})
+
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => mocks.storage
+}))
+
+vi.mock("@plasmohq/storage/hook", async () => {
+  const ReactModule =
+    await vi.importActual<typeof import("react")>("react")
+
+  return {
+    useStorage: (
+      config: string | { key: string; instance?: unknown },
+      defaultValue: unknown
+    ) => {
+      const key = typeof config === "string" ? config : config.key
+      const [value, setRenderValue] = ReactModule.useState(defaultValue)
+      const [isLoading, setIsLoading] = ReactModule.useState(true)
+
+      ReactModule.useEffect(() => {
+        let cancelled = false
+
+        Promise.resolve().then(() => {
+          if (cancelled) return
+          setRenderValue(
+            mocks.values.has(key) ? mocks.values.get(key) : defaultValue
+          )
+          setIsLoading(false)
+        })
+
+        return () => {
+          cancelled = true
+        }
+      }, [defaultValue, key])
+
+      const setValue = async (next: unknown) => {
+        const previous =
+          mocks.values.has(key) ? mocks.values.get(key) : defaultValue
+        const resolved =
+          typeof next === "function"
+            ? (next as (value: unknown) => unknown)(previous)
+            : next
+        mocks.values.set(key, resolved)
+        setRenderValue(resolved)
+        setIsLoading(false)
+      }
+
+      return [value, setValue, { isLoading, setRenderValue }] as const
+    }
+  }
+})
+
+import {
+  CHAT_MOOD_BADGE_DEFAULT,
+  CHAT_MOOD_BADGE_MIGRATION_STORAGE_KEY,
+  CHAT_MOOD_BADGE_STORAGE_KEY,
+  useChatMoodBadgePreference
+} from "../useChatMoodBadgePreference"
+
+describe("useChatMoodBadgePreference", () => {
+  beforeEach(() => {
+    mocks.values.clear()
+    mocks.storage.get.mockClear()
+    mocks.storage.set.mockClear()
+    mocks.storage.remove.mockClear()
+  })
+
+  it("forces a legacy enabled mood badge off once without surfacing a hydrated true state", async () => {
+    mocks.values.set(CHAT_MOOD_BADGE_STORAGE_KEY, true)
+
+    const seenValues: boolean[] = []
+    const { result } = renderHook(() => {
+      const state = useChatMoodBadgePreference()
+      React.useEffect(() => {
+        seenValues.push(state[0])
+      }, [state[0]])
+      return state
+    })
+
+    expect(result.current[0]).toBe(CHAT_MOOD_BADGE_DEFAULT)
+
+    await waitFor(() => {
+      expect(mocks.values.get(CHAT_MOOD_BADGE_STORAGE_KEY)).toBe(false)
+      expect(mocks.values.get(CHAT_MOOD_BADGE_MIGRATION_STORAGE_KEY)).toBe(true)
+      expect(result.current[0]).toBe(false)
+    })
+
+    expect(seenValues).not.toContain(true)
+  })
+
+  it("defaults to hidden when the preference has never been stored", async () => {
+    const { result } = renderHook(() => useChatMoodBadgePreference())
+
+    expect(result.current[0]).toBe(false)
+
+    await waitFor(() => {
+      expect(mocks.values.get(CHAT_MOOD_BADGE_STORAGE_KEY)).toBe(false)
+      expect(mocks.values.get(CHAT_MOOD_BADGE_MIGRATION_STORAGE_KEY)).toBe(true)
+    })
+  })
+
+  it("respects an enabled preference after the migration has already completed", async () => {
+    mocks.values.set(CHAT_MOOD_BADGE_STORAGE_KEY, true)
+    mocks.values.set(CHAT_MOOD_BADGE_MIGRATION_STORAGE_KEY, true)
+
+    const { result } = renderHook(() => useChatMoodBadgePreference())
+
+    await waitFor(() => {
+      expect(result.current[0]).toBe(true)
+    })
+
+    expect(mocks.storage.set).not.toHaveBeenCalledWith(
+      CHAT_MOOD_BADGE_STORAGE_KEY,
+      false
+    )
+  })
+})

--- a/apps/packages/ui/src/hooks/useChatMoodBadgePreference.ts
+++ b/apps/packages/ui/src/hooks/useChatMoodBadgePreference.ts
@@ -1,0 +1,118 @@
+import React from "react"
+import { useStorage } from "@plasmohq/storage/hook"
+import { createSafeStorage } from "@/utils/safe-storage"
+
+export const CHAT_MOOD_BADGE_STORAGE_KEY = "chatShowMoodBadge"
+export const CHAT_MOOD_BADGE_MIGRATION_STORAGE_KEY =
+  "chatShowMoodBadgeMigrationV1"
+export const CHAT_MOOD_BADGE_DEFAULT = false
+
+type StorageHookMeta<T> =
+  | {
+      isLoading?: boolean
+      setRenderValue?: (value: T | undefined) => void
+    }
+  | undefined
+
+type StorageHookResult = readonly [
+  boolean | undefined,
+  (value: boolean | ((prev: boolean | undefined) => boolean)) => Promise<void> | void,
+  StorageHookMeta<boolean>
+]
+
+const moodBadgeStorage = createSafeStorage({ area: "local" })
+
+const normalizeBoolean = (value: unknown, fallback: boolean): boolean =>
+  typeof value === "boolean" ? value : fallback
+
+export const useChatMoodBadgePreference = () => {
+  const preferenceResult = useStorage<boolean>(
+    {
+      key: CHAT_MOOD_BADGE_STORAGE_KEY,
+      instance: moodBadgeStorage
+    },
+    CHAT_MOOD_BADGE_DEFAULT
+  ) as StorageHookResult
+  const migrationResult = useStorage<boolean>(
+    {
+      key: CHAT_MOOD_BADGE_MIGRATION_STORAGE_KEY,
+      instance: moodBadgeStorage
+    },
+    false
+  ) as StorageHookResult
+
+  const [storedPreference, setStoredPreference, preferenceMeta] =
+    preferenceResult
+  const [migrationAppliedRaw, setMigrationApplied, migrationMeta] =
+    migrationResult
+  const migrationApplied = normalizeBoolean(migrationAppliedRaw, false)
+  const showMoodBadge = migrationApplied
+    ? normalizeBoolean(storedPreference, CHAT_MOOD_BADGE_DEFAULT)
+    : CHAT_MOOD_BADGE_DEFAULT
+
+  const setPreferenceRenderValueRef = React.useRef<
+    ((value: boolean | undefined) => void) | undefined
+  >(preferenceMeta?.setRenderValue)
+  const setMigrationRenderValueRef = React.useRef<
+    ((value: boolean | undefined) => void) | undefined
+  >(migrationMeta?.setRenderValue)
+  const migrationHandledRef = React.useRef(false)
+
+  React.useEffect(() => {
+    setPreferenceRenderValueRef.current = preferenceMeta?.setRenderValue
+  }, [preferenceMeta?.setRenderValue])
+
+  React.useEffect(() => {
+    setMigrationRenderValueRef.current = migrationMeta?.setRenderValue
+  }, [migrationMeta?.setRenderValue])
+
+  React.useEffect(() => {
+    if (preferenceMeta?.isLoading || migrationMeta?.isLoading) return
+    if (migrationHandledRef.current) return
+    migrationHandledRef.current = true
+
+    if (migrationApplied) return
+
+    setPreferenceRenderValueRef.current?.(CHAT_MOOD_BADGE_DEFAULT)
+    setMigrationRenderValueRef.current?.(true)
+
+    const applyMigration = async () => {
+      try {
+        await moodBadgeStorage.set(
+          CHAT_MOOD_BADGE_STORAGE_KEY,
+          CHAT_MOOD_BADGE_DEFAULT
+        )
+        await moodBadgeStorage.set(CHAT_MOOD_BADGE_MIGRATION_STORAGE_KEY, true)
+      } catch {
+        // Ignore storage failures and keep the default hidden render state.
+      }
+    }
+
+    void applyMigration()
+  }, [migrationApplied, migrationMeta?.isLoading, preferenceMeta?.isLoading])
+
+  const updateShowMoodBadge = React.useCallback(
+    async (next: boolean | ((prev: boolean) => boolean)) => {
+      const resolved =
+        typeof next === "function" ? next(showMoodBadge) : next
+      const normalized = Boolean(resolved)
+
+      setPreferenceRenderValueRef.current?.(normalized)
+      setMigrationRenderValueRef.current?.(true)
+      await setStoredPreference(normalized)
+      if (!migrationApplied) {
+        await setMigrationApplied(true)
+      }
+    },
+    [migrationApplied, setMigrationApplied, setStoredPreference, showMoodBadge]
+  )
+
+  return [
+    showMoodBadge,
+    updateShowMoodBadge,
+    {
+      isLoading: Boolean(preferenceMeta?.isLoading || migrationMeta?.isLoading),
+      setRenderValue: setPreferenceRenderValueRef.current
+    }
+  ] as const
+}


### PR DESCRIPTION
## Summary
- hide the chat mood badge by default across shared WebUI and extension chat surfaces
- force legacy stored mood badge preferences off once while preserving later user opt-in
- forward workspace scope when saving chat knowledge and propagate the shared voice-unavailable reason through PlaygroundForm

## Testing
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && bunx vitest run src/components/Common/Playground/__tests__/Message.routing-fallback.integration.test.tsx src/components/Option/Playground/__tests__/PlaygroundForm.voice-visibility.integration.test.tsx src/components/Option/Playground/__tests__/voice-conversation.cross-surface.contract.test.ts
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r apps/packages/ui/src/components/Common/Playground/Message.tsx apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx apps/packages/ui/src/hooks/useChatMoodBadgePreference.ts -f json -o /tmp/bandit_chat_mood_badge_pr_worktree.json
  - Bandit reported no findings and AST parse errors because the checked files are TypeScript.