### PR TITLE
feat: tabbed section navigation for Settings page (#956)

### DIFF
--- a/apps/packages/ui/src/components/Option/Settings/__tests__/tldw-settings-tabs.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/tldw-settings-tabs.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+
+import React from "react"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TldwSettingsTabs } from "../tldw-settings-tabs"
+
+const tabsRenderSpy = vi.fn()
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions?.defaultValue) return fallbackOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+vi.mock("antd", () => ({
+  Tabs: ({
+    activeKey,
+    className,
+    items,
+    onChange,
+    onTabClick
+  }: {
+    activeKey?: string
+    className?: string
+    items?: Array<{ key: string; label: React.ReactNode }>
+    onChange?: (key: string) => void
+    onTabClick?: (key: string) => void
+  }) => {
+    tabsRenderSpy({ activeKey, className, items })
+
+    return (
+      <div data-testid="tabs-root" data-active-key={activeKey} className={className}>
+        {items?.map((item) => (
+          <button
+            key={item.key}
+            type="button"
+            data-testid={`tab-${item.key}`}
+            data-active={activeKey === item.key ? "true" : "false"}
+            onClick={() => {
+              onTabClick?.(item.key)
+              if (item.key !== activeKey) {
+                onChange?.(item.key)
+              }
+            }}>
+            {item.label}
+          </button>
+        ))}
+      </div>
+    )
+  }
+}))
+
+type MockIntersectionObserverEntry = Pick<
+  IntersectionObserverEntry,
+  "target" | "isIntersecting" | "intersectionRatio"
+>
+
+const observerState = vi.hoisted(() => ({
+  instances: [] as Array<{
+    callback: IntersectionObserverCallback
+    observe: ReturnType<typeof vi.fn>
+    disconnect: ReturnType<typeof vi.fn>
+  }>
+}))
+
+class IntersectionObserverMock {
+  callback: IntersectionObserverCallback
+  observe = vi.fn()
+  disconnect = vi.fn()
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback
+    observerState.instances.push({
+      callback,
+      observe: this.observe,
+      disconnect: this.disconnect
+    })
+  }
+}
+
+const installSectionTargets = () => {
+  document.body.innerHTML = `
+    <div id="tldw-settings-connection"></div>
+    <div id="tldw-settings-timeouts"></div>
+    <div id="tldw-settings-billing"></div>
+  `
+}
+
+const emitIntersection = (entries: MockIntersectionObserverEntry[]) => {
+  const instance = observerState.instances.at(-1)
+  if (!instance) {
+    throw new Error("No IntersectionObserver instance registered")
+  }
+
+  instance.callback(entries as IntersectionObserverEntry[], {} as IntersectionObserver)
+}
+
+describe("TldwSettingsTabs", () => {
+  const originalIntersectionObserver = globalThis.IntersectionObserver
+
+  beforeEach(() => {
+    tabsRenderSpy.mockClear()
+    observerState.instances.length = 0
+    installSectionTargets()
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: IntersectionObserverMock
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.body.innerHTML = ""
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: originalIntersectionObserver
+    })
+  })
+
+  it("keeps the navigation sticky and shows billing only for logged-in multi-user mode", () => {
+    render(<TldwSettingsTabs authMode="multi-user" isLoggedIn />)
+
+    expect(screen.getByTestId("tabs-root")).toHaveClass("sticky", "top-0")
+    expect(screen.getByTestId("tab-billing")).toBeInTheDocument()
+  })
+
+  it("scrolls to the target section every time a tab is clicked, even if it is already active", () => {
+    const scrollIntoView = vi.fn()
+    Object.defineProperty(
+      document.getElementById("tldw-settings-timeouts") as HTMLElement,
+      "scrollIntoView",
+      {
+        configurable: true,
+        value: scrollIntoView
+      }
+    )
+
+    render(<TldwSettingsTabs authMode="single-user" isLoggedIn={false} />)
+
+    const timeoutsTab = screen.getByTestId("tab-timeouts")
+    fireEvent.click(timeoutsTab)
+    fireEvent.click(timeoutsTab)
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start"
+    })
+  })
+
+  it("updates the active tab when a different section becomes visible", () => {
+    render(<TldwSettingsTabs authMode="single-user" isLoggedIn={false} />)
+
+    act(() => {
+      emitIntersection([
+        {
+          target: document.getElementById("tldw-settings-timeouts") as Element,
+          isIntersecting: true,
+          intersectionRatio: 0.8
+        }
+      ])
+    })
+
+    expect(screen.getByTestId("tabs-root")).toHaveAttribute(
+      "data-active-key",
+      "timeouts"
+    )
+    expect(screen.getByTestId("tab-timeouts")).toHaveAttribute(
+      "data-active",
+      "true"
+    )
+  })
+
+  it("disconnects the observer on unmount", () => {
+    const { unmount } = render(
+      <TldwSettingsTabs authMode="single-user" isLoggedIn={false} />
+    )
+
+    const instance = observerState.instances.at(-1)
+    if (!instance) {
+      throw new Error("No IntersectionObserver instance registered")
+    }
+
+    unmount()
+
+    expect(instance.disconnect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Settings/tldw-settings-tabs.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/tldw-settings-tabs.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from "react"
+import { Tabs } from "antd"
+import { useTranslation } from "react-i18next"
+
+type TldwSettingsTabKey = "connection" | "timeouts" | "billing"
+
+type TldwSettingsTabsProps = {
+  authMode: "single-user" | "multi-user"
+  isLoggedIn: boolean
+}
+
+const SECTION_IDS: Record<TldwSettingsTabKey, string> = {
+  connection: "tldw-settings-connection",
+  timeouts: "tldw-settings-timeouts",
+  billing: "tldw-settings-billing"
+}
+
+const getVisibleSectionKeys = (
+  authMode: TldwSettingsTabsProps["authMode"],
+  isLoggedIn: boolean
+): TldwSettingsTabKey[] =>
+  authMode === "multi-user" && isLoggedIn
+    ? ["connection", "timeouts", "billing"]
+    : ["connection", "timeouts"]
+
+export const TldwSettingsTabs = ({
+  authMode,
+  isLoggedIn
+}: TldwSettingsTabsProps) => {
+  const { t } = useTranslation()
+  const visibleSectionKeys = getVisibleSectionKeys(authMode, isLoggedIn)
+  const [activeKey, setActiveKey] = useState<TldwSettingsTabKey>(
+    visibleSectionKeys[0]
+  )
+
+  useEffect(() => {
+    if (!visibleSectionKeys.includes(activeKey)) {
+      setActiveKey(visibleSectionKeys[0])
+    }
+  }, [activeKey, visibleSectionKeys, authMode, isLoggedIn])
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const mostVisibleEntry = entries
+          .filter((entry) => entry.isIntersecting)
+          .map((entry) => {
+            const key = visibleSectionKeys.find(
+              (candidate) => SECTION_IDS[candidate] === entry.target.id
+            )
+
+            if (!key) return null
+
+            return {
+              key,
+              ratio: entry.intersectionRatio
+            }
+          })
+          .filter((entry): entry is { key: TldwSettingsTabKey; ratio: number } =>
+            entry !== null
+          )
+          .sort((left, right) => right.ratio - left.ratio)[0]
+
+        if (mostVisibleEntry) {
+          setActiveKey(mostVisibleEntry.key)
+        }
+      },
+      {
+        threshold: [0.2, 0.4, 0.6],
+        rootMargin: "-72px 0px -45% 0px"
+      }
+    )
+
+    visibleSectionKeys.forEach((key) => {
+      const element = document.getElementById(SECTION_IDS[key])
+      if (element) {
+        observer.observe(element)
+      }
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [authMode, isLoggedIn, visibleSectionKeys])
+
+  return (
+    <Tabs
+      activeKey={activeKey}
+      size="small"
+      className="sticky top-0 z-20 mb-4 border-b border-border bg-surface/95 px-1 py-2 backdrop-blur supports-[backdrop-filter]:bg-surface/85"
+      items={[
+        {
+          key: "connection",
+          label: t("settings:tldw.tabs.connection", "Connection")
+        },
+        {
+          key: "timeouts",
+          label: t("settings:tldw.tabs.timeouts", "Timeouts")
+        },
+        ...(authMode === "multi-user" && isLoggedIn
+          ? [
+              {
+                key: "billing",
+                label: t("settings:tldw.tabs.billing", "Billing")
+              }
+            ]
+          : [])
+      ]}
+      onChange={(key) => {
+        setActiveKey(key as TldwSettingsTabKey)
+      }}
+      onTabClick={(key) => {
+        const element = document.getElementById(
+          SECTION_IDS[key as TldwSettingsTabKey]
+        )
+        if (element) {
+          element.scrollIntoView({
+            behavior: "smooth",
+            block: "start"
+          })
+        }
+      }}
+    />
+  )
+}

--- a/apps/packages/ui/src/components/Option/Settings/tldw.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/tldw.tsx
@@ -10,8 +10,7 @@ import {
   Button,
   Select,
   Collapse,
-  Tag,
-  Tabs
+  Tag
 } from "antd"
 import { Link, useNavigate } from "react-router-dom"
 import React, { useEffect, useState } from "react"
@@ -35,6 +34,7 @@ import {
   type CoreStatus,
   type RagStatus
 } from "./tldw-connection-status"
+import { TldwSettingsTabs } from "./tldw-settings-tabs"
 import { probeServerHealth } from "./server-health-probe"
 
 type TimeoutPresetKey = 'balanced' | 'extended'
@@ -398,7 +398,7 @@ export const TldwSettings = () => {
           apiKey: config.apiKey,
           authMode: config.authMode
         })
-        
+
         // Check if logged in for multi-user mode
         if (config.authMode === 'multi-user' && config.accessToken) {
           setIsLoggedIn(true)
@@ -467,7 +467,7 @@ export const TldwSettings = () => {
 
       await tldwClient.updateConfig(config)
       message.success(t("settings:savedSuccessfully"))
-      
+
       // Test connection after saving
       await testConnection({
         triggerSplashOnSuccess: values.authMode === "single-user"
@@ -602,7 +602,7 @@ export const TldwSettings = () => {
     setConnectionDetail("")
     setCoreStatus("checking")
     setRagStatus("unknown")
-    
+
     let values: any = {}
     try {
       values = form.getFieldsValue()
@@ -691,7 +691,7 @@ export const TldwSettings = () => {
       } catch (e) {
         setRagStatus('unhealthy')
       }
-      
+
       if (success) {
         message.success(t('settings:tldw.connection.success', 'Connection successful!'))
         if (options?.triggerSplashOnSuccess) {
@@ -792,18 +792,18 @@ export const TldwSettings = () => {
     try {
       const values = await form.validateFields(['username', 'password'])
       setLoading(true)
-      
+
       await tldwAuth.login({
         username: values.username,
         password: values.password
       })
-      
+
       setIsLoggedIn(true)
       message.success(t('settings:tldw.login.success', 'Login successful!'))
-      
+
       // Clear password field
       form.setFieldValue('password', '')
-      
+
       // Test connection after login
       await testConnection()
     } catch (error: any) {
@@ -1116,24 +1116,12 @@ export const TldwSettings = () => {
             <Button type="primary" onClick={() => { void testConnection() }} loading={testingConnection}>{t('settings:tldw.buttons.recheck', 'Recheck')}</Button>
           </Space>
         </div>
-        <Tabs
-          size="small"
-          className="mb-4"
-          items={[
-            { key: 'connection', label: t('settings:tldw.tabs.connection', 'Connection') },
-            { key: 'timeouts', label: t('settings:tldw.tabs.timeouts', 'Timeouts') },
-            ...(authMode === 'multi-user' && isLoggedIn ? [
-              { key: 'billing', label: t('settings:tldw.tabs.billing', 'Billing') },
-            ] : []),
-          ]}
-          onChange={(key) => {
-            const el = document.getElementById(`tldw-settings-${key}`)
-            if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          }}
-        />
-        <div id="tldw-settings-connection" />
-        <h2 className="text-base font-semibold mb-4 text-text">{t('settings:tldw.serverConfigTitle', 'tldw Server Configuration')}</h2>
-        
+        <TldwSettingsTabs authMode={authMode} isLoggedIn={isLoggedIn} />
+        <h2
+          id="tldw-settings-connection"
+          className="mb-4 scroll-mt-24 text-base font-semibold text-text">
+          {t('settings:tldw.serverConfigTitle', 'tldw Server Configuration')}
+        </h2>
         <Form
           form={form}
           onFinish={handleSave}
@@ -1405,9 +1393,9 @@ export const TldwSettings = () => {
               </div>
             </div>
           </Space>
-          <div id="tldw-settings-timeouts" />
           <Collapse
-            className="mt-4"
+            id="tldw-settings-timeouts"
+            className="mt-4 scroll-mt-24"
             items={[
               {
                 key: 'adv',
@@ -1736,7 +1724,9 @@ export const TldwSettings = () => {
         </Form>
 
         {authMode === 'multi-user' && isLoggedIn && (
-          <div id="tldw-settings-billing" className="mt-6 rounded-lg border border-border bg-surface2 p-4">
+          <div
+            id="tldw-settings-billing"
+            className="mt-6 scroll-mt-24 rounded-lg border border-border bg-surface2 p-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <h3 className="text-base font-semibold text-text">

--- a/apps/packages/ui/src/components/Option/Settings/tldw.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/tldw.tsx
@@ -10,7 +10,8 @@ import {
   Button,
   Select,
   Collapse,
-  Tag
+  Tag,
+  Tabs
 } from "antd"
 import { Link, useNavigate } from "react-router-dom"
 import React, { useEffect, useState } from "react"
@@ -1115,6 +1116,22 @@ export const TldwSettings = () => {
             <Button type="primary" onClick={() => { void testConnection() }} loading={testingConnection}>{t('settings:tldw.buttons.recheck', 'Recheck')}</Button>
           </Space>
         </div>
+        <Tabs
+          size="small"
+          className="mb-4"
+          items={[
+            { key: 'connection', label: t('settings:tldw.tabs.connection', 'Connection') },
+            { key: 'timeouts', label: t('settings:tldw.tabs.timeouts', 'Timeouts') },
+            ...(authMode === 'multi-user' && isLoggedIn ? [
+              { key: 'billing', label: t('settings:tldw.tabs.billing', 'Billing') },
+            ] : []),
+          ]}
+          onChange={(key) => {
+            const el = document.getElementById(`tldw-settings-${key}`)
+            if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          }}
+        />
+        <div id="tldw-settings-connection" />
         <h2 className="text-base font-semibold mb-4 text-text">{t('settings:tldw.serverConfigTitle', 'tldw Server Configuration')}</h2>
         
         <Form
@@ -1388,6 +1405,7 @@ export const TldwSettings = () => {
               </div>
             </div>
           </Space>
+          <div id="tldw-settings-timeouts" />
           <Collapse
             className="mt-4"
             items={[
@@ -1718,7 +1736,7 @@ export const TldwSettings = () => {
         </Form>
 
         {authMode === 'multi-user' && isLoggedIn && (
-          <div className="mt-6 rounded-lg border border-border bg-surface2 p-4">
+          <div id="tldw-settings-billing" className="mt-6 rounded-lg border border-border bg-surface2 p-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <h3 className="text-base font-semibold text-text">


### PR DESCRIPTION
## Summary

Closes #956. Adds tabbed navigation to the monolithic Settings page (2,086 lines) without restructuring the component.

### Approach
Rather than risk a full component extraction refactor on a 2K-line file with deeply nested JSX, this PR adds a **scroll-to-section tab bar** at the top using Ant Design Tabs:

- **Connection** — Server URL, auth mode, credentials, health status
- **Timeouts** — Timeout presets and individual timeout fields
- **Billing** — Plans, usage, subscription, invoices (only shown for multi-user + logged in)

Clicking a tab smoothly scrolls to that section. The existing page structure is preserved — no JSX restructuring.

### Future work
Full component extraction (splitting each tab into its own file) can be done as a follow-up when there's more time for testing.

## Test plan
- [ ] Open Settings → tldw Server → tab bar visible at top
- [ ] Click "Timeouts" → page scrolls to timeout section
- [ ] Click "Connection" → scrolls back to top
- [ ] In multi-user mode + logged in → "Billing" tab visible
- [ ] In single-user mode → only "Connection" and "Timeouts" tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)