### PR TITLE
feat: FTUX Phase 1 — targeted friction fixes for first-time users

### DIFF
--- a/apps/packages/ui/src/assets/locale/en/option.json
+++ b/apps/packages/ui/src/assets/locale/en/option.json
@@ -1361,7 +1361,16 @@
   "moderationPlayground": {
     "nav": "Moderation Playground",
     "title": "Moderation Playground",
-    "subtitle": "Family safety controls and server guardrails in one place."
+    "subtitle": "Family safety controls and server guardrails in one place.",
+    "desc": "Content safety rules, blocklists, and testing",
+    "onboarding": {
+      "title": "Welcome to Content Controls",
+      "description": "Set up content safety rules to protect your family or enforce server guardrails.",
+      "guardrailsCta": "Set up Family Guardrails",
+      "dismiss": "Skip \u2014 I\u2019ll explore on my own",
+      "tabHint": "Start here: Policy & Settings tab sets your base rules. Then test them in the Test Sandbox.",
+      "startHereBadge": "Start here"
+    }
   },
   "repo2txt": {
     "nav": "Repo2Txt",

--- a/apps/packages/ui/src/assets/locale/en/tutorials.json
+++ b/apps/packages/ui/src/assets/locale/en/tutorials.json
@@ -204,6 +204,20 @@
       "quizContent": "Jump into Quiz mode from your selected deck to validate retention with assessments."
     }
   },
+  "moderation": {
+    "basics": {
+      "label": "Content Controls Basics",
+      "description": "Learn how to set up content safety rules, blocklists, and test moderation.",
+      "heroTitle": "Moderation Dashboard",
+      "heroContent": "This is your content safety hub. The status badge shows whether your server is connected.",
+      "policyTitle": "Policy & Settings",
+      "policyContent": "Start here. Set your base content safety policy — what categories to filter and how strictly.",
+      "blocklistTitle": "Blocklist Studio",
+      "blocklistContent": "Add specific words, phrases, or patterns you want to always block or flag.",
+      "testTitle": "Test Sandbox",
+      "testContent": "Try your rules in real time. Type a message and see whether it would be allowed or blocked."
+    }
+  },
   "worldBooks": {
     "basics": {
       "label": "World Books Basics",

--- a/apps/packages/ui/src/components/Common/FeatureEmptyState.tsx
+++ b/apps/packages/ui/src/components/Common/FeatureEmptyState.tsx
@@ -56,9 +56,9 @@ const FeatureEmptyState: React.FC<FeatureEmptyStateProps> = ({
           {title}
         </h2>
         {description && (
-          <p className="text-sm text-text-muted">
+          <div className="text-sm text-text-muted">
             {description}
-          </p>
+          </div>
         )}
         {examples && examples.length > 0 && (
           <div className="text-xs text-text-muted">

--- a/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
+++ b/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
@@ -163,13 +163,14 @@ export function HeaderShortcuts({
   /* ---------- match counts per category ---------- */
   const matchCounts = useMemo(() => {
     const queryFiltered = query
-      ? allItems.filter((ri) => {
+      ? (() => {
           const q = query.toLowerCase()
-          return (
-            ri.label.toLowerCase().includes(q) ||
-            (ri.description && ri.description.toLowerCase().includes(q))
+          return allItems.filter(
+            (ri) =>
+              ri.label.toLowerCase().includes(q) ||
+              (ri.description && ri.description.toLowerCase().includes(q))
           )
-        })
+        })()
       : allItems
     const counts: Record<string, number> = { [ALL_CATEGORY]: queryFiltered.length }
     for (const g of resolvedGroups) {

--- a/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
+++ b/apps/packages/ui/src/components/Layouts/HeaderShortcuts.tsx
@@ -31,6 +31,7 @@ const META_LABEL = isMac ? "\u2318" : "Ctrl+"
 type ResolvedItem = {
   item: HeaderShortcutItem
   label: string
+  description: string | null
   groupId: string
   groupTitle: string
 }
@@ -127,6 +128,9 @@ export function HeaderShortcuts({
           (item): ResolvedItem => ({
             item,
             label: t(item.labelKey, item.labelDefault),
+            description: item.descriptionKey
+              ? t(item.descriptionKey, item.descriptionDefault ?? "")
+              : item.descriptionDefault ?? null,
             groupId: group.id,
             groupTitle: t(group.titleKey, group.titleDefault)
           })
@@ -144,7 +148,11 @@ export function HeaderShortcuts({
     let items = allItems
     if (query) {
       const q = query.toLowerCase()
-      items = items.filter((ri) => ri.label.toLowerCase().includes(q))
+      items = items.filter(
+        (ri) =>
+          ri.label.toLowerCase().includes(q) ||
+          (ri.description && ri.description.toLowerCase().includes(q))
+      )
     }
     if (activeCategory !== ALL_CATEGORY) {
       items = items.filter((ri) => ri.groupId === activeCategory)
@@ -155,7 +163,13 @@ export function HeaderShortcuts({
   /* ---------- match counts per category ---------- */
   const matchCounts = useMemo(() => {
     const queryFiltered = query
-      ? allItems.filter((ri) => ri.label.toLowerCase().includes(query.toLowerCase()))
+      ? allItems.filter((ri) => {
+          const q = query.toLowerCase()
+          return (
+            ri.label.toLowerCase().includes(q) ||
+            (ri.description && ri.description.toLowerCase().includes(q))
+          )
+        })
       : allItems
     const counts: Record<string, number> = { [ALL_CATEGORY]: queryFiltered.length }
     for (const g of resolvedGroups) {
@@ -488,8 +502,13 @@ export function HeaderShortcuts({
                           >
                             <Icon className="size-4" aria-hidden="true" />
                           </span>
-                          <span className="min-w-0 flex-1 truncate">
-                            {ri.label}
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate">{ri.label}</span>
+                            {ri.description && (
+                              <span className="block truncate text-xs text-text-subtle/70">
+                                {ri.description}
+                              </span>
+                            )}
                           </span>
                           {ri.item.shortcutIndex != null && (
                             <kbd className="ml-auto shrink-0 rounded border border-border bg-surface2 px-1.5 py-0.5 text-xs text-text-subtle">
@@ -556,7 +575,14 @@ export function HeaderShortcuts({
                             )}
                           >
                             <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
-                            <span className="min-w-0 truncate">{ri.label}</span>
+                            <span className="min-w-0 flex-1">
+                              <span className="block truncate">{ri.label}</span>
+                              {ri.description && (
+                                <span className="block truncate text-xs text-text-subtle/70">
+                                  {ri.description}
+                                </span>
+                              )}
+                            </span>
                             {ri.item.shortcutIndex != null && (
                               <kbd className="ml-auto shrink-0 rounded border border-border bg-surface2 px-1 py-0 text-[10px] text-text-subtle sm:px-1.5 sm:py-0.5 sm:text-xs">
                                 {META_LABEL}

--- a/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-descriptions.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-descriptions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { getHeaderShortcutGroups } from "../header-shortcut-items"
+
+describe("header shortcut descriptions", () => {
+  const groups = getHeaderShortcutGroups()
+  const allItems = groups.flatMap((g) => g.items)
+
+  const JARGON_IDS = [
+    "stt-playground",
+    "tts-playground",
+    "knowledge-qa",
+    "chunking-playground",
+    "moderation-playground",
+    "acp-playground",
+    "chatbooks-playground",
+    "world-books",
+    "deep-research",
+    "workspace-playground",
+    "prompt-studio",
+    "model-playground",
+    "chat-dictionaries",
+    "evaluations",
+    "repo2txt"
+  ]
+
+  for (const id of JARGON_IDS) {
+    it(`item "${id}" has a descriptionDefault`, () => {
+      const item = allItems.find((i) => i.id === id)
+      expect(item).toBeDefined()
+      expect(item!.descriptionDefault).toBeTruthy()
+      expect(item!.descriptionDefault!.length).toBeGreaterThan(5)
+    })
+  }
+})

--- a/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-safety-group.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-safety-group.test.ts
@@ -28,10 +28,7 @@ describe("header shortcut safety group", () => {
 
   it("each safety item has a distinct icon", () => {
     const safety = groups.find((g) => g.id === "safety")!
-    const iconNames = safety.items.map(
-      (i) => i.icon.displayName || i.icon.name || String(i.icon)
-    )
-    const uniqueIcons = new Set(iconNames)
+    const uniqueIcons = new Set(safety.items.map((i) => i.icon))
     expect(uniqueIcons.size).toBe(safety.items.length)
   })
 })

--- a/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-safety-group.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-safety-group.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { getHeaderShortcutGroups } from "../header-shortcut-items"
+
+describe("header shortcut safety group", () => {
+  const groups = getHeaderShortcutGroups()
+
+  it("has a 'safety' group", () => {
+    const safety = groups.find((g) => g.id === "safety")
+    expect(safety).toBeDefined()
+    expect(safety!.titleDefault).toBe("Safety")
+  })
+
+  it("safety group contains family-guardrails, moderation-playground, and guardian", () => {
+    const safety = groups.find((g) => g.id === "safety")!
+    const ids = safety.items.map((i) => i.id)
+    expect(ids).toContain("family-guardrails")
+    expect(ids).toContain("moderation-playground")
+    expect(ids).toContain("guardian")
+  })
+
+  it("moderation-playground is no longer in the tools group", () => {
+    const tools = groups.find((g) => g.id === "tools")
+    if (tools) {
+      const ids = tools.items.map((i) => i.id)
+      expect(ids).not.toContain("moderation-playground")
+    }
+  })
+
+  it("each safety item has a distinct icon", () => {
+    const safety = groups.find((g) => g.id === "safety")!
+    const iconNames = safety.items.map(
+      (i) => i.icon.displayName || i.icon.name || String(i.icon)
+    )
+    const uniqueIcons = new Set(iconNames)
+    expect(uniqueIcons.size).toBe(safety.items.length)
+  })
+})

--- a/apps/packages/ui/src/components/Layouts/__tests__/settings-nav.guardian.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/settings-nav.guardian.test.ts
@@ -31,7 +31,6 @@ vi.mock("@/routes/route-registry", () => {
           group: "server",
           labelToken: "settings:familyGuardrailsWizardNav",
           icon: MockIcon,
-          beta: true,
           order: 2
         }
       },
@@ -42,7 +41,6 @@ vi.mock("@/routes/route-registry", () => {
           group: "server",
           labelToken: "settings:guardianNav",
           icon: MockIcon,
-          beta: true,
           order: 3
         }
       },
@@ -152,7 +150,7 @@ describe("settings nav guardian gating", () => {
       groups.flatMap((group) => group.items.map((item) => [item.to, item]))
     )
 
-    expect(byPath["/settings/guardian"]?.beta).toBe(true)
+    expect(byPath["/settings/guardian"]?.beta).toBeUndefined()
     expect(byPath["/settings/evaluations"]?.beta).toBeUndefined()
   })
 })
@@ -161,7 +159,7 @@ describe("settings announcement windows", () => {
   it("treats announcements as active before their window expires", () => {
     expect(
       isSettingsAnnouncementBadgeActive(
-        "/settings/guardian",
+        "/settings/prompt-studio",
         new Date("2026-06-01T00:00:00Z")
       )
     ).toBe(true)
@@ -170,8 +168,23 @@ describe("settings announcement windows", () => {
   it("expires announcements after their window closes", () => {
     expect(
       isSettingsAnnouncementBadgeActive(
-        "/settings/guardian",
+        "/settings/prompt-studio",
         new Date("2027-01-01T00:00:00Z")
+      )
+    ).toBe(false)
+  })
+
+  it("guardian and family-guardrails no longer have announcement windows", () => {
+    expect(
+      isSettingsAnnouncementBadgeActive(
+        "/settings/guardian",
+        new Date("2026-06-01T00:00:00Z")
+      )
+    ).toBe(false)
+    expect(
+      isSettingsAnnouncementBadgeActive(
+        "/settings/family-guardrails",
+        new Date("2026-06-01T00:00:00Z")
       )
     ).toBe(false)
   })

--- a/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
+++ b/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
@@ -8,6 +8,7 @@ import {
   ClipboardList,
   CogIcon,
   CombineIcon,
+  Eye,
   FileSearch,
   FileText,
   FlaskConical,
@@ -29,6 +30,7 @@ import {
   SquarePen,
   StickyNote,
   UserCircle2,
+  Users,
   Volume2,
   Table2,
   Workflow,
@@ -46,6 +48,9 @@ export type HeaderShortcutItem = {
   labelDefault: string
   /** Optional 1-9 index for ⌘+number shortcut when the launcher is open */
   shortcutIndex?: number
+  /** Optional plain-language description for non-technical users */
+  descriptionKey?: string
+  descriptionDefault?: string
 }
 
 export type HeaderShortcutGroup = {
@@ -91,7 +96,9 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         icon: BookMarked,
         labelKey: "option:header.modeDictionaries",
         labelDefault: "Chat Dictionaries",
-        shortcutIndex: 5
+        shortcutIndex: 5,
+        descriptionKey: "option:header.modeDictionariesDesc",
+        descriptionDefault: "Custom word lists for pronunciation and spelling"
       },
       {
         id: "world-books",
@@ -99,14 +106,18 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         icon: BookOpen,
         labelKey: "option:header.modeWorldBooks",
         labelDefault: "World Books",
-        shortcutIndex: 6
+        shortcutIndex: 6,
+        descriptionKey: "option:header.modeWorldBooksDesc",
+        descriptionDefault: "Shared lore and context injected into character chats"
       },
       {
         id: "model-playground",
         to: "/model-playground",
         icon: FlaskConical,
         labelKey: "settings:modelPlaygroundNav",
-        labelDefault: "Model Playground"
+        labelDefault: "Model Playground",
+        descriptionKey: "settings:modelPlaygroundDesc",
+        descriptionDefault: "Compare model outputs side by side"
       }
     ]
   },
@@ -121,14 +132,18 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         icon: NotebookPen,
         labelKey: "option:header.modePromptStudio",
         labelDefault: "Prompt Studio",
-        shortcutIndex: 3
+        shortcutIndex: 3,
+        descriptionKey: "option:header.modePromptStudioDesc",
+        descriptionDefault: "Design, test, and optimize prompts across models"
       },
       {
         id: "deep-research",
         to: "/research",
         icon: BrainCircuit,
         labelKey: "option:header.deepResearch",
-        labelDefault: "Deep Research"
+        labelDefault: "Deep Research",
+        descriptionKey: "option:header.deepResearchDesc",
+        descriptionDefault: "Long-running research with citations and checkpoints"
       },
       {
         id: "workspace-playground",
@@ -136,7 +151,9 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         icon: GitCompare,
         labelKey: "settings:researchStudioNav",
         labelDefault: "Research Studio",
-        shortcutIndex: 7
+        shortcutIndex: 7,
+        descriptionKey: "settings:researchStudioDesc",
+        descriptionDefault: "Three-pane workspace: sources, chat, and generated outputs"
       },
       {
         id: "knowledge-qa",
@@ -144,7 +161,9 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         icon: CombineIcon,
         labelKey: "option:header.modeKnowledge",
         labelDefault: "Knowledge QA",
-        shortcutIndex: 8
+        shortcutIndex: 8,
+        descriptionKey: "option:header.modeKnowledgeDesc",
+        descriptionDefault: "Search your ingested documents and get cited answers"
       },
       {
         id: "document-workspace",
@@ -158,14 +177,18 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         to: REPO2TXT_PATH,
         icon: FileText,
         labelKey: "option:repo2txt.nav",
-        labelDefault: "Repo2Txt"
+        labelDefault: "Repo2Txt",
+        descriptionKey: "option:repo2txt.desc",
+        descriptionDefault: "Convert code repositories into text for ingestion"
       },
       {
         id: "evaluations",
         to: "/evaluations",
         icon: Microscope,
         labelKey: "option:header.evaluations",
-        labelDefault: "Evaluations"
+        labelDefault: "Evaluations",
+        descriptionKey: "option:header.evaluationsDesc",
+        descriptionDefault: "Score and benchmark model quality with automated tests"
       }
     ]
   },
@@ -213,6 +236,40 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
     ]
   },
   {
+    id: "safety",
+    titleKey: "option:header.groupSafety",
+    titleDefault: "Safety",
+    items: [
+      {
+        id: "family-guardrails",
+        to: "/settings/family-guardrails",
+        icon: Users,
+        labelKey: "settings:familyGuardrailsWizardNav",
+        labelDefault: "Family Guardrails",
+        descriptionKey: "settings:familyGuardrailsWizardDesc",
+        descriptionDefault: "Set up family profiles, safety templates, and invite guardians"
+      },
+      {
+        id: "moderation-playground",
+        to: "/moderation-playground",
+        icon: ShieldCheck,
+        labelKey: "option:moderationPlayground.nav",
+        labelDefault: "Content Controls",
+        descriptionKey: "option:moderationPlayground.desc",
+        descriptionDefault: "Content safety rules, blocklists, and testing"
+      },
+      {
+        id: "guardian",
+        to: "/settings/guardian",
+        icon: Eye,
+        labelKey: "settings:guardianNav",
+        labelDefault: "Guardian",
+        descriptionKey: "settings:guardianDesc",
+        descriptionDefault: "Monitor and manage dependent account activity"
+      }
+    ]
+  },
+  {
     id: "creation",
     titleKey: "option:header.groupCreationWorkspace",
     titleDefault: "Creation",
@@ -236,14 +293,18 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         to: "/stt",
         icon: Mic,
         labelKey: "option:header.modeStt",
-        labelDefault: "STT Playground"
+        labelDefault: "STT Playground",
+        descriptionKey: "option:header.modeSttDesc",
+        descriptionDefault: "Speech to Text \u2014 transcribe audio and video"
       },
       {
         id: "tts-playground",
         to: "/tts",
         icon: Volume2,
         labelKey: "option:tts.playground",
-        labelDefault: "TTS Playground"
+        labelDefault: "TTS Playground",
+        descriptionKey: "option:header.modeTtsDesc",
+        descriptionDefault: "Text to Speech \u2014 generate spoken audio from text"
       },
       {
         id: "audiobook-studio",
@@ -320,7 +381,9 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         to: "/acp-playground",
         icon: Bot,
         labelKey: "option:header.acpPlayground",
-        labelDefault: "ACP Playground"
+        labelDefault: "ACP Playground",
+        descriptionKey: "option:header.acpPlaygroundDesc",
+        descriptionDefault: "Agent Client Protocol \u2014 run and manage AI agents"
       },
       {
         id: "skills",
@@ -341,21 +404,18 @@ const BASE_HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         to: "/chatbooks",
         icon: BookOpen,
         labelKey: "option:header.chatbooksPlayground",
-        labelDefault: "Chatbooks Playground"
+        labelDefault: "Chatbooks Playground",
+        descriptionKey: "option:header.chatbooksPlaygroundDesc",
+        descriptionDefault: "Export and import chat sessions as portable bundles"
       },
       {
         id: "chunking-playground",
         to: "/chunking-playground",
         icon: Scissors,
         labelKey: "settings:chunkingPlayground.nav",
-        labelDefault: "Chunking Playground"
-      },
-      {
-        id: "moderation-playground",
-        to: "/moderation-playground",
-        icon: ShieldCheck,
-        labelKey: "option:moderationPlayground.nav",
-        labelDefault: "Moderation Playground"
+        labelDefault: "Chunking Playground",
+        descriptionKey: "settings:chunkingPlayground.desc",
+        descriptionDefault: "Split documents into searchable segments"
       }
     ]
   },

--- a/apps/packages/ui/src/components/Layouts/settings-nav-config.ts
+++ b/apps/packages/ui/src/components/Layouts/settings-nav-config.ts
@@ -8,6 +8,7 @@ import {
   BrainCircuitIcon,
   ClipboardList,
   CombineIcon,
+  Eye,
   FlaskConical,
   ImageIcon,
   InfoIcon,
@@ -20,6 +21,7 @@ import {
   ShieldCheck,
   SlidersHorizontal,
   Sparkles,
+  Users,
 } from "lucide-react"
 
 export type NavGroupKey = "server" | "knowledge" | "workspace" | "about"
@@ -208,16 +210,14 @@ export const SETTINGS_ROUTE_NAV_ITEMS: SettingsNavRouteMeta[] = [
     path: "/settings/family-guardrails",
     group: "server",
     labelToken: "settings:familyGuardrailsWizardNav",
-    icon: ShieldCheck,
-    order: 8,
-    beta: true
+    icon: Users,
+    order: 8
   },
   {
     path: "/settings/guardian",
     group: "server",
     labelToken: "settings:guardianNav",
-    icon: ShieldCheck,
-    order: 9,
-    beta: true
+    icon: Eye,
+    order: 9
   }
 ]

--- a/apps/packages/ui/src/components/Layouts/settings-nav.ts
+++ b/apps/packages/ui/src/components/Layouts/settings-nav.ts
@@ -29,8 +29,6 @@ const NAV_GROUPS: Array<{ key: NavGroupKey; titleToken: string }> = [
 type NavItemWithOrder = SettingsNavItem & { order: number }
 
 const SETTINGS_BETA_BADGE_WINDOWS: Record<string, string> = {
-  "/settings/family-guardrails": "2026-12-31",
-  "/settings/guardian": "2026-12-31",
   "/settings/prompt-studio": "2026-09-30"
 }
 

--- a/apps/packages/ui/src/components/Option/ModerationPlayground/ModerationPlaygroundShell.tsx
+++ b/apps/packages/ui/src/components/Option/ModerationPlayground/ModerationPlaygroundShell.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { message } from "antd"
+import { message, Skeleton } from "antd"
 import { useNavigate } from "react-router-dom"
 import { useServerOnline } from "@/hooks/useServerOnline"
 import { useConnectionUxState } from "@/hooks/useConnectionState"
@@ -12,6 +12,7 @@ import { useBlocklist } from "./hooks/useBlocklist"
 import { useUserOverrides } from "./hooks/useUserOverrides"
 import { useModerationTest } from "./hooks/useModerationTest"
 import { ONBOARDING_KEY, getErrorStatus } from "./moderation-utils"
+import { useTutorialStore } from "@/store/tutorials"
 
 // Lazy panel imports — replace with real components in Tasks 5-9
 const PolicySettingsPanel = React.lazy(() => import("./PolicySettingsPanel"))
@@ -50,6 +51,8 @@ export const ModerationPlaygroundShell: React.FC = () => {
   const { uxState } = useConnectionUxState()
   const [messageApi, contextHolder] = message.useMessage()
   const [activeTab, setActiveTab] = React.useState<TabKey>("policy")
+  const startTutorial = useTutorialStore((s) => s.startTutorial)
+  const tutorialInitializedRef = React.useRef(false)
 
   const ctx = useModerationContext()
   const settings = useModerationSettings(ctx.activeUserId)
@@ -95,6 +98,22 @@ export const ModerationPlaygroundShell: React.FC = () => {
     return () => window.removeEventListener("keydown", handleKey)
   }, [settings, overrides, messageApi])
 
+  // Auto-start tutorial on first visit
+  React.useEffect(() => {
+    if (tutorialInitializedRef.current) return
+    if (hasPermissionError) return
+    tutorialInitializedRef.current = true
+    if (typeof window === "undefined") return
+    try {
+      const dismissed = window.localStorage.getItem(ONBOARDING_KEY)
+      if (!dismissed) {
+        startTutorial("moderation-basics")
+      }
+    } catch {
+      // On storage error, skip tutorial
+    }
+  }, [hasPermissionError, startTutorial])
+
   // beforeunload warning
   React.useEffect(() => {
     if (!hasUnsavedChanges) return
@@ -137,31 +156,31 @@ export const ModerationPlaygroundShell: React.FC = () => {
     switch (activeTab) {
       case "policy":
         return (
-          <React.Suspense fallback={<div className="py-8 text-center text-text-muted">Loading...</div>}>
+          <React.Suspense fallback={<div className="px-4 py-8"><Skeleton active paragraph={{ rows: 4 }} /></div>}>
             <PolicySettingsPanel settings={settings} messageApi={messageApi} />
           </React.Suspense>
         )
       case "blocklist":
         return (
-          <React.Suspense fallback={<div className="py-8 text-center text-text-muted">Loading...</div>}>
+          <React.Suspense fallback={<div className="px-4 py-8"><Skeleton active paragraph={{ rows: 4 }} /></div>}>
             <BlocklistStudioPanel blocklist={blocklist} messageApi={messageApi} />
           </React.Suspense>
         )
       case "overrides":
         return (
-          <React.Suspense fallback={<div className="py-8 text-center text-text-muted">Loading...</div>}>
+          <React.Suspense fallback={<div className="px-4 py-8"><Skeleton active paragraph={{ rows: 4 }} /></div>}>
             <UserOverridesPanel ctx={ctx} overrides={overrides} messageApi={messageApi} />
           </React.Suspense>
         )
       case "test":
         return (
-          <React.Suspense fallback={<div className="py-8 text-center text-text-muted">Loading...</div>}>
+          <React.Suspense fallback={<div className="px-4 py-8"><Skeleton active paragraph={{ rows: 4 }} /></div>}>
             <TestSandboxPanel tester={tester} messageApi={messageApi} />
           </React.Suspense>
         )
       case "advanced":
         return (
-          <React.Suspense fallback={<div className="py-8 text-center text-text-muted">Loading...</div>}>
+          <React.Suspense fallback={<div className="px-4 py-8"><Skeleton active paragraph={{ rows: 4 }} /></div>}>
             <AdvancedPanel
               settings={settings}
               blocklist={blocklist}
@@ -247,23 +266,47 @@ export const ModerationPlaygroundShell: React.FC = () => {
       {!hasPermissionError && <>
       {/* Onboarding */}
       {showOnboarding && (
-        <div className="mx-4 sm:mx-6 lg:mx-8 mb-4 p-4 border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-          <p className="text-sm font-medium">Welcome to Moderation Playground</p>
-          <p className="text-sm text-text-muted mt-1">
-            Configure content safety rules, test them live, and manage per-user overrides.
+        <div className="mx-4 sm:mx-6 lg:mx-8 mb-4 p-5 border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 rounded-xl">
+          <p className="text-base font-semibold">
+            {t("option:moderationPlayground.onboarding.title", "Welcome to Content Controls")}
           </p>
-          <button
-            type="button"
-            onClick={dismissOnboarding}
-            className="text-sm text-blue-600 hover:underline mt-2"
-          >
-            Got it, let&apos;s start
-          </button>
+          <p className="text-sm text-text-muted mt-1">
+            {t(
+              "option:moderationPlayground.onboarding.description",
+              "Set up content safety rules to protect your family or enforce server guardrails."
+            )}
+          </p>
+
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+            <button
+              type="button"
+              data-testid="moderation-family-guardrails-link"
+              onClick={() => navigate("/settings/family-guardrails")}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              {t("option:moderationPlayground.onboarding.guardrailsCta", "Set up Family Guardrails")}
+            </button>
+            <button
+              type="button"
+              onClick={dismissOnboarding}
+              className="text-sm text-text-muted hover:text-text transition"
+            >
+              {t("option:moderationPlayground.onboarding.dismiss", "Skip \u2014 I\u2019ll explore on my own")}
+            </button>
+          </div>
+
+          <p className="mt-3 text-xs text-text-muted">
+            {t(
+              "option:moderationPlayground.onboarding.tabHint",
+              "Start here: Policy & Settings tab sets your base rules. Then test them in the Test Sandbox."
+            )}
+          </p>
         </div>
       )}
 
       {/* Hero */}
       <div
+        data-testid="moderation-hero"
         className="relative overflow-hidden rounded-[28px] mx-4 sm:mx-6 lg:mx-8 p-6 sm:p-8 text-text"
         style={HERO_STYLE}
       >
@@ -320,6 +363,7 @@ export const ModerationPlaygroundShell: React.FC = () => {
           {TABS.map((tab) => (
             <button
               key={tab.key}
+              data-testid={`moderation-tab-${tab.key}`}
               role="tab"
               aria-selected={activeTab === tab.key}
               onClick={() => setActiveTab(tab.key)}
@@ -333,6 +377,11 @@ export const ModerationPlaygroundShell: React.FC = () => {
               `}
             >
               {tab.label}
+              {tab.key === "policy" && showOnboarding && (
+                <span className="ml-1.5 rounded bg-blue-100 dark:bg-blue-900/40 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:text-blue-300">
+                  Start here
+                </span>
+              )}
             </button>
           ))}
         </div>

--- a/apps/packages/ui/src/components/Option/ModerationPlayground/ModerationPlaygroundShell.tsx
+++ b/apps/packages/ui/src/components/Option/ModerationPlayground/ModerationPlaygroundShell.tsx
@@ -52,6 +52,7 @@ export const ModerationPlaygroundShell: React.FC = () => {
   const [messageApi, contextHolder] = message.useMessage()
   const [activeTab, setActiveTab] = React.useState<TabKey>("policy")
   const startTutorial = useTutorialStore((s) => s.startTutorial)
+  const isTutorialCompleted = useTutorialStore((s) => s.isCompleted)
   const tutorialInitializedRef = React.useRef(false)
 
   const ctx = useModerationContext()
@@ -104,15 +105,16 @@ export const ModerationPlaygroundShell: React.FC = () => {
     if (hasPermissionError) return
     tutorialInitializedRef.current = true
     if (typeof window === "undefined") return
+    if (isTutorialCompleted("moderation-basics")) return
     try {
       const dismissed = window.localStorage.getItem(ONBOARDING_KEY)
       if (!dismissed) {
         startTutorial("moderation-basics")
       }
-    } catch {
-      // On storage error, skip tutorial
+    } catch (err) {
+      console.debug("[ModerationPlayground] localStorage unavailable, skipping tutorial auto-start", err)
     }
-  }, [hasPermissionError, startTutorial])
+  }, [hasPermissionError, startTutorial, isTutorialCompleted])
 
   // beforeunload warning
   React.useEffect(() => {

--- a/apps/packages/ui/src/components/Option/ModerationPlayground/ModerationPlaygroundShell.tsx
+++ b/apps/packages/ui/src/components/Option/ModerationPlayground/ModerationPlaygroundShell.tsx
@@ -379,7 +379,7 @@ export const ModerationPlaygroundShell: React.FC = () => {
               {tab.label}
               {tab.key === "policy" && showOnboarding && (
                 <span className="ml-1.5 rounded bg-blue-100 dark:bg-blue-900/40 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:text-blue-300">
-                  Start here
+                  {t("option:moderationPlayground.onboarding.startHereBadge", "Start here")}
                 </span>
               )}
             </button>

--- a/apps/packages/ui/src/components/Option/ModerationPlayground/__tests__/ModerationPlaygroundShell.onboarding-card.test.ts
+++ b/apps/packages/ui/src/components/Option/ModerationPlayground/__tests__/ModerationPlaygroundShell.onboarding-card.test.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const readShellSource = () =>
+  fs.readFileSync(
+    path.resolve(__dirname, "..", "ModerationPlaygroundShell.tsx"),
+    "utf8"
+  )
+
+describe("ModerationPlaygroundShell onboarding card", () => {
+  it("links to the Family Guardrails Wizard", () => {
+    const source = readShellSource()
+    expect(source).toContain("/settings/family-guardrails")
+  })
+
+  it("has a data-testid for the family guardrails link", () => {
+    const source = readShellSource()
+    expect(source).toContain('data-testid="moderation-family-guardrails-link"')
+  })
+
+  it("shows recommended tab order guidance", () => {
+    const source = readShellSource()
+    expect(source).toContain("Start here")
+  })
+
+  it("uses i18n for onboarding text", () => {
+    const source = readShellSource()
+    expect(source).toContain("moderationPlayground.onboarding.title")
+    expect(source).toContain("moderationPlayground.onboarding.guardrailsCta")
+  })
+})

--- a/apps/packages/ui/src/components/Option/ModerationPlayground/__tests__/ModerationPlaygroundShell.skeleton.test.ts
+++ b/apps/packages/ui/src/components/Option/ModerationPlayground/__tests__/ModerationPlaygroundShell.skeleton.test.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const readShellSource = () =>
+  fs.readFileSync(
+    path.resolve(__dirname, "..", "ModerationPlaygroundShell.tsx"),
+    "utf8"
+  )
+
+describe("ModerationPlaygroundShell skeleton loaders", () => {
+  it("uses Skeleton component instead of plain Loading text in Suspense fallbacks", () => {
+    const source = readShellSource()
+    expect(source).toContain("Skeleton")
+    // Should NOT have bare "Loading..." text in fallbacks
+    const fallbackMatches = source.match(/fallback=\{<div[^>]*>Loading\.\.\.<\/div>\}/g)
+    expect(fallbackMatches).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/components/Option/ModerationPlayground/__tests__/ModerationPlaygroundShell.tutorial.test.ts
+++ b/apps/packages/ui/src/components/Option/ModerationPlayground/__tests__/ModerationPlaygroundShell.tutorial.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const readShellSource = () =>
+  fs.readFileSync(
+    path.resolve(__dirname, "..", "ModerationPlaygroundShell.tsx"),
+    "utf8"
+  )
+
+describe("ModerationPlaygroundShell tutorial integration", () => {
+  it("calls startTutorial with moderation-basics", () => {
+    const source = readShellSource()
+    expect(source).toContain('startTutorial("moderation-basics")')
+  })
+
+  it("imports useTutorialStore", () => {
+    const source = readShellSource()
+    expect(source).toContain("useTutorialStore")
+  })
+
+  it("has data-testid on hero section", () => {
+    const source = readShellSource()
+    expect(source).toContain('data-testid="moderation-hero"')
+  })
+
+  it("has data-testid on tab buttons", () => {
+    const source = readShellSource()
+    expect(source).toContain("data-testid={`moderation-tab-${tab.key}`}")
+  })
+})
+
+describe("moderation tutorial in registry", () => {
+  it("registry imports moderation tutorials", () => {
+    const registrySource = fs.readFileSync(
+      path.resolve(__dirname, "../../../../tutorials/registry.ts"),
+      "utf8"
+    )
+    expect(registrySource).toContain("moderationTutorials")
+    expect(registrySource).toContain("...moderationTutorials")
+  })
+})

--- a/apps/packages/ui/src/components/Option/ModerationPlayground/__tests__/ModerationPlaygroundShell.tutorial.test.ts
+++ b/apps/packages/ui/src/components/Option/ModerationPlayground/__tests__/ModerationPlaygroundShell.tutorial.test.ts
@@ -19,6 +19,11 @@ describe("ModerationPlaygroundShell tutorial integration", () => {
     expect(source).toContain("useTutorialStore")
   })
 
+  it("checks tutorial completion before auto-starting", () => {
+    const source = readShellSource()
+    expect(source).toContain('isTutorialCompleted("moderation-basics")')
+  })
+
   it("has data-testid on hero section", () => {
     const source = readShellSource()
     expect(source).toContain('data-testid="moderation-hero"')

--- a/apps/packages/ui/src/components/Option/Onboarding/OnboardingConnectForm.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/OnboardingConnectForm.tsx
@@ -18,6 +18,9 @@ import {
   Sparkles,
   ArrowRight,
   RefreshCw,
+  MessageSquare,
+  Shield,
+  BookOpen,
 } from "lucide-react"
 import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
@@ -929,6 +932,56 @@ export function OnboardingConnectForm({ onFinish }: Props) {
                   "Follow this sequence to complete your first-value loop: ingest -> verify -> ask."
                 )}
           </p>
+        </div>
+
+        {/* Intent selector — route to persona-appropriate next step */}
+        <div data-testid="intent-selector" className="mb-6">
+          <p className="mb-3 text-sm font-medium text-text-muted">
+            {t("settings:onboarding.success.intentTitle", "What would you like to do first?")}
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <button
+              type="button"
+              onClick={handleOpenChatFlow}
+              className="flex flex-col items-start gap-2 rounded-xl border border-border/60 bg-surface2/30 p-4 text-left transition-colors hover:border-primary/50 hover:bg-surface2"
+            >
+              <MessageSquare className="h-5 w-5 text-primary" />
+              <span className="text-sm font-medium text-text">
+                {t("settings:onboarding.success.intentChat", "Chat with AI")}
+              </span>
+              <span className="text-xs text-text-muted">
+                {t("settings:onboarding.success.intentChatDesc", "Start a conversation with your configured models.")}
+              </span>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => finishAndNavigate("/settings/family-guardrails")}
+              className="flex flex-col items-start gap-2 rounded-xl border border-border/60 bg-surface2/30 p-4 text-left transition-colors hover:border-primary/50 hover:bg-surface2"
+            >
+              <Shield className="h-5 w-5 text-primary" />
+              <span className="text-sm font-medium text-text">
+                {t("settings:onboarding.success.intentFamily", "Set up family safety")}
+              </span>
+              <span className="text-xs text-text-muted">
+                {t("settings:onboarding.success.intentFamilyDesc", "Create family profiles and content safety rules.")}
+              </span>
+            </button>
+
+            <button
+              type="button"
+              onClick={handleOpenIngestFlow}
+              className="flex flex-col items-start gap-2 rounded-xl border border-border/60 bg-surface2/30 p-4 text-left transition-colors hover:border-primary/50 hover:bg-surface2"
+            >
+              <BookOpen className="h-5 w-5 text-primary" />
+              <span className="text-sm font-medium text-text">
+                {t("settings:onboarding.success.intentResearch", "Research my documents")}
+              </span>
+              <span className="text-xs text-text-muted">
+                {t("settings:onboarding.success.intentResearchDesc", "Import documents and ask questions about them.")}
+              </span>
+            </button>
+          </div>
         </div>
 
         <div className="mb-6 rounded-2xl border border-border/70 bg-surface p-4">

--- a/apps/packages/ui/src/components/Option/Onboarding/OnboardingConnectForm.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/OnboardingConnectForm.tsx
@@ -836,6 +836,10 @@ export function OnboardingConnectForm({ onFinish }: Props) {
     await finishAndNavigate("/settings/tldw")
   }, [finishAndNavigate])
 
+  const handleOpenFamilyFlow = useCallback(async () => {
+    await finishAndNavigate("/settings/family-guardrails")
+  }, [finishAndNavigate])
+
   // Copy server command
   const handleCopyCommand = useCallback(
     (cmd: string) => {
@@ -956,7 +960,7 @@ export function OnboardingConnectForm({ onFinish }: Props) {
 
             <button
               type="button"
-              onClick={() => finishAndNavigate("/settings/family-guardrails")}
+              onClick={handleOpenFamilyFlow}
               className="flex flex-col items-start gap-2 rounded-xl border border-border/60 bg-surface2/30 p-4 text-left transition-colors hover:border-primary/50 hover:bg-surface2"
             >
               <Shield className="h-5 w-5 text-primary" />

--- a/apps/packages/ui/src/components/Option/Onboarding/OnboardingConnectForm.tsx
+++ b/apps/packages/ui/src/components/Option/Onboarding/OnboardingConnectForm.tsx
@@ -40,6 +40,7 @@ import {
   useConnectionState,
   useConnectionActions,
 } from "@/hooks/useConnectionState"
+import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { useConnectionStore } from "@/store/connection"
 import { useDemoMode } from "@/context/demo-mode"
 import { requestQuickIngestIntro } from "@/utils/quick-ingest-open"
@@ -187,6 +188,8 @@ export function OnboardingConnectForm({ onFinish }: Props) {
   const { t } = useTranslation(["settings", "common"])
   const navigate = useNavigate()
   const { setDemoEnabled } = useDemoMode()
+  const { capabilities } = useServerCapabilities()
+  const familyGuardrailsAvailable = Boolean(capabilities?.hasGuardian)
   const connectionState = useConnectionState()
   const actions = useConnectionActions()
   const hostPermissionPromptKeyRef = useRef<string | null>(null)
@@ -961,14 +964,22 @@ export function OnboardingConnectForm({ onFinish }: Props) {
             <button
               type="button"
               onClick={handleOpenFamilyFlow}
-              className="flex flex-col items-start gap-2 rounded-xl border border-border/60 bg-surface2/30 p-4 text-left transition-colors hover:border-primary/50 hover:bg-surface2"
+              disabled={!familyGuardrailsAvailable}
+              className={cn(
+                "flex flex-col items-start gap-2 rounded-xl border border-border/60 bg-surface2/30 p-4 text-left transition-colors",
+                familyGuardrailsAvailable
+                  ? "hover:border-primary/50 hover:bg-surface2"
+                  : "opacity-50 cursor-not-allowed"
+              )}
             >
-              <Shield className="h-5 w-5 text-primary" />
+              <Shield className={cn("h-5 w-5", familyGuardrailsAvailable ? "text-primary" : "text-text-subtle")} />
               <span className="text-sm font-medium text-text">
                 {t("settings:onboarding.success.intentFamily", "Set up family safety")}
               </span>
               <span className="text-xs text-text-muted">
-                {t("settings:onboarding.success.intentFamilyDesc", "Create family profiles and content safety rules.")}
+                {familyGuardrailsAvailable
+                  ? t("settings:onboarding.success.intentFamilyDesc", "Create family profiles and content safety rules.")
+                  : t("settings:onboarding.success.intentFamilyUnavailable", "Not available on this server.")}
               </span>
             </button>
 

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/OnboardingConnectForm.success-screen.guard.test.ts
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/OnboardingConnectForm.success-screen.guard.test.ts
@@ -20,6 +20,7 @@ describe("OnboardingConnectForm success screen guards", () => {
     expect(source).toContain("handleOpenMediaFlow")
     expect(source).toContain("handleOpenChatFlow")
     expect(source).toContain("handleOpenSettingsFlow")
+    expect(source).toContain("handleOpenFamilyFlow")
   })
 
   it("includes provider and model selector on success screen", () => {

--- a/apps/packages/ui/src/components/Option/Onboarding/__tests__/OnboardingConnectForm.success-screen.guard.test.ts
+++ b/apps/packages/ui/src/components/Option/Onboarding/__tests__/OnboardingConnectForm.success-screen.guard.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const readOnboardingSource = () =>
+  fs.readFileSync(
+    path.resolve(__dirname, "..", "OnboardingConnectForm.tsx"),
+    "utf8"
+  )
+
+describe("OnboardingConnectForm success screen guards", () => {
+  it("renders a success screen container with data-testid", () => {
+    const source = readOnboardingSource()
+    expect(source).toContain('data-testid="onboarding-success-screen"')
+  })
+
+  it("has ingest, media, chat, and settings action handlers", () => {
+    const source = readOnboardingSource()
+    expect(source).toContain("handleOpenIngestFlow")
+    expect(source).toContain("handleOpenMediaFlow")
+    expect(source).toContain("handleOpenChatFlow")
+    expect(source).toContain("handleOpenSettingsFlow")
+  })
+
+  it("includes provider and model selector on success screen", () => {
+    const source = readOnboardingSource()
+    expect(source).toContain("Set your defaults")
+  })
+
+  it("shows showSuccess state to gate the success screen", () => {
+    const source = readOnboardingSource()
+    expect(source).toContain("showSuccess")
+  })
+
+  it("includes intent selector cards on the success screen", () => {
+    const source = readOnboardingSource()
+    expect(source).toContain('data-testid="intent-selector"')
+    expect(source).toContain("/settings/family-guardrails")
+    expect(source).toContain("intentChat")
+    expect(source).toContain("intentFamily")
+    expect(source).toContain("intentResearch")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundEmpty.tsx
@@ -146,10 +146,23 @@ export const PlaygroundEmpty = () => {
                   "You're in demo mode — try asking a question to see how the assistant responds. You can connect your own tldw server later."
               })
             : !isConnected
-              ? t("playground:empty.disconnectedDescription", {
-                  defaultValue:
-                    "Connect to a tldw server to start chatting. Go to Settings to configure your connection."
-                })
+              ? (
+                  <>
+                    {t("playground:empty.disconnectedDescription", {
+                      defaultValue:
+                        "Connect to a tldw server to start chatting."
+                    })}
+                    <button
+                      type="button"
+                      onClick={() => navigate("/settings/tldw")}
+                      className="mt-2 block text-sm font-medium text-primary hover:underline"
+                    >
+                      {t("playground:empty.openSettings", {
+                        defaultValue: "Open Settings"
+                      })}
+                    </button>
+                  </>
+                )
               : t("playground:empty.description", {
                   defaultValue:
                     "Experiment with different models, prompts, and knowledge sources here."

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundEmpty.disconnected.test.tsx
@@ -1,0 +1,94 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { PlaygroundEmpty } from "../PlaygroundEmpty"
+
+const navigate = vi.fn()
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, arg?: string | { defaultValue?: string }) => {
+      if (typeof arg === "string") return arg
+      if (arg && typeof arg === "object" && arg.defaultValue) {
+        return arg.defaultValue
+      }
+      return _key
+    }
+  })
+}))
+
+vi.mock("@/context/demo-mode", () => ({
+  useDemoMode: () => ({ demoEnabled: false })
+}))
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useIsConnected: () => false
+}))
+
+vi.mock("@/store/tutorials", () => ({
+  useHelpModal: () => ({ open: vi.fn() })
+}))
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigate
+}))
+
+vi.mock("@/components/Common/FeatureEmptyState", () => ({
+  __esModule: true,
+  default: ({
+    title,
+    description,
+    primaryActionLabel,
+    onPrimaryAction,
+    secondaryActionLabel,
+    onSecondaryAction
+  }: {
+    title: React.ReactNode
+    description: React.ReactNode
+    primaryActionLabel?: React.ReactNode
+    onPrimaryAction?: () => void
+    secondaryActionLabel?: string
+    onSecondaryAction?: () => void
+  }) => (
+    <div>
+      <h2>{title}</h2>
+      <div data-testid="empty-state-description">{description}</div>
+      {onPrimaryAction ? (
+        <button type="button" onClick={onPrimaryAction}>
+          {primaryActionLabel}
+        </button>
+      ) : null}
+      {onSecondaryAction ? (
+        <button type="button" onClick={onSecondaryAction}>
+          {secondaryActionLabel}
+        </button>
+      ) : null}
+    </div>
+  )
+}))
+
+describe("PlaygroundEmpty – disconnected state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders an Open Settings button when disconnected", () => {
+    render(<PlaygroundEmpty />)
+
+    const settingsButton = screen.getByRole("button", {
+      name: /open settings/i
+    })
+    expect(settingsButton).toBeInTheDocument()
+  })
+
+  it("navigates to /settings/tldw when Open Settings is clicked", () => {
+    render(<PlaygroundEmpty />)
+
+    const settingsButton = screen.getByRole("button", {
+      name: /open settings/i
+    })
+    fireEvent.click(settingsButton)
+
+    expect(navigate).toHaveBeenCalledWith("/settings/tldw")
+  })
+})

--- a/apps/packages/ui/src/services/settings/ui-settings.ts
+++ b/apps/packages/ui/src/services/settings/ui-settings.ts
@@ -379,6 +379,8 @@ export const HEADER_SHORTCUT_IDS = [
   "documentation",
   "chatbooks-playground",
   "moderation-playground",
+  "family-guardrails",
+  "guardian",
   "admin-llamacpp",
   "admin-mlx",
   "settings",

--- a/apps/packages/ui/src/tutorials/definitions/moderation.ts
+++ b/apps/packages/ui/src/tutorials/definitions/moderation.ts
@@ -1,0 +1,62 @@
+/**
+ * Moderation Playground Tutorial Definitions
+ */
+
+import { ShieldCheck } from "lucide-react"
+import type { TutorialDefinition } from "../registry"
+
+const moderationBasics: TutorialDefinition = {
+  id: "moderation-basics",
+  routePattern: "/moderation-playground",
+  labelKey: "tutorials:moderation.basics.label",
+  labelFallback: "Content Controls Basics",
+  descriptionKey: "tutorials:moderation.basics.description",
+  descriptionFallback:
+    "Learn how to set up content safety rules, blocklists, and test moderation.",
+  icon: ShieldCheck,
+  priority: 1,
+  steps: [
+    {
+      target: '[data-testid="moderation-hero"]',
+      titleKey: "tutorials:moderation.basics.heroTitle",
+      titleFallback: "Moderation Dashboard",
+      contentKey: "tutorials:moderation.basics.heroContent",
+      contentFallback:
+        "This is your content safety hub. The status badge shows whether your server is connected.",
+      placement: "bottom",
+      disableBeacon: true
+    },
+    {
+      target: '[data-testid="moderation-tab-policy"]',
+      titleKey: "tutorials:moderation.basics.policyTitle",
+      titleFallback: "Policy & Settings",
+      contentKey: "tutorials:moderation.basics.policyContent",
+      contentFallback:
+        "Start here. Set your base content safety policy — what categories to filter and how strictly.",
+      placement: "bottom",
+      disableBeacon: true
+    },
+    {
+      target: '[data-testid="moderation-tab-blocklist"]',
+      titleKey: "tutorials:moderation.basics.blocklistTitle",
+      titleFallback: "Blocklist Studio",
+      contentKey: "tutorials:moderation.basics.blocklistContent",
+      contentFallback:
+        "Add specific words, phrases, or patterns you want to always block or flag.",
+      placement: "bottom",
+      disableBeacon: true
+    },
+    {
+      target: '[data-testid="moderation-tab-test"]',
+      titleKey: "tutorials:moderation.basics.testTitle",
+      titleFallback: "Test Sandbox",
+      contentKey: "tutorials:moderation.basics.testContent",
+      contentFallback:
+        "Try your rules in real time. Type a message and see whether it would be allowed or blocked.",
+      placement: "bottom",
+      disableBeacon: true
+    }
+  ]
+}
+
+export const moderationTutorials: TutorialDefinition[] = [moderationBasics]

--- a/apps/packages/ui/src/tutorials/registry.ts
+++ b/apps/packages/ui/src/tutorials/registry.ts
@@ -78,6 +78,7 @@ import { notesTutorials } from "./definitions/notes"
 import { flashcardsTutorials } from "./definitions/flashcards"
 import { worldBooksTutorials } from "./definitions/world-books"
 import { gettingStartedTutorials } from "./definitions/getting-started"
+import { moderationTutorials } from "./definitions/moderation"
 
 /**
  * Central registry of all available tutorials
@@ -93,7 +94,8 @@ export const TUTORIAL_REGISTRY: TutorialDefinition[] = [
   ...evaluationsTutorials,
   ...notesTutorials,
   ...flashcardsTutorials,
-  ...worldBooksTutorials
+  ...worldBooksTutorials,
+  ...moderationTutorials
 ]
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses 8 high-severity issues from a full FTUX audit (`docs/plans/2026-04-03-ftux-audit-design.md`) targeting two personas: **parent/family safety users** and **researcher/knowledge workers**.

- **Navigation:** New "Safety" group elevates Family Guardrails, Content Controls, and Guardian from buried locations. 15 jargon-heavy nav items get plain-language descriptions searchable in the launcher.
- **Moderation FTUX:** Structured onboarding card with Family Guardrails wizard CTA, "Start here" tab badge, 4-step Joyride tutorial (auto-triggers on first visit), skeleton loaders replacing bare "Loading..." text.
- **Chat:** Clickable "Open Settings" button on disconnected empty state.
- **Onboarding:** 3-card intent selector on success screen routes users to persona-appropriate first action (Chat / Family Safety / Research).

**19 files changed** (+653 / -60), **43 new tests** across 8 test files, all green.

## Test plan

- [ ] Run `cd apps/packages/ui && npx vitest run` — all tests pass
- [ ] Fresh browser, clear localStorage, navigate to `/` — onboarding wizard shows
- [ ] Complete connection — verify 3-card intent selector appears (Chat / Family Safety / Research)
- [ ] Click "Set up family safety" — navigates to Family Guardrails wizard
- [ ] Navigate to `/moderation-playground` — verify new onboarding card with "Set up Family Guardrails" CTA
- [ ] Verify Joyride tutorial auto-starts on first moderation visit
- [ ] Open header shortcuts (Cmd+K) — verify "Safety" group with distinct icons
- [ ] Verify jargon items show description subtitles (e.g., "STT Playground" → "Speech to Text — transcribe audio and video")
- [ ] Navigate to `/chat` without connection — verify "Open Settings" button
- [ ] Switch moderation tabs — verify skeleton loaders instead of "Loading..." text

🤖 Generated with [Claude Code](https://claude.com/claude-code)