### PR TITLE
fix: surface buddy resolve errors and use backend-agnostic deleted filter

### DIFF
--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -10386,12 +10386,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 derived_core=item["derived_core"],
                 overlay_preferences=item["overlay_preferences"],
             )
-        except (TypeError, KeyError, ValueError):
-            logger.warning(
-                "Unable to resolve persona buddy profile for persona_id={}.",
+        except (TypeError, KeyError, ValueError) as exc:
+            logger.error(
+                "Corrupt or incomplete buddy data for persona_id={}: {}",
                 buddy_label,
+                exc,
             )
-            item["resolved_profile"] = None
+            raise CharactersRAGDBError(
+                f"Failed to resolve buddy profile for persona {buddy_label}: {exc}"
+            ) from exc
         return item
 
     def _persona_scope_rule_row_to_dict(self, row: Any) -> dict[str, Any] | None:
@@ -10652,7 +10655,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                AND pe.user_id = ?
                AND (? OR pe.enabled = 1)
                AND (? OR pe.deleted = 0)
-               AND (? OR pp.deleted = 0)
+               AND (? OR pp.deleted = FALSE)
              LIMIT 1
         """
         params = (
@@ -10688,7 +10691,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                AND (? IS NULL OR pe.persona_id = ?)
                AND (? OR pe.enabled = 1)
                AND (? OR pe.deleted = 0)
-               AND (? OR pp.deleted = 0)
+               AND (? OR pp.deleted = FALSE)
              ORDER BY pe.priority DESC, pe.last_modified DESC, pe.id ASC
              LIMIT ? OFFSET ?
         """

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+import json
+
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError, ConflictError
 from tldw_Server_API.app.core.Persona.buddy import ensure_persona_buddy_for_profile
 

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_persona_buddy_db.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError, ConflictError
 from tldw_Server_API.app.core.Persona.buddy import ensure_persona_buddy_for_profile
 
 
@@ -250,3 +250,50 @@ def test_restore_persona_profile_with_stale_expected_version_raises_conflict(
             user_id="user-1",
             expected_version=stale_version,
         )
+
+
+def test_row_to_dict_raises_on_corrupt_derived_core(db_instance: CharactersRAGDB) -> None:
+    """_persona_buddy_row_to_dict must raise CharactersRAGDBError when
+    derived_core is empty/corrupt, not silently return resolved_profile=None."""
+    fake_row = {
+        "persona_id": "test-persona-corrupt",
+        "user_id": "1",
+        "derivation_version": 1,
+        "source_fingerprint": "abc123",
+        "derived_core_json": "{}",
+        "overlay_preferences_json": "{}",
+        "created_at": "2026-03-31T00:00:00",
+        "last_modified": "2026-03-31T00:00:00",
+        "version": 1,
+    }
+    with pytest.raises(CharactersRAGDBError, match="Failed to resolve buddy profile"):
+        db_instance._persona_buddy_row_to_dict(fake_row)
+
+
+def test_row_to_dict_succeeds_with_valid_data(db_instance: CharactersRAGDB) -> None:
+    """Happy path: well-formed derived_core produces a resolved_profile."""
+    import json
+
+    derived_core = {
+        "species_id": "owl",
+        "silhouette_id": "owl_round",
+        "palette_id": "moss",
+        "behavior_family": "steady",
+        "expression_profile": "warm",
+    }
+    fake_row = {
+        "persona_id": "test-persona-valid",
+        "user_id": "1",
+        "derivation_version": 1,
+        "source_fingerprint": "abc123",
+        "derived_core_json": json.dumps(derived_core),
+        "overlay_preferences_json": "{}",
+        "created_at": "2026-03-31T00:00:00",
+        "last_modified": "2026-03-31T00:00:00",
+        "version": 1,
+    }
+    result = db_instance._persona_buddy_row_to_dict(fake_row)
+    assert result is not None
+    assert result["resolved_profile"] is not None
+    assert result["resolved_profile"]["species_id"] == "owl"
+    assert result["resolved_profile"]["compatibility_status"] == "exact"


### PR DESCRIPTION
## Summary
- **`_persona_buddy_row_to_dict`**: Replace blanket `except (TypeError, KeyError, ValueError)` that silently set `resolved_profile = None` with `logger.error()` + `raise CharactersRAGDBError(...) from exc`. Corrupt/incomplete buddy data now surfaces immediately instead of hiding behind downstream validation failures.
- **`get_persona_exemplar` / `list_persona_exemplars`**: Change `pp.deleted = 0` to `pp.deleted = FALSE` so the filter is backend-agnostic (both SQLite and Postgres accept `FALSE` natively) without depending on the boolean rewrite layer.

Addresses review findings from #949.

## Test plan
- [x] `test_row_to_dict_raises_on_corrupt_derived_core` — verifies `CharactersRAGDBError` on empty derived_core
- [x] `test_row_to_dict_succeeds_with_valid_data` — happy path produces proper resolved_profile
- [x] Existing 8 buddy DB tests pass (no regressions)
- [x] `test_persona_exemplar_crud_scoping_and_tag_normalization` passes (exercises `include_deleted_personas` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)