### PR TITLE
feat: add coordinated app shutdown flow

### DIFF
--- a/Docs/Design/2026-03-30-shutdown-dependency-inventory.md
+++ b/Docs/Design/2026-03-30-shutdown-dependency-inventory.md
@@ -1,0 +1,72 @@
+# Shutdown Dependency Inventory
+
+## Scope
+
+This note inventories the shutdown behavior currently embedded in `tldw_Server_API/app/main.py` so the new shadow-mode adapter can observe the existing teardown graph without replacing it yet.
+
+## Implicit Shutdown Groups In `main.py`
+
+1. Transition gate
+   - Flip lifecycle readiness to draining.
+   - Gate new job acquisition through `JobManager.set_acquire_gate(True)`.
+
+2. Background worker drain
+   - Cancel or signal shutdown for cleanup tasks and job workers.
+   - Includes ephemeral cleanup, chatbooks cleanup, core/file/data-table/prompt-studio/privilege/audio/presentation/media ingest/readiness digest/reminder/admin backup/notifications and related workers.
+
+3. Scheduler and helper shutdown
+   - Stop usage aggregators.
+   - Stop workflow, reading-digest, admin-backup, companion-reflection, reminders, and connectors sync schedulers.
+   - Stop AuthNZ scheduler.
+
+4. Service and cache cleanup
+   - Stop storage cleanup service.
+   - Reset storage and cleanup services.
+   - Reset AuthNZ limiter and other singleton helpers.
+
+5. Transport, session, and client owners
+   - Shut down session manager, MCP server, HTTP client sessions, and TTS/resource manager owners.
+   - Stop provider/request queue owners and local LLM cleanup hooks.
+
+6. Final process cleanup
+   - Close database pools, caches, audit services, evaluators, executors, and CPU pools.
+   - Clear the media DB cache and content backend pool.
+
+## Duplicate Owners / Duplicate Stop Paths
+
+- `JobManager.set_acquire_gate(False)` is the startup default, then the shutdown path flips it to `True`, and the very end flips it back to `False` again. That makes the gate both a transition concern and a process-finalization concern.
+- `AuthNZ scheduler` is a lifecycle-owned component that is stopped in the later shutdown block, while the transition gate is handled earlier. The scheduler itself is not duplicated, but its shutdown dependency is split across two separate ownership regions.
+- `storage_cleanup_service` has both an explicit `stop()` call and separate singleton reset helpers afterward. That is two stop-related ownership paths for one service boundary.
+- `audit` cleanup is split between dependency-injection managed shutdown and explicit adapter/service shutdown calls, which makes the ownership boundary easy to misread.
+
+## Aggregate Helpers Hiding Serial Work
+
+- `stop_usage_aggregator()` and `stop_llm_usage_aggregator()` hide work behind single helper calls even though they wrap task lifecycle management.
+- `shutdown_all_audit_services()` hides multiple service instances behind one helper.
+- `shutdown_all_registered_executors()` hides potentially many executor pools and thread/process resources.
+- `shutdown_content_backend()`, `shutdown_http_client()`, `shutdown_evaluations_pool_if_initialized()`, and `shutdown_webhook_manager_if_initialized()` each hide multiple concrete cleanup steps behind a single call.
+- The final teardown block reads as linear, but some of the helpers inside it are aggregate cleanups with their own internal ordering.
+
+## Long-Lived Transport / Session Owners
+
+- `session_manager`
+- `mcp_server`
+- `shutdown_http_client()`
+- `provider_manager`
+- `request_queue`
+- `tts_resource_manager`
+- `voice_manager`
+
+These owners are likely to hold connections or long-lived background state, so their relative ordering matters more than the call sites suggest.
+
+## Unknown Ordering Edges
+
+- Whether `usage_aggregator` and `llm_usage_aggregator` must stop before or after `AuthNZ scheduler`.
+- Whether `storage_cleanup_service.stop()` must complete before the later singleton reset helpers run.
+- Whether `mcp_server.shutdown()` should precede `shutdown_rate_limiter()` or vice versa.
+- Whether session/client shutdown should happen before or after executor teardown to avoid lingering callbacks.
+- Whether the final database/cache cleanup should run before or after audit service shutdown in all environments.
+
+## Shadow-Mode Adapter Targets
+
+The first shadow inventory only needs to make the legacy graph visible, not replace it. The initial adapter set should keep the transition gate, `usage_aggregator`, `llm_usage_aggregator`, `storage_cleanup_service`, `chatbooks_cleanup`, and `authnz_scheduler` explicit so later work can split the graph into smaller executable phases without guessing at the current ownership.

--- a/Docs/superpowers/specs/2026-03-30-app-shutdown-coordinator-design.md
+++ b/Docs/superpowers/specs/2026-03-30-app-shutdown-coordinator-design.md
@@ -1,0 +1,494 @@
+# App Shutdown Coordinator Design
+
+## Summary
+
+This design improves application shutdown performance by replacing the current large, serial FastAPI lifespan teardown with an explicit shutdown coordinator that supports:
+
+- immediate transition to a `draining` state
+- immediate readiness failure plus explicit admission gating for new work
+- parallel shutdown by ordered phases instead of one long serial await chain
+- different shutdown policies for local development and production-style runs
+- structured shutdown observability so tuning is based on data rather than log archaeology
+
+The target budgets confirmed with the user are:
+
+- development: under `5s`
+- production-style/self-hosted runtime: under `15s`, with a preference to let in-flight work finish even if shutdown occasionally exceeds that target
+
+This spec is intentionally scoped to shutdown orchestration, admission control, and observability. It does not attempt a full startup architecture rewrite in the first slice.
+
+## Goals
+
+- Reduce shutdown wall-clock time for local restarts and container stop events.
+- Fail readiness immediately when shutdown begins.
+- Reject new heavy or mutating work as soon as the app enters shutdown.
+- Preserve as much in-flight work as practical in production-style environments.
+- Make shutdown ordering explicit and testable.
+- Provide per-component shutdown timing and outcome data.
+- Preserve existing lifecycle reentrancy expectations in tests.
+
+## Non-Goals
+
+- Redesigning every startup path in the same tranche.
+- Rewriting every service to self-register on day one.
+- Guaranteeing resumable shutdown for job types that do not currently support checkpointing or safe requeue.
+- Changing request routing or deployment topology.
+- Optimizing unrelated startup latency beyond the minimum needed to handle deferred-startup shutdown interactions correctly.
+
+## Current State
+
+The app currently performs shutdown inside the main FastAPI lifespan handler in `tldw_Server_API/app/main.py`.
+
+Important current behaviors:
+
+- shutdown already flips readiness false via `mark_lifecycle_shutdown(...)`
+- background job acquisition is already gated via `JobManager.set_acquire_gate(True)`
+- many workers are stopped sequentially with repeated `await asyncio.wait_for(task, timeout=5.0)`
+- shared resources are cleaned up later through a long hand-written list of stop and shutdown calls
+- deferred startup can still be active when shutdown begins
+
+This has two practical consequences:
+
+1. Shutdown time scales with the number of components because many waits are serialized.
+2. Ordering and ownership are implicit in `main.py`, so regressions are easy to introduce and hard to reason about.
+
+The current teardown also shows duplicate-style responsibilities that a coordinator should eliminate, for example:
+
+- usage aggregator shutdown appears in more than one section
+- AuthNZ scheduler shutdown is handled more than once
+- shutdown summary information is not emitted as a first-class structured artifact
+
+## Requirements Confirmed With User
+
+- Support a two-tier operating model:
+  - aggressive fast exit for local development
+  - safer bounded drain for production-like Docker and mixed self-hosted installs
+- Primary budget targets:
+  - development under `5s`
+  - production under `15s`
+- In development, in-flight work may be cancelled aggressively.
+- In production-like environments, the system should prefer waiting longer for active jobs to finish, even if shutdown sometimes exceeds the target.
+- The user is comfortable with a larger cleanup effort rather than only incremental tuning.
+- The app should immediately stop advertising readiness and reject new work when shutdown begins.
+- The design should work for Docker/single-host installs and mixed self-hosted environments without assuming Kubernetes-specific primitives.
+
+## Problems To Solve
+
+### 1. Serial teardown dominates shutdown time
+
+The current lifespan teardown contains many per-component waits with `5s` budgets. Even when most services stop quickly, a few slow components can produce a long serial tail.
+
+### 2. Readiness flip alone is not enough
+
+Marking the app not ready is necessary, but it does not guarantee that no new requests or new internal work will start during the shutdown window. The design needs an admission gate in addition to readiness signaling.
+
+### 3. Shutdown policy is implicit
+
+Today the code does not have an explicit notion of:
+
+- development fast shutdown
+- production drain shutdown
+- best-effort cleanup that should never hold exit hostage
+
+### 4. Service ownership is too centralized
+
+`main.py` currently knows too much about individual workers, stop events, and resource cleanup details. That makes shutdown fragile and expensive to evolve.
+
+### 5. Test and reentrancy constraints are real
+
+Existing tests expect lifecycle startup and shutdown to be reentrant on the same app object. Any coordinator must preserve that contract and behave safely when lifespan is disabled in selected tests.
+
+## Approaches Considered
+
+### Approach 1: Tune the existing teardown only
+
+Reduce selected timeouts and parallelize a few calls inside the existing shutdown section.
+
+Pros:
+
+- minimal structural change
+- low short-term implementation risk
+
+Cons:
+
+- leaves shutdown ownership implicit
+- hard to enforce long-term consistency
+- likely to regress as more workers are added
+
+### Approach 2: Add a shutdown coordinator over the current lifecycle
+
+Introduce a coordinator that owns lifecycle state, admission gating, phase ordering, budgets, and summary reporting, while initially wrapping existing stop hooks from `main.py`.
+
+Pros:
+
+- most of the performance payoff
+- good fit for staged migration
+- does not require every service to be rewritten immediately
+
+Cons:
+
+- still leaves some startup/shutdown wiring in legacy form during migration
+
+### Approach 3: Full startup and shutdown ownership redesign
+
+Require each subsystem to own its lifecycle contract immediately and move both startup and shutdown into a unified registry design.
+
+Pros:
+
+- strongest long-term architecture
+
+Cons:
+
+- too broad for the first delivery
+- increases risk that shutdown optimization gets buried under general lifecycle cleanup
+
+## Recommendation
+
+Use Approach 2 as the first delivery, while designing it so the system can later evolve toward Approach 3.
+
+That means:
+
+- build a shutdown coordinator now
+- keep the first scope centered on shutdown, not a full lifecycle rewrite
+- initially register legacy stop hooks from `main.py` through coordinator adapters
+- migrate selected high-value services to first-class lifecycle registration later
+
+## Proposed Architecture
+
+### Lifecycle States
+
+The app should expose explicit lifecycle states:
+
+- `starting`
+- `ready`
+- `draining`
+- `stopped`
+
+`draining` is a first-class state, not just a side effect of readiness flipping false.
+
+Lifecycle state and admission-gate state must be scoped to the FastAPI app instance, not stored only in module-global state. The coordinator should keep its mutable runtime state on `app.state` or an equivalent per-app container so repeated lifespan runs in tests do not leak shutdown state across app reuse.
+
+Stage 1 must include the bridge work needed to move control-plane readiness and admission checks onto coordinator-owned app-scoped state. Control-plane handlers, middleware, and guards should read shutdown state from `request.app.state` or an equivalent app-scoped source rather than continuing to rely on module-global state.
+
+### Shutdown Coordinator
+
+A new coordinator owns shutdown sequencing and observability. `main.py` remains the FastAPI lifespan entry point, but delegates shutdown orchestration to the coordinator.
+
+The coordinator is responsible for:
+
+- transitioning lifecycle state
+- opening and closing admission gates
+- enforcing a global shutdown deadline
+- dividing remaining time into phase budgets
+- stopping registered components in ordered parallel phases
+- recording per-component outcomes and durations
+- emitting a structured shutdown summary before telemetry is torn down
+
+### Admission Control
+
+When shutdown begins, the coordinator must perform both of these actions immediately:
+
+1. mark readiness false
+2. activate an admission gate that rejects new heavy or mutating work
+
+The admission gate must cover more than background jobs. The practical rule is:
+
+- no new job acquisition
+- no new scheduler-enqueued work
+- no new long-running or mutating requests
+- lightweight diagnostic or liveness paths may remain available until late shutdown if needed
+
+The coordinator should define an explicit drain admission contract:
+
+- allowed during `draining`:
+  - control-plane liveness endpoints
+  - control-plane readiness endpoints that report non-ready
+  - only the explicitly allowlisted control-plane health aliases needed by current deployments and tests
+- rejected during `draining`:
+  - mutating API requests
+  - long-running requests
+  - requests that enqueue, lease, or begin background work
+
+For the first delivery, the allowlist should be intentionally narrow and route-specific rather than pattern-based. The default allowlist should be limited to the existing control-plane health routes such as `/health`, `/ready`, `/health/ready`, and the exact API-v1 health equivalents if required by current callers.
+
+Rejected work should return a consistent `503 Service Unavailable` response with a machine-readable shutdown reason and a retry hint where appropriate.
+
+Admission gating must not rely on request ingress checks alone. The first delivery should require a second drain-state check immediately before any handler or transport actually starts expensive or stateful work, such as:
+
+- enqueueing or leasing a job
+- starting a background task
+- launching a long-running stream
+- mutating durable state
+- invoking an expensive provider or subprocess
+
+This second check closes the race where a request or handshake enters just before `draining` begins but would otherwise still start new work afterward.
+
+The drain admission contract must also cover long-lived connection entry points:
+
+- new WebSocket handshakes that would start work must be rejected during `draining`
+- new SSE or other streaming response sessions that would start work must be rejected during `draining`
+- existing already-established long-lived connections should be handled later by the worker or resource phases according to their shutdown policy rather than being silently ignored
+
+Long-lived transport families must be coordinator-visible. Each transport family that can keep work alive across shutdown, such as WebSocket hubs, SSE session managers, or MCP connection managers, must expose one of the following before it is considered managed by the coordinator:
+
+- an explicit connection or session registry with active-count visibility, or
+- a dedicated shutdown hook that can enumerate and close or drain active sessions under a deadline
+
+Generic stream primitives that do not own global session tracking are not sufficient by themselves. The owning endpoint or transport manager must provide the coordinator-visible registry or shutdown surface.
+
+Protocol-specific rejection behavior should be explicit:
+
+- HTTP and SSE session creation: `503 Service Unavailable`
+- WebSocket handshakes: explicit close or rejection semantics appropriate to the server surface, documented and tested per endpoint family
+
+Readiness should fail immediately. Liveness should remain healthy until the process is actually in terminal teardown.
+
+For normal HTTP requests, the drain gate should sit early in the middleware chain after only the minimal request-context setup required to evaluate the gate, and before expensive auth, dependency resolution, or workload-start logic. Endpoint-local work-start checks remain required even when an early middleware gate exists.
+
+### Registration Model
+
+The coordinator manages registered shutdown components. Each registration contains:
+
+- `name`
+- `kind`
+  - `acceptor`
+  - `producer`
+  - `worker`
+  - `resource`
+  - `finalizer`
+- `phase`
+- `policy`
+  - `dev_fast`
+  - `prod_drain`
+  - `best_effort`
+- `default_timeout_ms`
+- `stop()` callable
+- optional `active_work_count()` hook
+- optional `health_snapshot()` hook
+- optional dependency metadata if ordering within a phase is required
+
+The first migration should allow registrations to wrap existing stop hooks in `main.py`. Self-registration by services is a later step, not a prerequisite.
+
+### Global Deadline Model
+
+The coordinator must enforce a single shutdown deadline per run, not independent fixed timeouts for every component.
+
+Profile defaults:
+
+- `dev_fast`: target budget `5s`
+- `prod_drain`: target budget `15s`
+
+The coordinator should track remaining time and allocate per-phase budgets from that remainder. If a phase consumes too much time, later phases inherit less budget instead of silently extending total shutdown indefinitely.
+
+Production behavior may allow a bounded soft overrun when in-flight work is still finishing, but that overrun must be explicit and observable.
+
+The coordinator must also define a hard terminal cutoff:
+
+- `dev_fast`: once the deadline is reached, cancel remaining work immediately and continue to terminal resource cleanup
+- `prod_drain`: allow a bounded soft overrun only for explicitly drain-eligible work, then force-cancel remaining components at the hard cutoff and record them as timed out or cancelled in the shutdown summary
+
+The hard cutoff exists to prevent indefinite hangs caused by workers, executors, subprocesses, or final flushes that fail to stop cooperatively.
+
+### Ordered Parallel Phases
+
+Shutdown should run in these phases:
+
+1. `transition`
+   - mark `draining`
+   - fail readiness
+   - enable admission gate
+   - stop new job acquisition
+
+2. `acceptors`
+   - stop anything that accepts or starts new externally-triggered work
+
+3. `producers`
+   - stop schedulers, queue pollers, recurring enqueuers, and health-check loops
+
+4. `workers`
+   - let workers drain or cancel according to policy and capability class
+
+5. `resources`
+   - close shared clients, pools, managers, queues, and servers
+
+6. `finalizers`
+   - emit shutdown summary
+   - perform last best-effort cleanup that must happen before telemetry and logging teardown
+
+Components inside a phase should stop concurrently unless a declared dependency requires a narrower order.
+
+### Worker Capability Classes
+
+Not every worker can make the same shutdown guarantees. Each worker should be classified as one of:
+
+- `resumable`
+  - can checkpoint and continue later
+- `retry_safe`
+  - cannot resume in-place, but can safely retry or requeue
+- `cancel_only`
+  - cannot provide stronger guarantees than cancellation
+
+This classification determines production behavior:
+
+- `resumable`: prefer checkpoint and clean exit
+- `retry_safe`: prefer requeue or retry-safe termination
+- `cancel_only`: allow longer wait, but cancel if the budget expires
+
+Development fast shutdown may cancel all three classes aggressively once the short budget is exhausted.
+
+### Startup-While-Shutting-Down Handling
+
+Shutdown must tolerate the case where deferred startup work is still running.
+
+The coordinator should treat startup tasks as registered components with shutdown semantics, not special-case locals. If shutdown begins before startup completes:
+
+- new startup work must not continue past the admission gate
+- in-progress deferred startup tasks must be cancelled or awaited under the same deadline model
+
+### Observability
+
+The coordinator should produce a structured shutdown report containing:
+
+- total shutdown wall time
+- selected shutdown profile
+- deadline and soft-overrun usage
+- per-phase duration
+- per-component:
+  - start time
+  - stop completion time
+  - duration
+  - result: `stopped`, `timed_out`, `cancelled`, `skipped`, `failed`
+  - active work count at drain start if available
+  - whether cleanup was downgraded due to profile
+
+This summary must be emitted before telemetry and audit shutdown.
+
+## Configuration
+
+Introduce a single shutdown profile selector:
+
+- `APP_SHUTDOWN_PROFILE=dev_fast|prod_drain|custom`
+
+Support optional overrides for:
+
+- global deadline
+- per-phase budget multipliers
+- per-component budget overrides
+- soft-overrun allowance for production drain
+
+Defaults should be runtime-agnostic and safe for Docker plus mixed self-hosted installs.
+
+## Migration Plan
+
+### Stage 0: Instrument Current Shutdown
+
+Before changing behavior, add structured timing around the current shutdown flow so the baseline is visible.
+
+Deliverables:
+
+- current shutdown wall time metric
+- per-component duration logging in the existing path
+- baseline evidence for local and Docker-stop runs
+
+### Stage 1: Add Coordinator, Lifecycle State, And Admission Gate
+
+Deliverables:
+
+- explicit `draining` state
+- immediate readiness false transition
+- explicit admission gate for new heavy and mutating work
+- early middleware placement for the HTTP drain gate
+- global deadline handling
+- control-plane readiness handlers return non-success status codes on all non-ready and shutdown-in-progress paths
+- control-plane handlers and admission checks read coordinator-owned app-scoped state rather than module globals
+- endpoint and transport work-start checks exist at the actual enqueue or start boundary for covered shutdown-sensitive flows
+
+### Stage 1.5: Inventory Legacy Shutdown Dependencies And Run Shadow Mode
+
+Before parallelizing teardown, document the current implicit ordering assumptions in `main.py` and classify legacy shutdown entries as:
+
+- safe to parallelize now
+- must stay ordered within a phase
+- unknown and requiring instrumentation first
+
+Stage 1.5 must also identify aggregate shutdown helpers that hide their own internal sequencing or unbounded waits. Examples include helpers that close many resources in a loop or call blocking shutdown APIs internally. These helpers must be either:
+
+- decomposed into coordinator-visible sub-registrations, or
+- updated to enforce their own bounded internal deadlines before they are treated as a single coordinator-managed component
+
+Deliverables:
+
+- dependency inventory for current shutdown steps
+- list of components that cannot safely run in parallel yet
+- inventory of aggregate shutdown helpers that would otherwise hide serial shutdown tails
+- inventory of long-lived transport families and their coordinator-visible session registries or shutdown hooks
+- optional shadow-mode coordinator run that records intended ordering and timing without owning final teardown behavior
+
+### Stage 2: Move Legacy Teardown Into Coordinator Phases
+
+Deliverables:
+
+- coordinator adapter registrations for existing `main.py` stop hooks
+- ordered parallel phase execution
+- deduplication of repeated shutdown responsibilities
+- preservation of known required ordering edges discovered in Stage 1.5
+
+### Stage 3: Migrate Critical Workers To Capability-Based Drain Semantics
+
+Priority candidates:
+
+- jobs workers
+- media ingest workers
+- audio, audiobook, and presentation workers
+- request queue and provider-health background loops
+- audit-adjacent services where final flush semantics matter
+
+### Stage 4: Expand Self-Registration And Tune Policies
+
+Deliverables:
+
+- selected services own their own lifecycle registration
+- tuned per-component budgets based on real timing data
+- optional future extension toward fuller lifecycle ownership
+
+## Risks
+
+- hidden ordering dependencies currently encoded only by manual shutdown order in `main.py`
+- underlying thread, executor, or subprocess work may outlive the asyncio task wrapper
+- some workers may not currently check shutdown or cancellation frequently enough
+- duplicate shutdown ownership can cause double-stop behavior during migration
+- test environments that disable lifespan may bypass coordinator paths unless explicitly covered
+
+## Validation And Tests
+
+Add focused tests for:
+
+- lifecycle transition order: `starting -> ready -> draining -> stopped`
+- coordinator runtime state is reset per app lifespan and does not leak across repeated test app reuse
+- immediate readiness failure on shutdown start
+- readiness endpoints return non-success HTTP status on shutdown-in-progress and other non-ready paths
+- admission gate rejects new heavy or mutating work during drain
+- drain admission allowlist remains available and rejected requests return the expected shutdown response contract
+- new WebSocket and SSE session establishment is rejected during `draining` for covered endpoint families
+- requests or sessions admitted just before `draining` do not start new work after the work-start boundary check fires
+- covered long-lived transport families expose coordinator-visible registries or deadline-bounded shutdown hooks
+- HTTP drain gate runs early enough to avoid expensive middleware or dependency work before rejection
+- reentrant startup/shutdown on the same app object remains safe
+- shutdown while deferred startup is still active
+- global deadline enforcement for `dev_fast`
+- bounded parallel shutdown for `prod_drain`
+- hard cutoff behavior after any permitted production soft overrun
+- component timeout handling and summary reporting
+- resource shutdown ordering so dependencies are not closed too early
+- idempotent shutdown for components that were previously stopped twice
+- selected tests that disable lifespan continue to behave correctly
+- started-TestClient fallback paths still enter and exit shutdown safely
+
+## Success Criteria
+
+- local shutdowns usually complete within `5s`
+- production-style shutdowns usually complete within `15s`
+- shutdown wall time no longer scales linearly with the count of registered components
+- new work is rejected immediately once the app enters `draining`
+- per-component shutdown summaries make slow or misbehaving services obvious
+- shutdown logic is no longer primarily encoded as one large serial block in `main.py`

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ See [MCP System Admin Guide](Docs/MCP/Unified/System_Admin_Guide.md) for details
 | Build apps against the API locally | [Local Single-User Profile](Docs/Getting_Started/Profile_Local_Single_User.md) |
 | Run on my home server with Docker | [Docker Single-User Profile](Docs/Getting_Started/Profile_Docker_Single_User.md) |
 | Deploy for a team with proper security | [Docker Multi-User + Postgres Profile](Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md) |
+| Develop the WebUI or browser extension | [Extension & Web UI Development Guide](apps/DEVELOPMENT.md) |
 
 ### Local Profile: Add the WebUI
 

--- a/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
@@ -6,7 +6,7 @@ import {
   classifySmokeIssues,
   SMOKE_LOAD_TIMEOUT
 } from "./smoke.setup"
-import { waitForAppShell } from "../utils/helpers"
+import { getAntdSelectTrigger, waitForAppShell } from "../utils/helpers"
 import type { Route } from "@playwright/test"
 
 const LOAD_TIMEOUT = SMOKE_LOAD_TIMEOUT
@@ -253,9 +253,9 @@ test.describe("Stage 7 audio regression gate", () => {
     await page.goto("/speech", { waitUntil: "domcontentloaded", timeout: LOAD_TIMEOUT })
     await waitForAppShell(page, LOAD_TIMEOUT)
 
-    const inputSourcePicker = page
-      .locator('[aria-label="Speech playground input source"]')
-      .first()
+    const inputSourcePicker = getAntdSelectTrigger(page, {
+      ariaLabel: "Speech playground input source"
+    })
     await expect(inputSourcePicker).toBeVisible({ timeout: LOAD_TIMEOUT })
     await inputSourcePicker.click()
     await expect(page.getByRole("option", { name: /Default microphone/i })).toBeVisible()

--- a/apps/tldw-frontend/e2e/utils/helpers.ts
+++ b/apps/tldw-frontend/e2e/utils/helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Common test helpers for E2E tests
  */
-import { type Page } from '@playwright/test';
+import { type Locator, type Page } from '@playwright/test';
 
 /**
  * Environment configuration for tests
@@ -362,6 +362,20 @@ export async function waitForVisualSettle(page: Page, timeoutMs = 5000): Promise
       });
     })
     .catch(() => {});
+}
+
+export function getAntdSelectTrigger(
+  page: Page,
+  options: {
+    ariaLabel: string | RegExp;
+  }
+): Locator {
+  const combobox = page.getByRole('combobox', { name: options.ariaLabel }).first();
+  return page
+    .locator('.ant-select')
+    .filter({ has: combobox })
+    .locator('.ant-select-selector')
+    .first();
 }
 
 /**

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
@@ -16,7 +16,7 @@ import {
 } from "../../utils/fixtures"
 import { SpeechPage } from "../../utils/page-objects/SpeechPage"
 import { expectApiCall } from "../../utils/api-assertions"
-import { seedAuth } from "../../utils/helpers"
+import { getAntdSelectTrigger, seedAuth } from "../../utils/helpers"
 
 test.describe("Speech Playground", () => {
   let speech: SpeechPage
@@ -54,9 +54,9 @@ test.describe("Speech Playground", () => {
       await expect(speech.stopButton).toBeVisible()
       await expect(speech.downloadButton).toBeVisible()
 
-      const inputSourcePicker = authedPage
-        .locator('[aria-label="Speech playground input source"]')
-        .first()
+      const inputSourcePicker = getAntdSelectTrigger(authedPage, {
+        ariaLabel: "Speech playground input source",
+      })
       await expect(inputSourcePicker).toBeVisible()
       await inputSourcePicker.click()
       await expect(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
@@ -85,6 +85,7 @@ from tldw_Server_API.app.core.testing import is_truthy
 from tldw_Server_API.app.core.TTS.realtime_session import RealtimeSessionConfig
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.model_utils import normalize_model_and_variant
+from tldw_Server_API.app.services.app_lifecycle import assert_may_start_work
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Streaming_Unified import (
@@ -324,6 +325,40 @@ def _audio_ws_quota_error_payload(
     if _audio_ws_compat_error_type_enabled():
         payload["quota"] = quota
     return payload
+
+
+async def _guard_audio_ws_work_start(
+    websocket: WebSocket,
+    *,
+    kind: str,
+    outer_stream: Any = None,
+    request_id: Optional[str] = None,
+) -> bool:
+    app = getattr(websocket, "app", None)
+    if app is None:
+        return True
+    try:
+        assert_may_start_work(app, kind)
+        return True
+    except HTTPException:
+        payload = _audio_ws_error_payload(
+            code="service_unavailable",
+            message="Shutdown in progress",
+            request_id=request_id,
+            data={"kind": kind},
+        )
+        try:
+            if outer_stream:
+                await outer_stream.send_json(payload)
+            else:
+                await websocket.send_json(payload)
+        except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS:
+            pass
+        try:
+            await websocket.close(code=1013, reason="shutdown_draining")
+        except _AUDIO_STREAMING_NONCRITICAL_EXCEPTIONS:
+            pass
+        return False
 
 
 def _coerce_bool(value: Any, default: bool = False) -> bool:
@@ -828,6 +863,13 @@ async def websocket_transcribe(
     )
     if not auth_ok:
         return
+    if not await _guard_audio_ws_work_start(
+        websocket,
+        kind="audio.stream.transcribe",
+        outer_stream=_outer_stream,
+        request_id=request_id,
+    ):
+        return
 
     try:
         # Default configuration prefers explicit streaming model selection from
@@ -1322,6 +1364,13 @@ async def websocket_audio_chat_stream(
         ws_path="/api/v1/audio/chat/stream",
     )
     if not auth_ok:
+        return
+    if not await _guard_audio_ws_work_start(
+        websocket,
+        kind="audio.chat.stream",
+        outer_stream=_outer_stream,
+        request_id=request_id,
+    ):
         return
 
     # Determine quota user id
@@ -2574,6 +2623,13 @@ async def websocket_tts(
     )
     if not auth_ok:
         return
+    if not await _guard_audio_ws_work_start(
+        websocket,
+        kind="audio.stream.tts",
+        outer_stream=_outer_stream,
+        request_id=request_id,
+    ):
+        return
 
     # Determine quota user id
     if is_multi_user_mode() and jwt_user_id is not None:
@@ -2839,6 +2895,13 @@ async def websocket_tts_realtime(
         ws_path="/api/v1/audio/stream/tts/realtime",
     )
     if not auth_ok:
+        return
+    if not await _guard_audio_ws_work_start(
+        websocket,
+        kind="audio.stream.tts.realtime",
+        outer_stream=_outer_stream,
+        request_id=request_id,
+    ):
         return
 
     if is_multi_user_mode() and jwt_user_id is not None:

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
@@ -40,6 +40,7 @@ from tldw_Server_API.app.core.Logging.log_context import ensure_request_id, ensu
 from tldw_Server_API.app.core.Streaming.streams import SSEStream
 from tldw_Server_API.app.core.exceptions import BadRequestError
 from tldw_Server_API.app.core.testing import is_test_mode
+from tldw_Server_API.app.services.app_lifecycle import assert_may_start_work
 
 router = APIRouter()
 
@@ -636,6 +637,7 @@ async def stream_media_ingest_job_events(
     principal: AuthPrincipal = Depends(get_auth_principal),
     jm: JobManager = Depends(get_job_manager),
 ) -> StreamingResponse:
+    assert_may_start_work(request.app, "media.ingest.jobs.events.stream")
     is_admin = _principal_has_admin_claims(principal)
     owner_filter = None if is_admin else str(current_user.id)
 

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_websocket.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_websocket.py
@@ -250,13 +250,14 @@ class ConnectionManager:
         """Close all active Prompt Studio sockets and clear tracking state."""
         with self._connections_lock:
             sockets = [socket for sockets in self.active_connections.values() for socket in sockets]
-            self.active_connections.clear()
-            self.connection_metadata.clear()
         if sockets:
             await asyncio.gather(
                 *(socket.close(code=1001, reason="Server shutdown") for socket in sockets),
                 return_exceptions=True,
             )
+        with self._connections_lock:
+            self.active_connections.clear()
+            self.connection_metadata.clear()
 
 # NOTE: A single, shared connection manager is defined later as
 # `connection_manager` and imported by the job processor for broadcasts.

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_websocket.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_websocket.py
@@ -14,12 +14,13 @@ Key responsibilities
 """
 
 import asyncio
+import contextlib
 import json
 import os
 from datetime import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
 from loguru import logger
 
 # Create router
@@ -66,6 +67,10 @@ from tldw_Server_API.app.core.Prompt_Management.prompt_studio.jobs_adapter impor
 )
 from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
 from tldw_Server_API.app.core.testing import env_flag_enabled
+from tldw_Server_API.app.services.app_lifecycle import assert_may_start_work
+from tldw_Server_API.app.services.shutdown_transport_registry import (
+    register_shutdown_transport_family,
+)
 
 ########################################################################################################################
 # Error Handling Utilities
@@ -194,19 +199,22 @@ class ConnectionManager:
             client_id: Client identifier
             message: Message to broadcast
         """
-        if client_id in self.active_connections:
-            disconnected = []
+        sockets = list(self.active_connections.get(client_id, ()))
+        if not sockets:
+            return
 
-            for websocket in self.active_connections[client_id]:
-                try:
-                    await websocket.send_text(message)
-                except _WS_SEND_EXCEPTIONS as e:
-                    logger.error(f"Failed to send to WebSocket: {e}")
-                    disconnected.append(websocket)
+        disconnected = []
 
-            # Clean up disconnected sockets
-            for ws in disconnected:
-                self.disconnect(ws)
+        for websocket in sockets:
+            try:
+                await websocket.send_text(message)
+            except _WS_SEND_EXCEPTIONS as e:
+                logger.error(f"Failed to send to WebSocket: {e}")
+                disconnected.append(websocket)
+
+        # Clean up disconnected sockets
+        for ws in disconnected:
+            self.disconnect(ws)
 
     async def broadcast_to_all(self, message: str):
         """
@@ -215,7 +223,7 @@ class ConnectionManager:
         Args:
             message: Message to broadcast
         """
-        for client_id in self.active_connections:
+        for client_id in list(self.active_connections):
             await self.broadcast_to_client(client_id, message)
 
     def get_connection_count(self) -> int:
@@ -225,6 +233,17 @@ class ConnectionManager:
     def get_client_count(self) -> int:
         """Get number of unique clients connected."""
         return len(self.active_connections)
+
+    async def close_all(self, timeout_s: float | None = None) -> None:
+        """Close all active Prompt Studio sockets and clear tracking state."""
+        sockets = [socket for sockets in self.active_connections.values() for socket in sockets]
+        if sockets:
+            await asyncio.gather(
+                *(socket.close(code=1001, reason="Server shutdown") for socket in sockets),
+                return_exceptions=True,
+            )
+        self.active_connections.clear()
+        self.connection_metadata.clear()
 
 # NOTE: A single, shared connection manager is defined later as
 # `connection_manager` and imported by the job processor for broadcasts.
@@ -238,9 +257,6 @@ class ConnectionManager:
 
 ########################################################################################################################
 # SSE (Server-Sent Events) Fallback
-
-
-import contextlib
 
 from fastapi.responses import StreamingResponse
 
@@ -394,6 +410,23 @@ async def sse_endpoint_route(
 
 # Initialize connection manager
 connection_manager = ConnectionManager()
+register_shutdown_transport_family(
+    "prompt_studio.websocket",
+    active_count=connection_manager.get_connection_count,
+    drain=connection_manager.close_all,
+)
+
+
+async def _guard_prompt_studio_websocket_start(websocket: WebSocket, kind: str) -> bool:
+    app = getattr(websocket, "app", None)
+    if app is None:
+        return True
+    try:
+        assert_may_start_work(app, kind)
+        return True
+    except HTTPException:
+        await websocket.close(code=1013, reason="shutdown_draining")
+        return False
 
 @router.websocket("")
 async def websocket_endpoint_base(websocket: WebSocket):
@@ -411,6 +444,8 @@ async def websocket_endpoint_base(websocket: WebSocket):
         close_on_done=False,
         labels={"component": "prompt_studio", "endpoint": "ps_ws_base"},
     )
+    if not await _guard_prompt_studio_websocket_start(websocket, "prompt_studio.websocket"):
+        return
     # Accept via manager first to avoid double-accept issues
     await connection_manager.connect(websocket, "global")
     await stream.start()
@@ -467,6 +502,8 @@ async def websocket_endpoint(
         close_on_done=False,
         labels={"component": "prompt_studio", "endpoint": "ps_ws_project"},
     )
+    if not await _guard_prompt_studio_websocket_start(websocket, "prompt_studio.websocket"):
+        return
     await connection_manager.connect(websocket, str(project_id))
     await stream.start()
 

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_websocket.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_websocket.py
@@ -18,6 +18,7 @@ import contextlib
 import json
 import os
 from datetime import datetime
+from threading import RLock
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
@@ -67,7 +68,7 @@ from tldw_Server_API.app.core.Prompt_Management.prompt_studio.jobs_adapter impor
 )
 from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
 from tldw_Server_API.app.core.testing import env_flag_enabled
-from tldw_Server_API.app.services.app_lifecycle import assert_may_start_work
+from tldw_Server_API.app.services.app_lifecycle import assert_may_start_work, is_lifecycle_draining
 from tldw_Server_API.app.services.shutdown_transport_registry import (
     register_shutdown_transport_family,
 )
@@ -125,9 +126,10 @@ class ConnectionManager:
         self.active_connections: dict[str, set[WebSocket]] = {}
         # Store connection metadata
         self.connection_metadata: dict[WebSocket, dict] = {}
+        self._connections_lock = RLock()
 
     async def connect(self, websocket: WebSocket, client_id: str,
-                     user_context: Optional[dict] = None):
+                     user_context: Optional[dict] = None) -> bool:
         """
         Accept and register a new WebSocket connection.
 
@@ -136,22 +138,31 @@ class ConnectionManager:
             client_id: Client identifier
             user_context: Optional user context
         """
-        await websocket.accept()
+        await _accept_prompt_studio_websocket_if_needed(websocket)
 
-        # Add to active connections
-        if client_id not in self.active_connections:
-            self.active_connections[client_id] = set()
+        should_close = False
+        with self._connections_lock:
+            app = getattr(websocket, "app", None)
+            if app is not None and is_lifecycle_draining(app):
+                should_close = True
+            else:
+                if client_id not in self.active_connections:
+                    self.active_connections[client_id] = set()
 
-        self.active_connections[client_id].add(websocket)
+                self.active_connections[client_id].add(websocket)
 
-        # Store metadata
-        self.connection_metadata[websocket] = {
-            "client_id": client_id,
-            "user_context": user_context,
-            "connected_at": datetime.utcnow().isoformat()
-        }
+                self.connection_metadata[websocket] = {
+                    "client_id": client_id,
+                    "user_context": user_context,
+                    "connected_at": datetime.utcnow().isoformat()
+                }
+
+        if should_close:
+            await websocket.close(code=1013, reason="shutdown_draining")
+            return False
 
         logger.info(f"WebSocket connected for client {client_id}")
+        return True
 
     def disconnect(self, websocket: WebSocket):
         """
@@ -160,22 +171,18 @@ class ConnectionManager:
         Args:
             websocket: WebSocket connection to remove
         """
-        metadata = self.connection_metadata.get(websocket)
-        if metadata:
-            client_id = metadata["client_id"]
+        with self._connections_lock:
+            metadata = self.connection_metadata.get(websocket)
+            if metadata:
+                client_id = metadata["client_id"]
 
-            # Remove from active connections
-            if client_id in self.active_connections:
-                self.active_connections[client_id].discard(websocket)
+                if client_id in self.active_connections:
+                    self.active_connections[client_id].discard(websocket)
+                    if not self.active_connections[client_id]:
+                        del self.active_connections[client_id]
 
-                # Clean up empty sets
-                if not self.active_connections[client_id]:
-                    del self.active_connections[client_id]
-
-            # Remove metadata
-            del self.connection_metadata[websocket]
-
-            logger.info(f"WebSocket disconnected for client {client_id}")
+                del self.connection_metadata[websocket]
+                logger.info(f"WebSocket disconnected for client {client_id}")
 
     async def send_personal_message(self, message: str, websocket: WebSocket):
         """
@@ -199,7 +206,8 @@ class ConnectionManager:
             client_id: Client identifier
             message: Message to broadcast
         """
-        sockets = list(self.active_connections.get(client_id, ()))
+        with self._connections_lock:
+            sockets = list(self.active_connections.get(client_id, ()))
         if not sockets:
             return
 
@@ -223,27 +231,32 @@ class ConnectionManager:
         Args:
             message: Message to broadcast
         """
-        for client_id in list(self.active_connections):
+        with self._connections_lock:
+            client_ids = list(self.active_connections)
+        for client_id in client_ids:
             await self.broadcast_to_client(client_id, message)
 
     def get_connection_count(self) -> int:
         """Get total number of active connections."""
-        return sum(len(connections) for connections in self.active_connections.values())
+        with self._connections_lock:
+            return sum(len(connections) for connections in self.active_connections.values())
 
     def get_client_count(self) -> int:
         """Get number of unique clients connected."""
-        return len(self.active_connections)
+        with self._connections_lock:
+            return len(self.active_connections)
 
     async def close_all(self, timeout_s: float | None = None) -> None:
         """Close all active Prompt Studio sockets and clear tracking state."""
-        sockets = [socket for sockets in self.active_connections.values() for socket in sockets]
+        with self._connections_lock:
+            sockets = [socket for sockets in self.active_connections.values() for socket in sockets]
+            self.active_connections.clear()
+            self.connection_metadata.clear()
         if sockets:
             await asyncio.gather(
                 *(socket.close(code=1001, reason="Server shutdown") for socket in sockets),
                 return_exceptions=True,
             )
-        self.active_connections.clear()
-        self.connection_metadata.clear()
 
 # NOTE: A single, shared connection manager is defined later as
 # `connection_manager` and imported by the job processor for broadcasts.
@@ -425,8 +438,21 @@ async def _guard_prompt_studio_websocket_start(websocket: WebSocket, kind: str) 
         assert_may_start_work(app, kind)
         return True
     except HTTPException:
+        await _accept_prompt_studio_websocket_if_needed(websocket)
         await websocket.close(code=1013, reason="shutdown_draining")
         return False
+
+
+async def _accept_prompt_studio_websocket_if_needed(websocket: WebSocket) -> None:
+    already_accepted = False
+    try:
+        state = getattr(websocket, "application_state", None)
+        if state is not None and str(state).upper().endswith("CONNECTED"):
+            already_accepted = True
+    except _STREAM_ACTIVITY_EXCEPTIONS:
+        already_accepted = False
+    if hasattr(websocket, "accept") and not already_accepted:
+        await websocket.accept()
 
 @router.websocket("")
 async def websocket_endpoint_base(websocket: WebSocket):
@@ -447,7 +473,8 @@ async def websocket_endpoint_base(websocket: WebSocket):
     if not await _guard_prompt_studio_websocket_start(websocket, "prompt_studio.websocket"):
         return
     # Accept via manager first to avoid double-accept issues
-    await connection_manager.connect(websocket, "global")
+    if not await connection_manager.connect(websocket, "global"):
+        return
     await stream.start()
 
     try:
@@ -461,11 +488,6 @@ async def websocket_endpoint_base(websocket: WebSocket):
             if data.get("type") == "subscribe":
                 project_id = data.get("project_id")
                 if project_id:
-                    # Add to project subscription
-                    if "global" not in connection_manager.active_connections:
-                        connection_manager.active_connections["global"] = set()
-                    connection_manager.active_connections["global"].add(websocket)
-
                     await stream.send_json({
                         "type": "subscribed",
                         "project_id": project_id
@@ -504,7 +526,8 @@ async def websocket_endpoint(
     )
     if not await _guard_prompt_studio_websocket_start(websocket, "prompt_studio.websocket"):
         return
-    await connection_manager.connect(websocket, str(project_id))
+    if not await connection_manager.connect(websocket, str(project_id)):
+        return
     await stream.start()
 
     try:

--- a/tldw_Server_API/app/core/MCP_unified/server.py
+++ b/tldw_Server_API/app/core/MCP_unified/server.py
@@ -30,6 +30,10 @@ from tldw_Server_API.app.core.testing import (
     is_test_mode as _is_test_mode,
     is_truthy as _is_truthy,
 )
+from tldw_Server_API.app.services.app_lifecycle import assert_may_start_work
+from tldw_Server_API.app.services.shutdown_transport_registry import (
+    register_shutdown_transport_family,
+)
 
 from .auth.authnz_rbac import get_rbac_policy
 from .auth.jwt_manager import JWTManager, get_jwt_manager
@@ -261,8 +265,30 @@ class MCPServer:
 
         # Background tasks
         self.background_tasks: set[asyncio.Task] = set()
+        register_shutdown_transport_family(
+            "mcp.websocket",
+            active_count=self.get_active_connection_count,
+            drain=self.drain_connections,
+        )
 
         logger.info("MCP Server created")
+
+    def get_active_connection_count(self) -> int:
+        return len(self.connections)
+
+    async def drain_connections(self, timeout_s: float | None = None) -> None:
+        await self._close_all_connections()
+
+    async def _guard_websocket_start(self, websocket: WebSocket) -> bool:
+        app = getattr(websocket, "app", None)
+        if app is None:
+            return True
+        try:
+            assert_may_start_work(app, "mcp.websocket")
+            return True
+        except HTTPException:
+            await websocket.close(code=1013, reason="shutdown_draining")
+            return False
 
     @staticmethod
     def _mask_secrets(text: str) -> str:
@@ -929,6 +955,16 @@ class MCPServer:
             await websocket.close(code=1008, reason="Authentication required")
             return
 
+        if stable_session_id:
+            metadata["session_id"] = stable_session_id
+        if workspace_key:
+            metadata["workspace_id"] = workspace_key
+        if cwd_key:
+            metadata["cwd"] = cwd_key
+
+        if not await self._guard_websocket_start(websocket):
+            return
+
         try:
             if stable_session_id:
                 await self._get_or_create_session(
@@ -940,13 +976,6 @@ class MCPServer:
         except PermissionError as exc:
             await websocket.close(code=1008, reason=str(exc))
             return
-
-        if stable_session_id:
-            metadata["session_id"] = stable_session_id
-        if workspace_key:
-            metadata["workspace_id"] = workspace_key
-        if cwd_key:
-            metadata["cwd"] = cwd_key
 
         # Check connection limits (global and per-IP)
         async with self.connection_lock:

--- a/tldw_Server_API/app/core/Security/drain_gate_middleware.py
+++ b/tldw_Server_API/app/core/Security/drain_gate_middleware.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import FastAPI
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from tldw_Server_API.app.services.app_lifecycle import is_lifecycle_draining
+CONTROL_PLANE_DRAIN_PATHS: frozenset[str] = frozenset({"/health", "/ready", "/health/ready"})
+CONTROL_PLANE_DRAIN_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {(method, path) for method in ("GET", "HEAD") for path in CONTROL_PLANE_DRAIN_PATHS}
+)
+
+
+def _is_allowlisted_control_plane_path(request: Request) -> bool:
+    method = request.method.upper()
+    path = request.url.path
+    return (method, path) in CONTROL_PLANE_DRAIN_ALLOWLIST
+
+
+class DrainGateMiddleware(BaseHTTPMiddleware):
+    """Reject non-control-plane requests while shutdown is draining."""
+
+    def __init__(self, app: FastAPI) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        if is_lifecycle_draining(request.app) and not _is_allowlisted_control_plane_path(request):
+            return JSONResponse(
+                {"status": "not_ready", "reason": "shutdown_in_progress"},
+                status_code=503,
+            )
+        return await call_next(request)
+
+
+__all__ = [
+    "CONTROL_PLANE_DRAIN_ALLOWLIST",
+    "CONTROL_PLANE_DRAIN_PATHS",
+    "DrainGateMiddleware",
+    "_is_allowlisted_control_plane_path",
+]

--- a/tldw_Server_API/app/core/Security/drain_gate_middleware.py
+++ b/tldw_Server_API/app/core/Security/drain_gate_middleware.py
@@ -8,7 +8,16 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from tldw_Server_API.app.services.app_lifecycle import is_lifecycle_draining
-CONTROL_PLANE_DRAIN_PATHS: frozenset[str] = frozenset({"/health", "/ready", "/health/ready"})
+CONTROL_PLANE_DRAIN_PATHS: frozenset[str] = frozenset(
+    {
+        "/health",
+        "/ready",
+        "/health/ready",
+        "/healthz",
+        "/api/v1/healthz",
+        "/api/v1/health/live",
+    }
+)
 CONTROL_PLANE_DRAIN_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
     {(method, path) for method in ("GET", "HEAD") for path in CONTROL_PLANE_DRAIN_PATHS}
 )

--- a/tldw_Server_API/app/core/Security/drain_gate_middleware.py
+++ b/tldw_Server_API/app/core/Security/drain_gate_middleware.py
@@ -13,6 +13,7 @@ CONTROL_PLANE_DRAIN_PATHS: frozenset[str] = frozenset(
     {
         "/health",
         "/ready",
+        "/readyz",
         "/health/ready",
         "/healthz",
         "/api/v1/health",

--- a/tldw_Server_API/app/core/Security/drain_gate_middleware.py
+++ b/tldw_Server_API/app/core/Security/drain_gate_middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import re
 
 from fastapi import FastAPI
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -29,6 +30,56 @@ def _is_allowlisted_control_plane_path(request: Request) -> bool:
     return (method, path) in CONTROL_PLANE_DRAIN_ALLOWLIST
 
 
+def _resolve_drain_gate_allow_origin(request: Request) -> str | None:
+    origin = request.headers.get("origin")
+    if not origin:
+        return None
+
+    config = getattr(getattr(request.app, "state", None), "_tldw_drain_gate_cors_config", None)
+    if not isinstance(config, dict):
+        return None
+
+    normalized_origin = origin.rstrip("/")
+    if config.get("allow_all_origins"):
+        return origin if config.get("allow_credentials") else "*"
+
+    allowed_origins = config.get("allowed_origins", set())
+    if normalized_origin in allowed_origins:
+        return origin
+
+    allow_origin_regex = config.get("allow_origin_regex")
+    if allow_origin_regex:
+        try:
+            if re.fullmatch(str(allow_origin_regex), origin):
+                return origin
+        except re.error:
+            return None
+    return None
+
+
+def _apply_drain_gate_cors_headers(request: Request, response: Response) -> Response:
+    allow_origin = _resolve_drain_gate_allow_origin(request)
+    if not allow_origin:
+        return response
+
+    config = getattr(getattr(request.app, "state", None), "_tldw_drain_gate_cors_config", {})
+    response.headers.setdefault("Access-Control-Allow-Origin", allow_origin)
+    if allow_origin != "*":
+        response.headers.setdefault("Vary", "Origin")
+    if config.get("allow_credentials"):
+        response.headers.setdefault("Access-Control-Allow-Credentials", "true")
+
+    requested_method = request.headers.get("access-control-request-method")
+    requested_headers = request.headers.get("access-control-request-headers")
+    response.headers.setdefault("Access-Control-Allow-Methods", requested_method or "*")
+    response.headers.setdefault("Access-Control-Allow-Headers", requested_headers or "*")
+    response.headers.setdefault(
+        "Access-Control-Expose-Headers",
+        config.get("expose_headers", "X-Request-ID, traceparent, X-Trace-Id"),
+    )
+    return response
+
+
 class DrainGateMiddleware(BaseHTTPMiddleware):
     """Reject non-control-plane requests while shutdown is draining."""
 
@@ -37,10 +88,11 @@ class DrainGateMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         if is_lifecycle_draining(request.app) and not _is_allowlisted_control_plane_path(request):
-            return JSONResponse(
+            response = JSONResponse(
                 {"status": "not_ready", "reason": "shutdown_in_progress"},
                 status_code=503,
             )
+            return _apply_drain_gate_cors_headers(request, response)
         return await call_next(request)
 
 
@@ -48,5 +100,6 @@ __all__ = [
     "CONTROL_PLANE_DRAIN_ALLOWLIST",
     "CONTROL_PLANE_DRAIN_PATHS",
     "DrainGateMiddleware",
+    "_apply_drain_gate_cors_headers",
     "_is_allowlisted_control_plane_path",
 ]

--- a/tldw_Server_API/app/core/Security/drain_gate_middleware.py
+++ b/tldw_Server_API/app/core/Security/drain_gate_middleware.py
@@ -15,8 +15,11 @@ CONTROL_PLANE_DRAIN_PATHS: frozenset[str] = frozenset(
         "/ready",
         "/health/ready",
         "/healthz",
+        "/api/v1/health",
         "/api/v1/healthz",
         "/api/v1/health/live",
+        "/api/v1/health/ready",
+        "/api/v1/readyz",
     }
 )
 CONTROL_PLANE_DRAIN_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(

--- a/tldw_Server_API/app/core/Utils/executor_registry.py
+++ b/tldw_Server_API/app/core/Utils/executor_registry.py
@@ -9,6 +9,9 @@ from loguru import logger
 
 _registry_lock = RLock()
 _executors: dict[str, Executor] = {}
+_EXECUTOR_SHUTDOWN_PRIORITIES: dict[str, int] = {
+    "db_thread_pool": 100,
+}
 
 
 def register_executor(name: str, executor: Executor) -> None:
@@ -34,6 +37,12 @@ def unregister_executor(name: str) -> None:
 def _snapshot() -> Iterable[tuple[str, Executor]]:
     with _registry_lock:
         return list(_executors.items())
+
+
+def _ordered_shutdown_snapshot() -> list[tuple[str, Executor]]:
+    snapshot = list(_snapshot())
+    snapshot.sort(key=lambda item: _EXECUTOR_SHUTDOWN_PRIORITIES.get(item[0], 0))
+    return snapshot
 
 
 def snapshot_registered_executors() -> tuple[tuple[str, Executor], ...]:
@@ -67,16 +76,12 @@ async def shutdown_executor(name: str, wait: bool = True, cancel_futures: bool =
 
 
 async def shutdown_all_registered_executors(wait: bool = True, cancel_futures: bool = True) -> None:
-    """Shutdown all registered executors concurrently."""
-    snapshot = list(_snapshot())
+    """Shutdown all registered executors in dependency-aware order."""
+    snapshot = _ordered_shutdown_snapshot()
     if not snapshot:
         return
-    await asyncio.gather(
-        *(
-            asyncio.to_thread(_shutdown_executor_blocking, name, executor, wait, cancel_futures)
-            for name, executor in snapshot
-        )
-    )
+    for name, executor in snapshot:
+        await asyncio.to_thread(_shutdown_executor_blocking, name, executor, wait, cancel_futures)
 
 
 def shutdown_executor_sync(name: str, wait: bool = True, cancel_futures: bool = True) -> None:
@@ -90,5 +95,5 @@ def shutdown_executor_sync(name: str, wait: bool = True, cancel_futures: bool = 
 
 def shutdown_all_registered_executors_sync(wait: bool = True, cancel_futures: bool = True) -> None:
     """Synchronous shutdown for environments without an event loop."""
-    for name, executor in _snapshot():
+    for name, executor in _ordered_shutdown_snapshot():
         _shutdown_executor_blocking(name, executor, wait, cancel_futures)

--- a/tldw_Server_API/app/core/Utils/executor_registry.py
+++ b/tldw_Server_API/app/core/Utils/executor_registry.py
@@ -36,6 +36,11 @@ def _snapshot() -> Iterable[tuple[str, Executor]]:
         return list(_executors.items())
 
 
+def snapshot_registered_executors() -> tuple[tuple[str, Executor], ...]:
+    """Expose a stable snapshot of registered executors for shutdown coordination."""
+    return tuple(_snapshot())
+
+
 def _shutdown_executor_blocking(name: str, executor: Executor, wait: bool, cancel_futures: bool) -> None:
     """Shutdown helper that runs in a worker thread when awaited."""
     try:
@@ -62,9 +67,16 @@ async def shutdown_executor(name: str, wait: bool = True, cancel_futures: bool =
 
 
 async def shutdown_all_registered_executors(wait: bool = True, cancel_futures: bool = True) -> None:
-    """Shutdown all registered executors, awaiting completion for each."""
-    for name, executor in _snapshot():
-        await asyncio.to_thread(_shutdown_executor_blocking, name, executor, wait, cancel_futures)
+    """Shutdown all registered executors concurrently."""
+    snapshot = list(_snapshot())
+    if not snapshot:
+        return
+    await asyncio.gather(
+        *(
+            asyncio.to_thread(_shutdown_executor_blocking, name, executor, wait, cancel_futures)
+            for name, executor in snapshot
+        )
+    )
 
 
 def shutdown_executor_sync(name: str, wait: bool = True, cancel_futures: bool = True) -> None:

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -4072,9 +4072,11 @@ async def lifespan(app: FastAPI):
                     )
 
                     await _stop_usage(usage_task)
+                    usage_task = None
         except _STARTUP_GUARD_EXCEPTIONS:
             with suppress(_STARTUP_GUARD_EXCEPTIONS):
                 usage_task.cancel()
+                usage_task = None
         try:
             if "llm_usage_aggregator" not in coordinated_legacy_component_names:
                 if "llm_usage_task" in locals() and llm_usage_task:
@@ -4531,6 +4533,7 @@ async def lifespan(app: FastAPI):
 
                 await stop_usage_aggregator(usage_task)
                 logger.info("Usage aggregator stopped")
+                usage_task = None
     except _STARTUP_GUARD_EXCEPTIONS as e:
         logger.exception(f"App Shutdown: Error stopping usage aggregator: {e}")
 

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -3805,9 +3805,14 @@ async def lifespan(app: FastAPI):
 
     # Execute the migrated legacy shutdown components through the coordinator.
     try:
+        non_transition_legacy_shutdown_plan = [
+            component
+            for component in legacy_shutdown_plan
+            if getattr(getattr(component, "phase", None), "value", None) != "transition"
+        ]
         coordinated_legacy_component_names = await _run_coordinated_shutdown(
             app,
-            legacy_shutdown_plan,
+            non_transition_legacy_shutdown_plan,
         )
     except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _coordinated_legacy_shutdown_err:
         logger.debug(f"Legacy coordinator shutdown skipped: {_coordinated_legacy_shutdown_err}")
@@ -5476,6 +5481,16 @@ else:
         enforce_explicit_origins=_cors_enforce_explicit_origins,
     )
     _cors_allowed_openapi_origins = {str(o).rstrip("/") for o in origins if isinstance(o, str)}
+    try:
+        app.state._tldw_drain_gate_cors_config = {
+            "allow_all_origins": _cors_allow_all_origins,
+            "allow_origin_regex": _cors_allow_origin_regex,
+            "allow_credentials": _cors_allow_credentials,
+            "allowed_origins": _cors_allowed_openapi_origins,
+            "expose_headers": "X-Request-ID, traceparent, X-Trace-Id",
+        }
+    except _STARTUP_GUARD_EXCEPTIONS:
+        pass
     # # -- If you have any global middleware, add it here --
     app.add_middleware(
         CORSMiddleware,

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -141,21 +141,46 @@ def _apply_shutdown_transition_gate(app: FastAPI, readiness_state: Any | None) -
     """Move the app into draining mode and gate new jobs."""
     try:
         lifecycle_state = get_or_create_lifecycle_state(app)
-    except _STARTUP_GUARD_EXCEPTIONS:
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
         lifecycle_state = None
+        logger.debug(f"Shutdown transition gate: lifecycle state lookup skipped: {exc}")
 
     try:
         if lifecycle_state is None or lifecycle_state.phase != "draining" or not lifecycle_state.draining:
             mark_lifecycle_shutdown(app, readiness_state)
-    except _STARTUP_GUARD_EXCEPTIONS:
-        pass
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.warning(f"Shutdown transition gate: failed to mark lifecycle shutdown: {exc}")
 
     try:
         from tldw_Server_API.app.core.Jobs.manager import JobManager as _JM
 
         _JM.set_acquire_gate(True)
-    except _IMPORT_EXCEPTIONS:
-        pass
+    except _IMPORT_EXCEPTIONS as exc:
+        logger.debug(f"Shutdown transition gate: job acquire gate unavailable: {exc}")
+
+
+def _build_legacy_shutdown_context(
+    *,
+    readiness_state: Any | None,
+    usage_task: Any = None,
+    llm_usage_task: Any = None,
+    authnz_scheduler_started: bool = False,
+    chatbooks_cleanup_task: Any = None,
+    chatbooks_cleanup_stop_event: Any = None,
+    storage_cleanup_service: Any = None,
+) -> "LegacyShutdownContext":
+    """Collect the explicit shutdown dependencies used by legacy adapters."""
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import LegacyShutdownContext
+
+    return LegacyShutdownContext(
+        readiness_state=readiness_state,
+        usage_task=usage_task,
+        llm_usage_task=llm_usage_task,
+        authnz_scheduler_started=authnz_scheduler_started,
+        chatbooks_cleanup_task=chatbooks_cleanup_task,
+        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
+        storage_cleanup_service=storage_cleanup_service,
+    )
 
 
 def _build_coordinated_shutdown_coordinator(
@@ -163,7 +188,7 @@ def _build_coordinated_shutdown_coordinator(
     legacy_shutdown_plan: list[Any],
     *,
     transport_registry: Any | None = None,
-):
+) -> tuple["ShutdownCoordinator", list["ShutdownComponent"], list["ShutdownComponent"]]:
     """Assemble the production drain coordinator with legacy and transport owners."""
     from tldw_Server_API.app.services.shutdown_coordinator import ShutdownCoordinator
     from tldw_Server_API.app.services.shutdown_transport_registry import (
@@ -1556,6 +1581,12 @@ async def lifespan(app: FastAPI):
         _JM.set_acquire_gate(False)
     except _IMPORT_EXCEPTIONS:
         pass
+    usage_task = None
+    llm_usage_task = None
+    chatbooks_cleanup_task = None
+    chatbooks_cleanup_stop_event = None
+    storage_cleanup_service = None
+    _authnz_sched_started = False
     # Fail fast if the assembled app contains duplicate method+path route registrations.
     _fail_on_duplicate_route_method_pairs(app, context="lifespan startup")
     # Run environmental preflight checks before heavy initialization.
@@ -3702,9 +3733,16 @@ async def lifespan(app: FastAPI):
             build_legacy_shutdown_plan,
         )
 
-        shutdown_locals = dict(locals())
-        shutdown_locals["READINESS_STATE"] = READINESS_STATE
-        legacy_shutdown_plan = build_legacy_shutdown_plan(app, shutdown_locals)
+        shutdown_context = _build_legacy_shutdown_context(
+            readiness_state=READINESS_STATE,
+            usage_task=usage_task,
+            llm_usage_task=llm_usage_task,
+            authnz_scheduler_started=_authnz_sched_started,
+            chatbooks_cleanup_task=chatbooks_cleanup_task,
+            chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
+            storage_cleanup_service=storage_cleanup_service,
+        )
+        legacy_shutdown_plan = build_legacy_shutdown_plan(app, shutdown_context)
         legacy_phase_groups: dict[str, list[str]] = {}
         for component in legacy_shutdown_plan:
             legacy_phase_groups.setdefault(component.phase.value, []).append(component.name)

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.routing import APIRoute
 from loguru import logger
 from starlette import status as _starlette_status
@@ -39,6 +39,7 @@ from tldw_Server_API.app.api.v1.router_registry import include_router_idempotent
 from tldw_Server_API.app.services.app_lifecycle import (
     mark_lifecycle_shutdown,
     mark_lifecycle_startup,
+    get_or_create_lifecycle_state,
 )
 from tldw_Server_API.app.core.testing import (
     env_flag_enabled as _shared_env_flag_enabled,
@@ -114,6 +115,10 @@ _REQUEST_GUARD_EXCEPTIONS = (
     UnicodeDecodeError,
     ValueError,
 )
+_READINESS_GUARD_EXCEPTIONS = _REQUEST_GUARD_EXCEPTIONS + (
+    ImportError,
+    ModuleNotFoundError,
+)
 
 
 @contextmanager
@@ -130,6 +135,123 @@ def _claims_rebuild_db_session(
         initialize=False,
     ) as db:
         yield user_id, db_path, db
+
+
+def _apply_shutdown_transition_gate(app: FastAPI, readiness_state: Any | None) -> None:
+    """Move the app into draining mode and gate new jobs."""
+    try:
+        lifecycle_state = get_or_create_lifecycle_state(app)
+    except _STARTUP_GUARD_EXCEPTIONS:
+        lifecycle_state = None
+
+    try:
+        if lifecycle_state is None or lifecycle_state.phase != "draining" or not lifecycle_state.draining:
+            mark_lifecycle_shutdown(app, readiness_state)
+    except _STARTUP_GUARD_EXCEPTIONS:
+        pass
+
+    try:
+        from tldw_Server_API.app.core.Jobs.manager import JobManager as _JM
+
+        _JM.set_acquire_gate(True)
+    except _IMPORT_EXCEPTIONS:
+        pass
+
+
+def _build_coordinated_shutdown_coordinator(
+    app: FastAPI,
+    legacy_shutdown_plan: list[Any],
+    *,
+    transport_registry: Any | None = None,
+):
+    """Assemble the production drain coordinator with legacy and transport owners."""
+    from tldw_Server_API.app.services.shutdown_coordinator import ShutdownCoordinator
+    from tldw_Server_API.app.services.shutdown_transport_registry import (
+        build_shutdown_components,
+    )
+
+    coordinator = ShutdownCoordinator(profile="prod_drain")
+    legacy_components: list[Any] = []
+    try:
+        from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+            register_legacy_shutdown_components,
+        )
+
+        legacy_components = register_legacy_shutdown_components(
+            coordinator,
+            legacy_shutdown_plan,
+        )
+    except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS):
+        legacy_components = []
+    transport_components = build_shutdown_components(transport_registry)
+    for component in transport_components:
+        coordinator.register(component)
+
+    try:
+        app.state._tldw_shutdown_transport_component_names = [
+            component.name for component in transport_components
+        ]
+    except _STARTUP_GUARD_EXCEPTIONS:
+        pass
+
+    return coordinator, legacy_components, transport_components
+
+
+async def _run_coordinated_shutdown(
+    app: FastAPI,
+    legacy_shutdown_plan: list[Any],
+    *,
+    transport_registry: Any | None = None,
+) -> set[str]:
+    """Run the coordinated shutdown slice used by the real lifespan teardown."""
+    try:
+        from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+            get_legacy_shutdown_suppressed_component_names,
+        )
+    except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS):
+        get_legacy_shutdown_suppressed_component_names = lambda _summary: set()
+
+    (
+        coordinated_legacy_coordinator,
+        coordinated_legacy_components,
+        coordinated_transport_components,
+    ) = _build_coordinated_shutdown_coordinator(
+        app,
+        legacy_shutdown_plan,
+        transport_registry=transport_registry,
+    )
+    all_components = list(coordinated_legacy_components) + list(coordinated_transport_components)
+    if not all_components:
+        return set()
+
+    coordinated_legacy_summary = await coordinated_legacy_coordinator.shutdown()
+    legacy_component_name_set = {component.name for component in coordinated_legacy_components}
+    coordinated_legacy_component_names = {
+        name
+        for name in get_legacy_shutdown_suppressed_component_names(coordinated_legacy_summary)
+        if name in legacy_component_name_set
+    }
+    try:
+        app.state._tldw_shutdown_legacy_coordinator_summary = coordinated_legacy_summary
+        app.state._tldw_shutdown_legacy_coordinator_component_names = [
+            component.name for component in all_components
+        ]
+        app.state._tldw_shutdown_legacy_coordinator_phase_groups = {
+            phase.value: phase_summary.component_names
+            for phase, phase_summary in coordinated_legacy_summary.phases.items()
+        }
+    except _STARTUP_GUARD_EXCEPTIONS:
+        pass
+    logger.info(
+        "App Shutdown: legacy coordinator summary components={} phase_groups={} wall_time_ms={}",
+        [component.name for component in all_components],
+        {
+            phase.value: phase_summary.component_names
+            for phase, phase_summary in coordinated_legacy_summary.phases.items()
+        },
+        coordinated_legacy_summary.wall_time_ms,
+    )
+    return coordinated_legacy_component_names
 
 _early_os.environ.setdefault("MCP_INHERIT_GLOBAL_LOGGER", "1")
 try:
@@ -3568,14 +3690,60 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    # Flip readiness early and gate new job acquisitions for graceful shutdown
+    # Build and record the legacy shutdown inventory first.
+    # Execute only the narrow transition gate handoff through the coordinator;
+    # the remaining legacy teardown paths stay on the existing direct teardown path.
+    transition_gate_applied = False
+    legacy_shutdown_plan: list[Any] = []
+    coordinated_legacy_component_names: set[str] = set()
     try:
-        mark_lifecycle_shutdown(app, READINESS_STATE)
-        from tldw_Server_API.app.core.Jobs.manager import JobManager as _JM
+        from tldw_Server_API.app.services.shutdown_coordinator import ShutdownCoordinator, ShutdownPhase
+        from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+            build_legacy_shutdown_plan,
+        )
 
-        _JM.set_acquire_gate(True)
-    except _STARTUP_GUARD_EXCEPTIONS:
-        pass
+        shutdown_locals = dict(locals())
+        shutdown_locals["READINESS_STATE"] = READINESS_STATE
+        legacy_shutdown_plan = build_legacy_shutdown_plan(app, shutdown_locals)
+        legacy_phase_groups: dict[str, list[str]] = {}
+        for component in legacy_shutdown_plan:
+            legacy_phase_groups.setdefault(component.phase.value, []).append(component.name)
+
+        try:
+            app.state._tldw_shutdown_legacy_plan = legacy_shutdown_plan
+            app.state._tldw_shutdown_legacy_phase_groups = legacy_phase_groups
+            app.state._tldw_shutdown_legacy_inventory_visible = bool(legacy_shutdown_plan)
+        except _STARTUP_GUARD_EXCEPTIONS:
+            pass
+
+        logger.info(
+            "App Shutdown: legacy inventory visible={} phase_groups={}",
+            bool(legacy_shutdown_plan),
+            legacy_phase_groups,
+        )
+
+        transition_coordinator = ShutdownCoordinator(profile="dev_fast")
+        for component in legacy_shutdown_plan:
+            if component.phase == ShutdownPhase.TRANSITION:
+                transition_coordinator.register(component)
+        if legacy_shutdown_plan:
+            transition_summary = await transition_coordinator.shutdown()
+            transition_gate_summary = transition_summary.components.get("lifecycle_gate")
+            transition_gate_applied = bool(
+                transition_gate_summary is not None and transition_gate_summary.result == "stopped"
+            )
+            if transition_gate_applied:
+                logger.info("App Shutdown: legacy transition gate handoff executed via coordinator")
+            else:
+                logger.warning(
+                    "App Shutdown: legacy transition gate handoff did not complete cleanly; "
+                    "falling back to direct drain",
+                )
+    except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _legacy_shutdown_err:
+        logger.debug(f"Legacy shutdown inventory skipped: {_legacy_shutdown_err}")
+    finally:
+        if not transition_gate_applied:
+            _apply_shutdown_transition_gate(app, READINESS_STATE)
 
     # Optionally wait for leases to finish (bounded wait)
     try:
@@ -3597,6 +3765,15 @@ async def lifespan(app: FastAPI):
     except _STARTUP_GUARD_EXCEPTIONS:
         pass
 
+    # Execute the migrated legacy shutdown components through the coordinator.
+    try:
+        coordinated_legacy_component_names = await _run_coordinated_shutdown(
+            app,
+            legacy_shutdown_plan,
+        )
+    except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _coordinated_legacy_shutdown_err:
+        logger.debug(f"Legacy coordinator shutdown skipped: {_coordinated_legacy_shutdown_err}")
+
     # Cancel/stop background worker(s)
     try:
         bg = getattr(app.state, "bg_tasks", None)
@@ -3610,17 +3787,19 @@ async def lifespan(app: FastAPI):
     try:
         if "cleanup_task" in locals() and cleanup_task:
             cleanup_task.cancel()
-        if "chatbooks_cleanup_stop_event" in locals() and chatbooks_cleanup_stop_event:
-            chatbooks_cleanup_stop_event.set()
-        if "chatbooks_cleanup_task" in locals() and chatbooks_cleanup_task:
-            chatbooks_cleanup_task.cancel()
+        if "chatbooks_cleanup" not in coordinated_legacy_component_names:
+            if "chatbooks_cleanup_stop_event" in locals() and chatbooks_cleanup_stop_event:
+                chatbooks_cleanup_stop_event.set()
+            if "chatbooks_cleanup_task" in locals() and chatbooks_cleanup_task:
+                chatbooks_cleanup_task.cancel()
         # Storage cleanup service shutdown
         if "storage_cleanup_service" in locals() and storage_cleanup_service:
-            try:
-                await storage_cleanup_service.stop()
-                logger.info("Storage cleanup worker stopped")
-            except _STARTUP_GUARD_EXCEPTIONS:
-                pass
+            if "storage_cleanup_service" not in coordinated_legacy_component_names:
+                try:
+                    await storage_cleanup_service.stop()
+                    logger.info("Storage cleanup worker stopped")
+                except _STARTUP_GUARD_EXCEPTIONS:
+                    pass
         try:
             from tldw_Server_API.app.services.storage_cleanup_service import (
                 reset_cleanup_service as _reset_cleanup_service,
@@ -3843,18 +4022,24 @@ async def lifespan(app: FastAPI):
             logger.info("WebSub renewal worker cancelled")
         # Stop usage aggregators gracefully
         try:
-            if "usage_task" in locals() and usage_task:
-                from tldw_Server_API.app.services.usage_aggregator import stop_usage_aggregator as _stop_usage
+            if "usage_aggregator" not in coordinated_legacy_component_names:
+                if "usage_task" in locals() and usage_task:
+                    from tldw_Server_API.app.services.usage_aggregator import (
+                        stop_usage_aggregator as _stop_usage,
+                    )
 
-                await _stop_usage(usage_task)
+                    await _stop_usage(usage_task)
         except _STARTUP_GUARD_EXCEPTIONS:
             with suppress(_STARTUP_GUARD_EXCEPTIONS):
                 usage_task.cancel()
         try:
-            if "llm_usage_task" in locals() and llm_usage_task:
-                from tldw_Server_API.app.services.llm_usage_aggregator import stop_llm_usage_aggregator as _stop_llm
+            if "llm_usage_aggregator" not in coordinated_legacy_component_names:
+                if "llm_usage_task" in locals() and llm_usage_task:
+                    from tldw_Server_API.app.services.llm_usage_aggregator import (
+                        stop_llm_usage_aggregator as _stop_llm,
+                    )
 
-                await _stop_llm(llm_usage_task)
+                    await _stop_llm(llm_usage_task)
         except _STARTUP_GUARD_EXCEPTIONS:
             with suppress(_STARTUP_GUARD_EXCEPTIONS):
                 llm_usage_task.cancel()
@@ -4073,7 +4258,11 @@ async def lifespan(app: FastAPI):
 
     # Stop AuthNZ scheduler early so it can't keep the loop alive during shutdown.
     try:
-        if "_authnz_sched_started" in locals() and _authnz_sched_started:
+        if (
+            "_authnz_sched_started" in locals()
+            and _authnz_sched_started
+            and "authnz_scheduler" not in coordinated_legacy_component_names
+        ):
             from tldw_Server_API.app.core.AuthNZ.scheduler import stop_authnz_scheduler
 
             await stop_authnz_scheduler()
@@ -4293,11 +4482,12 @@ async def lifespan(app: FastAPI):
 
     # Stop usage aggregator
     try:
-        if "usage_task" in locals() and usage_task:
-            from tldw_Server_API.app.services.usage_aggregator import stop_usage_aggregator
+        if "usage_aggregator" not in coordinated_legacy_component_names:
+            if "usage_task" in locals() and usage_task:
+                from tldw_Server_API.app.services.usage_aggregator import stop_usage_aggregator
 
-            await stop_usage_aggregator(usage_task)
-            logger.info("Usage aggregator stopped")
+                await stop_usage_aggregator(usage_task)
+                logger.info("Usage aggregator stopped")
     except _STARTUP_GUARD_EXCEPTIONS as e:
         logger.exception(f"App Shutdown: Error stopping usage aggregator: {e}")
 
@@ -4305,7 +4495,11 @@ async def lifespan(app: FastAPI):
     try:
         # Stop AuthNZ scheduler if started
         try:
-            if "_authnz_sched_started" in locals() and _authnz_sched_started:
+            if (
+                "_authnz_sched_started" in locals()
+                and _authnz_sched_started
+                and "authnz_scheduler" not in coordinated_legacy_component_names
+            ):
                 from tldw_Server_API.app.core.AuthNZ.scheduler import stop_authnz_scheduler
 
                 await stop_authnz_scheduler()
@@ -5304,6 +5498,7 @@ from tldw_Server_API.app.core.AuthNZ.llm_budget_middleware import LLMBudgetMiddl
 from tldw_Server_API.app.core.AuthNZ.usage_logging_middleware import UsageLoggingMiddleware
 from tldw_Server_API.app.core.Metrics.http_middleware import HTTPMetricsMiddleware
 from tldw_Server_API.app.core.Sandbox.middleware import SandboxArtifactTraversalGuardMiddleware
+from tldw_Server_API.app.core.Security.drain_gate_middleware import DrainGateMiddleware
 from tldw_Server_API.app.core.Security.middleware import SecurityHeadersMiddleware
 from tldw_Server_API.app.core.Security.request_id_middleware import RequestIDMiddleware
 from tldw_Server_API.app.core.Security.setup_access_guard import SetupAccessGuardMiddleware
@@ -5331,8 +5526,6 @@ if _TEST_FLAGS_SET and not _EXPLICIT_PYTEST_RUNTIME:
 
 if _TEST_MODE:
     logger.info("TEST_MODE detected: Skipping non-essential middlewares (security headers, metrics, usage logging)")
-    # Provide request id + trace headers even in tests for assertions
-    app.add_middleware(RequestIDMiddleware)
     # Apply Setup CSP nonce injection even in tests to keep behavior consistent
     try:
         app.add_middleware(SetupCSPMiddleware)
@@ -5431,9 +5624,6 @@ else:
     except _IMPORT_EXCEPTIONS as _e:
         logger.debug(f"Skipping AccessLogMiddleware: {_e}")
 
-    # Request ID propagation (adds X-Request-ID header)
-    app.add_middleware(RequestIDMiddleware)
-
     # Sandbox artifact traversal guard (pre-routing)
     try:
         app.add_middleware(SandboxArtifactTraversalGuardMiddleware)
@@ -5499,6 +5689,11 @@ try:
     app.add_middleware(LLMBudgetMiddleware)
 except _STARTUP_GUARD_EXCEPTIONS as _e:
     logger.debug(f"Skipping LLMBudgetMiddleware: {_e}")
+
+# Request ID context should be available before the drain gate, and the drain gate
+# should reject work before the LLM budget middleware gets a chance to do heavier setup.
+app.add_middleware(DrainGateMiddleware)
+app.add_middleware(RequestIDMiddleware)
 
 # Keep Setup UI HTML outside the static mounts to avoid bypassing the
 # /setup gating via direct file access.
@@ -6894,12 +7089,15 @@ async def health_check():
 
 
 # Readiness check (verifies critical dependencies) - registered conditionally below
-async def readiness_check():
+async def readiness_check(request: Request) -> JSONResponse:
     """Readiness probe for orchestrators and load balancers."""
     try:
-        # Early flip: when shutting down, report not ready immediately
-        if not READINESS_STATE.get("ready", True):
-            return {"status": "not_ready", "reason": "shutdown_in_progress"}
+        lifecycle = get_or_create_lifecycle_state(request.app)
+        if lifecycle.draining or lifecycle.phase == "draining":
+            return JSONResponse(
+                {"status": "not_ready", "reason": "shutdown_in_progress"},
+                status_code=503,
+            )
         # Engine stats
         try:
             from tldw_Server_API.app.core.Workflows.engine import WorkflowScheduler as _WS
@@ -6998,31 +7196,29 @@ async def readiness_check():
                         pass
         except _REQUEST_GUARD_EXCEPTIONS:
             pass
-        from fastapi.responses import JSONResponse as _JR
-
-        return _JR(body, status_code=(200 if ready else 503))
-    except _REQUEST_GUARD_EXCEPTIONS as e:
-        return {"status": "not_ready", "error": str(e)}
+        return JSONResponse(body, status_code=(200 if ready else 503))
+    except _READINESS_GUARD_EXCEPTIONS as e:
+        return JSONResponse({"status": "not_ready", "error": str(e)}, status_code=503)
 
 
 # /health/ready alias for some orchestrators (registered conditionally below)
-async def readiness_alias():
-    return await readiness_check()
+async def readiness_alias(request: Request) -> JSONResponse:
+    return await readiness_check(request)
 
 
 # Register control-plane health endpoints (works in both minimal and full modes)
 try:
     if route_enabled("health"):
-        app.add_api_route("/health", health_check, methods=["GET"], openapi_extra={"security": []})
-        app.add_api_route("/ready", readiness_check, methods=["GET"], openapi_extra={"security": []})
-        app.add_api_route("/health/ready", readiness_alias, methods=["GET"], openapi_extra={"security": []})
+        app.add_api_route("/health", health_check, methods=["GET", "HEAD"], openapi_extra={"security": []})
+        app.add_api_route("/ready", readiness_check, methods=["GET", "HEAD"], openapi_extra={"security": []})
+        app.add_api_route("/health/ready", readiness_alias, methods=["GET", "HEAD"], openapi_extra={"security": []})
     else:
         logger.info("Route disabled by policy: health (/health, /ready, /health/ready)")
 except _STARTUP_GUARD_EXCEPTIONS as _health_rt_err:
     logger.warning(f"Route gating error for health; including by default. Error: {_health_rt_err}")
-    app.add_api_route("/health", health_check, methods=["GET"], openapi_extra={"security": []})
-    app.add_api_route("/ready", readiness_check, methods=["GET"], openapi_extra={"security": []})
-    app.add_api_route("/health/ready", readiness_alias, methods=["GET"], openapi_extra={"security": []})
+    app.add_api_route("/health", health_check, methods=["GET", "HEAD"], openapi_extra={"security": []})
+    app.add_api_route("/ready", readiness_check, methods=["GET", "HEAD"], openapi_extra={"security": []})
+    app.add_api_route("/health/ready", readiness_alias, methods=["GET", "HEAD"], openapi_extra={"security": []})
 
 # Import-time CI/startup guard: fail immediately if the route table contains duplicates.
 _fail_on_duplicate_route_method_pairs(app, context="module import")

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -7250,8 +7250,12 @@ async def readiness_check(request: Request) -> JSONResponse:
         except _REQUEST_GUARD_EXCEPTIONS:
             pass
         return JSONResponse(body, status_code=(200 if ready else 503))
-    except _READINESS_GUARD_EXCEPTIONS as e:
-        return JSONResponse({"status": "not_ready", "error": str(e)}, status_code=503)
+    except _READINESS_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Readiness check failed: {type(exc).__name__}: {exc}")
+        return JSONResponse(
+            {"status": "not_ready", "reason": "dependency_check_failed"},
+            status_code=503,
+        )
 
 
 # /health/ready alias for some orchestrators (registered conditionally below)

--- a/tldw_Server_API/app/services/app_lifecycle.py
+++ b/tldw_Server_API/app/services/app_lifecycle.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping
+from dataclasses import dataclass
 from typing import Literal
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 _LIFECYCLE_EVENTS_ATTR = "_tldw_lifecycle_events"
+_LIFECYCLE_STATE_ATTR = "_tldw_lifecycle_state"
 _LifecycleEvent = Literal["startup", "shutdown"]
+
+
+@dataclass
+class AppLifecycleState:
+    phase: Literal["starting", "ready", "draining", "stopped"] = "starting"
+    ready: bool = False
+    draining: bool = False
 
 
 def _append_lifecycle_event(app: FastAPI, event: _LifecycleEvent) -> None:
@@ -17,13 +26,60 @@ def _append_lifecycle_event(app: FastAPI, event: _LifecycleEvent) -> None:
     events.append(event)
 
 
-def mark_lifecycle_startup(app: FastAPI, readiness_state: MutableMapping[str, bool]) -> None:
+def get_or_create_lifecycle_state(app: FastAPI) -> AppLifecycleState:
+    state = getattr(app.state, _LIFECYCLE_STATE_ATTR, None)
+    if state is None:
+        state = AppLifecycleState()
+        app.state._tldw_lifecycle_state = state
+    return state
+
+
+def reset_lifecycle_state(app: FastAPI) -> AppLifecycleState:
+    state = AppLifecycleState()
+    app.state._tldw_lifecycle_state = state
+    return state
+
+
+def is_lifecycle_draining(app: FastAPI) -> bool:
+    """Return True when the app is actively draining shutdown traffic."""
+    state = get_or_create_lifecycle_state(app)
+    return state.draining or state.phase == "draining"
+
+
+def assert_may_start_work(app: FastAPI, kind: str) -> None:
+    """Raise a 503 if the app is in draining mode and work should not start."""
+    if is_lifecycle_draining(app):
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Shutdown in progress", "kind": kind},
+        )
+
+
+def mark_lifecycle_startup(
+    app: FastAPI,
+    readiness_state: MutableMapping[str, bool] | None = None,
+) -> AppLifecycleState:
     """Record startup transition and mark readiness true."""
-    readiness_state["ready"] = True
+    state = get_or_create_lifecycle_state(app)
+    state.phase = "ready"
+    state.ready = True
+    state.draining = False
+    if readiness_state is not None:
+        readiness_state["ready"] = True
     _append_lifecycle_event(app, "startup")
+    return state
 
 
-def mark_lifecycle_shutdown(app: FastAPI, readiness_state: MutableMapping[str, bool]) -> None:
+def mark_lifecycle_shutdown(
+    app: FastAPI,
+    readiness_state: MutableMapping[str, bool] | None = None,
+) -> AppLifecycleState:
     """Record shutdown transition and mark readiness false."""
-    readiness_state["ready"] = False
+    state = get_or_create_lifecycle_state(app)
+    state.phase = "draining"
+    state.ready = False
+    state.draining = True
+    if readiness_state is not None:
+        readiness_state["ready"] = False
     _append_lifecycle_event(app, "shutdown")
+    return state

--- a/tldw_Server_API/app/services/shutdown_coordinator.py
+++ b/tldw_Server_API/app/services/shutdown_coordinator.py
@@ -183,13 +183,55 @@ class ShutdownCoordinator:
             return_exceptions=True,
         )
 
-        for outcome in outcomes:
-            if isinstance(outcome, ShutdownComponentSummary):
-                summary.components[outcome.name] = outcome
+        for component, outcome in zip(components, outcomes):
+            component_summary = self._coerce_component_outcome(
+                component,
+                outcome,
+                phase_started_at=phase_started,
+            )
+            summary.components[component_summary.name] = component_summary
 
         phase_finished = float(self._clock())
         phase_summary.finished_at = phase_finished
         phase_summary.duration_ms = max(0, int((phase_finished - phase_started) * 1000))
+
+    def _coerce_component_outcome(
+        self,
+        component: ShutdownComponent,
+        outcome: object,
+        *,
+        phase_started_at: float,
+    ) -> ShutdownComponentSummary:
+        if isinstance(outcome, ShutdownComponentSummary):
+            return outcome
+
+        finished_at = float(self._clock())
+        duration_ms = max(0, int((finished_at - phase_started_at) * 1000))
+        if isinstance(outcome, asyncio.CancelledError):
+            return ShutdownComponentSummary(
+                name=component.name,
+                phase=component.phase,
+                policy=component.policy,
+                result="cancelled",
+                started_at=phase_started_at,
+                finished_at=finished_at,
+                duration_ms=duration_ms,
+                timeout_ms=component.default_timeout_ms,
+                error=str(outcome) or outcome.__class__.__name__,
+            )
+        if isinstance(outcome, Exception):
+            return ShutdownComponentSummary(
+                name=component.name,
+                phase=component.phase,
+                policy=component.policy,
+                result="failed",
+                started_at=phase_started_at,
+                finished_at=finished_at,
+                duration_ms=duration_ms,
+                timeout_ms=component.default_timeout_ms,
+                error=str(outcome) or outcome.__class__.__name__,
+            )
+        raise TypeError(f"Unexpected shutdown component outcome for {component.name!r}: {outcome!r}")
 
     def _phase_budget_ms(
         self,
@@ -289,6 +331,7 @@ class ShutdownCoordinator:
                 finished_at=finished_at,
                 duration_ms=max(0, int((finished_at - started_at) * 1000)),
                 timeout_ms=0,
+                budget_exhausted=True,
             )
 
         if started_at >= summary.hard_cutoff_at:
@@ -303,6 +346,7 @@ class ShutdownCoordinator:
                 finished_at=finished_at,
                 duration_ms=0,
                 timeout_ms=timeout_ms,
+                budget_exhausted=True,
             )
 
         if timeout_ms <= 0:
@@ -316,6 +360,7 @@ class ShutdownCoordinator:
                 finished_at=started_at,
                 duration_ms=0,
                 timeout_ms=timeout_ms,
+                budget_exhausted=True,
             )
 
         stop_task = asyncio.create_task(self._invoke_stop(component, timeout_ms=timeout_ms))
@@ -330,6 +375,18 @@ class ShutdownCoordinator:
             await self._wait_for_task_quiescence(stop_task, deadline_at=summary.hard_cutoff_at)
             finished_at = float(self._clock())
             result = "timed_out" if finished_at < summary.hard_cutoff_at else "cancelled"
+            error: str | None = None
+            if stop_task.done():
+                if stop_task.cancelled():
+                    result = "cancelled"
+                else:
+                    try:
+                        stop_task.result()
+                    except Exception as exc:
+                        result = "failed"
+                        error = str(exc) or exc.__class__.__name__
+                    else:
+                        result = "stopped"
             return ShutdownComponentSummary(
                 name=component.name,
                 phase=component.phase,
@@ -339,6 +396,8 @@ class ShutdownCoordinator:
                 finished_at=finished_at,
                 duration_ms=max(0, int((finished_at - started_at) * 1000)),
                 timeout_ms=timeout_ms,
+                error=error,
+                budget_exhausted=True,
             )
         except asyncio.CancelledError:
             stop_task.cancel()

--- a/tldw_Server_API/app/services/shutdown_coordinator.py
+++ b/tldw_Server_API/app/services/shutdown_coordinator.py
@@ -321,6 +321,8 @@ class ShutdownCoordinator:
         stop_task.add_done_callback(self._consume_stop_task_result)
 
         try:
+            # Keep the stop task shielded so wait_for() can time out promptly even if
+            # the underlying stop path swallows CancelledError during hard cutoff.
             await asyncio.wait_for(asyncio.shield(stop_task), timeout=timeout_ms / 1000.0)
         except TimeoutError:
             stop_task.cancel()

--- a/tldw_Server_API/app/services/shutdown_coordinator.py
+++ b/tldw_Server_API/app/services/shutdown_coordinator.py
@@ -387,7 +387,13 @@ class ShutdownCoordinator:
 
     @staticmethod
     async def _invoke_stop(component: ShutdownComponent) -> None:
-        outcome = component.stop()
+        stop_callable = component.stop
+        if inspect.iscoroutinefunction(stop_callable) or inspect.iscoroutinefunction(
+            getattr(stop_callable, "__call__", None)
+        ):
+            outcome = stop_callable()
+        else:
+            outcome = await asyncio.to_thread(stop_callable)
         if inspect.isawaitable(outcome):
             await outcome
 

--- a/tldw_Server_API/app/services/shutdown_coordinator.py
+++ b/tldw_Server_API/app/services/shutdown_coordinator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from copy import deepcopy
 import inspect
 from collections import OrderedDict
@@ -317,7 +318,7 @@ class ShutdownCoordinator:
                 timeout_ms=timeout_ms,
             )
 
-        stop_task = asyncio.create_task(self._invoke_stop(component))
+        stop_task = asyncio.create_task(self._invoke_stop(component, timeout_ms=timeout_ms))
         stop_task.add_done_callback(self._consume_stop_task_result)
 
         try:
@@ -326,6 +327,7 @@ class ShutdownCoordinator:
             await asyncio.wait_for(asyncio.shield(stop_task), timeout=timeout_ms / 1000.0)
         except TimeoutError:
             stop_task.cancel()
+            await self._wait_for_task_quiescence(stop_task, deadline_at=summary.hard_cutoff_at)
             finished_at = float(self._clock())
             result = "timed_out" if finished_at < summary.hard_cutoff_at else "cancelled"
             return ShutdownComponentSummary(
@@ -388,16 +390,35 @@ class ShutdownCoordinator:
         return max(0, int((window_end - started_at) * 1000))
 
     @staticmethod
-    async def _invoke_stop(component: ShutdownComponent) -> None:
+    async def _invoke_stop(component: ShutdownComponent, *, timeout_ms: int) -> None:
         stop_callable = component.stop
+        accepts_timeout = ShutdownCoordinator._stop_accepts_timeout(stop_callable)
         if inspect.iscoroutinefunction(stop_callable) or inspect.iscoroutinefunction(
             getattr(stop_callable, "__call__", None)
         ):
-            outcome = stop_callable()
+            outcome = stop_callable(timeout_ms) if accepts_timeout else stop_callable()
         else:
-            outcome = await asyncio.to_thread(stop_callable)
+            if accepts_timeout:
+                outcome = await asyncio.to_thread(stop_callable, timeout_ms)
+            else:
+                outcome = await asyncio.to_thread(stop_callable)
         if inspect.isawaitable(outcome):
             await outcome
+
+    @staticmethod
+    def _stop_accepts_timeout(stop_callable: Callable[..., object]) -> bool:
+        try:
+            signature = inspect.signature(stop_callable)
+        except (TypeError, ValueError):
+            return False
+        return bool(signature.parameters)
+
+    async def _wait_for_task_quiescence(self, task: asyncio.Task[None], *, deadline_at: float) -> None:
+        remaining_s = max(0.0, deadline_at - float(self._clock()))
+        if remaining_s <= 0:
+            return
+        with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), timeout=remaining_s)
 
     @staticmethod
     def _consume_stop_task_result(task: asyncio.Task[None]) -> None:

--- a/tldw_Server_API/app/services/shutdown_coordinator.py
+++ b/tldw_Server_API/app/services/shutdown_coordinator.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+import inspect
+from collections import OrderedDict
+import threading
+import time
+from dataclasses import dataclass, replace
+from typing import Callable
+
+from tldw_Server_API.app.services.shutdown_models import (
+    ShutdownComponent,
+    ShutdownComponentSummary,
+    ShutdownPhase,
+    ShutdownPhaseSummary,
+    ShutdownPolicy,
+    ShutdownResult,
+    ShutdownSummary,
+)
+
+ORDERED_PHASES: tuple[ShutdownPhase, ...] = (
+    ShutdownPhase.TRANSITION,
+    ShutdownPhase.ACCEPTORS,
+    ShutdownPhase.PRODUCERS,
+    ShutdownPhase.WORKERS,
+    ShutdownPhase.RESOURCES,
+    ShutdownPhase.FINALIZERS,
+)
+
+
+@dataclass(slots=True)
+class _ShutdownProfile:
+    deadline_ms: int
+    soft_overrun_ms: int
+
+
+_PROFILE_DEFAULTS: dict[str, _ShutdownProfile] = {
+    "dev_fast": _ShutdownProfile(deadline_ms=5000, soft_overrun_ms=0),
+    "prod_drain": _ShutdownProfile(deadline_ms=15000, soft_overrun_ms=2000),
+}
+
+
+class ShutdownCoordinator:
+    def __init__(
+        self,
+        profile: str = "dev_fast",
+        *,
+        clock: Callable[[], float] | None = None,
+        deadline_ms: int | None = None,
+        soft_overrun_ms: int | None = None,
+    ) -> None:
+        if profile not in _PROFILE_DEFAULTS and profile != "custom":
+            raise ValueError(f"Unknown shutdown profile: {profile!r}")
+
+        config = _PROFILE_DEFAULTS.get(profile, _PROFILE_DEFAULTS["dev_fast"])
+        self.profile = profile
+        self._clock = clock or time.monotonic
+        self._deadline_ms = config.deadline_ms if deadline_ms is None else max(0, int(deadline_ms))
+        self._soft_overrun_ms = (
+            config.soft_overrun_ms if soft_overrun_ms is None else max(0, int(soft_overrun_ms))
+        )
+        self._components: OrderedDict[str, ShutdownComponent] = OrderedDict()
+        self._summary: ShutdownSummary | None = None
+        self._shutdown_task: asyncio.Task[ShutdownSummary] | None = None
+        self._state_lock = threading.Lock()
+        self._registration_closed = False
+        self._draining = False
+
+    def register(self, component: ShutdownComponent) -> ShutdownComponent:
+        with self._state_lock:
+            if self._registration_closed or self._summary is not None or self._shutdown_task is not None:
+                raise RuntimeError("Shutdown registration is closed")
+            if component.name in self._components:
+                raise ValueError(f"Shutdown component already registered: {component.name!r}")
+            self._components[component.name] = component
+        return component
+
+    async def shutdown(self) -> ShutdownSummary:
+        with self._state_lock:
+            if self._summary is not None:
+                return self._clone_summary(self._summary, idempotent=True)
+            task = self._shutdown_task
+            created_task = task is None
+            if task is None:
+                self._registration_closed = True
+                task = asyncio.create_task(self._shutdown_impl())
+                task.add_done_callback(self._clear_shutdown_task)
+                self._shutdown_task = task
+
+        summary = await asyncio.shield(task)
+        if created_task:
+            return self._clone_summary(summary, idempotent=False)
+        return self._clone_summary(summary, idempotent=True)
+
+    def _clear_shutdown_task(self, task: asyncio.Task[ShutdownSummary]) -> None:
+        with self._state_lock:
+            if self._shutdown_task is task:
+                self._shutdown_task = None
+
+    @staticmethod
+    def _clone_summary(summary: ShutdownSummary, *, idempotent: bool) -> ShutdownSummary:
+        return replace(
+            summary,
+            idempotent=idempotent,
+            components=deepcopy(summary.components),
+            phases=deepcopy(summary.phases),
+        )
+
+    async def _shutdown_impl(self) -> ShutdownSummary:
+        if self._summary is not None:
+            return self._summary
+
+        started_at = float(self._clock())
+        deadline_at = started_at + (self._deadline_ms / 1000.0)
+        hard_cutoff_at = deadline_at + (self._soft_overrun_ms / 1000.0)
+        summary = ShutdownSummary(
+            profile=self.profile,
+            started_at=started_at,
+            finished_at=started_at,
+            deadline_at=deadline_at,
+            hard_cutoff_at=hard_cutoff_at,
+            wall_time_ms=0,
+            soft_overrun_used_ms=0,
+        )
+        components_snapshot = OrderedDict(self._components)
+
+        self._draining = True
+        try:
+            await self._run_phase(ShutdownPhase.TRANSITION, summary, components_snapshot)
+
+            for phase in ORDERED_PHASES[1:]:
+                await self._run_phase(phase, summary, components_snapshot)
+
+            finished_at = float(self._clock())
+            summary.finished_at = finished_at
+            summary.wall_time_ms = max(0, int((finished_at - started_at) * 1000))
+            summary.soft_overrun_used_ms = max(
+                0,
+                min(
+                    self._soft_overrun_ms,
+                    int(max(0.0, (finished_at - deadline_at) * 1000)),
+                ),
+            )
+
+            self._summary = summary
+            return summary
+        finally:
+            self._draining = False
+
+    async def _run_phase(
+        self,
+        phase: ShutdownPhase,
+        summary: ShutdownSummary,
+        components_snapshot: OrderedDict[str, ShutdownComponent],
+    ) -> None:
+        components = [component for component in components_snapshot.values() if component.phase == phase]
+        phase_started = float(self._clock())
+        phase_budget_ms = self._phase_budget_ms(
+            summary,
+            current_phase=phase,
+            components_snapshot=components_snapshot,
+        )
+        phase_summary = ShutdownPhaseSummary(
+            phase=phase,
+            started_at=phase_started,
+            finished_at=phase_started,
+            duration_ms=0,
+            budget_ms=phase_budget_ms,
+            component_names=[component.name for component in components],
+        )
+        summary.phases[phase] = phase_summary
+
+        if not components:
+            return
+
+        outcomes = await asyncio.gather(
+            *(
+                self._run_component(component, phase_budget_ms=phase_budget_ms, summary=summary)
+                for component in components
+            ),
+            return_exceptions=True,
+        )
+
+        for outcome in outcomes:
+            if isinstance(outcome, ShutdownComponentSummary):
+                summary.components[outcome.name] = outcome
+
+        phase_finished = float(self._clock())
+        phase_summary.finished_at = phase_finished
+        phase_summary.duration_ms = max(0, int((phase_finished - phase_started) * 1000))
+
+    def _phase_budget_ms(
+        self,
+        summary: ShutdownSummary,
+        *,
+        current_phase: ShutdownPhase,
+        components_snapshot: OrderedDict[str, ShutdownComponent],
+    ) -> int:
+        now = float(self._clock())
+        try:
+            phase_index = ORDERED_PHASES.index(current_phase)
+        except ValueError:
+            return 0
+
+        runnable_phases = self._remaining_runnable_phase_count(
+            current_phase=current_phase,
+            components_snapshot=components_snapshot,
+        )
+        if runnable_phases <= 0:
+            return 0
+
+        window_end = summary.deadline_at
+        if (
+            self._phase_allows_soft_overrun(current_phase)
+            and self._soft_overrun_ms > 0
+            and any(
+                self._component_allows_soft_overrun(component)
+                for component in components_snapshot.values()
+                if component.phase == current_phase
+            )
+        ):
+            window_end = summary.hard_cutoff_at
+        remaining_ms = max(0, int((window_end - now) * 1000))
+        if remaining_ms <= 0:
+            return 0
+        return max(1, remaining_ms // runnable_phases)
+
+    def _remaining_runnable_phase_count(
+        self,
+        *,
+        current_phase: ShutdownPhase,
+        components_snapshot: OrderedDict[str, ShutdownComponent],
+    ) -> int:
+        current_index = ORDERED_PHASES.index(current_phase)
+        runnable_phases = 0
+        for phase in ORDERED_PHASES[current_index:]:
+            phase_components = [component for component in components_snapshot.values() if component.phase == phase]
+            if not phase_components:
+                continue
+            if phase == current_phase or any(
+                component.policy != ShutdownPolicy.BEST_EFFORT for component in phase_components
+            ):
+                runnable_phases += 1
+        return runnable_phases
+
+    def _phase_allows_soft_overrun(self, phase: ShutdownPhase) -> bool:
+        return phase in {
+            ShutdownPhase.WORKERS,
+            ShutdownPhase.RESOURCES,
+            ShutdownPhase.FINALIZERS,
+        }
+
+    def _component_allows_soft_overrun(self, component: ShutdownComponent) -> bool:
+        return (
+            self.profile in {"prod_drain", "custom"}
+            and component.policy == ShutdownPolicy.PROD_DRAIN
+            and self._phase_allows_soft_overrun(component.phase)
+        )
+
+    async def _run_component(
+        self,
+        component: ShutdownComponent,
+        *,
+        phase_budget_ms: int,
+        summary: ShutdownSummary,
+    ) -> ShutdownComponentSummary:
+        started_at = float(self._clock())
+        is_best_effort = component.policy == ShutdownPolicy.BEST_EFFORT
+
+        timeout_ms = max(
+            0,
+            min(
+                component.default_timeout_ms,
+                phase_budget_ms,
+                self._component_budget_ms(component, summary, started_at),
+            ),
+        )
+
+        if is_best_effort and timeout_ms <= 0:
+            finished_at = float(self._clock())
+            return ShutdownComponentSummary(
+                name=component.name,
+                phase=component.phase,
+                policy=component.policy,
+                result="skipped",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_ms=max(0, int((finished_at - started_at) * 1000)),
+                timeout_ms=0,
+            )
+
+        if started_at >= summary.hard_cutoff_at:
+            result: ShutdownResult = "cancelled"
+            finished_at = started_at
+            return ShutdownComponentSummary(
+                name=component.name,
+                phase=component.phase,
+                policy=component.policy,
+                result=result,
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_ms=0,
+                timeout_ms=timeout_ms,
+            )
+
+        if timeout_ms <= 0:
+            result = "cancelled"
+            return ShutdownComponentSummary(
+                name=component.name,
+                phase=component.phase,
+                policy=component.policy,
+                result=result,
+                started_at=started_at,
+                finished_at=started_at,
+                duration_ms=0,
+                timeout_ms=timeout_ms,
+            )
+
+        stop_task = asyncio.create_task(self._invoke_stop(component))
+        stop_task.add_done_callback(self._consume_stop_task_result)
+
+        try:
+            await asyncio.wait_for(asyncio.shield(stop_task), timeout=timeout_ms / 1000.0)
+        except TimeoutError:
+            stop_task.cancel()
+            finished_at = float(self._clock())
+            result = "timed_out" if finished_at < summary.hard_cutoff_at else "cancelled"
+            return ShutdownComponentSummary(
+                name=component.name,
+                phase=component.phase,
+                policy=component.policy,
+                result=result,
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_ms=max(0, int((finished_at - started_at) * 1000)),
+                timeout_ms=timeout_ms,
+            )
+        except asyncio.CancelledError:
+            stop_task.cancel()
+            finished_at = float(self._clock())
+            return ShutdownComponentSummary(
+                name=component.name,
+                phase=component.phase,
+                policy=component.policy,
+                result="cancelled",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_ms=max(0, int((finished_at - started_at) * 1000)),
+                timeout_ms=timeout_ms,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            stop_task.cancel()
+            finished_at = float(self._clock())
+            return ShutdownComponentSummary(
+                name=component.name,
+                phase=component.phase,
+                policy=component.policy,
+                result="failed",
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_ms=max(0, int((finished_at - started_at) * 1000)),
+                timeout_ms=timeout_ms,
+                error=str(exc),
+            )
+
+        finished_at = float(self._clock())
+        return ShutdownComponentSummary(
+            name=component.name,
+            phase=component.phase,
+            policy=component.policy,
+            result="stopped",
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_ms=max(0, int((finished_at - started_at) * 1000)),
+            timeout_ms=timeout_ms,
+        )
+
+    def _component_budget_ms(
+        self,
+        component: ShutdownComponent,
+        summary: ShutdownSummary,
+        started_at: float,
+    ) -> int:
+        window_end = summary.hard_cutoff_at if self._component_allows_soft_overrun(component) else summary.deadline_at
+        return max(0, int((window_end - started_at) * 1000))
+
+    @staticmethod
+    async def _invoke_stop(component: ShutdownComponent) -> None:
+        outcome = component.stop()
+        if inspect.isawaitable(outcome):
+            await outcome
+
+    @staticmethod
+    def _consume_stop_task_result(task: asyncio.Task[None]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            return

--- a/tldw_Server_API/app/services/shutdown_legacy_adapters.py
+++ b/tldw_Server_API/app/services/shutdown_legacy_adapters.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping, MutableMapping
+from collections.abc import Awaitable, Callable, MutableMapping
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -18,13 +18,24 @@ StopCallable = Callable[[], Awaitable[None] | None]
 
 
 @dataclass(frozen=True, slots=True)
+class LegacyShutdownContext:
+    readiness_state: MutableMapping[str, Any] | None = None
+    usage_task: Any = None
+    llm_usage_task: Any = None
+    authnz_scheduler_started: bool = False
+    chatbooks_cleanup_task: Any = None
+    chatbooks_cleanup_stop_event: Any = None
+    storage_cleanup_service: Any = None
+
+
+@dataclass(frozen=True, slots=True)
 class _LegacyShutdownSpec:
     name: str
     phase: ShutdownPhase
     policy: ShutdownPolicy
     default_timeout_ms: int
-    enabled: Callable[[Mapping[str, Any]], bool]
-    stop: Callable[[Any, Mapping[str, Any]], StopCallable]
+    enabled: Callable[[LegacyShutdownContext], bool]
+    stop: Callable[[Any, LegacyShutdownContext], StopCallable]
 
 
 def _plan_visibility(plan: list[ShutdownComponent]) -> dict[str, Any]:
@@ -107,12 +118,12 @@ def get_legacy_shutdown_suppressed_component_names(
     }
 
 
-def _transition_enabled(_: Mapping[str, Any]) -> bool:
+def _transition_enabled(_: LegacyShutdownContext) -> bool:
     return True
 
 
-def _transition_stop(app: Any, locals_map: Mapping[str, Any]) -> StopCallable:
-    readiness_state = locals_map.get("READINESS_STATE")
+def _transition_stop(app: Any, context: LegacyShutdownContext) -> StopCallable:
+    readiness_state = context.readiness_state
 
     async def _stop() -> None:
         from tldw_Server_API.app.core.Jobs.manager import JobManager as _JobManager
@@ -126,12 +137,12 @@ def _transition_stop(app: Any, locals_map: Mapping[str, Any]) -> StopCallable:
     return _stop
 
 
-def _usage_enabled(locals_map: Mapping[str, Any]) -> bool:
-    return locals_map.get("usage_task") is not None
+def _usage_enabled(context: LegacyShutdownContext) -> bool:
+    return context.usage_task is not None
 
 
-def _usage_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
-    usage_task = locals_map.get("usage_task")
+def _usage_stop(_: Any, context: LegacyShutdownContext) -> StopCallable:
+    usage_task = context.usage_task
 
     async def _stop() -> None:
         if usage_task is not None:
@@ -142,12 +153,12 @@ def _usage_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
     return _stop
 
 
-def _llm_usage_enabled(locals_map: Mapping[str, Any]) -> bool:
-    return locals_map.get("llm_usage_task") is not None
+def _llm_usage_enabled(context: LegacyShutdownContext) -> bool:
+    return context.llm_usage_task is not None
 
 
-def _llm_usage_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
-    llm_usage_task = locals_map.get("llm_usage_task")
+def _llm_usage_stop(_: Any, context: LegacyShutdownContext) -> StopCallable:
+    llm_usage_task = context.llm_usage_task
 
     async def _stop() -> None:
         if llm_usage_task is not None:
@@ -158,11 +169,11 @@ def _llm_usage_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
     return _stop
 
 
-def _authnz_enabled(locals_map: Mapping[str, Any]) -> bool:
-    return bool(locals_map.get("_authnz_sched_started"))
+def _authnz_enabled(context: LegacyShutdownContext) -> bool:
+    return bool(context.authnz_scheduler_started)
 
 
-def _authnz_stop(_: Any, __: Mapping[str, Any]) -> StopCallable:
+def _authnz_stop(_: Any, __: LegacyShutdownContext) -> StopCallable:
     async def _stop() -> None:
         from tldw_Server_API.app.core.AuthNZ.scheduler import stop_authnz_scheduler
 
@@ -171,15 +182,13 @@ def _authnz_stop(_: Any, __: Mapping[str, Any]) -> StopCallable:
     return _stop
 
 
-def _chatbooks_enabled(locals_map: Mapping[str, Any]) -> bool:
-    return locals_map.get("chatbooks_cleanup_task") is not None or locals_map.get(
-        "chatbooks_cleanup_stop_event"
-    ) is not None
+def _chatbooks_enabled(context: LegacyShutdownContext) -> bool:
+    return context.chatbooks_cleanup_task is not None or context.chatbooks_cleanup_stop_event is not None
 
 
-def _chatbooks_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
-    stop_event = locals_map.get("chatbooks_cleanup_stop_event")
-    task = locals_map.get("chatbooks_cleanup_task")
+def _chatbooks_stop(_: Any, context: LegacyShutdownContext) -> StopCallable:
+    stop_event = context.chatbooks_cleanup_stop_event
+    task = context.chatbooks_cleanup_task
 
     async def _stop() -> None:
         if stop_event is not None:
@@ -190,12 +199,12 @@ def _chatbooks_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
     return _stop
 
 
-def _storage_enabled(locals_map: Mapping[str, Any]) -> bool:
-    return locals_map.get("storage_cleanup_service") is not None
+def _storage_enabled(context: LegacyShutdownContext) -> bool:
+    return context.storage_cleanup_service is not None
 
 
-def _storage_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
-    storage_cleanup_service = locals_map.get("storage_cleanup_service")
+def _storage_stop(_: Any, context: LegacyShutdownContext) -> StopCallable:
+    storage_cleanup_service = context.storage_cleanup_service
 
     async def _stop() -> None:
         if storage_cleanup_service is not None:
@@ -256,11 +265,15 @@ _LEGACY_SHUTDOWN_SPECS: tuple[_LegacyShutdownSpec, ...] = (
 )
 
 
-def build_legacy_shutdown_plan(app: Any, locals_map: Mapping[str, Any]) -> list[ShutdownComponent]:
+def build_legacy_shutdown_plan(
+    app: Any,
+    context: LegacyShutdownContext | None = None,
+) -> list[ShutdownComponent]:
     """Build the legacy shutdown inventory without changing the teardown order yet."""
+    shutdown_context = context or LegacyShutdownContext()
     plan: list[ShutdownComponent] = []
     for spec in _LEGACY_SHUTDOWN_SPECS:
-        if not spec.enabled(locals_map):
+        if not spec.enabled(shutdown_context):
             continue
         plan.append(
             ShutdownComponent(
@@ -268,7 +281,7 @@ def build_legacy_shutdown_plan(app: Any, locals_map: Mapping[str, Any]) -> list[
                 phase=spec.phase,
                 policy=spec.policy,
                 default_timeout_ms=spec.default_timeout_ms,
-                stop=spec.stop(app, locals_map),
+                stop=spec.stop(app, shutdown_context),
             )
         )
 

--- a/tldw_Server_API/app/services/shutdown_legacy_adapters.py
+++ b/tldw_Server_API/app/services/shutdown_legacy_adapters.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, MutableMapping
+from collections.abc import Awaitable, Callable, Mapping, MutableMapping
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -87,6 +87,8 @@ def register_legacy_shutdown_components(
         phase = overrides.get(component_name)
         if phase is not None:
             component = replace(component, phase=phase)
+        if component.phase == ShutdownPhase.TRANSITION:
+            continue
         coordinator.register(component)
         registered_components.append(component)
 

--- a/tldw_Server_API/app/services/shutdown_legacy_adapters.py
+++ b/tldw_Server_API/app/services/shutdown_legacy_adapters.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, MutableMapping
+from dataclasses import dataclass, replace
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.services.app_lifecycle import mark_lifecycle_shutdown
+from tldw_Server_API.app.services.shutdown_models import (
+    ShutdownComponent,
+    ShutdownPhase,
+    ShutdownPolicy,
+    ShutdownSummary,
+)
+
+StopCallable = Callable[[], Awaitable[None] | None]
+
+
+@dataclass(frozen=True, slots=True)
+class _LegacyShutdownSpec:
+    name: str
+    phase: ShutdownPhase
+    policy: ShutdownPolicy
+    default_timeout_ms: int
+    enabled: Callable[[Mapping[str, Any]], bool]
+    stop: Callable[[Any, Mapping[str, Any]], StopCallable]
+
+
+def _plan_visibility(plan: list[ShutdownComponent]) -> dict[str, Any]:
+    phase_groups: dict[str, list[str]] = {}
+    for component in plan:
+        phase_groups.setdefault(component.phase.value, []).append(component.name)
+    return {
+        "visible": bool(plan),
+        "component_names": [component.name for component in plan],
+        "phase_groups": phase_groups,
+    }
+
+
+def _store_legacy_inventory(app: Any, plan: list[ShutdownComponent]) -> None:
+    state = getattr(app, "state", None)
+    if state is None:
+        return
+    inventory = _plan_visibility(plan)
+    try:
+        state._tldw_shutdown_legacy_plan = plan
+        state._tldw_shutdown_legacy_inventory = inventory
+        state._tldw_shutdown_legacy_phase_groups = inventory["phase_groups"]
+        state._tldw_shutdown_legacy_inventory_visible = inventory["visible"]
+    except Exception as exc:  # pragma: no cover - defensive logging only
+        logger.debug(f"Legacy shutdown inventory storage skipped: {exc}")
+
+
+def register_legacy_shutdown_components(
+    coordinator: Any,
+    plan: list[ShutdownComponent],
+    *,
+    component_names: tuple[str, ...] = (
+        "chatbooks_cleanup",
+        "usage_aggregator",
+        "llm_usage_aggregator",
+        "storage_cleanup_service",
+    ),
+    phase_overrides: Mapping[str, ShutdownPhase | str] | None = None,
+) -> list[ShutdownComponent]:
+    """Register the selected legacy shutdown components with a coordinator."""
+    selected_components = {component.name: component for component in plan}
+    overrides = phase_overrides or {}
+    registered_components: list[ShutdownComponent] = []
+
+    for component_name in component_names:
+        component = selected_components.get(component_name)
+        if component is None:
+            continue
+        phase = overrides.get(component_name)
+        if phase is not None:
+            component = replace(component, phase=phase)
+        coordinator.register(component)
+        registered_components.append(component)
+
+    return registered_components
+
+
+_COORDINATED_DIRECT_STOP_RESULTS = {"stopped"}
+
+
+def get_legacy_shutdown_suppressed_component_names(
+    summary: ShutdownSummary | None,
+) -> set[str]:
+    """Return migrated legacy components that own the direct stop path.
+
+    Only coordinator outcomes that actually completed the component (`stopped`)
+    suppress the old direct teardown. Best-effort `skipped` results mean the
+    coordinator never invoked the stop callable because budget was exhausted,
+    so the legacy direct stop path must remain enabled as fallback. Failed,
+    timed out, and cancelled results also leave the legacy direct stop path
+    enabled so shutdown can still fall back to the original behavior.
+    """
+    if summary is None:
+        return set()
+
+    return {
+        name
+        for name, component_summary in summary.components.items()
+        if component_summary.result in _COORDINATED_DIRECT_STOP_RESULTS
+    }
+
+
+def _transition_enabled(_: Mapping[str, Any]) -> bool:
+    return True
+
+
+def _transition_stop(app: Any, locals_map: Mapping[str, Any]) -> StopCallable:
+    readiness_state = locals_map.get("READINESS_STATE")
+
+    async def _stop() -> None:
+        from tldw_Server_API.app.core.Jobs.manager import JobManager as _JobManager
+
+        mark_lifecycle_shutdown(
+            app,
+            readiness_state if isinstance(readiness_state, MutableMapping) else None,
+        )
+        _JobManager.set_acquire_gate(True)
+
+    return _stop
+
+
+def _usage_enabled(locals_map: Mapping[str, Any]) -> bool:
+    return locals_map.get("usage_task") is not None
+
+
+def _usage_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
+    usage_task = locals_map.get("usage_task")
+
+    async def _stop() -> None:
+        if usage_task is not None:
+            from tldw_Server_API.app.services.usage_aggregator import stop_usage_aggregator
+
+            await stop_usage_aggregator(usage_task)
+
+    return _stop
+
+
+def _llm_usage_enabled(locals_map: Mapping[str, Any]) -> bool:
+    return locals_map.get("llm_usage_task") is not None
+
+
+def _llm_usage_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
+    llm_usage_task = locals_map.get("llm_usage_task")
+
+    async def _stop() -> None:
+        if llm_usage_task is not None:
+            from tldw_Server_API.app.services.llm_usage_aggregator import stop_llm_usage_aggregator
+
+            await stop_llm_usage_aggregator(llm_usage_task)
+
+    return _stop
+
+
+def _authnz_enabled(locals_map: Mapping[str, Any]) -> bool:
+    return bool(locals_map.get("_authnz_sched_started"))
+
+
+def _authnz_stop(_: Any, __: Mapping[str, Any]) -> StopCallable:
+    async def _stop() -> None:
+        from tldw_Server_API.app.core.AuthNZ.scheduler import stop_authnz_scheduler
+
+        await stop_authnz_scheduler()
+
+    return _stop
+
+
+def _chatbooks_enabled(locals_map: Mapping[str, Any]) -> bool:
+    return locals_map.get("chatbooks_cleanup_task") is not None or locals_map.get(
+        "chatbooks_cleanup_stop_event"
+    ) is not None
+
+
+def _chatbooks_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
+    stop_event = locals_map.get("chatbooks_cleanup_stop_event")
+    task = locals_map.get("chatbooks_cleanup_task")
+
+    async def _stop() -> None:
+        if stop_event is not None:
+            stop_event.set()
+        if task is not None:
+            task.cancel()
+
+    return _stop
+
+
+def _storage_enabled(locals_map: Mapping[str, Any]) -> bool:
+    return locals_map.get("storage_cleanup_service") is not None
+
+
+def _storage_stop(_: Any, locals_map: Mapping[str, Any]) -> StopCallable:
+    storage_cleanup_service = locals_map.get("storage_cleanup_service")
+
+    async def _stop() -> None:
+        if storage_cleanup_service is not None:
+            await storage_cleanup_service.stop()
+
+    return _stop
+
+
+_LEGACY_SHUTDOWN_SPECS: tuple[_LegacyShutdownSpec, ...] = (
+    _LegacyShutdownSpec(
+        name="lifecycle_gate",
+        phase=ShutdownPhase.TRANSITION,
+        policy=ShutdownPolicy.DEV_FAST,
+        default_timeout_ms=1000,
+        enabled=_transition_enabled,
+        stop=_transition_stop,
+    ),
+    _LegacyShutdownSpec(
+        name="chatbooks_cleanup",
+        phase=ShutdownPhase.WORKERS,
+        policy=ShutdownPolicy.PROD_DRAIN,
+        default_timeout_ms=5000,
+        enabled=_chatbooks_enabled,
+        stop=_chatbooks_stop,
+    ),
+    _LegacyShutdownSpec(
+        name="usage_aggregator",
+        phase=ShutdownPhase.RESOURCES,
+        policy=ShutdownPolicy.BEST_EFFORT,
+        default_timeout_ms=1000,
+        enabled=_usage_enabled,
+        stop=_usage_stop,
+    ),
+    _LegacyShutdownSpec(
+        name="llm_usage_aggregator",
+        phase=ShutdownPhase.RESOURCES,
+        policy=ShutdownPolicy.BEST_EFFORT,
+        default_timeout_ms=1000,
+        enabled=_llm_usage_enabled,
+        stop=_llm_usage_stop,
+    ),
+    _LegacyShutdownSpec(
+        name="storage_cleanup_service",
+        phase=ShutdownPhase.FINALIZERS,
+        policy=ShutdownPolicy.PROD_DRAIN,
+        default_timeout_ms=5000,
+        enabled=_storage_enabled,
+        stop=_storage_stop,
+    ),
+    _LegacyShutdownSpec(
+        name="authnz_scheduler",
+        phase=ShutdownPhase.FINALIZERS,
+        policy=ShutdownPolicy.PROD_DRAIN,
+        default_timeout_ms=5000,
+        enabled=_authnz_enabled,
+        stop=_authnz_stop,
+    ),
+)
+
+
+def build_legacy_shutdown_plan(app: Any, locals_map: Mapping[str, Any]) -> list[ShutdownComponent]:
+    """Build the legacy shutdown inventory without changing the teardown order yet."""
+    plan: list[ShutdownComponent] = []
+    for spec in _LEGACY_SHUTDOWN_SPECS:
+        if not spec.enabled(locals_map):
+            continue
+        plan.append(
+            ShutdownComponent(
+                name=spec.name,
+                phase=spec.phase,
+                policy=spec.policy,
+                default_timeout_ms=spec.default_timeout_ms,
+                stop=spec.stop(app, locals_map),
+            )
+        )
+
+    _store_legacy_inventory(app, plan)
+    return plan

--- a/tldw_Server_API/app/services/shutdown_models.py
+++ b/tldw_Server_API/app/services/shutdown_models.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import StrEnum
+from enum import Enum
 from typing import Awaitable, Callable, Literal
 
 
-class ShutdownPhase(StrEnum):
+class ShutdownPhase(str, Enum):
     TRANSITION = "transition"
     ACCEPTORS = "acceptors"
     PRODUCERS = "producers"
@@ -14,7 +14,7 @@ class ShutdownPhase(StrEnum):
     FINALIZERS = "finalizers"
 
 
-class ShutdownPolicy(StrEnum):
+class ShutdownPolicy(str, Enum):
     DEV_FAST = "dev_fast"
     PROD_DRAIN = "prod_drain"
     BEST_EFFORT = "best_effort"

--- a/tldw_Server_API/app/services/shutdown_models.py
+++ b/tldw_Server_API/app/services/shutdown_models.py
@@ -54,6 +54,7 @@ class ShutdownComponentSummary:
     duration_ms: int
     timeout_ms: int
     error: str | None = None
+    budget_exhausted: bool = False
 
 
 @dataclass(slots=True)

--- a/tldw_Server_API/app/services/shutdown_models.py
+++ b/tldw_Server_API/app/services/shutdown_models.py
@@ -21,6 +21,10 @@ class ShutdownPolicy(str, Enum):
 
 
 ShutdownResult = Literal["stopped", "timed_out", "cancelled", "skipped", "failed"]
+ShutdownStopCallable = (
+    Callable[[], Awaitable[None] | None]
+    | Callable[[int | None], Awaitable[None] | None]
+)
 
 
 @dataclass(slots=True)
@@ -29,7 +33,7 @@ class ShutdownComponent:
     phase: ShutdownPhase | str
     policy: ShutdownPolicy | str
     default_timeout_ms: int
-    stop: Callable[[], Awaitable[None] | None]
+    stop: ShutdownStopCallable
 
     def __post_init__(self) -> None:
         if not isinstance(self.phase, ShutdownPhase):

--- a/tldw_Server_API/app/services/shutdown_models.py
+++ b/tldw_Server_API/app/services/shutdown_models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Awaitable, Callable, Literal
+
+
+class ShutdownPhase(StrEnum):
+    TRANSITION = "transition"
+    ACCEPTORS = "acceptors"
+    PRODUCERS = "producers"
+    WORKERS = "workers"
+    RESOURCES = "resources"
+    FINALIZERS = "finalizers"
+
+
+class ShutdownPolicy(StrEnum):
+    DEV_FAST = "dev_fast"
+    PROD_DRAIN = "prod_drain"
+    BEST_EFFORT = "best_effort"
+
+
+ShutdownResult = Literal["stopped", "timed_out", "cancelled", "skipped", "failed"]
+
+
+@dataclass(slots=True)
+class ShutdownComponent:
+    name: str
+    phase: ShutdownPhase | str
+    policy: ShutdownPolicy | str
+    default_timeout_ms: int
+    stop: Callable[[], Awaitable[None] | None]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.phase, ShutdownPhase):
+            self.phase = ShutdownPhase(str(self.phase))
+        if not isinstance(self.policy, ShutdownPolicy):
+            self.policy = ShutdownPolicy(str(self.policy))
+        self.default_timeout_ms = max(0, int(self.default_timeout_ms))
+
+
+@dataclass(slots=True)
+class ShutdownComponentSummary:
+    name: str
+    phase: ShutdownPhase
+    policy: ShutdownPolicy
+    result: ShutdownResult
+    started_at: float
+    finished_at: float
+    duration_ms: int
+    timeout_ms: int
+    error: str | None = None
+
+
+@dataclass(slots=True)
+class ShutdownPhaseSummary:
+    phase: ShutdownPhase
+    started_at: float
+    finished_at: float
+    duration_ms: int
+    budget_ms: int
+    component_names: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ShutdownSummary:
+    profile: str
+    started_at: float
+    finished_at: float
+    deadline_at: float
+    hard_cutoff_at: float
+    wall_time_ms: int
+    soft_overrun_used_ms: int
+    idempotent: bool = False
+    components: dict[str, ShutdownComponentSummary] = field(default_factory=dict)
+    phases: dict[ShutdownPhase, ShutdownPhaseSummary] = field(default_factory=dict)

--- a/tldw_Server_API/app/services/shutdown_transport_registry.py
+++ b/tldw_Server_API/app/services/shutdown_transport_registry.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass
+from threading import RLock
+from typing import Awaitable, Callable
+
+from tldw_Server_API.app.services.shutdown_models import (
+    ShutdownComponent,
+    ShutdownPhase,
+    ShutdownPolicy,
+)
+
+
+_TRANSPORT_CLOSE_GRACE_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class TransportFamilySnapshot:
+    name: str
+    active_count: int
+    has_drain_hook: bool
+
+
+class RegisteredTransportFamily:
+    def __init__(
+        self,
+        *,
+        name: str,
+        active_count: Callable[[], int],
+        drain: Callable[[float | None], Awaitable[None] | None] | None,
+    ) -> None:
+        self.name = name
+        self._active_count = active_count
+        self._drain = drain
+
+    def current_active_count(self) -> int:
+        try:
+            return max(0, int(self._active_count()))
+        except Exception:
+            return 0
+
+    async def drain(self, timeout_s: float | None = None) -> None:
+        if self._drain is None:
+            return
+        result = self._drain(timeout_s)
+        if inspect.isawaitable(result):
+            if timeout_s is None:
+                await result
+            else:
+                await asyncio.wait_for(result, timeout=timeout_s)
+
+    def snapshot(self) -> TransportFamilySnapshot:
+        return TransportFamilySnapshot(
+            name=self.name,
+            active_count=self.current_active_count(),
+            has_drain_hook=self._drain is not None,
+        )
+
+
+class ShutdownTransportRegistry:
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._families: dict[str, RegisteredTransportFamily] = {}
+
+    def register_family(
+        self,
+        name: str,
+        *,
+        active_count: Callable[[], int],
+        drain: Callable[[float | None], Awaitable[None] | None] | None,
+    ) -> RegisteredTransportFamily:
+        family = RegisteredTransportFamily(name=name, active_count=active_count, drain=drain)
+        with self._lock:
+            self._families[name] = family
+        return family
+
+    def unregister_family(self, name: str) -> None:
+        with self._lock:
+            self._families.pop(name, None)
+
+    def get_family(self, name: str) -> RegisteredTransportFamily | None:
+        with self._lock:
+            return self._families.get(name)
+
+    def iter_families(self) -> tuple[RegisteredTransportFamily, ...]:
+        with self._lock:
+            return tuple(self._families.values())
+
+    def snapshot(self) -> tuple[TransportFamilySnapshot, ...]:
+        return tuple(family.snapshot() for family in self.iter_families())
+
+    def total_active_sessions(self) -> int:
+        return sum(snapshot.active_count for snapshot in self.snapshot())
+
+
+_shutdown_transport_registry = ShutdownTransportRegistry()
+
+
+def get_shutdown_transport_registry() -> ShutdownTransportRegistry:
+    return _shutdown_transport_registry
+
+
+def register_shutdown_transport_family(
+    name: str,
+    *,
+    active_count: Callable[[], int],
+    drain: Callable[[float | None], Awaitable[None] | None] | None,
+) -> RegisteredTransportFamily:
+    return _shutdown_transport_registry.register_family(
+        name,
+        active_count=active_count,
+        drain=drain,
+    )
+
+
+def unregister_shutdown_transport_family(name: str) -> None:
+    _shutdown_transport_registry.unregister_family(name)
+
+
+def build_shutdown_components(
+    registry: ShutdownTransportRegistry | None = None,
+    *,
+    phase: ShutdownPhase = ShutdownPhase.ACCEPTORS,
+    policy: ShutdownPolicy = ShutdownPolicy.PROD_DRAIN,
+    default_timeout_ms: int = int(_TRANSPORT_CLOSE_GRACE_SECONDS * 1000),
+) -> list[ShutdownComponent]:
+    selected_registry = registry or _shutdown_transport_registry
+    components: list[ShutdownComponent] = []
+    for family in selected_registry.iter_families():
+        components.append(
+            ShutdownComponent(
+                name=f"transport:{family.name}",
+                phase=phase,
+                policy=policy,
+                default_timeout_ms=default_timeout_ms,
+                stop=lambda family=family, timeout_ms=default_timeout_ms: family.drain(
+                    timeout_s=max(0.0, timeout_ms / 1000.0),
+                ),
+            )
+        )
+    return components

--- a/tldw_Server_API/app/services/shutdown_transport_registry.py
+++ b/tldw_Server_API/app/services/shutdown_transport_registry.py
@@ -46,12 +46,23 @@ class RegisteredTransportFamily:
     async def drain(self, timeout_s: float | None = None) -> None:
         if self._drain is None:
             return
-        result = self._drain(timeout_s)
-        if inspect.isawaitable(result):
+        if inspect.iscoroutinefunction(self._drain):
+            result = self._drain(timeout_s)
             if timeout_s is None:
                 await result
             else:
                 await asyncio.wait_for(result, timeout=timeout_s)
+            return
+
+        async def _run_sync_drain() -> None:
+            result = await asyncio.to_thread(self._drain, timeout_s)
+            if inspect.isawaitable(result):
+                await result
+
+        if timeout_s is None:
+            await _run_sync_drain()
+        else:
+            await asyncio.wait_for(_run_sync_drain(), timeout=timeout_s)
 
     def snapshot(self) -> TransportFamilySnapshot:
         return TransportFamilySnapshot(
@@ -139,8 +150,8 @@ def build_shutdown_components(
                 phase=phase,
                 policy=policy,
                 default_timeout_ms=default_timeout_ms,
-                stop=lambda family=family, timeout_ms=default_timeout_ms: family.drain(
-                    timeout_s=max(0.0, timeout_ms / 1000.0),
+                stop=lambda timeout_ms=None, family=family: family.drain(
+                    timeout_s=None if timeout_ms is None else max(0.0, timeout_ms / 1000.0),
                 ),
             )
         )

--- a/tldw_Server_API/app/services/shutdown_transport_registry.py
+++ b/tldw_Server_API/app/services/shutdown_transport_registry.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from threading import RLock
 from typing import Awaitable, Callable
 
+from loguru import logger
+
 from tldw_Server_API.app.services.shutdown_models import (
     ShutdownComponent,
     ShutdownPhase,
@@ -73,6 +75,8 @@ class ShutdownTransportRegistry:
     ) -> RegisteredTransportFamily:
         family = RegisteredTransportFamily(name=name, active_count=active_count, drain=drain)
         with self._lock:
+            if name in self._families:
+                logger.warning(f"Shutdown transport family re-registered; replacing existing entry: {name}")
             self._families[name] = family
         return family
 

--- a/tldw_Server_API/app/services/shutdown_transport_registry.py
+++ b/tldw_Server_API/app/services/shutdown_transport_registry.py
@@ -16,6 +16,7 @@ from tldw_Server_API.app.services.shutdown_models import (
 
 
 _TRANSPORT_CLOSE_GRACE_SECONDS = 1.0
+TransportDrainHook = Callable[[float | None], Awaitable[None] | None]
 
 
 @dataclass(frozen=True)
@@ -31,7 +32,7 @@ class RegisteredTransportFamily:
         *,
         name: str,
         active_count: Callable[[], int],
-        drain: Callable[[float | None], Awaitable[None] | None] | None,
+        drain: TransportDrainHook | None,
     ) -> None:
         self.name = name
         self._active_count = active_count
@@ -46,23 +47,17 @@ class RegisteredTransportFamily:
     async def drain(self, timeout_s: float | None = None) -> None:
         if self._drain is None:
             return
-        if inspect.iscoroutinefunction(self._drain):
-            result = self._drain(timeout_s)
-            if timeout_s is None:
-                await result
-            else:
-                await asyncio.wait_for(result, timeout=timeout_s)
+        result = self._drain(timeout_s)
+        if result is None:
             return
-
-        async def _run_sync_drain() -> None:
-            result = await asyncio.to_thread(self._drain, timeout_s)
-            if inspect.isawaitable(result):
-                await result
-
+        if not inspect.isawaitable(result):
+            raise TypeError(
+                f"Shutdown transport drain hook {self.name!r} must be async and return an awaitable"
+            )
         if timeout_s is None:
-            await _run_sync_drain()
+            await result
         else:
-            await asyncio.wait_for(_run_sync_drain(), timeout=timeout_s)
+            await asyncio.wait_for(result, timeout=timeout_s)
 
     def snapshot(self) -> TransportFamilySnapshot:
         return TransportFamilySnapshot(
@@ -82,8 +77,12 @@ class ShutdownTransportRegistry:
         name: str,
         *,
         active_count: Callable[[], int],
-        drain: Callable[[float | None], Awaitable[None] | None] | None,
+        drain: TransportDrainHook | None,
     ) -> RegisteredTransportFamily:
+        if drain is not None and not inspect.iscoroutinefunction(drain):
+            raise TypeError(
+                f"Shutdown transport drain hook {name!r} must be declared with async def"
+            )
         family = RegisteredTransportFamily(name=name, active_count=active_count, drain=drain)
         with self._lock:
             if name in self._families:
@@ -121,7 +120,7 @@ def register_shutdown_transport_family(
     name: str,
     *,
     active_count: Callable[[], int],
-    drain: Callable[[float | None], Awaitable[None] | None] | None,
+    drain: TransportDrainHook | None,
 ) -> RegisteredTransportFamily:
     return _shutdown_transport_registry.register_family(
         name,

--- a/tldw_Server_API/tests/CI/test_e2e_inprocess_client_contract.py
+++ b/tldw_Server_API/tests/CI/test_e2e_inprocess_client_contract.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 def test_inprocess_testclient_fallback_enters_lifespan() -> None:
     source = Path("tldw_Server_API/tests/e2e/fixtures.py").read_text(encoding="utf-8")
+    if "from tldw_Server_API.app.main import app" not in source:
+        raise AssertionError("fallback helper must import the shared FastAPI app")
     if "def _build_started_testclient():" not in source:
         raise AssertionError("missing _build_started_testclient helper")
     if "client.__enter__()" not in source:

--- a/tldw_Server_API/tests/CI/test_e2e_inprocess_client_contract.py
+++ b/tldw_Server_API/tests/CI/test_e2e_inprocess_client_contract.py
@@ -1,13 +1,39 @@
-from pathlib import Path
+import pytest
 
 
-def test_inprocess_testclient_fallback_enters_lifespan() -> None:
-    source = Path("tldw_Server_API/tests/e2e/fixtures.py").read_text(encoding="utf-8")
-    if "from tldw_Server_API.app.main import app" not in source:
-        raise AssertionError("fallback helper must import the shared FastAPI app")
-    if "def _build_started_testclient():" not in source:
-        raise AssertionError("missing _build_started_testclient helper")
-    if "client.__enter__()" not in source:
-        raise AssertionError("TestClient fallback must enter lifespan")
-    if source.count("return _build_started_testclient()") < 2:
-        raise AssertionError("both fallback branches must use started TestClient")
+def test_inprocess_testclient_fallback_enters_lifespan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.main import app as shared_app
+    from tldw_Server_API.tests.e2e import fixtures
+
+    entered_clients: list[object] = []
+
+    class _FakeStartedClient:
+        def __init__(self, app, **kwargs) -> None:
+            self.app = app
+            self.kwargs = kwargs
+
+        def __enter__(self):
+            entered_clients.append(self)
+            return self
+
+    def _raise_old_transport(*args, **kwargs):
+        raise TypeError("lifespan unsupported")
+
+    monkeypatch.setattr("starlette.testclient.TestClient", _FakeStartedClient)
+    helper_globals = fixtures._build_inprocess_httpx_client.__globals__
+    original_httpx = helper_globals["httpx"]
+    helper_globals["httpx"] = type(
+        "_FakeHttpxModule",
+        (),
+        {"ASGITransport": staticmethod(_raise_old_transport)},
+    )()
+    try:
+        client = fixtures._build_inprocess_httpx_client()
+    finally:
+        helper_globals["httpx"] = original_httpx
+
+    assert isinstance(client, _FakeStartedClient)
+    assert client.app is shared_app
+    assert entered_clients == [client]

--- a/tldw_Server_API/tests/Services/test_app_lifecycle_state.py
+++ b/tldw_Server_API/tests/Services/test_app_lifecycle_state.py
@@ -1,0 +1,62 @@
+from fastapi import FastAPI
+
+from tldw_Server_API.app.services.app_lifecycle import (
+    get_or_create_lifecycle_state,
+    mark_lifecycle_shutdown,
+    mark_lifecycle_startup,
+    reset_lifecycle_state,
+)
+
+
+def test_get_or_create_lifecycle_state_is_app_scoped() -> None:
+    app = FastAPI()
+    state = get_or_create_lifecycle_state(app)
+    assert state.phase == "starting"
+    assert state.ready is False
+
+
+def test_mark_lifecycle_startup_and_shutdown_update_app_state() -> None:
+    app = FastAPI()
+    state = get_or_create_lifecycle_state(app)
+    mark_lifecycle_startup(app)
+    assert state.phase == "ready"
+    assert state.ready is True
+    mark_lifecycle_shutdown(app)
+    assert state.phase == "draining"
+    assert state.ready is False
+
+
+def test_get_or_create_lifecycle_state_isolated_per_app_instance() -> None:
+    first_app = FastAPI()
+    second_app = FastAPI()
+
+    first_state = get_or_create_lifecycle_state(first_app)
+    second_state = get_or_create_lifecycle_state(second_app)
+
+    assert first_state is not second_state
+    assert first_state.phase == "starting"
+    assert second_state.phase == "starting"
+
+    mark_lifecycle_startup(first_app)
+    assert first_state.phase == "ready"
+    assert second_state.phase == "starting"
+
+
+def test_reset_lifecycle_state_restores_default_state_for_reuse() -> None:
+    app = FastAPI()
+    original_state = get_or_create_lifecycle_state(app)
+
+    mark_lifecycle_startup(app)
+    assert original_state.phase == "ready"
+    assert original_state.ready is True
+
+    reset_state = reset_lifecycle_state(app)
+
+    assert reset_state is not original_state
+    assert reset_state.phase == "starting"
+    assert reset_state.ready is False
+    assert reset_state.draining is False
+    assert app.state._tldw_lifecycle_state is reset_state
+
+    reused_state = get_or_create_lifecycle_state(app)
+    assert reused_state is reset_state

--- a/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
+++ b/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
@@ -38,12 +38,15 @@ def draining_client(test_app):
 def test_drain_gate_allows_health_and_liveness_but_rejects_mutation(test_app, draining_client):
     ok = draining_client.get("/health")
     head_ok = draining_client.head("/health")
+    api_health_ok = draining_client.get("/api/v1/health")
     liveness_ok = draining_client.get("/api/v1/healthz")
     blocked = draining_client.post("/api/v1/chat/completions", json={"messages": []})
     if ok.status_code != 200:
         raise AssertionError(f"expected /health to stay open, got {ok.status_code}")
     if head_ok.status_code != 200:
         raise AssertionError(f"expected HEAD /health to stay open, got {head_ok.status_code}")
+    if api_health_ok.status_code != 200:
+        raise AssertionError(f"expected /api/v1/health to stay open, got {api_health_ok.status_code}")
     if liveness_ok.status_code != 200:
         raise AssertionError(f"expected /api/v1/healthz to stay open, got {liveness_ok.status_code}")
     if blocked.status_code != 503:
@@ -124,8 +127,16 @@ def test_drain_gate_rejects_guarded_request_before_llm_budget_runs(test_app, dra
         ("HEAD", "/health/ready"),
         ("GET", "/healthz"),
         ("HEAD", "/healthz"),
+        ("GET", "/api/v1/health"),
+        ("HEAD", "/api/v1/health"),
+        ("GET", "/api/v1/health/live"),
+        ("HEAD", "/api/v1/health/live"),
+        ("GET", "/api/v1/health/ready"),
+        ("HEAD", "/api/v1/health/ready"),
         ("GET", "/api/v1/healthz"),
         ("HEAD", "/api/v1/healthz"),
+        ("GET", "/api/v1/readyz"),
+        ("HEAD", "/api/v1/readyz"),
     ],
 )
 def test_control_plane_probe_paths_are_allowlisted(method, path):

--- a/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
+++ b/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import os
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def test_app():
+    from tldw_Server_API.app.main import app
+    from tldw_Server_API.app.services.app_lifecycle import reset_lifecycle_state
+
+    reset_lifecycle_state(app)
+    return app
+
+
+@pytest.fixture()
+def draining_client(test_app):
+    from tldw_Server_API.app.services.app_lifecycle import get_or_create_lifecycle_state
+
+    headers = {"X-API-KEY": os.environ.get("SINGLE_USER_API_KEY", "test-api-key-12345")}
+
+    with TestClient(test_app, headers=headers) as client:
+        state = get_or_create_lifecycle_state(test_app)
+        state.phase = "draining"
+        state.ready = False
+        state.draining = True
+        yield client
+
+
+def test_drain_gate_allows_health_but_rejects_mutation(test_app, draining_client):
+    ok = draining_client.get("/health")
+    head_ok = draining_client.head("/health")
+    blocked = draining_client.post("/api/v1/chat/completions", json={"messages": []})
+    if ok.status_code != 200:
+        raise AssertionError(f"expected /health to stay open, got {ok.status_code}")
+    if head_ok.status_code != 200:
+        raise AssertionError(f"expected HEAD /health to stay open, got {head_ok.status_code}")
+    if blocked.status_code != 503:
+        raise AssertionError(f"expected drain gate to return 503, got {blocked.status_code}")
+    if blocked.json()["reason"] != "shutdown_in_progress":
+        raise AssertionError(f"unexpected drain reason: {blocked.json()['reason']!r}")
+
+
+def test_drain_gate_rejects_non_control_plane_head_request(test_app, draining_client):
+    blocked = draining_client.head("/api/v1/chat/completions")
+    if blocked.status_code != 503:
+        raise AssertionError(f"expected drain gate to reject HEAD /api/v1/chat/completions, got {blocked.status_code}")
+
+
+def test_assert_may_start_work_raises_when_draining(test_app):
+    from tldw_Server_API.app.services.app_lifecycle import (
+        assert_may_start_work,
+        get_or_create_lifecycle_state,
+    )
+
+    state = get_or_create_lifecycle_state(test_app)
+    state.draining = True
+    with pytest.raises(HTTPException) as excinfo:
+        assert_may_start_work(test_app, kind="job_enqueue")
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == {"message": "Shutdown in progress", "kind": "job_enqueue"}
+
+
+def test_assert_may_start_work_noops_when_not_draining(test_app):
+    from tldw_Server_API.app.services.app_lifecycle import assert_may_start_work
+
+    assert_may_start_work(test_app, kind="job_enqueue")
+
+
+def test_drain_gate_rejects_guarded_request_before_llm_budget_runs(test_app, draining_client, monkeypatch):
+    from tldw_Server_API.app.core.AuthNZ.llm_budget_middleware import LLMBudgetMiddleware
+
+    budget_called = {"value": False}
+
+    async def _unexpected_budget_dispatch(self, request, call_next):
+        budget_called["value"] = True
+        raise AssertionError("LLMBudgetMiddleware should not run while draining")
+
+    monkeypatch.setattr(LLMBudgetMiddleware, "dispatch", _unexpected_budget_dispatch)
+
+    blocked = draining_client.post("/api/v1/chat/completions", json={"messages": []})
+    if blocked.status_code != 503:
+        raise AssertionError(f"expected drain gate to return 503, got {blocked.status_code}")
+    if blocked.json()["reason"] != "shutdown_in_progress":
+        raise AssertionError(f"unexpected drain reason: {blocked.json()['reason']!r}")
+    if budget_called["value"]:
+        raise AssertionError("LLMBudgetMiddleware was invoked for a drained request")
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("HEAD", "/health"),
+        ("HEAD", "/ready"),
+        ("HEAD", "/health/ready"),
+    ],
+)
+def test_control_plane_head_paths_are_allowlisted(method, path):
+    from tldw_Server_API.app.core.Security.drain_gate_middleware import _is_allowlisted_control_plane_path
+
+    request = SimpleNamespace(method=method, url=SimpleNamespace(path=path))
+    if not _is_allowlisted_control_plane_path(request):
+        raise AssertionError(f"Expected {method} {path} to be allowlisted during drain")

--- a/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
+++ b/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
@@ -9,10 +9,14 @@ from fastapi.testclient import TestClient
 
 
 @pytest.fixture()
-def test_app():
+def test_app(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MCP_DEBUG", "true")
+    from tldw_Server_API.app.core.MCP_unified.config import get_config as get_mcp_config
     from tldw_Server_API.app.main import app
     from tldw_Server_API.app.services.app_lifecycle import reset_lifecycle_state
 
+    if hasattr(get_mcp_config, "cache_clear"):
+        get_mcp_config.cache_clear()
     reset_lifecycle_state(app)
     return app
 
@@ -52,6 +56,23 @@ def test_drain_gate_rejects_non_control_plane_head_request(test_app, draining_cl
     blocked = draining_client.head("/api/v1/chat/completions")
     if blocked.status_code != 503:
         raise AssertionError(f"expected drain gate to reject HEAD /api/v1/chat/completions, got {blocked.status_code}")
+
+
+def test_drain_gate_503_preserves_cors_headers_for_browser_clients(draining_client):
+    blocked = draining_client.options(
+        "/api/v1/chat/completions",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    if blocked.status_code != 503:
+        raise AssertionError(f"expected drain gate to return 503, got {blocked.status_code}")
+    if blocked.headers.get("Access-Control-Allow-Origin") != "http://localhost:3000":
+        raise AssertionError("drain gate should preserve CORS allow-origin on blocked responses")
+    if blocked.headers.get("Access-Control-Allow-Methods") != "POST":
+        raise AssertionError("drain gate should echo requested method for blocked preflight responses")
 
 
 def test_assert_may_start_work_raises_when_draining(test_app):

--- a/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
+++ b/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
@@ -31,14 +31,17 @@ def draining_client(test_app):
         yield client
 
 
-def test_drain_gate_allows_health_but_rejects_mutation(test_app, draining_client):
+def test_drain_gate_allows_health_and_liveness_but_rejects_mutation(test_app, draining_client):
     ok = draining_client.get("/health")
     head_ok = draining_client.head("/health")
+    liveness_ok = draining_client.get("/api/v1/healthz")
     blocked = draining_client.post("/api/v1/chat/completions", json={"messages": []})
     if ok.status_code != 200:
         raise AssertionError(f"expected /health to stay open, got {ok.status_code}")
     if head_ok.status_code != 200:
         raise AssertionError(f"expected HEAD /health to stay open, got {head_ok.status_code}")
+    if liveness_ok.status_code != 200:
+        raise AssertionError(f"expected /api/v1/healthz to stay open, got {liveness_ok.status_code}")
     if blocked.status_code != 503:
         raise AssertionError(f"expected drain gate to return 503, got {blocked.status_code}")
     if blocked.json()["reason"] != "shutdown_in_progress":
@@ -94,12 +97,17 @@ def test_drain_gate_rejects_guarded_request_before_llm_budget_runs(test_app, dra
 @pytest.mark.parametrize(
     "method,path",
     [
+        ("GET", "/health"),
         ("HEAD", "/health"),
         ("HEAD", "/ready"),
         ("HEAD", "/health/ready"),
+        ("GET", "/healthz"),
+        ("HEAD", "/healthz"),
+        ("GET", "/api/v1/healthz"),
+        ("HEAD", "/api/v1/healthz"),
     ],
 )
-def test_control_plane_head_paths_are_allowlisted(method, path):
+def test_control_plane_probe_paths_are_allowlisted(method, path):
     from tldw_Server_API.app.core.Security.drain_gate_middleware import _is_allowlisted_control_plane_path
 
     request = SimpleNamespace(method=method, url=SimpleNamespace(path=path))

--- a/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
+++ b/tldw_Server_API/tests/Services/test_drain_gate_middleware.py
@@ -123,7 +123,10 @@ def test_drain_gate_rejects_guarded_request_before_llm_budget_runs(test_app, dra
     [
         ("GET", "/health"),
         ("HEAD", "/health"),
+        ("GET", "/ready"),
         ("HEAD", "/ready"),
+        ("GET", "/readyz"),
+        ("HEAD", "/readyz"),
         ("HEAD", "/health/ready"),
         ("GET", "/healthz"),
         ("HEAD", "/healthz"),

--- a/tldw_Server_API/tests/Services/test_executor_registry_shutdown.py
+++ b/tldw_Server_API/tests/Services/test_executor_registry_shutdown.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import threading
 from concurrent.futures import Executor
 
 import pytest
@@ -10,28 +9,14 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-class _BlockingExecutor(Executor):
-    def __init__(
-        self,
-        expected_starts: int,
-        started_all: threading.Event,
-        release: threading.Event,
-        started_count: list[int],
-        started_lock: threading.Lock,
-    ) -> None:
-        self._expected_starts = expected_starts
-        self._started_all = started_all
-        self._release = release
-        self._started_count = started_count
-        self._started_lock = started_lock
+class _RecordingExecutor(Executor):
+    def __init__(self, name: str, shutdown_order: list[str]) -> None:
+        self._name = name
+        self._shutdown_order = shutdown_order
 
     def shutdown(self, wait: bool = True, cancel_futures: bool = True) -> None:
         del wait, cancel_futures
-        with self._started_lock:
-            self._started_count[0] += 1
-            if self._started_count[0] >= self._expected_starts:
-                self._started_all.set()
-        self._release.wait()
+        self._shutdown_order.append(self._name)
 
 
 def test_snapshot_registered_executors_exposes_registered_names() -> None:
@@ -41,10 +26,9 @@ def test_snapshot_registered_executors_exposes_registered_names() -> None:
         unregister_executor,
     )
 
-    started_lock = threading.Lock()
-    started_all = threading.Event()
-    first = _BlockingExecutor(1, started_all, threading.Event(), [0], started_lock)
-    second = _BlockingExecutor(1, started_all, threading.Event(), [0], started_lock)
+    shutdown_order: list[str] = []
+    first = _RecordingExecutor("alpha", shutdown_order)
+    second = _RecordingExecutor("beta", shutdown_order)
     register_executor("alpha", first)
     register_executor("beta", second)
 
@@ -59,29 +43,25 @@ def test_snapshot_registered_executors_exposes_registered_names() -> None:
 
 
 @pytest.mark.asyncio
-async def test_shutdown_all_registered_executors_runs_shutdowns_concurrently() -> None:
+async def test_shutdown_all_registered_executors_shuts_db_pool_down_last() -> None:
     from tldw_Server_API.app.core.Utils.executor_registry import (
         register_executor,
         shutdown_all_registered_executors,
         unregister_executor,
     )
 
-    started_all = threading.Event()
-    release = threading.Event()
-    started_count = [0]
-    started_lock = threading.Lock()
-    first = _BlockingExecutor(2, started_all, release, started_count, started_lock)
-    second = _BlockingExecutor(2, started_all, release, started_count, started_lock)
-    register_executor("alpha", first)
-    register_executor("beta", second)
+    shutdown_order: list[str] = []
+    db_executor = _RecordingExecutor("db_thread_pool", shutdown_order)
+    cpu_thread_executor = _RecordingExecutor("cpu_thread_pool", shutdown_order)
+    cpu_process_executor = _RecordingExecutor("cpu_process_pool", shutdown_order)
+    register_executor("db_thread_pool", db_executor)
+    register_executor("cpu_thread_pool", cpu_thread_executor)
+    register_executor("cpu_process_pool", cpu_process_executor)
 
     try:
-        shutdown_task = asyncio.create_task(shutdown_all_registered_executors())
-        await asyncio.wait_for(asyncio.to_thread(started_all.wait), timeout=1.5)
-        assert started_count[0] == 2
-
-        release.set()
-        await shutdown_task
+        await shutdown_all_registered_executors()
+        assert shutdown_order == ["cpu_thread_pool", "cpu_process_pool", "db_thread_pool"]
     finally:
-        unregister_executor("alpha")
-        unregister_executor("beta")
+        unregister_executor("db_thread_pool")
+        unregister_executor("cpu_thread_pool")
+        unregister_executor("cpu_process_pool")

--- a/tldw_Server_API/tests/Services/test_executor_registry_shutdown.py
+++ b/tldw_Server_API/tests/Services/test_executor_registry_shutdown.py
@@ -11,16 +11,27 @@ pytestmark = pytest.mark.unit
 
 
 class _BlockingExecutor(Executor):
-    def __init__(self, started: threading.Event, release: threading.Event, started_count: list[int]) -> None:
-        self._started = started
+    def __init__(
+        self,
+        expected_starts: int,
+        started_all: threading.Event,
+        release: threading.Event,
+        started_count: list[int],
+        started_lock: threading.Lock,
+    ) -> None:
+        self._expected_starts = expected_starts
+        self._started_all = started_all
         self._release = release
         self._started_count = started_count
+        self._started_lock = started_lock
 
     def shutdown(self, wait: bool = True, cancel_futures: bool = True) -> None:
-        self._started_count[0] += 1
-        if self._started_count[0] >= 2:
-            self._started.set()
-        self._release.wait(timeout=1.0)
+        del wait, cancel_futures
+        with self._started_lock:
+            self._started_count[0] += 1
+            if self._started_count[0] >= self._expected_starts:
+                self._started_all.set()
+        self._release.wait()
 
 
 def test_snapshot_registered_executors_exposes_registered_names() -> None:
@@ -30,8 +41,10 @@ def test_snapshot_registered_executors_exposes_registered_names() -> None:
         unregister_executor,
     )
 
-    first = _BlockingExecutor(threading.Event(), threading.Event(), [0])
-    second = _BlockingExecutor(threading.Event(), threading.Event(), [0])
+    started_lock = threading.Lock()
+    started_all = threading.Event()
+    first = _BlockingExecutor(1, started_all, threading.Event(), [0], started_lock)
+    second = _BlockingExecutor(1, started_all, threading.Event(), [0], started_lock)
     register_executor("alpha", first)
     register_executor("beta", second)
 
@@ -53,18 +66,18 @@ async def test_shutdown_all_registered_executors_runs_shutdowns_concurrently() -
         unregister_executor,
     )
 
-    started = threading.Event()
+    started_all = threading.Event()
     release = threading.Event()
     started_count = [0]
-    first = _BlockingExecutor(started, release, started_count)
-    second = _BlockingExecutor(started, release, started_count)
+    started_lock = threading.Lock()
+    first = _BlockingExecutor(2, started_all, release, started_count, started_lock)
+    second = _BlockingExecutor(2, started_all, release, started_count, started_lock)
     register_executor("alpha", first)
     register_executor("beta", second)
 
     try:
         shutdown_task = asyncio.create_task(shutdown_all_registered_executors())
-        await asyncio.wait_for(asyncio.to_thread(started.wait, 1.0), timeout=1.5)
-
+        await asyncio.wait_for(asyncio.to_thread(started_all.wait), timeout=1.5)
         assert started_count[0] == 2
 
         release.set()

--- a/tldw_Server_API/tests/Services/test_executor_registry_shutdown.py
+++ b/tldw_Server_API/tests/Services/test_executor_registry_shutdown.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import Executor
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+class _BlockingExecutor(Executor):
+    def __init__(self, started: threading.Event, release: threading.Event, started_count: list[int]) -> None:
+        self._started = started
+        self._release = release
+        self._started_count = started_count
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = True) -> None:
+        self._started_count[0] += 1
+        if self._started_count[0] >= 2:
+            self._started.set()
+        self._release.wait(timeout=1.0)
+
+
+def test_snapshot_registered_executors_exposes_registered_names() -> None:
+    from tldw_Server_API.app.core.Utils.executor_registry import (
+        register_executor,
+        snapshot_registered_executors,
+        unregister_executor,
+    )
+
+    first = _BlockingExecutor(threading.Event(), threading.Event(), [0])
+    second = _BlockingExecutor(threading.Event(), threading.Event(), [0])
+    register_executor("alpha", first)
+    register_executor("beta", second)
+
+    try:
+        snapshot = dict(snapshot_registered_executors())
+
+        assert snapshot["alpha"] is first
+        assert snapshot["beta"] is second
+    finally:
+        unregister_executor("alpha")
+        unregister_executor("beta")
+
+
+@pytest.mark.asyncio
+async def test_shutdown_all_registered_executors_runs_shutdowns_concurrently() -> None:
+    from tldw_Server_API.app.core.Utils.executor_registry import (
+        register_executor,
+        shutdown_all_registered_executors,
+        unregister_executor,
+    )
+
+    started = threading.Event()
+    release = threading.Event()
+    started_count = [0]
+    first = _BlockingExecutor(started, release, started_count)
+    second = _BlockingExecutor(started, release, started_count)
+    register_executor("alpha", first)
+    register_executor("beta", second)
+
+    try:
+        shutdown_task = asyncio.create_task(shutdown_all_registered_executors())
+        await asyncio.wait_for(asyncio.to_thread(started.wait, 1.0), timeout=1.5)
+
+        assert started_count[0] == 2
+
+        release.set()
+        await shutdown_task
+    finally:
+        unregister_executor("alpha")
+        unregister_executor("beta")

--- a/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
+++ b/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -11,10 +12,73 @@ def test_startup_shutdown_contract_is_reentrant() -> None:
     with TestClient(app) as first_client:
         first_response = first_client.get("/health")
         assert first_response.status_code == 200
+        first_state = app.state._tldw_lifecycle_state
+        assert first_state.phase == "ready"
+        assert first_state.ready is True
+
+    assert app.state._tldw_lifecycle_state is first_state
+    assert app.state._tldw_lifecycle_state.phase == "draining"
+    assert app.state._tldw_lifecycle_state.ready is False
 
     with TestClient(app) as second_client:
         second_response = second_client.get("/health")
         assert second_response.status_code == 200
+        assert app.state._tldw_lifecycle_state is first_state
+        assert app.state._tldw_lifecycle_state.phase == "ready"
+        assert app.state._tldw_lifecycle_state.ready is True
+
+    assert app.state._tldw_lifecycle_state is first_state
+    assert app.state._tldw_lifecycle_state.phase == "draining"
+    assert app.state._tldw_lifecycle_state.ready is False
+
+
+@pytest.mark.asyncio
+async def test_asgi_transport_without_lifespan_bypasses_shutdown_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = main_module.app
+
+    for attr_name in (
+        "_tldw_lifecycle_events",
+        "_tldw_lifecycle_state",
+        "_tldw_shutdown_legacy_coordinator_summary",
+        "_tldw_shutdown_legacy_coordinator_component_names",
+        "_tldw_shutdown_legacy_coordinator_phase_groups",
+    ):
+        if hasattr(app.state, attr_name):
+            delattr(app.state, attr_name)
+
+    startup_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    shutdown_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    original_mark_startup = main_module.mark_lifecycle_startup
+    original_mark_shutdown = main_module.mark_lifecycle_shutdown
+
+    def _record_mark_startup(*args, **kwargs):
+        startup_calls.append((args, kwargs))
+        return original_mark_startup(*args, **kwargs)
+
+    def _record_mark_shutdown(*args, **kwargs):
+        shutdown_calls.append((args, kwargs))
+        return original_mark_shutdown(*args, **kwargs)
+
+    monkeypatch.setattr(main_module, "mark_lifecycle_startup", _record_mark_startup)
+    monkeypatch.setattr(main_module, "mark_lifecycle_shutdown", _record_mark_shutdown)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+    assert startup_calls == []
+    assert shutdown_calls == []
+    assert not hasattr(app.state, "_tldw_shutdown_legacy_coordinator_summary")
+
+    lifecycle_state = getattr(app.state, "_tldw_lifecycle_state", None)
+    assert lifecycle_state is None or lifecycle_state.phase != "draining"
+    assert lifecycle_state is None or lifecycle_state.draining is False
 
 
 @pytest.mark.integration
@@ -23,11 +87,371 @@ def test_lifecycle_hooks_called_in_order() -> None:
 
     if hasattr(app.state, "_tldw_lifecycle_events"):
         delattr(app.state, "_tldw_lifecycle_events")
+    if hasattr(app.state, "_tldw_lifecycle_state"):
+        delattr(app.state, "_tldw_lifecycle_state")
 
     with TestClient(app):
         assert getattr(app.state, "_tldw_lifecycle_events", [])[-1:] == ["startup"]
+        assert app.state._tldw_lifecycle_state.phase == "ready"
+        assert app.state._tldw_lifecycle_state.ready is True
 
     assert getattr(app.state, "_tldw_lifecycle_events", [])[-2:] == ["startup", "shutdown"]
+    assert app.state._tldw_lifecycle_state.phase == "draining"
+    assert app.state._tldw_lifecycle_state.ready is False
+
+
+@pytest.mark.integration
+def test_shutdown_falls_back_to_direct_drain_when_transition_gate_component_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    from tldw_Server_API.app.main import app
+    from tldw_Server_API.app.services import shutdown_legacy_adapters
+    from tldw_Server_API.app.services.shutdown_models import (
+        ShutdownComponent,
+        ShutdownPhase,
+        ShutdownPolicy,
+    )
+
+    if hasattr(app.state, "_tldw_lifecycle_events"):
+        delattr(app.state, "_tldw_lifecycle_events")
+    if hasattr(app.state, "_tldw_lifecycle_state"):
+        delattr(app.state, "_tldw_lifecycle_state")
+
+    gate_calls: list[bool] = []
+
+    def _record_gate(cls, enabled: bool) -> None:
+        gate_calls.append(enabled)
+
+    monkeypatch.setattr(
+        JobManager,
+        "set_acquire_gate",
+        classmethod(_record_gate),
+    )
+    def _failing_transition_stop() -> None:
+        raise RuntimeError("shadow transition component failed")
+
+    monkeypatch.setattr(
+        shutdown_legacy_adapters,
+        "build_legacy_shutdown_plan",
+        lambda *_args, **_kwargs: [
+            ShutdownComponent(
+                name="lifecycle_gate",
+                phase=ShutdownPhase.TRANSITION,
+                policy=ShutdownPolicy.DEV_FAST,
+                default_timeout_ms=1000,
+                stop=_failing_transition_stop,
+            )
+        ],
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        assert app.state._tldw_lifecycle_state.phase == "ready"
+        assert app.state._tldw_lifecycle_state.ready is True
+        gate_calls.clear()
+
+    assert gate_calls == [True, False]
+    assert app.state._tldw_lifecycle_state.phase == "draining"
+    assert app.state._tldw_lifecycle_state.ready is False
+    assert app.state._tldw_lifecycle_state.draining is True
+
+
+@pytest.mark.integration
+def test_shutdown_migrated_legacy_slice_uses_prod_drain_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+    import types
+
+    from tldw_Server_API.app.services import shutdown_coordinator as shutdown_coordinator_module
+    from tldw_Server_API.app.services import shutdown_legacy_adapters
+    from tldw_Server_API.app.services.shutdown_models import (
+        ShutdownComponent,
+        ShutdownComponentSummary,
+        ShutdownPhase,
+        ShutdownPhaseSummary,
+        ShutdownPolicy,
+        ShutdownSummary,
+    )
+
+    class _SpyShutdownCoordinator:
+        created_profiles: list[str] = []
+        instances: list["_SpyShutdownCoordinator"] = []
+
+        def __init__(self, profile: str = "dev_fast", **_kwargs) -> None:
+            self.profile = profile
+            self.registered: list[ShutdownComponent] = []
+            type(self).created_profiles.append(profile)
+            type(self).instances.append(self)
+
+        def register(self, component: ShutdownComponent) -> ShutdownComponent:
+            self.registered.append(component)
+            return component
+
+        async def shutdown(self) -> ShutdownSummary:
+            phase_names: dict[ShutdownPhase, list[str]] = {}
+            component_summaries: dict[str, ShutdownComponentSummary] = {}
+
+            for component in self.registered:
+                phase_names.setdefault(component.phase, []).append(component.name)
+                component_summaries[component.name] = ShutdownComponentSummary(
+                    name=component.name,
+                    phase=component.phase,
+                    policy=component.policy,
+                    result="stopped",
+                    started_at=0.0,
+                    finished_at=0.0,
+                    duration_ms=0,
+                    timeout_ms=0,
+                )
+
+            phase_summaries = {
+                phase: ShutdownPhaseSummary(
+                    phase=phase,
+                    started_at=0.0,
+                    finished_at=0.0,
+                    duration_ms=0,
+                    budget_ms=0,
+                    component_names=component_names,
+                )
+                for phase, component_names in phase_names.items()
+            }
+            return ShutdownSummary(
+                profile=self.profile,
+                started_at=0.0,
+                finished_at=0.0,
+                deadline_at=0.0,
+                hard_cutoff_at=0.0,
+                wall_time_ms=0,
+                soft_overrun_used_ms=0,
+                components=component_summaries,
+                phases=phase_summaries,
+            )
+
+    def _fake_build_legacy_shutdown_plan(_app, _locals_map):
+        return [
+            ShutdownComponent(
+                name="lifecycle_gate",
+                phase=ShutdownPhase.TRANSITION,
+                policy=ShutdownPolicy.DEV_FAST,
+                default_timeout_ms=1000,
+                stop=lambda: None,
+            ),
+            ShutdownComponent(
+                name="chatbooks_cleanup",
+                phase=ShutdownPhase.WORKERS,
+                policy=ShutdownPolicy.BEST_EFFORT,
+                default_timeout_ms=1000,
+                stop=lambda: None,
+            ),
+            ShutdownComponent(
+                name="usage_aggregator",
+                phase=ShutdownPhase.RESOURCES,
+                policy=ShutdownPolicy.BEST_EFFORT,
+                default_timeout_ms=1000,
+                stop=lambda: None,
+            ),
+            ShutdownComponent(
+                name="storage_cleanup_service",
+                phase=ShutdownPhase.FINALIZERS,
+                policy=ShutdownPolicy.PROD_DRAIN,
+                default_timeout_ms=5000,
+                stop=lambda: None,
+            ),
+        ]
+
+    fake_shutdown_legacy_adapters = types.ModuleType(
+        "tldw_Server_API.app.services.shutdown_legacy_adapters"
+    )
+    fake_shutdown_legacy_adapters.build_legacy_shutdown_plan = _fake_build_legacy_shutdown_plan
+    fake_shutdown_legacy_adapters.register_legacy_shutdown_components = (
+        shutdown_legacy_adapters.register_legacy_shutdown_components
+    )
+    fake_shutdown_legacy_adapters.get_legacy_shutdown_suppressed_component_names = (
+        shutdown_legacy_adapters.get_legacy_shutdown_suppressed_component_names
+    )
+    monkeypatch.setitem(sys.modules, fake_shutdown_legacy_adapters.__name__, fake_shutdown_legacy_adapters)
+
+    monkeypatch.setattr(shutdown_coordinator_module, "ShutdownCoordinator", _SpyShutdownCoordinator)
+
+    from tldw_Server_API.app.main import app
+
+    if hasattr(app.state, "_tldw_lifecycle_events"):
+        delattr(app.state, "_tldw_lifecycle_events")
+    if hasattr(app.state, "_tldw_lifecycle_state"):
+        delattr(app.state, "_tldw_lifecycle_state")
+
+    expected_migrated_names = [
+        component.name
+        for component in _fake_build_legacy_shutdown_plan(None, None)
+        if component.name != "lifecycle_gate"
+    ]
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+
+    assert _SpyShutdownCoordinator.created_profiles == ["dev_fast", "prod_drain"]
+    assert [component.name for component in _SpyShutdownCoordinator.instances[0].registered] == [
+        "lifecycle_gate",
+    ]
+    expected_transport_names = getattr(app.state, "_tldw_shutdown_transport_component_names", [])
+    migrated_registered_names = [
+        component.name for component in _SpyShutdownCoordinator.instances[1].registered
+    ]
+    assert migrated_registered_names == expected_migrated_names + expected_transport_names
+    assert "lifecycle_gate" not in migrated_registered_names
+
+
+@pytest.mark.integration
+def test_shutdown_skipped_best_effort_component_falls_back_to_direct_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+    import types
+
+    from tldw_Server_API.app.services import shutdown_coordinator as shutdown_coordinator_module
+    from tldw_Server_API.app.services import shutdown_legacy_adapters
+    from tldw_Server_API.app.services.shutdown_models import (
+        ShutdownComponent,
+        ShutdownComponentSummary,
+        ShutdownPhase,
+        ShutdownPhaseSummary,
+        ShutdownPolicy,
+        ShutdownSummary,
+    )
+
+    class _DummyUsageTask:
+        def __init__(self) -> None:
+            self.cancel_calls = 0
+            self.stop_calls = 0
+            self._stopped = False
+
+        def cancel(self) -> None:
+            self.cancel_calls += 1
+
+    usage_task_holder: dict[str, _DummyUsageTask] = {}
+
+    async def _fake_start_usage_aggregator() -> _DummyUsageTask:
+        task = _DummyUsageTask()
+        usage_task_holder["task"] = task
+        return task
+
+    async def _fake_stop_usage_aggregator(task: _DummyUsageTask | None) -> None:
+        if task is None:
+            return
+        if not task._stopped:
+            task._stopped = True
+            task.stop_calls += 1
+        task.cancel()
+
+    class _SpyShutdownCoordinator:
+        def __init__(self, profile: str = "dev_fast", **_kwargs) -> None:
+            self.profile = profile
+            self.registered: list[ShutdownComponent] = []
+
+        def register(self, component: ShutdownComponent) -> ShutdownComponent:
+            self.registered.append(component)
+            return component
+
+        async def shutdown(self) -> ShutdownSummary:
+            phase_names: dict[ShutdownPhase, list[str]] = {}
+            component_summaries: dict[str, ShutdownComponentSummary] = {}
+
+            for component in self.registered:
+                phase_names.setdefault(component.phase, []).append(component.name)
+                result = "skipped" if component.name == "usage_aggregator" else "stopped"
+                component_summaries[component.name] = ShutdownComponentSummary(
+                    name=component.name,
+                    phase=component.phase,
+                    policy=component.policy,
+                    result=result,
+                    started_at=0.0,
+                    finished_at=0.0,
+                    duration_ms=0,
+                    timeout_ms=0,
+                )
+
+            phase_summaries = {
+                phase: ShutdownPhaseSummary(
+                    phase=phase,
+                    started_at=0.0,
+                    finished_at=0.0,
+                    duration_ms=0,
+                    budget_ms=0,
+                    component_names=component_names,
+                )
+                for phase, component_names in phase_names.items()
+            }
+            return ShutdownSummary(
+                profile=self.profile,
+                started_at=0.0,
+                finished_at=0.0,
+                deadline_at=0.0,
+                hard_cutoff_at=0.0,
+                wall_time_ms=0,
+                soft_overrun_used_ms=0,
+                components=component_summaries,
+                phases=phase_summaries,
+            )
+
+    def _fake_build_legacy_shutdown_plan(_app, _locals_map):
+        return [
+            ShutdownComponent(
+                name="lifecycle_gate",
+                phase=ShutdownPhase.TRANSITION,
+                policy=ShutdownPolicy.DEV_FAST,
+                default_timeout_ms=1000,
+                stop=lambda: None,
+            ),
+            ShutdownComponent(
+                name="usage_aggregator",
+                phase=ShutdownPhase.RESOURCES,
+                policy=ShutdownPolicy.BEST_EFFORT,
+                default_timeout_ms=1000,
+                stop=lambda: None,
+            ),
+        ]
+
+    fake_shutdown_legacy_adapters = types.ModuleType(
+        "tldw_Server_API.app.services.shutdown_legacy_adapters"
+    )
+    fake_shutdown_legacy_adapters.build_legacy_shutdown_plan = _fake_build_legacy_shutdown_plan
+    fake_shutdown_legacy_adapters.register_legacy_shutdown_components = (
+        shutdown_legacy_adapters.register_legacy_shutdown_components
+    )
+    fake_shutdown_legacy_adapters.get_legacy_shutdown_suppressed_component_names = (
+        shutdown_legacy_adapters.get_legacy_shutdown_suppressed_component_names
+    )
+    monkeypatch.setitem(sys.modules, fake_shutdown_legacy_adapters.__name__, fake_shutdown_legacy_adapters)
+
+    fake_usage_aggregator = types.ModuleType("tldw_Server_API.app.services.usage_aggregator")
+    fake_usage_aggregator.start_usage_aggregator = _fake_start_usage_aggregator
+    fake_usage_aggregator.stop_usage_aggregator = _fake_stop_usage_aggregator
+    monkeypatch.setitem(sys.modules, fake_usage_aggregator.__name__, fake_usage_aggregator)
+
+    monkeypatch.setenv("DISABLE_LLM_USAGE_AGGREGATOR", "1")
+    monkeypatch.setattr(shutdown_coordinator_module, "ShutdownCoordinator", _SpyShutdownCoordinator)
+
+    from tldw_Server_API.app.main import app
+
+    for attr_name in (
+        "_tldw_lifecycle_events",
+        "_tldw_lifecycle_state",
+        "_tldw_shutdown_legacy_coordinator_summary",
+        "_tldw_shutdown_legacy_coordinator_component_names",
+        "_tldw_shutdown_legacy_coordinator_phase_groups",
+    ):
+        if hasattr(app.state, attr_name):
+            delattr(app.state, attr_name)
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+
+    usage_task = usage_task_holder["task"]
+    assert usage_task.stop_calls == 1
+    assert usage_task.cancel_calls >= 1
+    assert app.state._tldw_shutdown_legacy_coordinator_summary.components["usage_aggregator"].result == "skipped"
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
+++ b/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
@@ -81,6 +81,82 @@ async def test_asgi_transport_without_lifespan_bypasses_shutdown_coordinator(
     assert lifecycle_state is None or lifecycle_state.draining is False
 
 
+def test_build_legacy_shutdown_context_uses_explicit_fields() -> None:
+    from tldw_Server_API.app.main import _build_legacy_shutdown_context
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import LegacyShutdownContext
+
+    readiness_state = {"ready": True}
+    usage_task = object()
+    llm_usage_task = object()
+    chatbooks_cleanup_task = object()
+    chatbooks_cleanup_stop_event = object()
+    storage_cleanup_service = object()
+
+    context = _build_legacy_shutdown_context(
+        readiness_state=readiness_state,
+        usage_task=usage_task,
+        llm_usage_task=llm_usage_task,
+        authnz_scheduler_started=True,
+        chatbooks_cleanup_task=chatbooks_cleanup_task,
+        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
+        storage_cleanup_service=storage_cleanup_service,
+    )
+
+    assert isinstance(context, LegacyShutdownContext)
+    assert context.readiness_state is readiness_state
+    assert context.usage_task is usage_task
+    assert context.llm_usage_task is llm_usage_task
+    assert context.authnz_scheduler_started is True
+    assert context.chatbooks_cleanup_task is chatbooks_cleanup_task
+    assert context.chatbooks_cleanup_stop_event is chatbooks_cleanup_stop_event
+    assert context.storage_cleanup_service is storage_cleanup_service
+
+
+def test_apply_shutdown_transition_gate_logs_guard_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+    import types
+
+    from fastapi import FastAPI
+
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    debug_messages: list[str] = []
+    warning_messages: list[str] = []
+
+    def _raise_lifecycle_state(_app):
+        raise RuntimeError("lookup failed")
+
+    def _raise_mark_shutdown(_app, _readiness_state):
+        raise RuntimeError("mark failed")
+
+    class _FailingJobManager:
+        @classmethod
+        def set_acquire_gate(cls, _enabled: bool) -> None:
+            raise RuntimeError("gate failed")
+
+    fake_jobs_manager = types.ModuleType("tldw_Server_API.app.core.Jobs.manager")
+    fake_jobs_manager.JobManager = _FailingJobManager
+
+    monkeypatch.setattr(main_module, "get_or_create_lifecycle_state", _raise_lifecycle_state)
+    monkeypatch.setattr(main_module, "mark_lifecycle_shutdown", _raise_mark_shutdown)
+    monkeypatch.setattr(main_module.logger, "debug", lambda message, *args, **kwargs: debug_messages.append(str(message)))
+    monkeypatch.setattr(
+        main_module.logger,
+        "warning",
+        lambda message, *args, **kwargs: warning_messages.append(str(message)),
+    )
+    monkeypatch.setitem(sys.modules, fake_jobs_manager.__name__, fake_jobs_manager)
+
+    main_module._apply_shutdown_transition_gate(app, {})
+
+    assert any("lifecycle state lookup skipped" in message for message in debug_messages)
+    assert any("failed to mark lifecycle shutdown" in message for message in warning_messages)
+    assert any("job acquire gate unavailable" in message for message in debug_messages)
+
+
 @pytest.mark.integration
 def test_lifecycle_hooks_called_in_order() -> None:
     from tldw_Server_API.app.main import app
@@ -229,7 +305,11 @@ def test_shutdown_migrated_legacy_slice_uses_prod_drain_profile(
                 phases=phase_summaries,
             )
 
-    def _fake_build_legacy_shutdown_plan(_app, _locals_map):
+    captured_contexts: list[object] = []
+
+    def _fake_build_legacy_shutdown_plan(_app, _context):
+        if _context is not None:
+            captured_contexts.append(_context)
         return [
             ShutdownComponent(
                 name="lifecycle_gate",
@@ -264,6 +344,7 @@ def test_shutdown_migrated_legacy_slice_uses_prod_drain_profile(
     fake_shutdown_legacy_adapters = types.ModuleType(
         "tldw_Server_API.app.services.shutdown_legacy_adapters"
     )
+    fake_shutdown_legacy_adapters.LegacyShutdownContext = shutdown_legacy_adapters.LegacyShutdownContext
     fake_shutdown_legacy_adapters.build_legacy_shutdown_plan = _fake_build_legacy_shutdown_plan
     fake_shutdown_legacy_adapters.register_legacy_shutdown_components = (
         shutdown_legacy_adapters.register_legacy_shutdown_components
@@ -292,6 +373,11 @@ def test_shutdown_migrated_legacy_slice_uses_prod_drain_profile(
         assert client.get("/health").status_code == 200
 
     assert _SpyShutdownCoordinator.created_profiles == ["dev_fast", "prod_drain"]
+    assert len(captured_contexts) == 1
+    assert getattr(captured_contexts[0], "readiness_state", None) is not None
+    assert hasattr(captured_contexts[0], "usage_task")
+    assert hasattr(captured_contexts[0], "llm_usage_task")
+    assert hasattr(captured_contexts[0], "authnz_scheduler_started")
     assert [component.name for component in _SpyShutdownCoordinator.instances[0].registered] == [
         "lifecycle_gate",
     ]
@@ -395,7 +481,7 @@ def test_shutdown_skipped_best_effort_component_falls_back_to_direct_stop(
                 phases=phase_summaries,
             )
 
-    def _fake_build_legacy_shutdown_plan(_app, _locals_map):
+    def _fake_build_legacy_shutdown_plan(_app, _context):
         return [
             ShutdownComponent(
                 name="lifecycle_gate",
@@ -416,6 +502,7 @@ def test_shutdown_skipped_best_effort_component_falls_back_to_direct_stop(
     fake_shutdown_legacy_adapters = types.ModuleType(
         "tldw_Server_API.app.services.shutdown_legacy_adapters"
     )
+    fake_shutdown_legacy_adapters.LegacyShutdownContext = shutdown_legacy_adapters.LegacyShutdownContext
     fake_shutdown_legacy_adapters.build_legacy_shutdown_plan = _fake_build_legacy_shutdown_plan
     fake_shutdown_legacy_adapters.register_legacy_shutdown_components = (
         shutdown_legacy_adapters.register_legacy_shutdown_components

--- a/tldw_Server_API/tests/Services/test_main_readiness_shutdown.py
+++ b/tldw_Server_API/tests/Services/test_main_readiness_shutdown.py
@@ -41,8 +41,10 @@ def test_ready_endpoint_returns_non_success_when_dependency_raises(monkeypatch) 
         raise AssertionError(f"expected 503, got {response.status_code}")
     if payload["status"] != "not_ready":
         raise AssertionError(f"unexpected status: {payload['status']!r}")
-    if "boom" not in payload["error"]:
-        raise AssertionError(f"unexpected error: {payload['error']!r}")
+    if payload["reason"] != "dependency_check_failed":
+        raise AssertionError(f"unexpected reason: {payload['reason']!r}")
+    if "error" in payload:
+        raise AssertionError(f"readiness probe should not echo raw errors: {payload!r}")
 
 
 @pytest.mark.integration
@@ -65,5 +67,7 @@ def test_ready_endpoint_returns_503_for_import_error(monkeypatch) -> None:
         raise AssertionError(f"expected 503, got {response.status_code}")
     if payload["status"] != "not_ready":
         raise AssertionError(f"unexpected status: {payload['status']!r}")
-    if "missing readiness dependency" not in payload["error"]:
-        raise AssertionError(f"unexpected error: {payload['error']!r}")
+    if payload["reason"] != "dependency_check_failed":
+        raise AssertionError(f"unexpected reason: {payload['reason']!r}")
+    if "error" in payload:
+        raise AssertionError(f"readiness probe should not echo raw errors: {payload!r}")

--- a/tldw_Server_API/tests/Services/test_main_readiness_shutdown.py
+++ b/tldw_Server_API/tests/Services/test_main_readiness_shutdown.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.integration
+def test_ready_endpoint_returns_503_when_draining() -> None:
+    from tldw_Server_API.app.main import app
+    from tldw_Server_API.app.services.app_lifecycle import get_or_create_lifecycle_state
+
+    with TestClient(app) as client:
+        state = get_or_create_lifecycle_state(app)
+        state.phase = "draining"
+        state.ready = False
+        state.draining = True
+
+        response = client.get("/ready")
+
+    if response.status_code != 503:
+        raise AssertionError(f"expected 503, got {response.status_code}")
+    payload = response.json()
+    if payload["reason"] != "shutdown_in_progress":
+        raise AssertionError(f"unexpected reason: {payload['reason']!r}")
+
+
+@pytest.mark.integration
+def test_ready_endpoint_returns_non_success_when_dependency_raises(monkeypatch) -> None:
+    from tldw_Server_API.app.main import app
+
+    def _fake_get_db_pool() -> object:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("tldw_Server_API.app.core.AuthNZ.database.get_db_pool", _fake_get_db_pool)
+
+    with TestClient(app) as client:
+        response = client.get("/ready")
+
+    payload = response.json()
+    if response.status_code != 503:
+        raise AssertionError(f"expected 503, got {response.status_code}")
+    if payload["status"] != "not_ready":
+        raise AssertionError(f"unexpected status: {payload['status']!r}")
+    if "boom" not in payload["error"]:
+        raise AssertionError(f"unexpected error: {payload['error']!r}")
+
+
+@pytest.mark.integration
+def test_ready_endpoint_returns_503_for_import_error(monkeypatch) -> None:
+    from tldw_Server_API.app.main import app
+
+    def _fake_create_workflows_database(*args, **kwargs) -> object:
+        raise ImportError("missing readiness dependency")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.DB_Management.DB_Manager.create_workflows_database",
+        _fake_create_workflows_database,
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/ready")
+
+    payload = response.json()
+    if response.status_code != 503:
+        raise AssertionError(f"expected 503, got {response.status_code}")
+    if payload["status"] != "not_ready":
+        raise AssertionError(f"unexpected status: {payload['status']!r}")
+    if "missing readiness dependency" not in payload["error"]:
+        raise AssertionError(f"unexpected error: {payload['error']!r}")

--- a/tldw_Server_API/tests/Services/test_shutdown_coordinator.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_coordinator.py
@@ -327,6 +327,33 @@ async def test_register_legacy_shutdown_components_keeps_authnz_in_inventory_but
     assert summary.phases[ShutdownPhase.FINALIZERS].component_names == ["storage_cleanup_service"]
 
 
+def test_register_legacy_shutdown_components_skips_effective_transition_overrides() -> None:
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+        register_legacy_shutdown_components,
+    )
+
+    class _Coordinator:
+        def __init__(self) -> None:
+            self.registered: list[ShutdownComponent] = []
+
+        def register(self, component: ShutdownComponent) -> ShutdownComponent:
+            self.registered.append(component)
+            return component
+
+    coordinator = _Coordinator()
+    registered = register_legacy_shutdown_components(
+        coordinator,
+        [
+            component("chatbooks_cleanup", phase=ShutdownPhase.WORKERS, stop=lambda: None),
+        ],
+        component_names=("chatbooks_cleanup",),
+        phase_overrides={"chatbooks_cleanup": ShutdownPhase.TRANSITION},
+    )
+
+    assert registered == []
+    assert coordinator.registered == []
+
+
 @pytest.mark.asyncio
 async def test_coordinator_runs_same_phase_components_in_parallel() -> None:
     coordinator = ShutdownCoordinator(profile="dev_fast")
@@ -398,16 +425,24 @@ async def test_transport_registry_components_are_visible_to_shutdown_coordinator
     )
 
     events: list[str] = []
+    async def _drain_mcp(timeout_s: float | None = None) -> None:
+        del timeout_s
+        events.append("mcp")
+
+    async def _drain_prompt_studio(timeout_s: float | None = None) -> None:
+        del timeout_s
+        events.append("prompt_studio")
+
     registry = ShutdownTransportRegistry()
     registry.register_family(
         "mcp.websocket",
         active_count=lambda: 2,
-        drain=lambda timeout_s=None: events.append("mcp"),
+        drain=_drain_mcp,
     )
     registry.register_family(
         "prompt_studio.websocket",
         active_count=lambda: 1,
-        drain=lambda timeout_s=None: events.append("prompt_studio"),
+        drain=_drain_prompt_studio,
     )
 
     coordinator = ShutdownCoordinator(profile="dev_fast")
@@ -422,7 +457,7 @@ async def test_transport_registry_components_are_visible_to_shutdown_coordinator
     ]
     assert summary.components["transport:mcp.websocket"].result == "stopped"
     assert summary.components["transport:prompt_studio.websocket"].result == "stopped"
-    assert events == ["mcp", "prompt_studio"]
+    assert sorted(events) == ["mcp", "prompt_studio"]
 
 
 def test_main_shutdown_path_registers_transport_registry_components() -> None:
@@ -432,15 +467,22 @@ def test_main_shutdown_path_registers_transport_registry_components() -> None:
     from tldw_Server_API.app.services.shutdown_transport_registry import ShutdownTransportRegistry
 
     registry = ShutdownTransportRegistry()
+
+    async def _drain_mcp(timeout_s: float | None = None) -> None:
+        del timeout_s
+
+    async def _drain_prompt_studio(timeout_s: float | None = None) -> None:
+        del timeout_s
+
     registry.register_family(
         "mcp.websocket",
         active_count=lambda: 2,
-        drain=lambda timeout_s=None: None,
+        drain=_drain_mcp,
     )
     registry.register_family(
         "prompt_studio.websocket",
         active_count=lambda: 1,
-        drain=lambda timeout_s=None: None,
+        drain=_drain_prompt_studio,
     )
 
     coordinator, legacy_components, transport_components = _build_coordinated_shutdown_coordinator(
@@ -470,15 +512,24 @@ async def test_main_shutdown_path_drains_transport_components_with_empty_legacy_
     app = FastAPI()
     events: list[str] = []
     registry = ShutdownTransportRegistry()
+
+    async def _drain_mcp(timeout_s: float | None = None) -> None:
+        del timeout_s
+        events.append("mcp")
+
+    async def _drain_prompt_studio(timeout_s: float | None = None) -> None:
+        del timeout_s
+        events.append("prompt_studio")
+
     registry.register_family(
         "mcp.websocket",
         active_count=lambda: 2,
-        drain=lambda timeout_s=None: events.append("mcp"),
+        drain=_drain_mcp,
     )
     registry.register_family(
         "prompt_studio.websocket",
         active_count=lambda: 1,
-        drain=lambda timeout_s=None: events.append("prompt_studio"),
+        drain=_drain_prompt_studio,
     )
 
     suppressed = await _run_coordinated_shutdown(
@@ -496,7 +547,25 @@ async def test_main_shutdown_path_drains_transport_components_with_empty_legacy_
         "transport:mcp.websocket",
         "transport:prompt_studio.websocket",
     ]
-    assert events == ["mcp", "prompt_studio"]
+    assert sorted(events) == ["mcp", "prompt_studio"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_synthesizes_failed_summary_for_unexpected_component_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    coordinator.register(component("producer-a", phase="producers", stop=lambda: None))
+
+    async def _boom(*args, **kwargs) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(coordinator, "_run_component", _boom)
+
+    summary = await coordinator.shutdown()
+
+    assert summary.components["producer-a"].result == "failed"
+    assert summary.components["producer-a"].error == "boom"
 
 
 @pytest.mark.asyncio
@@ -774,6 +843,39 @@ async def test_coordinator_records_timeout_when_stop_swallows_cancellation() -> 
 
     assert summary.components["producer-a"].result in {"timed_out", "cancelled"}
     assert summary.components["producer-a"].result != "stopped"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_preserves_completed_result_after_timeout_quiescence() -> None:
+    coordinator = ShutdownCoordinator(
+        profile="custom",
+        deadline_ms=10,
+        soft_overrun_ms=100,
+    )
+    cancelled = asyncio.Event()
+
+    async def _stop() -> None:
+        try:
+            await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            cancelled.set()
+            return
+
+    coordinator.register(
+        component(
+            "producer-a",
+            phase="producers",
+            stop=_stop,
+            policy=ShutdownPolicy.DEV_FAST,
+            default_timeout_ms=1_000,
+        )
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert cancelled.is_set()
+    assert summary.components["producer-a"].result == "stopped"
+    assert summary.components["producer-a"].budget_exhausted is True
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_shutdown_coordinator.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_coordinator.py
@@ -1,0 +1,884 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+import pytest
+
+from tldw_Server_API.app.services.shutdown_coordinator import ShutdownCoordinator
+from tldw_Server_API.app.services.shutdown_models import (
+    ShutdownComponent,
+    ShutdownPhase,
+    ShutdownPolicy,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _Clock:
+    now: float = 0.0
+
+    def __call__(self) -> float:
+        return float(self.now)
+
+    def advance(self, seconds: float) -> None:
+        self.now += float(seconds)
+
+
+def component(
+    name: str,
+    *,
+    phase: ShutdownPhase | str,
+    stop: Callable[[], Awaitable[None] | None],
+    policy: ShutdownPolicy | str = ShutdownPolicy.PROD_DRAIN,
+    default_timeout_ms: int = 250,
+) -> ShutdownComponent:
+    return ShutdownComponent(
+        name=name,
+        phase=phase,
+        policy=policy,
+        default_timeout_ms=default_timeout_ms,
+        stop=stop,
+    )
+
+
+def test_build_legacy_shutdown_plan_includes_known_legacy_components() -> None:
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import build_legacy_shutdown_plan
+
+    class _App:
+        pass
+
+    app = _App()
+    plan = build_legacy_shutdown_plan(
+        app,
+        {
+            "usage_task": object(),
+            "_authnz_sched_started": True,
+        },
+    )
+
+    assert [component.name for component in plan] == [
+        "lifecycle_gate",
+        "usage_aggregator",
+        "authnz_scheduler",
+    ]
+    assert plan[0].phase == ShutdownPhase.TRANSITION
+    assert plan[0].policy == ShutdownPolicy.DEV_FAST
+    assert plan[1].phase == ShutdownPhase.RESOURCES
+    assert plan[1].policy == ShutdownPolicy.BEST_EFFORT
+    assert plan[2].phase == ShutdownPhase.FINALIZERS
+    assert plan[2].policy == ShutdownPolicy.PROD_DRAIN
+
+
+def test_build_legacy_shutdown_plan_records_visibility_on_app_state() -> None:
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import build_legacy_shutdown_plan
+
+    class _State:
+        pass
+
+    class _App:
+        def __init__(self) -> None:
+            self.state = _State()
+
+    app = _App()
+
+    plan = build_legacy_shutdown_plan(app, {})
+
+    assert app.state._tldw_shutdown_legacy_inventory_visible is True
+    assert app.state._tldw_shutdown_legacy_phase_groups == {
+        "transition": ["lifecycle_gate"],
+    }
+    assert app.state._tldw_shutdown_legacy_inventory["component_names"] == ["lifecycle_gate"]
+    assert plan[0].name == "lifecycle_gate"
+
+
+def test_build_legacy_shutdown_plan_orders_migrated_components_usage_before_storage() -> None:
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import build_legacy_shutdown_plan
+
+    class _App:
+        pass
+
+    plan = build_legacy_shutdown_plan(
+        _App(),
+        {
+            "chatbooks_cleanup_task": object(),
+            "storage_cleanup_service": object(),
+            "usage_task": object(),
+            "llm_usage_task": object(),
+        },
+    )
+
+    assert [component.name for component in plan] == [
+        "lifecycle_gate",
+        "chatbooks_cleanup",
+        "usage_aggregator",
+        "llm_usage_aggregator",
+        "storage_cleanup_service",
+    ]
+    assert [component.phase for component in plan] == [
+        ShutdownPhase.TRANSITION,
+        ShutdownPhase.WORKERS,
+        ShutdownPhase.RESOURCES,
+        ShutdownPhase.RESOURCES,
+        ShutdownPhase.FINALIZERS,
+    ]
+
+
+def test_shutdown_legacy_adapters_import_is_lazy_for_optional_stop_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "tldw_Server_API.app.services.shutdown_legacy_adapters"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.core.AuthNZ.scheduler",
+        types.ModuleType("tldw_Server_API.app.core.AuthNZ.scheduler"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.services.usage_aggregator",
+        types.ModuleType("tldw_Server_API.app.services.usage_aggregator"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.services.llm_usage_aggregator",
+        types.ModuleType("tldw_Server_API.app.services.llm_usage_aggregator"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.core.Jobs.manager",
+        types.ModuleType("tldw_Server_API.app.core.Jobs.manager"),
+    )
+
+    module = importlib.import_module(module_name)
+
+    class _App:
+        pass
+
+    plan = module.build_legacy_shutdown_plan(
+        _App(),
+        {
+            "usage_task": object(),
+            "llm_usage_task": object(),
+            "_authnz_sched_started": True,
+        },
+    )
+
+    assert [component.name for component in plan] == [
+        "lifecycle_gate",
+        "usage_aggregator",
+        "llm_usage_aggregator",
+        "authnz_scheduler",
+    ]
+
+
+def test_get_legacy_shutdown_suppressed_component_names_uses_summary_results() -> None:
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+        get_legacy_shutdown_suppressed_component_names,
+    )
+    from tldw_Server_API.app.services.shutdown_models import (
+        ShutdownComponentSummary,
+        ShutdownPhase,
+        ShutdownPolicy,
+        ShutdownSummary,
+    )
+
+    summary = ShutdownSummary(
+        profile="prod_drain",
+        started_at=0.0,
+        finished_at=0.0,
+        deadline_at=0.0,
+        hard_cutoff_at=0.0,
+        wall_time_ms=0,
+        soft_overrun_used_ms=0,
+        components={
+            "chatbooks_cleanup": ShutdownComponentSummary(
+                name="chatbooks_cleanup",
+                phase=ShutdownPhase.WORKERS,
+                policy=ShutdownPolicy.PROD_DRAIN,
+                result="stopped",
+                started_at=0.0,
+                finished_at=0.0,
+                duration_ms=0,
+                timeout_ms=1000,
+            ),
+            "usage_aggregator": ShutdownComponentSummary(
+                name="usage_aggregator",
+                phase=ShutdownPhase.RESOURCES,
+                policy=ShutdownPolicy.BEST_EFFORT,
+                result="skipped",
+                started_at=0.0,
+                finished_at=0.0,
+                duration_ms=0,
+                timeout_ms=0,
+            ),
+            "llm_usage_aggregator": ShutdownComponentSummary(
+                name="llm_usage_aggregator",
+                phase=ShutdownPhase.RESOURCES,
+                policy=ShutdownPolicy.BEST_EFFORT,
+                result="timed_out",
+                started_at=0.0,
+                finished_at=0.0,
+                duration_ms=0,
+                timeout_ms=0,
+            ),
+            "storage_cleanup_service": ShutdownComponentSummary(
+                name="storage_cleanup_service",
+                phase=ShutdownPhase.FINALIZERS,
+                policy=ShutdownPolicy.PROD_DRAIN,
+                result="cancelled",
+                started_at=0.0,
+                finished_at=0.0,
+                duration_ms=0,
+                timeout_ms=0,
+            ),
+            "authnz_scheduler": ShutdownComponentSummary(
+                name="authnz_scheduler",
+                phase=ShutdownPhase.FINALIZERS,
+                policy=ShutdownPolicy.PROD_DRAIN,
+                result="failed",
+                started_at=0.0,
+                finished_at=0.0,
+                duration_ms=0,
+                timeout_ms=0,
+                error="boom",
+            ),
+        },
+    )
+
+    assert get_legacy_shutdown_suppressed_component_names(summary) == {"chatbooks_cleanup"}
+
+
+@pytest.mark.asyncio
+async def test_register_legacy_shutdown_components_keeps_authnz_in_inventory_but_not_in_migrated_set() -> None:
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+        register_legacy_shutdown_components,
+    )
+
+    events: list[str] = []
+    plan = [
+        component("chatbooks_cleanup", phase=ShutdownPhase.WORKERS, stop=lambda: events.append("chatbooks")),
+        component(
+            "storage_cleanup_service",
+            phase=ShutdownPhase.FINALIZERS,
+            stop=lambda: events.append("storage"),
+        ),
+        component(
+            "usage_aggregator",
+            phase=ShutdownPhase.RESOURCES,
+            stop=lambda: events.append("usage"),
+        ),
+        component(
+            "llm_usage_aggregator",
+            phase=ShutdownPhase.RESOURCES,
+            stop=lambda: events.append("llm"),
+        ),
+        component(
+            "authnz_scheduler",
+            phase=ShutdownPhase.FINALIZERS,
+            stop=lambda: events.append("authnz"),
+        ),
+    ]
+
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    registered = register_legacy_shutdown_components(
+        coordinator,
+        plan,
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert [component.name for component in registered] == [
+        "chatbooks_cleanup",
+        "usage_aggregator",
+        "llm_usage_aggregator",
+        "storage_cleanup_service",
+    ]
+    assert [component.phase for component in registered] == [
+        ShutdownPhase.WORKERS,
+        ShutdownPhase.RESOURCES,
+        ShutdownPhase.RESOURCES,
+        ShutdownPhase.FINALIZERS,
+    ]
+    assert plan[-1].phase == ShutdownPhase.FINALIZERS
+    assert sorted(events) == ["chatbooks", "llm", "storage", "usage"]
+    assert summary.phases[ShutdownPhase.PRODUCERS].component_names == []
+    assert summary.phases[ShutdownPhase.WORKERS].component_names == ["chatbooks_cleanup"]
+    assert summary.phases[ShutdownPhase.RESOURCES].component_names == [
+        "usage_aggregator",
+        "llm_usage_aggregator",
+    ]
+    assert summary.phases[ShutdownPhase.FINALIZERS].component_names == ["storage_cleanup_service"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_runs_same_phase_components_in_parallel() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    started = asyncio.Event()
+    release = asyncio.Event()
+    running = 0
+
+    async def _stop_a() -> None:
+        nonlocal running
+        running += 1
+        if running == 2:
+            started.set()
+        await release.wait()
+
+    async def _stop_b() -> None:
+        nonlocal running
+        running += 1
+        if running == 2:
+            started.set()
+        await release.wait()
+
+    coordinator.register(component("worker-a", phase=ShutdownPhase.WORKERS, stop=_stop_a))
+    coordinator.register(component("worker-b", phase=ShutdownPhase.WORKERS, stop=_stop_b))
+
+    shutdown_task = asyncio.create_task(coordinator.shutdown())
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    assert running == 2
+    release.set()
+
+    summary = await shutdown_task
+
+    assert summary.phases[ShutdownPhase.WORKERS].component_names == ["worker-a", "worker-b"]
+    assert summary.components["worker-a"].result == "stopped"
+    assert summary.components["worker-b"].result == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_transport_registry_components_are_visible_to_shutdown_coordinator() -> None:
+    from tldw_Server_API.app.services.shutdown_transport_registry import (
+        ShutdownTransportRegistry,
+        build_shutdown_components,
+    )
+
+    events: list[str] = []
+    registry = ShutdownTransportRegistry()
+    registry.register_family(
+        "mcp.websocket",
+        active_count=lambda: 2,
+        drain=lambda timeout_s=None: events.append("mcp"),
+    )
+    registry.register_family(
+        "prompt_studio.websocket",
+        active_count=lambda: 1,
+        drain=lambda timeout_s=None: events.append("prompt_studio"),
+    )
+
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    for shutdown_component in build_shutdown_components(registry):
+        coordinator.register(shutdown_component)
+
+    summary = await coordinator.shutdown()
+
+    assert summary.phases[ShutdownPhase.ACCEPTORS].component_names == [
+        "transport:mcp.websocket",
+        "transport:prompt_studio.websocket",
+    ]
+    assert summary.components["transport:mcp.websocket"].result == "stopped"
+    assert summary.components["transport:prompt_studio.websocket"].result == "stopped"
+    assert events == ["mcp", "prompt_studio"]
+
+
+def test_main_shutdown_path_registers_transport_registry_components() -> None:
+    from fastapi import FastAPI
+
+    from tldw_Server_API.app.main import _build_coordinated_shutdown_coordinator
+    from tldw_Server_API.app.services.shutdown_transport_registry import ShutdownTransportRegistry
+
+    registry = ShutdownTransportRegistry()
+    registry.register_family(
+        "mcp.websocket",
+        active_count=lambda: 2,
+        drain=lambda timeout_s=None: None,
+    )
+    registry.register_family(
+        "prompt_studio.websocket",
+        active_count=lambda: 1,
+        drain=lambda timeout_s=None: None,
+    )
+
+    coordinator, legacy_components, transport_components = _build_coordinated_shutdown_coordinator(
+        FastAPI(),
+        [],
+        transport_registry=registry,
+    )
+
+    assert legacy_components == []
+    assert [component.name for component in transport_components] == [
+        "transport:mcp.websocket",
+        "transport:prompt_studio.websocket",
+    ]
+    assert list(coordinator._components) == [
+        "transport:mcp.websocket",
+        "transport:prompt_studio.websocket",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_main_shutdown_path_drains_transport_components_with_empty_legacy_plan() -> None:
+    from fastapi import FastAPI
+
+    from tldw_Server_API.app.main import _run_coordinated_shutdown
+    from tldw_Server_API.app.services.shutdown_transport_registry import ShutdownTransportRegistry
+
+    app = FastAPI()
+    events: list[str] = []
+    registry = ShutdownTransportRegistry()
+    registry.register_family(
+        "mcp.websocket",
+        active_count=lambda: 2,
+        drain=lambda timeout_s=None: events.append("mcp"),
+    )
+    registry.register_family(
+        "prompt_studio.websocket",
+        active_count=lambda: 1,
+        drain=lambda timeout_s=None: events.append("prompt_studio"),
+    )
+
+    suppressed = await _run_coordinated_shutdown(
+        app,
+        [],
+        transport_registry=registry,
+    )
+
+    assert suppressed == set()
+    assert app.state._tldw_shutdown_transport_component_names == [
+        "transport:mcp.websocket",
+        "transport:prompt_studio.websocket",
+    ]
+    assert app.state._tldw_shutdown_legacy_coordinator_component_names == [
+        "transport:mcp.websocket",
+        "transport:prompt_studio.websocket",
+    ]
+    assert events == ["mcp", "prompt_studio"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_runs_components_by_phase_and_records_summary() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    events: list[str] = []
+
+    coordinator.register(
+        component("producer-a", phase="producers", stop=lambda: events.append("producer"))
+    )
+    coordinator.register(
+        component("resource-a", phase="resources", stop=lambda: events.append("resource"))
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert events == ["producer", "resource"]
+    assert summary.components["producer-a"].result == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_runs_transition_components_and_records_summary() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    events: list[str] = []
+
+    coordinator.register(
+        component("transition-a", phase="transition", stop=lambda: events.append("transition"))
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert events == ["transition"]
+    assert summary.components["transition-a"].result == "stopped"
+    assert summary.phases[ShutdownPhase.TRANSITION].component_names == ["transition-a"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_allocates_remaining_time_across_phases(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock()
+    timeout_calls: list[float] = []
+
+    async def _fake_wait_for(awaitable, timeout):
+        timeout_calls.append(timeout)
+        return await awaitable
+
+    async def _slow_producer() -> None:
+        clock.advance(4.0)
+
+    async def _resource() -> None:
+        return None
+
+    monkeypatch.setattr("tldw_Server_API.app.services.shutdown_coordinator.asyncio.wait_for", _fake_wait_for)
+
+    coordinator = ShutdownCoordinator(profile="dev_fast", clock=clock)
+    coordinator.register(
+        component("producer-a", phase="producers", stop=_slow_producer, default_timeout_ms=10_000)
+    )
+    coordinator.register(
+        component("resource-a", phase="resources", stop=_resource, default_timeout_ms=10_000)
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert timeout_calls[0] > timeout_calls[1]
+    assert summary.components["producer-a"].result == "stopped"
+    assert summary.components["resource-a"].result == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_hard_cutoff_after_soft_overrun(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock(now=0.009)
+    timeout_calls: list[float] = []
+
+    async def _fake_wait_for(awaitable, timeout):
+        timeout_calls.append(timeout)
+        return await awaitable
+
+    async def _drain_eligible_resource() -> None:
+        clock.advance(0.8)
+
+    monkeypatch.setattr("tldw_Server_API.app.services.shutdown_coordinator.asyncio.wait_for", _fake_wait_for)
+
+    coordinator = ShutdownCoordinator(
+        profile="prod_drain",
+        clock=clock,
+        deadline_ms=10,
+        soft_overrun_ms=1000,
+    )
+    coordinator.register(
+        component("worker-a", phase="workers", policy="dev_fast", stop=lambda: None, default_timeout_ms=5_000)
+    )
+    coordinator.register(
+        component("resource-a", phase="resources", stop=_drain_eligible_resource, default_timeout_ms=5_000)
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert timeout_calls[0] <= 0.01
+    assert timeout_calls[1] >= 0.5
+    assert summary.components["resource-a"].result == "stopped"
+    assert summary.soft_overrun_used_ms > 0
+
+
+@pytest.mark.asyncio
+async def test_coordinator_custom_profile_honors_configured_soft_overrun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock(now=0.009)
+    timeout_calls: list[float] = []
+
+    async def _fake_wait_for(awaitable, timeout):
+        timeout_calls.append(timeout)
+        return await awaitable
+
+    async def _resource() -> None:
+        clock.advance(0.8)
+
+    monkeypatch.setattr("tldw_Server_API.app.services.shutdown_coordinator.asyncio.wait_for", _fake_wait_for)
+
+    coordinator = ShutdownCoordinator(
+        profile="custom",
+        clock=clock,
+        deadline_ms=10,
+        soft_overrun_ms=1000,
+    )
+    coordinator.register(
+        component("resource-a", phase="resources", stop=_resource, default_timeout_ms=5_000)
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert timeout_calls[0] >= 0.5
+    assert summary.components["resource-a"].result == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_uses_full_budget_when_only_one_runnable_phase_remains(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock(now=0.009)
+    timeout_calls: list[float] = []
+
+    async def _fake_wait_for(awaitable, timeout):
+        timeout_calls.append(timeout)
+        return await awaitable
+
+    async def _resource() -> None:
+        clock.advance(0.2)
+
+    monkeypatch.setattr("tldw_Server_API.app.services.shutdown_coordinator.asyncio.wait_for", _fake_wait_for)
+
+    coordinator = ShutdownCoordinator(
+        profile="prod_drain",
+        clock=clock,
+        deadline_ms=10,
+        soft_overrun_ms=1000,
+    )
+    coordinator.register(
+        component("resource-a", phase="resources", stop=_resource, default_timeout_ms=5_000)
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert timeout_calls[0] >= 0.9
+    assert summary.components["resource-a"].result == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_best_effort_components_do_not_block_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock()
+    events: list[str] = []
+
+    async def _fake_wait_for(awaitable, timeout):
+        if timeout <= 0:
+            raise TimeoutError
+        return await awaitable
+
+    async def _producer_stop() -> None:
+        events.append("producer")
+        clock.advance(6.0)
+
+    async def _best_effort_stop() -> None:
+        events.append("best_effort")
+        raise AssertionError("best-effort stop should not have been awaited")
+
+    monkeypatch.setattr("tldw_Server_API.app.services.shutdown_coordinator.asyncio.wait_for", _fake_wait_for)
+
+    coordinator = ShutdownCoordinator(profile="dev_fast", clock=clock)
+    coordinator.register(component("producer-a", phase="producers", stop=_producer_stop))
+    coordinator.register(
+        ShutdownComponent(
+            name="resource-a",
+            phase="resources",
+            policy="best_effort",
+            default_timeout_ms=50,
+            stop=_best_effort_stop,
+        )
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert events == ["producer"]
+    assert summary.components["resource-a"].result == "skipped"
+    assert summary.components["resource-a"].timeout_ms == 0
+
+
+@pytest.mark.asyncio
+async def test_coordinator_best_effort_only_later_phases_do_not_reduce_mandatory_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    timeout_calls: list[float] = []
+    events: list[str] = []
+
+    async def _fake_wait_for(awaitable, timeout):
+        timeout_calls.append(timeout)
+        return await awaitable
+
+    async def _producer_stop() -> None:
+        events.append("producer")
+
+    async def _best_effort_stop() -> None:
+        events.append("best_effort")
+
+    monkeypatch.setattr("tldw_Server_API.app.services.shutdown_coordinator.asyncio.wait_for", _fake_wait_for)
+
+    coordinator = ShutdownCoordinator(profile="dev_fast", clock=clock)
+    coordinator.register(component("producer-a", phase="producers", stop=_producer_stop, default_timeout_ms=10_000))
+    coordinator.register(
+        ShutdownComponent(
+            name="resource-a",
+            phase="resources",
+            policy="best_effort",
+            default_timeout_ms=10_000,
+            stop=_best_effort_stop,
+        )
+    )
+
+    summary = await coordinator.shutdown()
+
+    assert timeout_calls[0] >= 4.9
+    assert summary.components["producer-a"].result == "stopped"
+    assert summary.components["resource-a"].result == "stopped"
+    assert events == ["producer", "best_effort"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_records_timeout_when_stop_swallows_cancellation() -> None:
+    coordinator = ShutdownCoordinator(
+        profile="custom",
+        deadline_ms=10,
+        soft_overrun_ms=0,
+    )
+    cancelled = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _stop() -> None:
+        try:
+            await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            cancelled.set()
+            await release.wait()
+
+    coordinator.register(
+        component(
+            "producer-a",
+            phase="producers",
+            stop=_stop,
+            policy=ShutdownPolicy.DEV_FAST,
+            default_timeout_ms=1_000,
+        )
+    )
+
+    summary = await asyncio.wait_for(coordinator.shutdown(), timeout=1.0)
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)
+    release.set()
+
+    assert summary.components["producer-a"].result in {"timed_out", "cancelled"}
+    assert summary.components["producer-a"].result != "stopped"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_records_failed_result_when_stop_raises() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+
+    def _stop() -> None:
+        raise RuntimeError("boom")
+
+    coordinator.register(component("producer-a", phase="producers", stop=_stop))
+
+    summary = await coordinator.shutdown()
+
+    assert summary.components["producer-a"].result == "failed"
+    assert summary.components["producer-a"].error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_concurrent_shutdown_calls_share_in_progress_run() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    started = asyncio.Event()
+    release = asyncio.Event()
+    stop_count = 0
+
+    async def _stop() -> None:
+        nonlocal stop_count
+        stop_count += 1
+        started.set()
+        await release.wait()
+
+    coordinator.register(
+        component("producer-a", phase="producers", stop=_stop, default_timeout_ms=5_000)
+    )
+
+    first = asyncio.create_task(coordinator.shutdown())
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    second = asyncio.create_task(coordinator.shutdown())
+    await asyncio.sleep(0)
+    release.set()
+
+    first_summary, second_summary = await asyncio.gather(first, second)
+
+    assert stop_count == 1
+    assert first_summary is not second_summary
+    assert first_summary.idempotent is False
+    assert second_summary.idempotent is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_cancelled_waiter_does_not_cancel_shared_shutdown_run() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    started = asyncio.Event()
+    release = asyncio.Event()
+    stop_count = 0
+
+    async def _stop() -> None:
+        nonlocal stop_count
+        stop_count += 1
+        started.set()
+        await release.wait()
+
+    coordinator.register(
+        component("producer-a", phase="producers", stop=_stop, default_timeout_ms=5_000)
+    )
+
+    waiter = asyncio.create_task(coordinator.shutdown())
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    waiter.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    second = asyncio.create_task(coordinator.shutdown())
+    release.set()
+    summary = await second
+
+    assert stop_count == 1
+    assert summary.components["producer-a"].result == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_rejects_registration_during_and_after_shutdown() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    events: list[str] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _stop() -> None:
+        events.append("producer")
+        started.set()
+        await release.wait()
+
+    coordinator.register(component("producer-a", phase="producers", stop=_stop))
+
+    task = asyncio.create_task(coordinator.shutdown())
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    with pytest.raises(RuntimeError):
+        coordinator.register(component("late-a", phase="resources", stop=lambda: None))
+
+    release.set()
+    await task
+
+    with pytest.raises(RuntimeError):
+        coordinator.register(component("late-b", phase="resources", stop=lambda: None))
+
+
+@pytest.mark.asyncio
+async def test_coordinator_second_shutdown_call_returns_copy_without_mutating_first_summary() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    events: list[str] = []
+
+    coordinator.register(component("producer-a", phase="producers", stop=lambda: events.append("producer")))
+
+    first = await coordinator.shutdown()
+    second = await coordinator.shutdown()
+
+    assert first is not second
+    assert first.idempotent is False
+    assert second.idempotent is True
+    second.components["producer-a"].result = "failed"
+    second.phases[ShutdownPhase.PRODUCERS].component_names.append("mutated")
+    assert first.components["producer-a"].result == "stopped"
+    assert first.phases[ShutdownPhase.PRODUCERS].component_names == ["producer-a"]
+    assert events == ["producer"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_first_shutdown_return_does_not_alias_cached_summary() -> None:
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+    events: list[str] = []
+
+    coordinator.register(component("producer-a", phase="producers", stop=lambda: events.append("producer")))
+
+    first = await coordinator.shutdown()
+    first.components["producer-a"].result = "failed"
+    first.phases[ShutdownPhase.PRODUCERS].component_names.append("mutated")
+
+    second = await coordinator.shutdown()
+
+    assert first is not second
+    assert second.idempotent is True
+    assert second.components["producer-a"].result == "stopped"
+    assert second.phases[ShutdownPhase.PRODUCERS].component_names == ["producer-a"]
+    assert events == ["producer"]

--- a/tldw_Server_API/tests/Services/test_shutdown_coordinator.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_coordinator.py
@@ -49,7 +49,10 @@ def component(
 
 
 def test_build_legacy_shutdown_plan_includes_known_legacy_components() -> None:
-    from tldw_Server_API.app.services.shutdown_legacy_adapters import build_legacy_shutdown_plan
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+        LegacyShutdownContext,
+        build_legacy_shutdown_plan,
+    )
 
     class _App:
         pass
@@ -57,10 +60,10 @@ def test_build_legacy_shutdown_plan_includes_known_legacy_components() -> None:
     app = _App()
     plan = build_legacy_shutdown_plan(
         app,
-        {
-            "usage_task": object(),
-            "_authnz_sched_started": True,
-        },
+        LegacyShutdownContext(
+            usage_task=object(),
+            authnz_scheduler_started=True,
+        ),
     )
 
     assert [component.name for component in plan] == [
@@ -77,7 +80,10 @@ def test_build_legacy_shutdown_plan_includes_known_legacy_components() -> None:
 
 
 def test_build_legacy_shutdown_plan_records_visibility_on_app_state() -> None:
-    from tldw_Server_API.app.services.shutdown_legacy_adapters import build_legacy_shutdown_plan
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+        LegacyShutdownContext,
+        build_legacy_shutdown_plan,
+    )
 
     class _State:
         pass
@@ -88,7 +94,7 @@ def test_build_legacy_shutdown_plan_records_visibility_on_app_state() -> None:
 
     app = _App()
 
-    plan = build_legacy_shutdown_plan(app, {})
+    plan = build_legacy_shutdown_plan(app, LegacyShutdownContext())
 
     assert app.state._tldw_shutdown_legacy_inventory_visible is True
     assert app.state._tldw_shutdown_legacy_phase_groups == {
@@ -99,19 +105,22 @@ def test_build_legacy_shutdown_plan_records_visibility_on_app_state() -> None:
 
 
 def test_build_legacy_shutdown_plan_orders_migrated_components_usage_before_storage() -> None:
-    from tldw_Server_API.app.services.shutdown_legacy_adapters import build_legacy_shutdown_plan
+    from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+        LegacyShutdownContext,
+        build_legacy_shutdown_plan,
+    )
 
     class _App:
         pass
 
     plan = build_legacy_shutdown_plan(
         _App(),
-        {
-            "chatbooks_cleanup_task": object(),
-            "storage_cleanup_service": object(),
-            "usage_task": object(),
-            "llm_usage_task": object(),
-        },
+        LegacyShutdownContext(
+            chatbooks_cleanup_task=object(),
+            storage_cleanup_service=object(),
+            usage_task=object(),
+            llm_usage_task=object(),
+        ),
     )
 
     assert [component.name for component in plan] == [
@@ -157,17 +166,18 @@ def test_shutdown_legacy_adapters_import_is_lazy_for_optional_stop_helpers(
     )
 
     module = importlib.import_module(module_name)
+    LegacyShutdownContext = module.LegacyShutdownContext
 
     class _App:
         pass
 
     plan = module.build_legacy_shutdown_plan(
         _App(),
-        {
-            "usage_task": object(),
-            "llm_usage_task": object(),
-            "_authnz_sched_started": True,
-        },
+        LegacyShutdownContext(
+            usage_task=object(),
+            llm_usage_task=object(),
+            authnz_scheduler_started=True,
+        ),
     )
 
     assert [component.name for component in plan] == [
@@ -351,6 +361,33 @@ async def test_coordinator_runs_same_phase_components_in_parallel() -> None:
     assert summary.phases[ShutdownPhase.WORKERS].component_names == ["worker-a", "worker-b"]
     assert summary.components["worker-a"].result == "stopped"
     assert summary.components["worker-b"].result == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_offloads_sync_stop_callables_to_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    to_thread_calls: list[Callable[[], Awaitable[None] | None]] = []
+    events: list[str] = []
+
+    async def _fake_to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append(func)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("tldw_Server_API.app.services.shutdown_coordinator.asyncio.to_thread", _fake_to_thread)
+
+    coordinator = ShutdownCoordinator(profile="dev_fast")
+
+    def _sync_stop() -> None:
+        events.append("sync")
+
+    coordinator.register(component("producer-a", phase="producers", stop=_sync_stop))
+
+    summary = await coordinator.shutdown()
+
+    assert to_thread_calls == [_sync_stop]
+    assert summary.components["producer-a"].result == "stopped"
+    assert events == ["sync"]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_shutdown_transport_registry.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_transport_registry.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException
+
+from tldw_Server_API.app.services.app_lifecycle import mark_lifecycle_shutdown
+
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeTransportSocket:
+    def __init__(self) -> None:
+        self.closed: list[tuple[int, str]] = []
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed.append((code, reason))
+
+
+class _BlockingPromptStudioSocket:
+    def __init__(
+        self,
+        *,
+        started: asyncio.Event | None = None,
+        release: asyncio.Event | None = None,
+    ) -> None:
+        self.started = started
+        self.release = release
+        self.sent_messages: list[str] = []
+        self.closed: list[tuple[int, str]] = []
+
+    async def send_text(self, message: str) -> None:
+        if self.started is not None:
+            self.started.set()
+        if self.release is not None:
+            await self.release.wait()
+        self.sent_messages.append(message)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed.append((code, reason))
+
+
+class _FakeOuterStream:
+    def __init__(self, websocket, **_: object) -> None:
+        self.websocket = websocket
+
+    async def start(self) -> None:
+        await self.websocket.accept()
+
+    async def send_json(self, payload: dict) -> None:
+        self.websocket.sent_json.append(payload)
+
+    async def error(self, code: str, message: str, *, data: dict | None = None) -> None:
+        payload = {"type": "error", "code": code, "message": message}
+        if data is not None:
+            payload["data"] = data
+        await self.send_json(payload)
+
+    async def done(self) -> None:
+        return None
+
+    def mark_activity(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+class _FakeAudioWebSocket:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+        self.query_params: dict[str, str] = {}
+        self.client = SimpleNamespace(host="127.0.0.1", port=8000)
+        self.accepted = 0
+        self.closed: list[tuple[int, str]] = []
+        self.sent_json: list[dict] = []
+        self.app = FastAPI()
+
+    async def accept(self) -> None:
+        self.accepted += 1
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed.append((code, reason))
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent_json.append(payload)
+
+    async def receive_text(self) -> str:
+        raise AssertionError("receive_text should not be reached while draining")
+
+    async def receive_json(self) -> dict:
+        raise AssertionError("receive_json should not be reached while draining")
+
+
+def test_transport_registry_snapshot_reports_active_counts() -> None:
+    from tldw_Server_API.app.services.shutdown_transport_registry import ShutdownTransportRegistry
+
+    registry = ShutdownTransportRegistry()
+    registry.register_family(
+        "alpha",
+        active_count=lambda: 2,
+        drain=lambda timeout_s=None: None,
+    )
+    registry.register_family(
+        "beta",
+        active_count=lambda: 5,
+        drain=lambda timeout_s=None: None,
+    )
+
+    snapshot = {item.name: item for item in registry.snapshot()}
+
+    assert snapshot["alpha"].active_count == 2
+    assert snapshot["beta"].active_count == 5
+    assert registry.total_active_sessions() == 7
+
+
+@pytest.mark.asyncio
+async def test_prompt_studio_transport_registry_hook_tracks_and_drains_connections() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.prompt_studio import prompt_studio_websocket
+    from tldw_Server_API.app.services.shutdown_transport_registry import get_shutdown_transport_registry
+
+    first = _FakeTransportSocket()
+    second = _FakeTransportSocket()
+    third = _FakeTransportSocket()
+    original_active = prompt_studio_websocket.connection_manager.active_connections
+    original_metadata = prompt_studio_websocket.connection_manager.connection_metadata
+    prompt_studio_websocket.connection_manager.active_connections = {
+        "client-a": {first, second},
+        "client-b": {third},
+    }
+    prompt_studio_websocket.connection_manager.connection_metadata = {
+        first: {"client_id": "client-a"},
+        second: {"client_id": "client-a"},
+        third: {"client_id": "client-b"},
+    }
+
+    try:
+        family = get_shutdown_transport_registry().get_family("prompt_studio.websocket")
+
+        assert family is not None
+        assert family.current_active_count() == 3
+
+        await family.drain(timeout_s=0.2)
+
+        assert prompt_studio_websocket.connection_manager.get_connection_count() == 0
+        assert first.closed == [(1001, "Server shutdown")]
+        assert second.closed == [(1001, "Server shutdown")]
+        assert third.closed == [(1001, "Server shutdown")]
+    finally:
+        prompt_studio_websocket.connection_manager.active_connections = original_active
+        prompt_studio_websocket.connection_manager.connection_metadata = original_metadata
+
+
+@pytest.mark.asyncio
+async def test_prompt_studio_broadcast_and_close_all_can_interleave_without_iteration_errors() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_websocket import (
+        ConnectionManager,
+    )
+
+    manager = ConnectionManager()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    first = _BlockingPromptStudioSocket(started=started, release=release)
+    second = _BlockingPromptStudioSocket(started=started, release=release)
+    third = _BlockingPromptStudioSocket()
+    manager.active_connections = {
+        "client-a": {first, second},
+        "client-b": {third},
+    }
+    manager.connection_metadata = {
+        first: {"client_id": "client-a"},
+        second: {"client_id": "client-a"},
+        third: {"client_id": "client-b"},
+    }
+
+    broadcast_task = asyncio.create_task(manager.broadcast_to_all("shutdown-check"))
+    await started.wait()
+    await manager.close_all(timeout_s=0.2)
+    release.set()
+    await broadcast_task
+
+    assert manager.active_connections == {}
+    assert manager.connection_metadata == {}
+    assert first.closed == [(1001, "Server shutdown")]
+    assert second.closed == [(1001, "Server shutdown")]
+    assert third.closed == [(1001, "Server shutdown")]
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_registers_transport_family_with_shutdown_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+    from tldw_Server_API.app.services.shutdown_transport_registry import get_shutdown_transport_registry
+
+    server = MCPServer()
+    server.connections = {"one": object(), "two": object()}
+    called: list[float | None] = []
+
+    async def _fake_close_all_connections() -> None:
+        called.append(1.0)
+
+    monkeypatch.setattr(server, "_close_all_connections", _fake_close_all_connections)
+    family = get_shutdown_transport_registry().get_family("mcp.websocket")
+
+    assert family is not None
+    assert family.current_active_count() == 2
+
+    await family.drain(timeout_s=0.2)
+
+    assert called == [1.0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mcp_session_id", [None, "stable-session-123"])
+async def test_mcp_websocket_rejects_new_connections_while_draining(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_session_id: str | None,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified import server as mcp_server_module
+    from tldw_Server_API.app.core.MCP_unified.server import MCPServer
+
+    websocket = _FakeAudioWebSocket()
+    mark_lifecycle_shutdown(websocket.app)
+    server = MCPServer()
+    server.config.ws_auth_required = False
+    server.config.ws_max_connections = 100
+    server.config.ws_max_connections_per_ip = 0
+    server.config.ws_allowed_origins = []
+
+    class _AllowAllController:
+        def resolve_client_ip(self, raw_remote_ip, forwarded_for, real_ip):
+            return "127.0.0.1"
+
+        def is_allowed(self, ip: str) -> bool:
+            return True
+
+    class _UnexpectedStream:
+        def __init__(self, *args, **kwargs) -> None:
+            raise AssertionError("MCP websocket stream should not start while draining")
+
+    session_calls: list[tuple[str, str | None, str | None, str | None]] = []
+
+    async def _unexpected_get_or_create_session(
+        session_id: str,
+        user_id: str | None = None,
+        workspace_id: str | None = None,
+        cwd: str | None = None,
+    ) -> object:
+        session_calls.append((session_id, user_id, workspace_id, cwd))
+        return object()
+
+    monkeypatch.setattr(mcp_server_module, "get_ip_access_controller", lambda: _AllowAllController())
+    monkeypatch.setattr(mcp_server_module, "enforce_client_certificate_headers", lambda *args, **kwargs: None)
+    monkeypatch.setattr(mcp_server_module, "WebSocketStream", _UnexpectedStream)
+    monkeypatch.setattr(server, "_get_or_create_session", _unexpected_get_or_create_session)
+
+    await server.handle_websocket(
+        websocket,
+        client_id="client-a",
+        mcp_session_id=mcp_session_id,
+    )
+
+    assert websocket.closed == [(1013, "shutdown_draining")]
+    assert server.connections == {}
+    assert session_calls == []
+
+
+class _UnexpectedPromptStudioStream:
+    def __init__(self, *args, **kwargs) -> None:
+        return None
+
+    async def start(self) -> None:
+        raise AssertionError("Prompt Studio websocket stream should not start while draining")
+
+    async def send_json(self, payload: dict) -> None:
+        return None
+
+    def mark_activity(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint_name", "kwargs"),
+    [
+        ("websocket_endpoint_base", {}),
+        ("websocket_endpoint", {"project_id": 7, "db": None}),
+    ],
+)
+async def test_prompt_studio_websockets_reject_new_connections_while_draining(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint_name: str,
+    kwargs: dict,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints.prompt_studio import prompt_studio_websocket
+
+    websocket = _FakeAudioWebSocket()
+    mark_lifecycle_shutdown(websocket.app)
+    connect_calls: list[str] = []
+
+    async def _unexpected_connect(*args, **kwargs) -> None:
+        connect_calls.append("called")
+        raise AssertionError("Prompt Studio connect should not run while draining")
+
+    monkeypatch.setattr(prompt_studio_websocket, "WebSocketStream", _UnexpectedPromptStudioStream)
+    monkeypatch.setattr(prompt_studio_websocket.connection_manager, "connect", _unexpected_connect)
+
+    endpoint = getattr(prompt_studio_websocket, endpoint_name)
+    await endpoint(websocket, **kwargs)
+
+    assert connect_calls == []
+    assert websocket.closed == [(1013, "shutdown_draining")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint_name", "expected_kind"),
+    [
+        ("websocket_transcribe", "audio.stream.transcribe"),
+        ("websocket_audio_chat_stream", "audio.chat.stream"),
+        ("websocket_tts", "audio.stream.tts"),
+        ("websocket_tts_realtime", "audio.stream.tts.realtime"),
+    ],
+)
+async def test_audio_websocket_handlers_block_new_work_when_draining(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint_name: str,
+    expected_kind: str,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints.audio import audio_streaming
+    from tldw_Server_API.app.core.Streaming import streams as streaming_streams
+
+    websocket = _FakeAudioWebSocket()
+    mark_lifecycle_shutdown(websocket.app)
+    observed_kinds: list[str] = []
+
+    async def _fake_authenticate(*args, **kwargs):
+        return True, 7
+
+    def _fake_guard(app: FastAPI, kind: str) -> None:
+        observed_kinds.append(kind)
+        raise HTTPException(status_code=503, detail={"kind": kind})
+
+    async def _unexpected_handle(*args, **kwargs):
+        raise AssertionError("expensive audio work should not start while draining")
+
+    monkeypatch.setattr(audio_streaming, "_shim_audio_ws_authenticate", _fake_authenticate)
+    monkeypatch.setattr(audio_streaming, "assert_may_start_work", _fake_guard)
+    monkeypatch.setattr(audio_streaming, "handle_unified_websocket", _unexpected_handle)
+    monkeypatch.setattr(audio_streaming, "_stream_tts_to_websocket", _unexpected_handle)
+    monkeypatch.setattr(streaming_streams, "WebSocketStream", _FakeOuterStream)
+
+    endpoint = getattr(audio_streaming, endpoint_name)
+    await endpoint(websocket, token=None)
+
+    assert observed_kinds == [expected_kind]
+    assert websocket.accepted >= 1
+    assert websocket.closed
+
+
+@pytest.mark.asyncio
+async def test_ingest_sse_rejects_new_stream_creation_while_draining() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.media.ingest_jobs import (
+        stream_media_ingest_job_events,
+    )
+
+    app = FastAPI()
+    mark_lifecycle_shutdown(app)
+    request = SimpleNamespace(app=app)
+    current_user = SimpleNamespace(id=42)
+    principal = SimpleNamespace(roles=[], permissions=[])
+    jm = SimpleNamespace()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await stream_media_ingest_job_events(
+            request=request,
+            batch_id=None,
+            after_id=0,
+            current_user=current_user,
+            principal=principal,
+            jm=jm,
+        )
+
+    assert exc_info.value.status_code == 503

--- a/tldw_Server_API/tests/Services/test_shutdown_transport_registry.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_transport_registry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import threading
 from types import SimpleNamespace
 
 import pytest
@@ -41,6 +40,25 @@ class _BlockingPromptStudioSocket:
         self.sent_messages.append(message)
 
     async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed.append((code, reason))
+
+
+class _BlockingClosePromptStudioSocket:
+    def __init__(
+        self,
+        *,
+        started: asyncio.Event | None = None,
+        release: asyncio.Event | None = None,
+    ) -> None:
+        self.started = started
+        self.release = release
+        self.closed: list[tuple[int, str]] = []
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        if self.started is not None:
+            self.started.set()
+        if self.release is not None:
+            await self.release.wait()
         self.closed.append((code, reason))
 
 
@@ -115,12 +133,12 @@ def test_transport_registry_snapshot_reports_active_counts() -> None:
     registry.register_family(
         "alpha",
         active_count=lambda: 2,
-        drain=lambda timeout_s=None: None,
+        drain=None,
     )
     registry.register_family(
         "beta",
         active_count=lambda: 5,
-        drain=lambda timeout_s=None: None,
+        drain=None,
     )
 
     snapshot = {item.name: item for item in registry.snapshot()}
@@ -147,12 +165,12 @@ def test_transport_registry_duplicate_registration_logs_and_replaces(
     first = registry.register_family(
         "alpha",
         active_count=lambda: 1,
-        drain=lambda timeout_s=None: None,
+        drain=None,
     )
     second = registry.register_family(
         "alpha",
         active_count=lambda: 2,
-        drain=lambda timeout_s=None: None,
+        drain=None,
     )
 
     assert first is not second
@@ -197,27 +215,20 @@ async def test_prompt_studio_transport_registry_hook_tracks_and_drains_connectio
         prompt_studio_websocket.connection_manager.connection_metadata = original_metadata
 
 
-@pytest.mark.asyncio
-async def test_transport_registry_offloads_sync_drain_hooks() -> None:
-    from tldw_Server_API.app.services.shutdown_transport_registry import RegisteredTransportFamily
+def test_transport_registry_rejects_sync_drain_hooks() -> None:
+    from tldw_Server_API.app.services.shutdown_transport_registry import ShutdownTransportRegistry
 
-    main_thread_id = threading.get_ident()
-    seen_thread_ids: list[int] = []
+    registry = ShutdownTransportRegistry()
 
     def _sync_drain(timeout_s: float | None = None) -> None:
         del timeout_s
-        seen_thread_ids.append(threading.get_ident())
 
-    family = RegisteredTransportFamily(
-        name="alpha",
-        active_count=lambda: 0,
-        drain=_sync_drain,
-    )
-
-    await family.drain(timeout_s=0.2)
-
-    assert seen_thread_ids
-    assert seen_thread_ids[0] != main_thread_id
+    with pytest.raises(TypeError, match="must be declared with async def"):
+        registry.register_family(
+            "alpha",
+            active_count=lambda: 0,
+            drain=_sync_drain,
+        )
 
 
 @pytest.mark.asyncio
@@ -228,11 +239,15 @@ async def test_transport_components_forward_runtime_timeout_budget() -> None:
     )
 
     observed_timeout_s: list[float | None] = []
+
+    async def _drain(timeout_s: float | None = None) -> None:
+        observed_timeout_s.append(timeout_s)
+
     registry = ShutdownTransportRegistry()
     registry.register_family(
         "alpha",
         active_count=lambda: 0,
-        drain=lambda timeout_s=None: observed_timeout_s.append(timeout_s),
+        drain=_drain,
     )
 
     component = build_shutdown_components(registry, default_timeout_ms=1000)[0]
@@ -380,6 +395,36 @@ async def test_prompt_studio_connect_rechecks_drain_after_accept() -> None:
     assert websocket.accepted == 1
     assert websocket.closed == [(1013, "shutdown_draining")]
     assert manager.get_connection_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_prompt_studio_close_all_keeps_tracking_when_cancelled_mid_close() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_websocket import (
+        ConnectionManager,
+    )
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    first = _BlockingClosePromptStudioSocket(started=started, release=release)
+    second = _BlockingClosePromptStudioSocket()
+    manager = ConnectionManager()
+    manager.active_connections = {
+        "client-a": {first, second},
+    }
+    manager.connection_metadata = {
+        first: {"client_id": "client-a"},
+        second: {"client_id": "client-a"},
+    }
+
+    close_task = asyncio.create_task(manager.close_all(timeout_s=0.2))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    close_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+
+    assert manager.get_connection_count() == 2
+    assert len(manager.connection_metadata) == 2
+    release.set()
 
 
 class _UnexpectedPromptStudioStream:

--- a/tldw_Server_API/tests/Services/test_shutdown_transport_registry.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_transport_registry.py
@@ -117,6 +117,36 @@ def test_transport_registry_snapshot_reports_active_counts() -> None:
     assert registry.total_active_sessions() == 7
 
 
+def test_transport_registry_duplicate_registration_logs_and_replaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_transport_registry as registry_module
+
+    registry = registry_module.ShutdownTransportRegistry()
+    warning_messages: list[str] = []
+
+    monkeypatch.setattr(
+        registry_module.logger,
+        "warning",
+        lambda message, *args, **kwargs: warning_messages.append(str(message)),
+    )
+
+    first = registry.register_family(
+        "alpha",
+        active_count=lambda: 1,
+        drain=lambda timeout_s=None: None,
+    )
+    second = registry.register_family(
+        "alpha",
+        active_count=lambda: 2,
+        drain=lambda timeout_s=None: None,
+    )
+
+    assert first is not second
+    assert registry.get_family("alpha") is second
+    assert any("alpha" in message for message in warning_messages)
+
+
 @pytest.mark.asyncio
 async def test_prompt_studio_transport_registry_hook_tracks_and_drains_connections() -> None:
     from tldw_Server_API.app.api.v1.endpoints.prompt_studio import prompt_studio_websocket

--- a/tldw_Server_API/tests/Services/test_shutdown_transport_registry.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_transport_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -95,6 +96,18 @@ class _FakeAudioWebSocket:
         raise AssertionError("receive_json should not be reached while draining")
 
 
+class _PausingPromptStudioWebSocket(_FakeAudioWebSocket):
+    def __init__(self, accepted: asyncio.Event, release_accept: asyncio.Event) -> None:
+        super().__init__()
+        self._accepted = accepted
+        self._release_accept = release_accept
+
+    async def accept(self) -> None:
+        self.accepted += 1
+        self._accepted.set()
+        await self._release_accept.wait()
+
+
 def test_transport_registry_snapshot_reports_active_counts() -> None:
     from tldw_Server_API.app.services.shutdown_transport_registry import ShutdownTransportRegistry
 
@@ -182,6 +195,52 @@ async def test_prompt_studio_transport_registry_hook_tracks_and_drains_connectio
     finally:
         prompt_studio_websocket.connection_manager.active_connections = original_active
         prompt_studio_websocket.connection_manager.connection_metadata = original_metadata
+
+
+@pytest.mark.asyncio
+async def test_transport_registry_offloads_sync_drain_hooks() -> None:
+    from tldw_Server_API.app.services.shutdown_transport_registry import RegisteredTransportFamily
+
+    main_thread_id = threading.get_ident()
+    seen_thread_ids: list[int] = []
+
+    def _sync_drain(timeout_s: float | None = None) -> None:
+        del timeout_s
+        seen_thread_ids.append(threading.get_ident())
+
+    family = RegisteredTransportFamily(
+        name="alpha",
+        active_count=lambda: 0,
+        drain=_sync_drain,
+    )
+
+    await family.drain(timeout_s=0.2)
+
+    assert seen_thread_ids
+    assert seen_thread_ids[0] != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_transport_components_forward_runtime_timeout_budget() -> None:
+    from tldw_Server_API.app.services.shutdown_transport_registry import (
+        ShutdownTransportRegistry,
+        build_shutdown_components,
+    )
+
+    observed_timeout_s: list[float | None] = []
+    registry = ShutdownTransportRegistry()
+    registry.register_family(
+        "alpha",
+        active_count=lambda: 0,
+        drain=lambda timeout_s=None: observed_timeout_s.append(timeout_s),
+    )
+
+    component = build_shutdown_components(registry, default_timeout_ms=1000)[0]
+    result = component.stop(125)
+    if result is not None:
+        await result
+
+    assert observed_timeout_s == [0.125]
 
 
 @pytest.mark.asyncio
@@ -299,6 +358,30 @@ async def test_mcp_websocket_rejects_new_connections_while_draining(
     assert session_calls == []
 
 
+@pytest.mark.asyncio
+async def test_prompt_studio_connect_rechecks_drain_after_accept() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_websocket import (
+        ConnectionManager,
+    )
+
+    accepted = asyncio.Event()
+    release_accept = asyncio.Event()
+    websocket = _PausingPromptStudioWebSocket(accepted, release_accept)
+    manager = ConnectionManager()
+
+    connect_task = asyncio.create_task(manager.connect(websocket, "global"))
+    await asyncio.wait_for(accepted.wait(), timeout=1.0)
+    mark_lifecycle_shutdown(websocket.app)
+    release_accept.set()
+
+    connected = await asyncio.wait_for(connect_task, timeout=1.0)
+
+    assert connected is False
+    assert websocket.accepted == 1
+    assert websocket.closed == [(1013, "shutdown_draining")]
+    assert manager.get_connection_count() == 0
+
+
 class _UnexpectedPromptStudioStream:
     def __init__(self, *args, **kwargs) -> None:
         return None
@@ -343,6 +426,7 @@ async def test_prompt_studio_websockets_reject_new_connections_while_draining(
     await endpoint(websocket, **kwargs)
 
     assert connect_calls == []
+    assert websocket.accepted == 1
     assert websocket.closed == [(1013, "shutdown_draining")]
 
 


### PR DESCRIPTION
## Summary
- add app-scoped lifecycle state, readiness/drain gating, and a coordinated phased shutdown flow in the FastAPI lifespan
- register legacy shutdown slices, transport/session owners, and executor visibility under the production drain coordinator
- add shutdown design docs plus focused regression coverage for lifecycle reuse, no-lifespan clients, drain gating, coordinator behavior, and transport draining

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_app_lifecycle_state.py tldw_Server_API/tests/Services/test_main_lifecycle_contract.py tldw_Server_API/tests/Services/test_main_readiness_shutdown.py tldw_Server_API/tests/Services/test_drain_gate_middleware.py tldw_Server_API/tests/Services/test_shutdown_coordinator.py tldw_Server_API/tests/Services/test_shutdown_transport_registry.py tldw_Server_API/tests/Services/test_executor_registry_shutdown.py tldw_Server_API/tests/CI/test_e2e_inprocess_client_contract.py -v`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/RAG_NEW/integration/test_rag_ablate_api.py tldw_Server_API/tests/RAG_NEW/integration/test_rag_agentic_api.py tldw_Server_API/tests/RAG_NEW/integration/test_rag_batch_checkpoint_api.py tldw_Server_API/tests/RAG_NEW/integration/test_rag_batch_resume_api.py tldw_Server_API/tests/RAG_NEW/integration/test_rag_benchmarks_ablation.py tldw_Server_API/tests/RAG_NEW/integration/test_rag_doc_researcher_api.py -v`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/app_lifecycle.py tldw_Server_API/app/services/shutdown_coordinator.py tldw_Server_API/app/services/shutdown_legacy_adapters.py tldw_Server_API/app/services/shutdown_models.py tldw_Server_API/app/services/shutdown_transport_registry.py tldw_Server_API/app/core/Utils/executor_registry.py tldw_Server_API/app/core/MCP_unified/server.py tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_websocket.py tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py tldw_Server_API/app/main.py -f json -o /tmp/bandit_shutdown_pr.json`
