### PR TITLE
fix: render flashcard markdown previews and workspace deck labels

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
@@ -26,6 +26,7 @@ import { MarkdownWithBoundary } from "./MarkdownWithBoundary"
 import { FlashcardImageInsertButton } from "./FlashcardImageInsertButton"
 import { DeckSchedulerSettingsEditor } from "./DeckSchedulerSettingsEditor"
 import { normalizeFlashcardTemplateFields } from "../utils/template-helpers"
+import { formatDeckDisplayName } from "../utils/deck-display"
 import {
   getSelectionFromElement,
   insertTextAtSelection,
@@ -371,7 +372,7 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
                 loading={decksLoading}
                 className="w-full"
                 options={decks.map((d) => ({
-                  label: d.name,
+                  label: formatDeckDisplayName(d, `Deck ${d.id}`),
                   value: d.id
                 }))}
                 popupRender={(menu) => (

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentRow.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentRow.tsx
@@ -5,6 +5,7 @@ import type { TextAreaRef } from "antd/es/input/TextArea"
 import type { Deck, Flashcard, FlashcardBulkUpdateItem, FlashcardBulkUpdateResponse } from "@/services/flashcards"
 import { getFlashcardSourceMeta } from "../utils/source-reference"
 import { FlashcardQueueStateBadge } from "../utils/queue-state-badges"
+import { formatDeckDisplayName } from "../utils/deck-display"
 import { useFlashcardDocumentRowState } from "../hooks/useFlashcardDocumentRowState"
 import type { DocumentQueryFilterContext } from "../utils/document-cache-policy"
 import { FlashcardImageInsertButton } from "./FlashcardImageInsertButton"
@@ -81,7 +82,10 @@ export const FlashcardDocumentRow: React.FC<FlashcardDocumentRowProps> = ({
   })
   const deckLabel =
     savedCard.deck_id != null
-      ? decks.find((deck) => deck.id === savedCard.deck_id)?.name || `Deck ${savedCard.deck_id}`
+      ? formatDeckDisplayName(
+          decks.find((deck) => deck.id === savedCard.deck_id),
+          `Deck ${savedCard.deck_id}`
+        )
       : "No deck"
   const sourceMeta = getFlashcardSourceMeta(savedCard)
 
@@ -304,7 +308,7 @@ export const FlashcardDocumentRow: React.FC<FlashcardDocumentRowProps> = ({
               allowClear
               value={draft.deck_id ?? undefined}
               options={decks.map((deck) => ({
-                label: deck.name,
+                label: formatDeckDisplayName(deck, `Deck ${deck.id}`),
                 value: deck.id
               }))}
               placeholder="Select deck"

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx
@@ -32,6 +32,7 @@ import {
   restoreSelection,
   type TextSelection
 } from "../utils/text-selection"
+import { formatDeckDisplayName } from "../utils/deck-display"
 import { FlashcardImageInsertButton } from "./FlashcardImageInsertButton"
 import { MarkdownWithBoundary } from "./MarkdownWithBoundary"
 import type { Flashcard, FlashcardUpdate, Deck } from "@/services/flashcards"
@@ -330,7 +331,7 @@ export const FlashcardEditDrawer: React.FC<FlashcardEditDrawerProps> = ({
                 defaultValue: "Select deck"
               })}
               options={decks.map((d) => ({
-                label: d.name,
+                label: formatDeckDisplayName(d, `Deck ${d.id}`),
                 value: d.id
               }))}
             />

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardMarkdownSnippet.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardMarkdownSnippet.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+
+import { MarkdownErrorBoundary } from "@/components/Common/MarkdownErrorBoundary"
+import { cn } from "@/libs/utils"
+
+const FLASHCARD_MARKDOWN_SNIPPET_CLASS =
+  "[&_p]:m-0 [&_ul]:m-0 [&_ol]:m-0 [&_pre]:m-0 [&_pre]:bg-transparent [&_pre]:p-0 [&_h1]:m-0 [&_h2]:m-0 [&_h3]:m-0 [&_h4]:m-0 [&_h5]:m-0 [&_h6]:m-0 [&_img]:hidden"
+
+interface FlashcardMarkdownSnippetProps {
+  content: string
+  className?: string
+}
+
+const stopSnippetLinkPropagation = (
+  event: React.MouseEvent<HTMLDivElement>
+) => {
+  const target = event.target
+  if (!(target instanceof Element)) return
+  if (target.closest("a")) {
+    event.stopPropagation()
+  }
+}
+
+const FlashcardMarkdownSnippetInner: React.FC<FlashcardMarkdownSnippetProps> = ({
+  content,
+  className = ""
+}) => (
+  <MarkdownErrorBoundary fallbackText={content}>
+    <div
+      className={cn(
+        "prose prose-xs max-w-none break-words text-inherit dark:prose-invert",
+        FLASHCARD_MARKDOWN_SNIPPET_CLASS,
+        className
+      )}
+      onClickCapture={stopSnippetLinkPropagation}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ({ className: anchorClassName, ...props }) => (
+            <a
+              {...props}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn("text-primary hover:underline", anchorClassName)}
+            />
+          ),
+          img: () => null
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  </MarkdownErrorBoundary>
+)
+
+export const FlashcardMarkdownSnippet = React.memo(FlashcardMarkdownSnippetInner)
+
+FlashcardMarkdownSnippet.displayName = "FlashcardMarkdownSnippet"
+
+export default FlashcardMarkdownSnippet

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardMarkdownSnippet.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardMarkdownSnippet.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { FlashcardMarkdownSnippet } from "../FlashcardMarkdownSnippet"
+
+describe("FlashcardMarkdownSnippet", () => {
+  it("renders inline markdown formatting for snippet previews", () => {
+    render(<FlashcardMarkdownSnippet content={"**Important** concept"} />)
+
+    expect(screen.getByText("Important").tagName).toBe("STRONG")
+    expect(screen.getByText("concept")).toBeInTheDocument()
+  })
+
+  it("prevents markdown link clicks from bubbling to the parent row", () => {
+    const onRowClick = vi.fn()
+
+    render(
+      <div onClick={onRowClick}>
+        <FlashcardMarkdownSnippet content={"[Reference](https://example.com)"} />
+      </div>
+    )
+
+    fireEvent.click(screen.getByRole("link", { name: "Reference" }))
+
+    expect(onRowClick).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/components/index.ts
+++ b/apps/packages/ui/src/components/Flashcards/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./MarkdownWithBoundary"
+export * from "./FlashcardMarkdownSnippet"
 export * from "./FileDropZone"
 export * from "./FlashcardActionsMenu"
 export * from "./ReviewProgress"

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -49,7 +49,13 @@ import {
   type DueStatus,
   type ManageSortBy
 } from "../hooks"
-import { MarkdownWithBoundary, FlashcardActionsMenu, FlashcardEditDrawer, FlashcardCreateDrawer } from "../components"
+import {
+  FlashcardActionsMenu,
+  FlashcardCreateDrawer,
+  FlashcardEditDrawer,
+  MarkdownWithBoundary,
+  FlashcardMarkdownSnippet
+} from "../components"
 import { FlashcardDocumentView } from "../components/FlashcardDocumentView"
 import { FLASHCARDS_DRAWER_WIDTH_PX } from "../constants"
 import { formatCardType } from "../utils/model-type-labels"
@@ -79,8 +85,6 @@ const { Text } = Typography
 const BULK_MUTATION_CHUNK_SIZE = 50
 const DELETE_UNDO_SECONDS = 30
 const DELETE_UNDO_MS = DELETE_UNDO_SECONDS * 1000
-const INLINE_MARKDOWN_SNIPPET_CLASS =
-  "[&_p]:m-0 [&_ul]:m-0 [&_ol]:m-0 [&_pre]:m-0 [&_pre]:bg-transparent [&_pre]:p-0 [&_h1]:m-0 [&_h2]:m-0 [&_h3]:m-0 [&_h4]:m-0 [&_h5]:m-0 [&_h6]:m-0"
 
 type PendingDeletion = {
   card: Flashcard
@@ -2071,10 +2075,8 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                       )}
                       <div className="min-w-0 flex-1 text-sm text-text">
                         <div className="line-clamp-1">
-                          <MarkdownWithBoundary
+                          <FlashcardMarkdownSnippet
                             content={item.front}
-                            size="xs"
-                            className={INLINE_MARKDOWN_SNIPPET_CLASS}
                           />
                         </div>
                       </div>
@@ -2153,20 +2155,16 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                       <div className="flex min-w-0 items-start gap-2">
                         <div className="min-w-0 flex-1 text-sm font-semibold text-text">
                           <div className="line-clamp-1">
-                            <MarkdownWithBoundary
+                            <FlashcardMarkdownSnippet
                               content={item.front}
-                              size="xs"
-                              className={INLINE_MARKDOWN_SNIPPET_CLASS}
                             />
                           </div>
                         </div>
                         <span className="text-text-subtle">-</span>
                         <div className="min-w-0 flex-1 text-sm text-text-muted">
                           <div className="line-clamp-1">
-                            <MarkdownWithBoundary
+                            <FlashcardMarkdownSnippet
                               content={item.back}
-                              size="xs"
-                              className={INLINE_MARKDOWN_SNIPPET_CLASS}
                             />
                           </div>
                         </div>

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -55,6 +55,7 @@ import { FLASHCARDS_DRAWER_WIDTH_PX } from "../constants"
 import { formatCardType } from "../utils/model-type-labels"
 import { FlashcardQueueStateBadge } from "../utils/queue-state-badges"
 import { getFlashcardSourceMeta } from "../utils/source-reference"
+import { formatDeckDisplayName } from "../utils/deck-display"
 import {
   formatFlashcardsUiErrorMessage,
   mapFlashcardsUiError
@@ -78,6 +79,8 @@ const { Text } = Typography
 const BULK_MUTATION_CHUNK_SIZE = 50
 const DELETE_UNDO_SECONDS = 30
 const DELETE_UNDO_MS = DELETE_UNDO_SECONDS * 1000
+const INLINE_MARKDOWN_SNIPPET_CLASS =
+  "[&_p]:m-0 [&_ul]:m-0 [&_ol]:m-0 [&_pre]:m-0 [&_pre]:bg-transparent [&_pre]:p-0 [&_h1]:m-0 [&_h2]:m-0 [&_h3]:m-0 [&_h4]:m-0 [&_h5]:m-0 [&_h6]:m-0"
 
 type PendingDeletion = {
   card: Flashcard
@@ -314,6 +317,19 @@ export const ManageTab: React.FC<ManageTabProps> = ({
       return null
     },
     [decksQuery.data, mDeckId]
+  )
+  const deckMap = React.useMemo(
+    () => new Map((decksQuery.data || []).map((deck) => [deck.id, deck])),
+    [decksQuery.data]
+  )
+  const resolveDeckLabel = React.useCallback(
+    (deckId: number | null | undefined) => {
+      if (deckId == null) {
+        return t("option:flashcards.noDeck", { defaultValue: "No deck" })
+      }
+      return formatDeckDisplayName(deckMap.get(deckId), `Deck ${deckId}`)
+    },
+    [deckMap, t]
   )
   const workspaceFilterOptions = React.useMemo(() => {
     const workspaceIds = new Set<string>()
@@ -1618,7 +1634,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
               className="min-w-44"
               data-testid="flashcards-manage-deck-select"
               options={(decksQuery.data || []).map((d) => ({
-                label: d.name,
+                label: formatDeckDisplayName(d, `Deck ${d.id}`),
                 value: d.id
               }))}
             />
@@ -2053,7 +2069,15 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                           <span className="inline-block w-2 h-2 rounded-full bg-success" />
                         </Tooltip>
                       )}
-                      <Text className="flex-1 truncate">{item.front}</Text>
+                      <div className="min-w-0 flex-1 text-sm text-text">
+                        <div className="line-clamp-1">
+                          <MarkdownWithBoundary
+                            content={item.front}
+                            size="xs"
+                            className={INLINE_MARKDOWN_SNIPPET_CLASS}
+                          />
+                        </div>
+                      </div>
                     </div>
                   }
                   description={
@@ -2061,7 +2085,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                       <div className="flex items-center gap-2">
                         {item.deck_id != null && (
                           <span className="text-text-muted">
-                            {(decksQuery.data || []).find((d) => d.id === item.deck_id)?.name || `Deck ${item.deck_id}`}
+                            {resolveDeckLabel(item.deck_id)}
                           </span>
                         )}
                         {item.due_at && (
@@ -2126,19 +2150,33 @@ export const ManageTab: React.FC<ManageTabProps> = ({
                 <>
                   <List.Item.Meta
                     title={
-                      <div className="flex items-center gap-2">
-                        <Text strong>{item.front.slice(0, 80)}</Text>
+                      <div className="flex min-w-0 items-start gap-2">
+                        <div className="min-w-0 flex-1 text-sm font-semibold text-text">
+                          <div className="line-clamp-1">
+                            <MarkdownWithBoundary
+                              content={item.front}
+                              size="xs"
+                              className={INLINE_MARKDOWN_SNIPPET_CLASS}
+                            />
+                          </div>
+                        </div>
                         <span className="text-text-subtle">-</span>
-                        <Text type="secondary">{item.back.slice(0, 80)}</Text>
+                        <div className="min-w-0 flex-1 text-sm text-text-muted">
+                          <div className="line-clamp-1">
+                            <MarkdownWithBoundary
+                              content={item.back}
+                              size="xs"
+                              className={INLINE_MARKDOWN_SNIPPET_CLASS}
+                            />
+                          </div>
+                        </div>
                       </div>
                     }
                     description={
                       <div className="flex items-center gap-2 flex-wrap">
                         {item.deck_id != null && (
                           <Tag color="blue">
-                            {(decksQuery.data || []).find(
-                              (d) => d.id === item.deck_id
-                            )?.name || `Deck ${item.deck_id}`}
+                            {resolveDeckLabel(item.deck_id)}
                           </Tag>
                         )}
                         <Tag>{formatCardType(item, t)}</Tag>

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
@@ -20,10 +20,13 @@ import {
   getManageServerOrderBy
 } from "../../hooks"
 
-const { trackShortcutHintTelemetryMock, markdownWithBoundaryMock } = vi.hoisted(() => ({
+const { trackShortcutHintTelemetryMock, markdownSnippetMock, markdownWithBoundaryMock } = vi.hoisted(() => ({
   trackShortcutHintTelemetryMock: vi.fn().mockResolvedValue(undefined),
+  markdownSnippetMock: vi.fn(({ content }: { content: string }) => (
+    <div data-testid="markdown-snippet">{content}</div>
+  )),
   markdownWithBoundaryMock: vi.fn(({ content }: { content: string }) => (
-    <div data-testid="markdown-boundary">{content}</div>
+    <div data-testid="markdown-with-boundary">{content}</div>
   ))
 }))
 
@@ -103,6 +106,7 @@ vi.mock("../../hooks", () => ({
 }))
 
 vi.mock("../../components", () => ({
+  FlashcardMarkdownSnippet: (props: { content: string }) => markdownSnippetMock(props),
   MarkdownWithBoundary: (props: { content: string }) => markdownWithBoundaryMock(props),
   FlashcardActionsMenu: () => <div />,
   FlashcardEditDrawer: () => null,
@@ -164,6 +168,7 @@ describe("ManageTab scheduling metadata visibility", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    markdownSnippetMock.mockClear()
     markdownWithBoundaryMock.mockClear()
     await clearSetting(FLASHCARDS_SHORTCUT_HINT_DENSITY_SETTING)
     vi.mocked(useDecksQuery).mockReturnValue({
@@ -279,7 +284,7 @@ describe("ManageTab scheduling metadata visibility", () => {
     )
 
     expect(
-      markdownWithBoundaryMock.mock.calls.some(
+      markdownSnippetMock.mock.calls.some(
         ([props]) => (props as { content?: string }).content === markdownFront
       )
     ).toBe(true)
@@ -303,7 +308,7 @@ describe("ManageTab scheduling metadata visibility", () => {
     expect(screen.getByText("Media #42")).toBeInTheDocument()
   }, 15000)
 
-  it("uses the markdown renderer for expanded front-and-answer previews", () => {
+  it("uses lightweight snippets in expanded rows and the full renderer for the answer preview", () => {
     const markdownFront = "## Heading"
     const markdownBack = "*Answer* details"
     vi.mocked(useManageQuery).mockReturnValue({
@@ -333,8 +338,13 @@ describe("ManageTab scheduling metadata visibility", () => {
     fireEvent.click(screen.getByTestId(`flashcard-item-${sampleCard.uuid}`))
 
     expect(
-      markdownWithBoundaryMock.mock.calls.some(
+      markdownSnippetMock.mock.calls.some(
         ([props]) => (props as { content?: string }).content === markdownFront
+      )
+    ).toBe(true)
+    expect(
+      markdownSnippetMock.mock.calls.some(
+        ([props]) => (props as { content?: string }).content === markdownBack
       )
     ).toBe(true)
     expect(

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
@@ -20,8 +20,11 @@ import {
   getManageServerOrderBy
 } from "../../hooks"
 
-const { trackShortcutHintTelemetryMock } = vi.hoisted(() => ({
-  trackShortcutHintTelemetryMock: vi.fn().mockResolvedValue(undefined)
+const { trackShortcutHintTelemetryMock, markdownWithBoundaryMock } = vi.hoisted(() => ({
+  trackShortcutHintTelemetryMock: vi.fn().mockResolvedValue(undefined),
+  markdownWithBoundaryMock: vi.fn(({ content }: { content: string }) => (
+    <div data-testid="markdown-boundary">{content}</div>
+  ))
 }))
 
 vi.mock("react-i18next", () => ({
@@ -100,7 +103,7 @@ vi.mock("../../hooks", () => ({
 }))
 
 vi.mock("../../components", () => ({
-  MarkdownWithBoundary: ({ content }: { content: string }) => <div>{content}</div>,
+  MarkdownWithBoundary: (props: { content: string }) => markdownWithBoundaryMock(props),
   FlashcardActionsMenu: () => <div />,
   FlashcardEditDrawer: () => null,
   FlashcardCreateDrawer: () => null
@@ -161,6 +164,7 @@ describe("ManageTab scheduling metadata visibility", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    markdownWithBoundaryMock.mockClear()
     await clearSetting(FLASHCARDS_SHORTCUT_HINT_DENSITY_SETTING)
     vi.mocked(useDecksQuery).mockReturnValue({
       data: [
@@ -250,6 +254,37 @@ describe("ManageTab scheduling metadata visibility", () => {
     expect(screen.getByText("Sort: Due date")).toBeInTheDocument()
   }, 15000)
 
+  it("uses the markdown renderer for compact flashcard snippets", () => {
+    const markdownFront = "**Important** concept"
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [
+          {
+            ...sampleCard,
+            front: markdownFront
+          }
+        ],
+        count: 1,
+        total: 1
+      },
+      isFetching: false
+    } as any)
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive
+      />
+    )
+
+    expect(
+      markdownWithBoundaryMock.mock.calls.some(
+        ([props]) => (props as { content?: string }).content === markdownFront
+      )
+    ).toBe(true)
+  })
+
   it("shows scheduling metadata in expanded list rows", () => {
     render(
       <ManageTab
@@ -267,6 +302,47 @@ describe("ManageTab scheduling metadata visibility", () => {
     expect(screen.getByText("Relearns 1")).toBeInTheDocument()
     expect(screen.getByText("Media #42")).toBeInTheDocument()
   }, 15000)
+
+  it("uses the markdown renderer for expanded front-and-answer previews", () => {
+    const markdownFront = "## Heading"
+    const markdownBack = "*Answer* details"
+    vi.mocked(useManageQuery).mockReturnValue({
+      data: {
+        items: [
+          {
+            ...sampleCard,
+            front: markdownFront,
+            back: markdownBack
+          }
+        ],
+        count: 1,
+        total: 1
+      },
+      isFetching: false
+    } as any)
+
+    render(
+      <ManageTab
+        onNavigateToImport={() => {}}
+        onReviewCard={() => {}}
+        isActive={false}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("flashcards-density-toggle"))
+    fireEvent.click(screen.getByTestId(`flashcard-item-${sampleCard.uuid}`))
+
+    expect(
+      markdownWithBoundaryMock.mock.calls.some(
+        ([props]) => (props as { content?: string }).content === markdownFront
+      )
+    ).toBe(true)
+    expect(
+      markdownWithBoundaryMock.mock.calls.some(
+        ([props]) => (props as { content?: string }).content === markdownBack
+      )
+    ).toBe(true)
+  })
 
   it("does not render source badges for manual cards", () => {
     vi.mocked(useManageQuery).mockReturnValue({
@@ -386,7 +462,7 @@ describe("ManageTab scheduling metadata visibility", () => {
             },
             {
               id: 9,
-              name: "Workspace Biology",
+              name: "Biology",
               description: "Scoped deck",
               workspace_id: "workspace-77",
               deleted: false,
@@ -432,18 +508,24 @@ describe("ManageTab scheduling metadata visibility", () => {
     )
 
     expect(screen.getByText("Deck 9")).toBeInTheDocument()
-    expect(screen.queryByText("Workspace Biology")).not.toBeInTheDocument()
+    expect(screen.queryByText("Biology · workspace-77")).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("checkbox", { name: /Show workspace decks/i }))
 
     await waitFor(() => {
-      expect(screen.getByText("Workspace Biology")).toBeInTheDocument()
+      expect(screen.getByText("Biology · workspace-77")).toBeInTheDocument()
     })
     expect(vi.mocked(useDecksQuery)).toHaveBeenLastCalledWith(
       expect.objectContaining({
         include_workspace_items: true
       })
     )
+
+    const deckSelect = within(
+      screen.getByTestId("flashcards-manage-deck-select")
+    ).getByRole("combobox")
+    fireEvent.mouseDown(deckSelect)
+    expect(screen.getAllByText("Biology · workspace-77").length).toBeGreaterThan(1)
   })
 
   it("filters decks and card queries to a selected workspace", async () => {

--- a/apps/packages/ui/src/components/Flashcards/utils/deck-display.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/deck-display.ts
@@ -1,0 +1,17 @@
+import type { Deck } from "@/services/flashcards"
+
+type DeckLabelInput = Pick<Deck, "name" | "workspace_id"> | null | undefined
+
+export const getDeckWorkspaceId = (deck: DeckLabelInput): string | null => {
+  const workspaceId = deck?.workspace_id?.trim()
+  return workspaceId ? workspaceId : null
+}
+
+export const formatDeckDisplayName = (
+  deck: DeckLabelInput,
+  fallbackName = "Untitled deck"
+): string => {
+  const baseName = deck?.name?.trim() || fallbackName
+  const workspaceId = getDeckWorkspaceId(deck)
+  return workspaceId ? `${baseName} · ${workspaceId}` : baseName
+}


### PR DESCRIPTION
## Summary
- render markdown in flashcard manage-row previews instead of showing raw markdown text
- format workspace deck labels consistently across manage, document-row, create, and edit surfaces
- add regression coverage for markdown preview rendering and workspace deck label visibility

## Test Plan
- `cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardDocumentRow.test.tsx ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.cloze-help.test.tsx ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.save.test.tsx ../packages/ui/src/components/Flashcards/components/__tests__/FlashcardEditDrawer.scheduling-metadata.test.tsx`
- `cd apps/extension && source ~/.nvm/nvm.sh && nvm use --lts >/dev/null && bun run build:chrome`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx apps/packages/ui/src/components/Flashcards/components/FlashcardDocumentRow.tsx apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx apps/packages/ui/src/components/Flashcards/components/FlashcardEditDrawer.tsx apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx apps/packages/ui/src/components/Flashcards/utils/deck-display.ts -f json -o /tmp/bandit_flashcards_preview_workspace_decks.json`
