### PR TITLE
feat: notification preferences UI (#958)

### DIFF
--- a/apps/packages/ui/src/services/__tests__/notifications.test.ts
+++ b/apps/packages/ui/src/services/__tests__/notifications.test.ts
@@ -14,11 +14,13 @@ import {
   buildNotificationsQuery,
   createNotificationStreamSubscription,
   dismissNotification,
+  getNotificationPreferences,
   getUnreadCount,
   listNotifications,
   markNotificationsRead,
   parseNotificationStreamEvent,
-  snoozeNotification
+  snoozeNotification,
+  updateNotificationPreferences
 } from "../notifications"
 
 describe("notifications service", () => {
@@ -47,6 +49,39 @@ describe("notifications service", () => {
     mocks.bgRequest.mockResolvedValue({ unread_count: 7 })
 
     await expect(getUnreadCount()).resolves.toEqual({ unread_count: 7 })
+  })
+
+  it("gets and updates notification preferences through shared UI services", async () => {
+    const initialPreferences = {
+      user_id: "user-1",
+      reminder_enabled: true,
+      job_completed_enabled: true,
+      job_failed_enabled: true,
+      updated_at: "2026-04-02T00:00:00Z"
+    }
+    const updatedPreferences = {
+      ...initialPreferences,
+      job_completed_enabled: false,
+      updated_at: "2026-04-02T00:01:00Z"
+    }
+    mocks.bgRequest.mockResolvedValueOnce(initialPreferences)
+    mocks.bgRequest.mockResolvedValueOnce(updatedPreferences)
+
+    await expect(getNotificationPreferences()).resolves.toEqual(initialPreferences)
+    await expect(
+      updateNotificationPreferences({ job_completed_enabled: false })
+    ).resolves.toEqual(updatedPreferences)
+
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(1, {
+      path: "/api/v1/notifications/preferences",
+      method: "GET"
+    })
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(2, {
+      path: "/api/v1/notifications/preferences",
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: { job_completed_enabled: false }
+    })
   })
 
   it("shares notification query serialization for parity-sensitive paths", () => {

--- a/apps/packages/ui/src/services/notifications.ts
+++ b/apps/packages/ui/src/services/notifications.ts
@@ -36,6 +36,20 @@ export type NotificationSnoozeResponse = {
   run_at: string
 }
 
+export type NotificationPreferences = {
+  user_id: string
+  reminder_enabled: boolean
+  job_completed_enabled: boolean
+  job_failed_enabled: boolean
+  updated_at: string
+}
+
+export type NotificationPreferencesUpdate = {
+  reminder_enabled?: boolean
+  job_completed_enabled?: boolean
+  job_failed_enabled?: boolean
+}
+
 export type NotificationStreamEvent = {
   event: string
   id?: number
@@ -277,6 +291,24 @@ export async function snoozeNotification(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: { minutes }
+  })
+}
+
+export async function getNotificationPreferences(): Promise<NotificationPreferences> {
+  return bgRequest<NotificationPreferences>({
+    path: "/api/v1/notifications/preferences" as any,
+    method: "GET"
+  })
+}
+
+export async function updateNotificationPreferences(
+  update: NotificationPreferencesUpdate
+): Promise<NotificationPreferences> {
+  return bgRequest<NotificationPreferences>({
+    path: "/api/v1/notifications/preferences" as any,
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: update
   })
 }
 

--- a/apps/tldw-frontend/__tests__/pages/notifications.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/notifications.test.tsx
@@ -5,6 +5,8 @@ import userEvent from '@testing-library/user-event';
 const mocks = vi.hoisted(() => ({
   listNotifications: vi.fn(),
   getUnreadCount: vi.fn(),
+  getNotificationPreferences: vi.fn(),
+  updateNotificationPreferences: vi.fn(),
   markNotificationsRead: vi.fn(),
   dismissNotification: vi.fn(),
   snoozeNotification: vi.fn(),
@@ -15,6 +17,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@web/lib/api/notifications', () => ({
   listNotifications: (...args: unknown[]) => mocks.listNotifications(...args),
   getUnreadCount: (...args: unknown[]) => mocks.getUnreadCount(...args),
+  getNotificationPreferences: (...args: unknown[]) => mocks.getNotificationPreferences(...args),
+  updateNotificationPreferences: (...args: unknown[]) => mocks.updateNotificationPreferences(...args),
   markNotificationsRead: (...args: unknown[]) => mocks.markNotificationsRead(...args),
   dismissNotification: (...args: unknown[]) => mocks.dismissNotification(...args),
   snoozeNotification: (...args: unknown[]) => mocks.snoozeNotification(...args),
@@ -25,11 +29,31 @@ vi.mock('@web/components/ui/ToastProvider', () => ({
   useToast: () => ({ show: mocks.showToast }),
 }));
 
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
 import NotificationsPage from '@web/pages/notifications';
 
 describe('NotificationsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getNotificationPreferences.mockResolvedValue({
+      user_id: 'user-1',
+      reminder_enabled: true,
+      job_completed_enabled: true,
+      job_failed_enabled: true,
+      updated_at: '2026-04-02T00:00:00Z',
+    });
+    mocks.updateNotificationPreferences.mockResolvedValue({
+      user_id: 'user-1',
+      reminder_enabled: true,
+      job_completed_enabled: false,
+      job_failed_enabled: true,
+      updated_at: '2026-04-02T00:01:00Z',
+    });
     mocks.listNotifications.mockResolvedValue({
       items: [
         {
@@ -96,5 +120,73 @@ describe('NotificationsPage', () => {
 
     expect(await screen.findByText('Open the report in Deep Research.')).toBeInTheDocument();
     expect(mocks.showToast).not.toHaveBeenCalled();
+  });
+
+  it('shows an unavailable state when notification preferences fail to load', async () => {
+    const user = userEvent.setup();
+    mocks.getNotificationPreferences.mockRejectedValueOnce(new Error('preferences unavailable'));
+
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText('Unread: 2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Preferences' }));
+
+    expect(
+      await screen.findByText('Notification preferences are currently unavailable.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Loading preferences...')).not.toBeInTheDocument();
+  });
+
+  it('disables preference toggles while a save is in flight and ignores duplicate clicks', async () => {
+    const user = userEvent.setup();
+    let resolveUpdate:
+      | ((value: {
+          user_id: string;
+          reminder_enabled: boolean;
+          job_completed_enabled: boolean;
+          job_failed_enabled: boolean;
+          updated_at: string;
+        }) => void)
+      | null = null;
+
+    mocks.updateNotificationPreferences.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        })
+    );
+
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText('Unread: 2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Preferences' }));
+
+    const [jobCompletedToggle] = await screen.findAllByRole('checkbox');
+
+    await user.click(jobCompletedToggle);
+
+    await waitFor(() => {
+      expect(mocks.updateNotificationPreferences).toHaveBeenCalledTimes(1);
+      expect(jobCompletedToggle).toBeDisabled();
+    });
+
+    await user.click(jobCompletedToggle);
+
+    expect(mocks.updateNotificationPreferences).toHaveBeenCalledTimes(1);
+
+    resolveUpdate?.({
+      user_id: 'user-1',
+      reminder_enabled: true,
+      job_completed_enabled: false,
+      job_failed_enabled: true,
+      updated_at: '2026-04-02T00:01:00Z',
+    });
+
+    await waitFor(() => {
+      expect(jobCompletedToggle).not.toBeDisabled();
+      expect(jobCompletedToggle).not.toBeChecked();
+    });
   });
 });

--- a/apps/tldw-frontend/e2e/utils/helpers.ts
+++ b/apps/tldw-frontend/e2e/utils/helpers.ts
@@ -370,10 +370,10 @@ export function getAntdSelectTrigger(
     ariaLabel: string | RegExp;
   }
 ): Locator {
-  const combobox = page.getByRole('combobox', { name: options.ariaLabel }).first();
+  const labeledControl = page.getByLabel(options.ariaLabel).first();
   return page
     .locator('.ant-select')
-    .filter({ has: combobox })
+    .filter({ has: labeledControl })
     .locator('.ant-select-selector')
     .first();
 }

--- a/apps/tldw-frontend/e2e/workflows/onboarding-ingestion-first.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/onboarding-ingestion-first.spec.ts
@@ -163,6 +163,12 @@ async function openOnboardingSuccessScreen(
 
   const needsConnect = await connect.isVisible().catch(() => false)
   if (needsConnect) {
+    const splash = page.getByRole("dialog", { name: "Splash screen" }).first()
+    if (await splash.isVisible().catch(() => false)) {
+      await splash.click({ force: true })
+      await splash.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {})
+    }
+    await dismissConnectionModals(page)
     await connect.click()
   }
 

--- a/apps/tldw-frontend/lib/__tests__/notifications.test.ts
+++ b/apps/tldw-frontend/lib/__tests__/notifications.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   apiGet: vi.fn(),
+  apiPatch: vi.fn(),
   apiPost: vi.fn(),
   buildAuthHeaders: vi.fn(),
   hasExplicitAuthHeaders: vi.fn(),
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@web/lib/api", () => ({
   apiClient: {
     get: (...args: unknown[]) => mocks.apiGet(...args),
+    patch: (...args: unknown[]) => mocks.apiPatch(...args),
     post: (...args: unknown[]) => mocks.apiPost(...args)
   },
   buildAuthHeaders: (...args: unknown[]) => mocks.buildAuthHeaders(...args),
@@ -35,11 +37,13 @@ vi.mock("@/services/background-proxy", () => ({
 
 import {
   dismissNotification,
+  getNotificationPreferences,
   getUnreadCount,
   listNotifications,
   markNotificationsRead,
   snoozeNotification,
-  subscribeNotificationsStream
+  subscribeNotificationsStream,
+  updateNotificationPreferences
 } from "../api/notifications"
 
 describe("web notifications adapter", () => {
@@ -52,6 +56,13 @@ describe("web notifications adapter", () => {
     mocks.hasExplicitAuthHeaders.mockReturnValue(true)
     mocks.getApiBaseUrl.mockReturnValue("http://example.test/api/v1")
     mocks.apiGet.mockResolvedValue({ items: [], total: 0 })
+    mocks.apiPatch.mockResolvedValue({
+      user_id: "user-1",
+      reminder_enabled: true,
+      job_completed_enabled: false,
+      job_failed_enabled: true,
+      updated_at: "2026-04-02T00:01:00Z"
+    })
     mocks.apiPost.mockResolvedValue({ updated: 1, dismissed: true, task_id: "task-1", run_at: "2026-03-20T00:15:00Z" })
     mocks.streamStructuredSSE.mockImplementation(async (_url, _options, onEvent) => {
       onEvent({
@@ -99,6 +110,47 @@ describe("web notifications adapter", () => {
     expect(mocks.apiPost).toHaveBeenCalledWith("/notifications/1/snooze", {
       minutes: 15
     }, { withCredentials: false })
+  })
+
+  it("uses the web apiClient transport for notification preferences", async () => {
+    const initialPreferences = {
+      user_id: "user-1",
+      reminder_enabled: true,
+      job_completed_enabled: true,
+      job_failed_enabled: true,
+      updated_at: "2026-04-02T00:00:00Z"
+    }
+    const updatedPreferences = {
+      ...initialPreferences,
+      job_failed_enabled: false,
+      updated_at: "2026-04-02T00:01:00Z"
+    }
+    mocks.apiGet.mockResolvedValueOnce(initialPreferences)
+    mocks.apiPatch.mockResolvedValueOnce(updatedPreferences)
+
+    await expect(getNotificationPreferences()).resolves.toEqual(initialPreferences)
+    await expect(
+      updateNotificationPreferences({ job_failed_enabled: false })
+    ).resolves.toEqual(updatedPreferences)
+
+    expect(mocks.buildAuthHeaders).toHaveBeenCalledWith("GET")
+    expect(mocks.buildAuthHeaders).toHaveBeenCalledWith("PATCH")
+    expect(mocks.apiGet).toHaveBeenCalledWith("/notifications/preferences", {
+      headers: {
+        Authorization: "Bearer web-token",
+        "X-CSRF-Token": "csrf-token"
+      },
+      withCredentials: false
+    })
+    expect(mocks.apiPatch).toHaveBeenCalledWith("/notifications/preferences", {
+      job_failed_enabled: false
+    }, {
+      headers: {
+        Authorization: "Bearer web-token",
+        "X-CSRF-Token": "csrf-token"
+      },
+      withCredentials: false
+    })
   })
 
   it("omits cookie credentials for the notification stream when header auth is present", async () => {

--- a/apps/tldw-frontend/lib/api/notifications.ts
+++ b/apps/tldw-frontend/lib/api/notifications.ts
@@ -126,3 +126,37 @@ export async function snoozeNotification(
     withCredentials: !hasExplicitAuthHeaders()
   })
 }
+
+// ── Notification Preferences ────────────────────────────────────────
+
+export type NotificationPreferences = {
+  user_id: string
+  reminder_enabled: boolean
+  job_completed_enabled: boolean
+  job_failed_enabled: boolean
+  updated_at: string
+}
+
+export type NotificationPreferencesUpdate = {
+  reminder_enabled?: boolean
+  job_completed_enabled?: boolean
+  job_failed_enabled?: boolean
+}
+
+export async function getNotificationPreferences(): Promise<NotificationPreferences> {
+  const headers = buildAuthHeaders("GET")
+  return apiClient.get<NotificationPreferences>("/notifications/preferences", {
+    headers,
+    withCredentials: !hasExplicitAuthHeaders()
+  })
+}
+
+export async function updateNotificationPreferences(
+  update: NotificationPreferencesUpdate
+): Promise<NotificationPreferences> {
+  const headers = buildAuthHeaders("PATCH")
+  return apiClient.patch<NotificationPreferences>("/notifications/preferences", update, {
+    headers,
+    withCredentials: !hasExplicitAuthHeaders()
+  })
+}

--- a/apps/tldw-frontend/pages/notifications.tsx
+++ b/apps/tldw-frontend/pages/notifications.tsx
@@ -18,6 +18,7 @@ import { formatRelativeTime } from '@web/lib/utils';
 
 const POLL_INTERVAL_MS = 30_000;
 const DEFAULT_SNOOZE_MINUTES = 15;
+type PreferenceKey = 'reminder_enabled' | 'job_completed_enabled' | 'job_failed_enabled';
 
 function resolveRouteForLinkType(linkType: string | null | undefined): string | undefined {
   if (!linkType) return undefined
@@ -56,6 +57,8 @@ export default function NotificationsPage() {
   const [showPrefs, setShowPrefs] = useState(false);
   const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
   const [prefsLoading, setPrefsLoading] = useState(false);
+  const [prefsError, setPrefsError] = useState<string | null>(null);
+  const [prefsSavingKey, setPrefsSavingKey] = useState<PreferenceKey | null>(null);
 
   const refreshInbox = useCallback(async () => {
     try {
@@ -98,29 +101,41 @@ export default function NotificationsPage() {
   );
 
   const loadPrefs = useCallback(async () => {
+    if (prefsLoading) return;
     setPrefsLoading(true);
+    setPrefsError(null);
     try {
       const p = await getNotificationPreferences();
       setPrefs(p);
     } catch {
-      // Preferences may not be available (e.g., single-user mode without auth)
+      setPrefs(null);
+      setPrefsError('Notification preferences are currently unavailable.');
     } finally {
       setPrefsLoading(false);
     }
-  }, []);
+  }, [prefsLoading]);
 
   const togglePref = useCallback(
-    async (key: 'reminder_enabled' | 'job_completed_enabled' | 'job_failed_enabled') => {
-      if (!prefs) return;
-      const updated = { [key]: !prefs[key] };
+    async (key: PreferenceKey) => {
+      if (!prefs || prefsSavingKey) return;
+      const nextValue = !prefs[key];
+      const updated =
+        key === 'reminder_enabled'
+          ? { reminder_enabled: nextValue }
+          : key === 'job_completed_enabled'
+            ? { job_completed_enabled: nextValue }
+            : { job_failed_enabled: nextValue };
+      setPrefsSavingKey(key);
       try {
         const result = await updateNotificationPreferences(updated);
         setPrefs(result);
       } catch {
         show({ title: 'Failed to update preference', variant: 'danger' });
+      } finally {
+        setPrefsSavingKey(null);
       }
     },
-    [prefs, show]
+    [prefs, prefsSavingKey, show]
   );
 
   const applyIncomingNotification = useCallback(
@@ -234,7 +249,13 @@ export default function NotificationsPage() {
               <button
                 type="button"
                 className="rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
-                onClick={() => { setShowPrefs(!showPrefs); if (!prefs) void loadPrefs(); }}
+                onClick={() => {
+                  const nextShowPrefs = !showPrefs;
+                  setShowPrefs(nextShowPrefs);
+                  if (nextShowPrefs && !prefs && !prefsLoading) {
+                    void loadPrefs();
+                  }
+                }}
                 aria-expanded={showPrefs}
               >
                 {showPrefs ? 'Hide Preferences' : 'Preferences'}
@@ -245,8 +266,23 @@ export default function NotificationsPage() {
           {showPrefs && (
             <div className="mb-4 rounded-lg border border-border bg-muted/30 p-4">
               <h3 className="mb-3 text-sm font-semibold">Notification Preferences</h3>
-              {prefsLoading || !prefs ? (
+              {prefsLoading ? (
                 <p className="text-sm text-muted-foreground">Loading preferences...</p>
+              ) : prefsError ? (
+                <div className="space-y-3">
+                  <p className="text-sm text-muted-foreground">{prefsError}</p>
+                  <button
+                    type="button"
+                    className="rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
+                    onClick={() => void loadPrefs()}
+                  >
+                    Retry
+                  </button>
+                </div>
+              ) : !prefs ? (
+                <p className="text-sm text-muted-foreground">
+                  Notification preferences are currently unavailable.
+                </p>
               ) : (
                 <div className="space-y-3">
                   {([
@@ -258,8 +294,9 @@ export default function NotificationsPage() {
                       <input
                         type="checkbox"
                         checked={prefs[key]}
+                        disabled={prefsSavingKey !== null}
                         onChange={() => void togglePref(key)}
-                        className="mt-1 h-4 w-4 rounded border-border"
+                        className="mt-1 h-4 w-4 rounded border-border disabled:cursor-not-allowed disabled:opacity-50"
                       />
                       <div>
                         <span className="text-sm font-medium">{label}</span>

--- a/apps/tldw-frontend/pages/notifications.tsx
+++ b/apps/tldw-frontend/pages/notifications.tsx
@@ -4,9 +4,12 @@ import { useToast } from '@web/components/ui/ToastProvider';
 import {
   dismissNotification,
   getUnreadCount,
+  getNotificationPreferences,
+  updateNotificationPreferences,
   listNotifications,
   markNotificationsRead,
   NotificationItem,
+  NotificationPreferences,
   NotificationStreamEvent,
   snoozeNotification,
   subscribeNotificationsStream,
@@ -50,6 +53,9 @@ export default function NotificationsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const cursorRef = useRef(0);
+  const [showPrefs, setShowPrefs] = useState(false);
+  const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
+  const [prefsLoading, setPrefsLoading] = useState(false);
 
   const refreshInbox = useCallback(async () => {
     try {
@@ -89,6 +95,32 @@ export default function NotificationsPage() {
       }
     },
     [show]
+  );
+
+  const loadPrefs = useCallback(async () => {
+    setPrefsLoading(true);
+    try {
+      const p = await getNotificationPreferences();
+      setPrefs(p);
+    } catch {
+      // Preferences may not be available (e.g., single-user mode without auth)
+    } finally {
+      setPrefsLoading(false);
+    }
+  }, []);
+
+  const togglePref = useCallback(
+    async (key: 'reminder_enabled' | 'job_completed_enabled' | 'job_failed_enabled') => {
+      if (!prefs) return;
+      const updated = { [key]: !prefs[key] };
+      try {
+        const result = await updateNotificationPreferences(updated);
+        setPrefs(result);
+      } catch {
+        show({ title: 'Failed to update preference', variant: 'danger' });
+      }
+    },
+    [prefs, show]
   );
 
   const applyIncomingNotification = useCallback(
@@ -191,14 +223,54 @@ export default function NotificationsPage() {
               <h1 className="text-2xl font-semibold text-foreground">Notifications</h1>
               <p className="mt-1 text-sm text-muted-foreground">{unreadLabel}</p>
             </div>
-            <button
-              type="button"
-              className="rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
-              onClick={() => void refreshInbox()}
-            >
-              Refresh
-            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
+                onClick={() => void refreshInbox()}
+              >
+                Refresh
+              </button>
+              <button
+                type="button"
+                className="rounded border border-border px-3 py-2 text-sm font-medium hover:bg-muted"
+                onClick={() => { setShowPrefs(!showPrefs); if (!prefs) void loadPrefs(); }}
+                aria-expanded={showPrefs}
+              >
+                {showPrefs ? 'Hide Preferences' : 'Preferences'}
+              </button>
+            </div>
           </header>
+
+          {showPrefs && (
+            <div className="mb-4 rounded-lg border border-border bg-muted/30 p-4">
+              <h3 className="mb-3 text-sm font-semibold">Notification Preferences</h3>
+              {prefsLoading || !prefs ? (
+                <p className="text-sm text-muted-foreground">Loading preferences...</p>
+              ) : (
+                <div className="space-y-3">
+                  {([
+                    { key: 'job_completed_enabled' as const, label: 'Job completed notifications', desc: 'Notify when watchlist jobs finish successfully' },
+                    { key: 'job_failed_enabled' as const, label: 'Job failed notifications', desc: 'Notify when watchlist jobs encounter errors' },
+                    { key: 'reminder_enabled' as const, label: 'Reminder notifications', desc: 'Notify when snoozed items resurface' },
+                  ]).map(({ key, label, desc }) => (
+                    <label key={key} className="flex items-start gap-3 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={prefs[key]}
+                        onChange={() => void togglePref(key)}
+                        className="mt-1 h-4 w-4 rounded border-border"
+                      />
+                      <div>
+                        <span className="text-sm font-medium">{label}</span>
+                        <p className="text-xs text-muted-foreground">{desc}</p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
           {error && (
             <div className="mb-4 rounded border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">


### PR DESCRIPTION
## Summary

Closes #958. Adds frontend API client and UI for notification preferences.

### Changes
- **API client**: `getNotificationPreferences()` and `updateNotificationPreferences()` in `@web/lib/api/notifications.ts`
- **Notifications page**: "Preferences" button in header that toggles a panel with 3 checkboxes:
  - Job completed notifications
  - Job failed notifications  
  - Reminder notifications
- Changes are saved immediately on toggle (PATCH to backend)

### Backend
Already implemented — `GET/PATCH /api/v1/notifications/preferences` with `NotificationPreferencesResponse` schema.

## Test plan
- [ ] Open /notifications → "Preferences" button visible next to "Refresh"
- [ ] Click "Preferences" → panel expands with 3 toggle checkboxes
- [ ] Toggle a checkbox → change saved immediately (verify via API)
- [ ] Disable "Job completed" → completed job notifications stop appearing
- [ ] Re-enable → notifications resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)