### PR TITLE
fix: typed query params and noopener link security

### DIFF
--- a/apps/packages/ui/src/components/Option/Settings/general-settings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/general-settings.tsx
@@ -408,7 +408,7 @@ export const GeneralSettings = () => {
             <a
               href="https://github.com/rmusser01/tldw_server"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="inline-flex items-center rounded border border-border bg-surface2 px-2 py-1 text-xs text-primary hover:bg-surface3"
             >
               {t("generalSettings.extensionPromo.cta", "Learn More")}

--- a/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
@@ -58,6 +58,8 @@ from tldw_Server_API.app.api.v1.schemas.writing_manuscript_schemas import (
     SceneSummary,
     SceneWorldInfoLink,
     SceneWorldInfoLinkResponse,
+    CHARACTER_ROLES,
+    WORLD_INFO_KINDS,
 )
 from tldw_Server_API.app.core.AuthNZ.rate_limiter import RateLimiter
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
@@ -942,7 +944,7 @@ async def create_character(
 )
 async def list_characters(
     project_id: str,
-    role: str | None = Query(None, description="Filter by role"),
+    role: CHARACTER_ROLES | None = Query(None, description="Filter by role"),
     cast_group: str | None = Query(None, description="Filter by cast group"),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("writing.manuscripts.list")),
@@ -1166,7 +1168,7 @@ async def create_world_info(
 )
 async def list_world_info(
     project_id: str,
-    kind: str | None = Query(None, description="Filter by kind"),
+    kind: WORLD_INFO_KINDS | None = Query(None, description="Filter by kind"),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("writing.manuscripts.list")),
 ) -> list[ManuscriptWorldInfoResponse]:

--- a/tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py
@@ -277,7 +277,8 @@ class ManuscriptSearchResponse(BaseModel):
 # Character
 # ---------------------------------------------------------------------------
 
-_CHARACTER_ROLES = Literal["protagonist", "antagonist", "supporting", "minor", "mentioned"]
+CHARACTER_ROLES = Literal["protagonist", "antagonist", "supporting", "minor", "mentioned"]
+_CHARACTER_ROLES = CHARACTER_ROLES
 
 
 class ManuscriptCharacterCreate(BaseModel):
@@ -372,7 +373,8 @@ class ManuscriptRelationshipResponse(BaseModel):
 # World Info
 # ---------------------------------------------------------------------------
 
-_WORLD_INFO_KINDS = Literal["location", "item", "faction", "concept", "event", "custom"]
+WORLD_INFO_KINDS = Literal["location", "item", "faction", "concept", "event", "custom"]
+_WORLD_INFO_KINDS = WORLD_INFO_KINDS
 
 
 class ManuscriptWorldInfoCreate(BaseModel):


### PR DESCRIPTION
## Summary
- Export `CHARACTER_ROLES` and `WORLD_INFO_KINDS` as public `Literal` types from manuscript schemas (backward-compatible aliases kept)
- Use those typed Literals for `role` and `kind` query parameters in manuscript endpoints instead of bare `str` — gives OpenAPI enum validation
- Add `noopener` to `rel="noreferrer"` on the GitHub link in general-settings (security best practice)

## Test plan
- [ ] Verify `/api/v1/manuscripts/{project_id}/characters?role=invalid` returns 422 (typed enum validation)
- [ ] Verify `/api/v1/manuscripts/{project_id}/world-info?kind=location` still works
- [ ] Confirm existing imports of `_CHARACTER_ROLES` / `_WORLD_INFO_KINDS` still resolve via aliases
- [ ] Check general-settings GitHub link opens correctly with `rel="noopener noreferrer"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)