### PR TITLE
feat: auto-open Quick Setup for first-time watchlist users

### DIFF
--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
@@ -230,6 +230,29 @@ export const OverviewTab: React.FC = () => {
     }
   }, [loadOverview])
 
+  // Auto-open Quick Setup for first-time users with no sources
+  const quickSetupAutoShownRef = useRef(false)
+  useEffect(() => {
+    if (
+      data &&
+      data.sources.total === 0 &&
+      !quickSetupOpen &&
+      !quickSetupAutoShownRef.current &&
+      onboardingPath === "beginner"
+    ) {
+      const autoShownKey = "watchlists:quickSetup:autoshown:v1"
+      try {
+        if (!localStorage.getItem(autoShownKey)) {
+          localStorage.setItem(autoShownKey, "1")
+          quickSetupAutoShownRef.current = true
+          openQuickSetup()
+        }
+      } catch {
+        // localStorage unavailable
+      }
+    }
+  }, [data, quickSetupOpen, onboardingPath, openQuickSetup])
+
   useLayoutEffect(() => {
     if (quickSetupOpen) {
       if (!quickSetupWasOpenRef.current) {

--- a/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
+++ b/apps/packages/ui/src/components/Option/Watchlists/OverviewTab/OverviewTab.tsx
@@ -230,28 +230,7 @@ export const OverviewTab: React.FC = () => {
     }
   }, [loadOverview])
 
-  // Auto-open Quick Setup for first-time users with no sources
   const quickSetupAutoShownRef = useRef(false)
-  useEffect(() => {
-    if (
-      data &&
-      data.sources.total === 0 &&
-      !quickSetupOpen &&
-      !quickSetupAutoShownRef.current &&
-      onboardingPath === "beginner"
-    ) {
-      const autoShownKey = "watchlists:quickSetup:autoshown:v1"
-      try {
-        if (!localStorage.getItem(autoShownKey)) {
-          localStorage.setItem(autoShownKey, "1")
-          quickSetupAutoShownRef.current = true
-          openQuickSetup()
-        }
-      } catch {
-        // localStorage unavailable
-      }
-    }
-  }, [data, quickSetupOpen, onboardingPath, openQuickSetup])
 
   useLayoutEffect(() => {
     if (quickSetupOpen) {
@@ -340,6 +319,44 @@ export const OverviewTab: React.FC = () => {
     setQuickSetupOpen(true)
     void trackWatchlistsOnboardingTelemetry({ type: "quick_setup_opened" })
   }, [quickSetupForm])
+
+  // Auto-open Quick Setup for first-time users with no sources
+  useEffect(() => {
+    const autoShownKey = "watchlists:quickSetup:autoshown:v1"
+
+    // If the wizard is already open, mark as shown to prevent re-opening after close
+    if (quickSetupOpen) {
+      quickSetupAutoShownRef.current = true
+      try {
+        localStorage.setItem(autoShownKey, "1")
+      } catch {
+        // ignore
+      }
+      return
+    }
+
+    if (
+      !data ||
+      data.sources.total !== 0 ||
+      quickSetupAutoShownRef.current ||
+      onboardingPath !== "beginner"
+    ) {
+      return
+    }
+
+    try {
+      if (localStorage.getItem(autoShownKey)) {
+        quickSetupAutoShownRef.current = true
+        return
+      }
+      localStorage.setItem(autoShownKey, "1")
+      quickSetupAutoShownRef.current = true
+      openQuickSetup()
+    } catch {
+      quickSetupAutoShownRef.current = true
+      openQuickSetup()
+    }
+  }, [data, quickSetupOpen, onboardingPath, openQuickSetup])
 
   const closeQuickSetup = useCallback(() => {
     quickSetupPreviewRequestRef.current += 1


### PR DESCRIPTION
## Summary

Phase 4 of the end-to-end user journey audit. Addresses watchlist onboarding discoverability.

### Changes

- **Auto-open Quick Setup wizard** — When a beginner-mode user visits Watchlists Overview with no sources, the Quick Setup wizard automatically opens on first visit. Uses `watchlists:quickSetup:autoshown:v1` localStorage flag to prevent re-showing.
- **Monitors dashboard** — Verified already implemented: Overview tab has 4 stat cards (Sources health, Monitors active/total/next-run, Articles unread, Activity running/pending) plus Recent Failed Runs list. No additional work needed.

### Conditions for auto-open
1. User has `onboardingPath === "beginner"` (default for new users)
2. `data.sources.total === 0` (no sources configured yet)
3. Quick Setup not already open
4. Not previously auto-shown (localStorage flag)

## Test plan
- [ ] First visit to Watchlists with no sources → Quick Setup wizard opens automatically
- [ ] Close wizard, navigate away and back → wizard does NOT auto-open again
- [ ] Clear `watchlists:quickSetup:autoshown:v1` from localStorage → auto-opens on next visit
- [ ] User with `onboardingPath !== "beginner"` → no auto-open

🤖 Generated with [Claude Code](https://claude.com/claude-code)