### PR TITLE
feat: add global flashcard tag suggestions

### DIFF
--- a/Docs/superpowers/plans/2026-04-02-flashcards-global-tag-suggestions-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-02-flashcards-global-tag-suggestions-implementation-plan.md
@@ -1,0 +1,709 @@
+# Flashcards Global Tag Suggestions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add global flashcard tag suggestions to the shared create and edit drawers so users can select existing tags across accessible flashcards in both the WebUI and extension while still typing new tags.
+
+**Architecture:** Add one backend `GET /api/v1/flashcards/tags` endpoint backed by flashcard-keyword aggregation instead of card-list scans. Keep the current ManageTab page-scan suggestion hook unchanged, add a dedicated create/edit suggestion service and React Query hook with abort-signal support, and route both drawers through one shared `FlashcardTagPicker` component. Preserve extension parity by keeping the behavior in shared UI and adding one explicit extension-path parity check.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite/PostgreSQL DB abstraction, React, TypeScript, Ant Design, TanStack Query, Vitest, React Testing Library, Playwright
+
+---
+
+## File Structure
+
+- `tldw_Server_API/app/api/v1/schemas/flashcards.py`
+  Purpose: define response models for the new tag suggestions endpoint so the API contract is explicit and typed.
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+  Purpose: add a dedicated database method that aggregates active flashcard tags globally for the current user without inheriting ManageTab visibility defaults.
+- `tldw_Server_API/app/api/v1/endpoints/flashcards.py`
+  Purpose: expose `GET /api/v1/flashcards/tags` before the dynamic `/{card_uuid}` alias route and return the new typed response.
+- `tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py`
+  Purpose: lock endpoint behavior for ordering, filtering, deleted rows, route precedence, and global visibility.
+- `apps/packages/ui/src/services/flashcards.ts`
+  Purpose: add typed client helpers for the new endpoint, including abort-signal support for typeahead requests.
+- `apps/packages/ui/src/services/__tests__/flashcards.test.ts`
+  Purpose: verify the service builds the correct `/api/v1/flashcards/tags` request and forwards abort signals.
+- `apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts`
+  Purpose: add a dedicated create/edit tag-suggestions query hook while preserving the existing ManageTab scan hook.
+- `apps/packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx`
+  Purpose: prove the new query hook uses the dedicated backend endpoint, respects `enabled`, and forwards the React Query abort signal.
+- `apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx`
+  Purpose: implement the shared hybrid tag picker used by both create and edit drawers.
+- `apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx`
+  Purpose: verify suggestion rendering, manual entry, whitespace trimming, case-insensitive dedupe, and fetch-failure fallback.
+- `apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx`
+  Purpose: replace the raw create-drawer tag field with the shared picker and provide stable test ids.
+- `apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx`
+  Purpose: replace the raw edit-drawer tag field with the shared picker and provide stable test ids.
+- `apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx`
+  Purpose: prove the create drawer can select a suggested tag and still submit a brand-new one.
+- `apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx`
+  Purpose: prove the edit drawer preserves existing tags and can append a suggested tag.
+- `apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts`
+  Purpose: add minimal locators and helpers for the create/edit tag picker flow in the shared workspace.
+- `apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts`
+  Purpose: add one real user flow that reproduces the complaint and proves selecting existing tags works in the web shell.
+- `apps/tldw-frontend/__tests__/extension/option-flashcards.shared-workspace.test.ts`
+  Purpose: add an extension-path parity check that locks the extension wrapper to the shared `FlashcardsWorkspace`.
+
+## Task 1: Add The Backend Tag Suggestions Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/flashcards.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/flashcards.py`
+- Modify: `tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py`
+
+- [ ] **Step 1: Write the failing backend integration tests**
+
+Add focused endpoint tests to `tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py` that cover:
+
+1. global visibility across a general deck and a workspace deck
+2. ordering by usage count, then alphabetically
+3. case-insensitive substring filtering with `q`
+4. deleted flashcards, deleted keywords, and deleted decks being excluded
+5. route precedence for `/api/v1/flashcards/tags`
+
+Use the existing `flashcards_db` fixture when you need direct row soft-deletes.
+
+```python
+def test_flashcard_tag_suggestions_are_global_and_ranked(
+    client_with_flashcards_db: TestClient,
+    flashcards_db: CharactersRAGDB,
+):
+    general = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "General Deck"},
+        headers=AUTH_HEADERS,
+    ).json()
+    workspace = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Workspace Deck", "workspace_id": "workspace-77"},
+        headers=AUTH_HEADERS,
+    ).json()
+
+    client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={"deck_id": general["id"], "front": "Q1", "back": "A1", "tags": ["biology", "alpha"]},
+        headers=AUTH_HEADERS,
+    )
+    client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={"deck_id": workspace["id"], "front": "Q2", "back": "A2", "tags": ["biology", "zeta"]},
+        headers=AUTH_HEADERS,
+    )
+
+    response = client_with_flashcards_db.get(
+        "/api/v1/flashcards/tags",
+        params={"q": "bio", "limit": 10},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["items"][0] == {"tag": "biology", "count": 2}
+```
+
+- [ ] **Step 2: Run the new backend tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py -k "flashcard_tag_suggestions" -v
+```
+
+Expected: FAIL because `/api/v1/flashcards/tags` does not exist yet.
+
+- [ ] **Step 3: Implement the minimal backend endpoint**
+
+Add two new schema models in `tldw_Server_API/app/api/v1/schemas/flashcards.py`.
+
+```python
+class FlashcardTagSuggestionItem(BaseModel):
+    tag: str
+    count: int
+
+
+class FlashcardTagSuggestionsResponse(BaseModel):
+    items: list[FlashcardTagSuggestionItem] = Field(default_factory=list)
+    count: int
+```
+
+Add a DB method in `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py` that does not reuse `list_flashcards` visibility defaults.
+
+```python
+def list_flashcard_tag_suggestions(
+    self,
+    q: str | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    keyword_table = self._map_table_for_backend("keywords")
+    where_clauses = [
+        "f.deleted = 0" if self.backend_type != BackendType.POSTGRESQL else "f.deleted = FALSE",
+        "kw.deleted = 0" if self.backend_type != BackendType.POSTGRESQL else "kw.deleted = FALSE",
+        "(d.id IS NULL OR d.deleted = 0)" if self.backend_type != BackendType.POSTGRESQL else "(d.id IS NULL OR d.deleted = FALSE)",
+    ]
+    params: list[Any] = []
+    if q and q.strip():
+        where_clauses.append("LOWER(kw.keyword) LIKE ?")
+        params.append(f"%{q.strip().lower()}%")
+
+    query = f'''
+        SELECT kw.keyword AS tag, COUNT(DISTINCT f.id) AS count
+          FROM flashcards f
+          LEFT JOIN decks d ON d.id = f.deck_id
+          JOIN flashcard_keywords fk ON fk.card_id = f.id
+          JOIN {keyword_table} kw ON kw.id = fk.keyword_id
+         WHERE {" AND ".join(where_clauses)}
+         GROUP BY kw.keyword
+         ORDER BY count DESC, kw.keyword COLLATE NOCASE ASC
+         LIMIT ?
+    '''
+    params.append(limit)
+```
+
+Then expose it in `tldw_Server_API/app/api/v1/endpoints/flashcards.py` before the later `@router.get("/{card_uuid}")` alias route.
+
+```python
+@router.get("/tags", response_model=FlashcardTagSuggestionsResponse)
+def list_flashcard_tag_suggestions(
+    q: Optional[str] = None,
+    limit: int = Query(20, ge=1, le=100),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+):
+    items = db.list_flashcard_tag_suggestions(q=q, limit=limit)
+    return {"items": items, "count": len(items)}
+```
+
+- [ ] **Step 4: Re-run the backend tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py -k "flashcard_tag_suggestions or get_flashcard_alias_path_returns_card" -v
+```
+
+Expected: PASS, proving the static `/tags` route works and the existing `/{card_uuid}` alias route still works.
+
+- [ ] **Step 5: Run Bandit on the touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/flashcards.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_flashcards_tag_suggestions.json
+```
+
+Expected: no new actionable findings in the touched code. If Bandit reports anything new in these edits, fix it before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/flashcards.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/flashcards.py \
+  tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+git commit -m "feat: add flashcard tag suggestions endpoint"
+```
+
+## Task 2: Add The Shared Service And Dedicated Create/Edit Query Hook
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/flashcards.ts`
+- Modify: `apps/packages/ui/src/services/__tests__/flashcards.test.ts`
+- Modify: `apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts`
+- Create: `apps/packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx`
+
+- [ ] **Step 1: Write the failing service and hook tests**
+
+Extend `apps/packages/ui/src/services/__tests__/flashcards.test.ts` to cover the new request path and abort signal.
+
+```ts
+import { buildQuery } from "@/services/resource-client"
+
+it("requests flashcard tag suggestions with query params and abort signal", async () => {
+  const signal = new AbortController().signal
+  vi.mocked(buildQuery).mockReturnValue("?q=bio&limit=15")
+
+  await listFlashcardTagSuggestions({ q: "bio", limit: 15, signal })
+
+  expect(mockBgRequest).toHaveBeenCalledWith(
+    expect.objectContaining({
+      path: "/api/v1/flashcards/tags?q=bio&limit=15",
+      method: "GET",
+      abortSignal: signal
+    })
+  )
+})
+```
+
+Create `apps/packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx` and assert the new hook:
+
+1. calls the dedicated service, not `listFlashcards`
+2. forwards the React Query abort signal
+3. stays disabled when `enabled: false`
+
+```tsx
+const { result } = renderHook(
+  () => useGlobalFlashcardTagSuggestionsQuery("bio", { enabled: true, limit: 15 }),
+  { wrapper: buildWrapper() }
+)
+
+await waitFor(() => {
+  expect(result.current.data?.items[0]?.tag).toBe("biology")
+})
+
+expect(listFlashcardTagSuggestions).toHaveBeenCalledWith(
+  expect.objectContaining({
+    q: "bio",
+    limit: 15,
+    signal: expect.any(AbortSignal)
+  })
+)
+```
+
+- [ ] **Step 2: Run the new frontend tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run \
+  ../packages/ui/src/services/__tests__/flashcards.test.ts \
+  ../packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx \
+  --reporter=verbose
+```
+
+Expected: FAIL because the service helper and hook do not exist yet.
+
+- [ ] **Step 3: Implement the minimal service and hook**
+
+Add typed client helpers in `apps/packages/ui/src/services/flashcards.ts`.
+
+```ts
+export type FlashcardTagSuggestion = {
+  tag: string
+  count: number
+}
+
+export type FlashcardTagSuggestionsResponse = {
+  items: FlashcardTagSuggestion[]
+  count: number
+}
+
+export async function listFlashcardTagSuggestions(params?: {
+  q?: string | null
+  limit?: number
+  signal?: AbortSignal
+}): Promise<FlashcardTagSuggestionsResponse> {
+  const query = buildQuery({
+    q: params?.q,
+    limit: params?.limit
+  })
+  const path = `/api/v1/flashcards/tags${query}` as AllowedPath
+  return await bgRequest<FlashcardTagSuggestionsResponse, AllowedPath, "GET">({
+    path,
+    method: "GET",
+    abortSignal: params?.signal
+  })
+}
+```
+
+Then add a dedicated create/edit hook in `apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts` and leave the existing `useTagSuggestionsQuery` for ManageTab untouched.
+
+```ts
+export function useGlobalFlashcardTagSuggestionsQuery(
+  search: string,
+  options?: { enabled?: boolean; limit?: number }
+) {
+  const { flashcardsEnabled } = useFlashcardsEnabled()
+  const normalizedQuery = search.trim()
+  const limit = options?.limit ?? 20
+
+  return useQuery({
+    queryKey: ["flashcards:tags:suggestions:global", normalizedQuery, limit],
+    queryFn: ({ signal }) =>
+      listFlashcardTagSuggestions({
+        q: normalizedQuery || undefined,
+        limit,
+        signal
+      }),
+    enabled: (options?.enabled ?? flashcardsEnabled),
+    staleTime: 30_000
+  })
+}
+```
+
+- [ ] **Step 4: Re-run the service and hook tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run \
+  ../packages/ui/src/services/__tests__/flashcards.test.ts \
+  ../packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx \
+  --reporter=verbose
+```
+
+Expected: PASS, with the hook proving that the new path is used and abort signals are forwarded.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/services/flashcards.ts \
+  apps/packages/ui/src/services/__tests__/flashcards.test.ts \
+  apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts \
+  apps/packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx
+git commit -m "feat: add shared flashcard tag suggestion query"
+```
+
+## Task 3: Build The Shared Hybrid `FlashcardTagPicker`
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx`
+- Create: `apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx`
+
+- [ ] **Step 1: Write the failing picker tests**
+
+Create `apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx` and cover:
+
+1. opening the picker shows backend suggestions
+2. selecting an existing suggestion emits the normalized tag list
+3. typing a new tag and pressing `Enter` still works
+4. whitespace-only values are ignored
+5. duplicate values collapse case-insensitively
+6. fetch failure falls back to free typing
+
+```tsx
+render(
+  <FlashcardTagPicker
+    value={["Existing"]}
+    onChange={onChange}
+    active
+    dataTestId="flashcards-create-tag-picker"
+  />
+)
+
+fireEvent.mouseDown(screen.getByLabelText("Tags"))
+expect(await screen.findByRole("option", { name: "biology" })).toBeInTheDocument()
+
+fireEvent.click(screen.getByRole("option", { name: "biology" }))
+expect(onChange).toHaveBeenLastCalledWith(["Existing", "biology"])
+```
+
+- [ ] **Step 2: Run the picker test to verify it fails**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx --reporter=verbose
+```
+
+Expected: FAIL because `FlashcardTagPicker` does not exist yet.
+
+- [ ] **Step 3: Implement the minimal shared picker**
+
+Create `apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx` and keep the behavior narrow:
+
+- own the dropdown-open state
+- debounce the search text
+- only enable the query when `active && dropdownOpen`
+- normalize `onChange` values by trimming and deduping case-insensitively
+- keep free typing intact when the query errors or returns nothing
+- expose stable `data-testid` values for the wrapper and search input
+
+```tsx
+const normalizeTagValues = (values: string[]): string[] => {
+  const seen = new Set<string>()
+  const next: string[] = []
+  for (const raw of values) {
+    const trimmed = String(raw || "").trim()
+    const key = trimmed.toLowerCase()
+    if (!trimmed || seen.has(key)) continue
+    seen.add(key)
+    next.push(trimmed)
+  }
+  return next
+}
+
+export const FlashcardTagPicker = ({ value, onChange, active, dataTestId, ...props }) => {
+  const [open, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState("")
+  const debouncedSearch = useDebouncedValue(search, 150)
+  const suggestionsQuery = useGlobalFlashcardTagSuggestionsQuery(debouncedSearch, {
+    enabled: active && open,
+    limit: 20
+  })
+
+  return (
+    <Select
+      mode="tags"
+      showSearch
+      filterOption={false}
+      open={open}
+      onOpenChange={setOpen}
+      searchValue={search}
+      onSearch={setSearch}
+      value={value}
+      onChange={(next) => onChange?.(normalizeTagValues(next as string[]))}
+      options={(suggestionsQuery.data?.items ?? []).map((item) => ({ value: item.tag, label: item.tag }))}
+    />
+  )
+}
+```
+
+If no shared `useDebouncedValue` helper exists in this area, keep the debounce local inside this component with `useEffect` and `setTimeout`.
+
+- [ ] **Step 4: Re-run the picker test**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx --reporter=verbose
+```
+
+Expected: PASS, including the fallback path when the suggestion query fails.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx \
+  apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx
+git commit -m "feat: add shared flashcard tag picker"
+```
+
+## Task 4: Wire The Create And Edit Drawers To The Shared Picker
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx`
+- Create: `apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx`
+- Create: `apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx`
+
+- [ ] **Step 1: Write the failing drawer tests**
+
+Create one focused test per drawer.
+
+Create drawer test expectations:
+
+1. opening the create drawer and choosing a suggested tag submits that tag
+2. typing a new tag still submits successfully
+
+Edit drawer test expectations:
+
+1. existing tags are shown on open
+2. selecting a suggested tag appends it
+3. whitespace-only edits are dropped before `onSave`
+
+```tsx
+render(<FlashcardCreateDrawer open onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+fireEvent.click(screen.getByText("Advanced options"))
+fireEvent.mouseDown(screen.getByLabelText("Tags"))
+fireEvent.click(await screen.findByRole("option", { name: "biology" }))
+fireEvent.click(screen.getByRole("button", { name: "Create" }))
+
+expect(mutateAsync).toHaveBeenCalledWith(
+  expect.objectContaining({ tags: ["biology"] })
+)
+```
+
+- [ ] **Step 2: Run the new drawer tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx \
+  --reporter=verbose
+```
+
+Expected: FAIL because both drawers still use raw `Select mode="tags"` fields with `open={false}`.
+
+- [ ] **Step 3: Replace the raw tag fields with `FlashcardTagPicker`**
+
+Update both drawer files to use the new component and pass stable test ids.
+
+```tsx
+<Form.Item
+  name="tags"
+  label={t("option:flashcards.tags", { defaultValue: "Tags" })}
+  className="!mb-0"
+>
+  <FlashcardTagPicker
+    active={open}
+    dataTestId="flashcards-create-tag-picker"
+    placeholder={t("option:flashcards.tagsPlaceholder", {
+      defaultValue: "tag1, tag2"
+    })}
+  />
+</Form.Item>
+```
+
+Use the edit-drawer equivalent:
+
+```tsx
+<FlashcardTagPicker
+  active={open}
+  dataTestId="flashcards-edit-tag-picker"
+  placeholder={t("option:flashcards.tagsPlaceholder", {
+    defaultValue: "Add tags..."
+  })}
+/>
+```
+
+Do not change the rest of the drawer submission flow. The existing create and update mutations already invalidate `flashcards:` queries globally.
+
+- [ ] **Step 4: Re-run the drawer tests plus one existing safety test per drawer**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.cloze-help.test.tsx \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.save.test.tsx \
+  --reporter=verbose
+```
+
+Expected: PASS, proving the tag-field change did not regress basic create/edit validation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx \
+  apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx \
+  apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx \
+  apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx
+git commit -m "feat: wire flashcard drawers to shared tag picker"
+```
+
+## Task 5: Add Real User Coverage And Extension Parity Checks
+
+**Files:**
+- Modify: `apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts`
+- Modify: `apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts`
+- Create: `apps/tldw-frontend/__tests__/extension/option-flashcards.shared-workspace.test.ts`
+
+- [ ] **Step 1: Write the failing web flow and extension parity tests**
+
+Add a Playwright test in `apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts` that:
+
+1. uses `fetchWithApiKey` to create a deck plus two cards sharing an existing tag
+2. navigates to Manage
+3. opens the create drawer and selects the existing tag from suggestions
+4. opens the edit drawer for one seeded card and adds another existing tag from suggestions
+
+Also add a small source-level extension parity test in `apps/tldw-frontend/__tests__/extension/option-flashcards.shared-workspace.test.ts` that locks the extension route wrapper to the shared workspace component.
+
+```ts
+expect(optionFlashcardsSource).toMatch(/FlashcardsWorkspace/)
+expect(optionFlashcardsSource).toMatch(/RouteErrorBoundary/)
+```
+
+- [ ] **Step 2: Run the new parity tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/extension/option-flashcards.shared-workspace.test.ts --reporter=verbose
+npx playwright test e2e/workflows/tier-2-features/flashcards.spec.ts --reporter=line
+```
+
+Expected: the Vitest parity test may pass immediately if the wrapper is already correct; the new Playwright tag-selection flow should FAIL until the page object and UI locators are in place.
+
+- [ ] **Step 3: Add the minimal page-object helpers and spec flow**
+
+Extend `apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts` with only the helpers needed for this scenario:
+
+- create drawer tag picker locator
+- edit button locator by card UUID
+- edit drawer tag picker locator
+- helper to select a tag suggestion by visible option name
+
+```ts
+get createTagPicker(): Locator {
+  return this.page.locator('[data-testid="flashcards-create-tag-picker"]')
+}
+
+get editTagPicker(): Locator {
+  return this.page.locator('[data-testid="flashcards-edit-tag-picker"]')
+}
+
+getEditButton(cardUuid: string): Locator {
+  return this.page.locator(`[data-testid="flashcard-edit-${cardUuid}"]`)
+}
+```
+
+In the Playwright spec, use `fetchWithApiKey` for setup instead of clicking through unrelated UI.
+
+```ts
+skipIfServerUnavailable(serverInfo)
+
+const deckResponse = await fetchWithApiKey(`${TEST_CONFIG.serverUrl}/api/v1/flashcards/decks`, TEST_CONFIG.apiKey, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ name: `Tag Deck ${Date.now()}` })
+})
+```
+
+Then assert the create and edit flows finish without console errors and that the saved payload shows the expected tags via a backend list/read call.
+
+- [ ] **Step 4: Run the targeted parity suite**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/extension/option-flashcards.shared-workspace.test.ts --reporter=verbose
+npx playwright test e2e/workflows/tier-2-features/flashcards.spec.ts --reporter=line
+```
+
+Expected: PASS, with the web flow proving the reported bug is fixed and the extension wrapper still anchored to the shared workspace.
+
+- [ ] **Step 5: Run the combined targeted verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py -k "flashcard_tag_suggestions" -v
+cd apps/tldw-frontend
+bunx vitest run \
+  ../packages/ui/src/services/__tests__/flashcards.test.ts \
+  ../packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx \
+  ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx \
+  __tests__/extension/option-flashcards.shared-workspace.test.ts \
+  --reporter=verbose
+npx playwright test e2e/workflows/tier-2-features/flashcards.spec.ts --reporter=line
+```
+
+Expected: PASS across backend, shared UI, extension parity, and the user-facing web flow.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts \
+  apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts \
+  apps/tldw-frontend/__tests__/extension/option-flashcards.shared-workspace.test.ts
+git commit -m "test: cover flashcard tag suggestion parity"
+```
+
+## Self-Review Checklist
+
+- [ ] `GET /api/v1/flashcards/tags` is declared before the dynamic `/{card_uuid}` alias route.
+- [ ] The backend query includes general-scope and workspace-scoped flashcards, but excludes deleted flashcards, deleted keywords, and cards attached to deleted decks.
+- [ ] The create/edit hook does not replace the existing `useTagSuggestionsQuery` used by ManageTab.
+- [ ] The picker only enables its suggestion query while the drawer is active and the picker is open.
+- [ ] The service helper forwards `AbortSignal` so stale typeahead requests can be cancelled.
+- [ ] The picker keeps free typing when suggestion loading fails.
+- [ ] The create and edit drawers expose stable tag-picker test ids.
+- [ ] The extension parity check still proves the extension route uses the shared workspace component.

--- a/Docs/superpowers/specs/2026-04-02-flashcards-global-tag-suggestions-design.md
+++ b/Docs/superpowers/specs/2026-04-02-flashcards-global-tag-suggestions-design.md
@@ -157,8 +157,13 @@ Visibility contract:
 
 - the initial endpoint is intentionally global for the current user
 - it returns tags across all non-deleted flashcards the current user can access
+- it must include both general-scope flashcards and workspace-scoped flashcards, not just decks where `workspace_id IS NULL`
 - it does not inherit current deck filters, workspace filters, or Manage-tab visibility toggles
 - create and edit drawers call it without deck or workspace scoping because the agreed behavior is “all accessible flashcard tags”
+
+Implementation note:
+
+- the endpoint should not blindly reuse the default `list_flashcards` visibility behavior because that path defaults to general-scope items when no workspace flags are provided
 
 Proposed response shape:
 
@@ -167,11 +172,12 @@ Proposed response shape:
   "items": [
     { "tag": "biology", "count": 42 },
     { "tag": "chapter-1", "count": 17 }
-  ]
+  ],
+  "count": 2
 }
 ```
 
-`count` means the number of distinct non-deleted flashcards currently using that tag.
+Per-item `count` means the number of distinct non-deleted flashcards currently using that tag. Top-level `count` means the number of suggestion items returned in the response.
 
 Rationale:
 
@@ -187,8 +193,9 @@ The endpoint should query active flashcard tags using the existing flashcard-key
 
 - include only non-deleted flashcards
 - include only non-deleted keywords
+- exclude flashcards whose joined deck row is deleted, while still allowing deckless flashcards
 - aggregate usage counts by keyword text
-- apply `q` as a case-insensitive substring or prefix filter
+- apply `q` as a trimmed, case-insensitive substring filter
 - sort by `count DESC`, then tag text case-insensitively
 
 This avoids the current client-side `MAX_SCAN` approach and aligns the API with the actual domain model already present in `ChaChaNotes_DB`.
@@ -197,10 +204,11 @@ Scope note:
 
 - this new endpoint is for create/edit tag suggestions only in the initial change
 - the existing Manage-tab filter suggestion flow remains unchanged for now
+- do not silently repurpose the current Manage-tab page-scan hook unless its existing behavior is preserved for that tab
 
 Routing note:
 
-- because the same router already exposes `GET /{card_uuid}/tags`, the new static `GET /tags` route must be registered before the dynamic `/{card_uuid}/tags` route so the literal path `tags` is not captured as a `card_uuid`
+- because the same router also exposes a later `GET /{card_uuid}` alias route, the new static `GET /tags` route must be registered before that dynamic route so the literal path `tags` is not captured as a `card_uuid`
 
 ### 3. Add one shared `FlashcardTagPicker` component
 
@@ -215,6 +223,7 @@ Expected behavior:
 - loads suggestions from the new endpoint
 - shows a normal dropdown instead of `open={false}`
 - updates suggestions as the user types with a short debounce
+- forwards the active request abort signal so stale typeahead requests can be cancelled cleanly
 - allows selecting existing tags from the dropdown
 - allows typing a new tag and confirming it with `Enter`
 - trims whitespace and dedupes case-insensitively within the current value
@@ -242,6 +251,11 @@ This ensures:
 - a newly added tag appears immediately in later create or edit sessions
 - the suggestion list stays in sync without full page reloads
 - both WebUI and extension see the same refreshed suggestion state because they share the same query client logic in shared UI
+
+Implementation note:
+
+- if the new suggestion query key stays under the existing `flashcards:` namespace, the current shared invalidation helper can keep handling this without special-case mutation logic
+- the suggestion query should only be enabled while the drawer and picker are active, and its request helper should accept React Query abort signals to avoid stale results during rapid typing
 
 ### 6. Preserve current create/edit behavior if suggestions fail
 
@@ -300,6 +314,7 @@ Add unit or integration coverage for the new flashcard tags endpoint verifying:
 - unique tags are returned only once
 - deleted flashcards do not contribute suggestions
 - deleted keywords do not contribute suggestions
+- flashcards attached to deleted decks do not contribute suggestions
 - `q` filters results correctly
 - results are ordered by usage count, then alphabetically
 - `limit` is respected
@@ -313,6 +328,7 @@ Add focused tests for the shared picker verifying:
 - duplicate tag entry is normalized case-insensitively
 - whitespace-only tags are ignored
 - fetch failure falls back to non-blocking free typing
+- the picker exposes stable test ids or labels that create, edit, and E2E coverage can target consistently
 
 ### Drawer tests
 

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
@@ -24,6 +24,7 @@ import {
 import { FLASHCARDS_DRAWER_WIDTH_PX } from "../constants"
 import { MarkdownWithBoundary } from "./MarkdownWithBoundary"
 import { FlashcardImageInsertButton } from "./FlashcardImageInsertButton"
+import { FlashcardTagPicker } from "./FlashcardTagPicker"
 import { DeckSchedulerSettingsEditor } from "./DeckSchedulerSettingsEditor"
 import { normalizeFlashcardTemplateFields } from "../utils/template-helpers"
 import { formatDeckDisplayName } from "../utils/deck-display"
@@ -46,6 +47,14 @@ const { Text } = Typography
 const CLOZE_PATTERN = /\{\{c\d+::[\s\S]+?\}\}/
 type FlashcardModelType = NonNullable<FlashcardCreate["model_type"]>
 type EditableTextField = "front" | "back" | "extra" | "notes"
+
+const normalizeTagValues = (tags?: string[] | null) => {
+  const normalized = Array.isArray(tags)
+    ? tags.map((tag) => tag.trim()).filter(Boolean)
+    : undefined
+
+  return normalized && normalized.length > 0 ? normalized : undefined
+}
 
 interface PreviewProps {
   content?: string
@@ -235,7 +244,12 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
   const handleCreate = async () => {
     try {
       const values = await form.validateFields()
-      await createMutation.mutateAsync(normalizeFlashcardTemplateFields(values))
+      await createMutation.mutateAsync(
+        normalizeFlashcardTemplateFields({
+          ...values,
+          tags: normalizeTagValues(values.tags)
+        })
+      )
       message.success(t("common:created", { defaultValue: "Created" }))
       form.resetFields()
       onSuccess?.()
@@ -251,7 +265,12 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
   const handleCreateAndAddAnother = async () => {
     try {
       const values = await form.validateFields()
-      await createMutation.mutateAsync(normalizeFlashcardTemplateFields(values))
+      await createMutation.mutateAsync(
+        normalizeFlashcardTemplateFields({
+          ...values,
+          tags: normalizeTagValues(values.tags)
+        })
+      )
       message.success(t("common:created", { defaultValue: "Created" }))
       // Keep deck selection but clear content
       const deckId = form.getFieldValue("deck_id")
@@ -694,13 +713,12 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
                     label={t("option:flashcards.tags", { defaultValue: "Tags" })}
                     className="!mb-0"
                   >
-                    <Select
-                      mode="tags"
+                    <FlashcardTagPicker
+                      active={open}
+                      dataTestId="flashcards-create-tag-picker"
                       placeholder={t("option:flashcards.tagsPlaceholder", {
                         defaultValue: "tag1, tag2"
                       })}
-                      open={false}
-                      allowClear
                     />
                   </Form.Item>
 

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
@@ -28,6 +28,7 @@ import { FlashcardTagPicker } from "./FlashcardTagPicker"
 import { DeckSchedulerSettingsEditor } from "./DeckSchedulerSettingsEditor"
 import { normalizeFlashcardTemplateFields } from "../utils/template-helpers"
 import { formatDeckDisplayName } from "../utils/deck-display"
+import { normalizeOptionalFlashcardTags } from "../utils/tag-normalization"
 import {
   getSelectionFromElement,
   insertTextAtSelection,
@@ -47,14 +48,6 @@ const { Text } = Typography
 const CLOZE_PATTERN = /\{\{c\d+::[\s\S]+?\}\}/
 type FlashcardModelType = NonNullable<FlashcardCreate["model_type"]>
 type EditableTextField = "front" | "back" | "extra" | "notes"
-
-const normalizeTagValues = (tags?: string[] | null) => {
-  const normalized = Array.isArray(tags)
-    ? tags.map((tag) => tag.trim()).filter(Boolean)
-    : undefined
-
-  return normalized && normalized.length > 0 ? normalized : undefined
-}
 
 interface PreviewProps {
   content?: string
@@ -247,7 +240,7 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
       await createMutation.mutateAsync(
         normalizeFlashcardTemplateFields({
           ...values,
-          tags: normalizeTagValues(values.tags)
+          tags: normalizeOptionalFlashcardTags(values.tags)
         })
       )
       message.success(t("common:created", { defaultValue: "Created" }))
@@ -268,7 +261,7 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
       await createMutation.mutateAsync(
         normalizeFlashcardTemplateFields({
           ...values,
-          tags: normalizeTagValues(values.tags)
+          tags: normalizeOptionalFlashcardTags(values.tags)
         })
       )
       message.success(t("common:created", { defaultValue: "Created" }))

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
@@ -34,12 +34,21 @@ import {
 } from "../utils/text-selection"
 import { formatDeckDisplayName } from "../utils/deck-display"
 import { FlashcardImageInsertButton } from "./FlashcardImageInsertButton"
+import { FlashcardTagPicker } from "./FlashcardTagPicker"
 import { MarkdownWithBoundary } from "./MarkdownWithBoundary"
 import type { Flashcard, FlashcardUpdate, Deck } from "@/services/flashcards"
 
 const { Text } = Typography
 dayjs.extend(relativeTime)
 const CLOZE_PATTERN = /\{\{c\d+::[\s\S]+?\}\}/
+
+const normalizeTagValues = (tags?: string[] | null) => {
+  const normalized = Array.isArray(tags)
+    ? tags.map((tag) => tag.trim()).filter(Boolean)
+    : undefined
+
+  return normalized && normalized.length > 0 ? normalized : undefined
+}
 
 type FlashcardModelType = Flashcard["model_type"]
 type EditableTextField = "front" | "back" | "extra" | "notes"
@@ -204,9 +213,11 @@ export const FlashcardEditDrawer: React.FC<FlashcardEditDrawerProps> = ({
 
   const handleSave = async () => {
     try {
-      const values = normalizeFlashcardTemplateFields(
-        (await form.validateFields()) as FlashcardUpdate
-      )
+      const rawValues = (await form.validateFields()) as FlashcardUpdate
+      const values = normalizeFlashcardTemplateFields({
+        ...rawValues,
+        tags: normalizeTagValues(rawValues.tags)
+      })
       await onSave(values)
     } catch (e: any) {
       // Validation errors handled by form
@@ -384,10 +395,9 @@ export const FlashcardEditDrawer: React.FC<FlashcardEditDrawerProps> = ({
             name="tags"
             label={t("option:flashcards.tags", { defaultValue: "Tags" })}
           >
-            <Select
-              mode="tags"
-              open={false}
-              allowClear
+            <FlashcardTagPicker
+              active={open}
+              dataTestId="flashcards-edit-tag-picker"
               placeholder={t("option:flashcards.tagsPlaceholder", {
                 defaultValue: "Add tags..."
               })}

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
@@ -20,6 +20,7 @@ import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { useDebouncedFormField } from "../hooks"
 import { FLASHCARDS_DRAWER_WIDTH_PX } from "../constants"
 import { normalizeFlashcardTemplateFields } from "../utils/template-helpers"
+import { normalizeOptionalFlashcardTags } from "../utils/tag-normalization"
 import {
   FLASHCARD_FIELD_MAX_BYTES,
   getFlashcardFieldLimitState,
@@ -41,14 +42,6 @@ import type { Flashcard, FlashcardUpdate, Deck } from "@/services/flashcards"
 const { Text } = Typography
 dayjs.extend(relativeTime)
 const CLOZE_PATTERN = /\{\{c\d+::[\s\S]+?\}\}/
-
-const normalizeTagValues = (tags?: string[] | null) => {
-  const normalized = Array.isArray(tags)
-    ? tags.map((tag) => tag.trim()).filter(Boolean)
-    : undefined
-
-  return normalized && normalized.length > 0 ? normalized : undefined
-}
 
 type FlashcardModelType = Flashcard["model_type"]
 type EditableTextField = "front" | "back" | "extra" | "notes"
@@ -216,7 +209,7 @@ export const FlashcardEditDrawer: React.FC<FlashcardEditDrawerProps> = ({
       const rawValues = (await form.validateFields()) as FlashcardUpdate
       const values = normalizeFlashcardTemplateFields({
         ...rawValues,
-        tags: normalizeTagValues(rawValues.tags)
+        tags: normalizeOptionalFlashcardTags(rawValues.tags)
       })
       await onSave(values)
     } catch (e: any) {

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx
@@ -1,0 +1,116 @@
+import React from "react"
+import { Select } from "antd"
+import { useTranslation } from "react-i18next"
+
+import { useDebounce } from "@/hooks/useDebounce"
+import { useGlobalFlashcardTagSuggestionsQuery } from "../hooks"
+
+type FlashcardTagPickerProps = {
+  value: string[]
+  onChange: (value: string[]) => void
+  active?: boolean
+  disabled?: boolean
+  placeholder?: string
+  className?: string
+  dataTestId?: string
+}
+
+const DEFAULT_WRAPPER_TEST_ID = "flashcard-tag-picker"
+const SEARCH_DEBOUNCE_MS = 250
+
+const normalizeTags = (tags: string[]) => {
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  for (const rawTag of tags) {
+    const tag = rawTag.trim()
+    if (!tag) continue
+
+    const dedupeKey = tag.toLowerCase()
+    if (seen.has(dedupeKey)) continue
+
+    seen.add(dedupeKey)
+    normalized.push(tag)
+  }
+
+  return normalized
+}
+
+export const FlashcardTagPicker: React.FC<FlashcardTagPickerProps> = ({
+  value,
+  onChange,
+  active = true,
+  disabled = false,
+  placeholder,
+  className,
+  dataTestId
+}) => {
+  const { t } = useTranslation(["option"])
+  const [dropdownOpen, setDropdownOpen] = React.useState(false)
+  const [searchText, setSearchText] = React.useState("")
+  const wrapperRef = React.useRef<HTMLDivElement>(null)
+  const wrapperTestId = dataTestId ?? DEFAULT_WRAPPER_TEST_ID
+  const searchInputTestId = `${wrapperTestId}-search-input`
+
+  const debouncedSearchText = useDebounce(searchText, SEARCH_DEBOUNCE_MS)
+  const normalizedValue = React.useMemo(() => normalizeTags(value ?? []), [value])
+  const queryEnabled = active && dropdownOpen
+
+  const tagSuggestionsQuery = useGlobalFlashcardTagSuggestionsQuery(debouncedSearchText, {
+    enabled: queryEnabled,
+    limit: 50
+  })
+
+  const options = React.useMemo(
+    () =>
+      (tagSuggestionsQuery.data?.items ?? []).map((item) => ({
+        label: item.tag,
+        value: item.tag
+      })),
+    [tagSuggestionsQuery.data]
+  )
+
+  React.useEffect(() => {
+    const searchInput = wrapperRef.current?.querySelector<HTMLInputElement>("input.ant-select-input")
+    if (searchInput && searchInput.getAttribute("data-testid") !== searchInputTestId) {
+      searchInput.setAttribute("data-testid", searchInputTestId)
+    }
+  }, [searchInputTestId])
+
+  const handleChange = React.useCallback(
+    (nextValue: unknown) => {
+      const nextTags = Array.isArray(nextValue) ? nextValue.map((tag) => String(tag)) : []
+      onChange(normalizeTags(nextTags))
+    },
+    [onChange]
+  )
+
+  return (
+    <div ref={wrapperRef} data-testid={wrapperTestId} className={className}>
+      <Select
+        mode="tags"
+        value={normalizedValue}
+        onChange={handleChange}
+        open={dropdownOpen}
+        onOpenChange={setDropdownOpen}
+        showSearch
+        searchValue={searchText}
+        onSearch={setSearchText}
+        filterOption={false}
+        allowClear
+        disabled={disabled}
+        placeholder={
+          placeholder ??
+          t("option:flashcards.tagsPlaceholder", {
+            defaultValue: "Add tags..."
+          })
+        }
+        options={options}
+        loading={Boolean(tagSuggestionsQuery.isLoading || tagSuggestionsQuery.isFetching)}
+        notFoundContent={tagSuggestionsQuery.isError ? null : undefined}
+      />
+    </div>
+  )
+}
+
+export default FlashcardTagPicker

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx
@@ -7,8 +7,8 @@ import { useGlobalFlashcardTagSuggestionsQuery } from "../hooks"
 import { normalizeFlashcardTags } from "../utils/tag-normalization"
 
 type FlashcardTagPickerProps = {
-  value: string[]
-  onChange: (value: string[]) => void
+  value?: string[]
+  onChange?: (value: string[]) => void
   active?: boolean
   disabled?: boolean
   placeholder?: string
@@ -77,7 +77,7 @@ export const FlashcardTagPicker: React.FC<FlashcardTagPickerProps> = ({
   const handleChange = React.useCallback(
     (nextValue: unknown) => {
       const nextTags = Array.isArray(nextValue) ? nextValue.map((tag) => String(tag)) : []
-      onChange(normalizeFlashcardTags(nextTags))
+      onChange?.(normalizeFlashcardTags(nextTags))
     },
     [onChange]
   )

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardTagPicker.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { useDebounce } from "@/hooks/useDebounce"
 import { useGlobalFlashcardTagSuggestionsQuery } from "../hooks"
+import { normalizeFlashcardTags } from "../utils/tag-normalization"
 
 type FlashcardTagPickerProps = {
   value: string[]
@@ -17,24 +18,6 @@ type FlashcardTagPickerProps = {
 
 const DEFAULT_WRAPPER_TEST_ID = "flashcard-tag-picker"
 const SEARCH_DEBOUNCE_MS = 250
-
-const normalizeTags = (tags: string[]) => {
-  const seen = new Set<string>()
-  const normalized: string[] = []
-
-  for (const rawTag of tags) {
-    const tag = rawTag.trim()
-    if (!tag) continue
-
-    const dedupeKey = tag.toLowerCase()
-    if (seen.has(dedupeKey)) continue
-
-    seen.add(dedupeKey)
-    normalized.push(tag)
-  }
-
-  return normalized
-}
 
 export const FlashcardTagPicker: React.FC<FlashcardTagPickerProps> = ({
   value,
@@ -53,7 +36,7 @@ export const FlashcardTagPicker: React.FC<FlashcardTagPickerProps> = ({
   const searchInputTestId = `${wrapperTestId}-search-input`
 
   const debouncedSearchText = useDebounce(searchText, SEARCH_DEBOUNCE_MS)
-  const normalizedValue = React.useMemo(() => normalizeTags(value ?? []), [value])
+  const normalizedValue = React.useMemo(() => normalizeFlashcardTags(value), [value])
   const queryEnabled = active && dropdownOpen
 
   const tagSuggestionsQuery = useGlobalFlashcardTagSuggestionsQuery(debouncedSearchText, {
@@ -71,16 +54,30 @@ export const FlashcardTagPicker: React.FC<FlashcardTagPickerProps> = ({
   )
 
   React.useEffect(() => {
-    const searchInput = wrapperRef.current?.querySelector<HTMLInputElement>("input.ant-select-input")
-    if (searchInput && searchInput.getAttribute("data-testid") !== searchInputTestId) {
-      searchInput.setAttribute("data-testid", searchInputTestId)
+    if (!dropdownOpen) return
+
+    const setSearchInputTestId = () => {
+      const searchInput = wrapperRef.current?.querySelector<HTMLInputElement>(
+        "input.ant-select-selection-search-input, input.ant-select-input"
+      )
+      if (searchInput && searchInput.getAttribute("data-testid") !== searchInputTestId) {
+        searchInput.setAttribute("data-testid", searchInputTestId)
+      }
     }
-  }, [searchInputTestId])
+
+    if (typeof window.requestAnimationFrame === "function") {
+      const frameId = window.requestAnimationFrame(setSearchInputTestId)
+      return () => window.cancelAnimationFrame(frameId)
+    }
+
+    const timeoutId = window.setTimeout(setSearchInputTestId, 0)
+    return () => window.clearTimeout(timeoutId)
+  }, [dropdownOpen, searchInputTestId])
 
   const handleChange = React.useCallback(
     (nextValue: unknown) => {
       const nextTags = Array.isArray(nextValue) ? nextValue.map((tag) => String(tag)) : []
-      onChange(normalizeTags(nextTags))
+      onChange(normalizeFlashcardTags(nextTags))
     },
     [onChange]
   )
@@ -106,7 +103,7 @@ export const FlashcardTagPicker: React.FC<FlashcardTagPickerProps> = ({
           })
         }
         options={options}
-        loading={Boolean(tagSuggestionsQuery.isLoading || tagSuggestionsQuery.isFetching)}
+        loading={tagSuggestionsQuery.isFetching}
         notFoundContent={tagSuggestionsQuery.isError ? null : undefined}
       />
     </div>

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
@@ -59,6 +59,12 @@ vi.mock("../MarkdownWithBoundary", () => ({
   MarkdownWithBoundary: ({ content }: { content: string }) => <div>{content}</div>
 }))
 
+vi.mock("../FlashcardTagPicker", () => ({
+  FlashcardTagPicker: ({ dataTestId }: { dataTestId?: string }) => (
+    <div data-testid={dataTestId ?? "flashcard-tag-picker"} />
+  )
+}))
+
 vi.mock("@/services/flashcard-assets", () => ({
   uploadFlashcardAsset
 }))

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx
@@ -1,8 +1,19 @@
+import React from "react"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+
 import { FlashcardCreateDrawer } from "../FlashcardCreateDrawer"
-import { useCreateFlashcardMutation, useCreateDeckMutation, useDecksQuery } from "../../hooks"
-import { FLASHCARDS_DRAWER_WIDTH_PX } from "../../constants"
+import {
+  useCreateDeckMutation,
+  useCreateFlashcardMutation,
+  useDecksQuery
+} from "../../hooks"
+
+const mockFlashcardTagPicker = vi.hoisted(() => vi.fn())
+
+vi.mock("../FlashcardTagPicker", () => ({
+  FlashcardTagPicker: (props: Record<string, unknown>) => mockFlashcardTagPicker(props)
+}))
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -50,12 +61,6 @@ vi.mock("../MarkdownWithBoundary", () => ({
   MarkdownWithBoundary: ({ content }: { content: string }) => <div>{content}</div>
 }))
 
-vi.mock("../FlashcardTagPicker", () => ({
-  FlashcardTagPicker: ({ dataTestId }: { dataTestId?: string }) => (
-    <div data-testid={dataTestId ?? "flashcard-tag-picker"} />
-  )
-}))
-
 if (!(globalThis as any).ResizeObserver) {
   ;(globalThis as any).ResizeObserver = class ResizeObserver {
     observe() {}
@@ -80,7 +85,44 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   })
 }
 
-describe("FlashcardCreateDrawer cloze helper and validation", () => {
+const renderMockTagPicker = ({
+  value = [],
+  onChange,
+  active,
+  placeholder,
+  dataTestId
+}: {
+  value?: string[]
+  onChange?: (next: string[]) => void
+  active?: boolean
+  placeholder?: string
+  dataTestId?: string
+}) => (
+  <div
+    data-testid={dataTestId}
+    data-active={String(active)}
+    data-placeholder={placeholder}
+  >
+    <div data-testid={`${dataTestId}-value`}>{JSON.stringify(value)}</div>
+    <button
+      type="button"
+      onClick={() => onChange?.([...(value ?? []), "Biology"])}
+    >
+      choose suggested tag
+    </button>
+    <input
+      aria-label={`${dataTestId}-input`}
+      data-testid={`${dataTestId}-input`}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          onChange?.([...(value ?? []), event.currentTarget.value])
+        }
+      }}
+    />
+  </div>
+)
+
+describe("FlashcardCreateDrawer tags", () => {
   const mutateAsync = vi.fn()
 
   beforeEach(() => {
@@ -106,9 +148,12 @@ describe("FlashcardCreateDrawer cloze helper and validation", () => {
       mutateAsync: vi.fn(),
       isPending: false
     } as any)
+    mockFlashcardTagPicker.mockImplementation(renderMockTagPicker)
   })
 
-  it("shows template guidance and blocks invalid cloze front syntax", async () => {
+  it("choosing a suggested tag in Advanced options submits that tag", async () => {
+    mutateAsync.mockResolvedValueOnce({ uuid: "card-1" })
+
     render(
       <FlashcardCreateDrawer
         open
@@ -117,85 +162,33 @@ describe("FlashcardCreateDrawer cloze helper and validation", () => {
       />
     )
 
-    const wrapper = document.querySelector(".ant-drawer-content-wrapper") as HTMLElement | null
-    expect(wrapper?.style.width).toBe(`${FLASHCARDS_DRAWER_WIDTH_PX}px`)
+    fireEvent.click(screen.getByText("Advanced options (tags, extra, notes)"))
 
-    expect(
-      screen.getByText(
-        "Choose Basic for direct question and answer cards (facts, definitions, short prompts)."
+    const picker = await screen.findByTestId("flashcards-create-tag-picker")
+    expect(picker).toHaveAttribute("data-active", "true")
+    expect(picker).toHaveAttribute("data-placeholder", "tag1, tag2")
+
+    fireEvent.click(screen.getByRole("button", { name: "choose suggested tag" }))
+
+    fireEvent.change(screen.getByPlaceholderText("Question or prompt..."), {
+      target: { value: "Front content" }
+    })
+    fireEvent.change(screen.getByPlaceholderText("Answer..."), {
+      target: { value: "Back content" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: ["Biology"]
+        })
       )
-    ).toBeInTheDocument()
-
-    fireEvent.mouseDown(screen.getByLabelText("Card template"))
-    fireEvent.click(screen.getByText("Cloze (Fill in the blank)"))
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Choose Cloze when you want to hide key words inside a sentence or paragraph."
-        )
-      ).toBeInTheDocument()
     })
-    await waitFor(() => {
-      expect(
-        screen.getByText("Cloze syntax: add at least one deletion like {{c1::answer}} in Front text.")
-      ).toBeInTheDocument()
-    })
-
-    fireEvent.change(screen.getByPlaceholderText("Question or prompt..."), {
-      target: { value: "This front has no cloze pattern" }
-    })
-    fireEvent.change(screen.getByPlaceholderText("Answer..."), {
-      target: { value: "Back content" }
-    })
-
-    fireEvent.click(screen.getByRole("button", { name: "Create" }))
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "For Cloze cards, include at least one deletion like {{c1::answer}}."
-        )
-      ).toBeInTheDocument()
-    })
-    expect(mutateAsync).not.toHaveBeenCalled()
   }, 15000)
 
-  it("shows byte-limit guidance and blocks over-limit front content", async () => {
-    render(
-      <FlashcardCreateDrawer
-        open
-        onClose={vi.fn()}
-        onSuccess={vi.fn()}
-      />
-    )
-
-    fireEvent.change(screen.getByPlaceholderText("Question or prompt..."), {
-      target: { value: "a".repeat(8192) }
-    })
-    fireEvent.change(screen.getByPlaceholderText("Answer..."), {
-      target: { value: "Back content" }
-    })
-
-    await waitFor(() => {
-      expect(screen.getByText("Front: 8192 / 8192 bytes. Approaching the 8192-byte limit.")).toBeInTheDocument()
-    })
-
-    fireEvent.change(screen.getByPlaceholderText("Question or prompt..."), {
-      target: { value: "a".repeat(8193) }
-    })
-    fireEvent.click(screen.getByRole("button", { name: "Create" }))
-
-    await waitFor(() => {
-      expect(screen.getByText("Front must be 8192 bytes or fewer.")).toBeInTheDocument()
-    })
-    expect(mutateAsync).not.toHaveBeenCalled()
-  }, 15000)
-
-  it("does not require cloze syntax for basic cards", async () => {
-    mutateAsync.mockResolvedValueOnce({
-      uuid: "card-1"
-    })
+  it("typing a new tag still submits successfully", async () => {
+    mutateAsync.mockResolvedValueOnce({ uuid: "card-1" })
 
     render(
       <FlashcardCreateDrawer
@@ -205,17 +198,31 @@ describe("FlashcardCreateDrawer cloze helper and validation", () => {
       />
     )
 
-    fireEvent.change(screen.getByPlaceholderText("Question or prompt..."), {
-      target: { value: "Plain front content without cloze syntax" }
-    })
-    fireEvent.change(screen.getByPlaceholderText("Answer..."), {
-      target: { value: "Plain back content" }
+    fireEvent.click(screen.getByText("Advanced options (tags, extra, notes)"))
+
+    const input = await screen.findByTestId("flashcards-create-tag-picker-input")
+    fireEvent.change(input, { target: { value: "Neuroscience" } })
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+      keyCode: 13
     })
 
+    fireEvent.change(screen.getByPlaceholderText("Question or prompt..."), {
+      target: { value: "Front content" }
+    })
+    fireEvent.change(screen.getByPlaceholderText("Answer..."), {
+      target: { value: "Back content" }
+    })
     fireEvent.click(screen.getByRole("button", { name: "Create" }))
 
     await waitFor(() => {
-      expect(mutateAsync).toHaveBeenCalledTimes(1)
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: ["Neuroscience"]
+        })
+      )
     })
   }, 15000)
 })

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.image-insert.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.image-insert.test.tsx
@@ -46,6 +46,12 @@ vi.mock("../MarkdownWithBoundary", () => ({
   MarkdownWithBoundary: ({ content }: { content: string }) => <div>{content}</div>
 }))
 
+vi.mock("../FlashcardTagPicker", () => ({
+  FlashcardTagPicker: ({ dataTestId }: { dataTestId?: string }) => (
+    <div data-testid={dataTestId ?? "flashcard-tag-picker"} />
+  )
+}))
+
 vi.mock("@/services/flashcard-assets", () => ({
   uploadFlashcardAsset
 }))

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.reset-scheduling.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.reset-scheduling.test.tsx
@@ -39,6 +39,12 @@ vi.mock("@/hooks/useAntdMessage", () => ({
   })
 }))
 
+vi.mock("../FlashcardTagPicker", () => ({
+  FlashcardTagPicker: ({ dataTestId }: { dataTestId?: string }) => (
+    <div data-testid={dataTestId ?? "flashcard-tag-picker"} />
+  )
+}))
+
 if (!(globalThis as any).ResizeObserver) {
   ;(globalThis as any).ResizeObserver = class ResizeObserver {
     observe() {}

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx
@@ -44,6 +44,12 @@ vi.mock("@/hooks/useAntdMessage", () => ({
   })
 }))
 
+vi.mock("../FlashcardTagPicker", () => ({
+  FlashcardTagPicker: ({ dataTestId }: { dataTestId?: string }) => (
+    <div data-testid={dataTestId ?? "flashcard-tag-picker"} />
+  )
+}))
+
 if (!(globalThis as any).ResizeObserver) {
   ;(globalThis as any).ResizeObserver = class ResizeObserver {
     observe() {}

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx
@@ -1,8 +1,16 @@
+import React from "react"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
 import { FlashcardEditDrawer } from "../FlashcardEditDrawer"
 import type { Flashcard } from "@/services/flashcards"
 import { DEFAULT_SCHEDULER_SETTINGS_ENVELOPE } from "../../utils/scheduler-settings"
+
+const mockFlashcardTagPicker = vi.hoisted(() => vi.fn())
+
+vi.mock("../FlashcardTagPicker", () => ({
+  FlashcardTagPicker: (props: Record<string, unknown>) => mockFlashcardTagPicker(props)
+}))
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -39,12 +47,6 @@ vi.mock("@/hooks/useAntdMessage", () => ({
   })
 }))
 
-vi.mock("../FlashcardTagPicker", () => ({
-  FlashcardTagPicker: ({ dataTestId }: { dataTestId?: string }) => (
-    <div data-testid={dataTestId ?? "flashcard-tag-picker"} />
-  )
-}))
-
 if (!(globalThis as any).ResizeObserver) {
   ;(globalThis as any).ResizeObserver = class ResizeObserver {
     observe() {}
@@ -77,7 +79,7 @@ const sampleCard: Flashcard = {
   notes: null,
   extra: null,
   is_cloze: false,
-  tags: [],
+  tags: ["biology", "chapter-1"],
   ef: 2.5,
   interval_days: 0,
   repetitions: 0,
@@ -93,97 +95,60 @@ const sampleCard: Flashcard = {
   reverse: false
 }
 
-describe("FlashcardEditDrawer save handling", () => {
-  it("awaits async save callback and handles save errors", async () => {
-    const onSave = vi.fn().mockRejectedValue(new Error("save failed"))
-    const consoleErrorSpy = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined)
+const decks = [
+  {
+    id: 1,
+    name: "Deck 1",
+    description: null,
+    deleted: false,
+    client_id: "1",
+    version: 1,
+    scheduler_type: "sm2_plus" as const,
+    scheduler_settings: DEFAULT_SCHEDULER_SETTINGS_ENVELOPE
+  }
+]
 
-    render(
-      <FlashcardEditDrawer
-        open
-        onClose={vi.fn()}
-        card={sampleCard}
-        onSave={onSave}
-        onDelete={vi.fn()}
-        decks={[
-          {
-            id: 1,
-            name: "Deck 1",
-            description: null,
-            deleted: false,
-            client_id: "1",
-            version: 1,
-            scheduler_type: "sm2_plus",
-            scheduler_settings: DEFAULT_SCHEDULER_SETTINGS_ENVELOPE
-          }
-        ]}
-      />
-    )
+const renderMockTagPicker = ({
+  value = [],
+  onChange,
+  active,
+  placeholder,
+  dataTestId
+}: {
+  value?: string[]
+  onChange?: (next: string[]) => void
+  active?: boolean
+  placeholder?: string
+  dataTestId?: string
+}) => (
+  <div
+    data-testid={dataTestId}
+    data-active={String(active)}
+    data-placeholder={placeholder}
+  >
+    <div data-testid={`${dataTestId}-value`}>{JSON.stringify(value)}</div>
+    <button
+      type="button"
+      onClick={() => onChange?.([...(value ?? []), "astronomy"])}
+    >
+      add suggested tag
+    </button>
+    <button
+      type="button"
+      onClick={() => onChange?.([...(value ?? []), "   "])}
+    >
+      add whitespace tag
+    </button>
+  </div>
+)
 
-    await waitFor(() => {
-      expect(screen.getByDisplayValue("Front text")).toBeInTheDocument()
-    })
+describe("FlashcardEditDrawer tags", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFlashcardTagPicker.mockImplementation(renderMockTagPicker)
+  })
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }))
-
-    await waitFor(() => {
-      expect(onSave).toHaveBeenCalledTimes(1)
-    })
-    await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Save error:", expect.any(Error))
-    })
-
-    consoleErrorSpy.mockRestore()
-  }, 15000)
-
-  it("shows actionable validation when cloze template is selected without cloze syntax", async () => {
-    const onSave = vi.fn().mockResolvedValue(undefined)
-
-    render(
-      <FlashcardEditDrawer
-        open
-        onClose={vi.fn()}
-        card={{
-          ...sampleCard,
-          model_type: "cloze",
-          is_cloze: true
-        }}
-        onSave={onSave}
-        onDelete={vi.fn()}
-        decks={[
-          {
-            id: 1,
-            name: "Deck 1",
-            description: null,
-            deleted: false,
-            client_id: "1",
-            version: 1,
-            scheduler_type: "sm2_plus",
-            scheduler_settings: DEFAULT_SCHEDULER_SETTINGS_ENVELOPE
-          }
-        ]}
-      />
-    )
-
-    await waitFor(() => {
-      expect(screen.getByText("Card template")).toBeInTheDocument()
-    })
-
-    fireEvent.click(screen.getByRole("button", { name: "Save" }))
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "For Cloze cards, include at least one deletion like {{c1::answer}}."
-        )
-      ).toBeInTheDocument()
-    })
-    expect(onSave).not.toHaveBeenCalled()
-  }, 15000)
-
-  it("blocks saving when front content exceeds byte limit", async () => {
+  it("shows existing tags on open", async () => {
     const onSave = vi.fn().mockResolvedValue(undefined)
 
     render(
@@ -193,33 +158,74 @@ describe("FlashcardEditDrawer save handling", () => {
         card={sampleCard}
         onSave={onSave}
         onDelete={vi.fn()}
-        decks={[
-          {
-            id: 1,
-            name: "Deck 1",
-            description: null,
-            deleted: false,
-            client_id: "1",
-            version: 1,
-            scheduler_type: "sm2_plus",
-            scheduler_settings: DEFAULT_SCHEDULER_SETTINGS_ENVELOPE
-          }
-        ]}
+        decks={decks}
       />
     )
 
     await waitFor(() => {
-      expect(screen.getByDisplayValue("Front text")).toBeInTheDocument()
+      expect(screen.getByTestId("flashcards-edit-tag-picker")).toHaveAttribute(
+        "data-active",
+        "true"
+      )
     })
+    expect(screen.getByTestId("flashcards-edit-tag-picker-value")).toHaveTextContent(
+      JSON.stringify(sampleCard.tags)
+    )
+    expect(screen.getByTestId("flashcards-edit-tag-picker")).toHaveAttribute(
+      "data-placeholder",
+      "Add tags..."
+    )
+  }, 15000)
 
-    fireEvent.change(screen.getByDisplayValue("Front text"), {
-      target: { value: "a".repeat(8193) }
-    })
+  it("selecting a suggested tag appends it", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <FlashcardEditDrawer
+        open
+        onClose={vi.fn()}
+        card={sampleCard}
+        onSave={onSave}
+        onDelete={vi.fn()}
+        decks={decks}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "add suggested tag" }))
     fireEvent.click(screen.getByRole("button", { name: "Save" }))
 
     await waitFor(() => {
-      expect(screen.getByText("Front must be 8192 bytes or fewer.")).toBeInTheDocument()
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: ["biology", "chapter-1", "astronomy"]
+        })
+      )
     })
-    expect(onSave).not.toHaveBeenCalled()
+  }, 15000)
+
+  it("drops whitespace-only edits before onSave", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <FlashcardEditDrawer
+        open
+        onClose={vi.fn()}
+        card={sampleCard}
+        onSave={onSave}
+        onDelete={vi.fn()}
+        decks={decks}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "add whitespace tag" }))
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: ["biology", "chapter-1"]
+        })
+      )
+    })
   }, 15000)
 })

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx
@@ -255,4 +255,37 @@ describe("FlashcardTagPicker", () => {
       expect(onChangeSpy).toHaveBeenCalledWith(["Cardiology"])
     })
   })
+
+  it("does not throw before Form.Item injects value and onChange", async () => {
+    mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
+      data: undefined,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      error: null
+    }))
+
+    render(
+      <FlashcardTagPicker
+        active
+        dataTestId="flashcards-form-controlled-tag-picker"
+      />
+    )
+
+    fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    const searchInput = await screen.findByTestId(
+      "flashcards-form-controlled-tag-picker-search-input"
+    )
+    fireEvent.change(searchInput, { target: { value: "Cardiology" } })
+
+    expect(() => {
+      fireEvent.keyDown(searchInput, {
+        key: "Enter",
+        code: "Enter",
+        charCode: 13,
+        keyCode: 13
+      })
+    }).not.toThrow()
+  })
 })

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx
@@ -1,0 +1,252 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { FlashcardTagPicker } from "../FlashcardTagPicker"
+
+const mockUseGlobalFlashcardTagSuggestionsQuery = vi.hoisted(() => vi.fn())
+
+vi.mock("../../hooks", () => ({
+  useGlobalFlashcardTagSuggestionsQuery: mockUseGlobalFlashcardTagSuggestionsQuery
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      return defaultValueOrOptions?.defaultValue ?? key
+    }
+  })
+}))
+
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  })
+}
+
+type HarnessProps = {
+  active?: boolean
+  initialValue?: string[]
+  onChangeSpy?: ReturnType<typeof vi.fn>
+  dataTestId?: string
+}
+
+function renderPicker({
+  active = true,
+  initialValue = [],
+  onChangeSpy = vi.fn(),
+  dataTestId
+}: HarnessProps = {}) {
+  const Harness = () => {
+    const [value, setValue] = React.useState<string[]>(initialValue)
+
+    return (
+      <FlashcardTagPicker
+        active={active}
+        value={value}
+        dataTestId={dataTestId}
+        onChange={(next) => {
+          onChangeSpy(next)
+          setValue(next)
+        }}
+      />
+    )
+  }
+
+  return {
+    onChangeSpy,
+    ...render(<Harness />)
+  }
+}
+
+describe("FlashcardTagPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows backend suggestions when opened", async () => {
+    mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(
+      (_query: string | null | undefined, options?: { enabled?: boolean }) => ({
+        data: options?.enabled
+          ? {
+              items: [
+                { tag: "Biology", count: 4 },
+                { tag: "bioinformatics", count: 2 }
+              ],
+              count: 2
+            }
+          : undefined,
+        isError: false,
+        isLoading: false,
+        error: null
+      })
+    )
+
+    renderPicker({ dataTestId: "flashcards-create-tag-picker" })
+
+    expect(screen.getByTestId("flashcards-create-tag-picker")).toBeInTheDocument()
+
+    fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "Biology" })).toBeInTheDocument()
+    })
+    expect(
+      await screen.findByTestId("flashcards-create-tag-picker-search-input")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "bioinformatics" })).toBeInTheDocument()
+  })
+
+  it("selecting an existing suggestion emits normalized tags", async () => {
+    mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(
+      (_query: string | null | undefined, options?: { enabled?: boolean }) => ({
+        data: options?.enabled
+          ? {
+              items: [{ tag: "  Biology  ", count: 4 }],
+              count: 1
+            }
+          : undefined,
+        isError: false,
+        isLoading: false,
+        error: null
+      })
+    )
+
+    const { onChangeSpy } = renderPicker()
+
+    fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    await waitFor(() => {
+      expect(document.querySelector(".ant-select-item-option")).toBeInTheDocument()
+    })
+    const suggestion = document.querySelector(".ant-select-item-option") as HTMLElement
+    fireEvent.mouseDown(suggestion)
+    fireEvent.click(suggestion)
+
+    await waitFor(() => {
+      expect(onChangeSpy).toHaveBeenCalledWith(["Biology"])
+    })
+  })
+
+  it("typing a new tag and pressing Enter works", async () => {
+    mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
+      data: undefined,
+      isError: false,
+      isLoading: false,
+      error: null
+    }))
+
+    const { onChangeSpy } = renderPicker()
+
+    fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    const searchInput = await screen.findByTestId("flashcard-tag-picker-search-input")
+    fireEvent.change(searchInput, { target: { value: "Neuroscience" } })
+    fireEvent.keyDown(searchInput, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+      keyCode: 13
+    })
+
+    await waitFor(() => {
+      expect(onChangeSpy).toHaveBeenCalledWith(["Neuroscience"])
+    })
+  })
+
+  it("ignores whitespace-only values", async () => {
+    mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
+      data: undefined,
+      isError: false,
+      isLoading: false,
+      error: null
+    }))
+
+    const { onChangeSpy } = renderPicker()
+
+    fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    const searchInput = await screen.findByTestId("flashcard-tag-picker-search-input")
+    fireEvent.change(searchInput, { target: { value: "   " } })
+    fireEvent.keyDown(searchInput, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+      keyCode: 13
+    })
+
+    await waitFor(() => {
+      expect(onChangeSpy).toHaveBeenCalledWith([])
+    })
+  })
+
+  it("collapses duplicate values case-insensitively", async () => {
+    mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
+      data: undefined,
+      isError: false,
+      isLoading: false,
+      error: null
+    }))
+
+    const { onChangeSpy } = renderPicker({ initialValue: ["Bio"] })
+
+    fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    const searchInput = await screen.findByTestId("flashcard-tag-picker-search-input")
+    fireEvent.change(searchInput, { target: { value: "bio" } })
+    fireEvent.keyDown(searchInput, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+      keyCode: 13
+    })
+
+    await waitFor(() => {
+      expect(onChangeSpy).toHaveBeenCalledWith(["Bio"])
+    })
+  })
+
+  it("allows free typing when fetch fails", async () => {
+    mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
+      data: undefined,
+      isError: true,
+      isLoading: false,
+      error: new Error("tag lookup failed")
+    }))
+
+    const { onChangeSpy } = renderPicker()
+
+    fireEvent.mouseDown(screen.getByRole("combobox"))
+
+    const searchInput = await screen.findByTestId("flashcard-tag-picker-search-input")
+    fireEvent.change(searchInput, { target: { value: "Cardiology" } })
+    fireEvent.keyDown(searchInput, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+      keyCode: 13
+    })
+
+    await waitFor(() => {
+      expect(onChangeSpy).toHaveBeenCalledWith(["Cardiology"])
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx
@@ -95,6 +95,7 @@ describe("FlashcardTagPicker", () => {
             }
           : undefined,
         isError: false,
+        isFetching: false,
         isLoading: false,
         error: null
       })
@@ -125,6 +126,7 @@ describe("FlashcardTagPicker", () => {
             }
           : undefined,
         isError: false,
+        isFetching: false,
         isLoading: false,
         error: null
       })
@@ -150,6 +152,7 @@ describe("FlashcardTagPicker", () => {
     mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
       data: undefined,
       isError: false,
+      isFetching: false,
       isLoading: false,
       error: null
     }))
@@ -176,6 +179,7 @@ describe("FlashcardTagPicker", () => {
     mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
       data: undefined,
       isError: false,
+      isFetching: false,
       isLoading: false,
       error: null
     }))
@@ -202,6 +206,7 @@ describe("FlashcardTagPicker", () => {
     mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
       data: undefined,
       isError: false,
+      isFetching: false,
       isLoading: false,
       error: null
     }))
@@ -228,6 +233,7 @@ describe("FlashcardTagPicker", () => {
     mockUseGlobalFlashcardTagSuggestionsQuery.mockImplementation(() => ({
       data: undefined,
       isError: true,
+      isFetching: false,
       isLoading: false,
       error: new Error("tag lookup failed")
     }))

--- a/apps/packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useGlobalFlashcardTagSuggestionsQuery } from "../useFlashcardQueries"
+import {
+  listFlashcardTagSuggestions,
+  listFlashcards,
+  type FlashcardTagSuggestionsResponse
+} from "@/services/flashcards"
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: { hasFlashcards: true },
+    loading: false
+  })
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => true
+}))
+
+vi.mock("@/services/flashcards", async () => {
+  const actual = await vi.importActual<typeof import("@/services/flashcards")>(
+    "@/services/flashcards"
+  )
+  return {
+    ...actual,
+    listFlashcardTagSuggestions: vi.fn(),
+    listFlashcards: vi.fn()
+  }
+})
+
+const buildWrapper = (queryClient: QueryClient) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe("useGlobalFlashcardTagSuggestionsQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("uses the dedicated tag suggestions service and forwards the react query signal", async () => {
+    const response: FlashcardTagSuggestionsResponse = {
+      items: [
+        { tag: "biology", count: 4 },
+        { tag: "bioinformatics", count: 2 }
+      ],
+      count: 2
+    }
+    vi.mocked(listFlashcardTagSuggestions).mockResolvedValue(response)
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false }
+      }
+    })
+
+    const { result } = renderHook(
+      () => useGlobalFlashcardTagSuggestionsQuery("  bio  ", { limit: 12 }),
+      { wrapper: buildWrapper(queryClient) }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.items[0]?.tag).toBe("biology")
+    })
+
+    expect(listFlashcardTagSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "bio",
+        limit: 12,
+        signal: expect.any(AbortSignal)
+      })
+    )
+    expect(listFlashcards).not.toHaveBeenCalled()
+  })
+
+  it("stays disabled when explicitly disabled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false }
+      }
+    })
+
+    const { result } = renderHook(
+      () => useGlobalFlashcardTagSuggestionsQuery("bio", { enabled: false }),
+      { wrapper: buildWrapper(queryClient) }
+    )
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe("idle")
+    })
+
+    expect(listFlashcardTagSuggestions).not.toHaveBeenCalled()
+    expect(listFlashcards).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   listDecks,
   listFlashcards,
+  listFlashcardTagSuggestions,
   createFlashcard,
   createFlashcardsBulk,
   updateFlashcardsBulk,
@@ -51,6 +52,11 @@ export interface UseFlashcardQueriesOptions {
   enabled?: boolean
   includeWorkspaceItems?: boolean
   workspaceId?: string | null
+}
+
+export interface UseGlobalFlashcardTagSuggestionsQueryOptions {
+  enabled?: boolean
+  limit?: number
 }
 
 const invalidateFlashcardsQueries = (qc: ReturnType<typeof useQueryClient>) =>
@@ -437,6 +443,29 @@ export function useTagSuggestionsQuery(
         left.localeCompare(right, undefined, { sensitivity: "base" })
       )
     },
+    enabled: options?.enabled ?? flashcardsEnabled
+  })
+}
+
+/**
+ * Hook for fetching global flashcard tag suggestions for create/edit tag autocompletion.
+ */
+export function useGlobalFlashcardTagSuggestionsQuery(
+  query: string | null | undefined,
+  options?: UseGlobalFlashcardTagSuggestionsQueryOptions
+) {
+  const { flashcardsEnabled } = useFlashcardsEnabled()
+  const limit = options?.limit ?? 50
+  const normalizedQuery = query?.trim() || undefined
+
+  return useQuery({
+    queryKey: ["flashcards:tags:suggestions:global", normalizedQuery ?? null, limit],
+    queryFn: ({ signal }) =>
+      listFlashcardTagSuggestions({
+        q: normalizedQuery,
+        limit,
+        signal
+      }),
     enabled: options?.enabled ?? flashcardsEnabled
   })
 }

--- a/apps/packages/ui/src/components/Flashcards/utils/tag-normalization.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/tag-normalization.ts
@@ -1,0 +1,30 @@
+export const normalizeFlashcardTags = (
+  tags?: readonly string[] | null
+): string[] => {
+  if (!Array.isArray(tags) || tags.length === 0) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  for (const rawTag of tags) {
+    const tag = rawTag.trim()
+    if (!tag) continue
+
+    const dedupeKey = tag.toLowerCase()
+    if (seen.has(dedupeKey)) continue
+
+    seen.add(dedupeKey)
+    normalized.push(tag)
+  }
+
+  return normalized
+}
+
+export const normalizeOptionalFlashcardTags = (
+  tags?: readonly string[] | null
+): string[] | undefined => {
+  const normalized = normalizeFlashcardTags(tags)
+  return normalized.length > 0 ? normalized : undefined
+}

--- a/apps/packages/ui/src/services/__tests__/flashcards.test.ts
+++ b/apps/packages/ui/src/services/__tests__/flashcards.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockBgRequest = vi.hoisted(() => vi.fn())
+const listSpy = vi.hoisted(() => vi.fn())
 
 vi.mock("@/services/background-proxy", () => ({
   bgRequest: mockBgRequest
@@ -9,7 +10,7 @@ vi.mock("@/services/background-proxy", () => ({
 vi.mock("@/services/resource-client", () => ({
   buildQuery: vi.fn(() => ""),
   createResourceClient: vi.fn(() => ({
-    list: vi.fn(),
+    list: listSpy,
     get: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
@@ -19,13 +20,16 @@ vi.mock("@/services/resource-client", () => ({
 
 import {
   FLASHCARD_GENERATION_TIMEOUT_MS,
-  generateFlashcards
+  generateFlashcards,
+  listFlashcardTagSuggestions
 } from "@/services/flashcards"
 
 describe("flashcards service", () => {
   beforeEach(() => {
     mockBgRequest.mockReset()
+    listSpy.mockReset()
     mockBgRequest.mockResolvedValue({ flashcards: [] })
+    listSpy.mockResolvedValue({ items: [], count: 0 })
   })
 
   it("uses extended timeout by default for flashcard generation", async () => {
@@ -37,6 +41,42 @@ describe("flashcards service", () => {
         method: "POST",
         timeoutMs: FLASHCARD_GENERATION_TIMEOUT_MS
       })
+    )
+  })
+
+  it("calls the global tag suggestions endpoint with q and limit", async () => {
+    const signal = new AbortController().signal
+
+    await listFlashcardTagSuggestions({
+      q: "bio",
+      limit: 25,
+      signal
+    })
+
+    expect(listSpy).toHaveBeenCalledWith(
+      {
+        q: "bio",
+        limit: 25
+      },
+      {
+        abortSignal: signal
+      }
+    )
+  })
+
+  it("omits blank q values when requesting global tag suggestions", async () => {
+    await listFlashcardTagSuggestions({
+      q: "   ",
+      limit: 10
+    })
+
+    expect(listSpy).toHaveBeenCalledWith(
+      {
+        limit: 10
+      },
+      {
+        abortSignal: undefined
+      }
     )
   })
 })

--- a/apps/packages/ui/src/services/flashcards.ts
+++ b/apps/packages/ui/src/services/flashcards.ts
@@ -13,6 +13,10 @@ const flashcardsClient = createResourceClient({
   basePath: "/api/v1/flashcards" as AllowedPath
 })
 
+const flashcardTagsClient = createResourceClient({
+  basePath: "/api/v1/flashcards/tags" as AllowedPath
+})
+
 export const FLASHCARD_GENERATION_TIMEOUT_MS = 120000
 
 export type DeckSchedulerSettings = {
@@ -299,6 +303,16 @@ export type FlashcardNextReviewResponse = {
   selection_reason?: "learning_due" | "review_due" | "new" | "none" | null
 }
 
+export type FlashcardTagSuggestionItem = {
+  tag: string
+  count: number
+}
+
+export type FlashcardTagSuggestionsResponse = {
+  items: FlashcardTagSuggestionItem[]
+  count: number
+}
+
 export type FlashcardsImportRequest = {
   content: string
   delimiter?: string | null
@@ -439,6 +453,21 @@ export async function listFlashcards(params: {
     limit: params.limit,
     offset: params.offset,
     order_by: params.order_by
+  })
+}
+
+export async function listFlashcardTagSuggestions(params?: {
+  q?: string | null
+  limit?: number | null
+  signal?: AbortSignal
+}): Promise<FlashcardTagSuggestionsResponse> {
+  const normalizedQuery = params?.q?.trim()
+
+  return await flashcardTagsClient.list<FlashcardTagSuggestionsResponse>({
+    ...(normalizedQuery ? { q: normalizedQuery } : {}),
+    limit: params?.limit
+  }, {
+    abortSignal: params?.signal
   })
 }
 

--- a/apps/tldw-frontend/__tests__/extension/option-flashcards.shared-workspace.test.ts
+++ b/apps/tldw-frontend/__tests__/extension/option-flashcards.shared-workspace.test.ts
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const loadSource = (...candidates: string[]) => {
+  const path = candidates.find((candidate) => existsSync(candidate))
+  if (!path) {
+    throw new Error(`Missing extension route source: ${candidates.join(" | ")}`)
+  }
+  return readFileSync(path, "utf8")
+}
+
+describe("extension option flashcards shared workspace parity", () => {
+  it("wraps the flashcards workspace in the shared layout and error boundary", () => {
+    const source = loadSource(
+      "apps/tldw-frontend/extension/routes/option-flashcards.tsx",
+      "tldw-frontend/extension/routes/option-flashcards.tsx",
+      "extension/routes/option-flashcards.tsx"
+    )
+
+    expect(source).toContain("FlashcardsWorkspace")
+    expect(source).toContain("RouteErrorBoundary")
+    expect(source).toContain("OptionLayout")
+    expect(source).toContain('routeId="flashcards"')
+    expect(source).toContain('routeLabel="Flashcards"')
+  })
+})

--- a/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts
@@ -9,237 +9,293 @@
  *   /api/v1/flashcards        (cards CRUD, review, generate, import, export)
  *   /api/v1/flashcards/decks  (deck CRUD)
  */
-import { type Page, type Locator, expect } from "@playwright/test"
-import { BasePage, type InteractiveElement } from "./BasePage"
-import { waitForAppShell, waitForConnection, dismissConnectionModals } from "../helpers"
+import { type Page, type Locator, expect } from '@playwright/test';
+import { BasePage, type InteractiveElement } from './BasePage';
+import { waitForAppShell, waitForConnection, dismissConnectionModals } from '../helpers';
 
 export class FlashcardsPage extends BasePage {
   constructor(page: Page) {
-    super(page)
+    super(page);
   }
 
   // -- Navigation ------------------------------------------------------------
 
   async goto(): Promise<void> {
-    await this.page.goto("/flashcards", { waitUntil: "domcontentloaded" })
-    await waitForConnection(this.page)
+    await this.page.goto('/flashcards', { waitUntil: 'domcontentloaded' });
+    await waitForConnection(this.page);
   }
 
   async gotoPath(path: string): Promise<void> {
-    await this.page.goto(path, { waitUntil: "domcontentloaded" })
-    await waitForConnection(this.page)
+    await this.page.goto(path, { waitUntil: 'domcontentloaded' });
+    await waitForConnection(this.page);
   }
 
   async assertPageReady(): Promise<void> {
-    await waitForAppShell(this.page, 30_000)
+    await waitForAppShell(this.page, 30_000);
     // Either the tabs container is visible (online) or a connection banner
-    const tabs = this.page.locator('[data-testid="flashcards-tabs"]')
-    const offline = this.page.getByText("Connect to use Flashcards")
-    const unsupported = this.page.getByText("Flashcards API not available")
+    const tabs = this.page.locator('[data-testid="flashcards-tabs"]');
+    const offline = this.page.getByText('Connect to use Flashcards');
+    const unsupported = this.page.getByText('Flashcards API not available');
     await Promise.race([
-      tabs.waitFor({ state: "visible", timeout: 20_000 }),
-      offline.first().waitFor({ state: "visible", timeout: 20_000 }),
-      unsupported.first().waitFor({ state: "visible", timeout: 20_000 }),
-    ]).catch(() => {})
+      tabs.waitFor({ state: 'visible', timeout: 20_000 }),
+      offline.first().waitFor({ state: 'visible', timeout: 20_000 }),
+      unsupported.first().waitFor({ state: 'visible', timeout: 20_000 }),
+    ]).catch(() => {});
   }
 
   // -- Locators: Top-level ---------------------------------------------------
 
   /** The Ant Design Tabs container wrapping Study / Manage / Transfer */
   get tabsContainer(): Locator {
-    return this.page.locator('[data-testid="flashcards-tabs"]')
+    return this.page.locator('[data-testid="flashcards-tabs"]');
   }
 
   /** Offline / not-connected banner */
   get offlineMessage(): Locator {
-    return this.page.getByText("Connect to use Flashcards")
+    return this.page.getByText('Connect to use Flashcards');
   }
 
   /** Feature-unavailable banner */
   get unsupportedMessage(): Locator {
-    return this.page.getByText("Flashcards API not available")
+    return this.page.getByText('Flashcards API not available');
   }
 
   // -- Locators: Tab buttons -------------------------------------------------
 
   get studyTab(): Locator {
-    return this.page.getByRole("tab", { name: /study/i })
+    return this.page.getByRole('tab', { name: /study/i });
   }
 
   get manageTab(): Locator {
-    return this.page.getByRole("tab", { name: /manage/i })
+    return this.page.getByRole('tab', { name: /manage/i });
   }
 
   get transferTab(): Locator {
-    return this.page.getByRole("tab", { name: /transfer/i })
+    return this.page.getByRole('tab', { name: /transfer/i });
   }
 
   // -- Locators: Tab bar extra content ---------------------------------------
 
   /** "Test with Quiz" CTA button in the tab bar */
   get testWithQuizButton(): Locator {
-    return this.page.locator('[data-testid="flashcards-to-quiz-cta"]')
+    return this.page.locator('[data-testid="flashcards-to-quiz-cta"]');
   }
 
   /** Keyboard shortcuts help button (icon-only) */
   get keyboardShortcutsButton(): Locator {
-    return this.page.getByRole("button", { name: /keyboard shortcuts/i })
+    return this.page.getByRole('button', { name: /keyboard shortcuts/i });
   }
 
   // -- Locators: Study (Review) tab ------------------------------------------
 
   get reviewDeckSelect(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-deck-select"]')
+    return this.page.locator('[data-testid="flashcards-review-deck-select"]');
   }
 
   get reviewModeToggle(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-mode-toggle"]')
+    return this.page.locator('[data-testid="flashcards-review-mode-toggle"]');
   }
 
   get reviewActiveCard(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-active-card"]')
+    return this.page.locator('[data-testid="flashcards-review-active-card"]');
   }
 
   get reviewShowAnswerButton(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-show-answer"]')
+    return this.page.locator('[data-testid="flashcards-review-show-answer"]');
   }
 
   get reviewEmptyCard(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-empty-card"]')
+    return this.page.locator('[data-testid="flashcards-review-empty-card"]');
   }
 
   get reviewAnalyticsSummary(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-analytics-summary"]')
+    return this.page.locator('[data-testid="flashcards-review-analytics-summary"]');
   }
 
   get reviewCreateCta(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-empty-create-cta"]')
+    return this.page.locator('[data-testid="flashcards-review-empty-create-cta"]');
   }
 
   get reviewImportCta(): Locator {
-    return this.page.locator('[data-testid="flashcards-review-empty-import-cta"]')
+    return this.page.locator('[data-testid="flashcards-review-empty-import-cta"]');
   }
 
   // -- Locators: Manage tab --------------------------------------------------
 
   get manageTopBar(): Locator {
-    return this.page.locator('[data-testid="flashcards-manage-topbar"]')
+    return this.page.locator('[data-testid="flashcards-manage-topbar"]');
   }
 
   get manageSearchInput(): Locator {
-    return this.page.locator('[data-testid="flashcards-manage-search"] input')
+    return this.page.locator('[data-testid="flashcards-manage-search"] input');
   }
 
   get manageDeckSelect(): Locator {
-    return this.page.locator('[data-testid="flashcards-manage-deck-select"]')
+    return this.page.locator('[data-testid="flashcards-manage-deck-select"]');
   }
 
   get manageDueStatusFilter(): Locator {
-    return this.page.locator('[data-testid="flashcards-manage-due-status"]')
+    return this.page.locator('[data-testid="flashcards-manage-due-status"]');
   }
 
   get manageSortSelect(): Locator {
-    return this.page.locator('[data-testid="flashcards-manage-sort-select"]')
+    return this.page.locator('[data-testid="flashcards-manage-sort-select"]');
   }
 
   get manageShowWorkspaceDecksToggle(): Locator {
-    return this.page.locator('[data-testid="flashcards-manage-show-workspace-decks"]')
+    return this.page.locator('[data-testid="flashcards-manage-show-workspace-decks"]');
   }
 
   get manageWorkspaceFilter(): Locator {
-    return this.page.locator('[data-testid="flashcards-manage-workspace-filter"]')
+    return this.page.locator('[data-testid="flashcards-manage-workspace-filter"]');
   }
 
   get manageMoveScopeButton(): Locator {
-    return this.page.locator('[data-testid="flashcards-manage-move-scope"]')
+    return this.page.locator('[data-testid="flashcards-manage-move-scope"]');
   }
 
   get fabCreateButton(): Locator {
-    return this.page.locator('[data-testid="flashcards-fab-create"]')
+    return this.page.locator('[data-testid="flashcards-fab-create"]');
+  }
+
+  get createDrawer(): Locator {
+    return this.page.locator('.ant-drawer-content').filter({ hasText: 'Create Flashcard' }).last();
+  }
+
+  get createDrawerDeckSelect(): Locator {
+    return this.createDrawer.locator('.ant-select').first();
+  }
+
+  get editDrawer(): Locator {
+    return this.page.locator('.ant-drawer-content').filter({ hasText: 'Edit Flashcard' }).last();
+  }
+
+  get editDrawerAdditionalFieldsToggle(): Locator {
+    return this.editDrawer.getByText('Additional fields', { exact: true });
+  }
+
+  get createTagPicker(): Locator {
+    return this.createDrawer.locator('[data-testid="flashcards-create-tag-picker"]');
+  }
+
+  get createTagPickerSearchInput(): Locator {
+    return this.createDrawer.locator('[data-testid="flashcards-create-tag-picker-search-input"]');
+  }
+
+  get editTagPicker(): Locator {
+    return this.editDrawer.locator('[data-testid="flashcards-edit-tag-picker"]');
+  }
+
+  get editTagPickerSearchInput(): Locator {
+    return this.editDrawer.locator('[data-testid="flashcards-edit-tag-picker-search-input"]');
   }
 
   // -- Locators: Transfer (Import/Export) tab --------------------------------
 
   get importFormatSelect(): Locator {
-    return this.page.locator('[data-testid="flashcards-import-format"]')
+    return this.page.locator('[data-testid="flashcards-import-format"]');
   }
 
   get importTextarea(): Locator {
-    return this.page.locator('[data-testid="flashcards-import-textarea"]')
+    return this.page.locator('[data-testid="flashcards-import-textarea"]');
   }
 
   get importButton(): Locator {
-    return this.page.locator('[data-testid="flashcards-import-button"]')
+    return this.page.locator('[data-testid="flashcards-import-button"]');
   }
 
   get exportDeckSelect(): Locator {
-    return this.page.locator('[data-testid="flashcards-export-deck"]')
+    return this.page.locator('[data-testid="flashcards-export-deck"]');
   }
 
   get exportFormatSelect(): Locator {
-    return this.page.locator('[data-testid="flashcards-export-format"]')
+    return this.page.locator('[data-testid="flashcards-export-format"]');
   }
 
   get exportButton(): Locator {
-    return this.page.locator('[data-testid="flashcards-export-button"]')
+    return this.page.locator('[data-testid="flashcards-export-button"]');
   }
 
   get generateTextarea(): Locator {
-    return this.page.locator('[data-testid="flashcards-generate-text"]')
+    return this.page.locator('[data-testid="flashcards-generate-text"]');
   }
 
   get generateButton(): Locator {
-    return this.page.locator('[data-testid="flashcards-generate-button"]')
+    return this.page.locator('[data-testid="flashcards-generate-button"]');
   }
 
   getManageFlashcardRow(cardUuid: string): Locator {
-    return this.page.locator(`[data-testid="flashcard-item-${cardUuid}"]`)
+    return this.page.locator(`[data-testid="flashcard-item-${cardUuid}"]`);
+  }
+
+  getManageFlashcardEditButton(cardUuid: string): Locator {
+    return this.page.locator(`[data-testid="flashcard-edit-${cardUuid}"]`);
   }
 
   getReviewDeckOption(deckName: string): Locator {
-    return this.page.getByRole("option", { name: deckName })
+    return this.page.getByRole('option', { name: deckName });
+  }
+
+  getActiveSelectOption(optionName: string, exact = false): Locator {
+    return this.page
+      .locator('.ant-select-dropdown')
+      .filter({ has: this.page.getByRole('option', { name: optionName, exact }) })
+      .locator('[role="option"]')
+      .filter({ hasText: optionName })
+      .first();
   }
 
   async openReviewDeckSelect(): Promise<void> {
-    await this.reviewDeckSelect.click({ force: true })
+    await this.reviewDeckSelect.click({ force: true });
   }
 
   async selectManageDeckByName(deckName: string): Promise<void> {
-    await this.manageDeckSelect.click({ force: true })
-    const deckOption = this.getReviewDeckOption(deckName)
-    await expect(deckOption).toBeVisible({ timeout: 10_000 })
-    await deckOption.click()
+    await this.manageDeckSelect.click({ force: true });
+    const deckOption = this.getActiveSelectOption(deckName);
+    await expect(deckOption).toBeVisible({ timeout: 10_000 });
+    await deckOption.click();
   }
 
   async selectManageWorkspaceById(workspaceId: string): Promise<void> {
-    await this.manageWorkspaceFilter.click({ force: true })
-    const option = this.page.getByRole("option", { name: workspaceId, exact: true })
-    await expect(option).toBeVisible({ timeout: 10_000 })
-    await option.click()
+    await this.manageWorkspaceFilter.click({ force: true });
+    const option = this.getActiveSelectOption(workspaceId, true);
+    await expect(option).toBeVisible({ timeout: 10_000 });
+    await option.click();
   }
 
   async selectFirstManageDeckOption(): Promise<void> {
-    await this.manageDeckSelect.click({ force: true })
-    await this.page.keyboard.press("ArrowDown")
-    await this.page.keyboard.press("Enter")
+    await this.manageDeckSelect.click({ force: true });
+    await this.page.keyboard.press('ArrowDown');
+    await this.page.keyboard.press('Enter');
+  }
+
+  async selectCreateDrawerDeckByName(deckName: string): Promise<void> {
+    await this.createDrawerDeckSelect.click({ force: true });
+    const deckOption = this.getActiveSelectOption(deckName);
+    await expect(deckOption).toBeVisible({ timeout: 10_000 });
+    await deckOption.click();
+  }
+
+  async openManageFlashcardEdit(cardUuid: string): Promise<void> {
+    await this.getManageFlashcardEditButton(cardUuid).click({ force: true });
   }
 
   // -- Tab Navigation --------------------------------------------------------
 
-  async switchToTab(tab: "study" | "manage" | "transfer"): Promise<void> {
+  async switchToTab(tab: 'study' | 'manage' | 'transfer'): Promise<void> {
     // Dismiss any overlays that might intercept clicks
-    await dismissConnectionModals(this.page)
+    await dismissConnectionModals(this.page);
     const tabLocator = {
       study: this.studyTab,
       manage: this.manageTab,
       transfer: this.transferTab,
-    }[tab]
-    await tabLocator.click({ force: true })
+    }[tab];
+    await tabLocator.click({ force: true });
   }
 
   /** Returns true when the main tabs container is visible (server online + feature available) */
   async isOnline(): Promise<boolean> {
-    return await this.tabsContainer.isVisible().catch(() => false)
+    return await this.tabsContainer.isVisible().catch(() => false);
   }
 
   // -- Interactive elements for assertAllButtonsWired() ----------------------
@@ -247,31 +303,35 @@ export class FlashcardsPage extends BasePage {
   async getInteractiveElements(): Promise<InteractiveElement[]> {
     return [
       {
-        name: "Export flashcards button",
+        name: 'Export flashcards button',
         locator: this.exportButton,
         expectation: {
-          type: "api_call",
+          type: 'api_call',
           apiPattern: /\/api\/v1\/flashcards\/export/,
-          method: "GET",
+          method: 'GET',
         },
         setup: async () => {
-          await this.switchToTab("transfer")
-          await expect(this.importTextarea.or(this.exportDeckSelect)).toBeVisible({ timeout: 5_000 })
+          await this.switchToTab('transfer');
+          await expect(this.importTextarea.or(this.exportDeckSelect)).toBeVisible({
+            timeout: 5_000,
+          });
         },
       },
       {
-        name: "Import flashcards button",
+        name: 'Import flashcards button',
         locator: this.importButton,
         expectation: {
-          type: "api_call",
+          type: 'api_call',
           apiPattern: /\/api\/v1\/flashcards\/import/,
-          method: "POST",
+          method: 'POST',
         },
         setup: async () => {
-          await this.switchToTab("transfer")
-          await expect(this.importTextarea.or(this.exportDeckSelect)).toBeVisible({ timeout: 5_000 })
+          await this.switchToTab('transfer');
+          await expect(this.importTextarea.or(this.exportDeckSelect)).toBeVisible({
+            timeout: 5_000,
+          });
         },
       },
-    ]
+    ];
   }
 }

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts
@@ -14,276 +14,466 @@ import {
   expect,
   skipIfServerUnavailable,
   assertNoCriticalErrors,
-} from "../../utils/fixtures"
-import { expectApiCall } from "../../utils/api-assertions"
-import { FlashcardsPage } from "../../utils/page-objects"
-import { seedAuth } from "../../utils/helpers"
+} from '../../utils/fixtures';
+import { expectApiCall } from '../../utils/api-assertions';
+import { FlashcardsPage } from '../../utils/page-objects';
+import { seedAuth, fetchWithApiKey, TEST_CONFIG } from '../../utils/helpers';
 
-test.describe("Flashcards", () => {
-  let flashcards: FlashcardsPage
+type SeededDeck = {
+  id: number;
+  name: string;
+};
+
+type SeededCard = {
+  uuid: string;
+  version: number;
+  tags: string[];
+};
+
+async function createFlashcardDeck(name: string): Promise<SeededDeck> {
+  const response = await fetchWithApiKey(
+    `${TEST_CONFIG.serverUrl}/api/v1/flashcards/decks`,
+    TEST_CONFIG.apiKey,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name,
+        description: 'E2E flashcard tag suggestion deck',
+      }),
+    }
+  );
+
+  expect(response.ok).toBeTruthy();
+
+  const payload = (await response.json()) as SeededDeck;
+  expect(payload.id).toBeGreaterThan(0);
+  return payload;
+}
+
+async function createFlashcardCard(input: {
+  deckId: number;
+  front: string;
+  back: string;
+  tags?: string[];
+}): Promise<SeededCard> {
+  const response = await fetchWithApiKey(
+    `${TEST_CONFIG.serverUrl}/api/v1/flashcards`,
+    TEST_CONFIG.apiKey,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        deck_id: input.deckId,
+        front: input.front,
+        back: input.back,
+        tags: input.tags ?? [],
+        source_ref_type: 'manual',
+      }),
+    }
+  );
+
+  expect(response.ok).toBeTruthy();
+
+  const payload = (await response.json()) as SeededCard;
+  expect(payload.uuid).toBeTruthy();
+  return payload;
+}
+
+test.describe('Flashcards', () => {
+  let flashcards: FlashcardsPage;
 
   test.beforeEach(async ({ page }) => {
-    await seedAuth(page)
-    flashcards = new FlashcardsPage(page)
-  })
+    await seedAuth(page);
+    flashcards = new FlashcardsPage(page);
+  });
 
   // =========================================================================
   // Page Load
   // =========================================================================
 
-  test.describe("Page Load", () => {
-    test("should render the Flashcards page with tabs or offline banner", async ({
+  test.describe('Page Load', () => {
+    test('should render the Flashcards page with tabs or offline banner', async ({
       authedPage,
       diagnostics,
     }) => {
-      flashcards = new FlashcardsPage(authedPage)
-      await flashcards.goto()
-      await flashcards.assertPageReady()
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
 
       // Either the tabs container is visible (server online) or an offline/unsupported message
-      const online = await flashcards.isOnline()
-      const offlineVisible = await flashcards.offlineMessage.isVisible().catch(() => false)
-      const unsupportedVisible = await flashcards.unsupportedMessage.isVisible().catch(() => false)
+      const online = await flashcards.isOnline();
+      const offlineVisible = await flashcards.offlineMessage.isVisible().catch(() => false);
+      const unsupportedVisible = await flashcards.unsupportedMessage.isVisible().catch(() => false);
 
-      expect(online || offlineVisible || unsupportedVisible).toBe(true)
+      expect(online || offlineVisible || unsupportedVisible).toBe(true);
 
       // If online, all three tabs should be present
       if (online) {
-        await expect(flashcards.studyTab).toBeVisible()
-        await expect(flashcards.manageTab).toBeVisible()
-        await expect(flashcards.transferTab).toBeVisible()
-        await expect(flashcards.testWithQuizButton).toBeVisible()
+        await expect(flashcards.studyTab).toBeVisible();
+        await expect(flashcards.manageTab).toBeVisible();
+        await expect(flashcards.transferTab).toBeVisible();
+        await expect(flashcards.testWithQuizButton).toBeVisible();
       }
 
-      await assertNoCriticalErrors(diagnostics)
-    })
+      await assertNoCriticalErrors(diagnostics);
+    });
 
-    test("should switch between tabs without errors", async ({
-      authedPage,
-      diagnostics,
-    }) => {
-      flashcards = new FlashcardsPage(authedPage)
-      await flashcards.goto()
-      await flashcards.assertPageReady()
+    test('should switch between tabs without errors', async ({ authedPage, diagnostics }) => {
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
 
-      const online = await flashcards.isOnline()
-      if (!online) return
+      const online = await flashcards.isOnline();
+      if (!online) return;
 
-      for (const tab of ["manage", "transfer", "study"] as const) {
-        await flashcards.switchToTab(tab)
-        if (tab === "manage") {
-          await expect(flashcards.manageTopBar).toBeVisible({ timeout: 10_000 })
-        } else if (tab === "transfer") {
-          await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 })
-          await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 })
+      for (const tab of ['manage', 'transfer', 'study'] as const) {
+        await flashcards.switchToTab(tab);
+        if (tab === 'manage') {
+          await expect(flashcards.manageTopBar).toBeVisible({ timeout: 10_000 });
+        } else if (tab === 'transfer') {
+          await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 });
+          await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 });
         } else {
-          await expect(flashcards.reviewDeckSelect).toBeVisible({ timeout: 10_000 })
+          await expect(flashcards.reviewDeckSelect).toBeVisible({ timeout: 10_000 });
         }
       }
 
-      await assertNoCriticalErrors(diagnostics)
-    })
-  })
+      await assertNoCriticalErrors(diagnostics);
+    });
+  });
 
   // =========================================================================
   // Study Tab
   // =========================================================================
 
-  test.describe("Study Tab", () => {
-    test("should show review deck selector and either a card or empty state", async ({
+  test.describe('Study Tab', () => {
+    test('should show review deck selector and either a card or empty state', async ({
       authedPage,
       diagnostics,
     }) => {
-      flashcards = new FlashcardsPage(authedPage)
-      await flashcards.goto()
-      await flashcards.assertPageReady()
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
 
-      const online = await flashcards.isOnline()
-      if (!online) return
+      const online = await flashcards.isOnline();
+      if (!online) return;
 
-      await flashcards.switchToTab("study")
+      await flashcards.switchToTab('study');
 
       // The deck selector should always be present on the Study tab
-      await expect(flashcards.reviewDeckSelect).toBeVisible({ timeout: 10_000 })
+      await expect(flashcards.reviewDeckSelect).toBeVisible({ timeout: 10_000 });
 
       // Either an active review card or the empty-state card should be shown
-      const hasActiveCard = await flashcards.reviewActiveCard.isVisible().catch(() => false)
-      const hasEmptyCard = await flashcards.reviewEmptyCard.isVisible().catch(() => false)
-      expect(hasActiveCard || hasEmptyCard).toBe(true)
+      const hasActiveCard = await flashcards.reviewActiveCard.isVisible().catch(() => false);
+      const hasEmptyCard = await flashcards.reviewEmptyCard.isVisible().catch(() => false);
+      expect(hasActiveCard || hasEmptyCard).toBe(true);
 
-      await assertNoCriticalErrors(diagnostics)
-    })
-  })
+      await assertNoCriticalErrors(diagnostics);
+    });
+  });
 
   // =========================================================================
   // Manage Tab
   // =========================================================================
 
-  test.describe("Manage Tab", () => {
-    test("should show search, deck filter, and FAB create button", async ({
+  test.describe('Manage Tab', () => {
+    test('should show search, deck filter, and FAB create button', async ({
       authedPage,
       diagnostics,
     }) => {
-      flashcards = new FlashcardsPage(authedPage)
-      await flashcards.goto()
-      await flashcards.assertPageReady()
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
 
-      const online = await flashcards.isOnline()
-      if (!online) return
+      const online = await flashcards.isOnline();
+      expect(online).toBe(true);
 
-      await flashcards.switchToTab("manage")
+      await flashcards.switchToTab('manage');
 
-      await expect(flashcards.manageTopBar).toBeVisible({ timeout: 10_000 })
-      await expect(flashcards.manageSearchInput).toBeVisible()
-      await expect(flashcards.manageDeckSelect).toBeVisible()
-      await expect(flashcards.fabCreateButton).toBeVisible()
+      await expect(flashcards.manageTopBar).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.manageSearchInput).toBeVisible();
+      await expect(flashcards.manageDeckSelect).toBeVisible();
+      await expect(flashcards.fabCreateButton).toBeVisible();
 
-      await assertNoCriticalErrors(diagnostics)
-    })
+      await assertNoCriticalErrors(diagnostics);
+    });
 
-    test("should fire flashcards list API when searching", async ({
+    test('should fire flashcards list API when searching', async ({
       authedPage,
       serverInfo,
       diagnostics,
     }) => {
-      skipIfServerUnavailable(serverInfo)
+      skipIfServerUnavailable(serverInfo);
 
-      flashcards = new FlashcardsPage(authedPage)
-      await flashcards.goto()
-      await flashcards.assertPageReady()
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
 
-      const online = await flashcards.isOnline()
-      if (!online) return
+      const online = await flashcards.isOnline();
+      if (!online) return;
 
-      await flashcards.switchToTab("manage")
-      await expect(flashcards.manageSearchInput).toBeVisible({ timeout: 10_000 })
+      await flashcards.switchToTab('manage');
+      await expect(flashcards.manageSearchInput).toBeVisible({ timeout: 10_000 });
 
-      const searchVisible = await flashcards.manageSearchInput.isVisible().catch(() => false)
-      if (!searchVisible) return
+      const searchVisible = await flashcards.manageSearchInput.isVisible().catch(() => false);
+      if (!searchVisible) return;
 
-      const apiCall = expectApiCall(authedPage, {
-        url: /\/api\/v1\/flashcards/,
-        method: "GET",
-      }, 15_000)
+      const apiCall = expectApiCall(
+        authedPage,
+        {
+          url: /\/api\/v1\/flashcards/,
+          method: 'GET',
+        },
+        15_000
+      );
 
-      await flashcards.manageSearchInput.fill("test query")
-      await flashcards.manageSearchInput.press("Enter")
+      await flashcards.manageSearchInput.fill('test query');
+      await flashcards.manageSearchInput.press('Enter');
 
       try {
-        const { response } = await apiCall
-        expect(response.status()).toBeLessThan(500)
+        const { response } = await apiCall;
+        expect(response.status()).toBeLessThan(500);
       } catch {
         // Search may debounce; acceptable if no immediate call
       }
 
-      await assertNoCriticalErrors(diagnostics)
-    })
-  })
+      await assertNoCriticalErrors(diagnostics);
+    });
+
+    test('should allow selecting existing tag suggestions in create and edit drawers', async ({
+      authedPage,
+      serverInfo,
+      diagnostics,
+    }) => {
+      test.setTimeout(120_000);
+      skipIfServerUnavailable(serverInfo);
+
+      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const deck = await createFlashcardDeck(`E2E Flashcard Tags ${runId}`);
+      const createSuggestionTag = `bio-create-${runId}`;
+      const editSuggestionTag = `bio-edit-${runId}`;
+
+      await createFlashcardCard({
+        deckId: deck.id,
+        front: `Suggestion source ${runId}`,
+        back: 'Seeds global tag suggestions',
+        tags: [createSuggestionTag, editSuggestionTag],
+      });
+
+      const knownCard = await createFlashcardCard({
+        deckId: deck.id,
+        front: `Known card ${runId}`,
+        back: 'Used for edit drawer verification',
+      });
+
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
+
+      const online = await flashcards.isOnline();
+      if (!online) return;
+
+      await flashcards.switchToTab('manage');
+      await expect(flashcards.manageTopBar).toBeVisible({ timeout: 10_000 });
+      await flashcards.selectManageDeckByName(deck.name);
+
+      await flashcards.fabCreateButton.click();
+      await expect(authedPage.getByText('Create Flashcard')).toBeVisible({ timeout: 10_000 });
+      await flashcards.selectCreateDrawerDeckByName(deck.name);
+      await authedPage.getByText('Advanced options (tags, extra, notes)').click();
+
+      await flashcards.createTagPicker.getByRole('combobox').click();
+      await expect(flashcards.createTagPickerSearchInput).toBeVisible({ timeout: 10_000 });
+      await flashcards.createTagPickerSearchInput.fill(createSuggestionTag);
+
+      const createTagOption = authedPage.getByRole('option', {
+        name: createSuggestionTag,
+        exact: true,
+      });
+      await expect(createTagOption).toBeVisible({ timeout: 10_000 });
+      await createTagOption.click();
+      await expect(flashcards.createTagPicker).toContainText(createSuggestionTag);
+
+      await authedPage.getByPlaceholder('Question or prompt...').fill(`Created via UI ${runId}`);
+      await authedPage.getByPlaceholder('Answer...').fill('Created tag suggestion answer');
+
+      const createResponsePromise = authedPage.waitForResponse((response) => {
+        return (
+          response.request().method() === 'POST' && /\/api\/v1\/flashcards$/.test(response.url())
+        );
+      });
+
+      await authedPage.getByRole('button', { name: 'Create', exact: true }).click();
+
+      const createResponse = await createResponsePromise;
+      expect(createResponse.status()).toBeLessThan(400);
+      const createdCard = (await createResponse.json()) as SeededCard;
+      expect(createdCard.tags).toContain(createSuggestionTag);
+
+      await expect(flashcards.getManageFlashcardEditButton(knownCard.uuid)).toBeVisible({
+        timeout: 10_000,
+      });
+      await flashcards.openManageFlashcardEdit(knownCard.uuid);
+
+      await expect(authedPage.getByText('Edit Flashcard')).toBeVisible({ timeout: 10_000 });
+      await flashcards.editDrawerAdditionalFieldsToggle.click();
+      await expect(flashcards.editTagPicker).toBeVisible({ timeout: 10_000 });
+
+      await flashcards.editTagPicker.getByRole('combobox').click();
+      await expect(flashcards.editTagPickerSearchInput).toBeVisible({ timeout: 10_000 });
+      await flashcards.editTagPickerSearchInput.fill(editSuggestionTag);
+
+      const editTagOption = authedPage.getByRole('option', {
+        name: editSuggestionTag,
+        exact: true,
+      });
+      await expect(editTagOption).toBeVisible({ timeout: 10_000 });
+      await editTagOption.click();
+      await expect(flashcards.editTagPicker).toContainText(editSuggestionTag);
+
+      const updateResponsePromise = authedPage.waitForResponse((response) => {
+        return (
+          response.request().method() === 'PATCH' &&
+          response.url().includes(`/api/v1/flashcards/${knownCard.uuid}`)
+        );
+      });
+
+      await authedPage.getByRole('button', { name: 'Save', exact: true }).click();
+
+      const updateResponse = await updateResponsePromise;
+      expect(updateResponse.status()).toBeLessThan(400);
+      const updatedCard = (await updateResponse.json()) as SeededCard;
+      expect(updatedCard.tags).toContain(editSuggestionTag);
+
+      await expect(authedPage.getByRole('button', { name: 'Save', exact: true })).toBeHidden({
+        timeout: 10_000,
+      });
+
+      await flashcards.openManageFlashcardEdit(knownCard.uuid);
+      await expect(authedPage.getByText('Edit Flashcard')).toBeVisible({ timeout: 10_000 });
+      await flashcards.editDrawerAdditionalFieldsToggle.click();
+      await expect(flashcards.editTagPicker).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.editTagPicker).toContainText(editSuggestionTag);
+
+      await assertNoCriticalErrors(diagnostics);
+    });
+  });
 
   // =========================================================================
   // Transfer Tab - Export
   // =========================================================================
 
-  test.describe("Export", () => {
-    test("should fire GET /api/v1/flashcards/export when Export button is clicked", async ({
+  test.describe('Export', () => {
+    test('should fire GET /api/v1/flashcards/export when Export button is clicked', async ({
       authedPage,
       serverInfo,
       diagnostics,
     }) => {
-      skipIfServerUnavailable(serverInfo)
+      skipIfServerUnavailable(serverInfo);
 
-      flashcards = new FlashcardsPage(authedPage)
-      await flashcards.goto()
-      await flashcards.assertPageReady()
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
 
-      const online = await flashcards.isOnline()
-      if (!online) return
+      const online = await flashcards.isOnline();
+      if (!online) return;
 
-      await flashcards.switchToTab("transfer")
-      await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 })
-      await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 })
+      await flashcards.switchToTab('transfer');
+      await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 });
 
-      const exportVisible = await flashcards.exportButton.isVisible().catch(() => false)
-      if (!exportVisible) return
+      const exportVisible = await flashcards.exportButton.isVisible().catch(() => false);
+      if (!exportVisible) return;
 
-      const exportEnabled = await flashcards.exportButton.isEnabled().catch(() => false)
-      if (!exportEnabled) return
+      const exportEnabled = await flashcards.exportButton.isEnabled().catch(() => false);
+      if (!exportEnabled) return;
 
-      const apiCall = expectApiCall(authedPage, {
-        url: /\/api\/v1\/flashcards\/export/,
-        method: "GET",
-      }, 15_000)
+      const apiCall = expectApiCall(
+        authedPage,
+        {
+          url: /\/api\/v1\/flashcards\/export/,
+          method: 'GET',
+        },
+        15_000
+      );
 
-      await flashcards.exportButton.click()
+      await flashcards.exportButton.click();
 
       try {
-        const { response } = await apiCall
-        expect(response.status()).toBeLessThan(500)
+        const { response } = await apiCall;
+        expect(response.status()).toBeLessThan(500);
       } catch {
         // Export may require deck selection; acceptable if button is not wired without selection
       }
 
-      await assertNoCriticalErrors(diagnostics)
-    })
-  })
+      await assertNoCriticalErrors(diagnostics);
+    });
+  });
 
   // =========================================================================
   // Transfer Tab - Import
   // =========================================================================
 
-  test.describe("Import", () => {
-    test("should show import textarea and format selector on Transfer tab", async ({
+  test.describe('Import', () => {
+    test('should show import textarea and format selector on Transfer tab', async ({
       authedPage,
       diagnostics,
     }) => {
-      flashcards = new FlashcardsPage(authedPage)
-      await flashcards.goto()
-      await flashcards.assertPageReady()
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
 
-      const online = await flashcards.isOnline()
-      if (!online) return
+      const online = await flashcards.isOnline();
+      if (!online) return;
 
-      await flashcards.switchToTab("transfer")
-      await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 })
-      await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 })
+      await flashcards.switchToTab('transfer');
+      await expect(flashcards.importButton).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.exportButton).toBeVisible({ timeout: 10_000 });
 
-      await expect(flashcards.importFormatSelect).toBeVisible({ timeout: 10_000 })
-      await expect(flashcards.importButton).toBeVisible()
+      await expect(flashcards.importFormatSelect).toBeVisible({ timeout: 10_000 });
+      await expect(flashcards.importButton).toBeVisible();
 
-      await assertNoCriticalErrors(diagnostics)
-    })
-  })
+      await assertNoCriticalErrors(diagnostics);
+    });
+  });
 
   // =========================================================================
   // Keyboard Shortcuts Modal
   // =========================================================================
 
-  test.describe("Keyboard Shortcuts", () => {
-    test("should open keyboard shortcuts modal via help button", async ({
+  test.describe('Keyboard Shortcuts', () => {
+    test('should open keyboard shortcuts modal via help button', async ({
       authedPage,
       diagnostics,
     }) => {
-      flashcards = new FlashcardsPage(authedPage)
-      await flashcards.goto()
-      await flashcards.assertPageReady()
+      flashcards = new FlashcardsPage(authedPage);
+      await flashcards.goto();
+      await flashcards.assertPageReady();
 
-      const online = await flashcards.isOnline()
-      if (!online) return
+      const online = await flashcards.isOnline();
+      if (!online) return;
 
-      const helpVisible = await flashcards.keyboardShortcutsButton.isVisible().catch(() => false)
-      if (!helpVisible) return
+      const helpVisible = await flashcards.keyboardShortcutsButton.isVisible().catch(() => false);
+      if (!helpVisible) return;
 
-      await flashcards.keyboardShortcutsButton.click()
+      await flashcards.keyboardShortcutsButton.click();
 
       // The modal should appear
-      const modal = authedPage.locator(".ant-modal")
-      await expect(modal.first()).toBeVisible({ timeout: 5_000 })
+      const modal = authedPage.locator('.ant-modal');
+      await expect(modal.first()).toBeVisible({ timeout: 5_000 });
 
       // Close it
-      await authedPage.keyboard.press("Escape")
-      await expect(modal.first()).toBeHidden({ timeout: 3_000 }).catch(() => {})
+      await authedPage.keyboard.press('Escape');
+      await expect(modal.first())
+        .toBeHidden({ timeout: 3_000 })
+        .catch(() => {});
 
-      await assertNoCriticalErrors(diagnostics)
-    })
-  })
-})
+      await assertNoCriticalErrors(diagnostics);
+    });
+  });
+});

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response, StreamingResponse
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import DEFAULT_LLM_PROVIDER
 from tldw_Server_API.app.api.v1.schemas.flashcards import (
@@ -930,15 +930,19 @@ def list_flashcards(
         raise HTTPException(status_code=500, detail="Failed to list flashcards") from e
 
 
-@router.get("/tags", response_model=FlashcardTagSuggestionsResponse)
+@router.get(
+    "/tags",
+    response_model=FlashcardTagSuggestionsResponse,
+    dependencies=[Depends(check_rate_limit)],
+)
 def list_flashcard_tag_suggestions(
     q: Optional[str] = None,
-    limit: int = Query(50, ge=1, le=1000),
+    limit: int = Query(50, ge=1, le=100),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
-):
+) -> FlashcardTagSuggestionsResponse:
     try:
         items = db.list_flashcard_tag_suggestions(q=q, limit=limit)
-        return {"items": items, "count": len(items)}
+        return FlashcardTagSuggestionsResponse(items=items, count=len(items))
     except CharactersRAGDBError as e:
         logger.error(f"Failed to list flashcard tag suggestions: {e}")
         raise HTTPException(status_code=500, detail="Failed to list flashcard tag suggestions") from e

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -940,6 +940,16 @@ def list_flashcard_tag_suggestions(
     limit: int = Query(50, ge=1, le=100),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> FlashcardTagSuggestionsResponse:
+    """List global flashcard tag suggestions.
+
+    Args:
+        q: Optional trimmed substring filter applied case-insensitively to tag names.
+        limit: Maximum number of suggestions to return.
+        db: Flashcards database dependency for the current user.
+
+    Returns:
+        A typed response containing matching tag suggestions and the number returned.
+    """
     try:
         items = db.list_flashcard_tag_suggestions(q=q, limit=limit)
         return FlashcardTagSuggestionsResponse(items=items, count=len(items))

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -32,6 +32,7 @@ from tldw_Server_API.app.api.v1.schemas.flashcards import (
     FlashcardReviewRequest,
     FlashcardReviewResponse,
     FlashcardResetSchedulingRequest,
+    FlashcardTagSuggestionsResponse,
     FlashcardsImportRequest,
     FlashcardTagsUpdate,
     StudyAssistantContextResponse,
@@ -927,6 +928,20 @@ def list_flashcards(
     except CharactersRAGDBError as e:
         logger.error(f"Failed to list flashcards: {e}")
         raise HTTPException(status_code=500, detail="Failed to list flashcards") from e
+
+
+@router.get("/tags", response_model=FlashcardTagSuggestionsResponse)
+def list_flashcard_tag_suggestions(
+    q: Optional[str] = None,
+    limit: int = Query(50, ge=1, le=1000),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+):
+    try:
+        items = db.list_flashcard_tag_suggestions(q=q, limit=limit)
+        return {"items": items, "count": len(items)}
+    except CharactersRAGDBError as e:
+        logger.error(f"Failed to list flashcard tag suggestions: {e}")
+        raise HTTPException(status_code=500, detail="Failed to list flashcard tag suggestions") from e
 
 
 @router.get("/analytics/summary", response_model=FlashcardAnalyticsSummaryResponse)

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -405,11 +405,15 @@ class StudyAssistantRespondResponse(BaseModel):
 
 
 class FlashcardTagSuggestionItem(BaseModel):
+    """A single tag suggestion and the number of flashcards using it."""
+
     tag: str
     count: int
 
 
 class FlashcardTagSuggestionsResponse(BaseModel):
+    """Global flashcard tag suggestions with item details and total result count."""
+
     items: list[FlashcardTagSuggestionItem] = Field(default_factory=list)
     count: int
 

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -404,6 +404,16 @@ class StudyAssistantRespondResponse(BaseModel):
     context_snapshot: dict[str, Any] = Field(default_factory=dict)
 
 
+class FlashcardTagSuggestionItem(BaseModel):
+    tag: str
+    count: int
+
+
+class FlashcardTagSuggestionsResponse(BaseModel):
+    items: list[FlashcardTagSuggestionItem] = Field(default_factory=list)
+    count: int
+
+
 class FlashcardTagsUpdate(BaseModel):
     tags: list[str]
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -21670,6 +21670,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
     def list_flashcard_tag_suggestions(self, q: str | None = None, limit: int = 50) -> list[dict[str, Any]]:
         """List global flashcard tag suggestions with per-tag usage counts."""
+        if limit <= 0:
+            return []
+
         keyword_table = self._map_table_for_backend("keywords")
         normalized_q = (q or "").strip()
         where_clauses: list[str] = []

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -21668,6 +21668,60 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except CharactersRAGDBError:  # noqa: TRY203
             raise
 
+    def list_flashcard_tag_suggestions(self, q: str | None = None, limit: int = 50) -> list[dict[str, Any]]:
+        """List global flashcard tag suggestions with per-tag usage counts."""
+        keyword_table = self._map_table_for_backend("keywords")
+        normalized_q = (q or "").strip()
+        where_clauses: list[str] = []
+        params: list[Any] = []
+
+        if self.backend_type == BackendType.POSTGRESQL:
+            where_clauses.extend(
+                [
+                    "f.deleted = FALSE",
+                    "kw.deleted = FALSE",
+                    "(f.deck_id IS NULL OR (d.id IS NOT NULL AND d.deleted = FALSE))",
+                ]
+            )
+        else:
+            where_clauses.extend(
+                [
+                    "f.deleted = 0",
+                    "kw.deleted = 0",
+                    "(f.deck_id IS NULL OR (d.id IS NOT NULL AND d.deleted = 0))",
+                ]
+            )
+
+        if normalized_q:
+            where_clauses.append("LOWER(kw.keyword) LIKE ?")
+            params.append(f"%{normalized_q.lower()}%")
+
+        order_keyword = self._case_insensitive_order_expression("kw.keyword")
+        where_sql = " AND ".join(where_clauses)
+        query = """
+            SELECT
+                kw.keyword AS tag,
+                COUNT(DISTINCT f.id) AS usage_count
+            FROM flashcards f
+            JOIN flashcard_keywords fk ON fk.card_id = f.id
+            JOIN {keyword_table} kw ON kw.id = fk.keyword_id
+            LEFT JOIN decks d ON d.id = f.deck_id
+            WHERE {where_sql}
+            GROUP BY kw.keyword
+            ORDER BY usage_count DESC, {order_keyword}
+            LIMIT ?
+        """.format_map(locals())  # nosec B608
+        params.append(limit)
+
+        try:
+            cursor = self.execute_query(query, tuple(params))
+            return [
+                {"tag": str(row["tag"]), "count": int(row["usage_count"] or 0)}
+                for row in cursor.fetchall()
+            ]
+        except CharactersRAGDBError:  # noqa: TRY203
+            raise
+
     def get_flashcards_by_uuids(self, uuids: list[str]) -> list[dict[str, Any]]:
         """Fetch multiple flashcards by UUIDs in one query. Order is not guaranteed; caller can reorder."""
         if not uuids:

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -21668,7 +21668,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except CharactersRAGDBError:  # noqa: TRY203
             raise
 
-    def list_flashcard_tag_suggestions(self, q: str | None = None, limit: int = 50) -> list[dict[str, Any]]:
+    def list_flashcard_tag_suggestions(
+        self,
+        q: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
         """List global flashcard tag suggestions with per-tag usage counts."""
         if limit <= 0:
             return []

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -46,6 +46,9 @@ def _build_flashcards_test_app() -> FastAPI:
     return app
 
 
+fastapi_app = _build_flashcards_test_app()
+
+
 @pytest.fixture(scope="function")
 def flashcards_db(tmp_path):
     db_path = tmp_path / "flashcards.db"
@@ -3078,3 +3081,15 @@ def test_flashcard_tag_suggestions_route_precedence_over_alias_path(
     assert response.status_code == 200
     payload = response.json()
     assert set(payload.keys()) == {"items", "count"}
+
+
+def test_flashcard_tag_suggestions_rejects_limit_over_max(
+    client_with_flashcards_db: TestClient,
+):
+    response = client_with_flashcards_db.get(
+        "/api/v1/flashcards/tags",
+        params={"limit": 101},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 422

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -6,6 +6,7 @@ import sqlite3
 import os
 from datetime import datetime
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from loguru import logger
 from PIL import Image
@@ -16,7 +17,8 @@ os.environ.setdefault("READING_DIGEST_JOBS_WORKER_ENABLED", "0")
 os.environ.setdefault("READING_DIGEST_SCHEDULER_ENABLED", "0")
 os.environ.setdefault("TEST_MODE", "1")
 
-from tldw_Server_API.app.main import app as fastapi_app
+from tldw_Server_API.app.api.v1.endpoints.config_info import router as config_info_router
+from tldw_Server_API.app.api.v1.endpoints.flashcards import router as flashcards_router
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Flashcards.asset_refs import extract_flashcard_asset_uuids
@@ -37,6 +39,13 @@ def _build_test_png_bytes() -> bytes:
 PNG_1X1_BYTES = _build_test_png_bytes()
 
 
+def _build_flashcards_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(config_info_router, prefix="/api/v1")
+    app.include_router(flashcards_router, prefix="/api/v1")
+    return app
+
+
 @pytest.fixture(scope="function")
 def flashcards_db(tmp_path):
     db_path = tmp_path / "flashcards.db"
@@ -49,6 +58,8 @@ def flashcards_db(tmp_path):
 def client_with_flashcards_db(flashcards_db: CharactersRAGDB):
     TestConfig.setup_test_environment()
     from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+    fastapi_app = _build_flashcards_test_app()
+
     def override_get_db():
         logger.info("[TEST] override get_chacha_db_for_user -> flashcards_db")
         try:
@@ -2855,3 +2866,215 @@ def test_bulk_create_with_invalid_deck_returns_400(client_with_flashcards_db: Te
     det = data.get("detail") or {}
     assert det.get("error")
     assert 42424242 in det.get("invalid_deck_ids", [])
+
+
+def test_flashcard_tag_suggestions_global_visibility_across_general_and_workspace_decks(
+    client_with_flashcards_db: TestClient,
+    flashcards_db: CharactersRAGDB,
+):
+    flashcards_db.upsert_workspace("ws-tags-global", "Workspace Tags Global")
+
+    general_deck = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Tags General Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert general_deck.status_code == 200
+    general_deck_id = general_deck.json()["id"]
+
+    workspace_deck = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Tags Workspace Deck", "workspace_id": "ws-tags-global"},
+        headers=AUTH_HEADERS,
+    )
+    assert workspace_deck.status_code == 200
+    workspace_deck_id = workspace_deck.json()["id"]
+
+    created_general = client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={
+            "deck_id": general_deck_id,
+            "front": "General card",
+            "back": "Answer",
+            "tags": ["general-only", "shared-tag"],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert created_general.status_code == 200
+
+    created_workspace = client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={
+            "deck_id": workspace_deck_id,
+            "front": "Workspace card",
+            "back": "Answer",
+            "tags": ["workspace-only", "shared-tag"],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert created_workspace.status_code == 200
+
+    suggestions = client_with_flashcards_db.get("/api/v1/flashcards/tags", headers=AUTH_HEADERS)
+    assert suggestions.status_code == 200
+    payload = suggestions.json()
+
+    counts = {item["tag"]: item["count"] for item in payload["items"]}
+    assert counts["shared-tag"] == 2
+    assert counts["general-only"] == 1
+    assert counts["workspace-only"] == 1
+
+
+def test_flashcard_tag_suggestions_orders_by_usage_then_alphabetically(
+    client_with_flashcards_db: TestClient,
+):
+    deck_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Tags Ordering Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert deck_response.status_code == 200
+    deck_id = deck_response.json()["id"]
+
+    inputs = [
+        ("Card 1", ["zeta", "beta"]),
+        ("Card 2", ["alpha", "zeta"]),
+        ("Card 3", ["beta", "zeta"]),
+        ("Card 4", ["alpha"]),
+    ]
+    for front, tags in inputs:
+        response = client_with_flashcards_db.post(
+            "/api/v1/flashcards",
+            json={"deck_id": deck_id, "front": front, "back": "Answer", "tags": tags},
+            headers=AUTH_HEADERS,
+        )
+        assert response.status_code == 200
+
+    suggestions = client_with_flashcards_db.get("/api/v1/flashcards/tags", headers=AUTH_HEADERS)
+    assert suggestions.status_code == 200
+    items = suggestions.json()["items"]
+    top_three = items[:3]
+
+    assert [item["tag"] for item in top_three] == ["zeta", "alpha", "beta"]
+    assert [item["count"] for item in top_three] == [3, 2, 2]
+
+
+def test_flashcard_tag_suggestions_filters_with_trimmed_case_insensitive_q(
+    client_with_flashcards_db: TestClient,
+):
+    deck_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Tags Filter Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert deck_response.status_code == 200
+    deck_id = deck_response.json()["id"]
+
+    cards = [
+        ("Alpha one", ["AlphaTag"]),
+        ("Alpha two", ["my-alpha-mix"]),
+        ("Beta one", ["beta"]),
+    ]
+    for front, tags in cards:
+        created = client_with_flashcards_db.post(
+            "/api/v1/flashcards",
+            json={"deck_id": deck_id, "front": front, "back": "Answer", "tags": tags},
+            headers=AUTH_HEADERS,
+        )
+        assert created.status_code == 200
+
+    suggestions = client_with_flashcards_db.get(
+        "/api/v1/flashcards/tags",
+        params={"q": "  AlPhA  "},
+        headers=AUTH_HEADERS,
+    )
+    assert suggestions.status_code == 200
+    payload = suggestions.json()
+
+    assert payload["count"] == 2
+    assert [item["tag"] for item in payload["items"]] == ["AlphaTag", "my-alpha-mix"]
+    assert [item["count"] for item in payload["items"]] == [1, 1]
+
+
+def test_flashcard_tag_suggestions_excludes_deleted_rows_and_keeps_deckless_cards(
+    client_with_flashcards_db: TestClient,
+    flashcards_db: CharactersRAGDB,
+):
+    keep_deck = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Tags Keep Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert keep_deck.status_code == 200
+    keep_deck_id = keep_deck.json()["id"]
+
+    deleted_deck = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Tags Deleted Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert deleted_deck.status_code == 200
+    deleted_deck_id = deleted_deck.json()["id"]
+
+    keep_card = client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={"deck_id": keep_deck_id, "front": "Keep", "back": "Answer", "tags": ["keep-tag"]},
+        headers=AUTH_HEADERS,
+    )
+    assert keep_card.status_code == 200
+
+    deleted_card = client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={"deck_id": keep_deck_id, "front": "Deleted card", "back": "Answer", "tags": ["deleted-card-tag"]},
+        headers=AUTH_HEADERS,
+    )
+    assert deleted_card.status_code == 200
+    deleted_card_uuid = deleted_card.json()["uuid"]
+
+    deleted_keyword_card = client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={"deck_id": keep_deck_id, "front": "Deleted keyword", "back": "Answer", "tags": ["deleted-keyword-tag"]},
+        headers=AUTH_HEADERS,
+    )
+    assert deleted_keyword_card.status_code == 200
+
+    deleted_deck_card = client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={"deck_id": deleted_deck_id, "front": "Deleted deck", "back": "Answer", "tags": ["deleted-deck-tag"]},
+        headers=AUTH_HEADERS,
+    )
+    assert deleted_deck_card.status_code == 200
+
+    deckless_card = client_with_flashcards_db.post(
+        "/api/v1/flashcards",
+        json={"front": "Deckless card", "back": "Answer", "tags": ["deckless-tag"]},
+        headers=AUTH_HEADERS,
+    )
+    assert deckless_card.status_code == 200
+
+    keyword_table = flashcards_db._map_table_for_backend("keywords")
+    with flashcards_db.transaction() as conn:
+        conn.execute("UPDATE flashcards SET deleted = 1 WHERE uuid = ?", (deleted_card_uuid,))
+        conn.execute(
+            f"UPDATE {keyword_table} SET deleted = 1 WHERE keyword = ?",
+            ("deleted-keyword-tag",),
+        )
+        conn.execute("UPDATE decks SET deleted = 1 WHERE id = ?", (deleted_deck_id,))
+
+    suggestions = client_with_flashcards_db.get("/api/v1/flashcards/tags", headers=AUTH_HEADERS)
+    assert suggestions.status_code == 200
+    tags = {item["tag"]: item["count"] for item in suggestions.json()["items"]}
+
+    assert tags["keep-tag"] == 1
+    assert tags["deckless-tag"] == 1
+    assert "deleted-card-tag" not in tags
+    assert "deleted-keyword-tag" not in tags
+    assert "deleted-deck-tag" not in tags
+
+
+def test_flashcard_tag_suggestions_route_precedence_over_alias_path(
+    client_with_flashcards_db: TestClient,
+):
+    response = client_with_flashcards_db.get("/api/v1/flashcards/tags", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload.keys()) == {"items", "count"}


### PR DESCRIPTION
## Summary
- add a backend `/api/v1/flashcards/tags` endpoint with typed response models and global tag aggregation
- add a shared flashcard tag suggestion service, query hook, and `FlashcardTagPicker` for create/edit drawers
- add focused backend, UI, extension parity, and WebUI E2E coverage for selecting existing flashcard tags
- include the reviewed design spec and implementation plan for the change

## Testing
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py -k "flashcard_tag_suggestions or get_flashcard_alias_path_returns_card" -v`
- `bunx vitest run src/services/__tests__/flashcards.test.ts src/components/Flashcards/hooks/__tests__/useFlashcardQueries.tag-suggestions.test.tsx src/components/Flashcards/components/__tests__/FlashcardTagPicker.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.tags.test.tsx src/components/Flashcards/components/__tests__/FlashcardEditDrawer.tags.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.cloze-help.test.tsx src/components/Flashcards/components/__tests__/FlashcardEditDrawer.save.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx src/components/Flashcards/components/__tests__/FlashcardEditDrawer.image-insert.test.tsx src/components/Flashcards/components/__tests__/FlashcardEditDrawer.reset-scheduling.test.tsx src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx`
- `bunx vitest run __tests__/extension/option-flashcards.shared-workspace.test.ts`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/flashcards.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py apps/packages/ui/src/components/Flashcards/components apps/packages/ui/src/components/Flashcards/hooks apps/packages/ui/src/services apps/tldw-frontend/e2e/utils/page-objects/FlashcardsPage.ts apps/tldw-frontend/e2e/workflows/tier-2-features/flashcards.spec.ts apps/tldw-frontend/__tests__/extension/option-flashcards.shared-workspace.test.ts -f json -o /tmp/bandit_flashcards_global_tag_suggestions_worktree.json`

## Known Blocker
- Full live Playwright execution still depends on starting the FastAPI app, and that is currently blocked by an unrelated duplicate-route startup error already present in `tldw_Server_API/app/main.py` on `dev`.
