### PR TITLE
fix(authnz): add missing admin CLI module docstrings

### DIFF
--- a/tldw_Server_API/app/core/AuthNZ/create_admin.py
+++ b/tldw_Server_API/app/core/AuthNZ/create_admin.py
@@ -7,7 +7,7 @@ not available. The command is idempotent: if an admin with the requested
 username already exists, it exits successfully without making changes.
 
 Usage:
-    python -m tldw_Server_API.app.core.AuthNZ.create_admin \
+    python -m tldw_Server_API.app.core.AuthNZ.create_admin \\
         --username myadmin --password 'S3cureP@ss!' [--email admin@example.com]
 """
 

--- a/tldw_Server_API/app/core/AuthNZ/create_admin.py
+++ b/tldw_Server_API/app/core/AuthNZ/create_admin.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-# create_admin.py
-# Description: Non-interactive CLI to create an initial admin user for multi-user mode.
-#
-# Designed to be called from Docker entrypoints or CI pipelines where interactive
-# input is not available. Idempotent: if an admin with the given username already
-# exists, the script exits successfully without making changes.
-#
-# Usage:
-#   python -m tldw_Server_API.app.core.AuthNZ.create_admin \
-#       --username myadmin --password 'S3cureP@ss!' [--email admin@example.com]
-#
+"""
+Non-interactive CLI for bootstrapping an initial admin user in multi-user mode.
+
+Designed for Docker entrypoints and CI environments where interactive input is
+not available. The command is idempotent: if an admin with the requested
+username already exists, it exits successfully without making changes.
+
+Usage:
+    python -m tldw_Server_API.app.core.AuthNZ.create_admin \
+        --username myadmin --password 'S3cureP@ss!' [--email admin@example.com]
+"""
 
 import argparse
 import asyncio

--- a/tldw_Server_API/app/core/AuthNZ/reset_admin_password.py
+++ b/tldw_Server_API/app/core/AuthNZ/reset_admin_password.py
@@ -6,7 +6,7 @@ This script works with both SQLite and PostgreSQL backends by using the same
 UsersDB abstraction as the rest of the AuthNZ subsystem.
 
 Usage:
-    python -m tldw_Server_API.app.core.AuthNZ.reset_admin_password \
+    python -m tldw_Server_API.app.core.AuthNZ.reset_admin_password \\
         --username admin --new-password 'N3wS3cure!'
 """
 

--- a/tldw_Server_API/app/core/AuthNZ/reset_admin_password.py
+++ b/tldw_Server_API/app/core/AuthNZ/reset_admin_password.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-# reset_admin_password.py
-# Description: CLI to reset an admin (or any) user's password in multi-user mode.
-#
-# Works with both SQLite and PostgreSQL backends by using the same UsersDB
-# abstraction as the rest of the AuthNZ subsystem.
-#
-# Usage:
-#   python -m tldw_Server_API.app.core.AuthNZ.reset_admin_password \
-#       --username admin --new-password 'N3wS3cure!'
-#
+"""
+CLI for resetting an admin or standard user's password in multi-user mode.
+
+This script works with both SQLite and PostgreSQL backends by using the same
+UsersDB abstraction as the rest of the AuthNZ subsystem.
+
+Usage:
+    python -m tldw_Server_API.app.core.AuthNZ.reset_admin_password \
+        --username admin --new-password 'N3wS3cure!'
+"""
 
 import argparse
 import asyncio

--- a/tldw_Server_API/tests/AuthNZ/unit/test_admin_cli_module_docstrings.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_admin_cli_module_docstrings.py
@@ -1,0 +1,32 @@
+"""
+Guardrail tests for AuthNZ admin CLI module docstrings.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_admin_cli_modules_define_module_docstrings() -> None:
+    project_root = Path(__file__).resolve().parents[3]
+    target_paths = (
+        project_root / "app" / "core" / "AuthNZ" / "create_admin.py",
+        project_root / "app" / "core" / "AuthNZ" / "reset_admin_password.py",
+    )
+
+    missing_docstrings: list[str] = []
+
+    for path in target_paths:
+        module_ast = ast.parse(path.read_text(encoding="utf-8"))
+        module_docstring = ast.get_docstring(module_ast, clean=False)
+        if not module_docstring or not module_docstring.strip():
+            missing_docstrings.append(path.relative_to(project_root).as_posix())
+
+    assert missing_docstrings == [], (  # nosec B101
+        "Expected AuthNZ admin CLI modules to define non-empty module docstrings: "
+        f"{missing_docstrings}"
+    )

--- a/tldw_Server_API/tests/AuthNZ/unit/test_admin_cli_module_docstrings.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_admin_cli_module_docstrings.py
@@ -10,17 +10,20 @@ from pathlib import Path
 import pytest
 
 
+_TARGET_MODULES = (
+    ("create_admin.py", "--username myadmin --password 'S3cureP@ss!' [--email admin@example.com]"),
+    ("reset_admin_password.py", "--username admin --new-password 'N3wS3cure!'"),
+)
+
+
 @pytest.mark.unit
 def test_admin_cli_modules_define_module_docstrings() -> None:
     project_root = Path(__file__).resolve().parents[3]
-    target_paths = (
-        project_root / "app" / "core" / "AuthNZ" / "create_admin.py",
-        project_root / "app" / "core" / "AuthNZ" / "reset_admin_password.py",
-    )
 
     missing_docstrings: list[str] = []
 
-    for path in target_paths:
+    for module_name, _ in _TARGET_MODULES:
+        path = project_root / "app" / "core" / "AuthNZ" / module_name
         module_ast = ast.parse(path.read_text(encoding="utf-8"))
         module_docstring = ast.get_docstring(module_ast, clean=False)
         if not module_docstring or not module_docstring.strip():
@@ -30,3 +33,23 @@ def test_admin_cli_modules_define_module_docstrings() -> None:
         "Expected AuthNZ admin CLI modules to define non-empty module docstrings: "
         f"{missing_docstrings}"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("module_name", "expected_args"), _TARGET_MODULES)
+def test_admin_cli_docstrings_preserve_multiline_usage_examples(
+    module_name: str,
+    expected_args: str,
+) -> None:
+    project_root = Path(__file__).resolve().parents[3]
+    path = project_root / "app" / "core" / "AuthNZ" / module_name
+
+    module_ast = ast.parse(path.read_text(encoding="utf-8"))
+    module_docstring = ast.get_docstring(module_ast, clean=False)
+    assert module_docstring is not None  # nosec B101
+
+    doc_lines = module_docstring.splitlines()
+    usage_index = doc_lines.index("Usage:")
+
+    assert doc_lines[usage_index + 1].rstrip().endswith("\\")  # nosec B101
+    assert doc_lines[usage_index + 2].strip() == expected_args  # nosec B101


### PR DESCRIPTION
## Summary
- replace header comments with proper module docstrings in the admin CLI modules
- add a regression test that fails if those module-level docstrings are removed again

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/AuthNZ/unit/test_admin_cli_module_docstrings.py -q
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/AuthNZ/create_admin.py tldw_Server_API/app/core/AuthNZ/reset_admin_password.py tldw_Server_API/tests/AuthNZ/unit/test_admin_cli_module_docstrings.py
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/AuthNZ/create_admin.py tldw_Server_API/app/core/AuthNZ/reset_admin_password.py tldw_Server_API/tests/AuthNZ/unit/test_admin_cli_module_docstrings.py -f json -o /tmp/bandit_authnz_module_docstrings_worktree.json