### PR TITLE
ci: publish GHCR main snapshots for app and UIs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -35,5 +35,8 @@ jobs:
           ./actionlint -color \
             .github/workflows/actionlint.yml \
             .github/workflows/codeql.yml \
+            .github/workflows/container-build-check.yml \
             .github/workflows/frontend-ux-gates.yml \
+            .github/workflows/publish-ghcr-main.yml \
+            .github/workflows/publish-docker.yml \
             .github/workflows/sbom.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,6 @@ jobs:
             psql -h 127.0.0.1 -p "$PORT" -U "$DB_USER" -d postgres -c "CREATE DATABASE ${DB_NAME}"
 
       - name: Run wizard tests (coverage gate)
-        env:
-          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: |
           # Keep this as a non-regression floor until wizard CLI coverage is expanded.
           pytest -q --maxfail=1 --disable-warnings -p pytest_cov -p pytest_asyncio.plugin \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,8 @@ jobs:
             psql -h 127.0.0.1 -p "$PORT" -U "$DB_USER" -d postgres -c "CREATE DATABASE ${DB_NAME}"
 
       - name: Run wizard tests (coverage gate)
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: |
           # Keep this as a non-regression floor until wizard CLI coverage is expanded.
           pytest -q --maxfail=1 --disable-warnings -p pytest_cov -p pytest_asyncio.plugin \

--- a/.github/workflows/container-build-check.yml
+++ b/.github/workflows/container-build-check.yml
@@ -1,0 +1,59 @@
+name: container-build-check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: container-build-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  container-build-check:
+    name: container-build-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: app
+            dockerfile: Dockerfiles/Dockerfile.prod
+            build_args: ""
+          - name: webui
+            dockerfile: Dockerfiles/Dockerfile.webui
+            build_args: |
+              NEXT_PUBLIC_API_URL=
+              NEXT_PUBLIC_API_BASE_URL=
+              NEXT_PUBLIC_API_VERSION=v1
+              NEXT_PUBLIC_X_API_KEY=
+              NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE=quickstart
+              TLDW_INTERNAL_API_ORIGIN=http://app:8000
+          - name: admin-ui
+            dockerfile: Dockerfiles/Dockerfile.admin-ui
+            build_args: |
+              NEXT_PUBLIC_API_URL=http://app:8000
+              NEXT_PUBLIC_API_VERSION=v1
+              NEXT_PUBLIC_DEFAULT_AUTH_MODE=multi_user
+              NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN=false
+              NEXT_PUBLIC_BILLING_ENABLED=false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Build container images
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          build-args: ${{ matrix.build_args }}
+          push: false

--- a/.github/workflows/e2e-required.yml
+++ b/.github/workflows/e2e-required.yml
@@ -88,6 +88,8 @@ jobs:
         if: needs.changes.outputs.e2e_changed == 'true'
         id: e2e_primary
         continue-on-error: true
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: |
           python -m pytest -p pytest_asyncio.plugin tldw_Server_API/tests/e2e/ --critical-only -q
 
@@ -95,6 +97,8 @@ jobs:
         if: needs.changes.outputs.e2e_changed == 'true' && steps.e2e_primary.outcome == 'failure'
         id: e2e_retry
         continue-on-error: true
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: |
           python -m pytest -p pytest_asyncio.plugin tldw_Server_API/tests/e2e/ --critical-only -q
 

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -31,6 +31,7 @@ jobs:
       EMBEDDINGS_REDIS_ALLOW_STUB: "1"
       SINGLE_USER_API_KEY: test-api-key-for-e2e-testing-12345
       SINGLE_USER_TEST_API_KEY: test-api-key-for-e2e-testing-12345
+      PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
       # Avoid matplotlib cache permission issues during imports
       MPLCONFIGDIR: ${{ github.workspace }}/.mpl-cache
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
@@ -74,7 +75,7 @@ jobs:
 
       - name: Run critical e2e smoke tests (in-process)
         run: |
-          python -m pytest tldw_Server_API/tests/e2e/ --critical-only -q
+          python -m pytest -p pytest_asyncio.plugin tldw_Server_API/tests/e2e/ --critical-only -q
 
       - name: Print server log (single-user)
         if: failure()
@@ -102,7 +103,8 @@ jobs:
           AUTH_MODE: multi_user
         shell: bash
         run: |
-          pytest -v -n 1 -m "multi_user and not jobs" --timeout=600 \
+          pytest -v -n 1 -p pytest_asyncio.plugin -p xdist.plugin -p pytest_timeout \
+            -m "multi_user and not jobs" --timeout=600 \
             tldw_Server_API/tests/e2e/test_multi_user_onboarding.py
 
       - name: Stop server (multi-user)

--- a/.github/workflows/onboarding-docs-gate.yml
+++ b/.github/workflows/onboarding-docs-gate.yml
@@ -83,6 +83,8 @@ jobs:
           python Helper_Scripts/docs/check_onboarding_endpoint_drift.py
 
       - name: Docs test suite
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: |
           python -m pytest -q -p pytest_asyncio.plugin tldw_Server_API/tests/Docs
 

--- a/.github/workflows/onboarding-docs-gate.yml
+++ b/.github/workflows/onboarding-docs-gate.yml
@@ -49,11 +49,6 @@ jobs:
         with:
           install-portaudio: 'true'
 
-      - name: Install FFmpeg and PortAudio (Linux)
-        uses: ./.github/actions/setup-ffmpeg
-        with:
-          install-portaudio: 'true'
-
       - name: Setup Python and dependencies
         uses: ./.github/actions/setup-python-deps
         with:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -87,7 +87,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation (GHCR)
-        uses: actions/attest-build-provenance@v4.1.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.ghcr_suffix }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -87,7 +87,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation (GHCR)
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.ghcr_suffix }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build and push Docker images
         id: push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -87,7 +87,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation (GHCR)
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.ghcr_suffix }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/publish-ghcr-main.yml
+++ b/.github/workflows/publish-ghcr-main.yml
@@ -1,0 +1,94 @@
+name: publish-ghcr-main
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-ghcr-main-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish-ghcr-main:
+    name: publish-ghcr-main
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: app
+            dockerfile: Dockerfiles/Dockerfile.prod
+            image_suffix: ""
+            build_args: ""
+          - name: webui
+            dockerfile: Dockerfiles/Dockerfile.webui
+            image_suffix: "-webui"
+            build_args: |
+              NEXT_PUBLIC_API_URL=
+              NEXT_PUBLIC_API_BASE_URL=
+              NEXT_PUBLIC_API_VERSION=v1
+              NEXT_PUBLIC_X_API_KEY=
+              NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE=quickstart
+              TLDW_INTERNAL_API_ORIGIN=http://app:8000
+          - name: admin-ui
+            dockerfile: Dockerfiles/Dockerfile.admin-ui
+            image_suffix: "-admin-ui"
+            build_args: |
+              NEXT_PUBLIC_API_URL=http://app:8000
+              NEXT_PUBLIC_API_VERSION=v1
+              NEXT_PUBLIC_DEFAULT_AUTH_MODE=multi_user
+              NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN=false
+              NEXT_PUBLIC_BILLING_ENABLED=false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Log in to GHCR
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for GHCR
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
+          tags: |
+            type=raw,value=main
+            type=sha,format=short
+
+      - name: Build and push Docker images
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          build-args: ${{ matrix.build_args }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation (GHCR)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/publish-ghcr-main.yml
+++ b/.github/workflows/publish-ghcr-main.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: publish-ghcr-main-${{ github.event.pull_request.number || github.ref }}
+  group: publish-ghcr-main-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/publish-ghcr-main.yml
+++ b/.github/workflows/publish-ghcr-main.yml
@@ -22,6 +22,7 @@ jobs:
   publish-ghcr-main:
     name: publish-ghcr-main
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,4 @@ Dockerfiles/Monitoring/secrets/
 /.hypothesis
 /admin-ui/.next
 /.playwright-cli
+/output

--- a/Dockerfiles/Dockerfile.admin-ui
+++ b/Dockerfiles/Dockerfile.admin-ui
@@ -1,0 +1,66 @@
+# Production Dockerfile for tldw Admin UI
+# - Builds as a standalone Next.js app
+# - Ships a minimal runtime image
+
+FROM oven/bun:1.3.2-debian AS builder
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# next.config.js sets outputFileTracingRoot to `${__dirname}/..`, so the
+# standalone output reproduces the directory tree relative to that root.
+# Working inside /build/admin-ui means the standalone artefact will contain
+# admin-ui/server.js (mirroring the real repo layout).
+WORKDIR /build/admin-ui
+
+COPY admin-ui/package.json admin-ui/bun.lock ./
+RUN bun install --frozen-lockfile
+
+COPY admin-ui/ ./
+# Ensure public/ exists even if the source tree has none, so the runtime
+# COPY stage always succeeds (Docker COPY fails on missing sources).
+RUN mkdir -p public
+
+# Build-time configuration baked into client bundle
+ARG NEXT_PUBLIC_API_URL=
+ARG NEXT_PUBLIC_API_VERSION=v1
+ARG NEXT_PUBLIC_DEFAULT_AUTH_MODE=multi_user
+ARG NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN=false
+ARG NEXT_PUBLIC_BILLING_ENABLED=false
+
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ENV NEXT_PUBLIC_API_VERSION=${NEXT_PUBLIC_API_VERSION}
+ENV NEXT_PUBLIC_DEFAULT_AUTH_MODE=${NEXT_PUBLIC_DEFAULT_AUTH_MODE}
+ENV NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN=${NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN}
+ENV NEXT_PUBLIC_BILLING_ENABLED=${NEXT_PUBLIC_BILLING_ENABLED}
+
+RUN bun run build
+
+
+FROM node:20-bookworm-slim AS runtime
+
+ARG APP_VERSION=0.0.0
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    HOSTNAME=0.0.0.0 \
+    PORT=3001 \
+    APP_VERSION=${APP_VERSION}
+
+WORKDIR /app
+
+RUN useradd -m -u 10003 adminui
+
+# Standalone output mirrors builder tree: standalone/admin-ui/server.js
+COPY --from=builder --chown=adminui:adminui /build/admin-ui/.next/standalone /app
+COPY --from=builder --chown=adminui:adminui /build/admin-ui/.next/static /app/admin-ui/.next/static
+COPY --from=builder --chown=adminui:adminui /build/admin-ui/public/ /app/admin-ui/public/
+
+USER adminui
+
+WORKDIR /app/admin-ui
+
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
+  CMD node -e "fetch('http://localhost:3001/api/health/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "server.js"]

--- a/Dockerfiles/Dockerfile.webui
+++ b/Dockerfiles/Dockerfile.webui
@@ -8,14 +8,16 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 WORKDIR /app/apps
 
-# Copy only the manifests and workspace sources needed for the WebUI build.
+# Copy the root manifest plus the workspace sources Bun needs during install.
+# The extension workspace must be present because its postinstall hook runs as
+# part of the root workspace install. The voice assistant SDK only needs its
+# manifest to satisfy the workspace graph for the committed lockfile.
 COPY apps/package.json /app/apps/package.json
 COPY apps/bun.lock /app/apps/bun.lock
+COPY apps/extension /app/apps/extension
+COPY apps/packages/voice-assistant-sdk/package.json /app/apps/packages/voice-assistant-sdk/package.json
 COPY apps/tldw-frontend /app/apps/tldw-frontend
 COPY apps/packages/ui /app/apps/packages/ui
-
-# Narrow the workspace manifest so the image install does not pull unrelated workspaces.
-RUN bun -e "const fs=require('fs');const path='/app/apps/package.json';const pkg=JSON.parse(fs.readFileSync(path,'utf8'));pkg.workspaces=['tldw-frontend','packages/ui'];fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');"
 
 # Install the frontend monorepo with Bun so workspace:* dependencies resolve correctly.
 RUN bun install --frozen-lockfile --cwd /app/apps

--- a/Dockerfiles/Dockerfile.webui
+++ b/Dockerfiles/Dockerfile.webui
@@ -9,17 +9,18 @@ ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /app/apps
 
 # Copy the root manifest plus the workspace sources Bun needs during install.
-# The extension workspace must be present because its postinstall hook runs as
-# part of the root workspace install. The voice assistant SDK only needs its
-# manifest to satisfy the workspace graph for the committed lockfile.
+# Only copy the extension manifest + prepare shim here so unrelated extension
+# source changes do not invalidate the WebUI dependency layer.
 COPY apps/package.json /app/apps/package.json
 COPY apps/bun.lock /app/apps/bun.lock
-COPY apps/extension /app/apps/extension
+COPY apps/extension/package.json /app/apps/extension/package.json
+COPY apps/extension/scripts/wxt-prepare.mjs /app/apps/extension/scripts/wxt-prepare.mjs
 COPY apps/packages/voice-assistant-sdk/package.json /app/apps/packages/voice-assistant-sdk/package.json
 COPY apps/tldw-frontend /app/apps/tldw-frontend
 COPY apps/packages/ui /app/apps/packages/ui
 
 # Install the frontend monorepo with Bun so workspace:* dependencies resolve correctly.
+ENV SKIP_WXT_PREPARE=1
 RUN bun install --frozen-lockfile --cwd /app/apps
 
 # Build-time API config baked into client bundle

--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -91,6 +91,7 @@ This folder contains the base Compose stack for tldw_server, optional overlays, 
 - `sha-<shortsha>` is the cross-image-consistent tag for pinning all three images to the same revision.
 - The API image is direct-run friendly.
 - The WebUI and Admin UI images are compose-first in v1 unless the operator supplies compatible runtime wiring.
+- `BYOK_ENCRYPTION_KEY` is only auto-generated for fresh auth databases. When reusing an existing auth DB or volume with encrypted provider secrets, keep the prior key (or rotate via `BYOK_SECONDARY_ENCRYPTION_KEY`) instead of starting with a blank placeholder.
 
 ## Notes
 

--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -81,6 +81,17 @@ This folder contains the base Compose stack for tldw_server, optional overlays, 
 - WebUI image: `Dockerfiles/Dockerfile.webui` (used by WebUI overlay)
 - Worker image: `Dockerfiles/Dockerfile.worker` (used by embeddings compose)
 
+## Published Images
+
+- The release workflow publishes release artifacts separately from the rolling `main` snapshot workflow.
+- `publish-ghcr-main` publishes `main` and `sha-<shortsha>` snapshots for the API, WebUI, and Admin UI images:
+  - API: `ghcr.io/<owner>/<repo>:main`
+  - WebUI: `ghcr.io/<owner>/<repo>-webui:main`
+  - Admin UI: `ghcr.io/<owner>/<repo>-admin-ui:main`
+- `sha-<shortsha>` is the cross-image-consistent tag for pinning all three images to the same revision.
+- The API image is direct-run friendly.
+- The WebUI and Admin UI images are compose-first in v1 unless the operator supplies compatible runtime wiring.
+
 ## Notes
 
 - Run compose commands from repo root so relative paths resolve correctly.

--- a/Dockerfiles/docker-compose.admin-ui.yml
+++ b/Dockerfiles/docker-compose.admin-ui.yml
@@ -1,0 +1,39 @@
+# docker-compose.admin-ui.yml
+# Overlay for admin-ui — use alongside the main docker-compose.yml:
+#
+# Usage (from repo root):
+#   docker compose --env-file tldw_Server_API/Config_Files/.env \
+#     -f Dockerfiles/docker-compose.yml \
+#     -f Dockerfiles/docker-compose.admin-ui.yml up -d --build
+
+services:
+  admin-ui:
+    build:
+      context: ..
+      dockerfile: Dockerfiles/Dockerfile.admin-ui
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://app:8000}
+        NEXT_PUBLIC_API_VERSION: ${NEXT_PUBLIC_API_VERSION:-v1}
+        NEXT_PUBLIC_DEFAULT_AUTH_MODE: ${NEXT_PUBLIC_DEFAULT_AUTH_MODE:-multi_user}
+        NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN: ${NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN:-false}
+        NEXT_PUBLIC_BILLING_ENABLED: ${NEXT_PUBLIC_BILLING_ENABLED:-false}
+    image: tldw-admin-ui:prod
+    container_name: tldw-admin-ui
+    restart: unless-stopped
+    ports:
+      - "${ADMIN_UI_PORT:-3001}:3001"
+    environment:
+      - NODE_ENV=production
+      - HOSTNAME=0.0.0.0
+      - PORT=3001
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is required}
+      - JWT_ALGORITHM=${JWT_ALGORITHM:-HS256}
+      - JWT_SECONDARY_SECRET=${JWT_SECONDARY_SECRET:-}  # optional — omit or leave empty to disable key rotation
+      - AUTH_MODE=${AUTH_MODE:-multi_user}
+      # Set to 'true' when running behind a reverse proxy that sets
+      # X-Forwarded-For / X-Real-IP. Without this, per-IP rate limiting
+      # is disabled (all clients share one bucket).
+      - TRUST_PROXY_HEADERS=${TRUST_PROXY_HEADERS:-false}
+    depends_on:
+      app:
+        condition: service_healthy

--- a/Dockerfiles/docker-compose.override.yml
+++ b/Dockerfiles/docker-compose.override.yml
@@ -23,6 +23,11 @@ services:
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:-}
       DATABASE_URL: ${DATABASE_URL:-postgresql://tldw_user:${POSTGRES_PASSWORD:-TestPassword123!}@postgres:5432/${POSTGRES_DB:-tldw_users}}
 
+      # Multi-user admin bootstrap (set for first run, remove after):
+      # ADMIN_USERNAME: ${ADMIN_USERNAME:-}
+      # ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
+      # ADMIN_EMAIL: ${ADMIN_EMAIL:-}
+
       # Networking / CORS
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-https://your.domain.com}
 

--- a/Dockerfiles/docker-compose.yml
+++ b/Dockerfiles/docker-compose.yml
@@ -13,8 +13,14 @@ services:
     environment:
       # Auth mode: set to multi_user for team deployments
       - AUTH_MODE=${AUTH_MODE:-single_user}
-      # Provide a secure API key in single_user mode
+      # Provide a secure API key in single_user mode.
+      # Placeholder values (change-me, CHANGE_ME*, etc.) are auto-replaced
+      # by the entrypoint with a secure random key on first run.
       - SINGLE_USER_API_KEY=${SINGLE_USER_API_KEY:-change-me}
+      # Multi-user admin bootstrap (uncomment for first run):
+      # - ADMIN_USERNAME=myadmin
+      # - ADMIN_PASSWORD=change-me-to-secure-password
+      # - ADMIN_EMAIL=admin@example.com
       # In production set: tldw_production=true (masks API key in logs and docs-info responses)
       - tldw_production=${tldw_production:-false}
       # Database URL: use Postgres in multi_user
@@ -23,6 +29,7 @@ services:
       # Example: postgresql://tldw_user:TestPassword123!@postgres:5432/tldw_users
       - JOBS_DB_URL=${JOBS_DB_URL:-}
       # Optional OpenTelemetry envs can be passed through here
+      # Worker count. Default 4. Set to 1-2 for machines with <4GB RAM.
       - UVICORN_WORKERS=${UVICORN_WORKERS:-4}
       - LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
@@ -84,4 +91,7 @@ volumes:
 #   #   export DATABASE_URL=postgresql://tldw_user:TestPassword123!@postgres:5432/tldw_users
 #   #   # Optional: point Jobs to Postgres as well (uses same DB by default)
 #   #   export JOBS_DB_URL=postgresql://tldw_user:TestPassword123!@postgres:5432/tldw_users
+#   #   # Bootstrap first admin user (only needed on first run):
+#   #   export ADMIN_USERNAME=myadmin
+#   #   export ADMIN_PASSWORD='YourSecurePassword1!'
 #   #   docker compose up --build

--- a/Dockerfiles/entrypoints/tldw-app-first-run.sh
+++ b/Dockerfiles/entrypoints/tldw-app-first-run.sh
@@ -3,7 +3,9 @@ set -eu
 
 ENV_FILE="${TLDW_ENV_FILE:-/app/tldw_Server_API/Config_Files/.env}"
 AUTH_MARKER_DIR="${TLDW_AUTH_MARKER_DIR:-/app/Databases}"
-AUTH_MARKER_FILE="${AUTH_MARKER_DIR}/.authnz_initialized_single_user"
+# NOTE: AUTH_MARKER_FILE is derived below *after* AUTH_MODE is resolved,
+# so that the marker is mode-specific (e.g. .authnz_initialized_single_user
+# vs .authnz_initialized_multi_user). Changing AUTH_MODE will re-trigger init.
 RUN_AUTH_INIT_ON_START="${TLDW_RUN_AUTH_INIT_ON_START:-1}"
 
 incoming_auth_mode="${AUTH_MODE:-}"
@@ -14,7 +16,7 @@ generate_key() {
   if command -v openssl >/dev/null 2>&1; then
     openssl rand -base64 32 | tr -d '\n'
   else
-    python -c "import secrets; print(secrets.token_urlsafe(32))"
+    python -c "import secrets, base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"
   fi
 }
 
@@ -90,6 +92,9 @@ fi
 AUTH_MODE="${AUTH_MODE:-single_user}"
 DATABASE_URL="${DATABASE_URL:-sqlite:///./Databases/users.db}"
 
+# Derive mode-specific marker so switching AUTH_MODE re-triggers init.
+AUTH_MARKER_FILE="${AUTH_MARKER_DIR}/.authnz_initialized_${AUTH_MODE}"
+
 upsert_env "AUTH_MODE" "$AUTH_MODE"
 upsert_env "DATABASE_URL" "$DATABASE_URL"
 
@@ -103,6 +108,19 @@ if [ "$AUTH_MODE" = "single_user" ]; then
   upsert_env "SINGLE_USER_API_KEY" "$current_key"
 fi
 
+# Auto-generate MCP secrets if missing or placeholder (min 32 chars each)
+for mcp_var in MCP_JWT_SECRET MCP_API_KEY_SALT BYOK_ENCRYPTION_KEY; do
+  eval current_val="\${$mcp_var:-}"
+  case "$current_val" in
+    ""|CHANGE_ME*)
+      new_val="$(generate_key)"
+      eval export "$mcp_var=$new_val"
+      upsert_env "$mcp_var" "$new_val"
+      echo "[entrypoint] Generated $mcp_var."
+      ;;
+  esac
+done
+
 should_run_auth_init=0
 case "$*" in
   *uvicorn*|*tldw_Server_API.app.main:app*)
@@ -110,13 +128,73 @@ case "$*" in
     ;;
 esac
 
-if [ "$AUTH_MODE" = "single_user" ] && [ "$RUN_AUTH_INIT_ON_START" != "0" ] && [ "$should_run_auth_init" = "1" ]; then
+if [ "$RUN_AUTH_INIT_ON_START" != "0" ] && [ "$should_run_auth_init" = "1" ]; then
   mkdir -p "$AUTH_MARKER_DIR"
+
+  # --- Standard AuthNZ initialization (single_user and multi_user) ---
   if [ ! -f "$AUTH_MARKER_FILE" ]; then
     echo "[entrypoint] Running first-use auth initialization..."
-    python -m tldw_Server_API.app.core.AuthNZ.initialize --non-interactive
-    touch "$AUTH_MARKER_FILE"
-    echo "[entrypoint] Auth initialization complete."
+    if python -m tldw_Server_API.app.core.AuthNZ.initialize --non-interactive 2>&1; then
+      touch "$AUTH_MARKER_FILE"
+      echo "[entrypoint] Auth initialization complete."
+    else
+      echo "" >&2
+      echo "╔══════════════════════════════════════════════════════════════╗" >&2
+      echo "║  AUTH INITIALIZATION FAILED                                  ║" >&2
+      echo "║                                                              ║" >&2
+      echo "║  Check the error above and verify:                           ║" >&2
+      echo "║  - MCP_JWT_SECRET is set in .env (min 32 chars)             ║" >&2
+      echo "║  - MCP_API_KEY_SALT is set in .env (min 32 chars)           ║" >&2
+      echo "║  - BYOK_ENCRYPTION_KEY is set (base64 encoded)              ║" >&2
+      echo "║  - DATABASE_URL is correct (if multi-user)                   ║" >&2
+      echo "╚══════════════════════════════════════════════════════════════╝" >&2
+      echo "" >&2
+      # Still start the server so /setup is accessible for configuration
+      echo "[first-run] Starting server despite init failure (setup wizard may be available)..." >&2
+    fi
+  fi
+
+  # --- Multi-user admin bootstrap via environment variables ---
+  if [ "$AUTH_MODE" = "multi_user" ]; then
+    if [ -n "${ADMIN_USERNAME:-}" ] && [ -n "${ADMIN_PASSWORD:-}" ]; then
+      echo "[first-run] Creating initial admin user: $ADMIN_USERNAME"
+      # Idempotent: exits 0 if user already exists
+      python -m tldw_Server_API.app.core.AuthNZ.create_admin \
+        --username "$ADMIN_USERNAME" \
+        --password "$ADMIN_PASSWORD" \
+        ${ADMIN_EMAIL:+--email "$ADMIN_EMAIL"} \
+        --non-interactive 2>&1 || {
+          echo "[first-run] WARNING: Admin user creation returned non-zero (see above)." >&2
+        }
+    else
+      # Check if any users exist; warn if not
+      has_users=$(python -c "
+import asyncio, sys
+async def check():
+    try:
+        from tldw_Server_API.app.core.DB_Management.Users_DB import get_users_db
+        db = await get_users_db()
+        users = await db.list_users(limit=1)
+        return len(users) > 0
+    except Exception:
+        return False
+sys.stdout.write('1' if asyncio.run(check()) else '0')
+" 2>/dev/null || echo "0")
+
+      if [ "$has_users" = "0" ]; then
+        echo ""
+        echo "======================================================================"
+        echo "  WARNING: Multi-user mode with no admin user configured!"
+        echo ""
+        echo "  Set ADMIN_USERNAME and ADMIN_PASSWORD env vars to create"
+        echo "  the first admin user automatically, or run:"
+        echo ""
+        echo "  docker compose exec app python -m \\"
+        echo "    tldw_Server_API.app.core.AuthNZ.create_admin"
+        echo "======================================================================"
+        echo ""
+      fi
+    fi
   fi
 fi
 

--- a/Dockerfiles/entrypoints/tldw-app-first-run.sh
+++ b/Dockerfiles/entrypoints/tldw-app-first-run.sh
@@ -54,6 +54,76 @@ upsert_env() {
   chmod 600 "$ENV_FILE"
 }
 
+has_existing_auth_state() {
+  [ -f "${AUTH_MARKER_DIR}/.authnz_initialized_single_user" ] || \
+    [ -f "${AUTH_MARKER_DIR}/.authnz_initialized_multi_user" ] || \
+    [ -f "${AUTH_MARKER_FILE}" ]
+}
+
+count_existing_byok_payloads() {
+  python - <<'PY'
+import os
+import sqlite3
+import sys
+from urllib.parse import unquote, urlparse
+
+TABLES = ("user_provider_secrets", "org_provider_secrets")
+
+
+def count_sqlite(database_url: str) -> int:
+    parsed = urlparse(database_url)
+    raw_path = unquote(parsed.path or "")
+    if raw_path.startswith("//"):
+        raw_path = raw_path[1:]
+    db_path = raw_path if os.path.isabs(raw_path) else os.path.abspath(raw_path or "./Databases/users.db")
+    if not os.path.exists(db_path):
+        return 0
+
+    conn = sqlite3.connect(db_path)
+    try:
+        total = 0
+        for table in TABLES:
+            try:
+                row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+            except sqlite3.Error:
+                continue
+            total += int((row or (0,))[0] or 0)
+        return total
+    finally:
+        conn.close()
+
+
+def count_postgres(database_url: str) -> int:
+    import psycopg
+
+    total = 0
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            for table in TABLES:
+                cur.execute("SELECT to_regclass(%s)", (table,))
+                row = cur.fetchone()
+                if not row or row[0] is None:
+                    continue
+                cur.execute(f"SELECT COUNT(*) FROM {table}")
+                count_row = cur.fetchone()
+                total += int((count_row or (0,))[0] or 0)
+    return total
+
+
+database_url = (os.getenv("DATABASE_URL") or "sqlite:///./Databases/users.db").strip()
+try:
+    if database_url.startswith("postgres"):
+        result = count_postgres(database_url)
+    else:
+        result = count_sqlite(database_url)
+except Exception as exc:  # pragma: no cover - shell guard path
+    print(f"error:{exc}", file=sys.stderr)
+    sys.exit(1)
+
+sys.stdout.write(str(result))
+PY
+}
+
 ensure_env_file() {
   if [ -f "$ENV_FILE" ]; then
     return
@@ -113,6 +183,17 @@ for mcp_var in MCP_JWT_SECRET MCP_API_KEY_SALT BYOK_ENCRYPTION_KEY; do
   eval current_val="\${$mcp_var:-}"
   case "$current_val" in
     ""|CHANGE_ME*)
+      if [ "$mcp_var" = "BYOK_ENCRYPTION_KEY" ]; then
+        if existing_byok_payloads="$(count_existing_byok_payloads 2>/dev/null)"; then
+          if [ "${existing_byok_payloads:-0}" -gt 0 ]; then
+            echo "[entrypoint] Refusing to auto-generate BYOK_ENCRYPTION_KEY because ${existing_byok_payloads} encrypted BYOK payload(s) already exist. Reuse the previous key or configure BYOK_SECONDARY_ENCRYPTION_KEY for rotation." >&2
+            exit 1
+          fi
+        elif has_existing_auth_state; then
+          echo "[entrypoint] Existing auth state was detected but BYOK_ENCRYPTION_KEY could not be validated. Refusing to auto-generate a replacement key; provide the prior key explicitly." >&2
+          exit 1
+        fi
+      fi
       new_val="$(generate_key)"
       eval export "$mcp_var=$new_val"
       upsert_env "$mcp_var" "$new_val"
@@ -149,8 +230,8 @@ if [ "$RUN_AUTH_INIT_ON_START" != "0" ] && [ "$should_run_auth_init" = "1" ]; th
       echo "║  - DATABASE_URL is correct (if multi-user)                   ║" >&2
       echo "╚══════════════════════════════════════════════════════════════╝" >&2
       echo "" >&2
-      # Still start the server so /setup is accessible for configuration
-      echo "[first-run] Starting server despite init failure (setup wizard may be available)..." >&2
+      echo "[first-run] Auth initialization failed in non-interactive startup; refusing to continue." >&2
+      exit 1
     fi
   fi
 

--- a/admin-ui/app/acp-agents/page.tsx
+++ b/admin-ui/app/acp-agents/page.tsx
@@ -18,12 +18,7 @@ import { useToast } from '@/components/ui/toast';
 import { RefreshCw, Bot, Plus, Pencil, Trash2, Shield } from 'lucide-react';
 import { AccessibleIconButton } from '@/components/ui/accessible-icon-button';
 import { api, ApiError } from '@/lib/api-client';
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
-  return String(n);
-}
+import { formatTokens } from '@/lib/format';
 
 interface AgentConfig {
   id: number;

--- a/admin-ui/app/acp-sessions/page.tsx
+++ b/admin-ui/app/acp-sessions/page.tsx
@@ -19,7 +19,7 @@ import { exportData, type ExportFormat } from '@/lib/export';
 import { RefreshCw, MessageSquare, XCircle, Wifi, WifiOff } from 'lucide-react';
 import { AccessibleIconButton } from '@/components/ui/accessible-icon-button';
 import { api, ApiError } from '@/lib/api-client';
-import { formatDateTime } from '@/lib/format';
+import { formatDateTime, formatTokens } from '@/lib/format';
 
 interface ACPSession {
   session_id: string;
@@ -136,12 +136,6 @@ export default function ACPSessionsPage() {
       default:
         return <Badge variant="outline">{status}</Badge>;
     }
-  };
-
-  const formatTokens = (count: number) => {
-    if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-    if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
-    return String(count);
   };
 
   return (

--- a/admin-ui/app/monitoring/page.tsx
+++ b/admin-ui/app/monitoring/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import { PermissionGuard } from '@/components/PermissionGuard';
 import { ResponsiveLayout } from '@/components/ResponsiveLayout';
 import MonitoringFeedbackBanners from './components/MonitoringFeedbackBanners';
@@ -8,7 +9,7 @@ import MonitoringMetricsSection from './components/MonitoringMetricsSection';
 import MonitoringPageHeader from './components/MonitoringPageHeader';
 import { useMonitoringPageController } from './use-monitoring-page-controller';
 
-export default function MonitoringPage() {
+function MonitoringPageContent() {
   const {
     headerProps,
     feedbackBannersProps,
@@ -27,5 +28,13 @@ export default function MonitoringPage() {
         </div>
       </ResponsiveLayout>
     </PermissionGuard>
+  );
+}
+
+export default function MonitoringPage() {
+  return (
+    <Suspense fallback={<div className="p-4 lg:p-8 text-muted-foreground">Loading monitoring...</div>}>
+      <MonitoringPageContent />
+    </Suspense>
   );
 }

--- a/admin-ui/app/monitoring/page.tsx
+++ b/admin-ui/app/monitoring/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Suspense } from 'react';
 import { PermissionGuard } from '@/components/PermissionGuard';
 import { ResponsiveLayout } from '@/components/ResponsiveLayout';
 import MonitoringFeedbackBanners from './components/MonitoringFeedbackBanners';
@@ -32,9 +31,5 @@ function MonitoringPageContent() {
 }
 
 export default function MonitoringPage() {
-  return (
-    <Suspense fallback={<div className="p-4 lg:p-8 text-muted-foreground">Loading monitoring...</div>}>
-      <MonitoringPageContent />
-    </Suspense>
-  );
+  return <MonitoringPageContent />;
 }

--- a/admin-ui/app/monitoring/page.tsx
+++ b/admin-ui/app/monitoring/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import { PermissionGuard } from '@/components/PermissionGuard';
 import { ResponsiveLayout } from '@/components/ResponsiveLayout';
 import MonitoringFeedbackBanners from './components/MonitoringFeedbackBanners';
@@ -30,6 +31,12 @@ function MonitoringPageContent() {
   );
 }
 
+// Suspense boundary required: useMonitoringPageController uses useSearchParams(),
+// which Next.js requires to be wrapped in Suspense for static generation.
 export default function MonitoringPage() {
-  return <MonitoringPageContent />;
+  return (
+    <Suspense fallback={<div className="p-4 lg:p-8 text-muted-foreground">Loading monitoring...</div>}>
+      <MonitoringPageContent />
+    </Suspense>
+  );
 }

--- a/admin-ui/app/onboarding/page.tsx
+++ b/admin-ui/app/onboarding/page.tsx
@@ -138,9 +138,7 @@ function OnboardingPageContent() {
       } finally {
         if (sequence === slugCheckSequence.current) {
           setSlugChecking(false);
-          if (slugCheckPromise.current === requestPromise) {
-            slugCheckPromise.current = null;
-          }
+          slugCheckPromise.current = null;
         }
       }
     })();

--- a/admin-ui/lib/format.ts
+++ b/admin-ui/lib/format.ts
@@ -67,8 +67,12 @@ export const formatLatency = (
   return `${value.toFixed(precision)} ms`;
 };
 
-export function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
+export function formatTokens(
+  value?: number | null,
+  { fallback = '—' }: { fallback?: string } = {}
+): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return fallback;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
 }

--- a/admin-ui/lib/format.ts
+++ b/admin-ui/lib/format.ts
@@ -66,3 +66,9 @@ export const formatLatency = (
   if (value === null || value === undefined || !Number.isFinite(value)) return fallback;
   return `${value.toFixed(precision)} ms`;
 };
+
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}

--- a/admin-ui/next.config.js
+++ b/admin-ui/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: 'standalone',
   outputFileTracingRoot: `${__dirname}/..`,
 }
 

--- a/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
@@ -7,7 +7,7 @@ import {
   SMOKE_LOAD_TIMEOUT
 } from "./smoke.setup"
 import { waitForAppShell } from "../utils/helpers"
-import type { Route } from "@playwright/test"
+import type { Page, Route } from "@playwright/test"
 
 const LOAD_TIMEOUT = SMOKE_LOAD_TIMEOUT
 const UNRESOLVED_TEMPLATE_PATTERN = /\{\{[^{}\n]{1,120}\}\}/g
@@ -37,6 +37,15 @@ const fulfillJson = async (route: Route, status: number, data: unknown) => {
     contentType: "application/json",
     body: JSON.stringify(data)
   })
+}
+
+async function openSpeechInputSourcePicker(page: Page) {
+  const inputSourcePicker = page
+    .locator('[aria-label="Speech playground input source"]')
+    .first()
+  await expect(inputSourcePicker).toBeVisible({ timeout: LOAD_TIMEOUT })
+  await inputSourcePicker.focus()
+  await page.keyboard.press("ArrowDown")
 }
 
 test.describe("Stage 7 audio regression gate", () => {
@@ -253,11 +262,7 @@ test.describe("Stage 7 audio regression gate", () => {
     await page.goto("/speech", { waitUntil: "domcontentloaded", timeout: LOAD_TIMEOUT })
     await waitForAppShell(page, LOAD_TIMEOUT)
 
-    const inputSourcePicker = page
-      .locator('[aria-label="Speech playground input source"]')
-      .first()
-    await expect(inputSourcePicker).toBeVisible({ timeout: LOAD_TIMEOUT })
-    await inputSourcePicker.click()
+    await openSpeechInputSourcePicker(page)
     await expect(page.getByRole("option", { name: /Default microphone/i })).toBeVisible()
     await expect(page.getByRole("option", { name: /Tab audio/i })).toHaveCount(0)
     await expect(page.getByRole("option", { name: /System audio/i })).toHaveCount(0)

--- a/apps/tldw-frontend/e2e/workflows/onboarding-ingestion-first.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/onboarding-ingestion-first.spec.ts
@@ -148,6 +148,15 @@ async function assertCardOrder(page: Page) {
   expect((mediaBox?.y ?? 0) < (chatBox?.y ?? 0)).toBeTruthy()
 }
 
+async function clearOnboardingBlockingOverlays(page: Page): Promise<void> {
+  const splash = page.getByRole("dialog", { name: "Splash screen" }).first()
+  if (await splash.isVisible().catch(() => false)) {
+    await splash.click({ force: true })
+    await splash.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {})
+  }
+  await dismissConnectionModals(page)
+}
+
 async function openOnboardingSuccessScreen(
   page: Page
 ): Promise<"connected-now" | "already-connected"> {
@@ -160,6 +169,13 @@ async function openOnboardingSuccessScreen(
     connect.waitFor({ state: "visible", timeout: 25_000 }),
     success.waitFor({ state: "visible", timeout: 25_000 }),
   ])
+
+  await clearOnboardingBlockingOverlays(page)
+
+  const alreadyConnected = await success.isVisible().catch(() => false)
+  if (alreadyConnected) {
+    return "already-connected"
+  }
 
   const needsConnect = await connect.isVisible().catch(() => false)
   if (needsConnect) {
@@ -182,20 +198,11 @@ async function clickOnboardingCtaAndExpectRoute(
   ctaTestId: string,
   expectedUrl: RegExp
 ): Promise<void> {
-  const clearBlockingOverlays = async () => {
-    const splash = page.getByRole("dialog", { name: "Splash screen" }).first()
-    if (await splash.isVisible().catch(() => false)) {
-      await splash.click({ force: true })
-      await splash.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {})
-    }
-    await dismissConnectionModals(page)
-  }
-
   const cta = page.getByTestId(ctaTestId)
   let lastError: unknown
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
-    await clearBlockingOverlays()
+    await clearOnboardingBlockingOverlays(page)
     await expect(cta).toBeVisible({ timeout: 15_000 })
     await cta.click()
     try {

--- a/apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/tier-2-features/speech-playground.spec.ts
@@ -14,9 +14,19 @@ import {
   skipIfServerUnavailable,
   assertNoCriticalErrors,
 } from "../../utils/fixtures"
+import type { Page } from "@playwright/test"
 import { SpeechPage } from "../../utils/page-objects/SpeechPage"
 import { expectApiCall } from "../../utils/api-assertions"
 import { seedAuth } from "../../utils/helpers"
+
+async function openSpeechInputSourcePicker(page: Page) {
+  const inputSourcePicker = page
+    .locator('[aria-label="Speech playground input source"]')
+    .first()
+  await expect(inputSourcePicker).toBeVisible()
+  await inputSourcePicker.focus()
+  await page.keyboard.press("ArrowDown")
+}
 
 test.describe("Speech Playground", () => {
   let speech: SpeechPage
@@ -54,11 +64,7 @@ test.describe("Speech Playground", () => {
       await expect(speech.stopButton).toBeVisible()
       await expect(speech.downloadButton).toBeVisible()
 
-      const inputSourcePicker = authedPage
-        .locator('[aria-label="Speech playground input source"]')
-        .first()
-      await expect(inputSourcePicker).toBeVisible()
-      await inputSourcePicker.click()
+      await openSpeechInputSourcePicker(authedPage)
       await expect(
         authedPage.getByRole("option", { name: /Default microphone/i })
       ).toBeVisible()


### PR DESCRIPTION
## Summary
- add a standalone `container-build-check` workflow and a `publish-ghcr-main` workflow to build and publish `app`, `webui`, and `admin-ui` snapshot images to GHCR on `main`
- document the snapshot contract, required branch protection status, and release-vs-snapshot image split, and extend workflow contract coverage and actionlint targeting
- fix the WebUI and Admin UI container build paths so the new snapshot workflow can build cleanly from CI, including workspace install handling, Admin UI type fixes, and admin webhook contract alignment

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/CI/test_container_publish_workflows.py tldw_Server_API/tests/CI/test_required_workflow_contracts.py tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py tldw_Server_API/tests/Utils/test_docker_quickstart_hardening.py -v`
- `bunx vitest run --dir apps/tldw-frontend apps/tldw-frontend/__tests__/pr-916-review-followups.test.ts`
- `./admin-ui/node_modules/.bin/tsc -p admin-ui/tsconfig.json --noEmit`
- `./actionlint -color .github/workflows/actionlint.yml .github/workflows/container-build-check.yml .github/workflows/publish-ghcr-main.yml .github/workflows/publish-docker.yml`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/tests/CI/test_container_publish_workflows.py tldw_Server_API/tests/CI/test_required_workflow_contracts.py tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py tldw_Server_API/tests/Utils/test_docker_quickstart_hardening.py -s B101 -f json -o /tmp/bandit_ghcr_main_snapshot_followup_filtered.json`
- `docker build -f Dockerfiles/Dockerfile.webui -t tldw-webui:ci-test --build-arg NEXT_PUBLIC_API_URL= --build-arg NEXT_PUBLIC_API_BASE_URL= --build-arg NEXT_PUBLIC_API_VERSION=v1 --build-arg NEXT_PUBLIC_X_API_KEY= --build-arg NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE=quickstart --build-arg TLDW_INTERNAL_API_ORIGIN=http://app:8000 .`
- `docker build -f Dockerfiles/Dockerfile.admin-ui -t tldw-admin-ui:ci-test --build-arg NEXT_PUBLIC_API_URL=http://app:8000 --build-arg NEXT_PUBLIC_API_VERSION=v1 --build-arg NEXT_PUBLIC_DEFAULT_AUTH_MODE=multi_user --build-arg NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN=false --build-arg NEXT_PUBLIC_BILLING_ENABLED=false .`

## Notes
- branch protection still needs to mark `container-build-check` as a required status outside workflow YAML
