### PR TITLE
feat: complete persona buddy track a backend

### DIFF
--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2738,14 +2738,20 @@ async def restore_persona_profile(
         raise HTTPException(status_code=404, detail="Persona disabled")
     user_id = _require_current_user_id(_current_user)
     try:
-        ok = db.restore_persona_profile(
+        ok = await _run_persona_db_call(
+            db.restore_persona_profile,
             persona_id=persona_id,
             user_id=user_id,
             expected_version=expected_version,
         )
         if not ok:
             raise HTTPException(status_code=404, detail="Persona profile not found")
-        profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+        profile = await _run_persona_db_call(
+            db.get_persona_profile,
+            persona_id,
+            user_id=user_id,
+            include_deleted=False,
+        )
         if profile is None:
             raise HTTPException(status_code=404, detail="Persona profile not found")
         return _persona_profile_to_response(profile)

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -44,6 +44,7 @@ from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaInfo,
     PersonaPolicyRulesReplaceRequest,
     PersonaPolicyRulesResponse,
+    PersonaBuddyResponse,
     PersonaProfileCreate,
     PersonaProfileResponse,
     PersonaProfileUpdate,
@@ -147,6 +148,7 @@ from tldw_Server_API.app.core.Persona.policy_evaluator import (
     evaluate_canonical_policy,
     normalize_policy_rules,
 )
+from tldw_Server_API.app.core.Persona.buddy import ensure_persona_buddy_for_profile
 from tldw_Server_API.app.core.Persona.session_manager import get_session_manager
 from tldw_Server_API.app.core.http_client import RetryPolicy, afetch
 from tldw_Server_API.app.core.Skills.context_integration import handle_skill_tool_call
@@ -1485,6 +1487,94 @@ def _persona_profile_to_response(profile: dict[str, Any]) -> PersonaProfileRespo
     )
 
 
+def _persona_buddy_to_response(buddy: dict[str, Any]) -> PersonaBuddyResponse:
+    return PersonaBuddyResponse(
+        persona_id=str(buddy.get("persona_id") or ""),
+        resolved_profile=buddy.get("resolved_profile") or {},
+        created_at=str(buddy.get("created_at") or _utc_now_iso()),
+        last_modified=str(buddy.get("last_modified") or buddy.get("created_at") or _utc_now_iso()),
+    )
+
+
+def _rollback_created_persona_profile_after_buddy_failure(
+    db: CharactersRAGDB,
+    *,
+    persona_id: str,
+    user_id: str,
+    expected_version: int,
+) -> None:
+    """Hide a newly created profile when buddy sync fails after commit."""
+    try:
+        rolled_back = db.soft_delete_persona_profile(
+            persona_id=persona_id,
+            user_id=user_id,
+            expected_version=expected_version,
+        )
+        if rolled_back:
+            logger.warning(
+                "Rolled back newly created persona profile {} after buddy sync failure.",
+                persona_id,
+            )
+        else:
+            logger.error(
+                "Failed to roll back newly created persona profile {} after buddy sync failure.",
+                persona_id,
+            )
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        logger.error(
+            "Error rolling back newly created persona profile {} after buddy sync failure: {}",
+            persona_id,
+            exc,
+        )
+
+
+def _rollback_updated_persona_profile_after_buddy_failure(
+    db: CharactersRAGDB,
+    *,
+    persona_id: str,
+    user_id: str,
+    update_data: dict[str, Any],
+    previous_profile: dict[str, Any],
+    expected_version: int,
+) -> None:
+    """Restore the previous visible profile state when buddy sync fails after update."""
+    rollback_data = {field: previous_profile.get(field) for field in update_data.keys()}
+    if not rollback_data:
+        return
+    try:
+        rolled_back = db.update_persona_profile(
+            persona_id=persona_id,
+            user_id=user_id,
+            update_data=rollback_data,
+            expected_version=expected_version,
+        )
+        if rolled_back:
+            logger.warning(
+                "Rolled back persona profile {} after buddy sync failure.",
+                persona_id,
+            )
+        else:
+            logger.error(
+                "Failed to roll back persona profile {} after buddy sync failure.",
+                persona_id,
+            )
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        logger.error(
+            "Error rolling back persona profile {} after buddy sync failure: {}",
+            persona_id,
+            exc,
+        )
+
+
+def _ensure_persona_buddy_after_profile_mutation(
+    *,
+    db: CharactersRAGDB,
+    profile: dict[str, Any],
+) -> None:
+    """Keep buddy state aligned after a committed profile mutation."""
+    _ = ensure_persona_buddy_for_profile(db, profile)
+
+
 def _persona_exemplar_to_response(exemplar: dict[str, Any]) -> PersonaExemplarResponse:
     return PersonaExemplarResponse(
         id=str(exemplar.get("id") or ""),
@@ -2464,10 +2554,20 @@ async def create_persona_profile(
                 persona_id=persona_id,
                 user_id=user_id,
                 rules=_DEFAULT_PERSONA_POLICY_RULES,
-            )
+        )
         profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
         if profile is None:
             raise HTTPException(status_code=500, detail="Failed to load created persona profile")
+        try:
+            _ensure_persona_buddy_after_profile_mutation(db=db, profile=profile)
+        except (ValueError, InputError, ConflictError, CharactersRAGDBError) as exc:
+            _rollback_created_persona_profile_after_buddy_failure(
+                db,
+                persona_id=persona_id,
+                user_id=user_id,
+                expected_version=int(profile.get("version") or 1),
+            )
+            raise HTTPException(status_code=500, detail="Persona buddy sync failed after profile create") from exc
         return _persona_profile_to_response(profile)
     except HTTPException:
         raise
@@ -2520,6 +2620,9 @@ async def update_persona_profile(
     if not update_data:
         raise HTTPException(status_code=400, detail="No profile fields provided for update")
     try:
+        previous_profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+        if previous_profile is None:
+            raise HTTPException(status_code=404, detail="Persona profile not found")
         ok = db.update_persona_profile(
             persona_id=persona_id,
             user_id=user_id,
@@ -2531,11 +2634,58 @@ async def update_persona_profile(
         profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
         if profile is None:
             raise HTTPException(status_code=404, detail="Persona profile not found")
+        try:
+            _ensure_persona_buddy_after_profile_mutation(db=db, profile=profile)
+        except (ValueError, InputError, ConflictError, CharactersRAGDBError) as exc:
+            _rollback_updated_persona_profile_after_buddy_failure(
+                db,
+                persona_id=persona_id,
+                user_id=user_id,
+                update_data=update_data,
+                previous_profile=previous_profile,
+                expected_version=int(profile.get("version") or 1),
+            )
+            raise HTTPException(status_code=500, detail="Persona buddy sync failed after profile update") from exc
         return _persona_profile_to_response(profile)
     except HTTPException:
         raise
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         raise _to_http_exception(exc, action="update persona profile") from exc
+
+
+@router.get(
+    "/profiles/{persona_id}/buddy",
+    response_model=PersonaBuddyResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+)
+async def get_persona_buddy(
+    persona_id: str,
+    _current_user: User = Depends(get_request_user),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> PersonaBuddyResponse:
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+        if profile is None:
+            raise HTTPException(status_code=404, detail="Persona profile not found")
+        _ = ensure_persona_buddy_for_profile(db, profile)
+        buddy = db.get_persona_buddy(
+            persona_id=persona_id,
+            user_id=user_id,
+            include_deleted_personas=False,
+        )
+        if buddy is None:
+            raise HTTPException(status_code=500, detail="Failed to load persona buddy")
+        return _persona_buddy_to_response(buddy)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        raise _to_http_exception(exc, action="get persona buddy") from exc
 
 
 @router.delete(
@@ -2566,6 +2716,39 @@ async def delete_persona_profile(
         raise
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         raise _to_http_exception(exc, action="delete persona profile") from exc
+
+
+@router.post(
+    "/profiles/{persona_id}/restore",
+    response_model=PersonaProfileResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+)
+async def restore_persona_profile(
+    persona_id: str,
+    expected_version: int = Query(..., ge=1),
+    _current_user: User = Depends(get_request_user),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> PersonaProfileResponse:
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        ok = db.restore_persona_profile(
+            persona_id=persona_id,
+            user_id=user_id,
+            expected_version=expected_version,
+        )
+        if not ok:
+            raise HTTPException(status_code=404, detail="Persona profile not found")
+        profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+        if profile is None:
+            raise HTTPException(status_code=404, detail="Persona profile not found")
+        return _persona_profile_to_response(profile)
+    except HTTPException:
+        raise
+    except (InputError, ConflictError, CharactersRAGDBError) as exc:
+        raise _to_http_exception(exc, action="restore persona profile") from exc
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2761,7 +2761,6 @@ async def restore_persona_profile(
         )
         if profile is None:
             raise HTTPException(status_code=404, detail="Persona profile not found")
-        await _run_persona_db_call(_ensure_persona_buddy_after_profile_mutation, db=db, profile=profile)
         return _persona_profile_to_response(profile)
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -1490,7 +1490,7 @@ def _persona_profile_to_response(profile: dict[str, Any]) -> PersonaProfileRespo
 def _persona_buddy_to_response(buddy: dict[str, Any]) -> PersonaBuddyResponse:
     return PersonaBuddyResponse(
         persona_id=str(buddy.get("persona_id") or ""),
-        resolved_profile=buddy.get("resolved_profile") or {},
+        resolved_profile=buddy.get("resolved_profile"),
         created_at=str(buddy.get("created_at") or _utc_now_iso()),
         last_modified=str(buddy.get("last_modified") or buddy.get("created_at") or _utc_now_iso()),
     )
@@ -1504,6 +1504,7 @@ def _rollback_created_persona_profile_after_buddy_failure(
     expected_version: int,
 ) -> None:
     """Hide a newly created profile when buddy sync fails after commit."""
+    persona_hash = _redacted_id_for_logs(persona_id)
     try:
         rolled_back = db.soft_delete_persona_profile(
             persona_id=persona_id,
@@ -1513,17 +1514,17 @@ def _rollback_created_persona_profile_after_buddy_failure(
         if rolled_back:
             logger.warning(
                 "Rolled back newly created persona profile {} after buddy sync failure.",
-                persona_id,
+                persona_hash,
             )
         else:
             logger.error(
                 "Failed to roll back newly created persona profile {} after buddy sync failure.",
-                persona_id,
+                persona_hash,
             )
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         logger.error(
             "Error rolling back newly created persona profile {} after buddy sync failure: {}",
-            persona_id,
+            persona_hash,
             exc,
         )
 
@@ -1538,6 +1539,7 @@ def _rollback_updated_persona_profile_after_buddy_failure(
     expected_version: int,
 ) -> None:
     """Restore the previous visible profile state when buddy sync fails after update."""
+    persona_hash = _redacted_id_for_logs(persona_id)
     rollback_data = {field: previous_profile.get(field) for field in update_data.keys()}
     if not rollback_data:
         return
@@ -1551,17 +1553,17 @@ def _rollback_updated_persona_profile_after_buddy_failure(
         if rolled_back:
             logger.warning(
                 "Rolled back persona profile {} after buddy sync failure.",
-                persona_id,
+                persona_hash,
             )
         else:
             logger.error(
                 "Failed to roll back persona profile {} after buddy sync failure.",
-                persona_id,
+                persona_hash,
             )
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         logger.error(
             "Error rolling back persona profile {} after buddy sync failure: {}",
-            persona_id,
+            persona_hash,
             exc,
         )
 
@@ -2559,9 +2561,10 @@ async def create_persona_profile(
         if profile is None:
             raise HTTPException(status_code=500, detail="Failed to load created persona profile")
         try:
-            _ensure_persona_buddy_after_profile_mutation(db=db, profile=profile)
+            await _run_persona_db_call(_ensure_persona_buddy_after_profile_mutation, db=db, profile=profile)
         except (ValueError, InputError, ConflictError, CharactersRAGDBError) as exc:
-            _rollback_created_persona_profile_after_buddy_failure(
+            await _run_persona_db_call(
+                _rollback_created_persona_profile_after_buddy_failure,
                 db,
                 persona_id=persona_id,
                 user_id=user_id,
@@ -2620,9 +2623,11 @@ async def update_persona_profile(
     if not update_data:
         raise HTTPException(status_code=400, detail="No profile fields provided for update")
     try:
-        previous_profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
-        if previous_profile is None:
-            raise HTTPException(status_code=404, detail="Persona profile not found")
+        previous_profile: dict[str, Any] | None = None
+        if expected_version is not None:
+            previous_profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+            if previous_profile is None:
+                raise HTTPException(status_code=404, detail="Persona profile not found")
         ok = db.update_persona_profile(
             persona_id=persona_id,
             user_id=user_id,
@@ -2635,16 +2640,18 @@ async def update_persona_profile(
         if profile is None:
             raise HTTPException(status_code=404, detail="Persona profile not found")
         try:
-            _ensure_persona_buddy_after_profile_mutation(db=db, profile=profile)
+            await _run_persona_db_call(_ensure_persona_buddy_after_profile_mutation, db=db, profile=profile)
         except (ValueError, InputError, ConflictError, CharactersRAGDBError) as exc:
-            _rollback_updated_persona_profile_after_buddy_failure(
-                db,
-                persona_id=persona_id,
-                user_id=user_id,
-                update_data=update_data,
-                previous_profile=previous_profile,
-                expected_version=int(profile.get("version") or 1),
-            )
+            if previous_profile is not None:
+                await _run_persona_db_call(
+                    _rollback_updated_persona_profile_after_buddy_failure,
+                    db,
+                    persona_id=persona_id,
+                    user_id=user_id,
+                    update_data=update_data,
+                    previous_profile=previous_profile,
+                    expected_version=int(profile.get("version") or 1),
+                )
             raise HTTPException(status_code=500, detail="Persona buddy sync failed after profile update") from exc
         return _persona_profile_to_response(profile)
     except HTTPException:
@@ -2658,6 +2665,7 @@ async def update_persona_profile(
     response_model=PersonaBuddyResponse,
     tags=["persona"],
     status_code=status.HTTP_200_OK,
+    dependencies=[Depends(check_rate_limit)],
 )
 async def get_persona_buddy(
     persona_id: str,
@@ -2668,15 +2676,10 @@ async def get_persona_buddy(
         raise HTTPException(status_code=404, detail="Persona disabled")
     user_id = _require_current_user_id(_current_user)
     try:
-        profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+        profile = await _run_persona_db_call(db.get_persona_profile, persona_id, user_id=user_id, include_deleted=False)
         if profile is None:
             raise HTTPException(status_code=404, detail="Persona profile not found")
-        _ = ensure_persona_buddy_for_profile(db, profile)
-        buddy = db.get_persona_buddy(
-            persona_id=persona_id,
-            user_id=user_id,
-            include_deleted_personas=False,
-        )
+        buddy = await _run_persona_db_call(ensure_persona_buddy_for_profile, db, profile)
         if buddy is None:
             raise HTTPException(status_code=500, detail="Failed to load persona buddy")
         return _persona_buddy_to_response(buddy)
@@ -2723,6 +2726,7 @@ async def delete_persona_profile(
     response_model=PersonaProfileResponse,
     tags=["persona"],
     status_code=status.HTTP_200_OK,
+    dependencies=[Depends(check_rate_limit)],
 )
 async def restore_persona_profile(
     persona_id: str,

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2550,14 +2550,15 @@ async def create_persona_profile(
     try:
         create_data = payload.model_dump(exclude_none=True)
         create_data["user_id"] = user_id
-        persona_id = db.create_persona_profile(create_data)
-        if not db.list_persona_policy_rules(persona_id=persona_id, user_id=user_id):
-            _ = db.replace_persona_policy_rules(
+        persona_id = await _run_persona_db_call(db.create_persona_profile, create_data)
+        if not await _run_persona_db_call(db.list_persona_policy_rules, persona_id=persona_id, user_id=user_id):
+            _ = await _run_persona_db_call(
+                db.replace_persona_policy_rules,
                 persona_id=persona_id,
                 user_id=user_id,
                 rules=_DEFAULT_PERSONA_POLICY_RULES,
-        )
-        profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+            )
+        profile = await _run_persona_db_call(db.get_persona_profile, persona_id, user_id=user_id, include_deleted=False)
         if profile is None:
             raise HTTPException(status_code=500, detail="Failed to load created persona profile")
         try:
@@ -2625,10 +2626,13 @@ async def update_persona_profile(
     try:
         previous_profile: dict[str, Any] | None = None
         if expected_version is not None:
-            previous_profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+            previous_profile = await _run_persona_db_call(
+                db.get_persona_profile, persona_id, user_id=user_id, include_deleted=False,
+            )
             if previous_profile is None:
                 raise HTTPException(status_code=404, detail="Persona profile not found")
-        ok = db.update_persona_profile(
+        ok = await _run_persona_db_call(
+            db.update_persona_profile,
             persona_id=persona_id,
             user_id=user_id,
             update_data=update_data,
@@ -2636,7 +2640,9 @@ async def update_persona_profile(
         )
         if not ok:
             raise HTTPException(status_code=404, detail="Persona profile not found")
-        profile = db.get_persona_profile(persona_id, user_id=user_id, include_deleted=False)
+        profile = await _run_persona_db_call(
+            db.get_persona_profile, persona_id, user_id=user_id, include_deleted=False,
+        )
         if profile is None:
             raise HTTPException(status_code=404, detail="Persona profile not found")
         try:
@@ -2707,7 +2713,8 @@ async def delete_persona_profile(
         raise HTTPException(status_code=404, detail="Persona disabled")
     user_id = _require_current_user_id(_current_user)
     try:
-        ok = db.soft_delete_persona_profile(
+        ok = await _run_persona_db_call(
+            db.soft_delete_persona_profile,
             persona_id=persona_id,
             user_id=user_id,
             expected_version=expected_version,
@@ -2754,6 +2761,7 @@ async def restore_persona_profile(
         )
         if profile is None:
             raise HTTPException(status_code=404, detail="Persona profile not found")
+        await _run_persona_db_call(_ensure_persona_buddy_after_profile_mutation, db=db, profile=profile)
         return _persona_profile_to_response(profile)
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -274,6 +274,25 @@ class PersonaProfileResponse(BaseModel):
     version: int = 1
 
 
+class PersonaBuddyResolvedProfile(BaseModel):
+    derivation_version: int
+    species_id: str
+    silhouette_id: str
+    palette_id: str
+    behavior_family: str
+    expression_profile: str
+    accessory_id: str | None = None
+    eye_style: str | None = None
+    compatibility_status: Literal["exact", "fallback_applied"] = "exact"
+
+
+class PersonaBuddyResponse(BaseModel):
+    persona_id: str
+    resolved_profile: PersonaBuddyResolvedProfile
+    created_at: str
+    last_modified: str
+
+
 class PersonaScopeRule(BaseModel):
     rule_type: PersonaScopeRuleType
     rule_value: str = Field(..., min_length=1, max_length=2048)

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -288,7 +288,7 @@ class PersonaBuddyResolvedProfile(BaseModel):
 
 class PersonaBuddyResponse(BaseModel):
     persona_id: str
-    resolved_profile: PersonaBuddyResolvedProfile
+    resolved_profile: PersonaBuddyResolvedProfile | None = None
     created_at: str
     last_modified: str
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -108,6 +108,7 @@ from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import (  # noqa: E402
     normalize_fsrs_settings,
     simulate_fsrs_review_transition,
 )
+from tldw_Server_API.app.core.Persona.buddy import resolve_persona_buddy_profile  # noqa: E402
 
 #
 ########################################################################################################################
@@ -530,7 +531,7 @@ class CharactersRAGDB:
         is_memory_db (bool): True if the database is in-memory.
         db_path_str (str): String representation of the database path for SQLite connection.
     """
-    _CURRENT_SCHEMA_VERSION = 39  # Schema v39 adds workspace ownership for quizzes/decks and workspace policy
+    _CURRENT_SCHEMA_VERSION = 40  # Schema v40 adds persona buddy storage contract table
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES: tuple[str, ...] = ("in-progress", "resolved", "backlog", "non-viable")
     _ALLOWED_CONVERSATION_CHARACTER_SCOPES: tuple[str, ...] = ("all", "character", "non_character")
@@ -3284,6 +3285,29 @@ UPDATE db_schema_version
  WHERE schema_name = 'rag_char_chat_schema'
    AND version < 39;
 """
+    _MIGRATION_SQL_V39_TO_V40 = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 40 - Persona buddy storage contract (2026-03-31)
+───────────────────────────────────────────────────────────────*/
+CREATE TABLE IF NOT EXISTS persona_buddies (
+  persona_id TEXT PRIMARY KEY REFERENCES persona_profiles(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
+  derivation_version INTEGER NOT NULL DEFAULT 1,
+  source_fingerprint TEXT NOT NULL,
+  derived_core_json TEXT NOT NULL DEFAULT '{}',
+  overlay_preferences_json TEXT NOT NULL DEFAULT '{}',
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  version INTEGER NOT NULL DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_persona_buddies_user
+  ON persona_buddies(user_id, persona_id);
+UPDATE db_schema_version
+   SET version = 40
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 40;
+"""
+    _MIGRATION_SQL_V39_TO_V40_POSTGRES = _MIGRATION_SQL_V39_TO_V40
     _MIGRATION_SQL_V10_TO_V11_POSTGRES = """
 ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 """
@@ -5087,6 +5111,26 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V38->V39: {e}", exc_info=True)
             raise SchemaError(f"Unexpected error migrating to V39 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
 
+    def _migrate_from_v39_to_v40(self, conn: sqlite3.Connection) -> None:
+        """Migrate schema from V39 to V40 (persona buddy storage contract)."""
+        logger.info(f"Migrating '{self._SCHEMA_NAME}' schema from V39 to V40 for DB: {self.db_path_str}...")
+        try:
+            conn.executescript(self._MIGRATION_SQL_V39_TO_V40)
+            final_version = self._get_db_version(conn)
+            if final_version != 40:
+                raise SchemaError(  # noqa: TRY003, TRY301
+                    f"[{self._SCHEMA_NAME}] Migration V39->V40 failed version check. Expected 40, got: {final_version}"
+                )
+            logger.info(f"[{self._SCHEMA_NAME}] Migration to V40 completed.")
+        except sqlite3.Error as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Migration V39->V40 failed: {e}", exc_info=True)
+            raise SchemaError(f"Migration V39->V40 failed for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+        except SchemaError:
+            raise
+        except _CHACHA_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V39->V40: {e}", exc_info=True)
+            raise SchemaError(f"Unexpected error migrating to V40 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+
     def _ensure_recent_persona_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Backfill recent persona schema columns after version-number collisions."""
         profile_cols = {row[1] for row in conn.execute("PRAGMA table_info('persona_profiles')").fetchall()}
@@ -6037,6 +6081,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     if target_version >= 39 and current_db_version == 38:
                         self._migrate_from_v38_to_v39(conn)
                         current_db_version = self._get_db_version(conn)
+                    if target_version >= 40 and current_db_version == 39:
+                        self._migrate_from_v39_to_v40(conn)
+                        current_db_version = self._get_db_version(conn)
                 # Ensure helpful indexes that may have been introduced post-creation
                 try:
                     conn.execute("CREATE INDEX IF NOT EXISTS idx_flashcards_created_at ON flashcards(created_at)")
@@ -6370,6 +6417,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                 self._migrate_from_v37_to_v38(conn)
                             elif fallback_version == 38:
                                 self._migrate_from_v38_to_v39(conn)
+                            elif fallback_version == 39:
+                                self._migrate_from_v39_to_v40(conn)
                             else:
                                 raise SchemaError(  # noqa: TRY003, TRY301
                                     f"Migration path undefined for '{self._SCHEMA_NAME}' from version {current_initial_version} to {target_version}. "
@@ -6462,6 +6511,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     current_db_version = self._get_db_version(conn)
                 if target_version >= 39 and current_db_version == 38:
                     self._migrate_from_v38_to_v39(conn)
+                    current_db_version = self._get_db_version(conn)
+                if target_version >= 40 and current_db_version == 39:
+                    self._migrate_from_v39_to_v40(conn)
                     current_db_version = self._get_db_version(conn)
 
                 self._ensure_recent_persona_schema_sqlite(conn)
@@ -7801,6 +7853,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 self._ensure_workspace_study_material_schema_postgres(conn)
                 self._apply_postgres_migration_script(self._MIGRATION_SQL_V38_TO_V39_POSTGRES, conn, expected_version=39)
                 current_version = 39
+            if current_version < 40:
+                self._apply_postgres_migration_script(self._MIGRATION_SQL_V39_TO_V40, conn, expected_version=40)
+                current_version = 40
 
             if current_version > target_version:
                 raise SchemaError(  # noqa: TRY003
@@ -10289,6 +10344,35 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         item["deleted"] = self._as_bool(item.get("deleted"))
         return item
 
+    def _persona_buddy_row_to_dict(self, row: Any) -> dict[str, Any] | None:
+        """Convert a persona buddy DB `row: Any` to an API-safe dict."""
+        if not row:
+            return None
+        item = dict(row)
+        buddy_label = str(item.get("persona_id") or "unknown")
+        item["derived_core"] = self._decode_persona_json_object(
+            item.get("derived_core_json"),
+            field_name="derived_core_json",
+            context_label=f"persona buddy {buddy_label}",
+        )
+        item["overlay_preferences"] = self._decode_persona_json_object(
+            item.get("overlay_preferences_json"),
+            field_name="overlay_preferences_json",
+            context_label=f"persona buddy {buddy_label}",
+        )
+        try:
+            item["resolved_profile"] = resolve_persona_buddy_profile(
+                derived_core=item["derived_core"],
+                overlay_preferences=item["overlay_preferences"],
+            )
+        except (TypeError, KeyError, ValueError):
+            logger.warning(
+                "Unable to resolve persona buddy profile for persona_id={}.",
+                buddy_label,
+            )
+            item["resolved_profile"] = {}
+        return item
+
     def _persona_scope_rule_row_to_dict(self, row: Any) -> dict[str, Any] | None:
         """Convert a scope rule DB `row: Any` to an API-safe dict.
 
@@ -11028,6 +11112,202 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             update_data=update_data,
             expected_version=expected_version,
         )
+
+    def restore_persona_profile(
+        self,
+        *,
+        persona_id: str,
+        user_id: str,
+        expected_version: int,
+    ) -> bool:
+        """Restore a soft-deleted persona profile using optimistic locking."""
+        now = self._get_current_utc_timestamp_iso()
+        expected_version_value = self._parse_version_input(expected_version)
+        deleted_false = False if self.backend_type == BackendType.POSTGRESQL else 0
+        is_active_true = True if self.backend_type == BackendType.POSTGRESQL else 1
+
+        with self.transaction() as conn:
+            row = conn.execute(
+                "SELECT version, deleted FROM persona_profiles WHERE id = ? AND user_id = ?",
+                (persona_id, user_id),
+            ).fetchone()
+            if not row:
+                return False
+
+            if not self._as_bool(row["deleted"]):
+                return True
+
+            current_db_version = int(row["version"])
+            if current_db_version != expected_version_value:
+                raise ConflictError(  # noqa: TRY003
+                    (
+                        f"Restore for persona profile {persona_id} failed: "
+                        f"version mismatch (db has {current_db_version}, expected {expected_version_value})."
+                    ),
+                    entity="persona_profiles",
+                    entity_id=persona_id,
+                )
+
+            query = (
+                "UPDATE persona_profiles "
+                "SET deleted = ?, is_active = ?, last_modified = ?, version = version + 1 "
+                "WHERE id = ? AND user_id = ? AND version = ? AND deleted = 1"
+            )
+            params = (
+                deleted_false,
+                is_active_true,
+                now,
+                persona_id,
+                user_id,
+                expected_version_value,
+            )
+            prepared_query, prepared_params = self._prepare_backend_statement(query, params)
+            cursor = conn.execute(prepared_query, prepared_params or ())
+            if cursor.rowcount > 0:
+                return True
+
+            final_state = conn.execute(
+                "SELECT version, deleted FROM persona_profiles WHERE id = ? AND user_id = ?",
+                (persona_id, user_id),
+            ).fetchone()
+            if final_state and not self._as_bool(final_state["deleted"]):
+                return True
+            return False
+
+    def get_persona_buddy(
+        self,
+        *,
+        persona_id: str,
+        user_id: str,
+        include_deleted_personas: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fetch one persona buddy row for a user-owned persona profile."""
+        query = """
+            SELECT pb.*
+              FROM persona_buddies pb
+              JOIN persona_profiles pp
+                ON pp.id = pb.persona_id
+               AND pp.user_id = pb.user_id
+             WHERE pb.persona_id = ?
+               AND pb.user_id = ?
+               AND (? OR pp.deleted = 0)
+             LIMIT 1
+        """
+        params = (
+            persona_id,
+            user_id,
+            bool(include_deleted_personas),
+        )
+        cursor = self.execute_query(query, params)
+        return self._persona_buddy_row_to_dict(cursor.fetchone())
+
+    def upsert_persona_buddy(
+        self,
+        *,
+        persona_id: str,
+        user_id: str,
+        derivation_version: int,
+        source_fingerprint: str,
+        derived_core: dict[str, Any] | None,
+        overlay_preferences: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Insert or update one persona buddy row keyed by persona_id."""
+        if not source_fingerprint:
+            raise InputError("source_fingerprint is required for persona buddy upsert.")  # noqa: TRY003
+        try:
+            derivation_version_value = int(derivation_version)
+        except (TypeError, ValueError) as exc:
+            raise InputError("derivation_version must be an integer >= 1.") from exc  # noqa: TRY003
+        if derivation_version_value < 1:
+            raise InputError("derivation_version must be an integer >= 1.")  # noqa: TRY003
+
+        derived_core_json = self._ensure_json_string(derived_core if isinstance(derived_core, dict) else {}) or "{}"
+        overlay_preferences_json = (
+            self._ensure_json_string(overlay_preferences if isinstance(overlay_preferences, dict) else {}) or "{}"
+        )
+        now = self._get_current_utc_timestamp_iso()
+        update_query = (
+            "UPDATE persona_buddies "
+            "SET user_id = ?, derivation_version = ?, source_fingerprint = ?, derived_core_json = ?, "
+            "overlay_preferences_json = ?, last_modified = ?, version = version + 1 "
+            "WHERE persona_id = ? AND ("
+            "user_id <> ? OR derivation_version <> ? OR source_fingerprint <> ? OR "
+            "derived_core_json <> ? OR overlay_preferences_json <> ?"
+            ")"
+        )
+        update_params = (
+            user_id,
+            derivation_version_value,
+            source_fingerprint,
+            derived_core_json,
+            overlay_preferences_json,
+            now,
+            persona_id,
+            user_id,
+            derivation_version_value,
+            source_fingerprint,
+            derived_core_json,
+            overlay_preferences_json,
+        )
+        insert_query = (
+            "INSERT INTO persona_buddies("
+            "persona_id, user_id, derivation_version, source_fingerprint, derived_core_json, "
+            "overlay_preferences_json, created_at, last_modified, version"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        insert_params = (
+            persona_id,
+            user_id,
+            derivation_version_value,
+            source_fingerprint,
+            derived_core_json,
+            overlay_preferences_json,
+            now,
+            now,
+            1,
+        )
+
+        def _load_persisted_item(connection: Any) -> dict[str, Any]:
+            row = connection.execute(
+                "SELECT * FROM persona_buddies WHERE persona_id = ? LIMIT 1",
+                (persona_id,),
+            ).fetchone()
+            item = self._persona_buddy_row_to_dict(row)
+            if not item:
+                raise CharactersRAGDBError("Failed to load persona buddy after upsert.")  # noqa: TRY003
+            return item
+
+        with self.transaction() as conn:
+            self._require_active_persona_profile_owner(conn, persona_id=persona_id, user_id=user_id)
+            prepared_update, prepared_update_params = self._prepare_backend_statement(update_query, update_params)
+            update_cursor = conn.execute(prepared_update, prepared_update_params or ())
+
+            if update_cursor.rowcount == 0:
+                existing_row = conn.execute(
+                    "SELECT 1 FROM persona_buddies WHERE persona_id = ? LIMIT 1",
+                    (persona_id,),
+                ).fetchone()
+                if existing_row:
+                    return _load_persisted_item(conn)
+
+                prepared_insert, prepared_insert_params = self._prepare_backend_statement(insert_query, insert_params)
+                try:
+                    conn.execute(prepared_insert, prepared_insert_params or ())
+                except sqlite3.IntegrityError as exc:
+                    msg = str(exc).lower()
+                    if "unique constraint failed" not in msg:
+                        raise
+                    update_cursor = conn.execute(prepared_update, prepared_update_params or ())
+                    if update_cursor.rowcount == 0:
+                        return _load_persisted_item(conn)
+                except BackendDatabaseError as exc:
+                    if not self._is_unique_violation(exc):
+                        raise
+                    update_cursor = conn.execute(prepared_update, prepared_update_params or ())
+                    if update_cursor.rowcount == 0:
+                        return _load_persisted_item(conn)
+
+            return _load_persisted_item(conn)
 
     def list_persona_scope_rules(
         self,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -3307,7 +3307,28 @@ UPDATE db_schema_version
  WHERE schema_name = 'rag_char_chat_schema'
    AND version < 40;
 """
-    _MIGRATION_SQL_V39_TO_V40_POSTGRES = _MIGRATION_SQL_V39_TO_V40
+    _MIGRATION_SQL_V39_TO_V40_POSTGRES = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 40 - Persona buddy storage contract (2026-03-31) [Postgres]
+───────────────────────────────────────────────────────────────*/
+CREATE TABLE IF NOT EXISTS persona_buddies (
+  persona_id TEXT PRIMARY KEY REFERENCES persona_profiles(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
+  derivation_version INTEGER NOT NULL DEFAULT 1,
+  source_fingerprint TEXT NOT NULL,
+  derived_core_json TEXT NOT NULL DEFAULT '{}',
+  overlay_preferences_json TEXT NOT NULL DEFAULT '{}',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  version INTEGER NOT NULL DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_persona_buddies_user
+  ON persona_buddies(user_id, persona_id);
+UPDATE db_schema_version
+   SET version = 40
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 40;
+"""
     _MIGRATION_SQL_V10_TO_V11_POSTGRES = """
 ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 """
@@ -7854,7 +7875,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 self._apply_postgres_migration_script(self._MIGRATION_SQL_V38_TO_V39_POSTGRES, conn, expected_version=39)
                 current_version = 39
             if current_version < 40:
-                self._apply_postgres_migration_script(self._MIGRATION_SQL_V39_TO_V40, conn, expected_version=40)
+                self._apply_postgres_migration_script(self._MIGRATION_SQL_V39_TO_V40_POSTGRES, conn, expected_version=40)
                 current_version = 40
 
             if current_version > target_version:
@@ -10370,7 +10391,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 "Unable to resolve persona buddy profile for persona_id={}.",
                 buddy_label,
             )
-            item["resolved_profile"] = {}
+            item["resolved_profile"] = None
         return item
 
     def _persona_scope_rule_row_to_dict(self, row: Any) -> dict[str, Any] | None:
@@ -11124,6 +11145,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         now = self._get_current_utc_timestamp_iso()
         expected_version_value = self._parse_version_input(expected_version)
         deleted_false = False if self.backend_type == BackendType.POSTGRESQL else 0
+        deleted_true = True if self.backend_type == BackendType.POSTGRESQL else 1
         is_active_true = True if self.backend_type == BackendType.POSTGRESQL else 1
 
         with self.transaction() as conn:
@@ -11151,7 +11173,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             query = (
                 "UPDATE persona_profiles "
                 "SET deleted = ?, is_active = ?, last_modified = ?, version = version + 1 "
-                "WHERE id = ? AND user_id = ? AND version = ? AND deleted = 1"
+                "WHERE id = ? AND user_id = ? AND version = ? AND deleted = ?"
             )
             params = (
                 deleted_false,
@@ -11160,6 +11182,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 persona_id,
                 user_id,
                 expected_version_value,
+                deleted_true,
             )
             prepared_query, prepared_params = self._prepare_backend_statement(query, params)
             cursor = conn.execute(prepared_query, prepared_params or ())
@@ -11170,9 +11193,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 "SELECT version, deleted FROM persona_profiles WHERE id = ? AND user_id = ?",
                 (persona_id, user_id),
             ).fetchone()
-            if final_state and not self._as_bool(final_state["deleted"]):
-                return True
-            return False
+            return bool(final_state and not self._as_bool(final_state["deleted"]))
 
     def get_persona_buddy(
         self,
@@ -11182,6 +11203,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         include_deleted_personas: bool = False,
     ) -> dict[str, Any] | None:
         """Fetch one persona buddy row for a user-owned persona profile."""
+        deleted_false = False if self.backend_type == BackendType.POSTGRESQL else 0
         query = """
             SELECT pb.*
               FROM persona_buddies pb
@@ -11190,13 +11212,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                AND pp.user_id = pb.user_id
              WHERE pb.persona_id = ?
                AND pb.user_id = ?
-               AND (? OR pp.deleted = 0)
+               AND (? OR pp.deleted = ?)
              LIMIT 1
         """
         params = (
             persona_id,
             user_id,
             bool(include_deleted_personas),
+            deleted_false,
         )
         cursor = self.execute_query(query, params)
         return self._persona_buddy_row_to_dict(cursor.fetchone())

--- a/tldw_Server_API/app/core/Persona/__init__.py
+++ b/tldw_Server_API/app/core/Persona/__init__.py
@@ -1,1 +1,17 @@
 """Persona core package (scaffold)."""
+
+from .buddy import (
+    PERSONA_BUDDY_DERIVATION_VERSION,
+    build_persona_buddy_source_fingerprint,
+    derive_persona_buddy_core,
+    normalize_persona_buddy_overlay_preferences,
+    resolve_persona_buddy_profile,
+)
+
+__all__ = [
+    "PERSONA_BUDDY_DERIVATION_VERSION",
+    "build_persona_buddy_source_fingerprint",
+    "derive_persona_buddy_core",
+    "normalize_persona_buddy_overlay_preferences",
+    "resolve_persona_buddy_profile",
+]

--- a/tldw_Server_API/app/core/Persona/buddy.py
+++ b/tldw_Server_API/app/core/Persona/buddy.py
@@ -23,6 +23,8 @@ _SILHOUETTES = {
 _PALETTES = ("moss", "ember", "sky", "ink")
 _BEHAVIOR_FAMILIES = ("steady", "curious", "playful", "measured")
 _EXPRESSION_PROFILES = ("warm", "focused", "calm", "bright")
+# Accessory and eye-style compatibility is opt-in per species. Unlisted species
+# fall back to universal defaults via .get() (accessories: {None}, eyes: "dot").
 _ACCESSORY_COMPATIBILITY = {
     "owl": {None, "scarf", "halo"},
     "robot": {None, "antenna", "visor"},

--- a/tldw_Server_API/app/core/Persona/buddy.py
+++ b/tldw_Server_API/app/core/Persona/buddy.py
@@ -1,0 +1,171 @@
+"""Deterministic persona buddy derivation and overlay resolution core."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+PERSONA_BUDDY_DERIVATION_VERSION = 1
+
+_SPECIES = ("cat", "duck", "owl", "ghost", "robot", "capybara")
+_SILHOUETTES = {
+    "cat": ("cat_round",),
+    "duck": ("duck_round",),
+    "owl": ("owl_round",),
+    "ghost": ("ghost_round",),
+    "robot": ("robot_round",),
+    "capybara": ("capybara_round",),
+}
+_PALETTES = ("moss", "ember", "sky", "ink")
+_BEHAVIOR_FAMILIES = ("steady", "curious", "playful", "measured")
+_EXPRESSION_PROFILES = ("warm", "focused", "calm", "bright")
+_ACCESSORY_COMPATIBILITY = {
+    "owl": {None, "scarf", "halo"},
+    "robot": {None, "antenna", "visor"},
+}
+_EYE_STYLE_COMPATIBILITY = {
+    "owl": {"dot", "sleepy"},
+    "robot": {"dot", "visor"},
+}
+_DEFAULT_ACCESSORY_BY_SPECIES = {"owl": None, "robot": "antenna"}
+_DEFAULT_EYE_STYLE_BY_SPECIES = {"owl": "dot", "robot": "dot"}
+
+
+def _normalize_stable_identity_value(value: Any) -> str:
+    """Normalize stable identity values for deterministic fingerprinting."""
+    if value is None:
+        return ""
+    return str(value)
+
+
+def build_persona_buddy_source_fingerprint(profile: dict[str, Any]) -> str:
+    """Build a stable source fingerprint from persona-authoritative fields."""
+    stable_payload = {
+        "id": _normalize_stable_identity_value(profile.get("id")),
+        "name": _normalize_stable_identity_value(profile.get("name")),
+        "origin_character_id": _normalize_stable_identity_value(profile.get("origin_character_id")),
+        "origin_character_name": _normalize_stable_identity_value(
+            profile.get("origin_character_name")
+        ),
+        "origin_character_snapshot_at": _normalize_stable_identity_value(
+            profile.get("origin_character_snapshot_at")
+        ),
+    }
+    raw = json.dumps(stable_payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _pick_catalog_value(values: tuple[str, ...], digest: str, offset: int) -> str:
+    index = int(digest[offset : offset + 8], 16) % len(values)
+    return values[index]
+
+
+def derive_persona_buddy_core(profile: dict[str, Any]) -> dict[str, Any]:
+    """Derive a deterministic buddy core from stable persona fields."""
+    digest = build_persona_buddy_source_fingerprint(profile)
+    species_id = _pick_catalog_value(_SPECIES, digest, 0)
+    return {
+        "species_id": species_id,
+        "silhouette_id": _pick_catalog_value(_SILHOUETTES[species_id], digest, 8),
+        "palette_id": _pick_catalog_value(_PALETTES, digest, 16),
+        "behavior_family": _pick_catalog_value(_BEHAVIOR_FAMILIES, digest, 24),
+        "expression_profile": _pick_catalog_value(_EXPRESSION_PROFILES, digest, 32),
+    }
+
+
+def normalize_persona_buddy_overlay_preferences(
+    overlay_preferences: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Normalize overlay preferences to known optional keys."""
+    overlay = overlay_preferences or {}
+    accessory_id = overlay.get("accessory_id")
+    eye_style = overlay.get("eye_style")
+    return {
+        "accessory_id": None if accessory_id is None else str(accessory_id),
+        "eye_style": None if eye_style is None else str(eye_style),
+    }
+
+
+def resolve_persona_buddy_profile(
+    *, derived_core: dict[str, Any], overlay_preferences: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Resolve a complete buddy profile with compatibility-aware overlay fallback."""
+    normalized_overlay = normalize_persona_buddy_overlay_preferences(overlay_preferences)
+    species_id = str(derived_core["species_id"])
+    overlay_accessory_id = normalized_overlay.get("accessory_id")
+    overlay_eye_style = normalized_overlay.get("eye_style")
+    compatibility_status = "exact"
+
+    allowed_accessories = _ACCESSORY_COMPATIBILITY.get(species_id, {None})
+    allowed_eye_styles = _EYE_STYLE_COMPATIBILITY.get(species_id, {"dot"})
+    default_accessory_id = _DEFAULT_ACCESSORY_BY_SPECIES.get(species_id)
+    default_eye_style = _DEFAULT_EYE_STYLE_BY_SPECIES.get(species_id, "dot")
+
+    if overlay_accessory_id is None:
+        accessory_id = default_accessory_id
+    elif overlay_accessory_id in allowed_accessories:
+        accessory_id = overlay_accessory_id
+    else:
+        accessory_id = default_accessory_id
+        compatibility_status = "fallback_applied"
+
+    if overlay_eye_style is None:
+        eye_style = default_eye_style
+    elif overlay_eye_style in allowed_eye_styles:
+        eye_style = overlay_eye_style
+    else:
+        eye_style = default_eye_style
+        compatibility_status = "fallback_applied"
+
+    return {
+        "derivation_version": PERSONA_BUDDY_DERIVATION_VERSION,
+        "species_id": species_id,
+        "silhouette_id": str(derived_core["silhouette_id"]),
+        "palette_id": str(derived_core["palette_id"]),
+        "behavior_family": str(derived_core["behavior_family"]),
+        "expression_profile": str(derived_core["expression_profile"]),
+        "accessory_id": accessory_id,
+        "eye_style": eye_style,
+        "compatibility_status": compatibility_status,
+    }
+
+
+def ensure_persona_buddy_for_profile(
+    db: "CharactersRAGDB",
+    profile: dict[str, Any],
+) -> dict[str, Any]:
+    """Ensure buddy row exists and is current for a persona profile."""
+    persona_id = str(profile.get("id") or "").strip()
+    user_id = str(profile.get("user_id") or "").strip()
+    if not persona_id or not user_id:
+        raise ValueError("profile must include id and user_id")
+
+    source_fingerprint = build_persona_buddy_source_fingerprint(profile)
+    current = db.get_persona_buddy(
+        persona_id=persona_id,
+        user_id=user_id,
+        include_deleted_personas=True,
+    )
+    if (
+        current
+        and int(current.get("derivation_version", 0)) == PERSONA_BUDDY_DERIVATION_VERSION
+        and str(current.get("source_fingerprint") or "") == source_fingerprint
+    ):
+        return current
+
+    overlay_preferences = {}
+    if current and isinstance(current.get("overlay_preferences"), dict):
+        overlay_preferences = current["overlay_preferences"]
+    derived_core = derive_persona_buddy_core(profile)
+    return db.upsert_persona_buddy(
+        persona_id=persona_id,
+        user_id=user_id,
+        derivation_version=PERSONA_BUDDY_DERIVATION_VERSION,
+        source_fingerprint=source_fingerprint,
+        derived_core=derived_core,
+        overlay_preferences=overlay_preferences,
+    )

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py
@@ -1,0 +1,252 @@
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+from tldw_Server_API.app.core.Persona.buddy import ensure_persona_buddy_for_profile
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "persona_buddy_test.sqlite"
+
+
+@pytest.fixture
+def db_instance(db_path: Path) -> Iterator[CharactersRAGDB]:
+    db = CharactersRAGDB(db_path, "persona-buddy-test-client")
+    yield db
+    db.close_connection()
+
+
+def test_migration_v39_to_latest_creates_persona_buddies_table(db_path: Path) -> None:
+    seeded = CharactersRAGDB(db_path, "seed-client")
+    seeded.close_connection()
+
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.execute(
+            "UPDATE db_schema_version SET version = ? WHERE schema_name = ?",
+            (39, CharactersRAGDB._SCHEMA_NAME),
+        )
+        conn.execute("DROP TABLE IF EXISTS persona_buddies")
+        conn.commit()
+
+    migrated = CharactersRAGDB(db_path, "migration-check-client")
+    raw_conn = migrated.get_connection()
+    tables = {
+        row["name"]
+        for row in raw_conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    }
+    buddy_columns = {
+        row["name"] for row in raw_conn.execute("PRAGMA table_info('persona_buddies')").fetchall()
+    }
+    buddy_indexes = {
+        row["name"] for row in raw_conn.execute("PRAGMA index_list('persona_buddies')").fetchall()
+    }
+    schema_version = raw_conn.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (CharactersRAGDB._SCHEMA_NAME,),
+    ).fetchone()["version"]
+    foreign_keys = raw_conn.execute("PRAGMA foreign_key_list('persona_buddies')").fetchall()
+
+    fk_targets = {(row["table"], row["from"], row["to"]) for row in foreign_keys}
+
+    assert schema_version == 40
+    assert "persona_buddies" in tables
+    assert "source_fingerprint" in buddy_columns
+    assert "derivation_version" in buddy_columns
+    assert "persona_id" in buddy_columns
+    assert "user_id" in buddy_columns
+    assert "derived_core_json" in buddy_columns
+    assert "overlay_preferences_json" in buddy_columns
+    assert "created_at" in buddy_columns
+    assert "last_modified" in buddy_columns
+    assert "version" in buddy_columns
+    assert "idx_persona_buddies_user" in buddy_indexes
+    assert ("persona_profiles", "persona_id", "id") in fk_targets
+    migrated.close_connection()
+
+
+def test_ensure_persona_buddy_persists_row_without_incrementing_persona_profile_version(
+    db_instance: CharactersRAGDB,
+) -> None:
+    persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Buddy Persona"})
+    before = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert before is not None
+
+    buddy = ensure_persona_buddy_for_profile(db_instance, before)
+    persisted = db_instance.get_persona_buddy(persona_id=persona_id, user_id="user-1")
+    after = db_instance.get_persona_profile(persona_id, user_id="user-1")
+
+    assert persisted is not None
+    assert after is not None
+    assert buddy["persona_id"] == persona_id
+    assert persisted["persona_id"] == persona_id
+    assert int(after["version"]) == int(before["version"])
+
+
+def test_ensure_persona_buddy_rederives_when_source_fingerprint_changes(
+    db_instance: CharactersRAGDB,
+) -> None:
+    persona_id = db_instance.create_persona_profile(
+        {"user_id": "user-1", "name": "Original Buddy Persona"}
+    )
+    profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert profile is not None
+    original = ensure_persona_buddy_for_profile(db_instance, profile)
+
+    assert db_instance.update_persona_profile(
+        persona_id=persona_id,
+        user_id="user-1",
+        update_data={"name": "Renamed Buddy Persona"},
+        expected_version=int(profile["version"]),
+    )
+    updated_profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert updated_profile is not None
+    repaired = ensure_persona_buddy_for_profile(db_instance, updated_profile)
+
+    assert repaired["source_fingerprint"] != original["source_fingerprint"]
+    assert int(repaired["version"]) > int(original["version"])
+
+
+def test_ensure_persona_buddy_is_idempotent_without_source_changes(
+    db_instance: CharactersRAGDB,
+) -> None:
+    persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Stable Buddy Persona"})
+    profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert profile is not None
+
+    first = ensure_persona_buddy_for_profile(db_instance, profile)
+    persisted_before = db_instance.get_persona_buddy(persona_id=persona_id, user_id="user-1")
+    second = ensure_persona_buddy_for_profile(db_instance, profile)
+    persisted_after = db_instance.get_persona_buddy(persona_id=persona_id, user_id="user-1")
+
+    assert persisted_before is not None
+    assert persisted_after is not None
+    assert int(first["version"]) == int(second["version"])
+    assert int(persisted_before["version"]) == int(persisted_after["version"])
+    assert persisted_before["last_modified"] == persisted_after["last_modified"]
+
+
+def test_upsert_persona_buddy_is_noop_when_payload_is_unchanged(
+    db_instance: CharactersRAGDB,
+) -> None:
+    persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Noop Upsert Persona"})
+    profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert profile is not None
+    original = ensure_persona_buddy_for_profile(db_instance, profile)
+
+    repeated = db_instance.upsert_persona_buddy(
+        persona_id=persona_id,
+        user_id="user-1",
+        derivation_version=int(original["derivation_version"]),
+        source_fingerprint=str(original["source_fingerprint"]),
+        derived_core=original["derived_core"],
+        overlay_preferences=original["overlay_preferences"],
+    )
+    persisted = db_instance.get_persona_buddy(persona_id=persona_id, user_id="user-1")
+
+    assert persisted is not None
+    assert int(repeated["version"]) == int(original["version"])
+    assert int(persisted["version"]) == int(original["version"])
+    assert repeated["last_modified"] == original["last_modified"]
+    assert persisted["last_modified"] == original["last_modified"]
+
+
+def test_ensure_persona_buddy_preserves_overlay_preferences_on_rederive(
+    db_instance: CharactersRAGDB,
+) -> None:
+    persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Overlay Persona"})
+    profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert profile is not None
+    original = ensure_persona_buddy_for_profile(db_instance, profile)
+    overlay_preferences = {"accessory_id": "scarf", "eye_style": "sleepy"}
+    db_instance.upsert_persona_buddy(
+        persona_id=persona_id,
+        user_id="user-1",
+        derivation_version=int(original["derivation_version"]),
+        source_fingerprint=str(original["source_fingerprint"]),
+        derived_core=original["derived_core"],
+        overlay_preferences=overlay_preferences,
+    )
+
+    assert db_instance.update_persona_profile(
+        persona_id=persona_id,
+        user_id="user-1",
+        update_data={"name": "Overlay Persona Renamed"},
+        expected_version=int(profile["version"]),
+    )
+    updated_profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert updated_profile is not None
+    repaired = ensure_persona_buddy_for_profile(db_instance, updated_profile)
+
+    assert repaired["source_fingerprint"] != original["source_fingerprint"]
+    assert repaired["overlay_preferences"] == overlay_preferences
+
+
+def test_soft_delete_hides_buddy_and_restore_reuses_same_row(
+    db_instance: CharactersRAGDB,
+) -> None:
+    persona_id = db_instance.create_persona_profile(
+        {"user_id": "user-1", "name": "Delete Restore Buddy Persona"}
+    )
+    profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert profile is not None
+    buddy_before_delete = ensure_persona_buddy_for_profile(db_instance, profile)
+    deleted_version = int(profile["version"])
+
+    assert db_instance.soft_delete_persona_profile(
+        persona_id=persona_id,
+        user_id="user-1",
+        expected_version=deleted_version,
+    )
+    assert db_instance.get_persona_buddy(persona_id=persona_id, user_id="user-1") is None
+    deleted_profile = db_instance.get_persona_profile(
+        persona_id,
+        user_id="user-1",
+        include_deleted=True,
+    )
+    assert deleted_profile is not None
+
+    restored = db_instance.restore_persona_profile(
+        persona_id=persona_id,
+        user_id="user-1",
+        expected_version=int(deleted_profile["version"]),
+    )
+    restored_profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    restored_buddy = db_instance.get_persona_buddy(persona_id=persona_id, user_id="user-1")
+
+    assert restored is True
+    assert restored_profile is not None
+    assert restored_profile["is_active"] is True
+    assert restored_buddy is not None
+    assert int(restored_buddy["version"]) == int(buddy_before_delete["version"])
+    assert restored_buddy["resolved_profile"] == buddy_before_delete["resolved_profile"]
+
+
+def test_restore_persona_profile_with_stale_expected_version_raises_conflict(
+    db_instance: CharactersRAGDB,
+) -> None:
+    persona_id = db_instance.create_persona_profile({"user_id": "user-1", "name": "Stale Restore Persona"})
+    profile = db_instance.get_persona_profile(persona_id, user_id="user-1")
+    assert profile is not None
+    assert db_instance.soft_delete_persona_profile(
+        persona_id=persona_id,
+        user_id="user-1",
+        expected_version=int(profile["version"]),
+    )
+    deleted_profile = db_instance.get_persona_profile(persona_id, user_id="user-1", include_deleted=True)
+    assert deleted_profile is not None
+    stale_version = int(deleted_profile["version"]) - 1
+
+    with pytest.raises(ConflictError):
+        db_instance.restore_persona_profile(
+            persona_id=persona_id,
+            user_id="user-1",
+            expected_version=stale_version,
+        )

--- a/tldw_Server_API/tests/DB_Management/test_chacha_postgres_migration_v26.py
+++ b/tldw_Server_API/tests/DB_Management/test_chacha_postgres_migration_v26.py
@@ -134,3 +134,17 @@ def test_postgres_statement_conversion_includes_persona_session_preferences_migr
     assert "ALTER TABLE persona_sessions" in full
     assert "preferences_json TEXT NOT NULL DEFAULT '{}'" in full
     assert re.search(r"SET\s+version\s*=\s*35", full, flags=re.IGNORECASE)
+
+
+def test_postgres_statement_conversion_includes_persona_buddy_migration(
+    char_rag_db: CharactersRAGDB,
+) -> None:
+    """Verify v40 conversion output uses a de-duplicated migration artifact and expected contract columns."""
+
+    assert char_rag_db._MIGRATION_SQL_V39_TO_V40_POSTGRES == char_rag_db._MIGRATION_SQL_V39_TO_V40
+    sql = char_rag_db._MIGRATION_SQL_V39_TO_V40
+    stmts = char_rag_db._convert_sqlite_schema_to_postgres_statements(sql)
+
+    full = "\n".join(stmts)
+    assert "CREATE TABLE IF NOT EXISTS persona_buddies" in full
+    assert "source_fingerprint TEXT NOT NULL" in full

--- a/tldw_Server_API/tests/DB_Management/test_chacha_postgres_migration_v26.py
+++ b/tldw_Server_API/tests/DB_Management/test_chacha_postgres_migration_v26.py
@@ -141,10 +141,12 @@ def test_postgres_statement_conversion_includes_persona_buddy_migration(
 ) -> None:
     """Verify v40 conversion output uses a de-duplicated migration artifact and expected contract columns."""
 
-    assert char_rag_db._MIGRATION_SQL_V39_TO_V40_POSTGRES == char_rag_db._MIGRATION_SQL_V39_TO_V40
-    sql = char_rag_db._MIGRATION_SQL_V39_TO_V40
+    assert char_rag_db._MIGRATION_SQL_V39_TO_V40_POSTGRES != char_rag_db._MIGRATION_SQL_V39_TO_V40
+    sql = char_rag_db._MIGRATION_SQL_V39_TO_V40_POSTGRES
     stmts = char_rag_db._convert_sqlite_schema_to_postgres_statements(sql)
 
     full = "\n".join(stmts)
     assert "CREATE TABLE IF NOT EXISTS persona_buddies" in full
     assert "source_fingerprint TEXT NOT NULL" in full
+    assert "TIMESTAMP" in full
+    assert re.search(r"SET\s+version\s*=\s*40", full, flags=re.IGNORECASE)

--- a/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
@@ -23,6 +23,12 @@ def _client_for_user(user_id: int, db: CharactersRAGDB) -> TestClient:
     return TestClient(fastapi_app)
 
 
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+
+
+
 @pytest.fixture()
 def persona_db(tmp_path):
     db = CharactersRAGDB(str(tmp_path / "persona_buddy_api.db"), client_id="persona-buddy-api-tests")
@@ -51,7 +57,7 @@ def test_get_buddy_lazily_creates_for_preexisting_persona_without_row(persona_db
     persisted = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
     assert persisted is not None
     assert persisted["resolved_profile"] == payload["resolved_profile"]
-    fastapi_app.dependency_overrides.clear()
+
 
 
 def test_api_create_keeps_buddy_row_aligned_immediately(persona_db: CharactersRAGDB):
@@ -65,7 +71,7 @@ def test_api_create_keeps_buddy_row_aligned_immediately(persona_db: CharactersRA
 
     buddy_row = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
     assert buddy_row is not None
-    fastapi_app.dependency_overrides.clear()
+
 
 
 def test_api_create_rolls_back_visible_profile_when_buddy_upkeep_fails(persona_db: CharactersRAGDB, monkeypatch):
@@ -88,7 +94,7 @@ def test_api_create_rolls_back_visible_profile_when_buddy_upkeep_fails(persona_d
     rolled_back = next(profile for profile in deleted_profiles if profile["name"] == "Create Best Effort Persona")
     assert rolled_back["deleted"] is True
     assert persona_db.get_persona_buddy(persona_id=rolled_back["id"], user_id="1") is None
-    fastapi_app.dependency_overrides.clear()
+
 
 
 def test_api_update_keeps_buddy_row_aligned_after_stable_input_change(persona_db: CharactersRAGDB):
@@ -115,7 +121,7 @@ def test_api_update_keeps_buddy_row_aligned_after_stable_input_change(persona_db
     assert after is not None
     assert after["source_fingerprint"] != before["source_fingerprint"]
     assert int(after["version"]) > int(before["version"])
-    fastapi_app.dependency_overrides.clear()
+
 
 
 def test_system_prompt_only_updates_do_not_rederive_buddy(persona_db: CharactersRAGDB):
@@ -144,7 +150,7 @@ def test_system_prompt_only_updates_do_not_rederive_buddy(persona_db: Characters
 
     assert after_payload["resolved_profile"] == before_payload["resolved_profile"]
     assert after_payload["last_modified"] == before_payload["last_modified"]
-    fastapi_app.dependency_overrides.clear()
+
 
 
 def test_api_update_reverts_profile_when_buddy_upkeep_fails(persona_db: CharactersRAGDB, monkeypatch):
@@ -181,7 +187,7 @@ def test_api_update_reverts_profile_when_buddy_upkeep_fails(persona_db: Characte
     assert refreshed["name"] == "Update Best Effort Persona"
     assert buddy_after is not None
     assert buddy_after["source_fingerprint"] == buddy_before["source_fingerprint"]
-    fastapi_app.dependency_overrides.clear()
+
 
 
 def test_deleted_persona_hides_buddy_until_restore_and_restore_preserves_buddy_response(
@@ -225,7 +231,7 @@ def test_deleted_persona_hides_buddy_until_restore_and_restore_preserves_buddy_r
     assert buddy_row_after_restore is not None
     assert int(buddy_row_after_restore["version"]) == int(buddy_row_before_delete["version"])
     assert before_payload == after_payload
-    fastapi_app.dependency_overrides.clear()
+
 
 
 def test_non_owner_access_to_buddy_and_restore_returns_404(persona_db: CharactersRAGDB):
@@ -254,4 +260,4 @@ def test_non_owner_access_to_buddy_and_restore_returns_404(persona_db: Character
         )
         assert denied_restore.status_code == 404, denied_restore.text
 
-    fastapi_app.dependency_overrides.clear()
+

--- a/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
@@ -1,0 +1,257 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints import persona as persona_ep
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+pytestmark = pytest.mark.unit
+
+fastapi_app = FastAPI()
+fastapi_app.include_router(persona_ep.router, prefix="/api/v1/persona")
+
+
+def _client_for_user(user_id: int, db: CharactersRAGDB) -> TestClient:
+    async def override_user():
+        return User(id=user_id, username=f"persona-buddy-user-{user_id}", email=None, is_active=True)
+
+    fastapi_app.dependency_overrides[get_request_user] = override_user
+    fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    return TestClient(fastapi_app)
+
+
+@pytest.fixture()
+def persona_db(tmp_path):
+    db = CharactersRAGDB(str(tmp_path / "persona_buddy_api.db"), client_id="persona-buddy-api-tests")
+    yield db
+    db.close_connection()
+
+
+def test_get_buddy_lazily_creates_for_preexisting_persona_without_row(persona_db: CharactersRAGDB):
+    persona_id = persona_db.create_persona_profile({"user_id": "1", "name": "Lazy Buddy Persona"})
+    assert persona_db.get_persona_buddy(persona_id=persona_id, user_id="1") is None
+
+    with _client_for_user(1, persona_db) as client:
+        before_profile = client.get(f"/api/v1/persona/profiles/{persona_id}")
+        assert before_profile.status_code == 200, before_profile.text
+
+        buddy_response = client.get(f"/api/v1/persona/profiles/{persona_id}/buddy")
+        assert buddy_response.status_code == 200, buddy_response.text
+        payload = buddy_response.json()
+        assert payload["persona_id"] == persona_id
+        assert "resolved_profile" in payload
+
+        after_profile = client.get(f"/api/v1/persona/profiles/{persona_id}")
+        assert after_profile.status_code == 200, after_profile.text
+        assert after_profile.json()["version"] == before_profile.json()["version"]
+
+    persisted = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
+    assert persisted is not None
+    assert persisted["resolved_profile"] == payload["resolved_profile"]
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_api_create_keeps_buddy_row_aligned_immediately(persona_db: CharactersRAGDB):
+    with _client_for_user(1, persona_db) as client:
+        created = client.post(
+            "/api/v1/persona/profiles",
+            json={"name": "Create Buddy API Persona", "mode": "session_scoped"},
+        )
+        assert created.status_code == 201, created.text
+        persona_id = created.json()["id"]
+
+    buddy_row = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
+    assert buddy_row is not None
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_api_create_rolls_back_visible_profile_when_buddy_upkeep_fails(persona_db: CharactersRAGDB, monkeypatch):
+    def _raise_buddy_failure(*_args, **_kwargs):
+        raise ValueError("buddy unavailable")
+
+    monkeypatch.setattr(persona_ep, "ensure_persona_buddy_for_profile", _raise_buddy_failure)
+
+    with _client_for_user(1, persona_db) as client:
+        created = client.post(
+            "/api/v1/persona/profiles",
+            json={"name": "Create Best Effort Persona", "mode": "session_scoped"},
+        )
+        assert created.status_code == 500, created.text
+
+    active_profiles = persona_db.list_persona_profiles(user_id="1", include_deleted=False, limit=20, offset=0)
+    assert not any(profile["name"] == "Create Best Effort Persona" for profile in active_profiles)
+
+    deleted_profiles = persona_db.list_persona_profiles(user_id="1", include_deleted=True, limit=20, offset=0)
+    rolled_back = next(profile for profile in deleted_profiles if profile["name"] == "Create Best Effort Persona")
+    assert rolled_back["deleted"] is True
+    assert persona_db.get_persona_buddy(persona_id=rolled_back["id"], user_id="1") is None
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_api_update_keeps_buddy_row_aligned_after_stable_input_change(persona_db: CharactersRAGDB):
+    with _client_for_user(1, persona_db) as client:
+        created = client.post(
+            "/api/v1/persona/profiles",
+            json={"name": "Update Buddy API Persona"},
+        )
+        assert created.status_code == 201, created.text
+        created_payload = created.json()
+        persona_id = created_payload["id"]
+
+        before = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
+        assert before is not None
+
+        updated = client.patch(
+            f"/api/v1/persona/profiles/{persona_id}",
+            params={"expected_version": int(created_payload["version"])},
+            json={"name": "Update Buddy API Persona Renamed"},
+        )
+        assert updated.status_code == 200, updated.text
+
+    after = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
+    assert after is not None
+    assert after["source_fingerprint"] != before["source_fingerprint"]
+    assert int(after["version"]) > int(before["version"])
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_system_prompt_only_updates_do_not_rederive_buddy(persona_db: CharactersRAGDB):
+    with _client_for_user(1, persona_db) as client:
+        created = client.post(
+            "/api/v1/persona/profiles",
+            json={"name": "Prompt Stable Buddy Persona"},
+        )
+        assert created.status_code == 201, created.text
+        persona_id = created.json()["id"]
+
+        buddy_before = client.get(f"/api/v1/persona/profiles/{persona_id}/buddy")
+        assert buddy_before.status_code == 200, buddy_before.text
+        before_payload = buddy_before.json()
+
+        updated = client.patch(
+            f"/api/v1/persona/profiles/{persona_id}",
+            params={"expected_version": int(created.json()["version"])},
+            json={"system_prompt": "This prompt changed, but buddy identity should not."},
+        )
+        assert updated.status_code == 200, updated.text
+
+        buddy_after = client.get(f"/api/v1/persona/profiles/{persona_id}/buddy")
+        assert buddy_after.status_code == 200, buddy_after.text
+        after_payload = buddy_after.json()
+
+    assert after_payload["resolved_profile"] == before_payload["resolved_profile"]
+    assert after_payload["last_modified"] == before_payload["last_modified"]
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_api_update_reverts_profile_when_buddy_upkeep_fails(persona_db: CharactersRAGDB, monkeypatch):
+    with _client_for_user(1, persona_db) as client:
+        created = client.post(
+            "/api/v1/persona/profiles",
+            json={"name": "Update Best Effort Persona"},
+        )
+        assert created.status_code == 201, created.text
+        created_payload = created.json()
+        persona_id = created_payload["id"]
+
+    profile = persona_db.get_persona_profile(persona_id, user_id="1")
+    buddy_before = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
+    assert profile is not None
+    assert buddy_before is not None
+
+    def _raise_buddy_failure(*_args, **_kwargs):
+        raise ValueError("buddy unavailable")
+
+    monkeypatch.setattr(persona_ep, "ensure_persona_buddy_for_profile", _raise_buddy_failure)
+
+    with _client_for_user(1, persona_db) as client:
+        updated = client.patch(
+            f"/api/v1/persona/profiles/{persona_id}",
+            params={"expected_version": int(created_payload["version"])},
+            json={"name": "Update Best Effort Persona Renamed"},
+        )
+        assert updated.status_code == 500, updated.text
+
+    refreshed = persona_db.get_persona_profile(persona_id, user_id="1")
+    buddy_after = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
+    assert refreshed is not None
+    assert refreshed["name"] == "Update Best Effort Persona"
+    assert buddy_after is not None
+    assert buddy_after["source_fingerprint"] == buddy_before["source_fingerprint"]
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_deleted_persona_hides_buddy_until_restore_and_restore_preserves_buddy_response(
+    persona_db: CharactersRAGDB,
+):
+    with _client_for_user(1, persona_db) as client:
+        created = client.post("/api/v1/persona/profiles", json={"name": "Delete Restore Buddy API Persona"})
+        assert created.status_code == 201, created.text
+        created_payload = created.json()
+        persona_id = created_payload["id"]
+
+        before = client.get(f"/api/v1/persona/profiles/{persona_id}/buddy")
+        assert before.status_code == 200, before.text
+        before_payload = before.json()
+        buddy_row_before_delete = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
+        assert buddy_row_before_delete is not None
+
+        deleted = client.delete(
+            f"/api/v1/persona/profiles/{persona_id}",
+            params={"expected_version": int(created_payload["version"])},
+        )
+        assert deleted.status_code == 200, deleted.text
+
+        hidden = client.get(f"/api/v1/persona/profiles/{persona_id}/buddy")
+        assert hidden.status_code == 404, hidden.text
+
+        deleted_profile = persona_db.get_persona_profile(persona_id, user_id="1", include_deleted=True)
+        assert deleted_profile is not None
+        restored = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/restore",
+            params={"expected_version": int(deleted_profile["version"])},
+        )
+        assert restored.status_code == 200, restored.text
+        assert restored.json()["is_active"] is True
+
+        after = client.get(f"/api/v1/persona/profiles/{persona_id}/buddy")
+        assert after.status_code == 200, after.text
+        after_payload = after.json()
+
+    buddy_row_after_restore = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
+    assert buddy_row_after_restore is not None
+    assert int(buddy_row_after_restore["version"]) == int(buddy_row_before_delete["version"])
+    assert before_payload == after_payload
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_non_owner_access_to_buddy_and_restore_returns_404(persona_db: CharactersRAGDB):
+    with _client_for_user(1, persona_db) as owner_client:
+        created = owner_client.post("/api/v1/persona/profiles", json={"name": "Owner Persona"})
+        assert created.status_code == 201, created.text
+        owner_payload = created.json()
+        persona_id = owner_payload["id"]
+
+        owner_buddy = owner_client.get(f"/api/v1/persona/profiles/{persona_id}/buddy")
+        assert owner_buddy.status_code == 200, owner_buddy.text
+
+        deleted = owner_client.delete(
+            f"/api/v1/persona/profiles/{persona_id}",
+            params={"expected_version": int(owner_payload["version"])},
+        )
+        assert deleted.status_code == 200, deleted.text
+
+    with _client_for_user(2, persona_db) as other_client:
+        hidden_buddy = other_client.get(f"/api/v1/persona/profiles/{persona_id}/buddy")
+        assert hidden_buddy.status_code == 404, hidden_buddy.text
+
+        denied_restore = other_client.post(
+            f"/api/v1/persona/profiles/{persona_id}/restore",
+            params={"expected_version": 1},
+        )
+        assert denied_restore.status_code == 404, denied_restore.text
+
+    fastapi_app.dependency_overrides.clear()

--- a/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
@@ -26,8 +26,7 @@ def _client_for_user(user_id: int, db: CharactersRAGDB) -> TestClient:
 @pytest.fixture(autouse=True)
 def _clear_overrides():
     yield
-
-
+    fastapi_app.dependency_overrides.clear()
 
 @pytest.fixture()
 def persona_db(tmp_path):
@@ -58,8 +57,6 @@ def test_get_buddy_lazily_creates_for_preexisting_persona_without_row(persona_db
     assert persisted is not None
     assert persisted["resolved_profile"] == payload["resolved_profile"]
 
-
-
 def test_api_create_keeps_buddy_row_aligned_immediately(persona_db: CharactersRAGDB):
     with _client_for_user(1, persona_db) as client:
         created = client.post(
@@ -71,8 +68,6 @@ def test_api_create_keeps_buddy_row_aligned_immediately(persona_db: CharactersRA
 
     buddy_row = persona_db.get_persona_buddy(persona_id=persona_id, user_id="1")
     assert buddy_row is not None
-
-
 
 def test_api_create_rolls_back_visible_profile_when_buddy_upkeep_fails(persona_db: CharactersRAGDB, monkeypatch):
     def _raise_buddy_failure(*_args, **_kwargs):
@@ -94,8 +89,6 @@ def test_api_create_rolls_back_visible_profile_when_buddy_upkeep_fails(persona_d
     rolled_back = next(profile for profile in deleted_profiles if profile["name"] == "Create Best Effort Persona")
     assert rolled_back["deleted"] is True
     assert persona_db.get_persona_buddy(persona_id=rolled_back["id"], user_id="1") is None
-
-
 
 def test_api_update_keeps_buddy_row_aligned_after_stable_input_change(persona_db: CharactersRAGDB):
     with _client_for_user(1, persona_db) as client:
@@ -121,8 +114,6 @@ def test_api_update_keeps_buddy_row_aligned_after_stable_input_change(persona_db
     assert after is not None
     assert after["source_fingerprint"] != before["source_fingerprint"]
     assert int(after["version"]) > int(before["version"])
-
-
 
 def test_system_prompt_only_updates_do_not_rederive_buddy(persona_db: CharactersRAGDB):
     with _client_for_user(1, persona_db) as client:
@@ -150,8 +141,6 @@ def test_system_prompt_only_updates_do_not_rederive_buddy(persona_db: Characters
 
     assert after_payload["resolved_profile"] == before_payload["resolved_profile"]
     assert after_payload["last_modified"] == before_payload["last_modified"]
-
-
 
 def test_api_update_reverts_profile_when_buddy_upkeep_fails(persona_db: CharactersRAGDB, monkeypatch):
     with _client_for_user(1, persona_db) as client:
@@ -187,8 +176,6 @@ def test_api_update_reverts_profile_when_buddy_upkeep_fails(persona_db: Characte
     assert refreshed["name"] == "Update Best Effort Persona"
     assert buddy_after is not None
     assert buddy_after["source_fingerprint"] == buddy_before["source_fingerprint"]
-
-
 
 def test_deleted_persona_hides_buddy_until_restore_and_restore_preserves_buddy_response(
     persona_db: CharactersRAGDB,
@@ -232,8 +219,6 @@ def test_deleted_persona_hides_buddy_until_restore_and_restore_preserves_buddy_r
     assert int(buddy_row_after_restore["version"]) == int(buddy_row_before_delete["version"])
     assert before_payload == after_payload
 
-
-
 def test_non_owner_access_to_buddy_and_restore_returns_404(persona_db: CharactersRAGDB):
     with _client_for_user(1, persona_db) as owner_client:
         created = owner_client.post("/api/v1/persona/profiles", json={"name": "Owner Persona"})
@@ -259,4 +244,3 @@ def test_non_owner_access_to_buddy_and_restore_returns_404(persona_db: Character
             params={"expected_version": 1},
         )
         assert denied_restore.status_code == 404, denied_restore.text
-

--- a/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
@@ -260,4 +260,3 @@ def test_non_owner_access_to_buddy_and_restore_returns_404(persona_db: Character
         )
         assert denied_restore.status_code == 404, denied_restore.text
 
-

--- a/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_buddy_api.py
@@ -219,6 +219,37 @@ def test_deleted_persona_hides_buddy_until_restore_and_restore_preserves_buddy_r
     assert int(buddy_row_after_restore["version"]) == int(buddy_row_before_delete["version"])
     assert before_payload == after_payload
 
+
+def test_restore_does_not_invoke_buddy_realignment(persona_db: CharactersRAGDB, monkeypatch):
+    with _client_for_user(1, persona_db) as client:
+        created = client.post("/api/v1/persona/profiles", json={"name": "Restore No Buddy Sync Persona"})
+        assert created.status_code == 201, created.text
+        created_payload = created.json()
+        persona_id = created_payload["id"]
+
+        deleted = client.delete(
+            f"/api/v1/persona/profiles/{persona_id}",
+            params={"expected_version": int(created_payload["version"])},
+        )
+        assert deleted.status_code == 200, deleted.text
+
+    deleted_profile = persona_db.get_persona_profile(persona_id, user_id="1", include_deleted=True)
+    assert deleted_profile is not None
+
+    def _raise_unexpected_restore_sync(*_args, **_kwargs):
+        raise AssertionError("restore should not invoke buddy realignment")
+
+    monkeypatch.setattr(persona_ep, "_ensure_persona_buddy_after_profile_mutation", _raise_unexpected_restore_sync)
+
+    with _client_for_user(1, persona_db) as client:
+        restored = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/restore",
+            params={"expected_version": int(deleted_profile["version"])},
+        )
+        assert restored.status_code == 200, restored.text
+        assert restored.json()["is_active"] is True
+
+
 def test_non_owner_access_to_buddy_and_restore_returns_404(persona_db: CharactersRAGDB):
     with _client_for_user(1, persona_db) as owner_client:
         created = owner_client.post("/api/v1/persona/profiles", json={"name": "Owner Persona"})

--- a/tldw_Server_API/tests/Persona/test_persona_buddy_core.py
+++ b/tldw_Server_API/tests/Persona/test_persona_buddy_core.py
@@ -1,0 +1,147 @@
+"""Core deterministic derivation tests for persona buddy helpers."""
+
+from tldw_Server_API.app.core.Persona.buddy import (
+    PERSONA_BUDDY_DERIVATION_VERSION,
+    build_persona_buddy_source_fingerprint,
+    derive_persona_buddy_core,
+    normalize_persona_buddy_overlay_preferences,
+    resolve_persona_buddy_profile,
+)
+
+
+def test_build_persona_buddy_core_ignores_system_prompt_voice_defaults_and_setup():
+    base_profile = {
+        "id": "persona-alpha",
+        "name": "Research Owl",
+        "origin_character_id": 42,
+        "origin_character_name": "Archivist",
+        "origin_character_snapshot_at": "2026-03-07T10:00:00Z",
+    }
+    mutable_only_changes = {
+        **base_profile,
+        "system_prompt": "Totally rewritten prompt",
+        "voice_defaults": {"tts_voice": "af_heart"},
+        "setup": {"status": "completed"},
+    }
+
+    assert derive_persona_buddy_core(base_profile) == derive_persona_buddy_core(mutable_only_changes)
+
+
+def test_resolve_persona_buddy_profile_falls_back_when_overlay_is_incompatible():
+    derived_core = {
+        "species_id": "owl",
+        "silhouette_id": "owl_round",
+        "palette_id": "moss",
+        "behavior_family": "steady",
+        "expression_profile": "warm",
+    }
+
+    resolved = resolve_persona_buddy_profile(
+        derived_core=derived_core,
+        overlay_preferences={"accessory_id": "tinyduck", "eye_style": "spiral"},
+    )
+
+    assert resolved["compatibility_status"] == "fallback_applied"
+    assert resolved["accessory_id"] is None
+    assert resolved["eye_style"] == "dot"
+
+
+def test_resolve_persona_buddy_profile_defaults_without_overlay_are_exact():
+    derived_core = {
+        "species_id": "owl",
+        "silhouette_id": "owl_round",
+        "palette_id": "moss",
+        "behavior_family": "steady",
+        "expression_profile": "warm",
+    }
+
+    resolved = resolve_persona_buddy_profile(
+        derived_core=derived_core,
+        overlay_preferences=None,
+    )
+
+    assert resolved["compatibility_status"] == "exact"
+    assert resolved["accessory_id"] is None
+    assert resolved["eye_style"] == "dot"
+
+
+def test_resolve_persona_buddy_profile_preserves_compatible_overlay_as_exact():
+    derived_core = {
+        "species_id": "owl",
+        "silhouette_id": "owl_round",
+        "palette_id": "moss",
+        "behavior_family": "steady",
+        "expression_profile": "warm",
+    }
+
+    resolved = resolve_persona_buddy_profile(
+        derived_core=derived_core,
+        overlay_preferences={"accessory_id": "scarf", "eye_style": "sleepy"},
+    )
+
+    assert resolved["compatibility_status"] == "exact"
+    assert resolved["accessory_id"] == "scarf"
+    assert resolved["eye_style"] == "sleepy"
+
+
+def test_build_persona_buddy_source_fingerprint_changes_for_name_or_origin_changes():
+    base = {
+        "id": "persona-alpha",
+        "name": "Research Owl",
+        "origin_character_id": 42,
+        "origin_character_name": "Archivist",
+        "origin_character_snapshot_at": "2026-03-07T10:00:00Z",
+    }
+    renamed = {**base, "name": "Renamed Persona"}
+
+    assert build_persona_buddy_source_fingerprint(base) != build_persona_buddy_source_fingerprint(
+        renamed
+    )
+
+
+def test_build_persona_buddy_source_fingerprint_normalizes_semantically_equivalent_stable_inputs():
+    base = {
+        "id": "persona-alpha",
+        "name": "Research Owl",
+        "origin_character_id": 42,
+        "origin_character_name": "Archivist",
+        "origin_character_snapshot_at": "2026-03-07T10:00:00Z",
+    }
+    equivalent = {
+        **base,
+        "origin_character_id": "42",
+    }
+
+    assert build_persona_buddy_source_fingerprint(base) == build_persona_buddy_source_fingerprint(
+        equivalent
+    )
+
+
+def test_derive_persona_buddy_core_golden_output_for_derivation_version():
+    profile = {
+        "id": "persona-alpha",
+        "name": "Research Owl",
+        "origin_character_id": 42,
+        "origin_character_name": "Archivist",
+        "origin_character_snapshot_at": "2026-03-07T10:00:00Z",
+    }
+
+    assert PERSONA_BUDDY_DERIVATION_VERSION == 1
+    assert derive_persona_buddy_core(profile) == {
+        "species_id": "duck",
+        "silhouette_id": "duck_round",
+        "palette_id": "ink",
+        "behavior_family": "curious",
+        "expression_profile": "focused",
+    }
+
+
+def test_normalize_persona_buddy_overlay_preferences_casts_to_contract_shape():
+    normalized = normalize_persona_buddy_overlay_preferences(
+        {"accessory_id": 7, "eye_style": False}
+    )
+
+    assert normalized == {
+        "accessory_id": "7",
+        "eye_style": "False",
+    }


### PR DESCRIPTION
## Summary
- add persona buddy Track A backend storage, derivation, and API routes
- add lazy buddy resolution plus restore-safe lifecycle handling for persona profiles
- add DB, core, and API regression coverage for buddy invariants and Postgres migration conversion

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_buddy_core.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py tldw_Server_API/tests/Persona/test_persona_buddy_api.py tldw_Server_API/tests/DB_Management/test_chacha_postgres_migration_v26.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py -v
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Persona/buddy.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/api/v1/schemas/persona.py -f json -o /tmp/bandit_persona_buddy_track_a.json