### PR TITLE
feat: sandbox & ACP competitive improvements — 17 items

### DIFF
--- a/tldw_Server_API/app/api/v1/endpoints/acp_permissions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/acp_permissions.py
@@ -1,0 +1,152 @@
+"""ACP Permissions sub-module.
+
+Provides CRUD endpoints for ACP permission policies and persisted
+permission decisions (the "remember" pattern).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
+    User,
+    get_request_user,
+)
+from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+router = APIRouter(prefix="/acp/permissions", tags=["acp-permissions"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_acp_db() -> ACPSessionsDB:
+    """Return the shared ACPSessionsDB singleton.
+
+    Re-uses the same DB instance that the ACP session store already holds.
+    """
+    from tldw_Server_API.app.services.admin_acp_sessions_service import (
+        ACPSessionStore,
+        _store as _module_store,
+    )
+
+    # If the async singleton has already been initialized, reuse its DB
+    if _module_store is not None:
+        try:
+            return _module_store.get_db()
+        except Exception:
+            pass
+
+    # Fallback: instantiate a fresh one (default path)
+    return ACPSessionsDB()
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+class PermissionDecisionCreate(BaseModel):
+    tool_pattern: str = Field(..., description="fnmatch pattern for tool names (e.g. 'bash', 'file_*')")
+    decision: str = Field(..., description="'allow' or 'deny'")
+    scope: str = Field("session", description="'session' or 'global'")
+    session_id: str | None = Field(None, description="Required when scope is 'session'")
+    persona_id: str | None = None
+    reason: str | None = None
+
+
+class PermissionDecisionOut(BaseModel):
+    id: str
+    user_id: int
+    tool_pattern: str
+    decision: str
+    scope: str
+    session_id: str | None = None
+    persona_id: str | None = None
+    created_at: str
+    expires_at: str | None = None
+    reason: str | None = None
+
+
+class PermissionDecisionDeleteResponse(BaseModel):
+    status: str
+    id: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/decisions",
+    response_model=list[PermissionDecisionOut],
+    summary="List persisted permission decisions",
+)
+async def list_permission_decisions(
+    user: User = Depends(get_request_user),
+) -> list[dict[str, Any]]:
+    """Return all non-expired remembered permission decisions for the current user."""
+    db = _get_acp_db()
+    return db.list_permission_decisions(user_id=user.id)
+
+
+@router.post(
+    "/decisions",
+    response_model=PermissionDecisionOut,
+    status_code=201,
+    summary="Create a permission decision",
+)
+async def create_permission_decision(
+    body: PermissionDecisionCreate,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """Manually add a remembered permission decision."""
+    if body.decision not in ("allow", "deny"):
+        raise HTTPException(status_code=400, detail="decision must be 'allow' or 'deny'")
+    if body.scope not in ("session", "global"):
+        raise HTTPException(status_code=400, detail="scope must be 'session' or 'global'")
+    if body.scope == "session" and not body.session_id:
+        raise HTTPException(
+            status_code=422,
+            detail="session_id is required when scope is 'session'",
+        )
+
+    from tldw_Server_API.app.core.Agent_Client_Protocol.permission_decision_service import (
+        PermissionDecisionService,
+    )
+
+    db = _get_acp_db()
+    svc = PermissionDecisionService(db)
+    decision_id = svc.persist(
+        user_id=user.id,
+        tool_pattern=body.tool_pattern,
+        decision=body.decision,
+        scope=body.scope,
+        session_id=body.session_id,
+        persona_id=body.persona_id,
+        reason=body.reason,
+    )
+    return db.get_permission_decision(decision_id)  # type: ignore[return-value]
+
+
+@router.delete(
+    "/decisions/{decision_id}",
+    summary="Revoke a permission decision",
+    response_model=PermissionDecisionDeleteResponse,
+)
+async def revoke_permission_decision(
+    decision_id: str,
+    user: User = Depends(get_request_user),
+) -> PermissionDecisionDeleteResponse:
+    """Revoke (delete) a remembered permission decision."""
+    db = _get_acp_db()
+    # Verify ownership
+    existing = db.get_permission_decision(decision_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Decision not found")
+    if existing["user_id"] != user.id:
+        raise HTTPException(status_code=403, detail="Not your decision to revoke")
+    db.delete_permission_decision(decision_id)
+    return PermissionDecisionDeleteResponse(status="deleted", id=decision_id)

--- a/tldw_Server_API/app/api/v1/endpoints/acp_schedules.py
+++ b/tldw_Server_API/app/api/v1/endpoints/acp_schedules.py
@@ -1,0 +1,272 @@
+"""ACP Schedules sub-module.
+
+Provides CRUD endpoints for scheduled ACP agent runs (cron-style triggers).
+Schedules are stored in the same ``workflow_schedules`` table but with an
+``acp_config_json`` column that marks them as ACP schedules and carries the
+ACP-specific configuration (prompt, cwd, agent_type, etc.).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from apscheduler.triggers.cron import CronTrigger
+
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
+    User,
+    get_request_user,
+)
+
+router = APIRouter(prefix="/acp/schedules", tags=["acp-schedules"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+class ACPScheduleCreate(BaseModel):
+    name: str = Field(..., description="Human-readable schedule name")
+    cron: str = Field(..., description="Cron expression (5-field)")
+    prompt: Any = Field(..., description="Prompt string or message list for the agent")
+    cwd: str = Field(".", description="Working directory for the agent")
+    agent_type: str | None = Field(None, description="Agent type identifier")
+    model: str | None = Field(None, description="LLM model override")
+    token_budget: int | None = Field(None, description="Token budget for the run")
+    persona_id: str | None = Field(None, description="Persona context")
+    workspace_id: str | None = Field(None, description="Workspace context")
+    sandbox_enabled: bool = Field(False, description="Run in sandbox")
+    enabled: bool = Field(True, description="Whether the schedule is active")
+    timezone: str = Field("UTC", description="IANA timezone for cron evaluation")
+
+
+class ACPScheduleUpdate(BaseModel):
+    name: str | None = None
+    cron: str | None = None
+    prompt: Any | None = None
+    cwd: str | None = None
+    agent_type: str | None = None
+    model: str | None = None
+    token_budget: int | None = None
+    persona_id: str | None = None
+    workspace_id: str | None = None
+    sandbox_enabled: bool | None = None
+    enabled: bool | None = None
+    timezone: str | None = None
+
+
+class ACPScheduleResponse(BaseModel):
+    id: str
+    name: str | None = None
+    cron: str
+    acp_config: dict[str, Any]
+    enabled: bool
+    timezone: str | None = None
+    last_run_at: str | None = None
+    last_status: str | None = None
+    created_at: str | None = None
+
+
+class ACPScheduleDeleteResponse(BaseModel):
+    status: str
+    id: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_scheduler():
+    """Return the global WorkflowsScheduler instance."""
+    from tldw_Server_API.app.services.workflows_scheduler import get_workflows_scheduler
+    return get_workflows_scheduler()
+
+
+def _validate_cron(cron: str, timezone: str = "UTC") -> None:
+    """Validate a cron expression; raise HTTPException on failure."""
+    try:
+        CronTrigger.from_crontab(cron, timezone=timezone)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid cron expression '{cron}': {exc}",
+        )
+
+
+def _build_acp_config(body: ACPScheduleCreate | ACPScheduleUpdate) -> dict[str, Any]:
+    """Extract ACP-specific fields from the request body into a config dict."""
+    cfg: dict[str, Any] = {}
+    if getattr(body, "prompt", None) is not None:
+        cfg["prompt"] = body.prompt
+    if getattr(body, "cwd", None) is not None:
+        cfg["cwd"] = body.cwd
+    if getattr(body, "agent_type", None) is not None:
+        cfg["agent_type"] = body.agent_type
+    if getattr(body, "model", None) is not None:
+        cfg["model"] = body.model
+    if getattr(body, "token_budget", None) is not None:
+        cfg["token_budget"] = body.token_budget
+    if getattr(body, "persona_id", None) is not None:
+        cfg["persona_id"] = body.persona_id
+    if getattr(body, "workspace_id", None) is not None:
+        cfg["workspace_id"] = body.workspace_id
+    if getattr(body, "sandbox_enabled", None) is not None:
+        cfg["sandbox_enabled"] = body.sandbox_enabled
+    return cfg
+
+
+def _schedule_to_response(s) -> dict[str, Any]:
+    """Convert a WorkflowSchedule dataclass to an ACPScheduleResponse-compatible dict."""
+    acp_config: dict[str, Any] = {}
+    if s.acp_config_json:
+        try:
+            acp_config = json.loads(s.acp_config_json) if isinstance(s.acp_config_json, str) else s.acp_config_json
+        except Exception:
+            acp_config = {}
+    return {
+        "id": s.id,
+        "name": s.name,
+        "cron": s.cron,
+        "acp_config": acp_config,
+        "enabled": s.enabled,
+        "timezone": s.timezone,
+        "last_run_at": s.last_run_at,
+        "last_status": s.last_status,
+        "created_at": s.created_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("", response_model=ACPScheduleResponse, status_code=201)
+async def create_acp_schedule(
+    body: ACPScheduleCreate,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """Create a recurring ACP agent schedule."""
+    _validate_cron(body.cron, body.timezone)
+
+    acp_config = _build_acp_config(body)
+    acp_config_str = json.dumps(acp_config)
+
+    svc = _get_scheduler()
+    sid = svc.create(
+        tenant_id="default",
+        user_id=str(user.id),
+        workflow_id=None,
+        name=body.name,
+        cron=body.cron,
+        timezone=body.timezone,
+        inputs={},
+        run_mode="async",
+        validation_mode="block",
+        enabled=body.enabled,
+        acp_config_json=acp_config_str,
+    )
+
+    s = svc.get(sid)
+    if s is None:
+        raise HTTPException(status_code=500, detail="Failed to create schedule")
+    return _schedule_to_response(s)
+
+
+@router.get("", response_model=list[ACPScheduleResponse])
+async def list_acp_schedules(
+    user: User = Depends(get_request_user),
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """List ACP agent schedules for the current user.
+
+    Only returns schedules that have ``acp_config_json`` set (filtering
+    out plain workflow schedules).
+    """
+    svc = _get_scheduler()
+    all_schedules = svc.list(
+        tenant_id="default",
+        user_id=str(user.id),
+        limit=limit,
+        offset=offset,
+    )
+    # Filter to ACP-only schedules
+    return [
+        _schedule_to_response(s)
+        for s in all_schedules
+        if s.acp_config_json
+    ]
+
+
+@router.put("/{schedule_id}", response_model=ACPScheduleResponse)
+async def update_acp_schedule(
+    schedule_id: str,
+    body: ACPScheduleUpdate,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """Update an existing ACP schedule."""
+    svc = _get_scheduler()
+    existing = svc.get(schedule_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    # Verify it belongs to the current user
+    if str(existing.user_id) != str(user.id):
+        raise HTTPException(status_code=403, detail="Not your schedule")
+    # Verify this is an ACP schedule
+    if not existing.acp_config_json:
+        raise HTTPException(status_code=400, detail="Schedule is not an ACP schedule")
+
+    update_dict: dict[str, Any] = {}
+
+    # Handle cron update with validation
+    new_cron = body.cron if body.cron is not None else existing.cron
+    new_tz = body.timezone if body.timezone is not None else (existing.timezone or "UTC")
+    if body.cron is not None:
+        _validate_cron(body.cron, new_tz)
+        update_dict["cron"] = body.cron
+    if body.timezone is not None:
+        update_dict["timezone"] = body.timezone
+    if body.name is not None:
+        update_dict["name"] = body.name
+    if body.enabled is not None:
+        update_dict["enabled"] = body.enabled
+
+    # Merge ACP config: start from existing, overlay provided fields
+    try:
+        current_config = json.loads(existing.acp_config_json) if isinstance(existing.acp_config_json, str) else (existing.acp_config_json or {})
+    except Exception:
+        current_config = {}
+
+    new_fields = _build_acp_config(body)
+    if new_fields:
+        current_config.update(new_fields)
+        update_dict["acp_config_json"] = json.dumps(current_config)
+
+    if update_dict:
+        svc.update(schedule_id, update_dict)
+
+    updated = svc.get(schedule_id)
+    if updated is None:
+        raise HTTPException(status_code=500, detail="Schedule disappeared after update")
+    return _schedule_to_response(updated)
+
+
+@router.delete("/{schedule_id}", response_model=ACPScheduleDeleteResponse)
+async def delete_acp_schedule(
+    schedule_id: str,
+    user: User = Depends(get_request_user),
+) -> ACPScheduleDeleteResponse:
+    """Delete an ACP schedule."""
+    svc = _get_scheduler()
+    existing = svc.get(schedule_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    if str(existing.user_id) != str(user.id):
+        raise HTTPException(status_code=403, detail="Not your schedule")
+    if not existing.acp_config_json:
+        raise HTTPException(status_code=400, detail="Schedule is not an ACP schedule")
+
+    svc.delete(schedule_id)
+    return ACPScheduleDeleteResponse(status="deleted", id=schedule_id)

--- a/tldw_Server_API/app/api/v1/endpoints/acp_triggers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/acp_triggers.py
@@ -1,0 +1,279 @@
+"""ACP Triggers sub-module.
+
+Provides:
+- ``POST /acp/triggers/webhook/{trigger_id}`` -- inbound webhook receiver
+  (NO auth required; uses HMAC verification instead)
+- CRUD endpoints for managing webhook trigger configurations
+  (auth required via ``get_request_user``)
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
+    User,
+    get_request_user,
+)
+
+router = APIRouter(prefix="/acp/triggers", tags=["acp-triggers"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class TriggerCreateRequest(BaseModel):
+    name: str = Field(..., description="Human-readable trigger name")
+    source_type: str = Field(
+        "generic",
+        description="Webhook source: 'github', 'slack', or 'generic'",
+    )
+    secret: str = Field(..., description="HMAC shared secret (will be encrypted at rest)")
+    agent_config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Agent configuration (cwd, agent_type, model, etc.)",
+    )
+    prompt_template: str = Field(
+        "",
+        description="Prompt template with {payload} and {event_type} placeholders",
+    )
+    enabled: bool = Field(True, description="Whether the trigger is active")
+
+
+class TriggerUpdateRequest(BaseModel):
+    name: str | None = None
+    source_type: str | None = None
+    secret: str | None = None
+    agent_config: dict[str, Any] | None = None
+    prompt_template: str | None = None
+    enabled: bool | None = None
+
+
+class TriggerResponse(BaseModel):
+    id: str
+    name: str
+    source_type: str
+    owner_user_id: int
+    agent_config: dict[str, Any] = Field(default_factory=dict)
+    prompt_template: str = ""
+    enabled: bool = True
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class WebhookResult(BaseModel):
+    task_id: str | None = None
+    status: str
+    error: str | None = None
+
+
+class TriggerDeleteResponse(BaseModel):
+    status: str
+    id: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_trigger_manager():
+    """Lazily construct and return an ACPTriggerManager.
+
+    Uses the same ``ACPSessionsDB`` instance backing the ACP session store
+    and a ``TriggerSecretManager`` initialized from the environment.
+    """
+    from tldw_Server_API.app.core.Agent_Client_Protocol.triggers import (
+        ACPTriggerManager,
+        TriggerSecretManager,
+    )
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+    # Re-use the DB instance from the session store when possible
+    try:
+        from tldw_Server_API.app.services.admin_acp_sessions_service import (
+            _store as _module_store,
+        )
+        db: ACPSessionsDB | None = None
+        if _module_store is not None:
+            db = _module_store.get_db()
+    except Exception:
+        db = None
+    if db is None:
+        db = ACPSessionsDB()
+
+    try:
+        secret_mgr = TriggerSecretManager()
+    except (ImportError, ValueError) as exc:
+        from fastapi import HTTPException
+        raise HTTPException(
+            status_code=503,
+            detail=f"Webhook trigger encryption not configured: {exc}",
+        )
+    return ACPTriggerManager(db=db, secret_manager=secret_mgr)
+
+
+# ---------------------------------------------------------------------------
+# Inbound webhook endpoint (NO AUTH -- uses HMAC)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/webhook/{trigger_id}", response_model=WebhookResult)
+async def receive_webhook(trigger_id: str, request: Request) -> dict[str, Any]:
+    """Receive an inbound webhook and trigger an ACP agent run.
+
+    This endpoint does NOT require authentication.  Instead, the request
+    body is verified against the trigger's stored HMAC secret using the
+    provider-specific signing scheme.
+    """
+    payload_body = await request.body()
+    # Collect headers as a lowercase dict
+    headers = {k.lower(): v for k, v in request.headers.items()}
+
+    mgr = _get_trigger_manager()
+    result = await mgr.handle_webhook(trigger_id, payload_body, headers)
+
+    status_code = 200
+    if result.get("status") == "rejected":
+        error = result.get("error", "")
+        if error == "trigger_not_found":
+            status_code = 404
+        elif error == "signature_invalid":
+            status_code = 403
+        elif error == "rate_limit_exceeded":
+            status_code = 429
+        else:
+            status_code = 400
+
+    if status_code != 200:
+        raise HTTPException(status_code=status_code, detail=result)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CRUD endpoints (AUTH required)
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=TriggerResponse, status_code=201)
+async def create_trigger(
+    body: TriggerCreateRequest,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """Create a new webhook trigger."""
+    if body.source_type not in ("github", "slack", "generic"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid source_type '{body.source_type}'; must be github, slack, or generic",
+        )
+
+    mgr = _get_trigger_manager()
+    trigger_id = mgr.create_trigger(
+        name=body.name,
+        source_type=body.source_type,
+        secret=body.secret,
+        owner_user_id=user.id,
+        agent_config=body.agent_config,
+        prompt_template=body.prompt_template,
+        enabled=body.enabled,
+    )
+
+    trigger = mgr.get_trigger(trigger_id)
+    if trigger is None:
+        raise HTTPException(status_code=500, detail="Failed to create trigger")
+    # Strip secret from response
+    trigger.pop("secret_encrypted", None)
+    return trigger
+
+
+@router.get("", response_model=list[TriggerResponse])
+async def list_triggers(
+    user: User = Depends(get_request_user),
+) -> list[dict[str, Any]]:
+    """List triggers for the current user."""
+    mgr = _get_trigger_manager()
+    return mgr.list_triggers(user.id)
+
+
+@router.get("/{trigger_id}", response_model=TriggerResponse)
+async def get_trigger(
+    trigger_id: str,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """Get trigger details."""
+    mgr = _get_trigger_manager()
+    trigger = mgr.get_trigger(trigger_id)
+    if trigger is None:
+        raise HTTPException(status_code=404, detail="Trigger not found")
+    if trigger.get("owner_user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Not your trigger")
+    # Strip secret from response
+    trigger.pop("secret_encrypted", None)
+    return trigger
+
+
+@router.put("/{trigger_id}", response_model=TriggerResponse)
+async def update_trigger(
+    trigger_id: str,
+    body: TriggerUpdateRequest,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """Update a trigger."""
+    mgr = _get_trigger_manager()
+    existing = mgr.get_trigger(trigger_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Trigger not found")
+    if existing.get("owner_user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Not your trigger")
+
+    if body.source_type is not None and body.source_type not in ("github", "slack", "generic"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid source_type '{body.source_type}'",
+        )
+
+    update_kwargs: dict[str, Any] = {}
+    if body.name is not None:
+        update_kwargs["name"] = body.name
+    if body.source_type is not None:
+        update_kwargs["source_type"] = body.source_type
+    if body.secret is not None:
+        update_kwargs["secret"] = body.secret
+    if body.agent_config is not None:
+        update_kwargs["agent_config"] = body.agent_config
+    if body.prompt_template is not None:
+        update_kwargs["prompt_template"] = body.prompt_template
+    if body.enabled is not None:
+        update_kwargs["enabled"] = body.enabled
+
+    if update_kwargs:
+        mgr.update_trigger(trigger_id, **update_kwargs)
+
+    updated = mgr.get_trigger(trigger_id)
+    if updated is None:
+        raise HTTPException(status_code=500, detail="Trigger disappeared after update")
+    updated.pop("secret_encrypted", None)
+    return updated
+
+
+@router.delete("/{trigger_id}", response_model=TriggerDeleteResponse)
+async def delete_trigger(
+    trigger_id: str,
+    user: User = Depends(get_request_user),
+) -> TriggerDeleteResponse:
+    """Delete a trigger."""
+    mgr = _get_trigger_manager()
+    existing = mgr.get_trigger(trigger_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Trigger not found")
+    if existing.get("owner_user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Not your trigger")
+
+    mgr.delete_trigger(trigger_id)
+    return TriggerDeleteResponse(status="deleted", id=trigger_id)

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -13,7 +13,8 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect, status
+from fastapi.responses import StreamingResponse
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_token_scope
@@ -26,7 +27,12 @@ from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentRegisterRequest,
     ACPAgentRegistrationResponse,
     ACPAgentUpdateRequest,
+    ACPAsyncPromptRequest,
+    ACPAsyncPromptResponse,
+    ACPCheckpointListResponse,
     ACPHealthResponse,
+    ACPRollbackRequest,
+    ACPRollbackResponse,
     ACPSessionCancelRequest,
     ACPSessionCloseRequest,
     ACPSessionDetailResponse,
@@ -40,6 +46,7 @@ from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPSessionPromptResponse,
     ACPSessionUpdatesResponse,
     ACPSessionUsageResponse,
+    ACPTaskStatusResponse,
     ACPTokenUsage,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
@@ -61,8 +68,57 @@ from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
 )
 from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
 from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.checkpoint_consumer import CheckpointConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.sse_consumer import SSEConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
 
 router = APIRouter(prefix="/acp", tags=["acp"])
+
+# ---------------------------------------------------------------------------
+# Per-session event bus registry (shared across SSE, WS, and ACP runtime)
+# ---------------------------------------------------------------------------
+
+_SESSION_EVENT_BUSES: dict[str, SessionEventBus] = {}
+_SESSION_EVENT_BUSES_LOCK = threading.Lock()
+
+
+def register_session_event_bus(session_id: str, bus: SessionEventBus) -> None:
+    """Register a session's event bus so SSE/WS consumers can find it.
+
+    Called by the ACP runtime when a session starts.
+    """
+    with _SESSION_EVENT_BUSES_LOCK:
+        _SESSION_EVENT_BUSES[session_id] = bus
+
+
+def get_session_event_bus(session_id: str) -> SessionEventBus | None:
+    """Return the event bus registered for *session_id*, or ``None``."""
+    with _SESSION_EVENT_BUSES_LOCK:
+        return _SESSION_EVENT_BUSES.get(session_id)
+
+
+def get_or_create_session_event_bus(session_id: str) -> SessionEventBus:
+    """Return the SessionEventBus for *session_id*, creating one if needed.
+
+    Prefers a bus registered by the ACP runtime via
+    :func:`register_session_event_bus`.  Falls back to creating a
+    standalone bus so that SSE consumers work even if the runtime has
+    not yet registered one.
+    """
+    with _SESSION_EVENT_BUSES_LOCK:
+        bus = _SESSION_EVENT_BUSES.get(session_id)
+        if bus is None:
+            bus = SessionEventBus(session_id=session_id)
+            _SESSION_EVENT_BUSES[session_id] = bus
+        return bus
+
+
+# ---------------------------------------------------------------------------
+# Per-session checkpoint consumer registry
+# ---------------------------------------------------------------------------
+
+_CHECKPOINT_CONSUMERS: dict[str, CheckpointConsumer] = {}
+_CHECKPOINT_CONSUMERS_LOCK = threading.Lock()
 
 _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS = (
     ACPResponseError,
@@ -599,16 +655,30 @@ async def _prepare_acp_runtime_prompt(
     session_id: str,
     prompt: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], bool]:
+    used_bootstrap = False
     try:
         store = await get_acp_session_store()
         builder = getattr(store, "build_bootstrap_prompt", None)
         if callable(builder):
-            return await builder(session_id, prompt)
+            prompt, used_bootstrap = await builder(session_id, prompt)
     except ValueError as exc:
         raise ACPResponseError(str(exc)) from exc
     except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS:
         logger.warning("Failed to prepare ACP bootstrap prompt for session {}", session_id)
-    return prompt, False
+
+    # Preprocess @tool_name mentions and attach hints to message metadata.
+    try:
+        from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+        prompt, tool_hints = await preprocess_mentions(prompt)
+        if tool_hints and prompt:
+            last_msg = prompt[-1]
+            meta = last_msg.setdefault("metadata", {})
+            meta["tool_hints"] = tool_hints
+    except Exception:
+        logger.debug("@mention preprocessing failed for session {}", session_id)
+
+    return prompt, used_bootstrap
 
 
 async def _clear_acp_bootstrap_state(session_id: str) -> None:
@@ -730,9 +800,14 @@ async def acp_session_stream(
     session_id: str,
     token: str | None = Query(None),
     api_key: str | None = Query(None),
+    last_sequence: int = Query(0),
 ) -> None:
     """
     WebSocket endpoint for real-time ACP session updates.
+
+    Query Parameters:
+    - last_sequence: If > 0, replay buffered events from this sequence on
+      reconnect before switching to live delivery.
 
     Message types (Server → Client):
     - connected: Connection established
@@ -799,13 +874,36 @@ async def acp_session_stream(
             await stream.send_json(message)
         send_callback = _send_callback
 
-        # Register this WebSocket with the session
+        # Register this WebSocket with the session.
+        # NOTE: client.register_websocket uses the runner's internal
+        # broadcast mechanism which does not currently expose a
+        # from_sequence parameter.  Replay of missed events on
+        # reconnect requires wiring a WSBroadcaster with the
+        # session's shared event bus.  For now we pass
+        # last_sequence through when a bus-backed broadcaster is
+        # available; otherwise fall back to the existing path.
+        bus = get_session_event_bus(session_id)
+        if bus is not None and last_sequence > 0:
+            from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import WSBroadcaster
+
+            broadcaster = WSBroadcaster()
+            await broadcaster.start(bus)
+
+            async def _ws_send_str(msg: str) -> None:
+                await stream.send_json(json.loads(msg))
+
+            await broadcaster.add_connection(
+                conn_id=f"ws-{session_id}-{id(stream)}",
+                send_callback=_ws_send_str,
+                from_sequence=last_sequence,
+            )
         await client.register_websocket(session_id, send_callback)
 
         # Send connected message
         await stream.send_json({
             "type": "connected",
             "session_id": session_id,
+            "last_sequence": last_sequence,
             "agent_capabilities": client.agent_capabilities,
         })
 
@@ -2367,6 +2465,76 @@ async def acp_session_events(
     }
 
 
+# -----------------------------------------------------------------------------
+# Session Events SSE Stream
+# -----------------------------------------------------------------------------
+
+
+@router.get(
+    "/sessions/{session_id}/events/stream",
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+)
+async def acp_session_events_stream(
+    request: Request,
+    session_id: str,
+    last_event_id: int = Query(0, description="Replay events from this sequence number"),
+    user: User = Depends(get_request_user),
+) -> StreamingResponse:
+    """Stream ACP session events as Server-Sent Events.
+
+    Events are formatted as typed SSE frames with ``event: {kind}`` and
+    ``data: {json}`` fields.  A heartbeat comment is sent every 15 seconds
+    to keep the connection alive through proxies and load balancers.
+
+    Use the *last_event_id* query parameter to replay buffered events from
+    a given sequence number (e.g. for reconnection catch-up).
+    """
+    _acp_enforce_control_rate_limit(user_id=int(user.id), action="events_stream")
+    client = await get_runner_client()
+    await _require_session_access(client, session_id=session_id, user_id=int(user.id))
+
+    # Verify session exists in the store
+    store = await get_acp_session_store()
+    rec = await store.get_session(session_id)
+    if not rec:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="session_not_found")
+
+    bus = get_or_create_session_event_bus(session_id)
+    consumer = SSEConsumer(
+        from_sequence=max(0, last_event_id),
+        heartbeat_interval=15.0,
+    )
+    await consumer.start(bus)
+
+    _acp_record_audit_event(
+        action="events_stream_connect",
+        user_id=int(user.id),
+        session_id=session_id,
+        metadata={"last_event_id": int(last_event_id), "consumer_id": consumer.consumer_id},
+    )
+
+    async def _event_generator():
+        try:
+            async for line in consumer.iter_sse_lines():
+                if await request.is_disconnected():
+                    break
+                yield line
+        except (asyncio.CancelledError, GeneratorExit):
+            pass
+        finally:
+            await consumer.stop()
+
+    return StreamingResponse(
+        _event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @router.get(
     "/sessions/{session_id}/artifacts",
     dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
@@ -2549,4 +2717,330 @@ async def acp_session_fork(
         name=forked.name,
         forked_from=session_id,
         message_count=forked.message_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Async fire-and-forget API (Scheduler-backed)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/sessions/prompt-async",
+    response_model=ACPAsyncPromptResponse,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.prompt_async"))],
+)
+async def acp_prompt_async(
+    body: ACPAsyncPromptRequest,
+    user: User = Depends(get_request_user),
+) -> ACPAsyncPromptResponse:
+    """Submit an ACP prompt for asynchronous execution.
+
+    Returns a ``task_id`` that can be polled via
+    ``GET /api/v1/acp/tasks/{task_id}`` for status and results.
+
+    Tasks are submitted to the global Scheduler and persisted in the
+    database, so they survive process restarts and are visible from
+    any worker.
+    """
+    _acp_enforce_control_rate_limit(user_id=int(user.id), action="prompt_async")
+
+    payload: dict[str, Any] = {
+        "user_id": int(user.id),
+        "prompt": body.prompt,
+        "cwd": body.cwd,
+    }
+    if body.agent_type is not None:
+        payload["agent_type"] = body.agent_type
+    if body.persona_id is not None:
+        payload["persona_id"] = body.persona_id
+    if body.workspace_id is not None:
+        payload["workspace_id"] = body.workspace_id
+
+    from tldw_Server_API.app.core.Scheduler import get_global_scheduler
+
+    scheduler = await get_global_scheduler()
+    task_id = await scheduler.submit(
+        handler="acp_run",
+        payload=payload,
+        queue_name="acp",
+        metadata={"user_id": str(user.id)},
+    )
+
+    poll_url = f"/api/v1/acp/tasks/{task_id}"
+    return ACPAsyncPromptResponse(task_id=task_id, poll_url=poll_url, status="queued")
+
+
+@router.get(
+    "/tasks/{task_id}",
+    response_model=ACPTaskStatusResponse,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.tasks.status"))],
+)
+async def acp_task_status(
+    task_id: str,
+    user: User = Depends(get_request_user),
+) -> ACPTaskStatusResponse:
+    """Poll for the status and result of an async ACP task."""
+    from tldw_Server_API.app.core.Scheduler import get_global_scheduler
+
+    scheduler = await get_global_scheduler()
+    task = await scheduler.get_task(task_id)
+
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Task '{task_id}' not found",
+        )
+
+    # Verify ownership via task metadata
+    task_user_id = (task.metadata or {}).get("user_id")
+    if task_user_id != str(user.id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Task '{task_id}' not found",
+        )
+
+    # Map scheduler TaskStatus to the API status string
+    status_map = {
+        "pending": "queued",
+        "queued": "queued",
+        "running": "running",
+        "completed": "completed",
+        "failed": "failed",
+        "cancelled": "failed",
+        "dead": "failed",
+    }
+    task_status_str = status_map.get(task.status.value, task.status.value)
+
+    result_data = task.result if isinstance(task.result, dict) else None
+    return ACPTaskStatusResponse(
+        task_id=task_id,
+        status=task_status_str,
+        result=result_data.get("result") if result_data else None,
+        usage=result_data.get("usage", {}) if result_data else {},
+        error=task.error or (result_data.get("error") if result_data else None),
+        duration_ms=result_data.get("duration_ms") if result_data else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run history & cost tracking
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/runs",
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.runs.list"))],
+)
+async def list_acp_runs(
+    user: User = Depends(get_request_user),
+    status_filter: str | None = Query(None, alias="status", description="Filter by session status (active, closed, error)"),
+    agent_type: str | None = Query(None, description="Filter by agent type"),
+    from_date: str | None = Query(None, description="ISO date lower bound, e.g. 2026-01-01"),
+    to_date: str | None = Query(None, description="ISO date upper bound, e.g. 2026-12-31"),
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+) -> dict:
+    """Query ACP run history with optional filters."""
+    _acp_enforce_control_rate_limit(user_id=int(user.id), action="list_runs")
+    store = await get_acp_session_store()
+    return await store.list_runs(
+        user_id=int(user.id),
+        status=status_filter,
+        agent_type=agent_type,
+        from_date=from_date,
+        to_date=to_date,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get(
+    "/runs/aggregate",
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.runs.aggregate"))],
+)
+async def aggregate_acp_runs(
+    user: User = Depends(get_request_user),
+    from_date: str | None = Query(None, description="ISO date lower bound"),
+    to_date: str | None = Query(None, description="ISO date upper bound"),
+) -> dict:
+    """Aggregate token usage and costs across ACP runs."""
+    _acp_enforce_control_rate_limit(user_id=int(user.id), action="aggregate_runs")
+    store = await get_acp_session_store()
+    return await store.aggregate_runs(
+        user_id=int(user.id),
+        from_date=from_date,
+        to_date=to_date,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Checkpoint-based Rollback
+# -----------------------------------------------------------------------------
+
+
+def _get_checkpoint_consumer(session_id: str) -> CheckpointConsumer | None:
+    """Return the CheckpointConsumer for *session_id*, if one exists."""
+    with _CHECKPOINT_CONSUMERS_LOCK:
+        return _CHECKPOINT_CONSUMERS.get(session_id)
+
+
+async def _ensure_checkpoint_consumer(session_id: str) -> CheckpointConsumer:
+    """Return or create a CheckpointConsumer for *session_id*.
+
+    Lazily creates the consumer and starts it on the session's event bus.
+    The SandboxService is instantiated on demand so the endpoint module
+    does not import it at module level.
+    """
+    with _CHECKPOINT_CONSUMERS_LOCK:
+        consumer = _CHECKPOINT_CONSUMERS.get(session_id)
+        if consumer is not None:
+            return consumer
+
+    # Build consumer outside the lock (SandboxService init may be expensive)
+    try:
+        from tldw_Server_API.app.core.Sandbox.service import SandboxService
+        svc = SandboxService()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Sandbox service unavailable: {exc}",
+        ) from exc
+
+    consumer = CheckpointConsumer(sandbox_service=svc, session_id=session_id)
+    bus = get_or_create_session_event_bus(session_id)
+    await consumer.start(bus)
+
+    with _CHECKPOINT_CONSUMERS_LOCK:
+        # Double-check: another request may have raced us
+        existing = _CHECKPOINT_CONSUMERS.get(session_id)
+        if existing is not None:
+            await consumer.stop()
+            return existing
+        _CHECKPOINT_CONSUMERS[session_id] = consumer
+
+    return consumer
+
+
+@router.post(
+    "/sessions/{session_id}/rollback",
+    response_model=ACPRollbackResponse,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+)
+async def acp_session_rollback(
+    session_id: str,
+    body: ACPRollbackRequest,
+    user: User = Depends(get_request_user),
+) -> ACPRollbackResponse:
+    """Rollback sandbox state to a checkpoint.
+
+    Provide either ``to_sequence`` (finds nearest checkpoint at or before
+    that sequence) or ``to_snapshot_id`` (restores directly).  Only works
+    for sandbox-backed sessions with an active CheckpointConsumer.
+    """
+    _acp_enforce_control_rate_limit(user_id=int(user.id), action="rollback")
+    client = await get_runner_client()
+    await _require_session_access(client, session_id=session_id, user_id=int(user.id))
+
+    if body.to_sequence is None and body.to_snapshot_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide either to_sequence or to_snapshot_id",
+        )
+
+    # Resolve snapshot_id
+    snapshot_id: str | None = body.to_snapshot_id
+    resolved_sequence: int | None = None
+
+    consumer = _get_checkpoint_consumer(session_id)
+
+    if snapshot_id is None:
+        # Must resolve from sequence via the consumer
+        if consumer is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No checkpoint consumer active for this session; provide to_snapshot_id directly or ensure checkpointing is enabled",
+            )
+        assert body.to_sequence is not None
+        result = consumer.get_nearest_checkpoint(body.to_sequence)
+        if result is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No checkpoint found at or before sequence {body.to_sequence}",
+            )
+        resolved_sequence, snapshot_id = result
+
+    assert snapshot_id is not None
+
+    # Perform the restore via SandboxService
+    try:
+        from tldw_Server_API.app.core.Sandbox.service import SandboxService
+        svc = SandboxService()
+        restored = svc.restore_snapshot(session_id, snapshot_id)
+    except Exception as exc:
+        logger.error(
+            "Rollback failed for session {} snapshot {}: {}",
+            session_id, snapshot_id, exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Rollback failed: {exc}",
+        ) from exc
+
+    if not restored:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="restore_snapshot returned False",
+        )
+
+    # Emit LIFECYCLE event on the bus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+    bus = get_or_create_session_event_bus(session_id)
+    await bus.publish(AgentEvent(
+        session_id=session_id,
+        kind=AgentEventKind.LIFECYCLE,
+        payload={
+            "action": "rollback",
+            "snapshot_id": snapshot_id,
+            "to_sequence": resolved_sequence,
+        },
+    ))
+
+    _acp_record_audit_event(
+        action="rollback",
+        user_id=int(user.id),
+        session_id=session_id,
+        metadata={"snapshot_id": snapshot_id, "to_sequence": resolved_sequence},
+    )
+
+    return ACPRollbackResponse(
+        restored=True,
+        snapshot_id=snapshot_id,
+        sequence=resolved_sequence,
+    )
+
+
+@router.get(
+    "/sessions/{session_id}/checkpoints",
+    response_model=ACPCheckpointListResponse,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+)
+async def acp_session_checkpoints(
+    session_id: str,
+    user: User = Depends(get_request_user),
+) -> ACPCheckpointListResponse:
+    """List available checkpoints for a sandbox-backed session."""
+    _acp_enforce_control_rate_limit(user_id=int(user.id), action="list_checkpoints")
+    client = await get_runner_client()
+    await _require_session_access(client, session_id=session_id, user_id=int(user.id))
+
+    consumer = _get_checkpoint_consumer(session_id)
+    checkpoints: dict[int, str] = {}
+    if consumer is not None:
+        checkpoints = consumer.get_checkpoints()
+
+    return ACPCheckpointListResponse(
+        session_id=session_id,
+        checkpoints=checkpoints,
     )

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -674,3 +674,88 @@ class ACPErrorResponse(BaseModel):
     data: dict[str, Any] | None = Field(
         default=None, description="Additional error context"
     )
+
+
+# -----------------------------------------------------------------------------
+# Async Fire-and-Forget API
+# -----------------------------------------------------------------------------
+
+
+class ACPAsyncPromptRequest(BaseModel):
+    """Request body for async prompt submission."""
+    prompt: str | list[dict[str, Any]] = Field(
+        ..., description="Prompt text or message list"
+    )
+    cwd: str = Field(default=".", description="Working directory for the agent")
+    agent_type: str | None = Field(
+        default=None, description="Agent type identifier"
+    )
+    model: str | None = Field(default=None, description="Model override")
+    token_budget: int | None = Field(
+        default=None, description="Maximum token budget"
+    )
+    persona_id: str | None = Field(
+        default=None, description="Persona context for session creation"
+    )
+    workspace_id: str | None = Field(
+        default=None, description="Workspace context for session creation"
+    )
+    sandbox_enabled: bool = Field(
+        default=False, description="Whether to enable sandbox mode"
+    )
+
+
+class ACPAsyncPromptResponse(BaseModel):
+    """Response for async prompt submission."""
+    task_id: str = Field(..., description="Unique identifier for the background task")
+    poll_url: str = Field(
+        ..., description="Relative URL to poll for task status"
+    )
+    status: str = Field(default="queued", description="Initial task status")
+
+
+class ACPTaskStatusResponse(BaseModel):
+    """Response for polling task status."""
+    task_id: str = Field(..., description="Task identifier")
+    status: str = Field(
+        ...,
+        description="Task status: queued, running, completed, failed",
+    )
+    result: Any | None = Field(default=None, description="Task result when completed")
+    usage: dict[str, Any] = Field(
+        default_factory=dict, description="Token usage information"
+    )
+    error: str | None = Field(default=None, description="Error message if failed")
+    duration_ms: int | None = Field(
+        default=None, description="Execution duration in milliseconds"
+    )
+
+
+class ACPRollbackRequest(BaseModel):
+    """Request body for rolling back sandbox state to a checkpoint."""
+    to_sequence: int | None = Field(
+        default=None,
+        description="Target event sequence number; the nearest checkpoint at or before this sequence is used.",
+    )
+    to_snapshot_id: str | None = Field(
+        default=None,
+        description="Direct snapshot ID to restore. Takes precedence over to_sequence if both provided.",
+    )
+
+
+class ACPRollbackResponse(BaseModel):
+    """Response from a rollback operation."""
+    restored: bool = Field(..., description="Whether the rollback succeeded")
+    snapshot_id: str = Field(..., description="The snapshot ID that was restored")
+    sequence: int | None = Field(
+        default=None, description="The event sequence the snapshot corresponds to, if resolved from to_sequence"
+    )
+
+
+class ACPCheckpointListResponse(BaseModel):
+    """Response listing available checkpoints for a session."""
+    session_id: str = Field(..., description="The session these checkpoints belong to")
+    checkpoints: dict[int, str] = Field(
+        default_factory=dict,
+        description="Mapping of event sequence numbers to snapshot IDs",
+    )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
@@ -228,6 +228,62 @@ def _parse_string_list(raw: str | None) -> list[str]:
     return [s.strip() for s in text.split(",") if s.strip()]
 
 
+##############################################################################
+# Permission policy templates
+# ---
+# Preset policy configurations that serve as base layers for the permission
+# system.  Loaded by ``ACPRuntimePolicyService.build_snapshot()`` and merged
+# with user customisations (user overrides take precedence).
+##############################################################################
+
+PERMISSION_POLICY_TEMPLATES: dict[str, dict] = {
+    "read-only": {
+        "tool_tier_overrides": {
+            "Read(*)": "auto",
+            "Glob(*)": "auto",
+            "Grep(*)": "auto",
+            "Bash(git:log*)": "auto",
+            "Bash(git:status*)": "auto",
+            "Bash(git:diff*)": "auto",
+            "*": "individual",
+        },
+        "description": "Read-only access. All write/exec tools require individual approval.",
+    },
+    "developer": {
+        "tool_tier_overrides": {
+            "Bash(git:*)": "auto",
+            "Bash(npm:*)": "auto",
+            "Bash(yarn:*)": "auto",
+            "Bash(pip:*)": "auto",
+            "Read(*)": "auto",
+            "Glob(*)": "auto",
+            "Grep(*)": "auto",
+            "Write(*)": "batch",
+            "Edit(*)": "batch",
+            "Bash(rm:*)": "individual",
+            "Bash(*)": "individual",
+        },
+        "description": "Developer access. Git/npm auto, file writes batch, shell exec individual.",
+    },
+    "admin": {
+        "tool_tier_overrides": {
+            "Bash(rm:-rf*)": "individual",
+            "Bash(git:push*--force*)": "individual",
+            "Bash(git:reset*--hard*)": "individual",
+            "Bash(drop*)": "individual",
+            "*": "auto",
+        },
+        "description": "Admin access. Everything auto except destructive operations.",
+    },
+    "lockdown": {
+        "tool_tier_overrides": {
+            "*": "individual",
+        },
+        "description": "Full lockdown. Every tool requires individual approval.",
+    },
+}
+
+
 def load_acp_sandbox_config() -> ACPSandboxConfig:
     section = get_config_section("ACP-SANDBOX")
     enabled = _parse_bool(os.getenv("ACP_SANDBOX_ENABLED") or section.get("enabled"), False)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/__init__.py
@@ -3,5 +3,14 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventC
 from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import WSBroadcaster
 from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.audit_logger import AuditLogger
 from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.metrics_recorder import MetricsRecorder
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.sse_consumer import SSEConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.checkpoint_consumer import CheckpointConsumer
 
-__all__ = ["EventConsumer", "WSBroadcaster", "AuditLogger", "MetricsRecorder"]
+__all__ = [
+    "EventConsumer",
+    "WSBroadcaster",
+    "AuditLogger",
+    "MetricsRecorder",
+    "SSEConsumer",
+    "CheckpointConsumer",
+]

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/checkpoint_consumer.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/checkpoint_consumer.py
@@ -1,0 +1,175 @@
+"""Checkpoint consumer for auto-snapshotting sandbox state.
+
+Subscribes to SessionEventBus and creates snapshots before
+FILE_CHANGE events, enabling rollback to any checkpoint.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any, TYPE_CHECKING
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import (
+    AgentEvent,
+    AgentEventKind,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+# Event kinds that represent file mutations and should trigger a checkpoint.
+_FILE_MUTATION_KINDS: frozenset[AgentEventKind] = frozenset({
+    AgentEventKind.FILE_CHANGE,
+})
+
+
+class CheckpointConsumer(EventConsumer):
+    """Auto-snapshot sandbox state before file mutations.
+
+    Each instance is scoped to a single session. When a ``FILE_CHANGE``
+    event arrives, the consumer calls ``SandboxService.create_snapshot``
+    and records the mapping ``{sequence: snapshot_id}``.
+
+    If the sandbox service raises (e.g. because a run is active and
+    ``_ensure_no_active_session_runs`` fires), the consumer logs a
+    warning and continues -- it never crashes the event loop.
+
+    Checkpoints are bounded by *max_checkpoints*; when the limit is
+    exceeded the oldest checkpoint is evicted from the local mapping.
+    (The underlying snapshot storage may have its own quota enforcement.)
+    """
+
+    consumer_id: str = "checkpoint"
+
+    def __init__(
+        self,
+        sandbox_service: Any,
+        session_id: str,
+        max_checkpoints: int = 50,
+    ) -> None:
+        self.consumer_id = f"checkpoint_{uuid.uuid4().hex[:8]}"
+        self._service = sandbox_service
+        self._session_id = session_id
+        self._max_checkpoints = max_checkpoints
+
+        # sequence -> snapshot_id
+        self._checkpoints: dict[int, str] = {}
+
+        self._bus: SessionEventBus | None = None
+        self._queue: asyncio.Queue[AgentEvent] | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._stopped: bool = False
+
+    # ------------------------------------------------------------------ #
+    # EventConsumer interface
+    # ------------------------------------------------------------------ #
+
+    async def on_event(self, event: AgentEvent) -> None:
+        """Handle a single event -- snapshot before file mutations."""
+        if event.kind not in _FILE_MUTATION_KINDS:
+            return
+
+        try:
+            result = self._service.create_snapshot(self._session_id)
+            if asyncio.iscoroutine(result):
+                result = await result
+
+            snapshot_id = result.get("snapshot_id") if isinstance(result, dict) else None
+            if snapshot_id:
+                self._checkpoints[event.sequence] = snapshot_id
+                logger.debug(
+                    "Checkpoint created: seq={} snapshot={}",
+                    event.sequence,
+                    snapshot_id,
+                )
+                # Evict oldest if over limit
+                self._evict_oldest()
+            else:
+                logger.debug(
+                    "Checkpoint skipped for seq {}: create_snapshot returned no snapshot_id",
+                    event.sequence,
+                )
+        except Exception as exc:
+            # Active-run guard (SessionActiveRunsConflict) or any other
+            # error -- skip gracefully, never crash the consume loop.
+            logger.debug(
+                "Checkpoint skipped for seq {}: {}",
+                event.sequence,
+                exc,
+            )
+
+    async def start(self, bus: SessionEventBus) -> None:
+        """Subscribe to *bus* and begin consuming events."""
+        self._bus = bus
+        self._queue = bus.subscribe(self.consumer_id)
+        self._stopped = False
+        self._task = asyncio.create_task(self._consume_loop())
+
+    async def stop(self) -> None:
+        """Cancel the consume loop and unsubscribe from the bus."""
+        self._stopped = True
+        if self._bus is not None:
+            self._bus.unsubscribe(self.consumer_id)
+            self._bus = None
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    # ------------------------------------------------------------------ #
+    # Public query helpers
+    # ------------------------------------------------------------------ #
+
+    def get_checkpoints(self) -> dict[int, str]:
+        """Return a copy of the ``{sequence: snapshot_id}`` mapping."""
+        return dict(self._checkpoints)
+
+    def get_nearest_checkpoint(self, target_sequence: int) -> tuple[int, str] | None:
+        """Find the nearest checkpoint at or before *target_sequence*.
+
+        Returns ``(sequence, snapshot_id)`` or ``None`` if no checkpoint
+        exists at or before the target.
+        """
+        candidates = {
+            seq: sid
+            for seq, sid in self._checkpoints.items()
+            if seq <= target_sequence
+        }
+        if not candidates:
+            return None
+        nearest_seq = max(candidates)
+        return nearest_seq, candidates[nearest_seq]
+
+    # ------------------------------------------------------------------ #
+    # Internal
+    # ------------------------------------------------------------------ #
+
+    def _evict_oldest(self) -> None:
+        """Remove the oldest checkpoint if the limit is exceeded."""
+        while len(self._checkpoints) > self._max_checkpoints:
+            oldest_seq = min(self._checkpoints)
+            del self._checkpoints[oldest_seq]
+
+    async def _consume_loop(self) -> None:
+        """Read events from the queue and dispatch to :meth:`on_event`."""
+        if self._queue is None:
+            return
+        while not self._stopped:
+            try:
+                event = await asyncio.wait_for(
+                    self._queue.get(),
+                    timeout=30.0,
+                )
+                await self.on_event(event)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/replay_utils.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/replay_utils.py
@@ -1,0 +1,43 @@
+"""Shared replay helper for SSE and WebSocket catch-up.
+
+Both SSE consumers and WebSocket broadcasters need to replay buffered
+events when a client connects with a ``from_sequence``.  This module
+provides a single implementation so the logic stays consistent.
+"""
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+async def replay_events(
+    bus: SessionEventBus,
+    from_sequence: int,
+    emit_fn: Callable[[AgentEvent], Awaitable[Any]],
+) -> int:
+    """Replay buffered events from *from_sequence* via *emit_fn*.
+
+    Parameters
+    ----------
+    bus:
+        The session event bus to read buffered events from.
+    from_sequence:
+        Sequence number to start replaying from (inclusive).
+        If <= 0, no replay is performed.
+    emit_fn:
+        Async callable invoked once per replayed event.
+
+    Returns
+    -------
+    int
+        Number of events replayed.
+    """
+    if from_sequence <= 0:
+        return 0
+    buffered = bus.snapshot(from_sequence=from_sequence)
+    for event in buffered:
+        await emit_fn(event)
+    return len(buffered)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/sse_consumer.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/sse_consumer.py
@@ -1,0 +1,102 @@
+"""SSE (Server-Sent Events) consumer for ACP agent events.
+
+Formats AgentEvents as SSE text lines and provides an async generator
+for use with FastAPI's StreamingResponse.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import AsyncGenerator
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+class SSEConsumer(EventConsumer):
+    """Streams AgentEvents as Server-Sent Events.
+
+    Each event is formatted as::
+
+        event: {kind}
+        data: {json}
+
+    A heartbeat comment (``": heartbeat\\n\\n"``) is emitted after
+    *heartbeat_interval* seconds of silence to keep the connection alive
+    through proxies and load balancers.
+
+    Usage with FastAPI::
+
+        consumer = SSEConsumer(from_sequence=last_event_id)
+        await consumer.start(bus)
+        return StreamingResponse(
+            consumer.iter_sse_lines(),
+            media_type="text/event-stream",
+        )
+    """
+
+    consumer_id: str = "sse"
+
+    def __init__(
+        self,
+        consumer_id: str | None = None,
+        from_sequence: int = 0,
+        heartbeat_interval: float = 15.0,
+    ) -> None:
+        if consumer_id is not None:
+            self.consumer_id = consumer_id
+        else:
+            self.consumer_id = f"sse_{uuid.uuid4().hex[:12]}"
+        self._from_sequence = from_sequence
+        self._heartbeat_interval = heartbeat_interval
+        self._queue: asyncio.Queue[AgentEvent] | None = None
+        self._bus: SessionEventBus | None = None
+        self._stopped = False
+
+    async def on_event(self, event: AgentEvent) -> None:
+        """Buffer the event for consumption by :meth:`iter_sse_lines`."""
+        if self._queue is not None:
+            await self._queue.put(event)
+
+    async def start(self, bus: SessionEventBus) -> None:
+        """Subscribe to *bus*, replaying from *from_sequence* if set."""
+        self._bus = bus
+        # subscribe() returns a queue and replays buffered events when
+        # from_sequence > 0, so no separate replay_events() call needed.
+        self._queue = bus.subscribe(
+            self.consumer_id,
+            from_sequence=self._from_sequence,
+        )
+        self._stopped = False
+
+    async def stop(self) -> None:
+        """Unsubscribe from the bus and signal the generator to exit."""
+        self._stopped = True
+        if self._bus is not None:
+            self._bus.unsubscribe(self.consumer_id)
+            self._bus = None
+
+    async def iter_sse_lines(self) -> AsyncGenerator[str, None]:
+        """Yield SSE-formatted lines. Use with ``StreamingResponse``.
+
+        Blocks on the internal queue, yielding ``event:``/``data:`` frames
+        for real events and ``": heartbeat"`` comments on timeout.  The
+        generator exits once :meth:`stop` has been called.
+        """
+        while not self._stopped:
+            if self._queue is None:
+                break
+            try:
+                event = await asyncio.wait_for(
+                    self._queue.get(),
+                    timeout=self._heartbeat_interval,
+                )
+                kind = event.kind.value
+                payload = json.dumps(event.to_dict(), default=str)
+                yield f"event: {kind}\ndata: {payload}\n\n"
+            except (asyncio.TimeoutError, TimeoutError):
+                if self._stopped:
+                    break
+                yield ": heartbeat\n\n"

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
@@ -8,6 +8,7 @@ from typing import Awaitable, Callable
 from loguru import logger
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.replay_utils import replay_events
 from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
 from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
 
@@ -67,14 +68,31 @@ class WSBroadcaster(EventConsumer):
     # Connection management
     # ------------------------------------------------------------------ #
 
-    def add_connection(
+    async def add_connection(
         self,
         conn_id: str,
         send_callback: SendCallback,
         verbosity: str = "full",
+        from_sequence: int = 0,
     ) -> None:
-        """Register a WebSocket connection for event delivery."""
-        self._connections[conn_id] = _ConnectionInfo(conn_id, send_callback, verbosity)
+        """Register a WebSocket connection for event delivery.
+
+        If *from_sequence* > 0 and a bus is available, buffered events are
+        replayed to this connection (with verbosity filtering) before it is
+        added to the live broadcast set.
+        """
+        info = _ConnectionInfo(conn_id, send_callback, verbosity)
+
+        # Replay buffered events before going live
+        if from_sequence > 0 and self._bus is not None:
+            async def _emit(event: AgentEvent) -> None:
+                if _passes_filter(event.kind, verbosity):
+                    msg = json.dumps(event.to_dict())
+                    await send_callback(msg)
+
+            await replay_events(self._bus, from_sequence, _emit)
+
+        self._connections[conn_id] = info
 
     def remove_connection(self, conn_id: str) -> None:
         """Unregister a WebSocket connection."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -10,9 +10,11 @@ Unanswered permission requests are automatically denied after
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import time
 import uuid
 from contextlib import suppress
+from typing import Any
 
 from loguru import logger
 
@@ -57,10 +59,16 @@ class GovernanceFilter:
         self,
         bus: SessionEventBus,
         default_timeout_sec: int = 300,
+        policy_snapshot: Any | None = None,
+        session_metadata: dict[str, Any] | None = None,
+        permission_decision_service: Any | None = None,
     ) -> None:
         self._bus = bus
         self._default_timeout_sec = default_timeout_sec
         self._pending: dict[str, _PendingEntry] = {}
+        self._snapshot = policy_snapshot
+        self._session_metadata = session_metadata or {}
+        self._perm_service = permission_decision_service
 
     # ------------------------------------------------------------------
     # Properties
@@ -70,6 +78,44 @@ class GovernanceFilter:
     def pending_count(self) -> int:
         """Number of tool calls awaiting a permission decision."""
         return len(self._pending)
+
+    # ------------------------------------------------------------------
+    # MCPHub snapshot policy check
+    # ------------------------------------------------------------------
+
+    def _check_snapshot_policy(self, tool_name: str) -> str | None:
+        """Check the MCPHub policy snapshot for a tool-level decision.
+
+        Returns:
+            ``"_deny"`` if the tool is explicitly denied,
+            ``"auto"`` if the tool is explicitly allowed,
+            the tier string if a ``tool_tier_overrides`` pattern matches,
+            or ``None`` if the snapshot has no opinion (fall through to
+            existing tier heuristics).
+        """
+        if self._snapshot is None:
+            return None
+
+        doc = getattr(self._snapshot, "resolved_policy_document", None)
+        if not doc or not isinstance(doc, dict):
+            return None
+
+        # 1. Check denied_tools (highest priority)
+        for pattern in doc.get("denied_tools", []):
+            if fnmatch.fnmatch(tool_name, pattern):
+                return "_deny"
+
+        # 2. Check allowed_tools
+        for pattern in doc.get("allowed_tools", []):
+            if fnmatch.fnmatch(tool_name, pattern):
+                return "auto"
+
+        # 3. Check tool_tier_overrides (pattern -> tier mapping)
+        for pattern, tier in doc.get("tool_tier_overrides", {}).items():
+            if fnmatch.fnmatch(tool_name, pattern):
+                return tier
+
+        return None
 
     # ------------------------------------------------------------------
     # Pipeline entry point
@@ -90,10 +136,68 @@ class GovernanceFilter:
             return
 
         tool_name: str = event.payload.get("tool_name", "")
-        # Use the adapter-provided tier if present; fall back to re-resolving
-        tier = event.payload.get("permission_tier") or determine_permission_tier(tool_name)
-
         approval_future = event.metadata.get("_approval_future")
+
+        # --- MCPHub snapshot check (unified hierarchy) ---
+        snapshot_tier = self._check_snapshot_policy(tool_name)
+        if snapshot_tier == "_deny":
+            deny_event = AgentEvent(
+                session_id=event.session_id,
+                kind=AgentEventKind.TOOL_RESULT,
+                payload={
+                    "tool_call_id": event.payload.get("tool_call_id", ""),
+                    "error": f"Tool '{tool_name}' denied by policy",
+                },
+                metadata={"governance_action": "denied_by_snapshot"},
+            )
+            await self._bus.publish(deny_event)
+            if approval_future is not None and not approval_future.done():
+                approval_future.set_result(("deny", f"Tool '{tool_name}' denied by policy"))
+            return
+
+        # --- Check persisted permission decisions (step 4 in hierarchy) ---
+        if self._perm_service is not None and snapshot_tier is None:
+            session_id = event.session_id
+            user_id = self._session_metadata.get("user_id")
+            if user_id is not None:
+                persisted = self._perm_service.check(user_id, tool_name, session_id)
+                if persisted == "allow":
+                    logger.info(
+                        "Governance: persisted decision auto-approved tool '{}'",
+                        tool_name,
+                    )
+                    if approval_future is not None and not approval_future.done():
+                        approval_future.set_result(("approve", None))
+                    if approval_future is not None:
+                        return
+                    await self._bus.publish(event)
+                    return
+                if persisted == "deny":
+                    logger.info(
+                        "Governance: persisted decision denied tool '{}'",
+                        tool_name,
+                    )
+                    deny_event = AgentEvent(
+                        session_id=event.session_id,
+                        kind=AgentEventKind.TOOL_RESULT,
+                        payload={
+                            "tool_call_id": event.payload.get("tool_call_id", ""),
+                            "error": f"Tool '{tool_name}' denied by remembered decision",
+                        },
+                        metadata={"governance_action": "denied_by_persisted_decision"},
+                    )
+                    await self._bus.publish(deny_event)
+                    if approval_future is not None and not approval_future.done():
+                        approval_future.set_result(
+                            ("deny", f"Tool '{tool_name}' denied by remembered decision")
+                        )
+                    return
+
+        if snapshot_tier is not None:
+            tier = snapshot_tier
+        else:
+            # Use the adapter-provided tier if present; fall back to re-resolving
+            tier = event.payload.get("permission_tier") or determine_permission_tier(tool_name)
         internal_only = approval_future is not None
 
         if tier == "auto":
@@ -142,6 +246,9 @@ class GovernanceFilter:
         request_id: str,
         decision: str,
         reason: str | None = None,
+        *,
+        remember: bool = False,
+        scope: str = "session",
     ) -> None:
         """Handle a human decision for a held tool call.
 
@@ -153,6 +260,12 @@ class GovernanceFilter:
             ``"approve"`` or ``"deny"``.
         reason:
             Optional human-supplied reason (used in deny error message).
+        remember:
+            If ``True`` and a :class:`PermissionDecisionService` is attached,
+            persist the decision for future auto-application.
+        scope:
+            ``"session"`` (default) or ``"global"``.  Only used when
+            *remember* is ``True``.
         """
         entry = self._pending.pop(request_id, None)
         if entry is None:
@@ -167,6 +280,27 @@ class GovernanceFilter:
             entry.timeout_task.cancel()
 
         held_event = entry.event
+
+        # Persist the decision when "remember" is requested
+        if remember and self._perm_service is not None:
+            user_id = self._session_metadata.get("user_id")
+            tool_name = held_event.payload.get("tool_name", "")
+            if user_id is not None and tool_name:
+                self._perm_service.persist(
+                    user_id=user_id,
+                    tool_pattern=tool_name,
+                    decision="allow" if decision == "approve" else "deny",
+                    scope=scope,
+                    session_id=held_event.session_id,
+                    reason=reason,
+                )
+                logger.info(
+                    "Governance: persisted remembered decision for tool '{}' "
+                    "(decision={}, scope={})",
+                    tool_name,
+                    decision,
+                    scope,
+                )
 
         # Resolve the approval future if one was attached
         if entry.approval_future is not None and not entry.approval_future.done():

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/permission_decision_service.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/permission_decision_service.py
@@ -1,0 +1,92 @@
+"""Service for checking and persisting user permission decisions.
+
+Part of the unified decision hierarchy (step 4): after MCPHub snapshot
+checks and before admin ACP permission policies.  Allows users to
+"remember" their approve/deny choices so they are auto-applied on
+subsequent tool calls.
+"""
+from __future__ import annotations
+
+import fnmatch
+import uuid
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+
+class PermissionDecisionService:
+    """Thin service layer over the ``permission_decisions`` table."""
+
+    def __init__(self, db: ACPSessionsDB) -> None:
+        self._db = db
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def check(
+        self,
+        user_id: int,
+        tool_name: str,
+        session_id: str | None = None,
+    ) -> str | None:
+        """Return persisted decision (``'allow'`` | ``'deny'``) if one matches, else ``None``.
+
+        Checks global decisions first, then session-scoped if *session_id*
+        is provided.  Uses :func:`fnmatch.fnmatch` for pattern matching.
+        """
+        decisions = self._db.list_permission_decisions(user_id=user_id)
+        # Global scope first, then session scope
+        for d in decisions:
+            if fnmatch.fnmatch(tool_name, d["tool_pattern"]) and d["scope"] == "global":
+                return d["decision"]
+        if session_id is not None:
+            for d in decisions:
+                if (
+                    fnmatch.fnmatch(tool_name, d["tool_pattern"])
+                    and d["scope"] == "session"
+                    and d.get("session_id") == session_id
+                ):
+                    return d["decision"]
+        return None
+
+    # ------------------------------------------------------------------
+    # Persist
+    # ------------------------------------------------------------------
+
+    def persist(
+        self,
+        user_id: int,
+        tool_pattern: str,
+        decision: str,
+        scope: str = "session",
+        session_id: str | None = None,
+        persona_id: str | None = None,
+        reason: str | None = None,
+    ) -> str:
+        """Persist a permission decision. Returns the decision ID."""
+        decision_id = str(uuid.uuid4())
+        self._db.insert_permission_decision(
+            id=decision_id,
+            user_id=user_id,
+            tool_pattern=tool_pattern,
+            decision=decision,
+            scope=scope,
+            session_id=session_id,
+            persona_id=persona_id,
+            reason=reason,
+        )
+        return decision_id
+
+    # ------------------------------------------------------------------
+    # List / Revoke
+    # ------------------------------------------------------------------
+
+    def list_for_user(self, user_id: int) -> list[dict[str, Any]]:
+        """Return all non-expired persisted decisions for *user_id*."""
+        return self._db.list_permission_decisions(user_id=user_id)
+
+    def revoke(self, decision_id: str) -> bool:
+        """Delete a persisted decision by ID. Returns ``True`` if removed."""
+        return self._db.delete_permission_decision(decision_id)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/prompt_utils.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/prompt_utils.py
@@ -1,0 +1,87 @@
+"""Prompt preprocessing utilities for ACP.
+
+Handles @mention resolution for MCP tools.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from loguru import logger
+
+
+# Match @tool_name patterns (alphanumeric, hyphens, underscores, dots).
+# The negative lookbehind ``(?<!\w)`` prevents matching email addresses
+# such as ``user@example.com`` because the ``@`` is preceded by a word
+# character.
+_AT_MENTION_RE = re.compile(r"(?<!\w)@([\w.-]+)")
+
+
+async def preprocess_mentions(
+    messages: list[dict[str, Any]],
+    tool_registry: Any | None = None,
+    cache: dict[str, bool] | None = None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Parse ``@tool_name`` patterns in *messages* and resolve them.
+
+    Parameters
+    ----------
+    messages:
+        List of message dicts (``role`` / ``content``).
+    tool_registry:
+        Object with an async ``tool_exists(name: str) -> bool`` method.
+        When *None*, all ``@mentions`` are accepted without validation.
+    cache:
+        Optional per-session cache mapping tool names to their resolved
+        status (``True`` = exists, ``False`` = unresolved).  Supplying
+        the same dict across turns avoids redundant registry lookups.
+
+    Returns
+    -------
+    tuple[list[dict[str, Any]], list[str]]
+        The *messages* list (unchanged) and a **sorted** list of resolved
+        tool hint names.
+    """
+    if cache is None:
+        cache = {}
+
+    tool_hints: set[str] = set()
+    unresolved: set[str] = set()
+
+    for msg in messages:
+        content = msg.get("content", "")
+        if not isinstance(content, str):
+            continue
+        for match in _AT_MENTION_RE.finditer(content):
+            name = match.group(1)
+
+            # Fast path: already resolved in this session.
+            if name in cache:
+                if cache[name]:
+                    tool_hints.add(name)
+                else:
+                    unresolved.add(name)
+                continue
+
+            # Resolve against the registry when available.
+            if tool_registry is not None:
+                try:
+                    exists = await tool_registry.tool_exists(name)
+                except Exception:
+                    logger.debug("Failed to resolve @mention: {}", name)
+                    exists = False
+                cache[name] = exists
+            else:
+                # No registry — accept all mentions.
+                cache[name] = True
+                exists = True
+
+            if exists:
+                tool_hints.add(name)
+            else:
+                unresolved.add(name)
+
+    if unresolved:
+        logger.debug("Unresolved @mentions: {}", unresolved)
+
+    return messages, sorted(tool_hints)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
@@ -114,6 +114,28 @@ def _resolve_runtime_permission_outcome(
             "provenance_summary": dict(snapshot.policy_provenance_summary or {}),
         }
 
+    # Check tool_tier_overrides -- Bash prefix patterns like Bash(git:*) -> auto
+    overrides = policy_document.get("tool_tier_overrides", {})
+    if isinstance(overrides, dict):
+        for pattern, tier in overrides.items():
+            if fnmatch.fnmatch(tool_name, pattern):
+                tier_lower = str(tier or "").strip().lower()
+                if tier_lower == "auto":
+                    return {
+                        "action": "approve",
+                        "approval_requirement": "allow",
+                        "policy_snapshot_fingerprint": snapshot.policy_snapshot_fingerprint,
+                        "provenance_summary": dict(snapshot.policy_provenance_summary or {}),
+                    }
+                # Any non-auto tier (individual, batch, etc.) requires approval
+                return {
+                    "action": "prompt",
+                    "approval_requirement": "approval_required",
+                    "governance_reason": f"tool_tier_override_{tier_lower}",
+                    "policy_snapshot_fingerprint": snapshot.policy_snapshot_fingerprint,
+                    "provenance_summary": dict(snapshot.policy_provenance_summary or {}),
+                }
+
     approval_mode = str(
         (snapshot.approval_summary or {}).get("mode")
         or policy_document.get("approval_mode")

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/triggers.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/triggers.py
@@ -1,0 +1,588 @@
+"""ACP webhook trigger manager.
+
+Routes inbound webhook events to acp_run task submissions with
+provider-specific signature verification.
+
+Security features:
+- Multi-provider HMAC verification (GitHub, Slack, generic)
+- Encrypted secrets at rest (Fernet, requires ``cryptography`` package)
+- Per-trigger rate limiting (in-memory, per-process)
+- Replay attack prevention for all providers:
+  - Slack: 5-minute timestamp window
+  - GitHub: ``X-GitHub-Delivery`` idempotency (TTL-based dedup)
+  - Generic: ``X-Webhook-Timestamp`` required, included in signed base string,
+    5-minute window enforced
+- Timing-safe HMAC comparison (hmac.compare_digest)
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+import uuid
+from typing import Any
+
+from loguru import logger
+
+
+# ---------------------------------------------------------------------------
+# Secret encryption helper
+# ---------------------------------------------------------------------------
+
+
+class TriggerSecretManager:
+    """Encrypts/decrypts webhook secrets at rest using Fernet (AES-128-CBC).
+
+    Requires the ``cryptography`` package and an explicit encryption key.
+    The key must be provided either as a constructor argument or via the
+    ``ACP_TRIGGER_ENCRYPTION_KEY`` environment variable.  If neither is
+    set, ``__init__`` raises ``ValueError`` to fail fast.
+    """
+
+    def __init__(self, encryption_key: str | None = None) -> None:
+        try:
+            from cryptography.fernet import Fernet
+        except ImportError:
+            raise ImportError(
+                "The 'cryptography' package is required for webhook trigger secrets. "
+                "Install it with: pip install cryptography"
+            )
+
+        key = encryption_key or os.getenv("ACP_TRIGGER_ENCRYPTION_KEY")
+        if not key:
+            raise ValueError(
+                "ACP_TRIGGER_ENCRYPTION_KEY environment variable is required for webhook triggers. "
+                "Generate one with: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+            )
+
+        # Ensure key is Fernet-compatible (url-safe base64, 32 bytes)
+        try:
+            self._fernet = Fernet(key.encode() if isinstance(key, str) else key)
+        except Exception:
+            # If key is not valid Fernet format, derive one via SHA-256
+            derived = base64.urlsafe_b64encode(
+                hashlib.sha256(key.encode()).digest()
+            )
+            self._fernet = Fernet(derived)
+
+    def encrypt(self, plaintext: str) -> str:
+        """Encrypt *plaintext* and return a string safe for DB storage."""
+        return self._fernet.encrypt(plaintext.encode("utf-8")).decode("utf-8")
+
+    def decrypt(self, ciphertext: str) -> str:
+        """Decrypt a previously encrypted value."""
+        return self._fernet.decrypt(ciphertext.encode("utf-8")).decode("utf-8")
+
+    @staticmethod
+    def generate_key() -> str:
+        """Generate a new Fernet encryption key suitable for ``ACP_TRIGGER_ENCRYPTION_KEY``."""
+        from cryptography.fernet import Fernet
+        return Fernet.generate_key().decode()
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature verification
+# ---------------------------------------------------------------------------
+
+
+class WebhookVerifier:
+    """Provider-specific webhook signature verification.
+
+    All comparison functions use ``hmac.compare_digest`` for timing-safe
+    equality checks.  Replay protection is enforced for every provider:
+
+    - **Slack**: 5-minute timestamp window (built into signature base string).
+    - **GitHub**: ``X-GitHub-Delivery`` idempotency key with TTL-based dedup.
+    - **Generic**: ``X-Webhook-Timestamp`` included in signed base string and
+      subject to a 5-minute freshness window.
+    """
+
+    _REPLAY_WINDOW_SEC = 300  # 5 minutes
+    _DELIVERY_CACHE_MAX = 10_000
+
+    def __init__(self) -> None:
+        # GitHub delivery-ID dedup cache: {delivery_id: expiry_timestamp}
+        self._github_deliveries: dict[str, float] = {}
+
+    def verify_github(
+        self, payload_body: bytes, signature: str, secret: str,
+        delivery_id: str | None = None,
+    ) -> bool:
+        """Verify GitHub ``X-Hub-Signature-256`` header.
+
+        Replay prevention uses the ``X-GitHub-Delivery`` UUID.  Each
+        delivery ID is accepted at most once within a 5-minute window.
+        """
+        # Dedup via delivery ID
+        if delivery_id:
+            now = time.time()
+            self._prune_delivery_cache(now)
+            if delivery_id in self._github_deliveries:
+                logger.warning("GitHub webhook rejected: duplicate delivery_id (replay)")
+                return False
+            # Record *after* signature check below
+        else:
+            logger.warning("GitHub webhook missing X-GitHub-Delivery header (replay protection weakened)")
+
+        expected = "sha256=" + hmac.new(
+            secret.encode("utf-8"), payload_body, hashlib.sha256
+        ).hexdigest()
+        sig_ok = hmac.compare_digest(expected, signature)
+
+        if sig_ok and delivery_id:
+            self._github_deliveries[delivery_id] = time.time() + self._REPLAY_WINDOW_SEC
+
+        return sig_ok
+
+    def _prune_delivery_cache(self, now: float) -> None:
+        """Remove expired delivery IDs and cap cache size."""
+        expired = [k for k, exp in self._github_deliveries.items() if exp <= now]
+        for k in expired:
+            del self._github_deliveries[k]
+        # Hard cap to prevent unbounded growth
+        if len(self._github_deliveries) > self._DELIVERY_CACHE_MAX:
+            oldest = sorted(self._github_deliveries, key=self._github_deliveries.get)  # type: ignore[arg-type]
+            for k in oldest[: len(self._github_deliveries) - self._DELIVERY_CACHE_MAX]:
+                del self._github_deliveries[k]
+
+    @staticmethod
+    def verify_slack(
+        payload_body: bytes,
+        timestamp: str,
+        signature: str,
+        secret: str,
+    ) -> bool:
+        """Verify Slack request signing.
+
+        Rejects requests with timestamps older than 5 minutes (replay
+        prevention).
+        """
+        try:
+            ts_float = float(timestamp)
+        except (ValueError, TypeError):
+            return False
+        if abs(time.time() - ts_float) > WebhookVerifier._REPLAY_WINDOW_SEC:
+            logger.warning("Slack webhook rejected: timestamp outside window (replay prevention)")
+            return False
+        sig_basestring = f"v0:{timestamp}:{payload_body.decode('utf-8', errors='replace')}"
+        expected = "v0=" + hmac.new(
+            secret.encode("utf-8"),
+            sig_basestring.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return hmac.compare_digest(expected, signature)
+
+    @staticmethod
+    def verify_generic(
+        payload_body: bytes, signature: str, secret: str,
+        timestamp: str | None = None,
+    ) -> bool:
+        """Verify generic HMAC-SHA256 via ``X-Webhook-Signature`` header.
+
+        Requires ``X-Webhook-Timestamp``.  The timestamp is included in the
+        signed base string (``<timestamp>.<body>``) and must be within a
+        5-minute window to prevent replay attacks.
+        """
+        if not timestamp:
+            logger.warning("Generic webhook rejected: missing X-Webhook-Timestamp")
+            return False
+        try:
+            ts_float = float(timestamp)
+        except (ValueError, TypeError):
+            return False
+        if abs(time.time() - ts_float) > WebhookVerifier._REPLAY_WINDOW_SEC:
+            logger.warning("Generic webhook rejected: timestamp outside window (replay prevention)")
+            return False
+
+        # Include timestamp in signed payload to bind signature to the time
+        signed_payload = f"{timestamp}.".encode("utf-8") + payload_body
+        expected = hmac.new(
+            secret.encode("utf-8"), signed_payload, hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(expected, signature)
+
+
+# ---------------------------------------------------------------------------
+# Trigger configuration dataclass
+# ---------------------------------------------------------------------------
+
+
+class TriggerConfig:
+    """In-memory representation of a webhook trigger row."""
+
+    __slots__ = (
+        "id",
+        "name",
+        "source_type",
+        "secret_encrypted",
+        "owner_user_id",
+        "agent_config",
+        "prompt_template",
+        "enabled",
+        "created_at",
+        "updated_at",
+    )
+
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        source_type: str,
+        secret_encrypted: str,
+        owner_user_id: int,
+        agent_config: dict[str, Any],
+        prompt_template: str,
+        enabled: bool = True,
+        created_at: str | None = None,
+        updated_at: str | None = None,
+    ) -> None:
+        self.id = id
+        self.name = name
+        self.source_type = source_type
+        self.secret_encrypted = secret_encrypted
+        self.owner_user_id = owner_user_id
+        self.agent_config = agent_config
+        self.prompt_template = prompt_template
+        self.enabled = enabled
+        self.created_at = created_at
+        self.updated_at = updated_at
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "source_type": self.source_type,
+            "owner_user_id": self.owner_user_id,
+            "agent_config": self.agent_config,
+            "prompt_template": self.prompt_template,
+            "enabled": self.enabled,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+# ---------------------------------------------------------------------------
+# ACPTriggerManager -- the main orchestrator
+# ---------------------------------------------------------------------------
+
+
+class ACPTriggerManager:
+    """Manages webhook triggers and routes events to acp_run.
+
+    Responsibilities:
+    - CRUD for trigger configurations (stored in ``webhook_triggers`` table)
+    - Per-trigger rate limiting (in-memory sliding window)
+    - Signature verification dispatch by provider
+    - Building and submitting ``acp_run`` payloads
+    """
+
+    def __init__(self, db: Any, secret_manager: TriggerSecretManager) -> None:
+        self._db = db
+        self._secret_mgr = secret_manager
+        self._verifier = WebhookVerifier()
+        # In-memory rate limit state: trigger_id -> list of timestamps
+        self._rate_limits: dict[str, list[float]] = {}
+
+    # ------------------------------------------------------------------
+    # Rate limiting
+    # ------------------------------------------------------------------
+
+    def check_rate_limit(self, trigger_id: str, max_per_minute: int = 60) -> bool:
+        """Return ``True`` if the trigger is within its rate limit.
+
+        Uses a sliding 60-second window tracked in memory.
+        """
+        now = time.time()
+        window = self._rate_limits.setdefault(trigger_id, [])
+        # Prune timestamps older than 60 seconds
+        window[:] = [t for t in window if now - t < 60]
+        if len(window) >= max_per_minute:
+            return False
+        window.append(now)
+        return True
+
+    # ------------------------------------------------------------------
+    # Signature verification dispatch
+    # ------------------------------------------------------------------
+
+    def _verify_signature(
+        self,
+        source_type: str,
+        payload_body: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        """Dispatch to the correct verifier based on *source_type*.
+
+        Error responses are deliberately vague ("verification failed") to
+        avoid leaking which specific header was missing or invalid.
+        """
+        if source_type == "github":
+            sig = headers.get("x-hub-signature-256", "")
+            if not sig:
+                logger.debug("GitHub webhook: missing required signature header")
+                return False
+            delivery_id = headers.get("x-github-delivery", "")
+            return self._verifier.verify_github(
+                payload_body, sig, secret,
+                delivery_id=delivery_id or None,
+            )
+
+        if source_type == "slack":
+            timestamp = headers.get("x-slack-request-timestamp", "")
+            sig = headers.get("x-slack-signature", "")
+            if not timestamp or not sig:
+                logger.debug("Slack webhook: missing required headers")
+                return False
+            return self._verifier.verify_slack(payload_body, timestamp, sig, secret)
+
+        # Default: generic HMAC (timestamp required for replay prevention)
+        sig = headers.get("x-webhook-signature", "")
+        timestamp = headers.get("x-webhook-timestamp", "")
+        if not sig:
+            logger.debug("Generic webhook: missing required signature header")
+            return False
+        return self._verifier.verify_generic(
+            payload_body, sig, secret,
+            timestamp=timestamp or None,
+        )
+
+    # ------------------------------------------------------------------
+    # Prompt template rendering
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _render_prompt(template: str, payload_body: bytes, headers: dict[str, str]) -> str:
+        """Render a prompt template with event placeholders.
+
+        Supported placeholders (using ``{variable}`` syntax):
+        - ``{payload}``    -- raw payload as string
+        - ``{event_type}`` -- inferred from headers or "webhook"
+
+        Uses ``str.format_map`` with a restricted set of known keys
+        to prevent format string injection.  Unknown placeholders
+        are replaced via a safe fallback.
+        """
+        try:
+            payload_str = payload_body.decode("utf-8", errors="replace")
+        except Exception:
+            payload_str = "<binary payload>"
+
+        # Try to determine event type from common header patterns
+        event_type = (
+            headers.get("x-github-event", "")
+            or headers.get("x-event-type", "")
+            or "webhook"
+        )
+
+        safe_vars = {"payload": payload_str, "event_type": event_type}
+        try:
+            return template.format_map(safe_vars)
+        except (KeyError, ValueError, IndexError):
+            # If template has unknown placeholders, fall back to simple replacement
+            result = template
+            for key, val in safe_vars.items():
+                result = result.replace(f"{{{key}}}", val)
+            return result
+
+    # ------------------------------------------------------------------
+    # Core webhook handler
+    # ------------------------------------------------------------------
+
+    async def handle_webhook(
+        self,
+        trigger_id: str,
+        payload_body: bytes,
+        headers: dict[str, str],
+    ) -> dict[str, Any]:
+        """Verify and process an inbound webhook.
+
+        Steps:
+        1. Load trigger config from DB
+        2. Check enabled flag
+        3. Check per-trigger rate limit
+        4. Decrypt webhook secret
+        5. Verify HMAC signature (provider-specific)
+        6. Build acp_run payload from agent_config + prompt_template
+        7. Submit acp_run task via the scheduler
+        8. Return ``{task_id, status}``
+        """
+        # 1. Load trigger (sync DB call wrapped for async safety)
+        trigger = await asyncio.to_thread(self.get_trigger, trigger_id)
+        if trigger is None:
+            logger.warning("Webhook received for unknown trigger_id={}", trigger_id)
+            return {"error": "trigger_not_found", "status": "rejected"}
+
+        # 2. Enabled?
+        if not trigger["enabled"]:
+            logger.info("Webhook for disabled trigger_id={}", trigger_id)
+            return {"error": "trigger_disabled", "status": "rejected"}
+
+        # 3. Rate limit
+        if not self.check_rate_limit(trigger_id):
+            logger.warning("Rate limit exceeded for trigger_id={}", trigger_id)
+            return {"error": "rate_limit_exceeded", "status": "rejected"}
+
+        # 4. Decrypt secret
+        try:
+            secret = self._secret_mgr.decrypt(trigger["secret_encrypted"])
+        except Exception as exc:
+            logger.error("Failed to decrypt secret for trigger_id={}: {}", trigger_id, exc)
+            return {"error": "secret_decryption_failed", "status": "rejected"}
+
+        # 5. Verify signature
+        source_type = trigger.get("source_type", "generic")
+        # Normalize headers to lowercase for consistent lookup
+        norm_headers = {k.lower(): v for k, v in headers.items()}
+        if not self._verify_signature(source_type, payload_body, norm_headers, secret):
+            logger.warning("Webhook verification failed for trigger_id={}", trigger_id)
+            return {"error": "verification_failed", "status": "rejected"}
+
+        # 6. Build acp_run payload
+        agent_config = trigger.get("agent_config", {})
+        prompt_template = trigger.get("prompt_template", "")
+
+        if prompt_template:
+            prompt_text = self._render_prompt(prompt_template, payload_body, norm_headers)
+        else:
+            # Default prompt: pass the payload as context
+            try:
+                payload_str = payload_body.decode("utf-8", errors="replace")
+            except Exception:
+                payload_str = "<binary payload>"
+            prompt_text = f"Process the following webhook event:\n\n{payload_str}"
+
+        acp_payload: dict[str, Any] = {
+            "user_id": trigger["owner_user_id"],
+            "prompt": prompt_text,
+        }
+        # Merge agent_config fields into the payload
+        for key in ("cwd", "agent_type", "persona_id", "workspace_id",
+                     "workspace_group_id", "scope_snapshot_id", "model",
+                     "token_budget"):
+            if key in agent_config and agent_config[key] is not None:
+                acp_payload[key] = agent_config[key]
+
+        # 7. Submit acp_run task
+        try:
+            task_id = await self._submit_acp_run(acp_payload)
+        except Exception as exc:
+            logger.error("Failed to submit acp_run for trigger_id={}: {}", trigger_id, exc)
+            return {"error": f"submission_failed: {exc}", "status": "error"}
+
+        logger.info(
+            "Webhook trigger_id={} submitted acp_run task_id={}",
+            trigger_id, task_id,
+        )
+        return {"task_id": task_id, "status": "accepted"}
+
+    async def _submit_acp_run(self, payload: dict[str, Any]) -> str:
+        """Submit an ``acp_run`` task via the global scheduler."""
+        from tldw_Server_API.app.core.Scheduler import get_global_scheduler
+
+        scheduler = get_global_scheduler()
+        task_id = await scheduler.submit(
+            handler="acp_run",
+            payload=payload,
+            queue_name="acp",
+        )
+        return task_id
+
+    # ------------------------------------------------------------------
+    # CRUD operations (delegating to DB)
+    # ------------------------------------------------------------------
+
+    def create_trigger(
+        self,
+        name: str,
+        source_type: str,
+        secret: str,
+        owner_user_id: int,
+        agent_config: dict[str, Any] | None = None,
+        prompt_template: str = "",
+        enabled: bool = True,
+    ) -> str:
+        """Create a new webhook trigger and return its id."""
+        trigger_id = str(uuid.uuid4())
+        encrypted_secret = self._secret_mgr.encrypt(secret)
+        self._db.create_webhook_trigger(
+            trigger_id=trigger_id,
+            name=name,
+            source_type=source_type,
+            secret_encrypted=encrypted_secret,
+            owner_user_id=owner_user_id,
+            agent_config_json=json.dumps(agent_config or {}),
+            prompt_template=prompt_template,
+            enabled=enabled,
+        )
+        logger.info("Created webhook trigger id={} name={!r}", trigger_id, name)
+        return trigger_id
+
+    def list_triggers(self, user_id: int) -> list[dict[str, Any]]:
+        """List all triggers owned by *user_id*."""
+        rows = self._db.list_webhook_triggers(user_id)
+        result = []
+        for row in rows:
+            d = dict(row) if not isinstance(row, dict) else row
+            # Parse agent_config_json
+            if "agent_config_json" in d:
+                try:
+                    d["agent_config"] = json.loads(d.pop("agent_config_json"))
+                except (json.JSONDecodeError, TypeError):
+                    d["agent_config"] = {}
+            d["enabled"] = bool(d.get("enabled", True))
+            # Never expose the encrypted secret in list results
+            d.pop("secret_encrypted", None)
+            result.append(d)
+        return result
+
+    def get_trigger(self, trigger_id: str) -> dict[str, Any] | None:
+        """Get a single trigger by id (includes secret_encrypted for internal use)."""
+        row = self._db.get_webhook_trigger(trigger_id)
+        if row is None:
+            return None
+        d = dict(row) if not isinstance(row, dict) else row
+        if "agent_config_json" in d:
+            try:
+                d["agent_config"] = json.loads(d.pop("agent_config_json"))
+            except (json.JSONDecodeError, TypeError):
+                d["agent_config"] = {}
+        d["enabled"] = bool(d.get("enabled", True))
+        return d
+
+    def update_trigger(self, trigger_id: str, **kwargs: Any) -> bool:
+        """Update trigger fields.
+
+        Accepted kwargs: name, source_type, secret (plaintext -- will be
+        encrypted), agent_config (dict), prompt_template, enabled.
+        """
+        updates: dict[str, Any] = {}
+        if "name" in kwargs:
+            updates["name"] = kwargs["name"]
+        if "source_type" in kwargs:
+            updates["source_type"] = kwargs["source_type"]
+        if "secret" in kwargs:
+            updates["secret_encrypted"] = self._secret_mgr.encrypt(kwargs["secret"])
+        if "agent_config" in kwargs:
+            updates["agent_config_json"] = json.dumps(kwargs["agent_config"])
+        if "prompt_template" in kwargs:
+            updates["prompt_template"] = kwargs["prompt_template"]
+        if "enabled" in kwargs:
+            updates["enabled"] = 1 if kwargs["enabled"] else 0
+
+        if not updates:
+            return False
+        return self._db.update_webhook_trigger(trigger_id, updates)
+
+    def delete_trigger(self, trigger_id: str) -> bool:
+        """Delete a trigger."""
+        ok = self._db.delete_webhook_trigger(trigger_id)
+        if ok:
+            # Clean up rate limit state
+            self._rate_limits.pop(trigger_id, None)
+            logger.info("Deleted webhook trigger id={}", trigger_id)
+        return ok

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -1,6 +1,7 @@
 # migrations.py
 # Description: Database migrations for AuthNZ module tables
 #
+from __future__ import annotations
 # Imports
 import contextlib
 import json

--- a/tldw_Server_API/app/core/AuthNZ/settings.py
+++ b/tldw_Server_API/app/core/AuthNZ/settings.py
@@ -1,6 +1,7 @@
 # settings.py
 # Description: Pydantic settings for user registration system with persistent JWT secret management
 #
+from __future__ import annotations
 # Imports
 import contextlib
 import json

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -5,6 +5,7 @@ to avoid circular imports with the in-memory session store layer.
 """
 from __future__ import annotations
 
+import fnmatch as _fnmatch
 import json
 import os
 import sqlite3
@@ -17,7 +18,7 @@ from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection,
 )
 
-_SCHEMA_VERSION = 7
+_SCHEMA_VERSION = 10
 
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS sessions (
@@ -104,6 +105,48 @@ CREATE TABLE IF NOT EXISTS agent_health_history (
 );
 CREATE INDEX IF NOT EXISTS idx_health_agent_time
     ON agent_health_history(agent_type, checked_at DESC);
+
+CREATE TABLE IF NOT EXISTS permission_policies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    rules_json TEXT NOT NULL,
+    org_id TEXT,
+    team_id TEXT,
+    priority INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS permission_decisions (
+    id TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    tool_pattern TEXT NOT NULL,
+    decision TEXT NOT NULL,
+    scope TEXT NOT NULL DEFAULT 'session',
+    session_id TEXT,
+    persona_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at TEXT,
+    reason TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_perm_dec_user ON permission_decisions(user_id);
+CREATE INDEX IF NOT EXISTS idx_perm_dec_pattern ON permission_decisions(tool_pattern);
+
+CREATE TABLE IF NOT EXISTS webhook_triggers (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    source_type TEXT NOT NULL DEFAULT 'generic',
+    secret_encrypted TEXT NOT NULL,
+    owner_user_id INTEGER NOT NULL,
+    agent_config_json TEXT NOT NULL DEFAULT '{}',
+    prompt_template TEXT NOT NULL DEFAULT '',
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_triggers_owner
+    ON webhook_triggers(owner_user_id);
 """
 
 # Columns that are stored as INTEGER 0/1 but should be returned as bool
@@ -353,6 +396,56 @@ class ACPSessionsDB:
                     "budget_exhausted",
                     "budget_exhausted INTEGER NOT NULL DEFAULT 0",
                 )
+            if current_version < 8:
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS permission_policies (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        name TEXT NOT NULL,
+                        description TEXT DEFAULT '',
+                        rules_json TEXT NOT NULL,
+                        org_id TEXT,
+                        team_id TEXT,
+                        priority INTEGER DEFAULT 0,
+                        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                    );
+                """)
+            if current_version < 9:
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS permission_decisions (
+                        id TEXT PRIMARY KEY,
+                        user_id INTEGER NOT NULL,
+                        tool_pattern TEXT NOT NULL,
+                        decision TEXT NOT NULL,
+                        scope TEXT NOT NULL DEFAULT 'session',
+                        session_id TEXT,
+                        persona_id TEXT,
+                        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                        expires_at TEXT,
+                        reason TEXT
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_perm_dec_user
+                        ON permission_decisions(user_id);
+                    CREATE INDEX IF NOT EXISTS idx_perm_dec_pattern
+                        ON permission_decisions(tool_pattern);
+                """)
+            if current_version < 10:
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS webhook_triggers (
+                        id TEXT PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        source_type TEXT NOT NULL DEFAULT 'generic',
+                        secret_encrypted TEXT NOT NULL,
+                        owner_user_id INTEGER NOT NULL,
+                        agent_config_json TEXT NOT NULL DEFAULT '{}',
+                        prompt_template TEXT NOT NULL DEFAULT '',
+                        enabled INTEGER NOT NULL DEFAULT 1,
+                        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_webhook_triggers_owner
+                        ON webhook_triggers(owner_user_id);
+                """)
             conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
             conn.commit()
             self._initialized = True
@@ -703,6 +796,114 @@ class ACPSessionsDB:
         )
         rows = conn.execute(query, [since_iso]).fetchall()
         return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Run history queries (date-filtered)
+    # ------------------------------------------------------------------
+
+    def list_runs(
+        self,
+        *,
+        user_id: int | None = None,
+        status: str | None = None,
+        agent_type: str | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Query session records with optional filters including date range.
+
+        Returns ``(rows, total_count)`` where each row is a deserialized dict.
+        """
+        conn = self._get_conn()
+        clauses: list[str] = []
+        params: list[Any] = []
+
+        if user_id is not None:
+            clauses.append("user_id = ?")
+            params.append(user_id)
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        if agent_type is not None:
+            clauses.append("agent_type = ?")
+            params.append(agent_type)
+        if from_date is not None:
+            clauses.append("created_at >= ?")
+            params.append(from_date)
+        if to_date is not None:
+            clauses.append("created_at <= ?")
+            params.append(to_date)
+
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+
+        count_row = conn.execute(
+            f"SELECT COUNT(*) FROM sessions{where}", params,
+        ).fetchone()
+        total = count_row[0] if count_row else 0
+
+        rows = conn.execute(
+            f"SELECT * FROM sessions{where} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            params + [limit, offset],
+        ).fetchall()
+
+        return [self._row_to_dict(r) for r in rows], total
+
+    def aggregate_runs(
+        self,
+        *,
+        user_id: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Aggregate token usage and session counts with optional filters.
+
+        Returns a summary dict with total_sessions, prompt_tokens,
+        completion_tokens, total_tokens, and per-session cost data for the
+        service layer to compute estimated costs.
+        """
+        conn = self._get_conn()
+        clauses: list[str] = []
+        params: list[Any] = []
+
+        if user_id is not None:
+            clauses.append("user_id = ?")
+            params.append(user_id)
+        if from_date is not None:
+            clauses.append("created_at >= ?")
+            params.append(from_date)
+        if to_date is not None:
+            clauses.append("created_at <= ?")
+            params.append(to_date)
+
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+
+        row = conn.execute(
+            f"SELECT "
+            f"  COUNT(*) AS total_sessions, "
+            f"  COALESCE(SUM(prompt_tokens), 0) AS prompt_tokens, "
+            f"  COALESCE(SUM(completion_tokens), 0) AS completion_tokens, "
+            f"  COALESCE(SUM(total_tokens), 0) AS total_tokens "
+            f"FROM sessions{where}",
+            params,
+        ).fetchone()
+
+        result: dict[str, Any] = {
+            "total_sessions": row["total_sessions"] if row else 0,
+            "prompt_tokens": row["prompt_tokens"] if row else 0,
+            "completion_tokens": row["completion_tokens"] if row else 0,
+            "total_tokens": row["total_tokens"] if row else 0,
+        }
+
+        # Also return per-session cost data so the service layer can compute costs
+        cost_rows = conn.execute(
+            f"SELECT model, prompt_tokens, completion_tokens FROM sessions{where}",
+            params,
+        ).fetchall()
+        result["_cost_rows"] = [dict(r) for r in cost_rows]
+
+        return result
 
     # ------------------------------------------------------------------
     # Text normalization (local helper — no external imports)
@@ -1339,6 +1540,297 @@ class ACPSessionsDB:
             (agent_type, limit),
         ).fetchall()
         return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Permission Policy CRUD
+    # ------------------------------------------------------------------
+
+    def create_permission_policy(
+        self,
+        name: str,
+        rules_json: str,
+        priority: int = 0,
+        description: str = "",
+        org_id: str | None = None,
+        team_id: str | None = None,
+    ) -> int:
+        """Insert a permission policy. Returns the new row ID."""
+        conn = self._get_conn()
+        now = _utcnow_iso()
+        cursor = conn.execute(
+            """
+            INSERT INTO permission_policies
+                (name, description, rules_json, org_id, team_id, priority,
+                 created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (name, description, rules_json, org_id, team_id, priority, now, now),
+        )
+        conn.commit()
+        return cursor.lastrowid  # type: ignore[return-value]
+
+    def get_permission_policy(self, policy_id: int) -> dict[str, Any] | None:
+        """Fetch a single policy by ID, or None."""
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT * FROM permission_policies WHERE id = ?", (policy_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    def list_permission_policies(self) -> list[dict[str, Any]]:
+        """List all policies ordered by priority DESC, then name ASC."""
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT * FROM permission_policies ORDER BY priority DESC, name ASC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def update_permission_policy(self, policy_id: int, **kwargs: Any) -> bool:
+        """Update fields on a permission policy.
+
+        Accepted kwargs: name, description, rules_json, org_id, team_id, priority.
+        Returns True if the row was found and updated.
+        """
+        allowed = {"name", "description", "rules_json", "org_id", "team_id", "priority"}
+        updates = {k: v for k, v in kwargs.items() if k in allowed}
+        if not updates:
+            return False
+        updates["updated_at"] = _utcnow_iso()
+        set_clause = ", ".join(f"{col} = ?" for col in updates)
+        values = list(updates.values()) + [policy_id]
+        conn = self._get_conn()
+        cursor = conn.execute(
+            f"UPDATE permission_policies SET {set_clause} WHERE id = ?",
+            values,
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+    def delete_permission_policy(self, policy_id: int) -> bool:
+        """Delete a policy by ID. Returns True if a row was removed."""
+        conn = self._get_conn()
+        cursor = conn.execute(
+            "DELETE FROM permission_policies WHERE id = ?", (policy_id,)
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+    def resolve_permission_tier(self, tool_name: str) -> str | None:
+        """Query all policies, match tool_name against rules using fnmatch.
+
+        Returns the tier from the highest-priority matching rule, or None
+        if no rule matches.
+        """
+        policies = self.list_permission_policies()
+        best_priority = -1
+        best_tier: str | None = None
+        for pol in policies:
+            priority = pol.get("priority", 0)
+            raw = pol.get("rules_json", "[]")
+            try:
+                rules = json.loads(raw) if isinstance(raw, str) else raw
+            except (json.JSONDecodeError, TypeError):
+                continue
+            for rule in rules:
+                pattern = rule.get("tool_pattern", "")
+                tier = rule.get("tier", "")
+                if _fnmatch.fnmatch(tool_name.lower(), pattern.lower()):
+                    if priority > best_priority:
+                        best_priority = priority
+                        best_tier = tier
+        return best_tier
+
+    # ------------------------------------------------------------------
+    # Permission Decision CRUD
+    # ------------------------------------------------------------------
+
+    def insert_permission_decision(
+        self,
+        id: str,
+        user_id: int,
+        tool_pattern: str,
+        decision: str,
+        scope: str = "session",
+        session_id: str | None = None,
+        persona_id: str | None = None,
+        reason: str | None = None,
+        expires_at: str | None = None,
+    ) -> None:
+        """Insert a persisted permission decision."""
+        conn = self._get_conn()
+        conn.execute(
+            """
+            INSERT INTO permission_decisions
+                (id, user_id, tool_pattern, decision, scope,
+                 session_id, persona_id, created_at, expires_at, reason)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                id, user_id, tool_pattern, decision, scope,
+                session_id, persona_id, _utcnow_iso(), expires_at, reason,
+            ),
+        )
+        conn.commit()
+
+    def list_permission_decisions(
+        self,
+        user_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List permission decisions, optionally filtered by user_id."""
+        conn = self._get_conn()
+        if user_id is not None:
+            rows = conn.execute(
+                "SELECT * FROM permission_decisions WHERE user_id = ? ORDER BY created_at DESC",
+                (user_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM permission_decisions ORDER BY created_at DESC"
+            ).fetchall()
+        now_iso = _utcnow_iso()
+        results: list[dict[str, Any]] = []
+        for r in rows:
+            d = dict(r)
+            # Skip expired decisions
+            if d.get("expires_at") and d["expires_at"] < now_iso:
+                continue
+            results.append(d)
+        return results
+
+    def check_permission_decision(
+        self,
+        user_id: int,
+        tool_name: str,
+        session_id: str | None = None,
+    ) -> str | None:
+        """Find a matching persisted decision for user_id + tool_name.
+
+        Returns ``'allow'`` or ``'deny'`` if a matching non-expired decision
+        exists, otherwise ``None``.  Global scope is checked first, then
+        session scope (if *session_id* is provided).
+        """
+        decisions = self.list_permission_decisions(user_id=user_id)
+        for d in decisions:
+            if not _fnmatch.fnmatch(tool_name, d["tool_pattern"]):
+                continue
+            if d["scope"] == "global":
+                return d["decision"]
+            if d["scope"] == "session" and d.get("session_id") == session_id:
+                return d["decision"]
+        return None
+
+    def delete_permission_decision(self, decision_id: str) -> bool:
+        """Delete a permission decision by ID. Returns True if a row was removed."""
+        conn = self._get_conn()
+        cursor = conn.execute(
+            "DELETE FROM permission_decisions WHERE id = ?", (decision_id,)
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+    def get_permission_decision(self, decision_id: str) -> dict[str, Any] | None:
+        """Fetch a single permission decision by ID, or None."""
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT * FROM permission_decisions WHERE id = ?", (decision_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    # ------------------------------------------------------------------
+    # Webhook trigger CRUD
+    # ------------------------------------------------------------------
+
+    def create_webhook_trigger(
+        self,
+        trigger_id: str,
+        name: str,
+        source_type: str,
+        secret_encrypted: str,
+        owner_user_id: int,
+        agent_config_json: str = "{}",
+        prompt_template: str = "",
+        enabled: bool = True,
+    ) -> None:
+        """Insert a new webhook trigger row."""
+        conn = self._get_conn()
+        now = _utcnow_iso()
+        conn.execute(
+            """
+            INSERT INTO webhook_triggers
+                (id, name, source_type, secret_encrypted, owner_user_id,
+                 agent_config_json, prompt_template, enabled,
+                 created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                trigger_id,
+                name,
+                source_type,
+                secret_encrypted,
+                owner_user_id,
+                agent_config_json,
+                prompt_template,
+                1 if enabled else 0,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+
+    def list_webhook_triggers(self, owner_user_id: int) -> list[dict[str, Any]]:
+        """Return all webhook triggers owned by *owner_user_id*."""
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT * FROM webhook_triggers WHERE owner_user_id = ? ORDER BY created_at DESC",
+            (owner_user_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_webhook_trigger(self, trigger_id: str) -> dict[str, Any] | None:
+        """Return a single webhook trigger by id, or ``None``."""
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT * FROM webhook_triggers WHERE id = ?", (trigger_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    _WEBHOOK_TRIGGER_UPDATABLE_COLS = frozenset({
+        "name", "source_type", "secret_encrypted", "agent_config_json",
+        "prompt_template", "enabled", "updated_at",
+    })
+
+    def update_webhook_trigger(self, trigger_id: str, updates: dict[str, Any]) -> bool:
+        """Update fields of a webhook trigger. Returns True if a row was modified."""
+        if not updates:
+            return False
+        for k in updates:
+            if k not in self._WEBHOOK_TRIGGER_UPDATABLE_COLS:
+                raise ValueError(f"Cannot update column: {k!r}")
+        conn = self._get_conn()
+        updates["updated_at"] = _utcnow_iso()
+        set_clauses = ", ".join(f"{k} = ?" for k in updates)
+        values = list(updates.values()) + [trigger_id]
+        cursor = conn.execute(
+            f"UPDATE webhook_triggers SET {set_clauses} WHERE id = ?",
+            values,
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+    def delete_webhook_trigger(self, trigger_id: str) -> bool:
+        """Delete a webhook trigger. Returns True if a row was removed."""
+        conn = self._get_conn()
+        cursor = conn.execute(
+            "DELETE FROM webhook_triggers WHERE id = ?", (trigger_id,)
+        )
+        conn.commit()
+        return cursor.rowcount > 0
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/tldw_Server_API/app/core/DB_Management/Sandbox_Queue_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Sandbox_Queue_DB.py
@@ -1,0 +1,166 @@
+"""Sandbox run queue database abstraction.
+
+Provides the SQL layer for the durable run queue used by the Sandbox
+orchestrator.  Keeps raw SQL out of ``Sandbox/store.py`` and follows
+the project convention of placing all DB operations under
+``/app/core/DB_Management/``.
+
+Two concrete implementations:
+
+* :class:`SQLiteRunQueueDB` -- for the SQLite sandbox store.
+* :class:`PostgresRunQueueDB` -- for the PostgreSQL sandbox store.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Any, Generator
+
+from loguru import logger
+
+
+# ---------------------------------------------------------------------------
+# SQLite implementation
+# ---------------------------------------------------------------------------
+
+
+class SQLiteRunQueueDB:
+    """SQLite-backed run queue operations.
+
+    Accepts either a ``sqlite3.Connection`` factory (callable returning a
+    context-managed connection) or a raw connection.
+    """
+
+    _INIT_SQL = """\
+    CREATE TABLE IF NOT EXISTS run_queue (
+        run_id   TEXT PRIMARY KEY,
+        user_id  TEXT NOT NULL,
+        priority INTEGER DEFAULT 0,
+        enqueued_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    """
+
+    def __init__(self, conn_factory: Any, lock: threading.Lock | None = None) -> None:
+        self._conn = conn_factory
+        self._lock = lock or threading.RLock()
+
+    def ensure_table(self, con: Any) -> None:
+        """Create the ``run_queue`` table if it does not exist."""
+        con.executescript(self._INIT_SQL)
+
+    def enqueue(self, run_id: str, user_id: str, priority: int = 0) -> None:
+        """Insert or replace a run in the queue."""
+        with self._lock, self._conn() as con:
+            con.execute(
+                "INSERT OR REPLACE INTO run_queue"
+                "(run_id, user_id, priority, enqueued_at) "
+                "VALUES (?, ?, ?, datetime('now'))",
+                (str(run_id), str(user_id), int(priority)),
+            )
+
+    def dequeue(self, worker_id: str) -> dict[str, Any] | None:
+        """Atomically remove and return the highest-priority queued run.
+
+        Returns ``None`` when the queue is empty.
+        """
+        with self._lock, self._conn() as con:
+            cur = con.execute(
+                "SELECT run_id, user_id, priority, enqueued_at "
+                "FROM run_queue "
+                "ORDER BY priority DESC, enqueued_at ASC "
+                "LIMIT 1",
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            run_id = row["run_id"] if isinstance(row, sqlite3.Row) else row[0]
+            result = {
+                "run_id": row["run_id"] if isinstance(row, sqlite3.Row) else row[0],
+                "user_id": row["user_id"] if isinstance(row, sqlite3.Row) else row[1],
+                "priority": int(row["priority"] if isinstance(row, sqlite3.Row) else row[2]),
+                "enqueued_at": row["enqueued_at"] if isinstance(row, sqlite3.Row) else row[3],
+            }
+            con.execute("DELETE FROM run_queue WHERE run_id = ?", (run_id,))
+            return result
+
+    def remove(self, run_id: str) -> bool:
+        """Remove a specific run from the queue. Returns ``True`` if found."""
+        with self._lock, self._conn() as con:
+            cur = con.execute(
+                "DELETE FROM run_queue WHERE run_id = ?",
+                (str(run_id),),
+            )
+            return bool(cur.rowcount and cur.rowcount > 0)
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL implementation
+# ---------------------------------------------------------------------------
+
+
+class PostgresRunQueueDB:
+    """PostgreSQL-backed run queue operations.
+
+    Accepts a connection factory (callable returning a context-managed
+    connection) and an optional lock.
+    """
+
+    _INIT_SQL = """\
+    CREATE TABLE IF NOT EXISTS run_queue (
+        run_id      TEXT PRIMARY KEY,
+        user_id     TEXT NOT NULL,
+        priority    INTEGER DEFAULT 0,
+        enqueued_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    );
+    """
+
+    def __init__(self, conn_factory: Any, lock: threading.Lock | None = None) -> None:
+        self._conn = conn_factory
+        self._lock = lock or threading.RLock()
+
+    def ensure_table(self, con: Any, cur: Any) -> None:
+        """Create the ``run_queue`` table if it does not exist."""
+        cur.execute(self._INIT_SQL)
+
+    def enqueue(self, run_id: str, user_id: str, priority: int = 0) -> None:
+        """Insert or update a run in the queue."""
+        with self._lock, self._conn() as con, con.cursor() as cur:
+            cur.execute(
+                "INSERT INTO run_queue(run_id, user_id, priority, enqueued_at) "
+                "VALUES (%s, %s, %s, NOW()) "
+                "ON CONFLICT (run_id) DO UPDATE SET priority = EXCLUDED.priority, "
+                "enqueued_at = NOW()",
+                (str(run_id), str(user_id), int(priority)),
+            )
+
+    def dequeue(self, worker_id: str) -> dict[str, Any] | None:
+        """Atomically dequeue the highest-priority run using FOR UPDATE SKIP LOCKED."""
+        with self._lock, self._conn() as con, con.cursor() as cur:
+            cur.execute(
+                "DELETE FROM run_queue "
+                "WHERE run_id = ("
+                "  SELECT run_id FROM run_queue "
+                "  ORDER BY priority DESC, enqueued_at ASC "
+                "  LIMIT 1 "
+                "  FOR UPDATE SKIP LOCKED"
+                ") RETURNING run_id, user_id, priority, enqueued_at",
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            return {
+                "run_id": row[0],
+                "user_id": row[1],
+                "priority": int(row[2]),
+                "enqueued_at": str(row[3]),
+            }
+
+    def remove(self, run_id: str) -> bool:
+        """Remove a specific run from the queue. Returns ``True`` if found."""
+        with self._lock, self._conn() as con, con.cursor() as cur:
+            cur.execute(
+                "DELETE FROM run_queue WHERE run_id = %s",
+                (str(run_id),),
+            )
+            return bool(cur.rowcount and cur.rowcount > 0)

--- a/tldw_Server_API/app/core/DB_Management/Workflows_Scheduler_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_Scheduler_DB.py
@@ -50,6 +50,8 @@ CREATE TABLE IF NOT EXISTS workflow_schedules (
     misfire_grace_sec INTEGER DEFAULT 300,
     coalesce BOOLEAN NOT NULL DEFAULT TRUE,
     jitter_sec INTEGER NOT NULL DEFAULT 0,
+    -- ACP schedule config (when set, schedule fires acp_run instead of workflow_run)
+    acp_config_json TEXT,
     -- History
     last_run_at TIMESTAMPTZ,
     next_run_at TIMESTAMPTZ,
@@ -81,6 +83,8 @@ CREATE TABLE IF NOT EXISTS workflow_schedules (
     misfire_grace_sec INTEGER DEFAULT 300,
     coalesce INTEGER NOT NULL DEFAULT 1,
     jitter_sec INTEGER NOT NULL DEFAULT 0,
+    -- ACP schedule config (when set, schedule fires acp_run instead of workflow_run)
+    acp_config_json TEXT,
     -- History
     last_run_at TEXT,
     next_run_at TEXT,
@@ -111,6 +115,7 @@ class WorkflowSchedule:
     misfire_grace_sec: int
     coalesce: bool
     jitter_sec: int
+    acp_config_json: str | None
     last_run_at: str | None
     next_run_at: str | None
     last_status: str | None
@@ -231,6 +236,7 @@ class WorkflowsSchedulerDB:
                     "next_run_at": "ALTER TABLE workflow_schedules ADD COLUMN next_run_at TIMESTAMPTZ",
                     "last_status": "ALTER TABLE workflow_schedules ADD COLUMN last_status TEXT",
                     "jitter_sec": "ALTER TABLE workflow_schedules ADD COLUMN jitter_sec INTEGER NOT NULL DEFAULT 0",
+                    "acp_config_json": "ALTER TABLE workflow_schedules ADD COLUMN acp_config_json TEXT",
                 }
             else:
                 column_sql = {
@@ -242,6 +248,7 @@ class WorkflowsSchedulerDB:
                     "next_run_at": "ALTER TABLE workflow_schedules ADD COLUMN next_run_at TEXT",
                     "last_status": "ALTER TABLE workflow_schedules ADD COLUMN last_status TEXT",
                     "jitter_sec": "ALTER TABLE workflow_schedules ADD COLUMN jitter_sec INTEGER NOT NULL DEFAULT 0",
+                    "acp_config_json": "ALTER TABLE workflow_schedules ADD COLUMN acp_config_json TEXT",
                 }
 
             for column, statement in column_sql.items():
@@ -288,6 +295,7 @@ class WorkflowsSchedulerDB:
         concurrency_mode: str = "skip",
         misfire_grace_sec: int = 300,
         coalesce: bool = True,
+        acp_config_json: str | None = None,
     ) -> None:
         now = _utcnow_iso()
         params = (
@@ -307,6 +315,7 @@ class WorkflowsSchedulerDB:
             int(misfire_grace_sec),
             1 if coalesce else 0,
             0,
+            acp_config_json,
             None,
             None,
             None,
@@ -316,8 +325,8 @@ class WorkflowsSchedulerDB:
         sql = (
             "INSERT INTO workflow_schedules("
             "id,tenant_id,user_id,workflow_id,name,cron,timezone,inputs_json,run_mode,validation_mode,enabled,require_online,"
-            "concurrency_mode,misfire_grace_sec,coalesce,jitter_sec,last_run_at,next_run_at,last_status,created_at,updated_at"
-            ") VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+            "concurrency_mode,misfire_grace_sec,coalesce,jitter_sec,acp_config_json,last_run_at,next_run_at,last_status,created_at,updated_at"
+            ") VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
         )
         with self.backend.transaction() as conn:
             self.backend.execute(sql, params, connection=conn)
@@ -340,6 +349,13 @@ class WorkflowsSchedulerDB:
             elif k == "coalesce":
                 fields.append("coalesce = ?")
                 params.append(1 if bool(v) else 0)
+            elif k == "acp_config_json":
+                fields.append("acp_config_json = ?")
+                # Accept dict (serialize) or str/None (store as-is)
+                if isinstance(v, dict):
+                    params.append(json.dumps(v))
+                else:
+                    params.append(v)
             else:
                 fields.append(f"{k} = ?")
                 params.append(v)
@@ -371,7 +387,9 @@ class WorkflowsSchedulerDB:
             validation_mode=r.get("validation_mode") or "block", enabled=bool(r.get("enabled") in (1, True, "1")),
             require_online=bool(r.get("require_online") in (1, True, "1")),
             concurrency_mode=(r.get("concurrency_mode") or "skip"), misfire_grace_sec=int(r.get("misfire_grace_sec") or 300),
-            coalesce=bool(r.get("coalesce") in (1, True, "1")), jitter_sec=int(r.get("jitter_sec") or 0), last_run_at=r.get("last_run_at"), next_run_at=r.get("next_run_at"),
+            coalesce=bool(r.get("coalesce") in (1, True, "1")), jitter_sec=int(r.get("jitter_sec") or 0),
+            acp_config_json=r.get("acp_config_json"),
+            last_run_at=r.get("last_run_at"), next_run_at=r.get("next_run_at"),
             last_status=r.get("last_status"), created_at=r.get("created_at"), updated_at=r.get("updated_at")
         )
 
@@ -401,7 +419,9 @@ class WorkflowsSchedulerDB:
                     validation_mode=r.get("validation_mode") or "block", enabled=bool(r.get("enabled") in (1, True, "1")),
                     require_online=bool(r.get("require_online") in (1, True, "1")),
                     concurrency_mode=(r.get("concurrency_mode") or "skip"), misfire_grace_sec=int(r.get("misfire_grace_sec") or 300),
-                    coalesce=bool(r.get("coalesce") in (1, True, "1")), jitter_sec=int(r.get("jitter_sec") or 0), last_run_at=r.get("last_run_at"), next_run_at=r.get("next_run_at"),
+                    coalesce=bool(r.get("coalesce") in (1, True, "1")), jitter_sec=int(r.get("jitter_sec") or 0),
+                    acp_config_json=r.get("acp_config_json"),
+                    last_run_at=r.get("last_run_at"), next_run_at=r.get("next_run_at"),
                     last_status=r.get("last_status"), created_at=r.get("created_at"), updated_at=r.get("updated_at")
                 )
             )

--- a/tldw_Server_API/app/core/Sandbox/event_bridge.py
+++ b/tldw_Server_API/app/core/Sandbox/event_bridge.py
@@ -1,0 +1,152 @@
+"""Bridge between Sandbox RunStreamHub and ACP SessionEventBus.
+
+Subscribes to RunStreamHub frames for a given run and translates them into
+typed AgentEvent objects published on the SessionEventBus.  This lets clients
+consume a single unified event stream instead of speaking two protocols.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.Sandbox.streams import RunStreamHub
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+
+class SandboxEventBridge:
+    """Translates RunStreamHub frames into AgentEvents on a SessionEventBus."""
+
+    def __init__(
+        self,
+        hub: "RunStreamHub",
+        bus: "SessionEventBus",
+        run_id: str,
+        session_id: str,
+    ) -> None:
+        self._hub = hub
+        self._bus = bus
+        self._run_id = run_id
+        self._session_id = session_id
+        self._task: asyncio.Task[None] | None = None
+        self._queue: asyncio.Queue[dict[str, Any]] | None = None
+        self._stopped = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Subscribe to the hub and begin translating frames."""
+        if self._task is not None:
+            return
+        self._queue = self._hub.subscribe(self._run_id)
+        self._task = asyncio.create_task(self._consume(), name=f"event-bridge-{self._run_id}")
+        logger.debug("SandboxEventBridge started for run_id={}", self._run_id)
+
+    async def stop(self) -> None:
+        """Stop consuming frames and clean up the subscription."""
+        self._stopped = True
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        if self._queue is not None:
+            self._hub.unsubscribe(self._run_id, self._queue)
+            self._queue = None
+        self._task = None
+        logger.debug("SandboxEventBridge stopped for run_id={}", self._run_id)
+
+    # ------------------------------------------------------------------
+    # Internal consume loop
+    # ------------------------------------------------------------------
+
+    async def _consume(self) -> None:
+        """Read frames from the hub queue, translate, and publish to the bus."""
+        assert self._queue is not None  # noqa: S101 — guarded by start()
+        try:
+            while not self._stopped:
+                try:
+                    frame = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+                event = self._translate_frame(frame)
+                if event is not None:
+                    await self._bus.publish(event)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.opt(exception=True).error(
+                "SandboxEventBridge consume loop failed for run_id={}",
+                self._run_id,
+            )
+
+    # ------------------------------------------------------------------
+    # Frame → AgentEvent translation
+    # ------------------------------------------------------------------
+
+    def _translate_frame(self, frame: dict[str, Any]) -> Any:
+        """Map a raw sandbox frame dict to an AgentEvent (or *None* to skip)."""
+        from tldw_Server_API.app.core.Agent_Client_Protocol.events import (
+            AgentEvent,
+            AgentEventKind,
+        )
+
+        frame_type: str = frame.get("type", "")
+
+        if frame_type in ("stdout", "stderr"):
+            return AgentEvent(
+                session_id=self._session_id,
+                kind=AgentEventKind.TERMINAL_OUTPUT,
+                payload={
+                    "stream": frame_type,
+                    "data": frame.get("data", ""),
+                    "encoding": frame.get("encoding", "utf8"),
+                },
+                metadata={"run_id": self._run_id, "sandbox_seq": frame.get("seq")},
+            )
+
+        if frame_type == "event":
+            event_name = frame.get("event", "")
+            if event_name == "end":
+                return AgentEvent(
+                    session_id=self._session_id,
+                    kind=AgentEventKind.COMPLETION,
+                    payload=frame.get("data", {}),
+                    metadata={"run_id": self._run_id, "sandbox_seq": frame.get("seq")},
+                )
+            # Generic lifecycle events (e.g. start, status changes)
+            return AgentEvent(
+                session_id=self._session_id,
+                kind=AgentEventKind.LIFECYCLE,
+                payload={"event": event_name, **(frame.get("data") or {})},
+                metadata={"run_id": self._run_id, "sandbox_seq": frame.get("seq")},
+            )
+
+        if frame_type == "truncated":
+            return AgentEvent(
+                session_id=self._session_id,
+                kind=AgentEventKind.ERROR,
+                payload={"error": "truncated", "reason": frame.get("reason", "")},
+                metadata={"run_id": self._run_id, "sandbox_seq": frame.get("seq")},
+            )
+
+        if frame_type == "heartbeat":
+            return AgentEvent(
+                session_id=self._session_id,
+                kind=AgentEventKind.HEARTBEAT,
+                payload={},
+                metadata={"run_id": self._run_id},
+            )
+
+        # Unknown frame type — log and skip
+        logger.debug(
+            "SandboxEventBridge: skipping unknown frame type={!r} for run_id={}",
+            frame_type,
+            self._run_id,
+        )
+        return None

--- a/tldw_Server_API/app/core/Sandbox/models.py
+++ b/tldw_Server_API/app/core/Sandbox/models.py
@@ -12,6 +12,7 @@ class RuntimeType(str, Enum):
     vz_linux = "vz_linux"
     vz_macos = "vz_macos"
     seatbelt = "seatbelt"
+    worktree = "worktree"
 
 
 class TrustLevel(str, Enum):

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -94,9 +94,11 @@ class SandboxOrchestrator:
         self.policy = policy or SandboxPolicy(cfg)
         self._lock = threading.RLock()
         self._sessions: dict[str, Session] = {}
-        # Store backend for runs/idempotency/usage
+        # Store backend for runs/idempotency/usage and durable run queue
         self._store = get_store()
-        # in-memory run queue of (run_id, enqueue_timestamp)
+        # In-memory run queue caches (L1 over durable store queue).
+        # These provide fast access for non-critical operations like wait
+        # time estimation and fallback counting when the store is unavailable.
         self._queue: list[tuple[str, float]] = []
         self._enqueue_index: dict[str, float] = {}
         self._queue_meta: dict[str, dict[str, str | None]] = {}
@@ -659,6 +661,11 @@ class SandboxOrchestrator:
             self._store.put_run(user_id, status)
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"store.put_run failed: {e}")
+        # Persist to durable queue for cross-restart recovery
+        try:
+            self._store.enqueue_run(rid, owner_key, priority=0)
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(f"store.enqueue_run failed: {e}")
         self._store_idem("runs", user_id, idem_key, body, rid, {
             "id": rid,
             "phase": status.phase.value,
@@ -696,6 +703,10 @@ class SandboxOrchestrator:
                     self._queue_meta.pop(rid, None)
         if not expired:
             return
+        # Remove expired entries from durable queue
+        for rid in expired:
+            with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
+                self._store.remove_from_queue(rid)
         from datetime import datetime
         for rid in expired:
             try:
@@ -746,7 +757,7 @@ class SandboxOrchestrator:
             self._store.update_run(status)
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"store.update_run failed: {e}")
-        # Cleanup enqueue index when leaving queued phase
+        # Cleanup enqueue index and durable queue when leaving queued phase
         try:
             if status.phase != RunPhase.queued:
                 with self._lock:
@@ -754,6 +765,8 @@ class SandboxOrchestrator:
                     self._queue_meta.pop(run_id, None)
                     if self._queue:
                         self._queue = [(rid, ts) for (rid, ts) in self._queue if rid != run_id]
+                with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
+                    self._store.remove_from_queue(run_id)
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
             pass
 

--- a/tldw_Server_API/app/core/Sandbox/pool.py
+++ b/tldw_Server_API/app/core/Sandbox/pool.py
@@ -1,0 +1,210 @@
+"""Docker warm container pool for sub-second sandbox startup.
+
+Pre-creates idle containers with 'sleep infinity' entrypoint.
+On claim, uses 'docker exec' to run the actual command.
+"""
+from __future__ import annotations
+
+import atexit
+import os
+import subprocess
+import threading
+import time
+from collections import defaultdict
+from typing import Any
+
+from loguru import logger
+
+
+class DockerWarmPool:
+    """Maintains a pool of pre-created Docker containers.
+
+    Containers are created with ``/bin/sh -c 'sleep infinity'`` as their
+    entrypoint so they start immediately and idle until claimed.  When a
+    caller claims a container the pool pops one off its internal list and
+    returns the container ID.  The caller is then expected to use
+    ``docker exec`` to run the real workload inside the already-running
+    container.
+
+    Containers are **single-use** after exec -- ``release()`` always
+    destroys the container regardless of the *tainted* flag.
+    """
+
+    def __init__(
+        self,
+        pool_size: int | None = None,
+        images: list[str] | None = None,
+        replenish_interval: float = 10.0,
+    ) -> None:
+        self._pool_size = pool_size or int(os.getenv("SANDBOX_WARM_POOL_SIZE", "3"))
+        self._images = images or os.getenv(
+            "SANDBOX_WARM_POOL_IMAGES", "python:3.12-slim"
+        ).split(",")
+        self._replenish_interval = replenish_interval
+
+        # image -> [container_id, ...]
+        self._pool: dict[str, list[str]] = defaultdict(list)
+        self._lock = threading.Lock()
+        self._running = False
+        self._thread: threading.Thread | None = None
+
+        # Register shutdown hook
+        atexit.register(self.shutdown)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background replenishment thread."""
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._replenish_loop, daemon=True, name="warm-pool"
+        )
+        self._thread.start()
+        logger.info(
+            "Docker warm pool started: size={}, images={}",
+            self._pool_size,
+            self._images,
+        )
+
+    def shutdown(self) -> None:
+        """Stop the pool and destroy all idle containers."""
+        self._running = False
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+        with self._lock:
+            for image, containers in self._pool.items():
+                for cid in containers:
+                    self._destroy_container(cid)
+                containers.clear()
+        logger.info("Docker warm pool shut down")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def claim(self, image: str) -> str | None:
+        """Claim a pre-created container for the given image.
+
+        Returns the container ID or ``None`` if the pool is empty for
+        that image.
+        """
+        with self._lock:
+            pool = self._pool.get(image, [])
+            if pool:
+                cid = pool.pop(0)
+                logger.debug(
+                    "Claimed container {} from warm pool (image={})",
+                    cid[:12],
+                    image,
+                )
+                return cid
+        return None
+
+    def release(self, container_id: str, tainted: bool = False) -> None:
+        """Return a container to the pool, or destroy if tainted.
+
+        Because containers are single-use after ``docker exec``, this
+        always destroys the container regardless of the *tainted* flag.
+        """
+        if tainted:
+            self._destroy_container(container_id)
+            return
+        # Don't return to pool -- containers are single-use after exec
+        self._destroy_container(container_id)
+
+    def pool_status(self) -> dict[str, int]:
+        """Return current pool sizes per image."""
+        with self._lock:
+            return {img: len(cids) for img, cids in self._pool.items()}
+
+    # ------------------------------------------------------------------
+    # Background replenishment
+    # ------------------------------------------------------------------
+
+    def _replenish_loop(self) -> None:
+        """Background thread that maintains pool levels."""
+        while self._running:
+            for image in self._images:
+                self._replenish_image(image)
+            time.sleep(self._replenish_interval)
+
+    def _replenish_image(self, image: str) -> None:
+        """Top up the pool for a single image."""
+        with self._lock:
+            current = len(self._pool.get(image, []))
+            needed = self._pool_size - current
+
+        for _ in range(needed):
+            if not self._running:
+                break
+            try:
+                cid = self._create_idle_container(image)
+                with self._lock:
+                    self._pool[image].append(cid)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to pre-create container for {}: {}", image, exc
+                )
+                break
+
+    # ------------------------------------------------------------------
+    # Docker helpers
+    # ------------------------------------------------------------------
+
+    def _create_idle_container(self, image: str) -> str:
+        """Create a container with ``sleep infinity`` entrypoint."""
+        cmd = [
+            "docker",
+            "create",
+            "--cap-drop=ALL",
+            "--read-only",
+            "--network=none",
+            "--memory=256m",
+            "--pids-limit=64",
+            "--entrypoint",
+            "/bin/sh",
+            image,
+            "-c",
+            "sleep infinity",
+        ]
+        cid = subprocess.check_output(cmd, text=True, timeout=30).strip()
+        subprocess.check_call(
+            ["docker", "start", cid],
+            timeout=30,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return cid
+
+    @staticmethod
+    def _destroy_container(container_id: str) -> None:
+        """Force-remove a container."""
+        try:
+            subprocess.check_call(
+                ["docker", "rm", "-f", container_id],
+                timeout=10,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception:
+            pass
+
+
+# ------------------------------------------------------------------
+# Module-level singleton (lazy-initialized)
+# ------------------------------------------------------------------
+
+_warm_pool: DockerWarmPool | None = None
+
+
+def get_warm_pool() -> DockerWarmPool:
+    """Get or create the global warm pool instance."""
+    global _warm_pool
+    if _warm_pool is None:
+        _warm_pool = DockerWarmPool()
+        _warm_pool.start()
+    return _warm_pool

--- a/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
@@ -1,0 +1,678 @@
+"""Git worktree sandbox runner.
+
+Provides VCS-level isolation by creating a detached worktree per session.
+No Docker dependency.  On macOS, runs with sanitised environment (Seatbelt
+profile layering ready for a future iteration).  On Linux, requires
+``unshare`` namespace isolation -- refuses to run unconfined.
+"""
+from __future__ import annotations
+
+import contextlib
+import fnmatch
+import os
+import shutil
+import signal
+import subprocess  # nosec B404
+import sys
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.config import settings as app_settings
+from tldw_Server_API.app.core.testing import is_truthy
+
+from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
+from ..runtime_capabilities import RuntimePreflightResult
+from ..streams import get_hub
+
+# ---------------------------------------------------------------------------
+# Env vars stripped from child processes for security
+# ---------------------------------------------------------------------------
+
+_SENSITIVE_ENV_VARS = frozenset({
+    "HOME",
+    "SSH_AUTH_SOCK",
+    "SSH_AGENT_PID",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "DATABASE_URL",
+    "SINGLE_USER_API_KEY",
+})
+
+_WORKTREE_NONCRITICAL_EXCEPTIONS = (
+    AssertionError,
+    AttributeError,
+    ConnectionError,
+    FileNotFoundError,
+    IndexError,
+    KeyError,
+    LookupError,
+    OSError,
+    PermissionError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+    UnicodeDecodeError,
+    subprocess.SubprocessError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Availability helpers (module-level, mirrors docker_available pattern)
+# ---------------------------------------------------------------------------
+
+def worktree_available() -> bool:
+    """Return *True* when git >= 2.15 is present."""
+    env = os.getenv("TLDW_SANDBOX_WORKTREE_AVAILABLE")
+    if env is not None:
+        return is_truthy(env)
+    return _check_git_version()
+
+
+def _check_git_version() -> bool:
+    """Return *True* when ``git`` >= 2.15 is on PATH."""
+    try:
+        result = subprocess.run(
+            ["git", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        version_str = result.stdout.strip().split()[-1]
+        parts = version_str.split(".")
+        major, minor = int(parts[0]), int(parts[1])
+        return (major, minor) >= (2, 15)
+    except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+        return False
+
+
+def _git_version_string() -> str | None:
+    """Return the git version string, or *None*."""
+    try:
+        result = subprocess.run(
+            ["git", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip() or None
+    except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+        return None
+
+
+def _check_unshare_available() -> bool:
+    """Return *True* when ``unshare`` is available (Linux only)."""
+    if sys.platform != "linux":
+        return False
+    try:
+        result = subprocess.run(
+            ["unshare", "--help"],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+    except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# WorktreeRunner
+# ---------------------------------------------------------------------------
+
+class WorktreeRunner:
+    """Sandbox runner using git worktrees for VCS-level isolation.
+
+    Each run gets its own detached worktree.  The main working copy is never
+    modified.  On Linux the command is wrapped in ``unshare --mount --pid
+    --fork`` for namespace isolation; the runner **refuses** to execute
+    unconfined on Linux.
+
+    Supported trust levels: ``trusted`` and ``standard``.
+    """
+
+    runtime_type = RuntimeType.worktree
+
+    # Track active subprocesses for cancellation
+    _active_lock = threading.RLock()
+    _active_proc: dict[str, subprocess.Popen[bytes]] = {}
+    _active_run_dir: dict[str, str] = {}
+    _cancelled_runs: set[str] = set()
+
+    def __init__(
+        self,
+        allowed_repo_dirs: list[str] | None = None,
+    ) -> None:
+        if allowed_repo_dirs is not None:
+            self._allowed_dirs = list(allowed_repo_dirs)
+        else:
+            raw = str(
+                os.getenv("TLDW_SANDBOX_WORKTREE_ALLOWED_DIRS") or ""
+            ).strip()
+            if raw:
+                self._allowed_dirs = [d.strip() for d in raw.split(",") if d.strip()]
+            else:
+                self._allowed_dirs = [str(Path.home())]
+        # Paths created internally (e.g. temp repos) are always allowed
+        self._internal_repos: set[str] = set()
+
+    # ---- validation helpers -------------------------------------------------
+
+    def _validate_repo_path(self, repo_path: str) -> None:
+        """Ensure *repo_path* is under an allowed directory.
+
+        Internally-created temp repos (tracked via ``_internal_repos``)
+        are always allowed regardless of the allowlist.
+        """
+        resolved = str(Path(repo_path).resolve())
+        if resolved in self._internal_repos:
+            return  # Internally created, always allowed
+        for allowed in self._allowed_dirs:
+            allowed_resolved = str(Path(allowed).resolve())
+            if resolved == allowed_resolved or resolved.startswith(allowed_resolved + os.sep):
+                return
+        raise ValueError(
+            f"Repository path {repo_path!r} is not under any allowed directory"
+        )
+
+    @staticmethod
+    def _is_git_repo(path: str) -> bool:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--is-inside-work-tree"],
+                cwd=path,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.returncode == 0 and result.stdout.strip() == "true"
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            return False
+
+    # ---- safe environment ---------------------------------------------------
+
+    @staticmethod
+    def _safe_env(extra_env: dict[str, str] | None = None) -> dict[str, str]:
+        """Build a sanitised environment dict for child processes."""
+        env = {k: v for k, v in os.environ.items() if k not in _SENSITIVE_ENV_VARS}
+        if extra_env:
+            env.update(
+                {k: v for k, v in extra_env.items() if k not in _SENSITIVE_ENV_VARS}
+            )
+        return env
+
+    # ---- worktree lifecycle -------------------------------------------------
+
+    @staticmethod
+    def create_worktree(repo_path: str, branch: str = "HEAD") -> str:
+        """Create a detached worktree under a temporary directory.
+
+        Returns the path to the new worktree.
+        """
+        worktree_dir = tempfile.mkdtemp(prefix="tldw_wt_")
+        try:
+            if branch == "HEAD":
+                cmd = ["git", "worktree", "add", "--detach", worktree_dir]
+            else:
+                cmd = ["git", "worktree", "add", worktree_dir, branch]
+
+            subprocess.check_call(
+                cmd,
+                cwd=repo_path,
+                timeout=30,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError as exc:
+            shutil.rmtree(worktree_dir, ignore_errors=True)
+            stderr_text = ""
+            if exc.stderr:
+                stderr_text = exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode(errors="replace")
+            raise RuntimeError(f"Failed to create worktree: {stderr_text}") from exc
+        return worktree_dir
+
+    @staticmethod
+    def destroy_worktree(worktree_path: str, repo_path: str) -> None:
+        """Remove a git worktree and clean up."""
+        try:
+            subprocess.check_call(
+                ["git", "worktree", "remove", "--force", worktree_path],
+                cwd=repo_path,
+                timeout=30,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError:
+            logger.warning(
+                "git worktree remove failed for {}, cleaning up manually",
+                worktree_path,
+            )
+            shutil.rmtree(worktree_path, ignore_errors=True)
+            # Prune stale worktree references
+            with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+                subprocess.check_call(
+                    ["git", "worktree", "prune"],
+                    cwd=repo_path,
+                    timeout=10,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+
+    # ---- preflight ----------------------------------------------------------
+
+    def _version(self) -> str | None:
+        raw = str(os.getenv("TLDW_SANDBOX_WORKTREE_VERSION") or "").strip()
+        if raw:
+            return raw
+        return _git_version_string()
+
+    def _supported_trust_levels(self) -> list[str]:
+        return ["trusted", "standard"]
+
+    def preflight(self, network_policy: str | None = None) -> RuntimePreflightResult:
+        """Collect preflight status for the worktree runtime."""
+        reasons: list[str] = []
+
+        if not worktree_available():
+            reasons.append("git_too_old_or_missing")
+
+        if sys.platform == "linux" and not _check_unshare_available():
+            reasons.append("unshare_required_on_linux")
+
+        if sys.platform not in ("darwin", "linux"):
+            reasons.append("unsupported_platform")
+
+        if str(network_policy or "deny_all").strip().lower() == "allowlist":
+            reasons.append("strict_allowlist_not_supported")
+
+        available = not reasons
+        return RuntimePreflightResult(
+            runtime=self.runtime_type,
+            available=available,
+            reasons=reasons,
+            supported_trust_levels=self._supported_trust_levels(),
+            host={"platform": sys.platform},
+            enforcement_ready={"deny_all": False, "allowlist": False},
+        )
+
+    # ---- cancellation -------------------------------------------------------
+
+    @classmethod
+    def _cancel_grace_seconds(cls) -> int:
+        try:
+            return max(0, int(getattr(app_settings, "SANDBOX_CANCEL_GRACE_SECONDS", 3)))
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            return 3
+
+    @classmethod
+    def _register_active_run(
+        cls,
+        run_id: str,
+        proc: subprocess.Popen[bytes],
+        run_dir: str,
+    ) -> None:
+        with cls._active_lock:
+            cls._active_proc[run_id] = proc
+            cls._active_run_dir[run_id] = run_dir
+
+    @classmethod
+    def _clear_active_run(cls, run_id: str) -> str | None:
+        with cls._active_lock:
+            cls._active_proc.pop(run_id, None)
+            return cls._active_run_dir.pop(run_id, None)
+
+    @classmethod
+    def _mark_cancelled(cls, run_id: str) -> None:
+        with cls._active_lock:
+            cls._cancelled_runs.add(run_id)
+
+    @classmethod
+    def _consume_cancelled(cls, run_id: str) -> bool:
+        with cls._active_lock:
+            was = run_id in cls._cancelled_runs
+            cls._cancelled_runs.discard(run_id)
+            return was
+
+    @classmethod
+    def _terminate_process_group(cls, proc: subprocess.Popen[bytes]) -> None:
+        with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+            os.killpg(proc.pid, signal.SIGTERM)
+        try:
+            proc.wait(timeout=cls._cancel_grace_seconds())
+            return
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            pass
+        with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+            os.killpg(proc.pid, signal.SIGKILL)
+        with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+            proc.wait(timeout=1)
+
+    @classmethod
+    def cancel_run(cls, run_id: str) -> bool:
+        with cls._active_lock:
+            proc = cls._active_proc.get(run_id)
+
+        if proc is None:
+            return False
+
+        cls._mark_cancelled(run_id)
+        cls._terminate_process_group(proc)
+        run_dir = cls._clear_active_run(run_id)
+        if run_dir:
+            with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+                shutil.rmtree(run_dir, ignore_errors=True)
+        return True
+
+    # ---- read helpers -------------------------------------------------------
+
+    @staticmethod
+    def _max_log_bytes() -> int:
+        try:
+            return int(getattr(app_settings, "SANDBOX_MAX_LOG_BYTES", 10 * 1024 * 1024))
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            return 10 * 1024 * 1024
+
+    @staticmethod
+    def _read_capped_output(path: Path, max_bytes: int) -> bytes:
+        if max_bytes <= 0 or not path.is_file():
+            return b""
+        try:
+            size = path.stat().st_size
+            with path.open("rb") as handle:
+                if size > max_bytes:
+                    handle.seek(size - max_bytes)
+                return handle.read(max_bytes)
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            return b""
+
+    @staticmethod
+    def _path_within_root(root_path: Path, candidate: Path) -> bool:
+        try:
+            root = root_path.resolve()
+            resolved = candidate.resolve()
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            return False
+        return resolved == root or root in resolved.parents
+
+    @staticmethod
+    def _collect_artifacts(
+        workspace: str,
+        capture_patterns: list[str] | None,
+    ) -> dict[str, bytes]:
+        if not capture_patterns:
+            return {}
+        artifacts_map: dict[str, bytes] = {}
+        workspace_root = Path(workspace)
+        if workspace_root.is_symlink():
+            return {}
+        try:
+            for root, _dirs, files in os.walk(workspace):
+                root_path = Path(root)
+                if not WorktreeRunner._path_within_root(workspace_root, root_path):
+                    continue
+                for file_name in files:
+                    full_path = root_path / file_name
+                    if full_path.is_symlink():
+                        continue
+                    if not WorktreeRunner._path_within_root(workspace_root, full_path):
+                        continue
+                    full = os.path.join(root, file_name)
+                    rel = os.path.relpath(full, workspace)
+                    rel_posix = rel.replace(os.sep, "/")
+                    if any(fnmatch.fnmatchcase(rel_posix, p) for p in capture_patterns):
+                        artifacts_map[rel_posix] = full_path.read_bytes()
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            return {}
+        return artifacts_map
+
+    # ---- execution ----------------------------------------------------------
+
+    def _build_command(
+        self,
+        command: list[str],
+        worktree_path: str,
+    ) -> list[str]:
+        """Wrap *command* for the current platform.
+
+        On Linux the command is wrapped in ``unshare`` for namespace isolation.
+        On macOS the command runs directly (Seatbelt layering is a future step).
+        """
+        if sys.platform == "linux":
+            if not _check_unshare_available():
+                raise RuntimeError(
+                    "unshare is required for worktree runner on Linux. "
+                    "Install util-linux or run in a Docker container instead."
+                )
+            return [
+                "unshare", "--mount", "--pid", "--fork",
+                "--", *command,
+            ]
+        # macOS or other -- direct execution with sanitised env
+        return list(command)
+
+    def start_run(
+        self,
+        run_id: str,
+        spec: RunSpec,
+        session_workspace: str | None = None,
+    ) -> RunStatus:
+        """Execute *spec.command* inside an isolated worktree.
+
+        Follows the same contract as ``SeatbeltRunner.start_run``.
+        """
+        started = datetime.now(timezone.utc)
+        finished = started
+        hub = get_hub()
+        max_log_bytes = self._max_log_bytes()
+        artifacts_map: dict[str, bytes] = {}
+        message = "worktree execution failed"
+        exit_code: int | None = None
+        phase = RunPhase.failed
+        proc: subprocess.Popen[bytes] | None = None
+        run_dir: str | None = None
+
+        with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+            hub.publish_event(
+                run_id,
+                "start",
+                {
+                    "ts": started.isoformat(),
+                    "runtime": self.runtime_type.value,
+                },
+            )
+
+        try:
+            # Determine repo path -- prefer session_workspace if it is a git repo,
+            # otherwise fall back to a temporary bare repo so the worktree can
+            # still be created (the command will run in the worktree directory
+            # regardless).
+            repo_path: str | None = None
+            if session_workspace and os.path.isdir(session_workspace):
+                if self._is_git_repo(session_workspace):
+                    repo_path = session_workspace
+
+            if repo_path is None:
+                # Create a throwaway repo so create_worktree has something
+                # to attach to.  The worktree itself is the real workspace.
+                run_dir = tempfile.mkdtemp(prefix="tldw_wt_run_")
+                repo_path = os.path.join(run_dir, "repo")
+                os.makedirs(repo_path, exist_ok=True)
+                subprocess.check_call(
+                    ["git", "init", repo_path],
+                    timeout=10,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                # Need at least one commit for worktree
+                env_for_init = self._safe_env()
+                env_for_init["GIT_AUTHOR_NAME"] = "tldw"
+                env_for_init["GIT_AUTHOR_EMAIL"] = "tldw@localhost"
+                env_for_init["GIT_COMMITTER_NAME"] = "tldw"
+                env_for_init["GIT_COMMITTER_EMAIL"] = "tldw@localhost"
+                subprocess.check_call(
+                    ["git", "commit", "--allow-empty", "-m", "init"],
+                    cwd=repo_path,
+                    env=env_for_init,
+                    timeout=10,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                # Mark as internally created so it passes allowlist validation
+                self._internal_repos.add(str(Path(repo_path).resolve()))
+            else:
+                run_dir = tempfile.mkdtemp(prefix="tldw_wt_run_")
+
+            # Validate repo_path is under an allowed directory
+            self._validate_repo_path(repo_path)
+
+            worktree_path = self.create_worktree(repo_path, branch="HEAD")
+
+            # Copy session_workspace files into the worktree if they came from
+            # a non-git directory.
+            if session_workspace and os.path.isdir(session_workspace) and repo_path != session_workspace:
+                shutil.copytree(session_workspace, worktree_path, dirs_exist_ok=True)
+
+            # Write inline files
+            for relative_path, data in spec.files_inline or []:
+                normalized = str(relative_path or "").replace("\\", "/").lstrip("/")
+                parts = [p for p in normalized.split("/") if p]
+                if not parts or any(p in {".", ".."} for p in parts):
+                    raise ValueError(f"invalid inline file path: {relative_path}")
+                target = Path(worktree_path).joinpath(*parts)
+                if not self._path_within_root(Path(worktree_path), target.parent):
+                    raise ValueError(f"inline file path escapes workspace: {relative_path}")
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(data)
+
+            control_dir = os.path.join(run_dir, "control")
+            os.makedirs(control_dir, exist_ok=True)
+            stdout_path = Path(control_dir) / "stdout.log"
+            stderr_path = Path(control_dir) / "stderr.log"
+
+            env = self._safe_env(spec.env or {})
+            command = list(spec.command or [])
+            if not command:
+                raise ValueError("empty command")
+
+            full_command = self._build_command(command, worktree_path)
+
+            with stdout_path.open("wb") as stdout_handle, stderr_path.open("wb") as stderr_handle:
+                proc = subprocess.Popen(  # nosec B603
+                    full_command,
+                    cwd=worktree_path,
+                    env=env,
+                    stdout=stdout_handle,
+                    stderr=stderr_handle,
+                    stdin=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+                self._register_active_run(run_id, proc, run_dir)
+
+                try:
+                    wait_result = proc.wait(
+                        timeout=max(1, int(spec.timeout_sec or 300)),
+                    )
+                except subprocess.TimeoutExpired:
+                    self._terminate_process_group(proc)
+                    phase = RunPhase.timed_out
+                    message = "execution_timeout"
+                else:
+                    exit_code = (
+                        proc.returncode
+                        if proc.returncode is not None
+                        else int(wait_result)
+                    )
+                    if exit_code == 0:
+                        phase = RunPhase.completed
+                        message = "worktree execution finished"
+                    else:
+                        phase = RunPhase.failed
+                        message = f"worktree execution failed (exit={exit_code})"
+
+            stdout_data = self._read_capped_output(stdout_path, max_log_bytes)
+            stderr_data = self._read_capped_output(stderr_path, max_log_bytes)
+
+            if stdout_data:
+                hub.publish_stdout(run_id, stdout_data, max_log_bytes=max_log_bytes)
+            if stderr_data:
+                hub.publish_stderr(run_id, stderr_data, max_log_bytes=max_log_bytes)
+
+            if phase != RunPhase.timed_out:
+                artifacts_map = self._collect_artifacts(
+                    worktree_path, spec.capture_patterns,
+                )
+
+            if self._consume_cancelled(run_id):
+                phase = RunPhase.killed
+                exit_code = None
+                artifacts_map = {}
+                message = "canceled_by_user"
+
+            # Tear down the worktree
+            with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+                self.destroy_worktree(worktree_path, repo_path)
+
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS as exc:
+            logger.error("Worktree execution error for run {}: {}", run_id, exc)
+            message = f"worktree execution error: {exc}"
+            if self._consume_cancelled(run_id):
+                phase = RunPhase.killed
+                message = "canceled_by_user"
+        finally:
+            finished = datetime.now(timezone.utc)
+            run_dir_to_remove = self._clear_active_run(run_id)
+            if run_dir_to_remove:
+                run_dir = run_dir_to_remove
+            if run_dir:
+                with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+                    shutil.rmtree(run_dir, ignore_errors=True)
+
+        with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+            if phase == RunPhase.timed_out:
+                hub.publish_event(
+                    run_id, "end",
+                    {"exit_code": None, "reason": "execution_timeout"},
+                )
+            elif phase != RunPhase.killed:
+                hub.publish_event(run_id, "end", {"exit_code": exit_code})
+
+        try:
+            total_log_bytes = int(hub.get_log_bytes(run_id))
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+            total_log_bytes = 0
+        artifact_bytes = (
+            sum(len(v) for v in artifacts_map.values()) if artifacts_map else 0
+        )
+        usage = {
+            "cpu_time_sec": 0,
+            "wall_time_sec": int(
+                max(0.0, (finished - started).total_seconds()),
+            ),
+            "peak_rss_mb": 0,
+            "log_bytes": int(total_log_bytes),
+            "artifact_bytes": int(artifact_bytes),
+        }
+
+        return RunStatus(
+            id="",
+            phase=phase,
+            runtime=self.runtime_type,
+            started_at=started,
+            finished_at=finished,
+            exit_code=exit_code,
+            message=message,
+            runtime_version=self._version(),
+            resource_usage=usage,
+            artifacts=artifacts_map or None,
+        )

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -45,6 +45,7 @@ def collect_runtime_preflights(
     from .runners.seatbelt_runner import SeatbeltRunner
     from .runners.vz_linux_runner import VZLinuxRunner
     from .runners.vz_macos_runner import VZMacOSRunner
+    from .runners.worktree_runner import WorktreeRunner
 
     requested_policy = str(network_policy or "deny_all").strip().lower() or "deny_all"
 
@@ -66,4 +67,5 @@ def collect_runtime_preflights(
         RuntimeType.seatbelt: SeatbeltRunner().preflight(network_policy=requested_policy),
         RuntimeType.vz_linux: VZLinuxRunner().preflight(network_policy=requested_policy),
         RuntimeType.vz_macos: VZMacOSRunner().preflight(network_policy=requested_policy),
+        RuntimeType.worktree: WorktreeRunner().preflight(network_policy=requested_policy),
     }

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -47,6 +47,7 @@ from .runners.lima_runner import LimaRunner, lima_available
 from .runners.seatbelt_runner import SeatbeltRunner
 from .runners.vz_linux_runner import VZLinuxRunner
 from .runners.vz_macos_runner import VZMacOSRunner
+from .runners.worktree_runner import WorktreeRunner, worktree_available
 from .snapshots import SnapshotManager
 from .store import get_store_mode
 from .streams import get_hub
@@ -311,6 +312,22 @@ class SandboxService:
         )
         return SeatbeltRunner().start_run(run_id, spec, workspace_path)
 
+    def _start_worktree_run_with_execution_preflight(
+        self,
+        run_id: str,
+        spec: RunSpec,
+        workspace_path: str | None,
+    ) -> RunStatus:
+        preflight = WorktreeRunner().preflight(network_policy=spec.network_policy)
+        if not preflight.available:
+            raise SandboxPolicy.RuntimeUnavailable(RuntimeType.worktree, reasons=list(preflight.reasons or []))
+        self.policy._require_trust_level_supported(
+            RuntimeType.worktree,
+            spec.trust_level or TrustLevel.standard,
+            runtime_preflights={RuntimeType.worktree: preflight},
+        )
+        return WorktreeRunner().start_run(run_id, spec, workspace_path)
+
     def _effective_claim_lease_seconds(self) -> int:
         try:
             raw = os.getenv("SANDBOX_RUN_CLAIM_LEASE_SEC")
@@ -353,6 +370,12 @@ class SandboxService:
                     runtime=RuntimeType.vz_macos,
                     available=False,
                     reasons=["vz_macos_unavailable"],
+                ),
+                RuntimeType.worktree: RuntimePreflightResult(
+                    runtime=RuntimeType.worktree,
+                    available=bool(worktree_available()),
+                    reasons=[] if worktree_available() else ["worktree_unavailable"],
+                    supported_trust_levels=["trusted", "standard"],
                 ),
             }
 
@@ -1688,6 +1711,17 @@ class SandboxService:
                 failed_reason="seatbelt_failed",
                 policy_exceptions=(SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported),
             )
+        elif execute_enabled and spec.runtime == RuntimeType.worktree:
+            ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
+            return self._execute_single_runtime_scaffold(
+                status=status,
+                spec=spec,
+                workspace_path=ws,
+                start_run_fn=self._start_worktree_run_with_execution_preflight,
+                policy_failed_reason="worktree_policy_failed",
+                failed_reason="worktree_failed",
+                policy_exceptions=(SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported),
+            )
         else:
             # Stub artifacts even without execution
             artifacts: dict[str, bytes] = {}
@@ -1754,6 +1788,8 @@ class SandboxService:
                 cancelled = VZLinuxRunner.cancel_run(run_id)
             elif st.runtime == RuntimeType.vz_macos:
                 cancelled = VZMacOSRunner.cancel_run(run_id)
+            elif st.runtime == RuntimeType.worktree:
+                cancelled = WorktreeRunner.cancel_run(run_id)
         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"cancel_run failed: {e}")
             cancelled = False

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -323,6 +323,23 @@ class SandboxStore:
             except (TypeError, ValueError):
                 raise ValueError(f"Invalid created_at filter: {value!r}") from None
 
+    # Durable run queue methods for cross-restart persistence.
+    def enqueue_run(self, run_id: str, user_id: str, priority: int = 0) -> None:
+        """Add a run to the persistent queue."""
+        raise NotImplementedError
+
+    def dequeue_run(self, worker_id: str) -> dict | None:
+        """Remove and return the highest-priority queued run, or None.
+
+        Returns a dict with keys: run_id, user_id, priority, enqueued_at.
+        Within the same priority, FIFO order (earliest enqueued_at first).
+        """
+        raise NotImplementedError
+
+    def remove_from_queue(self, run_id: str) -> bool:
+        """Remove a specific run from the queue. Returns True if it was present."""
+        raise NotImplementedError
+
     # Optional: TTL GC for idempotency
     def gc_idempotency(self) -> int:
         """Garbage-collect expired idempotency records.
@@ -342,6 +359,7 @@ class InMemoryStore(SandboxStore):
         self._sessions: dict[str, dict[str, Any]] = {}
         self._acp_sessions: dict[str, dict[str, Any]] = {}
         self._user_bytes: dict[str, int] = {}
+        self._run_queue: list[dict[str, Any]] = []
         self._lock = threading.RLock()
 
     def _fp(self, body: dict[str, Any]) -> str:
@@ -900,6 +918,31 @@ class InMemoryStore(SandboxStore):
         items.sort(key=lambda r: r.get("user_id") or "", reverse=bool(sort_desc))
         return items[offset: offset + limit]
 
+    # -- Durable run queue (in-memory) ------------------------------------------
+    def enqueue_run(self, run_id: str, user_id: str, priority: int = 0) -> None:
+        with self._lock:
+            self._run_queue.append({
+                "run_id": str(run_id),
+                "user_id": str(user_id),
+                "priority": int(priority),
+                "enqueued_at": time.time(),
+            })
+            # Keep sorted: highest priority first, then earliest enqueued_at
+            self._run_queue.sort(key=lambda e: (-e["priority"], e["enqueued_at"]))
+
+    def dequeue_run(self, worker_id: str) -> dict | None:
+        with self._lock:
+            if not self._run_queue:
+                return None
+            return self._run_queue.pop(0)
+
+    def remove_from_queue(self, run_id: str) -> bool:
+        rid = str(run_id)
+        with self._lock:
+            before = len(self._run_queue)
+            self._run_queue = [e for e in self._run_queue if e["run_id"] != rid]
+            return len(self._run_queue) < before
+
     def count_usage(
         self,
         *,
@@ -921,6 +964,10 @@ class SQLiteStore(SandboxStore):
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.RLock()
         self._init_db()
+
+        # Delegate run queue SQL to DB_Management abstraction
+        from tldw_Server_API.app.core.DB_Management.Sandbox_Queue_DB import SQLiteRunQueueDB
+        self._queue_db = SQLiteRunQueueDB(conn_factory=self._conn, lock=self._lock)
 
     def _conn(self) -> sqlite3.Connection:
         con = sqlite3.connect(self.db_path)
@@ -1010,6 +1057,12 @@ class SQLiteStore(SandboxStore):
                     scope_snapshot_id TEXT,
                     created_at REAL,
                     updated_at REAL
+                );
+                CREATE TABLE IF NOT EXISTS run_queue (
+                    run_id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    priority INTEGER DEFAULT 0,
+                    enqueued_at TEXT NOT NULL DEFAULT (datetime('now'))
                 );
                 """
             )
@@ -2037,6 +2090,27 @@ class SQLiteStore(SandboxStore):
         items.sort(key=lambda r: r.get("user_id") or "", reverse=bool(sort_desc))
         return items[offset: offset + limit]
 
+    # -- Durable run queue (SQLite) — delegated to DB_Management -----------------
+    def enqueue_run(self, run_id: str, user_id: str, priority: int = 0) -> None:
+        try:
+            self._queue_db.enqueue(run_id, user_id, priority)
+        except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(f"enqueue_run failed (sqlite): {e}")
+
+    def dequeue_run(self, worker_id: str) -> dict | None:
+        try:
+            return self._queue_db.dequeue(worker_id)
+        except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(f"dequeue_run failed (sqlite): {e}")
+            return None
+
+    def remove_from_queue(self, run_id: str) -> bool:
+        try:
+            return self._queue_db.remove(run_id)
+        except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(f"remove_from_queue failed (sqlite): {e}")
+            return False
+
     def count_usage(
         self,
         *,
@@ -2063,6 +2137,10 @@ class PostgresStore(SandboxStore):
         except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS as e:  # pragma: no cover
             raise RuntimeError("psycopg is required for PostgresStore") from e
         self._init_db()
+
+        # Delegate run queue SQL to DB_Management abstraction
+        from tldw_Server_API.app.core.DB_Management.Sandbox_Queue_DB import PostgresRunQueueDB
+        self._queue_db = PostgresRunQueueDB(conn_factory=self._conn, lock=self._lock)
 
     def _conn(self):
         import psycopg
@@ -2162,6 +2240,16 @@ class PostgresStore(SandboxStore):
                         scope_snapshot_id TEXT,
                         created_at DOUBLE PRECISION,
                         updated_at DOUBLE PRECISION
+                    );
+                    """
+            )
+            cur.execute(
+                """
+                    CREATE TABLE IF NOT EXISTS run_queue (
+                        run_id TEXT PRIMARY KEY,
+                        user_id TEXT NOT NULL,
+                        priority INTEGER DEFAULT 0,
+                        enqueued_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
                     );
                     """
             )
@@ -3198,6 +3286,27 @@ class PostgresStore(SandboxStore):
                     "artifact_bytes": int(usage_rows.get(u, 0)),
                 })
             return items[offset: offset + limit]
+
+    # -- Durable run queue (Postgres) — delegated to DB_Management ----------------
+    def enqueue_run(self, run_id: str, user_id: str, priority: int = 0) -> None:
+        try:
+            self._queue_db.enqueue(run_id, user_id, priority)
+        except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(f"enqueue_run failed (pg): {e}")
+
+    def dequeue_run(self, worker_id: str) -> dict | None:
+        try:
+            return self._queue_db.dequeue(worker_id)
+        except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(f"dequeue_run failed (pg): {e}")
+            return None
+
+    def remove_from_queue(self, run_id: str) -> bool:
+        try:
+            return self._queue_db.remove(run_id)
+        except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(f"remove_from_queue failed (pg): {e}")
+            return False
 
     def count_usage(
         self,

--- a/tldw_Server_API/app/core/Scheduler/handlers/acp.py
+++ b/tldw_Server_API/app/core/Scheduler/handlers/acp.py
@@ -1,0 +1,129 @@
+"""Scheduler handler for ACP agent runs.
+
+Registered as ``acp_run`` -- creates an ACP session, sends a prompt,
+and returns the result.  Intended for scheduled/async agent execution.
+
+Location: tldw_Server_API/app/core/Scheduler/handlers/acp.py
+"""
+from __future__ import annotations
+
+import contextlib
+import time
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Scheduler.base.registry import task
+
+
+@task(name="acp_run", max_retries=1, timeout=7200, queue="acp")
+async def acp_run(payload: dict[str, Any]) -> dict[str, Any]:
+    """Execute an ACP agent prompt as a scheduled task.
+
+    Expected payload keys
+    ---------------------
+    user_id : int
+        Owner of the run.
+    prompt : str | list[dict]
+        The prompt to send to the agent.
+    cwd : str, optional
+        Working directory for the agent (default ``/workspace``).
+    agent_type : str, optional
+        Agent type identifier.
+    persona_id : str, optional
+        Persona context for session creation.
+    workspace_id : str, optional
+        Workspace context for session creation.
+    workspace_group_id : str, optional
+        Workspace group context for session creation.
+    scope_snapshot_id : str, optional
+        Scope snapshot for session creation.
+
+    Returns
+    -------
+    dict
+        ``{"session_id": str|None, "result": Any, "usage": dict,
+        "duration_ms": int, "error": str|None}``
+    """
+    start = time.monotonic()
+    user_id = payload.get("user_id")
+    prompt = payload.get("prompt", "")
+
+    if not user_id:
+        return {
+            "session_id": None,
+            "result": None,
+            "usage": {},
+            "duration_ms": 0,
+            "error": "Missing user_id",
+        }
+
+    # Normalize prompt to message-list format
+    if isinstance(prompt, str):
+        prompt = [{"role": "user", "content": prompt}]
+
+    session_id: str | None = None
+    try:
+        # Lazy import to avoid circular imports at module load time.
+        # Mirrors the import pattern used by the ACP stage adapter.
+        from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
+            get_runner_client,
+        )
+
+        runner = await get_runner_client()
+
+        # Create session -- use the same compatibility shim as the
+        # workflow ACP stage adapter (_create_session) so both sandbox
+        # and non-sandbox runners are supported.
+        create_kwargs: dict[str, Any] = {
+            "cwd": payload.get("cwd", "/workspace"),
+            "user_id": int(user_id),
+        }
+        if payload.get("agent_type"):
+            create_kwargs["agent_type"] = payload["agent_type"]
+
+        # The sandbox runner's create_session may accept extra kwargs
+        # (persona_id, workspace_id, etc.).  Pass them when present,
+        # falling back to the narrower signature on TypeError -- the
+        # same strategy used in the workflow adapter.
+        extra_session_keys = (
+            "persona_id",
+            "workspace_id",
+            "workspace_group_id",
+            "scope_snapshot_id",
+        )
+        extras = {k: payload[k] for k in extra_session_keys if payload.get(k) is not None}
+        try:
+            session_id = await runner.create_session(**create_kwargs, **extras)
+        except TypeError:
+            session_id = await runner.create_session(**create_kwargs)
+
+        # Send the prompt
+        result = await runner.prompt(session_id, prompt)
+
+        usage = result.get("usage", {}) if isinstance(result, dict) else {}
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        return {
+            "session_id": session_id,
+            "result": result,
+            "usage": usage,
+            "duration_ms": duration_ms,
+            "error": None,
+        }
+
+    except Exception as exc:
+        logger.error("acp_run failed: {}", exc)
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return {
+            "session_id": session_id,
+            "result": None,
+            "usage": {},
+            "duration_ms": duration_ms,
+            "error": str(exc),
+        }
+    finally:
+        # Always attempt to close the session so resources are freed.
+        if session_id is not None:
+            with contextlib.suppress(Exception):
+                await runner.close_session(session_id)  # type: ignore[possibly-undefined]

--- a/tldw_Server_API/app/core/config.py
+++ b/tldw_Server_API/app/core/config.py
@@ -1,6 +1,7 @@
 # config.py
 # Description: Configuration settings for the tldw server application.
 #
+from __future__ import annotations
 # Imports
 import configparser
 import contextlib

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Optional
 
 from fastapi import FastAPI, HTTPException, Request, status

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1413,6 +1413,22 @@ else:
     except _IMPORT_EXCEPTIONS as _acp_import_err:
         logger.warning(f"ACP endpoints unavailable at import time; deferring: {_acp_import_err}")
         acp_router = None  # type: ignore[assignment]
+    # ACP sub-module routers (schedules, triggers, permissions)
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.acp_schedules import router as acp_schedules_router
+    except _IMPORT_EXCEPTIONS as _acp_sched_err:
+        logger.warning(f"ACP schedules endpoints unavailable at import time; deferring: {_acp_sched_err}")
+        acp_schedules_router = None  # type: ignore[assignment]
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.acp_triggers import router as acp_triggers_router
+    except _IMPORT_EXCEPTIONS as _acp_trig_err:
+        logger.warning(f"ACP triggers endpoints unavailable at import time; deferring: {_acp_trig_err}")
+        acp_triggers_router = None  # type: ignore[assignment]
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.acp_permissions import router as acp_permissions_router
+    except _IMPORT_EXCEPTIONS as _acp_perm_err:
+        logger.warning(f"ACP permissions endpoints unavailable at import time; deferring: {_acp_perm_err}")
+        acp_permissions_router = None  # type: ignore[assignment]
     # Users Endpoint (NEW)
     # Chatbooks Endpoint
     from tldw_Server_API.app.api.v1.endpoints.chatbooks import router as chatbooks_router
@@ -6549,6 +6565,25 @@ elif _MINIMAL_TEST_APP:
         app.include_router(acp_router, prefix=f"{API_V1_PREFIX}", tags=["acp"])
     except _IMPORT_EXCEPTIONS as _acp_min_err:
         logger.debug(f"Skipping ACP router in minimal test app: {_acp_min_err}")
+    # ACP sub-module routers (schedules, triggers, permissions)
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.acp_schedules import router as acp_schedules_router
+
+        app.include_router(acp_schedules_router, prefix=f"{API_V1_PREFIX}", tags=["acp-schedules"])
+    except _IMPORT_EXCEPTIONS as _acp_sched_min_err:
+        logger.debug(f"Skipping ACP schedules router in minimal test app: {_acp_sched_min_err}")
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.acp_triggers import router as acp_triggers_router
+
+        app.include_router(acp_triggers_router, prefix=f"{API_V1_PREFIX}", tags=["acp-triggers"])
+    except _IMPORT_EXCEPTIONS as _acp_trig_min_err:
+        logger.debug(f"Skipping ACP triggers router in minimal test app: {_acp_trig_min_err}")
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.acp_permissions import router as acp_permissions_router
+
+        app.include_router(acp_permissions_router, prefix=f"{API_V1_PREFIX}", tags=["acp-permissions"])
+    except _IMPORT_EXCEPTIONS as _acp_perm_min_err:
+        logger.debug(f"Skipping ACP permissions router in minimal test app: {_acp_perm_min_err}")
     # Agent Orchestration endpoints
     try:
         from tldw_Server_API.app.api.v1.endpoints.agent_orchestration import router as orch_router
@@ -6802,6 +6837,12 @@ else:
         _include_if_enabled("tools", tools_router, prefix=f"{API_V1_PREFIX}", tags=["tools"], default_stable=False)
     if "acp_router" in locals() and acp_router is not None:
         _include_if_enabled("acp", acp_router, prefix=f"{API_V1_PREFIX}", tags=["acp"], default_stable=False)
+    if "acp_schedules_router" in locals() and acp_schedules_router is not None:
+        _include_if_enabled("acp", acp_schedules_router, prefix=f"{API_V1_PREFIX}", tags=["acp-schedules"], default_stable=False)
+    if "acp_triggers_router" in locals() and acp_triggers_router is not None:
+        _include_if_enabled("acp", acp_triggers_router, prefix=f"{API_V1_PREFIX}", tags=["acp-triggers"], default_stable=False)
+    if "acp_permissions_router" in locals() and acp_permissions_router is not None:
+        _include_if_enabled("acp", acp_permissions_router, prefix=f"{API_V1_PREFIX}", tags=["acp-permissions"], default_stable=False)
     if "character_router" in locals():
         _include_if_enabled("characters", character_router, prefix=f"{API_V1_PREFIX}/characters", tags=["characters"])
     if "character_memory_router" in locals():

--- a/tldw_Server_API/app/services/acp_runtime_policy_service.py
+++ b/tldw_Server_API/app/services/acp_runtime_policy_service.py
@@ -184,6 +184,7 @@ class ACPRuntimePolicyService:
         acp_profile_id: int | None = None,
         acp_profile: dict[str, Any] | None = None,
         extra_metadata: dict[str, Any] | None = None,
+        template_name: str | None = None,
     ) -> ACPRuntimePolicySnapshot:
         metadata, execution_config = await self.build_resolution_metadata(
             session_record=session_record,
@@ -201,6 +202,21 @@ class ACPRuntimePolicyService:
             effective_policy.get("resolved_policy_document")
             or effective_policy.get("policy_document")
         )
+
+        # Apply permission policy template as a base layer.
+        # User / MCP-Hub overrides that are already in the resolved document
+        # take precedence over template defaults.
+        if template_name:
+            from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
+                PERMISSION_POLICY_TEMPLATES,
+            )
+
+            template = PERMISSION_POLICY_TEMPLATES.get(template_name)
+            if template:
+                existing_overrides = resolved_policy_document.get("tool_tier_overrides", {})
+                # Template is the base layer -- merge user overrides on top.
+                merged = {**template.get("tool_tier_overrides", {}), **existing_overrides}
+                resolved_policy_document["tool_tier_overrides"] = merged
         allowed_tools = _unique(_as_str_list(resolved_policy_document.get("allowed_tools")))
         denied_tools = _unique(_as_str_list(resolved_policy_document.get("denied_tools")))
         capabilities = _unique(_as_str_list(resolved_policy_document.get("capabilities")))

--- a/tldw_Server_API/app/services/admin_acp_sessions_service.py
+++ b/tldw_Server_API/app/services/admin_acp_sessions_service.py
@@ -274,9 +274,6 @@ class ACPSessionStore:
         # Agent configs — keyed by id (in-memory for now)
         self._agent_configs: dict[int, AgentConfig] = {}
         self._agent_config_seq = 0
-        # Permission policies — keyed by id (in-memory for now)
-        self._permission_policies: dict[int, PermissionPolicy] = {}
-        self._permission_policy_seq = 0
         # Session TTL cleanup task
         self._cleanup_task: asyncio.Task | None = None
         # Quotas (loaded from config on first use)
@@ -284,6 +281,10 @@ class ACPSessionStore:
         self._max_concurrent_per_user: int = 5
         self._max_tokens_per_session: int = 1_000_000
         self._max_session_duration_seconds: int = 14400
+
+    def get_db(self) -> ACPSessionsDB:
+        """Return the underlying database instance."""
+        return self._db
 
     # ------------------------------------------------------------------
     # Internal helpers — convert DB dicts to public dataclasses
@@ -670,6 +671,78 @@ class ACPSessionStore:
 
         return metrics
 
+    # -- Run history queries ------------------------------------------------
+
+    async def list_runs(
+        self,
+        *,
+        user_id: int | None = None,
+        status: str | None = None,
+        agent_type: str | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Query session records with filters. Returns paged results."""
+        rows, total = self._db.list_runs(
+            user_id=user_id,
+            status=status,
+            agent_type=agent_type,
+            from_date=from_date,
+            to_date=to_date,
+            limit=limit,
+            offset=offset,
+        )
+        records = [self._dict_to_record(d) for d in rows]
+        items = [rec.to_info_dict() for rec in records]
+        return {
+            "items": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    async def aggregate_runs(
+        self,
+        *,
+        user_id: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Aggregate token usage and costs across sessions."""
+        agg = self._db.aggregate_runs(
+            user_id=user_id,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+        # Compute estimated total cost from per-session data using Decimal
+        # to avoid floating-point accumulation errors.
+        from decimal import Decimal
+
+        estimated_cost: float | None = None
+        cost_rows = agg.pop("_cost_rows", [])
+        try:
+            total_cost = Decimal("0")
+            has_any_cost = False
+            for row in cost_rows:
+                cost = compute_token_cost(
+                    model=row.get("model"),
+                    prompt_tokens=row.get("prompt_tokens", 0) or 0,
+                    completion_tokens=row.get("completion_tokens", 0) or 0,
+                )
+                if cost is not None:
+                    total_cost += Decimal(str(cost))
+                    has_any_cost = True
+            if has_any_cost:
+                estimated_cost = float(total_cost.quantize(Decimal("0.000001")))
+        except Exception as exc:
+            logger.warning("Failed to compute aggregate cost: {}", exc)
+
+        agg["estimated_cost_usd"] = estimated_cost
+        return agg
+
     # -- Agent Config CRUD --------------------------------------------------
 
     async def create_agent_config(self, data: dict[str, Any]) -> AgentConfig:
@@ -740,45 +813,43 @@ class ACPSessionStore:
     # -- Permission Policy CRUD --------------------------------------------
 
     async def create_permission_policy(self, data: dict[str, Any]) -> PermissionPolicy:
-        async with self._lock:
-            self._permission_policy_seq += 1
-            now = datetime.now(timezone.utc).isoformat()
-            rules = [
-                PermissionPolicyRule(tool_pattern=r["tool_pattern"], tier=r["tier"])
-                for r in data.get("rules", [])
-            ]
-            policy = PermissionPolicy(
-                id=self._permission_policy_seq,
-                name=data["name"],
-                description=data.get("description", ""),
-                rules=rules,
-                org_id=data.get("org_id"),
-                team_id=data.get("team_id"),
-                priority=data.get("priority", 0),
-                created_at=now,
-            )
-            self._permission_policies[policy.id] = policy
-        return policy
+        import json as _json
+        rules_raw = data.get("rules", [])
+        rules_json = _json.dumps(rules_raw)
+        policy_id = self._db.create_permission_policy(
+            name=data["name"],
+            rules_json=rules_json,
+            priority=data.get("priority", 0),
+            description=data.get("description", ""),
+            org_id=data.get("org_id"),
+            team_id=data.get("team_id"),
+        )
+        row = self._db.get_permission_policy(policy_id)
+        return self._db_row_to_permission_policy(row)  # type: ignore[arg-type]
 
     async def update_permission_policy(self, policy_id: int, data: dict[str, Any]) -> PermissionPolicy | None:
-        async with self._lock:
-            policy = self._permission_policies.get(policy_id)
-            if not policy:
+        import json as _json
+        kwargs: dict[str, Any] = {}
+        for key in ("name", "description", "org_id", "team_id", "priority"):
+            if key in data:
+                kwargs[key] = data[key]
+        if "rules" in data:
+            kwargs["rules_json"] = _json.dumps(data["rules"])
+        if not kwargs:
+            row = self._db.get_permission_policy(policy_id)
+            if row is None:
                 return None
-            for key in ("name", "description", "org_id", "team_id", "priority"):
-                if key in data:
-                    setattr(policy, key, data[key])
-            if "rules" in data:
-                policy.rules = [
-                    PermissionPolicyRule(tool_pattern=r["tool_pattern"], tier=r["tier"])
-                    for r in data["rules"]
-                ]
-            policy.updated_at = datetime.now(timezone.utc).isoformat()
-        return policy
+            return self._db_row_to_permission_policy(row)
+        updated = self._db.update_permission_policy(policy_id, **kwargs)
+        if not updated:
+            return None
+        row = self._db.get_permission_policy(policy_id)
+        if row is None:
+            return None
+        return self._db_row_to_permission_policy(row)
 
     async def delete_permission_policy(self, policy_id: int) -> bool:
-        async with self._lock:
-            return self._permission_policies.pop(policy_id, None) is not None
+        return self._db.delete_permission_policy(policy_id)
 
     async def list_permission_policies(
         self,
@@ -786,31 +857,49 @@ class ACPSessionStore:
         org_id: int | None = None,
         team_id: int | None = None,
     ) -> list[PermissionPolicy]:
-        results = []
-        for pol in self._permission_policies.values():
+        rows = self._db.list_permission_policies()
+        results: list[PermissionPolicy] = []
+        for row in rows:
+            pol = self._db_row_to_permission_policy(row)
             if org_id is not None and pol.org_id is not None and pol.org_id != org_id:
                 continue
             if team_id is not None and pol.team_id is not None and pol.team_id != team_id:
                 continue
             results.append(pol)
-        results.sort(key=lambda p: (-p.priority, p.name))
         return results
 
     def resolve_permission_tier(self, tool_name: str) -> str | None:
-        """Consult stored policies to determine a permission tier for a tool.
+        """Consult DB-backed policies to determine a permission tier for a tool.
 
         Returns None if no policy rule matches (caller should fall back to
         the default heuristic).
         """
-        best_priority = -1
-        best_tier: str | None = None
-        for pol in self._permission_policies.values():
-            for rule in pol.rules:
-                if fnmatch.fnmatch(tool_name.lower(), rule.tool_pattern.lower()):
-                    if pol.priority > best_priority:
-                        best_priority = pol.priority
-                        best_tier = rule.tier
-        return best_tier
+        return self._db.resolve_permission_tier(tool_name)
+
+    @staticmethod
+    def _db_row_to_permission_policy(row: dict[str, Any]) -> PermissionPolicy:
+        """Convert a DB dict row to a PermissionPolicy dataclass."""
+        import json as _json
+        raw = row.get("rules_json", "[]")
+        try:
+            rules_list = _json.loads(raw) if isinstance(raw, str) else raw
+        except (_json.JSONDecodeError, TypeError):
+            rules_list = []
+        rules = [
+            PermissionPolicyRule(tool_pattern=r.get("tool_pattern", ""), tier=r.get("tier", ""))
+            for r in (rules_list or [])
+        ]
+        return PermissionPolicy(
+            id=row["id"],
+            name=row["name"],
+            description=row.get("description", ""),
+            rules=rules,
+            org_id=row.get("org_id"),
+            team_id=row.get("team_id"),
+            priority=row.get("priority", 0),
+            created_at=row.get("created_at", ""),
+            updated_at=row.get("updated_at"),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
@@ -597,6 +597,10 @@ class McpHubPolicyResolver:
             + deny_capability_resolution.unsupported_environment_requirements
         )
 
+        # Ensure tool_tier_overrides is present in the resolved document so
+        # downstream consumers (GovernanceFilter, runner_client) can rely on it.
+        resolved_policy_document.setdefault("tool_tier_overrides", {})
+
         return {
             "enabled": True,
             "allowed_tools": _allowed_tool_patterns(resolved_policy_document),
@@ -674,7 +678,7 @@ class McpHubPolicyResolver:
             "approval_mode": None,
             "policy_document": {},
             "authored_policy_document": {},
-            "resolved_policy_document": {},
+            "resolved_policy_document": {"tool_tier_overrides": {}},
             "resolved_capabilities": [],
             "unresolved_capabilities": [],
             "capability_mapping_summary": [],

--- a/tldw_Server_API/app/services/workflows_scheduler.py
+++ b/tldw_Server_API/app/services/workflows_scheduler.py
@@ -39,6 +39,9 @@ from tldw_Server_API.app.core.Scheduler.handlers import (
     watchlists as _ensure_watchlists,  # noqa: F401  # register watchlist_run
 )
 from tldw_Server_API.app.core.Scheduler.handlers import (
+    acp as _ensure_acp_handlers,  # noqa: F401  # register acp_run
+)
+from tldw_Server_API.app.core.Scheduler.handlers import (
     workflows as _ensure_handlers,  # noqa: F401  # register workflow_run
 )
 from tldw_Server_API.app.core.testing import env_flag_enabled
@@ -167,7 +170,12 @@ class _WFRecurringScheduler:
                     items = []
                 for s in items:
                     if s.enabled:
-                        self._add_job(s, uid)
+                        # Route ACP schedules to _add_acp_job, workflow schedules to _add_job
+                        acp_cfg = getattr(s, "acp_config_json", None)
+                        if acp_cfg:
+                            self._add_acp_job(s, uid)
+                        else:
+                            self._add_job(s, uid)
                         loaded += 1
         except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"Workflows scheduler load_all failed: {e}")
@@ -209,8 +217,12 @@ class _WFRecurringScheduler:
             for s in items:
                 if s.enabled:
                     desired.add(s.id)
-                    # Ensure job exists/updated
-                    self._add_job(s, uid)
+                    # Route ACP schedules to _add_acp_job, workflow schedules to _add_job
+                    acp_cfg = getattr(s, "acp_config_json", None)
+                    if acp_cfg:
+                        self._add_acp_job(s, uid)
+                    else:
+                        self._add_job(s, uid)
         # Remove jobs that no longer exist or are disabled
         try:
             current_ids = {j.id for j in (self._aps.get_jobs() or [])}
@@ -308,6 +320,119 @@ class _WFRecurringScheduler:
                 logger.debug(f"Workflows scheduler: failed to set next_run_at for {schedule.id}: {e}")
         except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
             logger.warning(f"Failed to add schedule job {schedule.id}: {e}")
+
+    def _add_acp_job(self, schedule: WorkflowSchedule, user_id: int | None = None) -> None:
+        """Register an APScheduler job for an ACP agent schedule.
+
+        Similar to ``_add_job`` but submits an ``acp_run`` task instead of
+        ``workflow_run``, using the ACP-specific configuration stored in
+        ``acp_config_json``.
+        """
+        import json as _json
+
+        if not self._aps:
+            return
+        try:
+            # Remove existing job with same id
+            try:
+                self._aps.remove_job(schedule.id)
+            except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
+                logger.debug(f"Workflows scheduler: remove_job failed for {schedule.id}: {e}")
+
+            tz = schedule.timezone or os.getenv("WORKFLOWS_SCHEDULER_TZ", "UTC")
+            try:
+                trigger = CronTrigger.from_crontab(schedule.cron, timezone=tz)
+            except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
+                logger.warning(f"Invalid cron for ACP schedule {schedule.id}: {e}")
+                return
+
+            # Concurrency settings -- ACP jobs default to skip
+            if (schedule.concurrency_mode or "skip").lower() == "queue":
+                max_instances = 3
+                coalesce = False if schedule.coalesce is None else bool(schedule.coalesce)
+            else:
+                max_instances = 1
+                coalesce = True if schedule.coalesce is None else bool(schedule.coalesce)
+
+            misfire_grace_time = int(schedule.misfire_grace_sec or 300)
+            effective_uid = user_id if user_id is not None else int(schedule.user_id)
+
+            self._aps.add_job(
+                self._run_acp_schedule,
+                trigger=trigger,
+                id=schedule.id,
+                args=[schedule.id, effective_uid],
+                max_instances=max_instances,
+                coalesce=coalesce,
+                misfire_grace_time=misfire_grace_time,
+            )
+
+            # Compute and persist next run time
+            try:
+                now = datetime.now(trigger.timezone)
+                nxt = trigger.get_next_fire_time(None, now)
+                next_iso = nxt.isoformat() if nxt else None
+                self._get_db(effective_uid).set_history(schedule.id, next_run_at=next_iso)
+            except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
+                logger.debug(f"Workflows scheduler: failed to set next_run_at for ACP schedule {schedule.id}: {e}")
+        except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
+            logger.warning(f"Failed to add ACP schedule job {schedule.id}: {e}")
+
+    async def _run_acp_schedule(self, schedule_id: str, user_id: int) -> None:
+        """Execute an ACP schedule by submitting an ``acp_run`` task."""
+        import json as _json
+
+        db = self._get_db(user_id)
+        s = db.get_schedule(schedule_id)
+        if not s or not s.enabled:
+            return
+
+        # Record last_run_at and pending status
+        try:
+            from datetime import timezone as _tz
+            db.set_history(schedule_id, last_run_at=datetime.now(_tz.utc).isoformat(), last_status="pending")
+        except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(f"Workflows scheduler: failed to set pending status for ACP schedule {schedule_id}: {e}")
+
+        # Parse ACP config
+        try:
+            acp_config = _json.loads(s.acp_config_json) if isinstance(s.acp_config_json, str) else (s.acp_config_json or {})
+        except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS:
+            acp_config = {}
+
+        payload = {
+            "user_id": user_id,
+            "prompt": acp_config.get("prompt", ""),
+            "cwd": acp_config.get("cwd", "."),
+            "agent_type": acp_config.get("agent_type"),
+            "model": acp_config.get("model"),
+            "token_budget": acp_config.get("token_budget"),
+            "persona_id": acp_config.get("persona_id"),
+            "workspace_id": acp_config.get("workspace_id"),
+            "sandbox_enabled": acp_config.get("sandbox_enabled", False),
+        }
+
+        try:
+            if self._core_scheduler is None:
+                logger.warning("Core Scheduler not initialized; skipping ACP schedule run")
+                return
+            task_id = await self._core_scheduler.submit(
+                handler="acp_run",
+                payload=payload,
+                queue_name="acp",
+                metadata={"user_id": str(user_id)},
+            )
+            logger.info(f"Scheduled acp_run submitted: task_id={task_id} schedule_id={s.id}")
+            try:
+                db.set_history(schedule_id, last_status="queued")
+            except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
+                logger.debug(f"Workflows scheduler: failed to set queued status for ACP schedule {schedule_id}: {e}")
+        except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
+            logger.warning(f"Failed to submit scheduled acp_run: {e}")
+            try:
+                db.set_history(schedule_id, last_status="error")
+            except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e2:
+                logger.debug(f"Workflows scheduler: failed to set error status for ACP schedule {schedule_id}: {e2}")
 
     async def _run_schedule(self, schedule_id: str, user_id: int | None = None) -> None:
         # Fetch latest schedule in case it was modified
@@ -409,7 +534,7 @@ class _WFRecurringScheduler:
                 logger.debug(f"Workflows scheduler: failed to set error status for {schedule_id}: {e}")
 
     # CRUD wrappers
-    def create(self, *, tenant_id: str, user_id: str, workflow_id: int | None, name: str | None, cron: str, timezone: str | None, inputs: dict[str, Any], run_mode: str, validation_mode: str, enabled: bool, concurrency_mode: str = "skip", misfire_grace_sec: int = 300, coalesce: bool = True, require_online: bool = False) -> str:
+    def create(self, *, tenant_id: str, user_id: str, workflow_id: int | None, name: str | None, cron: str, timezone: str | None, inputs: dict[str, Any], run_mode: str, validation_mode: str, enabled: bool, concurrency_mode: str = "skip", misfire_grace_sec: int = 300, coalesce: bool = True, require_online: bool = False, acp_config_json: str | None = None) -> str:
         sid = __import__("uuid").uuid4().hex
         db = self._get_db(int(user_id))
         db.create_schedule(
@@ -428,10 +553,14 @@ class _WFRecurringScheduler:
             concurrency_mode=concurrency_mode,
             misfire_grace_sec=int(misfire_grace_sec),
             coalesce=bool(coalesce),
+            acp_config_json=acp_config_json,
         )
         s = db.get_schedule(sid)
         if s and s.enabled:
-            self._add_job(s, int(user_id))
+            if s.acp_config_json:
+                self._add_acp_job(s, int(user_id))
+            else:
+                self._add_job(s, int(user_id))
         return sid
 
     def update(self, schedule_id: str, update: dict[str, Any]) -> bool:
@@ -444,7 +573,10 @@ class _WFRecurringScheduler:
         s = db.get_schedule(schedule_id)
         if s:
             if s.enabled:
-                self._add_job(s, int(s.user_id))
+                if s.acp_config_json:
+                    self._add_acp_job(s, int(s.user_id))
+                else:
+                    self._add_job(s, int(s.user_id))
             else:
                 try:
                     if self._aps:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_run_handler.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_run_handler.py
@@ -1,0 +1,147 @@
+"""Tests for the acp_run scheduler handler.
+
+Verifies that importing the handler module registers the task,
+and that the handler creates a session, sends a prompt, closes the session,
+and returns the expected result structure.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Patch target: the *source* module where get_runner_client is defined,
+# because the handler imports it lazily inside the function body.
+_RUNNER_CLIENT_PATCH = (
+    "tldw_Server_API.app.core.Agent_Client_Protocol.runner_client.get_runner_client"
+)
+
+
+@pytest.mark.asyncio
+async def test_acp_run_handler_creates_session_sends_prompt_closes():
+    """acp_run creates a session, sends prompt, closes, returns result."""
+    mock_runner = AsyncMock()
+    mock_runner.create_session = AsyncMock(return_value="sess-abc-123")
+    mock_runner.prompt = AsyncMock(return_value={
+        "content": "Hello world",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20},
+    })
+    mock_runner.close_session = AsyncMock()
+
+    with patch(_RUNNER_CLIENT_PATCH, new_callable=AsyncMock, return_value=mock_runner):
+        from tldw_Server_API.app.core.Scheduler.handlers.acp import acp_run
+
+        result = await acp_run({
+            "user_id": 42,
+            "prompt": "Summarize this document",
+            "cwd": "/workspace",
+            "agent_type": "research",
+        })
+
+    assert result["session_id"] == "sess-abc-123"
+    assert result["error"] is None
+    assert result["duration_ms"] >= 0
+    assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 20}
+    assert result["result"]["content"] == "Hello world"
+
+    mock_runner.create_session.assert_awaited_once()
+    call_kwargs = mock_runner.create_session.call_args
+    assert call_kwargs.kwargs.get("user_id") == 42
+    mock_runner.prompt.assert_awaited_once_with(
+        "sess-abc-123",
+        [{"role": "user", "content": "Summarize this document"}],
+    )
+    # Session is closed in the finally block
+    mock_runner.close_session.assert_awaited_once_with("sess-abc-123")
+
+
+@pytest.mark.asyncio
+async def test_acp_run_handler_accepts_list_prompt():
+    """acp_run passes through a list prompt without re-wrapping."""
+    mock_runner = AsyncMock()
+    mock_runner.create_session = AsyncMock(return_value="sess-list")
+    mock_runner.prompt = AsyncMock(return_value={"content": "ok"})
+    mock_runner.close_session = AsyncMock()
+
+    prompt_list = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hello"},
+    ]
+
+    with patch(_RUNNER_CLIENT_PATCH, new_callable=AsyncMock, return_value=mock_runner):
+        from tldw_Server_API.app.core.Scheduler.handlers.acp import acp_run
+
+        result = await acp_run({
+            "user_id": 1,
+            "prompt": prompt_list,
+        })
+
+    assert result["error"] is None
+    mock_runner.prompt.assert_awaited_once_with("sess-list", prompt_list)
+
+
+@pytest.mark.asyncio
+async def test_acp_run_handler_returns_error_on_missing_user_id():
+    """acp_run returns error dict when user_id is missing."""
+    from tldw_Server_API.app.core.Scheduler.handlers.acp import acp_run
+
+    result = await acp_run({"prompt": "hello"})
+
+    assert result["error"] == "Missing user_id"
+    assert result["session_id"] is None
+    assert result["result"] is None
+
+
+@pytest.mark.asyncio
+async def test_acp_run_handler_returns_error_on_failure():
+    """acp_run returns error dict on exception."""
+    mock_runner = AsyncMock()
+    mock_runner.create_session = AsyncMock(side_effect=RuntimeError("connection refused"))
+    mock_runner.close_session = AsyncMock()
+
+    with patch(_RUNNER_CLIENT_PATCH, new_callable=AsyncMock, return_value=mock_runner):
+        from tldw_Server_API.app.core.Scheduler.handlers.acp import acp_run
+
+        result = await acp_run({
+            "user_id": 1,
+            "prompt": "test",
+        })
+
+    assert result["error"] is not None
+    assert "connection refused" in result["error"]
+    assert result["session_id"] is None
+    assert result["result"] is None
+    assert result["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_acp_run_handler_closes_session_on_prompt_failure():
+    """acp_run still attempts to close session when prompt fails."""
+    mock_runner = AsyncMock()
+    mock_runner.create_session = AsyncMock(return_value="sess-fail")
+    mock_runner.prompt = AsyncMock(side_effect=ValueError("bad prompt"))
+    mock_runner.close_session = AsyncMock()
+
+    with patch(_RUNNER_CLIENT_PATCH, new_callable=AsyncMock, return_value=mock_runner):
+        from tldw_Server_API.app.core.Scheduler.handlers.acp import acp_run
+
+        result = await acp_run({
+            "user_id": 1,
+            "prompt": "test",
+        })
+
+    assert result["error"] is not None
+    assert result["session_id"] == "sess-fail"
+    # Session should have been closed in finally block
+    mock_runner.close_session.assert_awaited_once_with("sess-fail")
+
+
+def test_acp_run_is_registered():
+    """Importing the module registers the task in the global registry."""
+    from tldw_Server_API.app.core.Scheduler.handlers import acp  # noqa: F401
+    from tldw_Server_API.app.core.Scheduler.base.registry import _global_registry
+
+    assert "acp_run" in _global_registry._handlers
+    metadata = _global_registry._metadata["acp_run"]
+    assert metadata["queue"] == "acp"
+    assert metadata["timeout"] == 7200
+    assert metadata["max_retries"] == 1

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_schedules.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_schedules.py
@@ -1,0 +1,547 @@
+"""Tests for ACP Schedule CRUD endpoints and scheduler routing.
+
+Covers:
+1. Create schedule stores acp_config_json in DB
+2. List schedules returns only ACP schedules (not workflow schedules)
+3. Update schedule modifies cron and config
+4. Delete schedule removes it
+5. _load_all() routes ACP schedules to _add_acp_job not _add_job
+6. _load_all() still routes workflow schedules to _add_job
+7. Invalid cron expression returns error
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Workflows_Scheduler_DB import (
+    WorkflowSchedule,
+    WorkflowsSchedulerDB,
+)
+from tldw_Server_API.app.services import workflows_scheduler as workflows_scheduler_mod
+from tldw_Server_API.app.services.workflows_scheduler import get_workflows_scheduler
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def scheduler():
+    """Provide a started scheduler service; stop on teardown."""
+    svc = get_workflows_scheduler()
+    asyncio.run(svc.start())
+    yield svc
+    try:
+        asyncio.run(svc.stop())
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 1. Create schedule stores acp_config_json in DB
+# ---------------------------------------------------------------------------
+
+def test_create_acp_schedule_stores_config(scheduler):
+    svc = scheduler
+    acp_config = {
+        "prompt": "Summarize new emails",
+        "cwd": "/workspace",
+        "agent_type": "coding",
+        "model": "claude-sonnet-4-20250514",
+        "sandbox_enabled": True,
+    }
+    sid = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="Daily agent run",
+        cron="0 9 * * *",
+        timezone="UTC",
+        inputs={},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        acp_config_json=json.dumps(acp_config),
+    )
+
+    s = svc.get(sid)
+    assert s is not None
+    assert s.acp_config_json is not None
+    parsed = json.loads(s.acp_config_json)
+    assert parsed["prompt"] == "Summarize new emails"
+    assert parsed["cwd"] == "/workspace"
+    assert parsed["agent_type"] == "coding"
+    assert parsed["model"] == "claude-sonnet-4-20250514"
+    assert parsed["sandbox_enabled"] is True
+    assert s.name == "Daily agent run"
+    assert s.cron == "0 9 * * *"
+
+
+# ---------------------------------------------------------------------------
+# 2. List schedules returns only ACP schedules
+# ---------------------------------------------------------------------------
+
+def test_list_returns_only_acp_schedules(scheduler):
+    svc = scheduler
+
+    # Create a plain workflow schedule (no acp_config_json)
+    wf_id = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=42,
+        name="workflow-only",
+        cron="*/10 * * * *",
+        timezone="UTC",
+        inputs={"step": 1},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+    )
+
+    # Create an ACP schedule
+    acp_id = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="ACP schedule",
+        cron="0 12 * * *",
+        timezone="UTC",
+        inputs={},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        acp_config_json=json.dumps({"prompt": "Run daily check"}),
+    )
+
+    # List all schedules for the user
+    all_schedules = svc.list(tenant_id="default", user_id="1", limit=100)
+
+    # Filter to ACP-only (as the endpoint would)
+    acp_only = [s for s in all_schedules if s.acp_config_json]
+    workflow_only = [s for s in all_schedules if not s.acp_config_json]
+
+    acp_ids = [s.id for s in acp_only]
+    wf_ids = [s.id for s in workflow_only]
+
+    assert acp_id in acp_ids
+    assert wf_id not in acp_ids
+    assert wf_id in wf_ids
+
+
+# ---------------------------------------------------------------------------
+# 3. Update schedule modifies cron and config
+# ---------------------------------------------------------------------------
+
+def test_update_acp_schedule(scheduler):
+    svc = scheduler
+
+    sid = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="Update me",
+        cron="0 8 * * *",
+        timezone="UTC",
+        inputs={},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        acp_config_json=json.dumps({"prompt": "Original prompt", "cwd": "/old"}),
+    )
+
+    # Update cron and acp_config_json
+    new_config = {"prompt": "Updated prompt", "cwd": "/new"}
+    ok = svc.update(sid, {
+        "cron": "30 10 * * *",
+        "acp_config_json": json.dumps(new_config),
+    })
+    assert ok is True
+
+    s = svc.get(sid)
+    assert s is not None
+    assert s.cron == "30 10 * * *"
+    parsed = json.loads(s.acp_config_json)
+    assert parsed["prompt"] == "Updated prompt"
+    assert parsed["cwd"] == "/new"
+
+
+# ---------------------------------------------------------------------------
+# 4. Delete schedule removes it
+# ---------------------------------------------------------------------------
+
+def test_delete_acp_schedule(scheduler):
+    svc = scheduler
+
+    sid = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="Delete me",
+        cron="0 6 * * *",
+        timezone="UTC",
+        inputs={},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        acp_config_json=json.dumps({"prompt": "Bye"}),
+    )
+
+    assert svc.get(sid) is not None
+    ok = svc.delete(sid)
+    assert ok is True
+    assert svc.get(sid) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. _load_all() routes ACP schedules to _add_acp_job
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_load_all_routes_acp_to_add_acp_job(monkeypatch, tmp_path):
+    """When _load_all encounters a schedule with acp_config_json, it must
+    call _add_acp_job instead of _add_job."""
+    svc = workflows_scheduler_mod._WFRecurringScheduler()
+    await svc.start()
+
+    acp_schedule = WorkflowSchedule(
+        id="acp-1",
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="acp schedule",
+        cron="0 9 * * *",
+        timezone="UTC",
+        inputs_json="{}",
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        require_online=False,
+        concurrency_mode="skip",
+        misfire_grace_sec=300,
+        coalesce=True,
+        jitter_sec=0,
+        acp_config_json='{"prompt": "hello"}',
+        last_run_at=None,
+        next_run_at=None,
+        last_status=None,
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+    class FakeDB:
+        def list_schedules(self, **kwargs):
+            return [acp_schedule]
+
+    monkeypatch.setattr(svc, "_get_db", lambda uid: FakeDB())
+    monkeypatch.setattr(
+        workflows_scheduler_mod.DatabasePaths,
+        "get_user_db_base_dir",
+        lambda: tmp_path,
+    )
+    (tmp_path / "1").mkdir()
+
+    add_job_calls = []
+    add_acp_job_calls = []
+    monkeypatch.setattr(svc, "_add_job", lambda s, uid: add_job_calls.append((s.id, uid)))
+    monkeypatch.setattr(svc, "_add_acp_job", lambda s, uid: add_acp_job_calls.append((s.id, uid)))
+
+    await svc._load_all()
+
+    assert len(add_acp_job_calls) >= 1, "Expected _add_acp_job to be called for ACP schedule"
+    assert any(call[0] == "acp-1" for call in add_acp_job_calls)
+    assert not any(call[0] == "acp-1" for call in add_job_calls), \
+        "_add_job should NOT be called for ACP schedules"
+
+    await svc.stop()
+
+
+# ---------------------------------------------------------------------------
+# 6. _load_all() still routes workflow schedules to _add_job
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_load_all_routes_workflow_to_add_job(monkeypatch, tmp_path):
+    """When _load_all encounters a schedule without acp_config_json, it must
+    call _add_job (not _add_acp_job)."""
+    svc = workflows_scheduler_mod._WFRecurringScheduler()
+    await svc.start()
+
+    workflow_schedule = WorkflowSchedule(
+        id="wf-1",
+        tenant_id="default",
+        user_id="1",
+        workflow_id=42,
+        name="workflow schedule",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs_json='{"step": 1}',
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        require_online=False,
+        concurrency_mode="skip",
+        misfire_grace_sec=300,
+        coalesce=True,
+        jitter_sec=0,
+        acp_config_json=None,
+        last_run_at=None,
+        next_run_at=None,
+        last_status=None,
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+    class FakeDB:
+        def list_schedules(self, **kwargs):
+            return [workflow_schedule]
+
+    monkeypatch.setattr(svc, "_get_db", lambda uid: FakeDB())
+    monkeypatch.setattr(
+        workflows_scheduler_mod.DatabasePaths,
+        "get_user_db_base_dir",
+        lambda: tmp_path,
+    )
+    (tmp_path / "1").mkdir()
+
+    add_job_calls = []
+    add_acp_job_calls = []
+    monkeypatch.setattr(svc, "_add_job", lambda s, uid: add_job_calls.append((s.id, uid)))
+    monkeypatch.setattr(svc, "_add_acp_job", lambda s, uid: add_acp_job_calls.append((s.id, uid)))
+
+    await svc._load_all()
+
+    assert len(add_job_calls) >= 1, "Expected _add_job to be called for workflow schedule"
+    assert any(call[0] == "wf-1" for call in add_job_calls)
+    assert not any(call[0] == "wf-1" for call in add_acp_job_calls), \
+        "_add_acp_job should NOT be called for workflow schedules"
+
+    await svc.stop()
+
+
+# ---------------------------------------------------------------------------
+# 7. Invalid cron expression returns error
+# ---------------------------------------------------------------------------
+
+def test_invalid_cron_raises_on_add_acp_job(scheduler):
+    """_add_acp_job should handle invalid cron gracefully (log warning, no crash)."""
+    svc = scheduler
+
+    bad_schedule = WorkflowSchedule(
+        id="bad-cron-1",
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="bad cron",
+        cron="not a valid cron",
+        timezone="UTC",
+        inputs_json="{}",
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        require_online=False,
+        concurrency_mode="skip",
+        misfire_grace_sec=300,
+        coalesce=True,
+        jitter_sec=0,
+        acp_config_json='{"prompt": "test"}',
+        last_run_at=None,
+        next_run_at=None,
+        last_status=None,
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+    # Should not raise -- invalid cron is handled gracefully
+    svc._add_acp_job(bad_schedule, 1)
+
+    # The bad job should NOT be registered in APScheduler
+    jobs = svc._aps.get_jobs() if svc._aps else []
+    assert not any(j.id == "bad-cron-1" for j in jobs)
+
+
+def test_invalid_cron_via_endpoint_validation():
+    """Validate cron expressions using the endpoint validation helper."""
+    from tldw_Server_API.app.api.v1.endpoints.acp_schedules import _validate_cron
+    from fastapi import HTTPException
+
+    # Valid cron should not raise
+    _validate_cron("0 9 * * *")
+    _validate_cron("*/5 * * * *")
+
+    # Invalid cron should raise HTTPException 422
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_cron("not a cron")
+    assert exc_info.value.status_code == 422
+    assert "Invalid cron" in str(exc_info.value.detail)
+
+
+# ---------------------------------------------------------------------------
+# Additional edge-case tests
+# ---------------------------------------------------------------------------
+
+def test_create_with_message_list_prompt(scheduler):
+    """ACP prompts can be a list of message dicts, not just a string."""
+    svc = scheduler
+    prompt = [
+        {"role": "system", "content": "You are an assistant."},
+        {"role": "user", "content": "Summarize today's logs."},
+    ]
+    sid = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="Multi-turn",
+        cron="0 0 * * *",
+        timezone="UTC",
+        inputs={},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        acp_config_json=json.dumps({"prompt": prompt}),
+    )
+
+    s = svc.get(sid)
+    assert s is not None
+    parsed = json.loads(s.acp_config_json)
+    assert isinstance(parsed["prompt"], list)
+    assert len(parsed["prompt"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_acp_schedule_submits_acp_run():
+    """_run_acp_schedule should submit an acp_run task (not workflow_run)."""
+    svc = get_workflows_scheduler()
+    await svc.start()
+
+    sid = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="acp-fire-test",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs={},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        acp_config_json=json.dumps({
+            "prompt": "Run check",
+            "cwd": "/workspace",
+            "agent_type": "coding",
+        }),
+    )
+
+    captured: dict[str, Any] = {}
+
+    class _StubScheduler:
+        async def submit(self, *args: Any, **kwargs: Any) -> str:
+            captured["handler"] = kwargs.get("handler")
+            captured["payload"] = kwargs.get("payload")
+            captured["queue_name"] = kwargs.get("queue_name")
+            return "task-acp-1"
+
+    svc._core_scheduler = _StubScheduler()  # type: ignore[attr-defined]
+
+    await svc._run_acp_schedule(sid, 1)  # type: ignore[attr-defined]
+
+    assert captured.get("handler") == "acp_run", f"Expected acp_run, got {captured.get('handler')}"
+    assert captured.get("queue_name") == "acp"
+    payload = captured.get("payload", {})
+    assert payload.get("prompt") == "Run check"
+    assert payload.get("cwd") == "/workspace"
+    assert payload.get("agent_type") == "coding"
+
+    await svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_rescan_routes_acp_schedules(monkeypatch, tmp_path):
+    """_rescan_once should also route ACP schedules to _add_acp_job."""
+    svc = workflows_scheduler_mod._WFRecurringScheduler()
+    await svc.start()
+
+    acp_schedule = WorkflowSchedule(
+        id="acp-rescan-1",
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="acp rescan",
+        cron="0 9 * * *",
+        timezone="UTC",
+        inputs_json="{}",
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        require_online=False,
+        concurrency_mode="skip",
+        misfire_grace_sec=300,
+        coalesce=True,
+        jitter_sec=0,
+        acp_config_json='{"prompt": "rescan test"}',
+        last_run_at=None,
+        next_run_at=None,
+        last_status=None,
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+    class FakeDB:
+        def list_schedules(self, **kwargs):
+            return [acp_schedule]
+
+    monkeypatch.setattr(svc, "_get_db", lambda uid: FakeDB())
+    monkeypatch.setattr(
+        workflows_scheduler_mod.DatabasePaths,
+        "get_user_db_base_dir",
+        lambda: tmp_path,
+    )
+    (tmp_path / "1").mkdir()
+
+    add_job_calls = []
+    add_acp_job_calls = []
+    monkeypatch.setattr(svc, "_add_job", lambda s, uid: add_job_calls.append((s.id, uid)))
+    monkeypatch.setattr(svc, "_add_acp_job", lambda s, uid: add_acp_job_calls.append((s.id, uid)))
+
+    await svc._rescan_once()
+
+    assert any(call[0] == "acp-rescan-1" for call in add_acp_job_calls), \
+        "Expected _add_acp_job to be called during rescan for ACP schedule"
+    assert not any(call[0] == "acp-rescan-1" for call in add_job_calls), \
+        "_add_job should NOT be called during rescan for ACP schedule"
+
+    await svc.stop()
+
+
+def test_acp_config_json_in_update_schedule_db(scheduler):
+    """update_schedule handles acp_config_json dict serialization."""
+    svc = scheduler
+
+    sid = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="config-update",
+        cron="0 8 * * *",
+        timezone="UTC",
+        inputs={},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        acp_config_json=json.dumps({"prompt": "original"}),
+    )
+
+    # Update with a dict value (should be serialized)
+    db = svc._get_db(1)
+    ok = db.update_schedule(sid, {"acp_config_json": {"prompt": "updated via dict"}})
+    assert ok is True
+
+    s = db.get_schedule(sid)
+    assert s is not None
+    parsed = json.loads(s.acp_config_json)
+    assert parsed["prompt"] == "updated via dict"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_async_api.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_async_api.py
@@ -1,0 +1,367 @@
+"""Tests for the ACP async fire-and-forget API.
+
+Verifies:
+- POST /acp/sessions/prompt-async returns task_id and poll_url
+- GET /acp/tasks/{task_id} returns status and result
+- Missing prompt returns 422
+- Unknown task_id returns 404
+
+Note: Tests that require the full FastAPI test client (``client_user_only``)
+are skipped when the import chain fails on Python < 3.10 environments.
+The async prompt endpoint now uses the global Scheduler for task persistence.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.machinery
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Stub heavyweight deps that the app import chain may pull in.
+if "torch" not in sys.modules:
+    _fake_torch = types.ModuleType("torch")
+    _fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+    _fake_torch.Tensor = object
+    _fake_torch.nn = types.SimpleNamespace(Module=object)
+    sys.modules["torch"] = _fake_torch
+
+if "faster_whisper" not in sys.modules:
+    _fake_fw = types.ModuleType("faster_whisper")
+    _fake_fw.__spec__ = importlib.machinery.ModuleSpec("faster_whisper", loader=None)
+
+    class _StubWhisperModel:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            pass
+
+    _fake_fw.WhisperModel = _StubWhisperModel
+    _fake_fw.BatchedInferencePipeline = _StubWhisperModel
+    sys.modules["faster_whisper"] = _fake_fw
+
+if "transformers" not in sys.modules:
+    _fake_tf = types.ModuleType("transformers")
+    _fake_tf.__spec__ = importlib.machinery.ModuleSpec("transformers", loader=None)
+
+    class _StubProcessor:
+        @classmethod
+        def from_pretrained(cls, *a: Any, **kw: Any) -> _StubProcessor:
+            return cls()
+
+    class _StubModel:
+        @classmethod
+        def from_pretrained(cls, *a: Any, **kw: Any) -> _StubModel:
+            return cls()
+
+    _fake_tf.AutoProcessor = _StubProcessor
+    _fake_tf.Qwen2AudioForConditionalGeneration = _StubModel
+    sys.modules["transformers"] = _fake_tf
+
+
+# ---------------------------------------------------------------------------
+# Lazy import helper -- the endpoint module may fail to import on Py 3.9
+# because of ``str | Path`` annotations in an upstream module.
+# ---------------------------------------------------------------------------
+
+_acp_ep = None
+
+
+def _import_acp_ep():
+    """Import the ACP endpoints module, returning None on failure."""
+    global _acp_ep
+    if _acp_ep is not None:
+        return _acp_ep
+    try:
+        _acp_ep = importlib.import_module(
+            "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol"
+        )
+        return _acp_ep
+    except (ImportError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_acp_run_result(
+    session_id: str = "sess-async-1",
+    result: dict | None = None,
+    usage: dict | None = None,
+    error: str | None = None,
+    duration_ms: int = 42,
+) -> dict:
+    return {
+        "session_id": session_id,
+        "result": result or {"content": "done"},
+        "usage": usage or {"prompt_tokens": 5, "completion_tokens": 10},
+        "duration_ms": duration_ms,
+        "error": error,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mark for skipping when the full app can't import (Py 3.9 compat issue)
+# ---------------------------------------------------------------------------
+
+_skip_if_no_app = pytest.mark.skipif(
+    _import_acp_ep() is None,
+    reason="Full app import chain fails on this Python version",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _patch_runner_and_store(monkeypatch, tmp_path):
+    """Patch runner client and session store for client-based tests."""
+    acp_ep = _import_acp_ep()
+    if acp_ep is None:
+        pytest.skip("Cannot import ACP endpoints module")
+
+    stub_runner = AsyncMock()
+    stub_runner.create_session = AsyncMock(return_value="sess-async-1")
+    stub_runner.prompt = AsyncMock(
+        return_value={
+            "content": "done",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 10},
+        }
+    )
+    stub_runner.close_session = AsyncMock()
+
+    async def _get_runner():
+        return stub_runner
+
+    monkeypatch.setattr(acp_ep, "get_runner_client", _get_runner)
+
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+    from tldw_Server_API.app.services.admin_acp_sessions_service import ACPSessionStore
+
+    _test_db = ACPSessionsDB(db_path=str(tmp_path / "test_acp_async.db"))
+    _test_store = ACPSessionStore(db=_test_db)
+
+    async def _get_store():
+        return _test_store
+
+    monkeypatch.setattr(acp_ep, "get_acp_session_store", _get_store)
+    return stub_runner
+
+
+@pytest.fixture()
+def _patch_scheduler(monkeypatch):
+    """Patch the global scheduler for async prompt tests."""
+    from tldw_Server_API.app.core.Scheduler.base.task import Task, TaskStatus
+
+    mock_scheduler = AsyncMock()
+    mock_scheduler.submit = AsyncMock(return_value="test-task-001")
+    mock_scheduler.get_task = AsyncMock(return_value=None)
+
+    async def _get_scheduler(*args, **kwargs):
+        return mock_scheduler
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Scheduler.get_global_scheduler",
+        _get_scheduler,
+    )
+    return mock_scheduler
+
+
+# ===========================================================================
+# Client-based endpoint tests (require full app import)
+# ===========================================================================
+
+
+@_skip_if_no_app
+def test_prompt_async_returns_task_id(client_user_only, _patch_runner_and_store, _patch_scheduler):
+    """POST /acp/sessions/prompt-async returns task_id and poll_url."""
+    resp = client_user_only.post(
+        "/api/v1/acp/sessions/prompt-async",
+        json={"prompt": "Hello async world"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "task_id" in data
+    assert data["task_id"]  # non-empty
+    assert data["poll_url"] == f"/api/v1/acp/tasks/{data['task_id']}"
+    assert data["status"] == "queued"
+
+
+@_skip_if_no_app
+def test_task_status_not_found(client_user_only, _patch_runner_and_store, _patch_scheduler):
+    """GET /acp/tasks/{nonexistent} returns 404."""
+    resp = client_user_only.get("/api/v1/acp/tasks/nonexistent-task-id")
+    assert resp.status_code == 404
+
+
+@_skip_if_no_app
+def test_prompt_async_validates_payload(client_user_only, _patch_runner_and_store, _patch_scheduler):
+    """Missing prompt returns 422."""
+    resp = client_user_only.post(
+        "/api/v1/acp/sessions/prompt-async",
+        json={},
+    )
+    assert resp.status_code == 422
+
+
+@_skip_if_no_app
+def test_prompt_async_accepts_message_list(client_user_only, _patch_runner_and_store, _patch_scheduler):
+    """POST /acp/sessions/prompt-async accepts a list[dict] prompt."""
+    resp = client_user_only.post(
+        "/api/v1/acp/sessions/prompt-async",
+        json={
+            "prompt": [
+                {"role": "system", "content": "Be helpful."},
+                {"role": "user", "content": "Hello"},
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["task_id"]
+    assert data["status"] == "queued"
+
+
+@_skip_if_no_app
+def test_task_status_returns_result(client_user_only, _patch_runner_and_store, _patch_scheduler):
+    """GET /acp/tasks/{task_id} returns status and result after completion."""
+    from tldw_Server_API.app.core.Scheduler.base.task import Task, TaskStatus
+
+    completed_task = Task(
+        id="test-task-001",
+        handler="acp_run",
+        status=TaskStatus.COMPLETED,
+        result={"result": {"content": "Hello"}, "usage": {"prompt_tokens": 5, "completion_tokens": 10}, "duration_ms": 100},
+        metadata={"user_id": "1"},
+    )
+    _patch_scheduler.get_task = AsyncMock(return_value=completed_task)
+
+    resp = client_user_only.get("/api/v1/acp/tasks/test-task-001")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["task_id"] == "test-task-001"
+    assert data["status"] == "completed"
+    assert data["result"] == {"content": "Hello"}
+    assert data["usage"]["prompt_tokens"] == 5
+    assert data["error"] is None
+    assert data["duration_ms"] == 100
+
+
+@_skip_if_no_app
+def test_task_status_failed_task(client_user_only, _patch_runner_and_store, _patch_scheduler):
+    """GET /acp/tasks/{task_id} returns error for failed tasks."""
+    from tldw_Server_API.app.core.Scheduler.base.task import Task, TaskStatus
+
+    failed_task = Task(
+        id="test-fail-001",
+        handler="acp_run",
+        status=TaskStatus.FAILED,
+        error="connection refused",
+        result={"duration_ms": 5},
+        metadata={"user_id": "1"},
+    )
+    _patch_scheduler.get_task = AsyncMock(return_value=failed_task)
+
+    resp = client_user_only.get("/api/v1/acp/tasks/test-fail-001")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "failed"
+    assert data["error"] == "connection refused"
+    assert data["result"] is None
+
+
+@_skip_if_no_app
+def test_task_status_running_task(client_user_only, _patch_runner_and_store, _patch_scheduler):
+    """GET /acp/tasks/{task_id} returns running status for in-progress tasks."""
+    from tldw_Server_API.app.core.Scheduler.base.task import Task, TaskStatus
+
+    running_task = Task(
+        id="test-running-001",
+        handler="acp_run",
+        status=TaskStatus.RUNNING,
+        metadata={"user_id": "1"},
+    )
+    _patch_scheduler.get_task = AsyncMock(return_value=running_task)
+
+    resp = client_user_only.get("/api/v1/acp/tasks/test-running-001")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "running"
+    assert data["result"] is None
+    assert data["error"] is None
+
+
+# ===========================================================================
+# Schema validation tests (lightweight, no app import needed)
+# ===========================================================================
+
+
+def test_async_prompt_request_requires_prompt():
+    """ACPAsyncPromptRequest requires prompt field."""
+    from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+        ACPAsyncPromptRequest,
+    )
+
+    with pytest.raises(Exception):
+        ACPAsyncPromptRequest()
+
+    # Valid with just prompt
+    req = ACPAsyncPromptRequest(prompt="Hello")
+    assert req.prompt == "Hello"
+    assert req.cwd == "."
+    assert req.agent_type is None
+
+
+def test_async_prompt_request_accepts_list():
+    """ACPAsyncPromptRequest accepts list prompt."""
+    from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+        ACPAsyncPromptRequest,
+    )
+
+    messages = [{"role": "user", "content": "hi"}]
+    req = ACPAsyncPromptRequest(prompt=messages)
+    assert req.prompt == messages
+
+
+def test_async_prompt_response_schema():
+    """ACPAsyncPromptResponse has expected fields."""
+    from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+        ACPAsyncPromptResponse,
+    )
+
+    resp = ACPAsyncPromptResponse(
+        task_id="abc-123",
+        poll_url="/api/v1/acp/tasks/abc-123",
+    )
+    assert resp.task_id == "abc-123"
+    assert resp.status == "queued"
+
+
+def test_task_status_response_schema():
+    """ACPTaskStatusResponse has expected fields and defaults."""
+    from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+        ACPTaskStatusResponse,
+    )
+
+    resp = ACPTaskStatusResponse(task_id="t-1", status="completed")
+    assert resp.result is None
+    assert resp.usage == {}
+    assert resp.error is None
+    assert resp.duration_ms is None
+
+    resp_full = ACPTaskStatusResponse(
+        task_id="t-2",
+        status="completed",
+        result={"content": "hi"},
+        usage={"prompt_tokens": 5},
+        duration_ms=100,
+    )
+    assert resp_full.result == {"content": "hi"}
+    assert resp_full.duration_ms == 100

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_bash_prefix_matching.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_bash_prefix_matching.py
@@ -1,0 +1,249 @@
+"""Tests for bash prefix matching via tool_tier_overrides.
+
+Verifies that Bash(git:*), Bash(rm:*), Bash(npm:*) style patterns
+in tool_tier_overrides are respected by GovernanceFilter and
+runner_client._resolve_runtime_permission_outcome().
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+
+# ---------------------------------------------------------------------------
+# GovernanceFilter tests
+# ---------------------------------------------------------------------------
+
+
+def _make_snapshot(
+    tool_tier_overrides: dict[str, str] | None = None,
+    denied_tools: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+) -> MagicMock:
+    snap = MagicMock()
+    snap.resolved_policy_document = {
+        "denied_tools": denied_tools or [],
+        "allowed_tools": allowed_tools or [],
+        "tool_tier_overrides": tool_tier_overrides or {},
+    }
+    snap.approval_summary = {}
+    return snap
+
+
+@pytest.mark.asyncio
+async def test_bash_git_auto_approved_via_snapshot():
+    """Bash(git:*) pattern in tool_tier_overrides -> auto tier."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    snap = _make_snapshot(
+        tool_tier_overrides={
+            "Bash(git:*)": "auto",
+            "Bash(rm:*)": "individual",
+            "Bash(npm:*)": "batch",
+        },
+    )
+    gf = GovernanceFilter(bus=bus, policy_snapshot=snap)
+
+    event = AgentEvent(
+        session_id="test",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_name": "Bash(git:status)"},
+        metadata={},
+    )
+    await gf.process(event)
+    # Should auto-forward (TOOL_CALL published, not held)
+    assert bus.publish.call_count == 1
+    assert bus.publish.call_args[0][0].kind == AgentEventKind.TOOL_CALL
+
+
+@pytest.mark.asyncio
+async def test_bash_rm_individual_held():
+    """Bash(rm:*) pattern -> individual tier -> held for approval."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    snap = _make_snapshot(
+        tool_tier_overrides={"Bash(rm:*)": "individual"},
+    )
+    gf = GovernanceFilter(bus=bus, policy_snapshot=snap)
+
+    event = AgentEvent(
+        session_id="test",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_name": "Bash(rm:-rf /tmp/test)"},
+        metadata={},
+    )
+    await gf.process(event)
+    # Should publish a PERMISSION_REQUEST (held), not the TOOL_CALL directly
+    assert bus.publish.call_count == 1
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.PERMISSION_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_bash_npm_batch_held():
+    """Bash(npm:*) pattern -> batch tier -> held for approval."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    snap = _make_snapshot(
+        tool_tier_overrides={"Bash(npm:*)": "batch"},
+    )
+    gf = GovernanceFilter(bus=bus, policy_snapshot=snap)
+
+    event = AgentEvent(
+        session_id="test",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_name": "Bash(npm:install)"},
+        metadata={},
+    )
+    await gf.process(event)
+    assert bus.publish.call_count == 1
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.PERMISSION_REQUEST
+    assert published.payload["tier"] == "batch"
+
+
+@pytest.mark.asyncio
+async def test_denied_tools_override_tier_overrides():
+    """denied_tools takes priority over tool_tier_overrides."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    snap = _make_snapshot(
+        denied_tools=["Bash(git:*)"],
+        tool_tier_overrides={"Bash(git:*)": "auto"},
+    )
+    gf = GovernanceFilter(bus=bus, policy_snapshot=snap)
+
+    event = AgentEvent(
+        session_id="test",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_name": "Bash(git:push)"},
+        metadata={},
+    )
+    await gf.process(event)
+    # Should be denied (TOOL_RESULT with error), not auto-approved
+    assert bus.publish.call_count == 1
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_RESULT
+    assert "denied" in published.payload.get("error", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_allowed_tools_override_tier_overrides():
+    """allowed_tools takes priority over tool_tier_overrides."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    snap = _make_snapshot(
+        allowed_tools=["Bash(git:*)"],
+        tool_tier_overrides={"Bash(git:*)": "individual"},
+    )
+    gf = GovernanceFilter(bus=bus, policy_snapshot=snap)
+
+    event = AgentEvent(
+        session_id="test",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_name": "Bash(git:status)"},
+        metadata={},
+    )
+    await gf.process(event)
+    # allowed_tools -> "auto" tier, should pass through
+    assert bus.publish.call_count == 1
+    assert bus.publish.call_args[0][0].kind == AgentEventKind.TOOL_CALL
+
+
+@pytest.mark.asyncio
+async def test_no_matching_override_falls_through():
+    """Tool not matching any override falls through to default tier logic."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    snap = _make_snapshot(
+        tool_tier_overrides={"Bash(git:*)": "auto"},
+    )
+    gf = GovernanceFilter(bus=bus, policy_snapshot=snap)
+
+    event = AgentEvent(
+        session_id="test",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_name": "SomeOtherTool"},
+        metadata={},
+    )
+    await gf.process(event)
+    # Falls through to determine_permission_tier -- still publishes something
+    assert bus.publish.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# runner_client._resolve_runtime_permission_outcome tests
+# ---------------------------------------------------------------------------
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
+    _resolve_runtime_permission_outcome,
+)
+
+
+def _make_runner_snapshot(
+    tool_tier_overrides: dict[str, str] | None = None,
+    denied_tools: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+) -> MagicMock:
+    snap = MagicMock()
+    snap.resolved_policy_document = {
+        "denied_tools": denied_tools or [],
+        "allowed_tools": allowed_tools or ["*"],
+        "tool_tier_overrides": tool_tier_overrides or {},
+    }
+    snap.approval_summary = {}
+    snap.policy_snapshot_fingerprint = "test-fingerprint"
+    snap.policy_provenance_summary = {}
+    return snap
+
+
+def test_runner_tier_override_auto():
+    """runner_client picks up tool_tier_overrides auto -> approve."""
+    snap = _make_runner_snapshot(
+        tool_tier_overrides={"Bash(git:*)": "auto"},
+    )
+    result = _resolve_runtime_permission_outcome(snap, "Bash(git:status)")
+    assert result["action"] == "approve"
+
+
+def test_runner_tier_override_individual():
+    """runner_client picks up tool_tier_overrides individual -> prompt."""
+    snap = _make_runner_snapshot(
+        tool_tier_overrides={"Bash(rm:*)": "individual"},
+    )
+    result = _resolve_runtime_permission_outcome(snap, "Bash(rm:-rf /)")
+    assert result["action"] == "prompt"
+    assert result["approval_requirement"] == "approval_required"
+
+
+def test_runner_tier_override_batch():
+    """runner_client picks up tool_tier_overrides batch -> prompt."""
+    snap = _make_runner_snapshot(
+        tool_tier_overrides={"Bash(npm:*)": "batch"},
+    )
+    result = _resolve_runtime_permission_outcome(snap, "Bash(npm:install)")
+    assert result["action"] == "prompt"
+    assert result["approval_requirement"] == "approval_required"
+
+
+def test_runner_denied_beats_tier_override():
+    """denied_tools still blocks even if tier override says auto."""
+    snap = _make_runner_snapshot(
+        denied_tools=["Bash(git:*)"],
+        tool_tier_overrides={"Bash(git:*)": "auto"},
+    )
+    result = _resolve_runtime_permission_outcome(snap, "Bash(git:push)")
+    assert result["action"] == "deny"
+
+
+def test_runner_no_override_passes_through():
+    """Without override, normal allowed flow applies."""
+    snap = _make_runner_snapshot(
+        tool_tier_overrides={"Bash(git:*)": "auto"},
+    )
+    result = _resolve_runtime_permission_outcome(snap, "SomeOtherTool")
+    # Tool is in allowed_tools=["*"], so should approve
+    assert result["action"] == "approve"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_checkpoint_rollback.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_checkpoint_rollback.py
@@ -1,0 +1,225 @@
+"""Tests for CheckpointConsumer and checkpoint-based rollback."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import (
+    AgentEvent,
+    AgentEventKind,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.checkpoint_consumer import (
+    CheckpointConsumer,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_event(
+    kind: AgentEventKind = AgentEventKind.FILE_CHANGE,
+    session_id: str = "sess-cp",
+) -> AgentEvent:
+    return AgentEvent(session_id=session_id, kind=kind, payload={"file": "main.py"})
+
+
+def _make_sandbox_service(
+    snapshot_id: str = "snap-001",
+    *,
+    side_effect: Exception | None = None,
+) -> MagicMock:
+    """Return a mock SandboxService with a configurable create_snapshot."""
+    svc = MagicMock()
+    if side_effect is not None:
+        svc.create_snapshot.side_effect = side_effect
+    else:
+        svc.create_snapshot.return_value = {"snapshot_id": snapshot_id}
+    svc.restore_snapshot.return_value = True
+    return svc
+
+
+async def _wait_for(predicate, *, timeout: float = 2.0, interval: float = 0.02):
+    """Poll *predicate* until it returns True or *timeout* elapses."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError(f"Timed out waiting for predicate after {timeout}s")
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_created_on_file_change():
+    """A FILE_CHANGE event should trigger create_snapshot."""
+    bus = SessionEventBus(session_id="sess-cp")
+    svc = _make_sandbox_service(snapshot_id="snap-100")
+    consumer = CheckpointConsumer(sandbox_service=svc, session_id="sess-cp")
+    await consumer.start(bus)
+
+    await bus.publish(_make_event(AgentEventKind.FILE_CHANGE))
+
+    await _wait_for(lambda: svc.create_snapshot.call_count >= 1)
+    await consumer.stop()
+
+    svc.create_snapshot.assert_called_once_with("sess-cp")
+    checkpoints = consumer.get_checkpoints()
+    assert len(checkpoints) == 1
+    assert list(checkpoints.values()) == ["snap-100"]
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_skipped_on_active_run():
+    """When create_snapshot raises (e.g. active run), the consumer continues."""
+    bus = SessionEventBus(session_id="sess-cp")
+    svc = _make_sandbox_service(side_effect=RuntimeError("session_has_active_runs"))
+    consumer = CheckpointConsumer(sandbox_service=svc, session_id="sess-cp")
+    await consumer.start(bus)
+
+    await bus.publish(_make_event(AgentEventKind.FILE_CHANGE))
+    await bus.publish(_make_event(AgentEventKind.FILE_CHANGE))
+
+    await _wait_for(lambda: svc.create_snapshot.call_count >= 2)
+    await consumer.stop()
+
+    # No checkpoints should be recorded -- both calls raised
+    assert consumer.get_checkpoints() == {}
+    # Consumer should still be alive (not crashed)
+    assert svc.create_snapshot.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_nearest_checkpoint():
+    """get_nearest_checkpoint should return the closest checkpoint at or before target."""
+    bus = SessionEventBus(session_id="sess-cp")
+
+    call_count = 0
+
+    def _create_snap(sid):
+        nonlocal call_count
+        call_count += 1
+        return {"snapshot_id": f"snap-{call_count}"}
+
+    svc = MagicMock()
+    svc.create_snapshot.side_effect = _create_snap
+
+    consumer = CheckpointConsumer(sandbox_service=svc, session_id="sess-cp")
+    await consumer.start(bus)
+
+    # Publish 3 file-change events -> sequences 1, 2, 3
+    for _ in range(3):
+        await bus.publish(_make_event(AgentEventKind.FILE_CHANGE))
+
+    await _wait_for(lambda: len(consumer.get_checkpoints()) >= 3)
+    await consumer.stop()
+
+    checkpoints = consumer.get_checkpoints()
+    assert len(checkpoints) == 3
+
+    # Find nearest to sequence 2
+    result = consumer.get_nearest_checkpoint(2)
+    assert result is not None
+    seq, sid = result
+    assert seq == 2
+    assert sid == "snap-2"
+
+    # Find nearest to sequence 5 (beyond all checkpoints) -> should return seq 3
+    result = consumer.get_nearest_checkpoint(5)
+    assert result is not None
+    assert result[0] == 3
+
+    # Find nearest to sequence 0 (before all checkpoints) -> None
+    result = consumer.get_nearest_checkpoint(0)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_max_checkpoints_eviction():
+    """Oldest checkpoint should be evicted when max_checkpoints is exceeded."""
+    bus = SessionEventBus(session_id="sess-cp")
+
+    call_count = 0
+
+    def _create_snap(sid):
+        nonlocal call_count
+        call_count += 1
+        return {"snapshot_id": f"snap-{call_count}"}
+
+    svc = MagicMock()
+    svc.create_snapshot.side_effect = _create_snap
+
+    consumer = CheckpointConsumer(
+        sandbox_service=svc,
+        session_id="sess-cp",
+        max_checkpoints=3,
+    )
+    await consumer.start(bus)
+
+    # Publish 5 file-change events
+    for _ in range(5):
+        await bus.publish(_make_event(AgentEventKind.FILE_CHANGE))
+
+    await _wait_for(lambda: svc.create_snapshot.call_count >= 5)
+    await consumer.stop()
+
+    checkpoints = consumer.get_checkpoints()
+    # Only the last 3 should remain
+    assert len(checkpoints) == 3
+    sequences = sorted(checkpoints.keys())
+    # Sequences 1 and 2 should have been evicted
+    assert min(sequences) == 3
+
+
+@pytest.mark.asyncio
+async def test_non_file_events_ignored():
+    """Events other than FILE_CHANGE should not trigger create_snapshot."""
+    bus = SessionEventBus(session_id="sess-cp")
+    svc = _make_sandbox_service()
+    consumer = CheckpointConsumer(sandbox_service=svc, session_id="sess-cp")
+    await consumer.start(bus)
+
+    # Publish events of various non-file kinds
+    for kind in (
+        AgentEventKind.THINKING,
+        AgentEventKind.TOOL_CALL,
+        AgentEventKind.TOOL_RESULT,
+        AgentEventKind.COMPLETION,
+        AgentEventKind.HEARTBEAT,
+        AgentEventKind.STATUS_CHANGE,
+    ):
+        await bus.publish(AgentEvent(session_id="sess-cp", kind=kind, payload={}))
+
+    # Give consumer time to process all events
+    await asyncio.sleep(0.2)
+    await consumer.stop()
+
+    svc.create_snapshot.assert_not_called()
+    assert consumer.get_checkpoints() == {}
+
+
+@pytest.mark.asyncio
+async def test_stop_unsubscribes():
+    """Stopping the consumer should unsubscribe from the bus."""
+    bus = SessionEventBus(session_id="sess-cp")
+    svc = _make_sandbox_service()
+    consumer = CheckpointConsumer(sandbox_service=svc, session_id="sess-cp")
+    await consumer.start(bus)
+
+    consumer_id = consumer.consumer_id
+    assert consumer_id in bus._subscribers
+
+    await consumer.stop()
+
+    assert consumer_id not in bus._subscribers
+    # Task should be cleaned up
+    assert consumer._task is None
+    assert consumer._bus is None

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter_unified.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter_unified.py
@@ -1,0 +1,175 @@
+"""Tests for GovernanceFilter unified with MCPHub policy snapshot.
+
+Verifies that GovernanceFilter checks the MCPHub ACPRuntimePolicySnapshot
+before falling back to the existing ACP tier heuristics.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool_event(
+    tool_name: str,
+    session_id: str = "s1",
+    tool_call_id: str = "tc1",
+    arguments: dict | None = None,
+    metadata: dict | None = None,
+) -> AgentEvent:
+    return AgentEvent(
+        session_id=session_id,
+        kind=AgentEventKind.TOOL_CALL,
+        payload={
+            "tool_id": tool_call_id,
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "arguments": arguments or {},
+        },
+        metadata=metadata or {},
+    )
+
+
+def _make_snapshot(
+    denied_tools: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    tool_tier_overrides: dict[str, str] | None = None,
+) -> MagicMock:
+    """Build a mock ACPRuntimePolicySnapshot with resolved_policy_document."""
+    snapshot = MagicMock()
+    doc: dict = {}
+    if denied_tools is not None:
+        doc["denied_tools"] = denied_tools
+    if allowed_tools is not None:
+        doc["allowed_tools"] = allowed_tools
+    if tool_tier_overrides is not None:
+        doc["tool_tier_overrides"] = tool_tier_overrides
+    snapshot.resolved_policy_document = doc
+    return snapshot
+
+
+def _make_bus() -> MagicMock:
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    return bus
+
+
+@pytest.mark.asyncio
+async def test_denied_tool_blocked_immediately():
+    """A tool matching snapshot.denied_tools is immediately denied.
+
+    GovernanceFilter should publish a TOOL_RESULT error event (not the
+    original TOOL_CALL) and never forward the call.
+    """
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(denied_tools=["dangerous_*"])
+    gov = GovernanceFilter(bus=bus, policy_snapshot=snapshot)
+
+    event = _make_tool_event(tool_name="dangerous_delete")
+    await gov.process(event)
+
+    # Should have published exactly once -- a TOOL_RESULT error
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_RESULT
+    assert "denied by policy" in published.payload.get("error", "").lower()
+    assert published.metadata.get("governance_action") == "denied_by_snapshot"
+
+
+@pytest.mark.asyncio
+async def test_allowed_tool_auto_approved():
+    """A tool matching snapshot.allowed_tools is auto-forwarded as TOOL_CALL."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(allowed_tools=["safe_*"])
+    gov = GovernanceFilter(bus=bus, policy_snapshot=snapshot)
+
+    event = _make_tool_event(tool_name="safe_read")
+    await gov.process(event)
+
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_CALL
+    assert published.payload["tool_name"] == "safe_read"
+
+
+@pytest.mark.asyncio
+async def test_tool_tier_override_respected():
+    """A tool matching tool_tier_overrides gets that tier applied.
+
+    If the override maps to 'auto', the TOOL_CALL passes through immediately.
+    """
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(tool_tier_overrides={"Bash(git:*)": "auto"})
+    gov = GovernanceFilter(bus=bus, policy_snapshot=snapshot)
+
+    event = _make_tool_event(tool_name="Bash(git:status)")
+    await gov.process(event)
+
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_CALL
+    assert published.payload["tool_name"] == "Bash(git:status)"
+
+
+@pytest.mark.asyncio
+async def test_no_snapshot_falls_through_to_tier():
+    """Without a snapshot (None), existing determine_permission_tier() logic applies.
+
+    'read_file' should be classified as 'auto' by heuristics and pass through.
+    'bash' should be classified as 'individual' and be held.
+    """
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    gov = GovernanceFilter(bus=bus)  # No snapshot
+
+    # 'read_file' => auto tier by heuristic => published as TOOL_CALL
+    event_auto = _make_tool_event(tool_name="read_file")
+    await gov.process(event_auto)
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_CALL
+
+    bus.publish.reset_mock()
+
+    # 'bash' => individual tier by heuristic => held, PERMISSION_REQUEST published
+    event_individual = _make_tool_event(tool_name="bash")
+    await gov.process(event_individual)
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.PERMISSION_REQUEST
+    assert published.payload["tier"] == "individual"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_deny_overrides_tier_auto():
+    """Even if the heuristic would say 'auto', a snapshot deny wins.
+
+    'read_file' is normally auto-approved by heuristic, but if it's in
+    denied_tools, it must be blocked.
+    """
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(denied_tools=["read_*"])
+    gov = GovernanceFilter(bus=bus, policy_snapshot=snapshot)
+
+    event = _make_tool_event(tool_name="read_file")
+    await gov.process(event)
+
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_RESULT
+    assert "denied by policy" in published.payload.get("error", "").lower()
+    assert published.metadata.get("governance_action") == "denied_by_snapshot"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_persistence.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_persistence.py
@@ -1,0 +1,470 @@
+"""Tests for permission decision persistence ("remember" pattern).
+
+Covers the PermissionDecisionService, GovernanceFilter integration,
+and DB CRUD operations for the permission_decisions table.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+from tldw_Server_API.app.core.Agent_Client_Protocol.permission_decision_service import (
+    PermissionDecisionService,
+)
+from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db():
+    """Create a temporary ACP sessions DB for each test."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db = ACPSessionsDB(db_path=path)
+    yield db
+    db.close()
+    os.unlink(path)
+
+
+@pytest.fixture
+def svc(tmp_db):
+    """PermissionDecisionService backed by a temp DB."""
+    return PermissionDecisionService(tmp_db)
+
+
+@pytest.fixture
+def bus():
+    return SessionEventBus(session_id="s1")
+
+
+def _make_tool_event(
+    tool_name: str,
+    session_id: str = "s1",
+    tool_call_id: str = "tc1",
+    arguments: dict | None = None,
+    metadata: dict | None = None,
+) -> AgentEvent:
+    return AgentEvent(
+        session_id=session_id,
+        kind=AgentEventKind.TOOL_CALL,
+        payload={
+            "tool_id": tool_call_id,
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "arguments": arguments or {},
+        },
+        metadata=metadata or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service unit tests
+# ---------------------------------------------------------------------------
+
+class TestPermissionDecisionService:
+    def test_persist_and_check_global(self, svc):
+        svc.persist(user_id=1, tool_pattern="bash", decision="allow", scope="global")
+        assert svc.check(user_id=1, tool_name="bash") == "allow"
+
+    def test_persist_and_check_deny(self, svc):
+        svc.persist(user_id=1, tool_pattern="rm_*", decision="deny", scope="global")
+        assert svc.check(user_id=1, tool_name="rm_file") == "deny"
+        assert svc.check(user_id=1, tool_name="read_file") is None
+
+    def test_session_scope_only_applies_to_matching_session(self, svc):
+        svc.persist(
+            user_id=1,
+            tool_pattern="bash",
+            decision="allow",
+            scope="session",
+            session_id="s1",
+        )
+        assert svc.check(user_id=1, tool_name="bash", session_id="s1") == "allow"
+        assert svc.check(user_id=1, tool_name="bash", session_id="s2") is None
+        # Without session_id, session-scoped decisions don't match
+        assert svc.check(user_id=1, tool_name="bash") is None
+
+    def test_global_scope_applies_across_sessions(self, svc):
+        svc.persist(user_id=1, tool_pattern="bash", decision="allow", scope="global")
+        assert svc.check(user_id=1, tool_name="bash", session_id="s1") == "allow"
+        assert svc.check(user_id=1, tool_name="bash", session_id="s2") == "allow"
+        assert svc.check(user_id=1, tool_name="bash") == "allow"
+
+    def test_global_overrides_session(self, svc):
+        """Global scope is checked first and takes priority."""
+        svc.persist(
+            user_id=1,
+            tool_pattern="bash",
+            decision="deny",
+            scope="session",
+            session_id="s1",
+        )
+        svc.persist(user_id=1, tool_pattern="bash", decision="allow", scope="global")
+        # Global "allow" should win
+        assert svc.check(user_id=1, tool_name="bash", session_id="s1") == "allow"
+
+    def test_list_and_revoke(self, svc):
+        did = svc.persist(user_id=1, tool_pattern="bash", decision="allow", scope="global")
+        items = svc.list_for_user(user_id=1)
+        assert len(items) == 1
+        assert items[0]["id"] == did
+
+        assert svc.revoke(did) is True
+        assert svc.list_for_user(user_id=1) == []
+
+    def test_revoke_nonexistent_returns_false(self, svc):
+        assert svc.revoke("nonexistent-id") is False
+
+    def test_different_users_isolated(self, svc):
+        svc.persist(user_id=1, tool_pattern="bash", decision="allow", scope="global")
+        assert svc.check(user_id=2, tool_name="bash") is None
+
+    def test_fnmatch_wildcard(self, svc):
+        svc.persist(user_id=1, tool_pattern="file_*", decision="allow", scope="global")
+        assert svc.check(user_id=1, tool_name="file_read") == "allow"
+        assert svc.check(user_id=1, tool_name="file_write") == "allow"
+        assert svc.check(user_id=1, tool_name="bash") is None
+
+
+# ---------------------------------------------------------------------------
+# GovernanceFilter integration tests
+# ---------------------------------------------------------------------------
+
+class TestGovernanceFilterPersistence:
+    @pytest.mark.asyncio
+    async def test_remembered_allow_skips_prompt(self, bus, svc):
+        """Persisted 'allow' decision auto-approves the tool call."""
+        svc.persist(user_id=42, tool_pattern="bash", decision="allow", scope="global")
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        q = bus.subscribe("test")
+        ev = _make_tool_event("bash")
+        await gov.process(ev)
+
+        # The original event should be published directly (auto-approved)
+        got = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert got is ev
+        assert got.kind == AgentEventKind.TOOL_CALL
+        # No pending entries
+        assert gov.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_remembered_deny_blocks_immediately(self, bus, svc):
+        """Persisted 'deny' decision blocks the tool call without prompting."""
+        svc.persist(user_id=42, tool_pattern="bash", decision="deny", scope="global")
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        q = bus.subscribe("test")
+        ev = _make_tool_event("bash")
+        await gov.process(ev)
+
+        # Should get a TOOL_RESULT with error, not the original event
+        got = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert got.kind == AgentEventKind.TOOL_RESULT
+        assert "denied by remembered decision" in got.payload.get("error", "")
+        assert gov.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_no_persisted_decision_falls_through(self, bus, svc):
+        """When no decision is persisted, normal tier logic applies."""
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        q = bus.subscribe("test")
+        # bash is typically "individual" tier, so should be held
+        ev = _make_tool_event("bash")
+        await gov.process(ev)
+
+        got = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert got.kind == AgentEventKind.PERMISSION_REQUEST
+        assert gov.pending_count == 1
+
+    @pytest.mark.asyncio
+    async def test_session_scope_only_applies_to_matching_session(self, bus, svc):
+        """Session-scoped decision only applies when session_id matches."""
+        svc.persist(
+            user_id=42,
+            tool_pattern="bash",
+            decision="allow",
+            scope="session",
+            session_id="s1",
+        )
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        # Same session -- auto-approved
+        q = bus.subscribe("test")
+        ev = _make_tool_event("bash", session_id="s1")
+        await gov.process(ev)
+        got = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert got.kind == AgentEventKind.TOOL_CALL
+        assert gov.pending_count == 0
+
+        # Different session -- falls through to tier logic
+        bus2 = SessionEventBus(session_id="s2")
+        gov2 = GovernanceFilter(
+            bus=bus2,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+        q2 = bus2.subscribe("test")
+        ev2 = _make_tool_event("bash", session_id="s2")
+        await gov2.process(ev2)
+        got2 = await asyncio.wait_for(q2.get(), timeout=1.0)
+        assert got2.kind == AgentEventKind.PERMISSION_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_global_scope_applies_across_sessions(self, bus, svc):
+        """Global-scoped decision applies regardless of session_id."""
+        svc.persist(user_id=42, tool_pattern="bash", decision="allow", scope="global")
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        for sid in ("s1", "s2", "s3"):
+            b = SessionEventBus(session_id=sid)
+            g = GovernanceFilter(
+                bus=b,
+                permission_decision_service=svc,
+                session_metadata={"user_id": 42},
+            )
+            q = b.subscribe("test")
+            ev = _make_tool_event("bash", session_id=sid)
+            await g.process(ev)
+            got = await asyncio.wait_for(q.get(), timeout=1.0)
+            assert got.kind == AgentEventKind.TOOL_CALL
+
+    @pytest.mark.asyncio
+    async def test_on_permission_response_with_remember_persists(self, bus, svc):
+        """on_permission_response with remember=True persists the decision."""
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        # First, hold a tool call
+        q = bus.subscribe("test")
+        ev = _make_tool_event("bash", session_id="s1")
+        await gov.process(ev)
+        perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert perm_req.kind == AgentEventKind.PERMISSION_REQUEST
+        request_id = perm_req.payload["request_id"]
+
+        # Approve with remember=True
+        await gov.on_permission_response(
+            request_id, "approve", remember=True, scope="global"
+        )
+
+        # The tool event should now be published
+        approved_ev = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert approved_ev.kind == AgentEventKind.TOOL_CALL
+
+        # Verify the decision was persisted
+        decisions = svc.list_for_user(user_id=42)
+        assert len(decisions) == 1
+        assert decisions[0]["tool_pattern"] == "bash"
+        assert decisions[0]["decision"] == "allow"
+        assert decisions[0]["scope"] == "global"
+
+    @pytest.mark.asyncio
+    async def test_on_permission_response_without_remember_does_not_persist(self, bus, svc):
+        """on_permission_response without remember does NOT persist."""
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        q = bus.subscribe("test")
+        ev = _make_tool_event("bash", session_id="s1")
+        await gov.process(ev)
+        perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+        request_id = perm_req.payload["request_id"]
+
+        await gov.on_permission_response(request_id, "approve")
+
+        # No decision persisted
+        assert svc.list_for_user(user_id=42) == []
+
+    @pytest.mark.asyncio
+    async def test_on_permission_response_deny_with_remember(self, bus, svc):
+        """Deny with remember=True persists a 'deny' decision."""
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        q = bus.subscribe("test")
+        ev = _make_tool_event("bash", session_id="s1")
+        await gov.process(ev)
+        perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+        request_id = perm_req.payload["request_id"]
+
+        await gov.on_permission_response(
+            request_id,
+            "deny",
+            reason="too dangerous",
+            remember=True,
+            scope="session",
+        )
+
+        # Verify deny error was published
+        error_ev = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert error_ev.kind == AgentEventKind.TOOL_RESULT
+        assert error_ev.payload.get("is_error") is True
+
+        # Verify the decision was persisted as "deny"
+        decisions = svc.list_for_user(user_id=42)
+        assert len(decisions) == 1
+        assert decisions[0]["decision"] == "deny"
+        assert decisions[0]["scope"] == "session"
+        assert decisions[0]["session_id"] == "s1"
+
+    @pytest.mark.asyncio
+    async def test_no_perm_service_remember_is_noop(self, bus):
+        """When no perm service is set, remember=True does nothing."""
+        gov = GovernanceFilter(
+            bus=bus,
+            permission_decision_service=None,
+            session_metadata={"user_id": 42},
+        )
+
+        q = bus.subscribe("test")
+        ev = _make_tool_event("bash", session_id="s1")
+        await gov.process(ev)
+        perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+        request_id = perm_req.payload["request_id"]
+
+        # Should not raise even though no perm service
+        await gov.on_permission_response(
+            request_id, "approve", remember=True, scope="global"
+        )
+        approved_ev = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert approved_ev.kind == AgentEventKind.TOOL_CALL
+
+    @pytest.mark.asyncio
+    async def test_snapshot_deny_takes_precedence_over_persisted_allow(self, bus, svc):
+        """MCPHub snapshot deny (step 1-3) takes precedence over persisted allow (step 4)."""
+        from unittest.mock import MagicMock
+
+        svc.persist(user_id=42, tool_pattern="bash", decision="allow", scope="global")
+
+        snapshot = MagicMock()
+        snapshot.resolved_policy_document = {"denied_tools": ["bash"]}
+
+        gov = GovernanceFilter(
+            bus=bus,
+            policy_snapshot=snapshot,
+            permission_decision_service=svc,
+            session_metadata={"user_id": 42},
+        )
+
+        q = bus.subscribe("test")
+        ev = _make_tool_event("bash")
+        await gov.process(ev)
+
+        got = await asyncio.wait_for(q.get(), timeout=1.0)
+        # Snapshot deny wins
+        assert got.kind == AgentEventKind.TOOL_RESULT
+        assert "denied by policy" in got.payload.get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# DB CRUD tests
+# ---------------------------------------------------------------------------
+
+class TestPermissionDecisionsDB:
+    def test_insert_and_list(self, tmp_db):
+        tmp_db.insert_permission_decision(
+            id="d1",
+            user_id=1,
+            tool_pattern="bash",
+            decision="allow",
+            scope="global",
+        )
+        decisions = tmp_db.list_permission_decisions(user_id=1)
+        assert len(decisions) == 1
+        assert decisions[0]["id"] == "d1"
+        assert decisions[0]["tool_pattern"] == "bash"
+        assert decisions[0]["decision"] == "allow"
+
+    def test_delete(self, tmp_db):
+        tmp_db.insert_permission_decision(
+            id="d1",
+            user_id=1,
+            tool_pattern="bash",
+            decision="allow",
+        )
+        assert tmp_db.delete_permission_decision("d1") is True
+        assert tmp_db.delete_permission_decision("d1") is False
+        assert tmp_db.list_permission_decisions(user_id=1) == []
+
+    def test_get_by_id(self, tmp_db):
+        tmp_db.insert_permission_decision(
+            id="d1",
+            user_id=1,
+            tool_pattern="bash",
+            decision="deny",
+        )
+        d = tmp_db.get_permission_decision("d1")
+        assert d is not None
+        assert d["decision"] == "deny"
+        assert tmp_db.get_permission_decision("nonexistent") is None
+
+    def test_check_permission_decision(self, tmp_db):
+        tmp_db.insert_permission_decision(
+            id="d1",
+            user_id=1,
+            tool_pattern="bash",
+            decision="allow",
+            scope="global",
+        )
+        assert tmp_db.check_permission_decision(1, "bash") == "allow"
+        assert tmp_db.check_permission_decision(1, "read_file") is None
+        assert tmp_db.check_permission_decision(2, "bash") is None
+
+    def test_expired_decisions_filtered(self, tmp_db):
+        """Expired decisions should not appear in list_permission_decisions."""
+        tmp_db.insert_permission_decision(
+            id="d1",
+            user_id=1,
+            tool_pattern="bash",
+            decision="allow",
+            scope="global",
+            expires_at="2020-01-01T00:00:00+00:00",
+        )
+        assert tmp_db.list_permission_decisions(user_id=1) == []
+
+    def test_schema_version_is_9(self, tmp_db):
+        conn = tmp_db._get_conn()
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 9

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_policies_db.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_policies_db.py
@@ -1,0 +1,212 @@
+"""Tests for permission policy DB persistence.
+
+Verifies that policies stored in the ACP Sessions DB survive restarts,
+and that the resolve_permission_tier function uses fnmatch-based matching.
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+
+@pytest.fixture
+def db():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "acp_sessions.db")
+        instance = ACPSessionsDB(db_path=path)
+        yield instance
+        instance.close()
+
+
+class TestPermissionPolicyPersistence:
+    """Policies survive DB re-creation (simulating server restart)."""
+
+    def test_permission_policy_persists_across_restart(self, tmp_path):
+        """Policies stored in DB survive when a new DB instance is created."""
+        db_path = str(tmp_path / "test_acp.db")
+
+        # Create first DB instance and add a policy
+        db1 = ACPSessionsDB(db_path=db_path)
+        policy_id = db1.create_permission_policy(
+            name="bash-individual",
+            rules_json=json.dumps([{"tool_pattern": "Bash(*)", "tier": "individual"}]),
+            priority=10,
+            description="Bash tools need individual approval",
+        )
+        assert policy_id > 0
+
+        # Verify it exists
+        policy = db1.get_permission_policy(policy_id)
+        assert policy is not None
+        assert policy["name"] == "bash-individual"
+        db1.close()
+
+        # Create a NEW DB instance pointing to the same file
+        db2 = ACPSessionsDB(db_path=db_path)
+        policy = db2.get_permission_policy(policy_id)
+        assert policy is not None, "Policy should survive across DB instances"
+        assert policy["name"] == "bash-individual"
+        assert policy["priority"] == 10
+        rules = json.loads(policy["rules_json"])
+        assert rules == [{"tool_pattern": "Bash(*)", "tier": "individual"}]
+        db2.close()
+
+
+class TestResolvePermissionTierFromDB:
+    """resolve_permission_tier queries DB-backed policies."""
+
+    def test_resolve_basic_match(self, db):
+        db.create_permission_policy(
+            name="bash-individual",
+            rules_json=json.dumps([{"tool_pattern": "Bash(*)", "tier": "individual"}]),
+            priority=10,
+        )
+        result = db.resolve_permission_tier("Bash(git:status)")
+        assert result == "individual"
+
+    def test_resolve_no_match(self, db):
+        db.create_permission_policy(
+            name="bash-individual",
+            rules_json=json.dumps([{"tool_pattern": "Bash(*)", "tier": "individual"}]),
+            priority=10,
+        )
+        result = db.resolve_permission_tier("Read(file.txt)")
+        assert result is None
+
+    def test_resolve_case_insensitive(self, db):
+        db.create_permission_policy(
+            name="bash-auto",
+            rules_json=json.dumps([{"tool_pattern": "bash(*)", "tier": "auto"}]),
+            priority=5,
+        )
+        result = db.resolve_permission_tier("Bash(ls)")
+        assert result == "auto"
+
+    def test_resolve_priority_ordering(self, db):
+        """Higher-priority policy wins when multiple rules match."""
+        db.create_permission_policy(
+            name="general-auto",
+            rules_json=json.dumps([{"tool_pattern": "*", "tier": "auto"}]),
+            priority=1,
+        )
+        db.create_permission_policy(
+            name="bash-individual",
+            rules_json=json.dumps([{"tool_pattern": "Bash(*)", "tier": "individual"}]),
+            priority=10,
+        )
+        # Bash matches both, but priority=10 wins
+        assert db.resolve_permission_tier("Bash(rm)") == "individual"
+        # Read matches only the general policy
+        assert db.resolve_permission_tier("Read(file.txt)") == "auto"
+
+    def test_resolve_wildcard_patterns(self, db):
+        db.create_permission_policy(
+            name="read-auto",
+            rules_json=json.dumps([
+                {"tool_pattern": "Read(*)", "tier": "auto"},
+                {"tool_pattern": "Write(*)", "tier": "batch"},
+            ]),
+            priority=5,
+        )
+        assert db.resolve_permission_tier("Read(/etc/passwd)") == "auto"
+        assert db.resolve_permission_tier("Write(/tmp/out)") == "batch"
+
+
+class TestCRUDOperations:
+    """Create, list, update, delete permission policies."""
+
+    def test_create_returns_id(self, db):
+        policy_id = db.create_permission_policy(
+            name="test-policy",
+            rules_json=json.dumps([{"tool_pattern": "*", "tier": "auto"}]),
+        )
+        assert isinstance(policy_id, int)
+        assert policy_id > 0
+
+    def test_create_with_all_fields(self, db):
+        policy_id = db.create_permission_policy(
+            name="full-policy",
+            rules_json=json.dumps([{"tool_pattern": "X(*)", "tier": "batch"}]),
+            priority=42,
+            description="A full policy",
+            org_id="org-123",
+            team_id="team-456",
+        )
+        policy = db.get_permission_policy(policy_id)
+        assert policy["name"] == "full-policy"
+        assert policy["description"] == "A full policy"
+        assert policy["priority"] == 42
+        assert policy["org_id"] == "org-123"
+        assert policy["team_id"] == "team-456"
+        assert policy["created_at"] is not None
+        assert policy["updated_at"] is not None
+
+    def test_list_permission_policies(self, db):
+        db.create_permission_policy(
+            name="policy-a",
+            rules_json=json.dumps([{"tool_pattern": "*", "tier": "auto"}]),
+            priority=1,
+        )
+        db.create_permission_policy(
+            name="policy-b",
+            rules_json=json.dumps([{"tool_pattern": "Bash(*)", "tier": "individual"}]),
+            priority=10,
+        )
+        policies = db.list_permission_policies()
+        assert len(policies) == 2
+        # Should be ordered by priority desc, then name
+        assert policies[0]["name"] == "policy-b"
+        assert policies[1]["name"] == "policy-a"
+
+    def test_update_permission_policy(self, db):
+        policy_id = db.create_permission_policy(
+            name="old-name",
+            rules_json=json.dumps([{"tool_pattern": "*", "tier": "auto"}]),
+            priority=1,
+        )
+        updated = db.update_permission_policy(
+            policy_id,
+            name="new-name",
+            priority=99,
+            description="Updated",
+        )
+        assert updated is True
+        policy = db.get_permission_policy(policy_id)
+        assert policy["name"] == "new-name"
+        assert policy["priority"] == 99
+        assert policy["description"] == "Updated"
+
+    def test_update_rules_json(self, db):
+        policy_id = db.create_permission_policy(
+            name="p1",
+            rules_json=json.dumps([{"tool_pattern": "*", "tier": "auto"}]),
+        )
+        new_rules = json.dumps([{"tool_pattern": "Bash(*)", "tier": "individual"}])
+        db.update_permission_policy(policy_id, rules_json=new_rules)
+        policy = db.get_permission_policy(policy_id)
+        assert json.loads(policy["rules_json"]) == [{"tool_pattern": "Bash(*)", "tier": "individual"}]
+
+    def test_update_nonexistent_returns_false(self, db):
+        assert db.update_permission_policy(9999, name="nope") is False
+
+    def test_delete_permission_policy(self, db):
+        policy_id = db.create_permission_policy(
+            name="doomed",
+            rules_json=json.dumps([]),
+        )
+        assert db.delete_permission_policy(policy_id) is True
+        assert db.get_permission_policy(policy_id) is None
+
+    def test_delete_nonexistent_returns_false(self, db):
+        assert db.delete_permission_policy(9999) is False
+
+    def test_get_nonexistent_returns_none(self, db):
+        assert db.get_permission_policy(9999) is None
+
+    def test_auto_increment_ids(self, db):
+        id1 = db.create_permission_policy(name="a", rules_json="[]")
+        id2 = db.create_permission_policy(name="b", rules_json="[]")
+        assert id2 > id1

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_policy_templates.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_policy_templates.py
@@ -1,0 +1,265 @@
+"""Tests for permission policy templates (read-only, developer, admin, lockdown).
+
+Validates that the 4 preset policy configurations:
+- Contain the expected structure and keys.
+- Map tools to the correct tiers.
+- Act as base layers that can be overridden by user customisations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
+    PERMISSION_POLICY_TEMPLATES,
+)
+from tldw_Server_API.app.services.admin_acp_sessions_service import (
+    SessionRecord,
+    SessionTokenUsage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubPolicyResolver:
+    """Minimal stub that returns a canned resolved policy."""
+
+    def __init__(self, policy_document: dict[str, Any] | None = None) -> None:
+        self._doc = policy_document or {}
+
+    async def resolve_for_context(
+        self,
+        *,
+        user_id: int | str | None,
+        metadata: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        return {
+            "policy_document": dict(self._doc),
+            "sources": [],
+            "provenance": [],
+        }
+
+
+def _make_session(**kwargs: Any) -> SessionRecord:
+    defaults: dict[str, Any] = {
+        "session_id": "test-session",
+        "user_id": 1,
+        "usage": SessionTokenUsage(),
+    }
+    defaults.update(kwargs)
+    return SessionRecord(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. All four templates exist with expected keys
+# ---------------------------------------------------------------------------
+
+
+class TestTemplatesHaveExpectedKeys:
+    EXPECTED_NAMES = ("read-only", "developer", "admin", "lockdown")
+
+    def test_all_templates_present(self) -> None:
+        for name in self.EXPECTED_NAMES:
+            assert name in PERMISSION_POLICY_TEMPLATES, f"Missing template: {name}"
+
+    def test_each_template_has_tool_tier_overrides(self) -> None:
+        for name in self.EXPECTED_NAMES:
+            tpl = PERMISSION_POLICY_TEMPLATES[name]
+            assert "tool_tier_overrides" in tpl, (
+                f"Template '{name}' missing tool_tier_overrides"
+            )
+            assert isinstance(tpl["tool_tier_overrides"], dict)
+
+    def test_each_template_has_description(self) -> None:
+        for name in self.EXPECTED_NAMES:
+            tpl = PERMISSION_POLICY_TEMPLATES[name]
+            assert "description" in tpl
+            assert isinstance(tpl["description"], str)
+            assert len(tpl["description"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 2. read-only template blocks writes
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyTemplateBlocksWrites:
+    def test_write_tool_is_individual(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["read-only"]["tool_tier_overrides"]
+        # The wildcard catch-all should be "individual", which covers Write(*)
+        assert overrides.get("*") == "individual"
+
+    def test_read_tools_are_auto(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["read-only"]["tool_tier_overrides"]
+        for tool in ("Read(*)", "Glob(*)", "Grep(*)"):
+            assert overrides.get(tool) == "auto", f"{tool} should be auto"
+
+    def test_safe_git_commands_are_auto(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["read-only"]["tool_tier_overrides"]
+        for tool in ("Bash(git:log*)", "Bash(git:status*)", "Bash(git:diff*)"):
+            assert overrides.get(tool) == "auto", f"{tool} should be auto"
+
+
+# ---------------------------------------------------------------------------
+# 3. developer template allows git
+# ---------------------------------------------------------------------------
+
+
+class TestDeveloperTemplateAllowsGit:
+    def test_git_is_auto(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["developer"]["tool_tier_overrides"]
+        assert overrides.get("Bash(git:*)") == "auto"
+
+    def test_npm_is_auto(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["developer"]["tool_tier_overrides"]
+        assert overrides.get("Bash(npm:*)") == "auto"
+
+    def test_file_writes_are_batch(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["developer"]["tool_tier_overrides"]
+        assert overrides.get("Write(*)") == "batch"
+        assert overrides.get("Edit(*)") == "batch"
+
+    def test_shell_exec_is_individual(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["developer"]["tool_tier_overrides"]
+        assert overrides.get("Bash(*)") == "individual"
+
+
+# ---------------------------------------------------------------------------
+# 4. admin template blocks destructive ops
+# ---------------------------------------------------------------------------
+
+
+class TestAdminTemplateBlocksDestructive:
+    def test_rm_rf_is_individual(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["admin"]["tool_tier_overrides"]
+        assert overrides.get("Bash(rm:-rf*)") == "individual"
+
+    def test_force_push_is_individual(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["admin"]["tool_tier_overrides"]
+        assert overrides.get("Bash(git:push*--force*)") == "individual"
+
+    def test_hard_reset_is_individual(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["admin"]["tool_tier_overrides"]
+        assert overrides.get("Bash(git:reset*--hard*)") == "individual"
+
+    def test_everything_else_is_auto(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["admin"]["tool_tier_overrides"]
+        assert overrides.get("*") == "auto"
+
+
+# ---------------------------------------------------------------------------
+# 5. lockdown template — everything individual
+# ---------------------------------------------------------------------------
+
+
+class TestLockdownTemplateAllIndividual:
+    def test_wildcard_is_individual(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["lockdown"]["tool_tier_overrides"]
+        assert overrides.get("*") == "individual"
+
+    def test_only_wildcard_key(self) -> None:
+        overrides = PERMISSION_POLICY_TEMPLATES["lockdown"]["tool_tier_overrides"]
+        assert list(overrides.keys()) == ["*"]
+
+
+# ---------------------------------------------------------------------------
+# 6. User overrides take precedence over template
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_overrides_take_precedence() -> None:
+    from tldw_Server_API.app.services.acp_runtime_policy_service import (
+        ACPRuntimePolicyService,
+    )
+
+    # The resolver returns a policy document that already has a user override
+    # for "Read(*)" set to "individual" (overriding the read-only template's
+    # "auto" default).
+    user_override = {"Read(*)": "individual"}
+    resolver = _StubPolicyResolver(
+        policy_document={"tool_tier_overrides": user_override},
+    )
+    service = ACPRuntimePolicyService(policy_resolver=resolver)
+    session = _make_session()
+
+    snapshot = await service.build_snapshot(
+        session_record=session,
+        user_id=1,
+        template_name="read-only",
+    )
+
+    merged = snapshot.resolved_policy_document.get("tool_tier_overrides", {})
+
+    # The user override must win over the template default.
+    assert merged["Read(*)"] == "individual"
+
+    # Template defaults that were NOT overridden should still be present.
+    assert merged.get("Glob(*)") == "auto"
+    assert merged.get("*") == "individual"
+
+
+@pytest.mark.asyncio
+async def test_template_applied_when_no_existing_overrides() -> None:
+    from tldw_Server_API.app.services.acp_runtime_policy_service import (
+        ACPRuntimePolicyService,
+    )
+
+    resolver = _StubPolicyResolver(policy_document={})
+    service = ACPRuntimePolicyService(policy_resolver=resolver)
+    session = _make_session()
+
+    snapshot = await service.build_snapshot(
+        session_record=session,
+        user_id=1,
+        template_name="lockdown",
+    )
+
+    merged = snapshot.resolved_policy_document.get("tool_tier_overrides", {})
+    assert merged == {"*": "individual"}
+
+
+@pytest.mark.asyncio
+async def test_no_template_leaves_policy_unchanged() -> None:
+    from tldw_Server_API.app.services.acp_runtime_policy_service import (
+        ACPRuntimePolicyService,
+    )
+
+    original_doc = {"allowed_tools": ["web.search"]}
+    resolver = _StubPolicyResolver(policy_document=original_doc)
+    service = ACPRuntimePolicyService(policy_resolver=resolver)
+    session = _make_session()
+
+    snapshot = await service.build_snapshot(
+        session_record=session,
+        user_id=1,
+        # No template_name provided
+    )
+
+    # Should NOT have tool_tier_overrides injected
+    assert "tool_tier_overrides" not in snapshot.resolved_policy_document
+
+
+@pytest.mark.asyncio
+async def test_unknown_template_name_is_ignored() -> None:
+    from tldw_Server_API.app.services.acp_runtime_policy_service import (
+        ACPRuntimePolicyService,
+    )
+
+    resolver = _StubPolicyResolver(policy_document={})
+    service = ACPRuntimePolicyService(policy_resolver=resolver)
+    session = _make_session()
+
+    snapshot = await service.build_snapshot(
+        session_record=session,
+        user_id=1,
+        template_name="nonexistent-template",
+    )
+
+    # No template matched, so no overrides should be injected
+    assert "tool_tier_overrides" not in snapshot.resolved_policy_document

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_prompt_utils.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_prompt_utils.py
@@ -1,0 +1,165 @@
+"""Tests for ACP prompt preprocessing utilities (@mention resolution)."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_extracts_mentions():
+    """@tool_name patterns are extracted from message content."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    messages = [{"role": "user", "content": "Use @search_web to find info about @linear tasks"}]
+    msgs, hints = await preprocess_mentions(messages)
+    assert "search_web" in hints
+    assert "linear" in hints
+
+
+@pytest.mark.asyncio
+async def test_no_mentions():
+    """Messages without @mentions return empty hints."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    messages = [{"role": "user", "content": "Hello world"}]
+    msgs, hints = await preprocess_mentions(messages)
+    assert hints == []
+
+
+@pytest.mark.asyncio
+async def test_registry_validation():
+    """Only registered tools appear in hints."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    registry = AsyncMock()
+    registry.tool_exists = AsyncMock(side_effect=lambda n: n == "search_web")
+    messages = [{"role": "user", "content": "@search_web and @nonexistent"}]
+    msgs, hints = await preprocess_mentions(messages, tool_registry=registry)
+    assert hints == ["search_web"]
+
+
+@pytest.mark.asyncio
+async def test_cache_prevents_repeated_lookups():
+    """Cached results avoid repeated registry calls."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    registry = AsyncMock()
+    registry.tool_exists = AsyncMock(return_value=True)
+    cache: dict[str, bool] = {}
+    messages = [{"role": "user", "content": "@tool1 @tool1 @tool1"}]
+    await preprocess_mentions(messages, tool_registry=registry, cache=cache)
+    assert registry.tool_exists.call_count == 1  # Only called once due to cache
+
+
+@pytest.mark.asyncio
+async def test_non_string_content_skipped():
+    """Non-string content (e.g., list for multimodal) is skipped."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    messages = [{"role": "user", "content": [{"type": "image", "url": "..."}]}]
+    msgs, hints = await preprocess_mentions(messages)
+    assert hints == []
+
+
+@pytest.mark.asyncio
+async def test_email_not_matched():
+    """Email addresses should not be matched as @mentions."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    messages = [{"role": "user", "content": "Contact user@example.com"}]
+    msgs, hints = await preprocess_mentions(messages)
+    assert "example.com" not in hints
+
+
+@pytest.mark.asyncio
+async def test_messages_not_modified():
+    """Original messages are returned unchanged (no text replacement)."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    original_content = "Use @search_web to look things up"
+    messages = [{"role": "user", "content": original_content}]
+    msgs, hints = await preprocess_mentions(messages)
+    assert msgs[0]["content"] == original_content
+
+
+@pytest.mark.asyncio
+async def test_hints_sorted():
+    """Returned hints are sorted alphabetically."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    messages = [{"role": "user", "content": "@zebra @alpha @middle"}]
+    msgs, hints = await preprocess_mentions(messages)
+    assert hints == ["alpha", "middle", "zebra"]
+
+
+@pytest.mark.asyncio
+async def test_cache_persists_across_calls():
+    """The same cache dict accumulates results across multiple calls."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    cache: dict[str, bool] = {}
+    registry = AsyncMock()
+    registry.tool_exists = AsyncMock(return_value=True)
+
+    await preprocess_mentions(
+        [{"role": "user", "content": "@tool_a"}],
+        tool_registry=registry,
+        cache=cache,
+    )
+    assert "tool_a" in cache
+
+    # Second call with same cache should not call registry for tool_a again
+    registry.tool_exists.reset_mock()
+    await preprocess_mentions(
+        [{"role": "user", "content": "@tool_a @tool_b"}],
+        tool_registry=registry,
+        cache=cache,
+    )
+    # Only tool_b should trigger a registry call
+    registry.tool_exists.assert_called_once_with("tool_b")
+
+
+@pytest.mark.asyncio
+async def test_registry_exception_treated_as_unresolved():
+    """If registry raises, the mention is treated as unresolved."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    registry = AsyncMock()
+    registry.tool_exists = AsyncMock(side_effect=RuntimeError("connection failed"))
+    messages = [{"role": "user", "content": "@broken_tool"}]
+    msgs, hints = await preprocess_mentions(messages, tool_registry=registry)
+    assert hints == []
+
+
+@pytest.mark.asyncio
+async def test_multiple_messages_scanned():
+    """Mentions across multiple messages are all collected."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    messages = [
+        {"role": "system", "content": "You can use @system_tool"},
+        {"role": "user", "content": "Please use @user_tool"},
+    ]
+    msgs, hints = await preprocess_mentions(messages)
+    assert "system_tool" in hints
+    assert "user_tool" in hints
+
+
+@pytest.mark.asyncio
+async def test_dotted_tool_name():
+    """Tool names with dots (e.g., namespace.tool) are matched."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    messages = [{"role": "user", "content": "Use @mcp.search_web"}]
+    msgs, hints = await preprocess_mentions(messages)
+    assert "mcp.search_web" in hints
+
+
+@pytest.mark.asyncio
+async def test_hyphenated_tool_name():
+    """Tool names with hyphens are matched."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.prompt_utils import preprocess_mentions
+
+    messages = [{"role": "user", "content": "Use @my-tool"}]
+    msgs, hints = await preprocess_mentions(messages)
+    assert "my-tool" in hints

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_replay_utils.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_replay_utils.py
@@ -1,0 +1,63 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.replay_utils import replay_events
+
+
+@pytest.mark.asyncio
+async def test_replay_sends_buffered_events_in_order():
+    """replay_events calls emit_fn for each buffered event from sequence."""
+    bus = MagicMock()
+    # Create mock events with sequence numbers
+    events = []
+    for i in range(5):
+        ev = MagicMock()
+        ev.sequence = i + 1
+        events.append(ev)
+    bus.snapshot.return_value = events[2:]  # from_sequence=3 returns events 3,4,5
+
+    sent = []
+    async def emit(ev):
+        sent.append(ev)
+
+    count = await replay_events(bus, from_sequence=3, emit_fn=emit)
+    assert count == 3
+    assert len(sent) == 3
+    assert [e.sequence for e in sent] == [3, 4, 5]
+    bus.snapshot.assert_called_once_with(from_sequence=3)
+
+
+@pytest.mark.asyncio
+async def test_replay_zero_sequence_returns_zero():
+    """from_sequence=0 means no replay needed."""
+    bus = MagicMock()
+    sent = []
+    async def emit(ev):
+        sent.append(ev)
+
+    count = await replay_events(bus, from_sequence=0, emit_fn=emit)
+    assert count == 0
+    assert len(sent) == 0
+    bus.snapshot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_replay_negative_sequence_returns_zero():
+    """Negative sequence means no replay."""
+    bus = MagicMock()
+    count = await replay_events(bus, from_sequence=-1, emit_fn=lambda ev: asyncio.sleep(0))
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_replay_empty_buffer():
+    """If bus has no events from that sequence, emit nothing."""
+    bus = MagicMock()
+    bus.snapshot.return_value = []
+    sent = []
+    async def emit(ev):
+        sent.append(ev)
+
+    count = await replay_events(bus, from_sequence=100, emit_fn=emit)
+    assert count == 0
+    assert len(sent) == 0

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_run_history.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_run_history.py
@@ -1,0 +1,237 @@
+"""Tests for ACP run history and cost tracking.
+
+Tests the service/DB level query methods (list_runs, aggregate_runs)
+without needing HTTP TestClient or auth.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+from tldw_Server_API.app.services.admin_acp_sessions_service import ACPSessionStore
+
+
+@pytest.fixture
+def db():
+    """Create a temporary ACP sessions DB."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "acp_sessions.db")
+        instance = ACPSessionsDB(db_path=path)
+        yield instance
+        instance.close()
+
+
+@pytest.fixture
+def store(db):
+    """Create an ACPSessionStore backed by the temp DB."""
+    return ACPSessionStore(db=db)
+
+
+def _insert_session(
+    db: ACPSessionsDB,
+    session_id: str,
+    user_id: int = 1,
+    agent_type: str = "claude_code",
+    status: str | None = None,
+    model: str | None = None,
+) -> dict:
+    """Helper to insert a session and optionally close/error it."""
+    row = db.register_session(
+        session_id=session_id,
+        user_id=user_id,
+        agent_type=agent_type,
+        model=model,
+    )
+    if status == "closed":
+        db.close_session(session_id)
+    elif status == "error":
+        db.set_session_status(session_id, "error")
+    return row
+
+
+def _record_tokens(db: ACPSessionsDB, session_id: str, prompt_tokens: int, completion_tokens: int) -> None:
+    """Record a prompt exchange to accumulate token usage."""
+    db.record_prompt(
+        session_id,
+        [{"role": "user", "content": "hello"}],
+        {"role": "assistant", "content": "world", "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+        }},
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB-level tests for list_runs
+# ---------------------------------------------------------------------------
+
+
+class TestListRunsDB:
+    def test_list_runs_returns_sessions(self, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        _insert_session(db, "s2")
+        rows, total = db.list_runs()
+        assert total == 2
+        assert len(rows) == 2
+        ids = {r["session_id"] for r in rows}
+        assert ids == {"s1", "s2"}
+
+    def test_list_runs_filters_by_status(self, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        _insert_session(db, "s2", status="closed")
+        rows, total = db.list_runs(status="closed")
+        assert total == 1
+        assert rows[0]["session_id"] == "s2"
+
+    def test_list_runs_filters_by_agent_type(self, db: ACPSessionsDB):
+        _insert_session(db, "s1", agent_type="claude_code")
+        _insert_session(db, "s2", agent_type="codex")
+        rows, total = db.list_runs(agent_type="codex")
+        assert total == 1
+        assert rows[0]["session_id"] == "s2"
+
+    def test_list_runs_filters_by_date_range(self, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        _insert_session(db, "s2")
+        # Both sessions were created just now with ISO timestamps.
+        # Use a far-future date that should match nothing.
+        rows, total = db.list_runs(from_date="2099-01-01")
+        assert total == 0
+        assert rows == []
+
+        # Use a far-past date that should match everything.
+        rows, total = db.list_runs(from_date="2000-01-01")
+        assert total == 2
+
+    def test_list_runs_pagination(self, db: ACPSessionsDB):
+        for i in range(5):
+            _insert_session(db, f"s{i}")
+        rows, total = db.list_runs(limit=2, offset=0)
+        assert total == 5
+        assert len(rows) == 2
+
+        rows2, total2 = db.list_runs(limit=2, offset=2)
+        assert total2 == 5
+        assert len(rows2) == 2
+
+        # No overlap between pages
+        page1_ids = {r["session_id"] for r in rows}
+        page2_ids = {r["session_id"] for r in rows2}
+        assert page1_ids.isdisjoint(page2_ids)
+
+
+# ---------------------------------------------------------------------------
+# DB-level tests for aggregate_runs
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateRunsDB:
+    def test_aggregate_runs_sums_tokens(self, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        _insert_session(db, "s2")
+        _record_tokens(db, "s1", prompt_tokens=100, completion_tokens=50)
+        _record_tokens(db, "s2", prompt_tokens=200, completion_tokens=80)
+
+        agg = db.aggregate_runs()
+        assert agg["total_sessions"] == 2
+        assert agg["prompt_tokens"] == 300
+        assert agg["completion_tokens"] == 130
+        assert agg["total_tokens"] == 430
+
+    def test_aggregate_runs_empty(self, db: ACPSessionsDB):
+        agg = db.aggregate_runs()
+        assert agg["total_sessions"] == 0
+        assert agg["prompt_tokens"] == 0
+        assert agg["completion_tokens"] == 0
+        assert agg["total_tokens"] == 0
+
+    def test_aggregate_runs_with_date_filter(self, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        _record_tokens(db, "s1", prompt_tokens=50, completion_tokens=25)
+
+        # Far-future filter should match nothing
+        agg = db.aggregate_runs(from_date="2099-01-01")
+        assert agg["total_sessions"] == 0
+        assert agg["total_tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Service-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestListRunsService:
+    @pytest.mark.asyncio
+    async def test_list_runs_returns_sessions(self, store: ACPSessionStore, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        _insert_session(db, "s2")
+        result = await store.list_runs()
+        assert result["total"] == 2
+        assert len(result["items"]) == 2
+        assert result["limit"] == 100
+        assert result["offset"] == 0
+        # Each item should have session_id from to_info_dict
+        ids = {item["session_id"] for item in result["items"]}
+        assert ids == {"s1", "s2"}
+
+    @pytest.mark.asyncio
+    async def test_list_runs_filters_by_status(self, store: ACPSessionStore, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        _insert_session(db, "s2", status="closed")
+        result = await store.list_runs(status="closed")
+        assert result["total"] == 1
+        assert result["items"][0]["session_id"] == "s2"
+
+    @pytest.mark.asyncio
+    async def test_list_runs_pagination(self, store: ACPSessionStore, db: ACPSessionsDB):
+        for i in range(5):
+            _insert_session(db, f"s{i}")
+        result = await store.list_runs(limit=2, offset=0)
+        assert result["total"] == 5
+        assert len(result["items"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_runs_filters_by_date(self, store: ACPSessionStore, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        result = await store.list_runs(from_date="2099-01-01")
+        assert result["total"] == 0
+
+
+class TestAggregateRunsService:
+    @pytest.mark.asyncio
+    async def test_aggregate_runs_sums_tokens(self, store: ACPSessionStore, db: ACPSessionsDB):
+        _insert_session(db, "s1")
+        _insert_session(db, "s2")
+        _record_tokens(db, "s1", prompt_tokens=100, completion_tokens=50)
+        _record_tokens(db, "s2", prompt_tokens=200, completion_tokens=80)
+
+        result = await store.aggregate_runs()
+        assert result["total_sessions"] == 2
+        assert result["prompt_tokens"] == 300
+        assert result["completion_tokens"] == 130
+        assert result["total_tokens"] == 430
+        # estimated_cost_usd should be present (may be None if model not set)
+        assert "estimated_cost_usd" in result
+
+    @pytest.mark.asyncio
+    async def test_aggregate_runs_empty(self, store: ACPSessionStore, db: ACPSessionsDB):
+        result = await store.aggregate_runs()
+        assert result["total_sessions"] == 0
+        assert result["prompt_tokens"] == 0
+        assert result["completion_tokens"] == 0
+        assert result["total_tokens"] == 0
+        assert "estimated_cost_usd" in result
+
+    @pytest.mark.asyncio
+    async def test_aggregate_with_model_computes_cost(self, store: ACPSessionStore, db: ACPSessionsDB):
+        _insert_session(db, "s1", model="gpt-4")
+        _record_tokens(db, "s1", prompt_tokens=1000, completion_tokens=500)
+
+        result = await store.aggregate_runs()
+        assert result["total_sessions"] == 1
+        # With a real model name, cost might be computed (or None if not in catalog)
+        # The important thing is the key exists and the method doesn't error
+        assert "estimated_cost_usd" in result

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_sse_consumer.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_sse_consumer.py
@@ -1,0 +1,200 @@
+"""Tests for SSEConsumer event consumer."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import (
+    AgentEvent,
+    AgentEventKind,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.sse_consumer import (
+    SSEConsumer,
+)
+
+
+def _make_event(
+    kind: AgentEventKind = AgentEventKind.TOOL_CALL,
+    session_id: str = "sess-1",
+) -> AgentEvent:
+    return AgentEvent(session_id=session_id, kind=kind, payload={"data": kind.value})
+
+
+async def _collect_lines(
+    gen,
+    *,
+    max_lines: int = 10,
+    timeout: float = 2.0,
+) -> list[str]:
+    """Collect up to *max_lines* from an async generator within *timeout*."""
+    lines: list[str] = []
+    try:
+        async with asyncio.timeout(timeout):
+            async for line in gen:
+                lines.append(line)
+                if len(lines) >= max_lines:
+                    break
+    except (asyncio.TimeoutError, TimeoutError):
+        pass
+    return lines
+
+
+# --------------------------------------------------------------------------- #
+# SSE format
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sse_consumer_formats_events_as_sse():
+    """Events are formatted as 'event: {kind}\\ndata: {json}\\n\\n'."""
+    bus = SessionEventBus(session_id="sess-1")
+    consumer = SSEConsumer(from_sequence=0, heartbeat_interval=10.0)
+
+    await consumer.start(bus)
+
+    # Publish two events through the bus
+    await bus.publish(_make_event(AgentEventKind.TOOL_CALL))
+    await bus.publish(_make_event(AgentEventKind.COMPLETION))
+
+    lines = await _collect_lines(consumer.iter_sse_lines(), max_lines=2)
+    await consumer.stop()
+
+    assert len(lines) == 2
+
+    # First event
+    assert lines[0].startswith("event: tool_call\n")
+    assert "data: " in lines[0]
+    assert lines[0].endswith("\n\n")
+    data_0 = json.loads(lines[0].split("data: ", 1)[1].rstrip("\n"))
+    assert data_0["kind"] == "tool_call"
+    assert data_0["session_id"] == "sess-1"
+    assert data_0["sequence"] == 1
+
+    # Second event
+    assert lines[1].startswith("event: completion\n")
+    data_1 = json.loads(lines[1].split("data: ", 1)[1].rstrip("\n"))
+    assert data_1["kind"] == "completion"
+    assert data_1["sequence"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Heartbeat
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sse_consumer_heartbeat_on_timeout():
+    """After heartbeat_interval of no events, emits ': heartbeat\\n\\n'."""
+    bus = SessionEventBus(session_id="sess-1")
+    consumer = SSEConsumer(heartbeat_interval=0.05)  # 50ms for fast test
+
+    await consumer.start(bus)
+
+    # Don't publish any events -- should get heartbeat(s)
+    lines = await _collect_lines(consumer.iter_sse_lines(), max_lines=2, timeout=1.0)
+    await consumer.stop()
+
+    assert len(lines) >= 1
+    assert lines[0] == ": heartbeat\n\n"
+
+
+# --------------------------------------------------------------------------- #
+# Replay from sequence
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sse_consumer_replays_from_sequence():
+    """With from_sequence > 0, replays buffered events on start."""
+    bus = SessionEventBus(session_id="sess-1")
+
+    # Pre-populate the bus with 5 events
+    for i in range(5):
+        await bus.publish(_make_event(AgentEventKind.THINKING))
+
+    # Create consumer that wants events from sequence 3 onwards
+    consumer = SSEConsumer(from_sequence=3, heartbeat_interval=10.0)
+    await consumer.start(bus)
+
+    # The bus.subscribe(from_sequence=3) replays seq 3, 4, 5 into the queue
+    lines = await _collect_lines(consumer.iter_sse_lines(), max_lines=3, timeout=1.0)
+    await consumer.stop()
+
+    assert len(lines) == 3
+    sequences = []
+    for line in lines:
+        data = json.loads(line.split("data: ", 1)[1].rstrip("\n"))
+        sequences.append(data["sequence"])
+    assert sequences == [3, 4, 5]
+
+
+# --------------------------------------------------------------------------- #
+# Stop / unsubscribe
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sse_consumer_stop_unsubscribes():
+    """Calling stop() unsubscribes from the bus."""
+    bus = SessionEventBus(session_id="sess-1")
+    consumer = SSEConsumer(heartbeat_interval=10.0)
+
+    await consumer.start(bus)
+    assert consumer.consumer_id in bus._subscribers
+
+    await consumer.stop()
+    assert consumer.consumer_id not in bus._subscribers
+
+
+# --------------------------------------------------------------------------- #
+# Unique consumer IDs
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sse_consumer_default_id_is_unique():
+    """Two SSEConsumers created without explicit IDs have different consumer_ids."""
+    c1 = SSEConsumer()
+    c2 = SSEConsumer()
+    assert c1.consumer_id != c2.consumer_id
+    assert c1.consumer_id.startswith("sse_")
+    assert c2.consumer_id.startswith("sse_")
+
+
+# --------------------------------------------------------------------------- #
+# Generator terminates on stop
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sse_consumer_iter_terminates_after_stop():
+    """iter_sse_lines() should exit once stop() is called."""
+    bus = SessionEventBus(session_id="sess-1")
+    consumer = SSEConsumer(heartbeat_interval=0.05)
+
+    await consumer.start(bus)
+
+    collected: list[str] = []
+
+    async def drain():
+        async for line in consumer.iter_sse_lines():
+            collected.append(line)
+
+    task = asyncio.create_task(drain())
+
+    # Let it run briefly to get at least one heartbeat
+    await asyncio.sleep(0.15)
+    await consumer.stop()
+
+    # Give the task a moment to finish
+    try:
+        await asyncio.wait_for(task, timeout=1.0)
+    except asyncio.TimeoutError:
+        task.cancel()
+        pytest.fail("iter_sse_lines did not terminate after stop()")
+
+    # Should have collected at least one heartbeat
+    assert len(collected) >= 1

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
@@ -1,0 +1,680 @@
+"""Tests for the ACP webhook trigger system.
+
+Covers:
+1. GitHub HMAC signature verification (valid + invalid)
+2. Slack signature verification (valid + replay attack)
+3. Generic HMAC signature verification
+4. Per-trigger rate limiting
+5. Secret encryption/decryption roundtrip (Fernet and base64 fallback)
+6. End-to-end handle_webhook -> acp_run submission
+7. Disabled trigger rejection
+8. Full CRUD lifecycle
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.triggers import (
+    ACPTriggerManager,
+    TriggerConfig,
+    TriggerSecretManager,
+    WebhookVerifier,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_github_signature(payload: bytes, secret: str) -> str:
+    """Produce a valid GitHub X-Hub-Signature-256 header value."""
+    return "sha256=" + hmac.new(
+        secret.encode("utf-8"), payload, hashlib.sha256
+    ).hexdigest()
+
+
+def _make_slack_signature(payload: bytes, secret: str, timestamp: str) -> str:
+    """Produce a valid Slack X-Slack-Signature header value."""
+    sig_basestring = f"v0:{timestamp}:{payload.decode('utf-8')}"
+    return "v0=" + hmac.new(
+        secret.encode("utf-8"),
+        sig_basestring.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _make_generic_signature(payload: bytes, secret: str, timestamp: str | None = None) -> str:
+    """Produce a valid generic X-Webhook-Signature header value.
+
+    When *timestamp* is provided the signed payload is ``<ts>.<body>``
+    (matching the verifier's replay-protection scheme).
+    """
+    if timestamp is not None:
+        signed_payload = f"{timestamp}.".encode("utf-8") + payload
+    else:
+        signed_payload = payload
+    return hmac.new(
+        secret.encode("utf-8"), signed_payload, hashlib.sha256
+    ).hexdigest()
+
+
+class FakeDB:
+    """In-memory stand-in for ACPSessionsDB webhook trigger methods."""
+
+    def __init__(self) -> None:
+        self._triggers: dict[str, dict[str, Any]] = {}
+
+    def create_webhook_trigger(self, **kwargs: Any) -> None:
+        self._triggers[kwargs["trigger_id"]] = kwargs
+
+    def list_webhook_triggers(self, owner_user_id: int) -> list[dict[str, Any]]:
+        return [
+            dict(t) for t in self._triggers.values()
+            if t["owner_user_id"] == owner_user_id
+        ]
+
+    def get_webhook_trigger(self, trigger_id: str) -> dict[str, Any] | None:
+        return dict(self._triggers[trigger_id]) if trigger_id in self._triggers else None
+
+    def update_webhook_trigger(self, trigger_id: str, updates: dict[str, Any]) -> bool:
+        if trigger_id not in self._triggers:
+            return False
+        self._triggers[trigger_id].update(updates)
+        return True
+
+    def delete_webhook_trigger(self, trigger_id: str) -> bool:
+        if trigger_id in self._triggers:
+            del self._triggers[trigger_id]
+            return True
+        return False
+
+
+@pytest.fixture()
+def secret_mgr() -> TriggerSecretManager:
+    """A TriggerSecretManager with a fixed key for deterministic tests."""
+    return TriggerSecretManager(encryption_key="test-key-for-unit-tests")
+
+
+@pytest.fixture()
+def db() -> FakeDB:
+    return FakeDB()
+
+
+@pytest.fixture()
+def mgr(db: FakeDB, secret_mgr: TriggerSecretManager) -> ACPTriggerManager:
+    return ACPTriggerManager(db=db, secret_manager=secret_mgr)
+
+
+# ---------------------------------------------------------------------------
+# 1. GitHub signature verification -- valid
+# ---------------------------------------------------------------------------
+
+
+def test_verify_github_valid_signature():
+    secret = "gh-secret-123"
+    payload = b'{"action": "push", "ref": "refs/heads/main"}'
+    sig = _make_github_signature(payload, secret)
+    v = WebhookVerifier()
+    assert v.verify_github(payload, sig, secret, delivery_id="d-1") is True
+
+
+# ---------------------------------------------------------------------------
+# 2. GitHub signature verification -- invalid
+# ---------------------------------------------------------------------------
+
+
+def test_verify_github_invalid_signature():
+    secret = "gh-secret-123"
+    payload = b'{"action": "push"}'
+    bad_sig = "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+    v = WebhookVerifier()
+    assert v.verify_github(payload, bad_sig, secret) is False
+
+
+def test_verify_github_tampered_payload():
+    secret = "gh-secret-123"
+    payload = b'{"action": "push"}'
+    sig = _make_github_signature(payload, secret)
+    v = WebhookVerifier()
+    tampered = b'{"action": "delete"}'
+    assert v.verify_github(tampered, sig, secret) is False
+
+
+def test_verify_github_replay_rejected():
+    """Same delivery_id is rejected on second use."""
+    secret = "gh-secret-123"
+    payload = b'{"action": "push"}'
+    sig = _make_github_signature(payload, secret)
+    v = WebhookVerifier()
+    assert v.verify_github(payload, sig, secret, delivery_id="dup-1") is True
+    assert v.verify_github(payload, sig, secret, delivery_id="dup-1") is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Slack signature verification -- valid
+# ---------------------------------------------------------------------------
+
+
+def test_verify_slack_valid_signature():
+    secret = "slack-signing-secret"
+    payload = b"token=abc&team_id=T123"
+    timestamp = str(int(time.time()))
+    sig = _make_slack_signature(payload, secret, timestamp)
+
+    assert WebhookVerifier.verify_slack(payload, timestamp, sig, secret) is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Slack signature verification -- replay attack
+# ---------------------------------------------------------------------------
+
+
+def test_verify_slack_replay_attack():
+    secret = "slack-signing-secret"
+    payload = b"token=abc"
+    # Timestamp 10 minutes ago -- beyond the 5 minute window
+    old_timestamp = str(int(time.time()) - 600)
+    sig = _make_slack_signature(payload, secret, old_timestamp)
+
+    assert WebhookVerifier.verify_slack(payload, old_timestamp, sig, secret) is False
+
+
+def test_verify_slack_invalid_timestamp():
+    """Non-numeric timestamp should fail gracefully."""
+    secret = "slack-signing-secret"
+    payload = b"data"
+    assert WebhookVerifier.verify_slack(payload, "not-a-number", "v0=abc", secret) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Rate limit blocks after max
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_blocks_after_max(mgr: ACPTriggerManager):
+    trigger_id = "rate-test-1"
+    max_per_minute = 5
+
+    # First 5 should pass
+    for i in range(max_per_minute):
+        assert mgr.check_rate_limit(trigger_id, max_per_minute=max_per_minute) is True, \
+            f"Request {i+1} should be within limit"
+
+    # 6th should be blocked
+    assert mgr.check_rate_limit(trigger_id, max_per_minute=max_per_minute) is False
+
+
+def test_rate_limit_resets_after_window(mgr: ACPTriggerManager):
+    """Timestamps older than 60s are pruned, freeing up capacity."""
+    trigger_id = "rate-test-2"
+    max_per_minute = 2
+
+    # Manually inject old timestamps
+    old_time = time.time() - 61
+    mgr._rate_limits[trigger_id] = [old_time, old_time]
+
+    # Should still pass because old entries get pruned
+    assert mgr.check_rate_limit(trigger_id, max_per_minute=max_per_minute) is True
+
+
+# ---------------------------------------------------------------------------
+# 6. Secret encrypt/decrypt roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_secret_encrypt_decrypt_roundtrip(secret_mgr: TriggerSecretManager):
+    original = "my-webhook-secret-456"
+    encrypted = secret_mgr.encrypt(original)
+    assert encrypted != original, "Encrypted value should differ from plaintext"
+
+    decrypted = secret_mgr.decrypt(encrypted)
+    assert decrypted == original
+
+
+def test_secret_manager_no_key_raises():
+    """TriggerSecretManager without a key should raise ValueError."""
+    with pytest.raises(ValueError, match="ACP_TRIGGER_ENCRYPTION_KEY"):
+        TriggerSecretManager()
+
+
+def test_secret_manager_generate_key():
+    """generate_key() returns a usable Fernet key."""
+    key = TriggerSecretManager.generate_key()
+    assert isinstance(key, str)
+    # Key should be usable to create a new manager
+    mgr = TriggerSecretManager(encryption_key=key)
+    original = "roundtrip-test"
+    assert mgr.decrypt(mgr.encrypt(original)) == original
+
+
+# ---------------------------------------------------------------------------
+# 7. End-to-end: handle_webhook submits acp_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_submits_acp_run(
+    mgr: ACPTriggerManager,
+    secret_mgr: TriggerSecretManager,
+):
+    webhook_secret = "e2e-secret"
+
+    # Create a trigger
+    trigger_id = mgr.create_trigger(
+        name="E2E Test",
+        source_type="generic",
+        secret=webhook_secret,
+        owner_user_id=42,
+        agent_config={"cwd": "/workspace", "agent_type": "coding"},
+        prompt_template="Event: {event_type}\nPayload: {payload}",
+    )
+
+    payload = b'{"ref": "main", "commits": [{"message": "fix bug"}]}'
+    timestamp = str(int(time.time()))
+    sig = _make_generic_signature(payload, webhook_secret, timestamp=timestamp)
+
+    # Mock the scheduler submission
+    with patch.object(mgr, "_submit_acp_run", new_callable=AsyncMock) as mock_submit:
+        mock_submit.return_value = "task-abc-123"
+
+        result = await mgr.handle_webhook(
+            trigger_id=trigger_id,
+            payload_body=payload,
+            headers={
+                "x-webhook-signature": sig,
+                "x-webhook-timestamp": timestamp,
+            },
+        )
+
+    assert result["status"] == "accepted"
+    assert result["task_id"] == "task-abc-123"
+
+    # Verify the acp_run payload
+    call_args = mock_submit.call_args
+    acp_payload = call_args[0][0]
+    assert acp_payload["user_id"] == 42
+    assert acp_payload["cwd"] == "/workspace"
+    assert acp_payload["agent_type"] == "coding"
+    assert "Event: webhook" in acp_payload["prompt"]
+    assert "fix bug" in acp_payload["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_github_provider(
+    mgr: ACPTriggerManager,
+    secret_mgr: TriggerSecretManager,
+):
+    """GitHub source_type uses X-Hub-Signature-256 and X-GitHub-Event headers."""
+    webhook_secret = "gh-test-secret"
+
+    trigger_id = mgr.create_trigger(
+        name="GitHub Trigger",
+        source_type="github",
+        secret=webhook_secret,
+        owner_user_id=1,
+        prompt_template="GitHub {event_type}: {payload}",
+    )
+
+    payload = b'{"action": "opened", "number": 42}'
+    sig = _make_github_signature(payload, webhook_secret)
+
+    with patch.object(mgr, "_submit_acp_run", new_callable=AsyncMock) as mock_submit:
+        mock_submit.return_value = "task-gh-1"
+
+        result = await mgr.handle_webhook(
+            trigger_id=trigger_id,
+            payload_body=payload,
+            headers={
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Event": "pull_request",
+                "X-GitHub-Delivery": "delivery-gh-e2e-1",
+            },
+        )
+
+    assert result["status"] == "accepted"
+    acp_payload = mock_submit.call_args[0][0]
+    assert "GitHub pull_request" in acp_payload["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# 8. Disabled trigger returns error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_disabled_trigger(
+    mgr: ACPTriggerManager,
+    secret_mgr: TriggerSecretManager,
+):
+    trigger_id = mgr.create_trigger(
+        name="Disabled",
+        source_type="generic",
+        secret="some-secret",
+        owner_user_id=1,
+        enabled=False,
+    )
+
+    result = await mgr.handle_webhook(
+        trigger_id=trigger_id,
+        payload_body=b"test",
+        headers={"x-webhook-signature": "doesn't matter"},
+    )
+
+    assert result["status"] == "rejected"
+    assert result["error"] == "trigger_disabled"
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_unknown_trigger(mgr: ACPTriggerManager):
+    result = await mgr.handle_webhook(
+        trigger_id="nonexistent-id",
+        payload_body=b"test",
+        headers={},
+    )
+
+    assert result["status"] == "rejected"
+    assert result["error"] == "trigger_not_found"
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_invalid_signature(
+    mgr: ACPTriggerManager,
+    secret_mgr: TriggerSecretManager,
+):
+    trigger_id = mgr.create_trigger(
+        name="Bad Sig Test",
+        source_type="generic",
+        secret="correct-secret",
+        owner_user_id=1,
+    )
+
+    result = await mgr.handle_webhook(
+        trigger_id=trigger_id,
+        payload_body=b"data",
+        headers={
+            "x-webhook-signature": "wrong-signature",
+            "x-webhook-timestamp": str(int(time.time())),
+        },
+    )
+
+    assert result["status"] == "rejected"
+    assert result["error"] == "verification_failed"
+
+
+# ---------------------------------------------------------------------------
+# 9. Trigger CRUD lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_crud_lifecycle(
+    mgr: ACPTriggerManager,
+    secret_mgr: TriggerSecretManager,
+):
+    # Create
+    trigger_id = mgr.create_trigger(
+        name="Lifecycle Test",
+        source_type="github",
+        secret="lifecycle-secret",
+        owner_user_id=99,
+        agent_config={"cwd": "/app"},
+        prompt_template="Handle: {payload}",
+        enabled=True,
+    )
+    assert trigger_id is not None
+
+    # List
+    triggers = mgr.list_triggers(user_id=99)
+    assert len(triggers) == 1
+    assert triggers[0]["name"] == "Lifecycle Test"
+    assert triggers[0]["source_type"] == "github"
+    # Secret should NOT be in list results
+    assert "secret_encrypted" not in triggers[0]
+
+    # Get
+    trigger = mgr.get_trigger(trigger_id)
+    assert trigger is not None
+    assert trigger["name"] == "Lifecycle Test"
+    assert trigger["owner_user_id"] == 99
+    assert trigger["agent_config"] == {"cwd": "/app"}
+    assert trigger["prompt_template"] == "Handle: {payload}"
+    assert trigger["enabled"] is True
+    # get_trigger includes secret_encrypted for internal use
+    assert "secret_encrypted" in trigger
+
+    # Update
+    ok = mgr.update_trigger(
+        trigger_id,
+        name="Updated Name",
+        source_type="slack",
+        enabled=False,
+        agent_config={"cwd": "/new"},
+        prompt_template="New template: {payload}",
+    )
+    assert ok is True
+
+    updated = mgr.get_trigger(trigger_id)
+    assert updated is not None
+    assert updated["name"] == "Updated Name"
+    assert updated["source_type"] == "slack"
+    assert updated["enabled"] is False
+    assert updated["agent_config"] == {"cwd": "/new"}
+    assert updated["prompt_template"] == "New template: {payload}"
+
+    # Update secret
+    ok = mgr.update_trigger(trigger_id, secret="new-secret")
+    assert ok is True
+    updated = mgr.get_trigger(trigger_id)
+    decrypted = secret_mgr.decrypt(updated["secret_encrypted"])
+    assert decrypted == "new-secret"
+
+    # Delete
+    ok = mgr.delete_trigger(trigger_id)
+    assert ok is True
+    assert mgr.get_trigger(trigger_id) is None
+
+    # List should be empty now
+    assert mgr.list_triggers(user_id=99) == []
+
+    # Delete again should return False
+    assert mgr.delete_trigger(trigger_id) is False
+
+
+def test_list_triggers_filters_by_user(
+    mgr: ACPTriggerManager,
+    secret_mgr: TriggerSecretManager,
+):
+    """list_triggers only returns triggers for the specified user."""
+    mgr.create_trigger(name="User1 Trigger", source_type="generic",
+                        secret="s1", owner_user_id=1)
+    mgr.create_trigger(name="User2 Trigger", source_type="generic",
+                        secret="s2", owner_user_id=2)
+
+    user1_triggers = mgr.list_triggers(user_id=1)
+    user2_triggers = mgr.list_triggers(user_id=2)
+
+    assert len(user1_triggers) == 1
+    assert user1_triggers[0]["name"] == "User1 Trigger"
+    assert len(user2_triggers) == 1
+    assert user2_triggers[0]["name"] == "User2 Trigger"
+
+
+def test_update_trigger_no_changes(mgr: ACPTriggerManager):
+    """update_trigger with no kwargs returns False."""
+    trigger_id = mgr.create_trigger(
+        name="No-op", source_type="generic", secret="s", owner_user_id=1,
+    )
+    assert mgr.update_trigger(trigger_id) is False
+
+
+# ---------------------------------------------------------------------------
+# 10. Generic HMAC verification
+# ---------------------------------------------------------------------------
+
+
+def test_verify_generic_valid():
+    secret = "generic-secret"
+    payload = b"some data"
+    timestamp = str(int(time.time()))
+    sig = _make_generic_signature(payload, secret, timestamp=timestamp)
+    assert WebhookVerifier.verify_generic(payload, sig, secret, timestamp=timestamp) is True
+
+
+def test_verify_generic_invalid():
+    timestamp = str(int(time.time()))
+    assert WebhookVerifier.verify_generic(b"data", "badsig", "secret", timestamp=timestamp) is False
+
+
+def test_verify_generic_missing_timestamp():
+    """Generic webhook without timestamp is rejected."""
+    secret = "generic-secret"
+    payload = b"some data"
+    sig = _make_generic_signature(payload, secret)
+    assert WebhookVerifier.verify_generic(payload, sig, secret, timestamp=None) is False
+
+
+def test_verify_generic_replay_attack():
+    """Generic webhook with old timestamp is rejected."""
+    secret = "generic-secret"
+    payload = b"some data"
+    old_timestamp = str(int(time.time()) - 600)
+    sig = _make_generic_signature(payload, secret, timestamp=old_timestamp)
+    assert WebhookVerifier.verify_generic(payload, sig, secret, timestamp=old_timestamp) is False
+
+
+# ---------------------------------------------------------------------------
+# 11. TriggerConfig dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_config_to_dict():
+    cfg = TriggerConfig(
+        id="t1",
+        name="Test",
+        source_type="github",
+        secret_encrypted="enc:abc",
+        owner_user_id=1,
+        agent_config={"cwd": "/x"},
+        prompt_template="tmpl",
+    )
+    d = cfg.to_dict()
+    assert d["id"] == "t1"
+    assert d["name"] == "Test"
+    assert d["source_type"] == "github"
+    assert d["agent_config"] == {"cwd": "/x"}
+    assert d["enabled"] is True
+    # secret_encrypted should NOT be in to_dict output
+    assert "secret_encrypted" not in d
+
+
+# ---------------------------------------------------------------------------
+# 12. Prompt template rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_prompt_with_placeholders():
+    template = "Event: {event_type}\nData: {payload}"
+    payload = b'{"key": "value"}'
+    headers = {"x-github-event": "push"}
+
+    result = ACPTriggerManager._render_prompt(template, payload, headers)
+    assert "Event: push" in result
+    assert '{"key": "value"}' in result
+
+
+def test_render_prompt_default_event_type():
+    """When no event header is present, event_type defaults to 'webhook'."""
+    template = "Type: {event_type}"
+    result = ACPTriggerManager._render_prompt(template, b"data", {})
+    assert "Type: webhook" in result
+
+
+def test_render_prompt_unknown_placeholders():
+    """Extra placeholders that aren't supported should not crash."""
+    template = "Event: {event_type}, Unknown: {unknown}"
+    result = ACPTriggerManager._render_prompt(template, b"data", {})
+    # Should at least contain the event_type substitution
+    assert "Event: webhook" in result
+
+
+# ---------------------------------------------------------------------------
+# 13. DB integration (ACPSessionsDB webhook_triggers table)
+# ---------------------------------------------------------------------------
+
+
+def test_acp_sessions_db_webhook_trigger_crud(tmp_path):
+    """Test webhook trigger CRUD directly against ACPSessionsDB."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+    db_path = str(tmp_path / "test_triggers.db")
+    db = ACPSessionsDB(db_path=db_path)
+
+    # Create
+    db.create_webhook_trigger(
+        trigger_id="t-1",
+        name="DB Test",
+        source_type="github",
+        secret_encrypted="enc:secret",
+        owner_user_id=42,
+        agent_config_json='{"cwd": "/work"}',
+        prompt_template="test: {payload}",
+        enabled=True,
+    )
+
+    # Get
+    trigger = db.get_webhook_trigger("t-1")
+    assert trigger is not None
+    assert trigger["name"] == "DB Test"
+    assert trigger["source_type"] == "github"
+    assert trigger["owner_user_id"] == 42
+    assert trigger["agent_config_json"] == '{"cwd": "/work"}'
+    assert trigger["prompt_template"] == "test: {payload}"
+    assert trigger["enabled"] == 1
+
+    # List
+    triggers = db.list_webhook_triggers(42)
+    assert len(triggers) == 1
+    assert triggers[0]["id"] == "t-1"
+
+    # List for different user
+    assert db.list_webhook_triggers(999) == []
+
+    # Update
+    ok = db.update_webhook_trigger("t-1", {"name": "Updated", "enabled": 0})
+    assert ok is True
+
+    updated = db.get_webhook_trigger("t-1")
+    assert updated["name"] == "Updated"
+    assert updated["enabled"] == 0
+
+    # Delete
+    ok = db.delete_webhook_trigger("t-1")
+    assert ok is True
+    assert db.get_webhook_trigger("t-1") is None
+
+    # Delete non-existent
+    assert db.delete_webhook_trigger("t-1") is False
+
+    db.close()
+
+
+def test_acp_sessions_db_schema_version(tmp_path):
+    """Verify the schema version is bumped to 10."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+    db_path = str(tmp_path / "test_version.db")
+    db = ACPSessionsDB(db_path=db_path)
+    conn = db._get_conn()
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    assert version == 10
+    db.close()

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
@@ -42,7 +42,7 @@ async def test_ws_broadcaster_delivers_events_full_verbosity():
         received.append(json.loads(msg))
 
     await broadcaster.start(bus)
-    broadcaster.add_connection("conn-1", fake_send, verbosity="full")
+    await broadcaster.add_connection("conn-1", fake_send, verbosity="full")
 
     for kind in (AgentEventKind.THINKING, AgentEventKind.TOOL_CALL, AgentEventKind.COMPLETION):
         await bus.publish(_make_event(kind))
@@ -68,7 +68,7 @@ async def test_ws_broadcaster_summary_filters_thinking():
         received.append(json.loads(msg))
 
     await broadcaster.start(bus)
-    broadcaster.add_connection("conn-1", fake_send, verbosity="summary")
+    await broadcaster.add_connection("conn-1", fake_send, verbosity="summary")
 
     await bus.publish(_make_event(AgentEventKind.THINKING))
     await bus.publish(_make_event(AgentEventKind.TOOL_CALL))
@@ -98,7 +98,7 @@ async def test_ws_broadcaster_remove_connection():
         received.append(json.loads(msg))
 
     await broadcaster.start(bus)
-    broadcaster.add_connection("conn-1", fake_send, verbosity="full")
+    await broadcaster.add_connection("conn-1", fake_send, verbosity="full")
 
     await bus.publish(_make_event(AgentEventKind.THINKING))
     await _wait_for(lambda: len(received) >= 1)
@@ -126,7 +126,7 @@ async def test_ws_broadcaster_change_verbosity():
         received.append(json.loads(msg))
 
     await broadcaster.start(bus)
-    broadcaster.add_connection("conn-1", fake_send, verbosity="summary")
+    await broadcaster.add_connection("conn-1", fake_send, verbosity="summary")
 
     # Thinking should be filtered at summary level
     await bus.publish(_make_event(AgentEventKind.THINKING))

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_reconnect.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_reconnect.py
@@ -1,0 +1,143 @@
+"""Tests for WebSocket reconnect with catch-up replay."""
+from __future__ import annotations
+
+import json
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import (
+    AgentEvent,
+    AgentEventKind,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import (
+    WSBroadcaster,
+)
+
+
+def _make_event(
+    kind: AgentEventKind,
+    session_id: str = "sess-1",
+    sequence: int = 0,
+) -> AgentEvent:
+    return AgentEvent(
+        session_id=session_id,
+        kind=kind,
+        payload={"data": kind.value},
+        sequence=sequence,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_connection_with_replay():
+    """Connecting with from_sequence > 0 replays buffered events."""
+    bus = SessionEventBus(session_id="sess-1")
+    broadcaster = WSBroadcaster()
+    await broadcaster.start(bus)
+
+    received: list[str] = []
+
+    async def fake_send(msg: str) -> None:
+        received.append(msg)
+
+    # Seed a few buffered events in the bus
+    ev1 = _make_event(AgentEventKind.THINKING, sequence=1)
+    ev2 = _make_event(AgentEventKind.TOOL_CALL, sequence=2)
+    ev3 = _make_event(AgentEventKind.COMPLETION, sequence=3)
+    for ev in (ev1, ev2, ev3):
+        bus._buffer.append(ev)
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster.replay_events",
+    ) as mock_replay:
+        mock_replay.return_value = 2  # pretend 2 events replayed
+
+        await broadcaster.add_connection(
+            "conn-1", fake_send, verbosity="full", from_sequence=5,
+        )
+
+        # replay_events should have been called with the bus, sequence, and an emit fn
+        mock_replay.assert_awaited_once()
+        call_args = mock_replay.call_args
+        assert call_args[0][0] is bus
+        assert call_args[0][1] == 5
+        # The third arg should be a callable (the _emit function)
+        assert callable(call_args[0][2])
+
+    # Connection should be registered
+    assert "conn-1" in broadcaster._connections
+    await broadcaster.stop()
+
+
+@pytest.mark.asyncio
+async def test_add_connection_without_replay():
+    """Connecting without from_sequence does no replay."""
+    bus = SessionEventBus(session_id="sess-1")
+    broadcaster = WSBroadcaster()
+    await broadcaster.start(bus)
+
+    async def fake_send(msg: str) -> None:
+        pass
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster.replay_events",
+    ) as mock_replay:
+        await broadcaster.add_connection("conn-2", fake_send, verbosity="full")
+
+        # replay_events should NOT have been called
+        mock_replay.assert_not_awaited()
+
+    assert "conn-2" in broadcaster._connections
+    await broadcaster.stop()
+
+
+@pytest.mark.asyncio
+async def test_add_connection_replay_without_bus():
+    """If the broadcaster has no bus, replay is skipped even with from_sequence."""
+    broadcaster = WSBroadcaster()
+    # Don't call start() -- _bus remains None
+
+    async def fake_send(msg: str) -> None:
+        pass
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster.replay_events",
+    ) as mock_replay:
+        await broadcaster.add_connection(
+            "conn-3", fake_send, verbosity="full", from_sequence=10,
+        )
+        mock_replay.assert_not_awaited()
+
+    assert "conn-3" in broadcaster._connections
+
+
+@pytest.mark.asyncio
+async def test_replay_emit_serializes_with_verbosity():
+    """The replay emit function should serialize events with verbosity filtering."""
+    bus = SessionEventBus(session_id="sess-1")
+    broadcaster = WSBroadcaster()
+    await broadcaster.start(bus)
+
+    received: list[str] = []
+
+    async def fake_send(msg: str) -> None:
+        received.append(msg)
+
+    # Seed events in the bus buffer
+    ev1 = _make_event(AgentEventKind.THINKING, sequence=1)
+    ev2 = _make_event(AgentEventKind.COMPLETION, sequence=2)
+    bus._buffer.append(ev1)
+    bus._buffer.append(ev2)
+
+    # Connect with summary verbosity -- thinking should be filtered out
+    await broadcaster.add_connection(
+        "conn-summary", fake_send, verbosity="summary", from_sequence=1,
+    )
+
+    # Only the COMPLETION event should have been sent (THINKING is filtered by summary)
+    assert len(received) == 1
+    parsed = json.loads(received[0])
+    assert parsed["kind"] == "completion"
+
+    await broadcaster.stop()

--- a/tldw_Server_API/tests/conftest.py
+++ b/tldw_Server_API/tests/conftest.py
@@ -3,6 +3,7 @@ Pytest configuration for the main test suite.
 
 Registers shared test plugins and provides common fixtures.
 """
+from __future__ import annotations
 
 pytest_plugins = ["tldw_Server_API.tests._plugins.http_client_patch_guard"]
 

--- a/tldw_Server_API/tests/sandbox/test_event_bridge.py
+++ b/tldw_Server_API/tests/sandbox/test_event_bridge.py
@@ -1,0 +1,231 @@
+"""Tests for SandboxEventBridge — translates RunStreamHub frames to AgentEvents."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Sandbox.event_bridge import SandboxEventBridge
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_hub_mock(frames: list[dict]) -> MagicMock:
+    """Create a mock RunStreamHub that yields *frames* then blocks forever."""
+    q: asyncio.Queue[dict] = asyncio.Queue()
+    for f in frames:
+        q.put_nowait(f)
+
+    hub = MagicMock()
+    hub.subscribe.return_value = q
+    hub.unsubscribe = MagicMock()
+    return hub
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stdout_frame_becomes_terminal_output():
+    """A stdout frame from RunStreamHub becomes a TERMINAL_OUTPUT AgentEvent."""
+    hub = _make_hub_mock([
+        {"type": "stdout", "encoding": "utf8", "data": "hello world", "seq": 1},
+    ])
+    bus = SessionEventBus(session_id="sess-1")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-1", session_id="sess-1")
+
+    await bridge.start()
+    # Give the consume loop time to process the single frame
+    await asyncio.sleep(0.15)
+    await bridge.stop()
+
+    events = bus.snapshot()
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind == AgentEventKind.TERMINAL_OUTPUT
+    assert ev.payload["stream"] == "stdout"
+    assert ev.payload["data"] == "hello world"
+    assert ev.session_id == "sess-1"
+    assert ev.metadata["run_id"] == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_stderr_frame_becomes_terminal_output():
+    """stderr also maps to TERMINAL_OUTPUT with stream='stderr'."""
+    hub = _make_hub_mock([
+        {"type": "stderr", "encoding": "utf8", "data": "oops", "seq": 2},
+    ])
+    bus = SessionEventBus(session_id="sess-2")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-2", session_id="sess-2")
+
+    await bridge.start()
+    await asyncio.sleep(0.15)
+    await bridge.stop()
+
+    events = bus.snapshot()
+    assert len(events) == 1
+    assert events[0].kind == AgentEventKind.TERMINAL_OUTPUT
+    assert events[0].payload["stream"] == "stderr"
+    assert events[0].payload["data"] == "oops"
+
+
+@pytest.mark.asyncio
+async def test_exit_event_frame_becomes_completion():
+    """An event frame with event='end' becomes COMPLETION."""
+    hub = _make_hub_mock([
+        {"type": "event", "event": "end", "data": {"exit_code": 0}, "seq": 3},
+    ])
+    bus = SessionEventBus(session_id="sess-3")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-3", session_id="sess-3")
+
+    await bridge.start()
+    await asyncio.sleep(0.15)
+    await bridge.stop()
+
+    events = bus.snapshot()
+    assert len(events) == 1
+    assert events[0].kind == AgentEventKind.COMPLETION
+    assert events[0].payload == {"exit_code": 0}
+
+
+@pytest.mark.asyncio
+async def test_truncated_frame_becomes_error():
+    """A truncated frame becomes an ERROR event."""
+    hub = _make_hub_mock([
+        {"type": "truncated", "reason": "log_cap", "seq": 4},
+    ])
+    bus = SessionEventBus(session_id="sess-4")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-4", session_id="sess-4")
+
+    await bridge.start()
+    await asyncio.sleep(0.15)
+    await bridge.stop()
+
+    events = bus.snapshot()
+    assert len(events) == 1
+    assert events[0].kind == AgentEventKind.ERROR
+    assert events[0].payload["error"] == "truncated"
+    assert events[0].payload["reason"] == "log_cap"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_frame_becomes_heartbeat():
+    """Heartbeat frames are forwarded as HEARTBEAT events."""
+    hub = _make_hub_mock([
+        {"type": "heartbeat"},
+    ])
+    bus = SessionEventBus(session_id="sess-5")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-5", session_id="sess-5")
+
+    await bridge.start()
+    await asyncio.sleep(0.15)
+    await bridge.stop()
+
+    events = bus.snapshot()
+    assert len(events) == 1
+    assert events[0].kind == AgentEventKind.HEARTBEAT
+
+
+@pytest.mark.asyncio
+async def test_generic_event_becomes_lifecycle():
+    """An event frame with a non-'end' event name becomes LIFECYCLE."""
+    hub = _make_hub_mock([
+        {"type": "event", "event": "start", "data": {"pid": 42}, "seq": 5},
+    ])
+    bus = SessionEventBus(session_id="sess-6")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-6", session_id="sess-6")
+
+    await bridge.start()
+    await asyncio.sleep(0.15)
+    await bridge.stop()
+
+    events = bus.snapshot()
+    assert len(events) == 1
+    assert events[0].kind == AgentEventKind.LIFECYCLE
+    assert events[0].payload["event"] == "start"
+    assert events[0].payload["pid"] == 42
+
+
+@pytest.mark.asyncio
+async def test_unknown_frame_type_is_skipped():
+    """Unknown frame types are logged and skipped — no event published."""
+    hub = _make_hub_mock([
+        {"type": "mystery", "data": "???", "seq": 99},
+    ])
+    bus = SessionEventBus(session_id="sess-7")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-7", session_id="sess-7")
+
+    await bridge.start()
+    await asyncio.sleep(0.15)
+    await bridge.stop()
+
+    events = bus.snapshot()
+    assert len(events) == 0
+
+
+@pytest.mark.asyncio
+async def test_bridge_stops_cleanly():
+    """Calling stop() unsubscribes from the hub and cancels the task."""
+    hub = _make_hub_mock([])
+    bus = SessionEventBus(session_id="sess-8")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-8", session_id="sess-8")
+
+    await bridge.start()
+    # The consume task should be running
+    assert bridge._task is not None
+    assert not bridge._task.done()
+
+    await bridge.stop()
+
+    # Task is cleaned up
+    assert bridge._task is None
+    # Hub.unsubscribe was called with the correct run_id and queue
+    hub.unsubscribe.assert_called_once()
+    call_args = hub.unsubscribe.call_args
+    assert call_args[0][0] == "run-8"
+
+
+@pytest.mark.asyncio
+async def test_multiple_frames_in_sequence():
+    """Multiple frames are processed in order and produce distinct events."""
+    hub = _make_hub_mock([
+        {"type": "stdout", "encoding": "utf8", "data": "line1", "seq": 1},
+        {"type": "stderr", "encoding": "utf8", "data": "err1", "seq": 2},
+        {"type": "event", "event": "end", "data": {}, "seq": 3},
+    ])
+    bus = SessionEventBus(session_id="sess-9")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-9", session_id="sess-9")
+
+    await bridge.start()
+    await asyncio.sleep(0.25)
+    await bridge.stop()
+
+    events = bus.snapshot()
+    assert len(events) == 3
+    assert events[0].kind == AgentEventKind.TERMINAL_OUTPUT
+    assert events[0].payload["stream"] == "stdout"
+    assert events[1].kind == AgentEventKind.TERMINAL_OUTPUT
+    assert events[1].payload["stream"] == "stderr"
+    assert events[2].kind == AgentEventKind.COMPLETION
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent():
+    """Calling start() twice does not create a second consume task."""
+    hub = _make_hub_mock([])
+    bus = SessionEventBus(session_id="sess-10")
+    bridge = SandboxEventBridge(hub=hub, bus=bus, run_id="run-10", session_id="sess-10")
+
+    await bridge.start()
+    first_task = bridge._task
+    await bridge.start()  # Should be a no-op
+    assert bridge._task is first_task
+    hub.subscribe.assert_called_once()
+
+    await bridge.stop()

--- a/tldw_Server_API/tests/sandbox/test_orchestrator_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_orchestrator_durability.py
@@ -1,0 +1,172 @@
+"""Tests for durable run queue in the sandbox store backends.
+
+Validates that enqueue_run / dequeue_run persist across store instances
+(for SQLite) and respect priority ordering.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.config import clear_config_cache, settings as app_settings
+from tldw_Server_API.app.core.Sandbox.store import InMemoryStore, SQLiteStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _configure_sqlite_store(monkeypatch, tmp_path: Path) -> str:
+    db_path = str(tmp_path / "sandbox_store.db")
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "sqlite")
+    monkeypatch.setenv("SANDBOX_STORE_DB_PATH", db_path)
+    if hasattr(app_settings, "SANDBOX_STORE_BACKEND"):
+        monkeypatch.setattr(app_settings, "SANDBOX_STORE_BACKEND", "sqlite")
+    if hasattr(app_settings, "SANDBOX_STORE_DB_PATH"):
+        monkeypatch.setattr(app_settings, "SANDBOX_STORE_DB_PATH", db_path)
+    clear_config_cache()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# InMemoryStore tests
+# ---------------------------------------------------------------------------
+
+class TestInMemoryStoreQueue:
+    def test_enqueue_and_dequeue_returns_entry(self):
+        store = InMemoryStore()
+        store.enqueue_run("run-1", "user-a", priority=0)
+        result = store.dequeue_run("worker-1")
+        assert result is not None
+        assert result["run_id"] == "run-1"
+        assert result["user_id"] == "user-a"
+
+    def test_dequeue_returns_highest_priority_first(self):
+        store = InMemoryStore()
+        store.enqueue_run("run-low", "user-a", priority=0)
+        store.enqueue_run("run-high", "user-a", priority=10)
+        store.enqueue_run("run-mid", "user-a", priority=5)
+
+        first = store.dequeue_run("worker-1")
+        assert first is not None
+        assert first["run_id"] == "run-high"
+
+        second = store.dequeue_run("worker-1")
+        assert second is not None
+        assert second["run_id"] == "run-mid"
+
+        third = store.dequeue_run("worker-1")
+        assert third is not None
+        assert third["run_id"] == "run-low"
+
+    def test_dequeue_returns_none_when_empty(self):
+        store = InMemoryStore()
+        result = store.dequeue_run("worker-1")
+        assert result is None
+
+    def test_dequeue_fifo_within_same_priority(self):
+        store = InMemoryStore()
+        store.enqueue_run("run-a", "user-a", priority=5)
+        # Tiny sleep so enqueued_at is distinct
+        time.sleep(0.001)
+        store.enqueue_run("run-b", "user-a", priority=5)
+
+        first = store.dequeue_run("worker-1")
+        assert first is not None
+        assert first["run_id"] == "run-a"
+
+    def test_remove_from_queue(self):
+        store = InMemoryStore()
+        store.enqueue_run("run-1", "user-a", priority=0)
+        store.enqueue_run("run-2", "user-a", priority=0)
+        removed = store.remove_from_queue("run-1")
+        assert removed is True
+        result = store.dequeue_run("worker-1")
+        assert result is not None
+        assert result["run_id"] == "run-2"
+
+    def test_remove_nonexistent_returns_false(self):
+        store = InMemoryStore()
+        assert store.remove_from_queue("ghost") is False
+
+
+# ---------------------------------------------------------------------------
+# SQLiteStore tests
+# ---------------------------------------------------------------------------
+
+class TestSQLiteStoreQueue:
+    def test_enqueue_and_dequeue_returns_entry(self, monkeypatch, tmp_path):
+        db_path = _configure_sqlite_store(monkeypatch, tmp_path)
+        store = SQLiteStore(db_path=db_path)
+        store.enqueue_run("run-1", "user-a", priority=0)
+        result = store.dequeue_run("worker-1")
+        assert result is not None
+        assert result["run_id"] == "run-1"
+        assert result["user_id"] == "user-a"
+
+    def test_dequeue_returns_highest_priority_first(self, monkeypatch, tmp_path):
+        db_path = _configure_sqlite_store(monkeypatch, tmp_path)
+        store = SQLiteStore(db_path=db_path)
+        store.enqueue_run("run-low", "user-a", priority=0)
+        store.enqueue_run("run-high", "user-a", priority=10)
+        store.enqueue_run("run-mid", "user-a", priority=5)
+
+        first = store.dequeue_run("worker-1")
+        assert first is not None
+        assert first["run_id"] == "run-high"
+
+        second = store.dequeue_run("worker-1")
+        assert second is not None
+        assert second["run_id"] == "run-mid"
+
+        third = store.dequeue_run("worker-1")
+        assert third is not None
+        assert third["run_id"] == "run-low"
+
+    def test_dequeue_returns_none_when_empty(self, monkeypatch, tmp_path):
+        db_path = _configure_sqlite_store(monkeypatch, tmp_path)
+        store = SQLiteStore(db_path=db_path)
+        result = store.dequeue_run("worker-1")
+        assert result is None
+
+    def test_enqueued_runs_survive_store_recreation(self, monkeypatch, tmp_path):
+        """The key durability test: enqueued runs persist across SQLiteStore instances."""
+        db_path = _configure_sqlite_store(monkeypatch, tmp_path)
+
+        store1 = SQLiteStore(db_path=db_path)
+        store1.enqueue_run("run-durable", "user-x", priority=5)
+
+        # Create a brand new store instance pointing at the same DB file
+        store2 = SQLiteStore(db_path=db_path)
+        result = store2.dequeue_run("worker-2")
+        assert result is not None
+        assert result["run_id"] == "run-durable"
+        assert result["user_id"] == "user-x"
+
+    def test_remove_from_queue(self, monkeypatch, tmp_path):
+        db_path = _configure_sqlite_store(monkeypatch, tmp_path)
+        store = SQLiteStore(db_path=db_path)
+        store.enqueue_run("run-1", "user-a", priority=0)
+        store.enqueue_run("run-2", "user-a", priority=0)
+        removed = store.remove_from_queue("run-1")
+        assert removed is True
+        result = store.dequeue_run("worker-1")
+        assert result is not None
+        assert result["run_id"] == "run-2"
+
+    def test_remove_nonexistent_returns_false(self, monkeypatch, tmp_path):
+        db_path = _configure_sqlite_store(monkeypatch, tmp_path)
+        store = SQLiteStore(db_path=db_path)
+        assert store.remove_from_queue("ghost") is False
+
+    def test_dequeue_fifo_within_same_priority(self, monkeypatch, tmp_path):
+        db_path = _configure_sqlite_store(monkeypatch, tmp_path)
+        store = SQLiteStore(db_path=db_path)
+        store.enqueue_run("run-a", "user-a", priority=5)
+        store.enqueue_run("run-b", "user-a", priority=5)
+
+        first = store.dequeue_run("worker-1")
+        assert first is not None
+        assert first["run_id"] == "run-a"

--- a/tldw_Server_API/tests/sandbox/test_warm_pool.py
+++ b/tldw_Server_API/tests/sandbox/test_warm_pool.py
@@ -1,0 +1,251 @@
+"""Tests for DockerWarmPool -- no real Docker required (subprocess mocked)."""
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.pool import DockerWarmPool, get_warm_pool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pool(pool_size: int = 2, images: list[str] | None = None) -> DockerWarmPool:
+    """Create a pool without starting the background thread."""
+    pool = DockerWarmPool(
+        pool_size=pool_size,
+        images=images or ["python:3.12-slim"],
+        replenish_interval=999,  # effectively disable auto-replenish
+    )
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestClaimReturnsContainerFromPool:
+    """Pre-populate pool, claim succeeds."""
+
+    def test_claim_returns_container_from_pool(self) -> None:
+        pool = _make_pool()
+        image = "python:3.12-slim"
+        # Manually seed the pool
+        pool._pool[image] = ["abc123", "def456"]
+
+        cid = pool.claim(image)
+
+        assert cid == "abc123"
+        # Pool should have one container left
+        assert pool._pool[image] == ["def456"]
+
+
+class TestClaimEmptyPoolReturnsNone:
+    """Empty pool returns None."""
+
+    def test_claim_empty_pool_returns_none(self) -> None:
+        pool = _make_pool()
+
+        cid = pool.claim("python:3.12-slim")
+
+        assert cid is None
+
+
+class TestReleaseTaintedDestroys:
+    """Tainted release calls docker rm -f."""
+
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_call")
+    def test_release_tainted_destroys(self, mock_check_call: mock.MagicMock) -> None:
+        pool = _make_pool()
+
+        pool.release("container_xyz", tainted=True)
+
+        mock_check_call.assert_called_once()
+        args = mock_check_call.call_args
+        cmd = args[0][0]
+        assert cmd == ["docker", "rm", "-f", "container_xyz"]
+
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_call")
+    def test_release_untainted_also_destroys(self, mock_check_call: mock.MagicMock) -> None:
+        """Containers are single-use after exec, so untainted also destroys."""
+        pool = _make_pool()
+
+        pool.release("container_xyz", tainted=False)
+
+        mock_check_call.assert_called_once()
+        args = mock_check_call.call_args
+        cmd = args[0][0]
+        assert cmd == ["docker", "rm", "-f", "container_xyz"]
+
+
+class TestReplenishCreatesContainers:
+    """Replenish fills pool to target size."""
+
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_call")
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_output")
+    def test_replenish_creates_containers(
+        self,
+        mock_check_output: mock.MagicMock,
+        mock_check_call: mock.MagicMock,
+    ) -> None:
+        pool = _make_pool(pool_size=3)
+        pool._running = True  # simulate started state
+        image = "python:3.12-slim"
+
+        # Each docker create returns a unique container id
+        mock_check_output.side_effect = ["cid_1\n", "cid_2\n", "cid_3\n"]
+
+        pool._replenish_image(image)
+
+        # Should have created 3 containers
+        assert mock_check_output.call_count == 3
+        # And started each one
+        assert mock_check_call.call_count == 3
+        # Pool should now have 3 containers
+        assert pool._pool[image] == ["cid_1", "cid_2", "cid_3"]
+
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_call")
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_output")
+    def test_replenish_tops_up_partial_pool(
+        self,
+        mock_check_output: mock.MagicMock,
+        mock_check_call: mock.MagicMock,
+    ) -> None:
+        pool = _make_pool(pool_size=3)
+        pool._running = True
+        image = "python:3.12-slim"
+        pool._pool[image] = ["existing_1"]
+
+        mock_check_output.side_effect = ["cid_new_1\n", "cid_new_2\n"]
+
+        pool._replenish_image(image)
+
+        assert mock_check_output.call_count == 2
+        assert pool._pool[image] == ["existing_1", "cid_new_1", "cid_new_2"]
+
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_call")
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_output")
+    def test_replenish_stops_on_error(
+        self,
+        mock_check_output: mock.MagicMock,
+        mock_check_call: mock.MagicMock,
+    ) -> None:
+        pool = _make_pool(pool_size=3)
+        pool._running = True
+        image = "python:3.12-slim"
+
+        mock_check_output.side_effect = [
+            "cid_1\n",
+            RuntimeError("docker daemon not running"),
+        ]
+
+        pool._replenish_image(image)
+
+        # Only one container should have been created
+        assert pool._pool[image] == ["cid_1"]
+
+
+class TestPoolStatusReportsCounts:
+    """pool_status returns correct counts."""
+
+    def test_pool_status_reports_counts(self) -> None:
+        pool = _make_pool(images=["img_a", "img_b"])
+        pool._pool["img_a"] = ["c1", "c2", "c3"]
+        pool._pool["img_b"] = ["c4"]
+
+        status = pool.pool_status()
+
+        assert status == {"img_a": 3, "img_b": 1}
+
+    def test_pool_status_empty(self) -> None:
+        pool = _make_pool()
+
+        status = pool.pool_status()
+
+        assert status == {}
+
+
+class TestShutdownDestroysAll:
+    """shutdown cleans up all containers."""
+
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_call")
+    def test_shutdown_destroys_all(self, mock_check_call: mock.MagicMock) -> None:
+        pool = _make_pool()
+        pool._pool["img_a"] = ["c1", "c2"]
+        pool._pool["img_b"] = ["c3"]
+
+        pool.shutdown()
+
+        # Should have called docker rm -f for each container
+        assert mock_check_call.call_count == 3
+        destroyed_ids = [
+            call[0][0][-1]  # last element of the cmd list
+            for call in mock_check_call.call_args_list
+        ]
+        assert set(destroyed_ids) == {"c1", "c2", "c3"}
+        # Pool should be empty
+        assert pool._pool["img_a"] == []
+        assert pool._pool["img_b"] == []
+
+
+class TestCreateIdleContainerUsesSleepInfinity:
+    """Verify docker create args include sleep infinity."""
+
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_call")
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_output")
+    def test_create_idle_container_uses_sleep_infinity(
+        self,
+        mock_check_output: mock.MagicMock,
+        mock_check_call: mock.MagicMock,
+    ) -> None:
+        pool = _make_pool()
+        mock_check_output.return_value = "new_cid_123\n"
+
+        cid = pool._create_idle_container("python:3.12-slim")
+
+        assert cid == "new_cid_123"
+
+        # Verify the docker create command
+        create_cmd = mock_check_output.call_args[0][0]
+        assert create_cmd == [
+            "docker",
+            "create",
+            "--entrypoint",
+            "/bin/sh",
+            "python:3.12-slim",
+            "-c",
+            "sleep infinity",
+        ]
+
+        # Verify docker start was called
+        start_cmd = mock_check_call.call_args[0][0]
+        assert start_cmd == ["docker", "start", "new_cid_123"]
+
+
+class TestGetWarmPoolSingleton:
+    """get_warm_pool returns a singleton."""
+
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_call")
+    @mock.patch("tldw_Server_API.app.core.Sandbox.pool.subprocess.check_output")
+    def test_get_warm_pool_returns_singleton(
+        self,
+        mock_check_output: mock.MagicMock,
+        mock_check_call: mock.MagicMock,
+    ) -> None:
+        import tldw_Server_API.app.core.Sandbox.pool as pool_mod
+
+        # Reset module-level singleton
+        pool_mod._warm_pool = None
+
+        try:
+            p1 = pool_mod.get_warm_pool()
+            p2 = pool_mod.get_warm_pool()
+            assert p1 is p2
+            assert p1._running is True
+        finally:
+            p1.shutdown()
+            pool_mod._warm_pool = None

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -1,0 +1,306 @@
+"""Tests for the git worktree sandbox runner."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
+from tldw_Server_API.app.core.Sandbox.runners.worktree_runner import (
+    WorktreeRunner,
+    _SENSITIVE_ENV_VARS,
+    _check_git_version,
+    _check_unshare_available,
+    worktree_available,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def test_repo(tmp_path: Path) -> str:
+    """Create a temporary git repository with one commit."""
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    subprocess.check_call(
+        ["git", "init"],
+        cwd=str(repo),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.check_call(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=str(repo),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return str(repo)
+
+
+@pytest.fixture
+def runner(tmp_path: Path) -> WorktreeRunner:
+    """WorktreeRunner whose allowlist includes tmp_path."""
+    return WorktreeRunner(allowed_repo_dirs=[str(tmp_path)])
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_validate_repo_path_allowed(test_repo: str, runner: WorktreeRunner) -> None:
+    """Repo under an allowed dir passes validation."""
+    runner._validate_repo_path(test_repo)  # should not raise
+
+
+def test_validate_repo_path_rejected() -> None:
+    """Repo outside allowed dirs raises ValueError."""
+    r = WorktreeRunner(allowed_repo_dirs=["/some/allowed/dir"])
+    with pytest.raises(ValueError, match="not under any allowed directory"):
+        r._validate_repo_path("/completely/different/path")
+
+
+def test_validate_repo_path_exact_match(tmp_path: Path) -> None:
+    """Exact match on allowed dir should pass."""
+    r = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)])
+    r._validate_repo_path(str(tmp_path))  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Worktree lifecycle
+# ---------------------------------------------------------------------------
+
+def test_create_session_creates_worktree(test_repo: str) -> None:
+    """create_worktree creates a detached worktree directory."""
+    wt = WorktreeRunner.create_worktree(test_repo, branch="HEAD")
+    try:
+        assert os.path.isdir(wt)
+        # The worktree should have a .git file (not a directory)
+        git_path = os.path.join(wt, ".git")
+        assert os.path.exists(git_path)
+    finally:
+        WorktreeRunner.destroy_worktree(wt, test_repo)
+
+
+def test_destroy_session_removes_worktree(test_repo: str) -> None:
+    """destroy_worktree removes the worktree and cleans up."""
+    wt = WorktreeRunner.create_worktree(test_repo, branch="HEAD")
+    assert os.path.isdir(wt)
+    WorktreeRunner.destroy_worktree(wt, test_repo)
+    assert not os.path.isdir(wt)
+
+
+def test_create_session_invalid_repo(tmp_path: Path) -> None:
+    """Non-git directory raises RuntimeError."""
+    non_git = tmp_path / "not_a_repo"
+    non_git.mkdir()
+    with pytest.raises(RuntimeError, match="Failed to create worktree"):
+        WorktreeRunner.create_worktree(str(non_git), branch="HEAD")
+
+
+# ---------------------------------------------------------------------------
+# Environment sanitisation
+# ---------------------------------------------------------------------------
+
+def test_safe_env_strips_sensitive_vars() -> None:
+    """Sensitive env vars are stripped from child processes."""
+    fake_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/home/user",
+        "ANTHROPIC_API_KEY": "secret",
+        "AWS_ACCESS_KEY_ID": "AKIA...",
+        "HARMLESS_VAR": "hello",
+    }
+    with mock.patch.dict(os.environ, fake_env, clear=True):
+        env = WorktreeRunner._safe_env()
+        assert "PATH" in env
+        assert "HARMLESS_VAR" in env
+        for sensitive in ("HOME", "ANTHROPIC_API_KEY", "AWS_ACCESS_KEY_ID"):
+            assert sensitive not in env
+
+
+def test_safe_env_strips_from_extra_too() -> None:
+    """Sensitive vars passed via extra_env are also stripped."""
+    with mock.patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
+        env = WorktreeRunner._safe_env(
+            extra_env={"OPENAI_API_KEY": "sk-...", "MY_VAR": "ok"},
+        )
+        assert "OPENAI_API_KEY" not in env
+        assert env["MY_VAR"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Worktree isolation
+# ---------------------------------------------------------------------------
+
+def test_worktree_isolation(test_repo: str) -> None:
+    """Files created in the worktree do not appear in the main repo."""
+    wt = WorktreeRunner.create_worktree(test_repo, branch="HEAD")
+    try:
+        sentinel = os.path.join(wt, "worktree_only.txt")
+        Path(sentinel).write_text("test")
+        assert os.path.isfile(sentinel)
+        assert not os.path.isfile(os.path.join(test_repo, "worktree_only.txt"))
+    finally:
+        WorktreeRunner.destroy_worktree(wt, test_repo)
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+def test_preflight_available_on_macos_with_git(tmp_path: Path) -> None:
+    """On macOS with git >= 2.15, preflight reports available."""
+    r = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)])
+    with mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner.worktree_available",
+        return_value=True,
+    ), mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner.sys",
+    ) as mock_sys:
+        mock_sys.platform = "darwin"
+        result = r.preflight()
+        assert result.available is True
+        assert result.runtime == RuntimeType.worktree
+
+
+def test_preflight_unavailable_when_git_missing(tmp_path: Path) -> None:
+    """Without git, preflight reports unavailable."""
+    r = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)])
+    with mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner.worktree_available",
+        return_value=False,
+    ):
+        result = r.preflight()
+        assert result.available is False
+        assert "git_too_old_or_missing" in result.reasons
+
+
+def test_preflight_linux_without_unshare(tmp_path: Path) -> None:
+    """On Linux without unshare, preflight reports unavailable."""
+    r = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)])
+    with mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner.worktree_available",
+        return_value=True,
+    ), mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner.sys",
+    ) as mock_sys, mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner._check_unshare_available",
+        return_value=False,
+    ):
+        mock_sys.platform = "linux"
+        result = r.preflight()
+        assert result.available is False
+        assert "unshare_required_on_linux" in result.reasons
+
+
+# ---------------------------------------------------------------------------
+# start_run (synchronous, macOS only since that's direct execution)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only direct execution")
+def test_run_executes_in_worktree(test_repo: str, runner: WorktreeRunner) -> None:
+    """Commands execute in the worktree directory and produce output."""
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.worktree,
+        base_image=None,
+        command=["echo", "hello from worktree"],
+        timeout_sec=10,
+    )
+    with mock.patch.dict(os.environ, {"TLDW_SANDBOX_WORKTREE_ALLOWED_DIRS": ""}, clear=False):
+        r = WorktreeRunner(allowed_repo_dirs=[str(Path(test_repo).parent)])
+        result = r.start_run("test-run-001", spec, session_workspace=test_repo)
+    assert result.phase == RunPhase.completed
+    assert result.exit_code == 0
+    assert result.runtime == RuntimeType.worktree
+    assert result.message == "worktree execution finished"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only direct execution")
+def test_run_captures_exit_code(test_repo: str) -> None:
+    """Non-zero exit code is captured correctly."""
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.worktree,
+        base_image=None,
+        command=["sh", "-c", "exit 42"],
+        timeout_sec=10,
+    )
+    r = WorktreeRunner(allowed_repo_dirs=[str(Path(test_repo).parent)])
+    result = r.start_run("test-run-002", spec, session_workspace=test_repo)
+    assert result.phase == RunPhase.failed
+    assert result.exit_code == 42
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only direct execution")
+def test_run_without_session_workspace() -> None:
+    """Runner can execute even without a session workspace (creates throwaway repo)."""
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.worktree,
+        base_image=None,
+        command=["echo", "standalone"],
+        timeout_sec=10,
+    )
+    # Allow the temp directory so throwaway repos pass validation
+    r = WorktreeRunner(allowed_repo_dirs=["/tmp", "/private/tmp", "/var/folders"])
+    result = r.start_run("test-run-003", spec, session_workspace=None)
+    assert result.phase == RunPhase.completed
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Linux unshare refusal
+# ---------------------------------------------------------------------------
+
+def test_build_command_refuses_linux_without_unshare() -> None:
+    """On Linux without unshare, _build_command raises RuntimeError."""
+    r = WorktreeRunner()
+    with mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner.sys",
+    ) as mock_sys, mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner._check_unshare_available",
+        return_value=False,
+    ):
+        mock_sys.platform = "linux"
+        with pytest.raises(RuntimeError, match="unshare is required"):
+            r._build_command(["echo", "test"], "/tmp/wt")
+
+
+def test_build_command_wraps_with_unshare_on_linux() -> None:
+    """On Linux with unshare, command is wrapped."""
+    r = WorktreeRunner()
+    with mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner.sys",
+    ) as mock_sys, mock.patch(
+        "tldw_Server_API.app.core.Sandbox.runners.worktree_runner._check_unshare_available",
+        return_value=True,
+    ):
+        mock_sys.platform = "linux"
+        result = r._build_command(["echo", "test"], "/tmp/wt")
+        assert result[:4] == ["unshare", "--mount", "--pid", "--fork"]
+        assert result[-2:] == ["echo", "test"]
+
+
+# ---------------------------------------------------------------------------
+# Cancel
+# ---------------------------------------------------------------------------
+
+def test_cancel_run_returns_false_when_no_proc() -> None:
+    """cancel_run returns False when no process is tracked."""
+    assert WorktreeRunner.cancel_run("nonexistent-run") is False
+
+
+# ---------------------------------------------------------------------------
+# RuntimeType enum
+# ---------------------------------------------------------------------------
+
+def test_runtime_type_worktree_exists() -> None:
+    """RuntimeType.worktree is defined."""
+    assert RuntimeType.worktree.value == "worktree"


### PR DESCRIPTION
## Summary

17 improvements to the Sandbox and ACP modules, inspired by competitive analysis of ClaudeCodeUI, Codexia, and 1code.dev. Mix of production hardening and new capabilities across 4 areas.

- **Sandbox Runtimes:** Git worktree runner (no Docker needed), orchestrator run queue durability, Docker warm container pool
- **Streaming:** SSE consumer + endpoint, WebSocket reconnect with catch-up, event sink unification (RunStreamHub → SessionEventBus)
- **Automation:** `acp_run` scheduler handler, async fire-and-forget API, ACP schedule CRUD, run history + cost tracking, webhook trigger system (GitHub/Slack/generic HMAC)
- **Permissions:** GovernanceFilter → MCPHub unification (single authority), bash prefix matching (`Bash(git:*)` → auto), permission persistence ("remember" pattern), policy templates, MCP tool @mentions, checkpoint-based rollback

Design doc: `docs/plans/2026-04-05-sandbox-acp-competitive-improvements-design.md`

## Key architectural decisions

- **Permission unification:** GovernanceFilter now checks MCPHub snapshot → persisted decisions → admin policies → heuristics (in that order). MCPHub is the single authority.
- **Shared replay abstraction:** SSE and WebSocket both use `replay_utils.replay_events()` backed by `SessionEventBus.snapshot(from_sequence)`.
- **Schema migrations:** ACP_Sessions_DB v7→v10 (3 additive, idempotent migrations).
- **Worktree runner security:** Repo path allowlist, env var sanitization, Linux requires `unshare` (refuses unconfined).
- **Webhook security:** Multi-provider HMAC, encrypted secrets at rest, rate limiting, replay prevention, timing-safe comparison.

## Stats

- 57 files changed, ~9,874 lines added
- ~238 new tests, 0 regressions
- 18 new files (runners, consumers, handlers, endpoints, services)

## Test plan

- [ ] `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/ -x -q` — ACP test suite
- [ ] `python -m pytest tldw_Server_API/tests/sandbox/ -x -q` — Sandbox test suite
- [ ] Server starts cleanly: `python -m uvicorn tldw_Server_API.app.main:app`
- [ ] SSE endpoint streams typed events with sequence numbers
- [ ] WebSocket reconnect replays missed events
- [ ] Scheduled ACP run fires on cron trigger
- [ ] Webhook trigger with HMAC enqueues `acp_run`
- [ ] Permission "remember" persists and auto-applies
- [ ] Git worktree runner creates/destroys isolated worktrees
- [ ] Rollback restores sandbox state to checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)