### PR TITLE
fix: remediate embeddings correctness regressions

### DIFF
--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -27,7 +27,7 @@ from datetime import datetime
 from enum import Enum
 from fnmatch import fnmatch
 from functools import lru_cache
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 from typing import Any
 
 import numpy as np
@@ -1218,6 +1218,24 @@ def get_cache_key(
     return hashlib.sha256(key_string.encode()).hexdigest()
 
 
+_SENSITIVE_QUERY_KEYS = frozenset({
+    "access_token", "api_key", "apikey", "auth", "bearer",
+    "credential", "key", "passwd", "password", "secret", "token",
+})
+
+
+def _sanitize_query(query: str) -> str:
+    """Remove known sensitive query params, keep the rest sorted for determinism."""
+    params = parse_qs(query, keep_blank_values=True)
+    filtered = {
+        k: v for k, v in params.items()
+        if k.lower() not in _SENSITIVE_QUERY_KEYS
+    }
+    if not filtered:
+        return ""
+    return urlencode(sorted(filtered.items()), doseq=True)
+
+
 def _normalize_cache_backend_identity(config: dict[str, Any], provider: str) -> str | None:
     """Derive stable backend identity for cache partitioning."""
     if provider != "local_api":
@@ -1232,7 +1250,8 @@ def _normalize_cache_backend_identity(config: dict[str, Any], provider: str) -> 
         host = parsed.hostname
         if parsed.port is not None:
             host = f"{host}:{parsed.port}"
-        return urlunsplit((parsed.scheme, host, parsed.path.rstrip("/"), "", ""))
+        sanitized_query = _sanitize_query(parsed.query)
+        return urlunsplit((parsed.scheme, host, parsed.path.rstrip("/"), sanitized_query, ""))
     return api_url.rstrip("/")
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from enum import Enum
 from fnmatch import fnmatch
 from functools import lru_cache
+from urllib.parse import urlsplit, urlunsplit
 from typing import Any
 
 import numpy as np
@@ -1200,13 +1201,39 @@ def count_tokens(text: str, model_name: str) -> int:
         logger.warning(f"Token counting failed: {e}, estimating")
         return len(text) // 4
 
-def get_cache_key(text: str, provider: str, model: str, dimensions: int | None = None) -> str:
+def get_cache_key(
+    text: str,
+    provider: str,
+    model: str,
+    dimensions: int | None = None,
+    backend_identity: str | None = None,
+) -> str:
     """Generate cache key for embedding"""
     key_parts = [text, provider, model]
     if dimensions:
         key_parts.append(str(dimensions))
+    if backend_identity:
+        key_parts.append(backend_identity)
     key_string = "|".join(key_parts)
     return hashlib.sha256(key_string.encode()).hexdigest()
+
+
+def _normalize_cache_backend_identity(config: dict[str, Any], provider: str) -> str | None:
+    """Derive stable backend identity for cache partitioning."""
+    if provider != "local_api":
+        return None
+
+    api_url = str(config.get("api_url") or "").strip()
+    if not api_url:
+        return None
+
+    parsed = urlsplit(api_url)
+    if parsed.scheme and parsed.hostname:
+        host = parsed.hostname
+        if parsed.port is not None:
+            host = f"{host}:{parsed.port}"
+        return urlunsplit((parsed.scheme, host, parsed.path.rstrip("/"), "", ""))
+    return api_url.rstrip("/")
 
 
 # ---------------------------------------------------------------------------
@@ -1291,9 +1318,7 @@ def tokens_to_texts(
                 len(arr),
                 exc,
             )
-            # Fall back to an empty string to preserve request shape; the raw
-            # token counts are still used for limits/usage accounting.
-            texts.append("")
+            raise ValueError("Invalid token array input") from exc
         return texts, total_tokens, token_counts
 
     # Batch of token arrays
@@ -1313,7 +1338,7 @@ def tokens_to_texts(
                     len(arr),
                     exc,
                 )
-                texts.append("")
+                raise ValueError("Invalid token array input") from exc
         return texts, total_tokens, token_counts
 
     raise ValueError("Invalid token array input")
@@ -2004,9 +2029,40 @@ async def create_embeddings_batch_async(
     uncached_texts = []
     uncached_indices = []
 
+    try:
+        provider_enum = EmbeddingProvider(provider)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown provider: {provider}"
+        ) from None
+
+    try:
+        _validate_dimensions_request(provider, model_id or "", dimensions)
+        config = build_provider_config(
+            provider_enum,
+            model_id,
+            api_key,
+            api_url,
+            dimensions,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    backend_identity = _normalize_cache_backend_identity(config, provider)
+
     # Check cache
     for i, text in enumerate(texts):
-        cache_key = get_cache_key(text, provider, model_id or "default", dimensions)
+        cache_key = get_cache_key(
+            text,
+            provider,
+            model_id or "default",
+            dimensions,
+            backend_identity=backend_identity,
+        )
         cached = await embedding_cache.get(cache_key)
 
         if cached:
@@ -2020,29 +2076,6 @@ async def create_embeddings_batch_async(
 
     # Process uncached texts
     if uncached_texts:
-        try:
-            provider_enum = EmbeddingProvider(provider)
-        except ValueError:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Unknown provider: {provider}"
-            ) from None
-
-        try:
-            _validate_dimensions_request(provider, model_id or "", dimensions)
-            config = build_provider_config(
-                provider_enum,
-                model_id,
-                api_key,
-                api_url,
-                dimensions
-            )
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(exc),
-            ) from exc
-
         # Process in batches with circuit breaker (or synthesize in test mode for OpenAI)
         all_new_embeddings = []
         if (
@@ -2121,7 +2154,13 @@ async def create_embeddings_batch_async(
             embedding = all_new_embeddings[i]
             embeddings[idx] = embedding
 
-            cache_key = get_cache_key(text, provider, model_id or "default", dimensions)
+            cache_key = get_cache_key(
+                text,
+                provider,
+                model_id or "default",
+                dimensions,
+                backend_identity=backend_identity,
+            )
             await embedding_cache.set(cache_key, embedding)
 
     return embeddings

--- a/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
@@ -797,10 +797,9 @@ async def generate_embeddings_batch(
     for media_id in media_ids:
         media_item = get_media_by_id(db, media_id)
         if not media_item:
-            raise HTTPException(
-                status_code=http_status.HTTP_404_NOT_FOUND,
-                detail=f"Media item {media_id} not found"
-            )
+            failed_media_ids.append(int(media_id))
+            failure_reasons.append(f"media_id={media_id}: not found")
+            continue
         job_id: Optional[str] = None
         try:
             job_row = adapter.create_job(

--- a/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
@@ -447,7 +447,7 @@ async def generate_embeddings_for_media(
             *,
             model_name: str,
             provider_name: str,
-            embeddings_to_store,
+            embeddings_to_store: list[Any],
         ) -> None:
             collection_name = f"user_{user_id}_media_embeddings"
 

--- a/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
@@ -8,7 +8,7 @@
 
 import json
 import os
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import status as http_status
@@ -196,9 +196,11 @@ class BatchMediaEmbeddingsRequest(BaseModel):
 
 
 class BatchMediaEmbeddingsResponse(BaseModel):
-    status: str
+    status: Literal["accepted", "partial"]
     job_ids: list[str]
     submitted: int
+    failed_media_ids: list[int] = Field(default_factory=list)
+    failure_reasons: list[str] = Field(default_factory=list)
 
 
 class EmbeddingsSearchRequest(BaseModel):
@@ -431,28 +433,24 @@ async def generate_embeddings_for_media(
                     return "Embedding service returned invalid embedding vectors"
             return None
 
-        # Generate embeddings
-        try:
-            embeddings = await create_embeddings_batch_async(
-                texts=chunk_texts,
-                provider=embedding_provider,
-                model_id=embedding_model,
-                metadata=request_metadata,
-            )
-            validation_error = _validate_embeddings_result(embeddings, len(chunk_texts))
-            if validation_error:
-                return {
-                    "status": "error",
-                    "message": validation_error,
-                    "error": validation_error,
-                    "embedding_count": len(embeddings) if embeddings else 0,
-                    "chunks_processed": len(chunks),
-                }
+        def _storage_failure_result(exc: Exception, embedding_count: int) -> dict[str, Any]:
+            message = f"Storage failure while saving embeddings to ChromaDB: {exc}"
+            return {
+                "status": "error",
+                "message": message,
+                "error": message,
+                "embedding_count": embedding_count,
+                "chunks_processed": len(chunks),
+            }
 
-            # Store in ChromaDB using per-user collections
+        def _store_embeddings(
+            *,
+            model_name: str,
+            provider_name: str,
+            embeddings_to_store,
+        ) -> None:
             collection_name = f"user_{user_id}_media_embeddings"
 
-            # Prepare metadata for each chunk
             extra_metadata = {}
             try:
                 media_item_meta = media_content.get("media_item", {})
@@ -460,6 +458,7 @@ async def generate_embeddings_for_media(
                     extra_metadata = media_item_meta.get("metadata") or {}
             except _MEDIA_EMBEDDINGS_NONCRITICAL_EXCEPTIONS:
                 extra_metadata = {}
+
             metadatas = []
             for _i, chunk in enumerate(chunks):
                 metadata = {
@@ -470,25 +469,29 @@ async def generate_embeddings_for_media(
                     "chunk_type": _chunk_type_for_metadata(chunk),
                     "title": media_content["media_item"].get("title", ""),
                     "author": media_content["media_item"].get("author", ""),
-                    "embedding_model": embedding_model,
-                    "embedding_provider": embedding_provider
+                    "embedding_model": model_name,
+                    "embedding_provider": provider_name,
                 }
                 if isinstance(extra_metadata, dict) and extra_metadata:
                     metadata["extra"] = dict(extra_metadata)
                 metadatas.append(metadata)
 
-            # Store embeddings
             ids = [f"media_{media_id}_chunk_{i}" for i in range(len(chunks))]
 
-            # Convert embeddings to list format if they're numpy arrays
-            logger.info(f"Embeddings type: {type(embeddings)}, first item type: {type(embeddings[0]) if embeddings else 'None'}")
-            if embeddings and hasattr(embeddings[0], 'tolist'):
-                embeddings_list = [emb.tolist() for emb in embeddings]
+            logger.info(
+                f"Embeddings type: {type(embeddings_to_store)}, first item type: {type(embeddings_to_store[0]) if embeddings_to_store else 'None'}"
+            )
+            if embeddings_to_store and hasattr(embeddings_to_store[0], "tolist"):
+                embeddings_list = [emb.tolist() for emb in embeddings_to_store]
             else:
-                embeddings_list = embeddings
+                embeddings_list = embeddings_to_store
 
-            logger.info(f"After conversion - embeddings_list type: {type(embeddings_list)}, first item type: {type(embeddings_list[0]) if embeddings_list else 'None'}")
-            logger.info(f"First embedding length: {len(embeddings_list[0]) if embeddings_list and embeddings_list[0] else 0}")
+            logger.info(
+                f"After conversion - embeddings_list type: {type(embeddings_list)}, first item type: {type(embeddings_list[0]) if embeddings_list else 'None'}"
+            )
+            logger.info(
+                f"First embedding length: {len(embeddings_list[0]) if embeddings_list and embeddings_list[0] else 0}"
+            )
 
             manager = ChromaDBManager(
                 user_id=str(user_id),
@@ -500,26 +503,36 @@ async def generate_embeddings_for_media(
                 embeddings=embeddings_list,
                 ids=ids,
                 metadatas=metadatas,
-                embedding_model_id_for_dim_check=embedding_model,
+                embedding_model_id_for_dim_check=model_name,
             )
 
-            return {
-                "status": "success",
-                "message": f"Successfully generated {len(embeddings)} embeddings",
-                "embedding_count": len(embeddings),
-                "chunks_processed": len(chunks)
-            }
-
+        try:
+            embeddings = await create_embeddings_batch_async(
+                texts=chunk_texts,
+                provider=embedding_provider,
+                model_id=embedding_model,
+                metadata=request_metadata,
+            )
         except Exception:
-            # Try fallback model if primary fails
             if embedding_model != FALLBACK_EMBEDDING_MODEL:
                 logger.warning(f"Failed with {embedding_model}, trying fallback {FALLBACK_EMBEDDING_MODEL}")
-                embeddings = await create_embeddings_batch_async(
-                    texts=chunk_texts,
-                    provider="huggingface",
-                    model_id=FALLBACK_EMBEDDING_MODEL,
-                    metadata=request_metadata,
-                )
+                try:
+                    embeddings = await create_embeddings_batch_async(
+                        texts=chunk_texts,
+                        provider="huggingface",
+                        model_id=FALLBACK_EMBEDDING_MODEL,
+                        metadata=request_metadata,
+                    )
+                except Exception as exc:
+                    logger.error(f"Fallback embedding generation failed: {exc}")
+                    return {
+                        "status": "error",
+                        "message": f"Failed to generate embeddings: {exc}",
+                        "error": str(exc),
+                        "embedding_count": 0,
+                        "chunks_processed": len(chunks),
+                    }
+
                 validation_error = _validate_embeddings_result(embeddings, len(chunk_texts))
                 if validation_error:
                     return {
@@ -530,62 +543,50 @@ async def generate_embeddings_for_media(
                         "chunks_processed": len(chunks),
                     }
 
-                # Store with fallback model info in per-user collection
-                collection_name = f"user_{user_id}_media_embeddings"
-
-                metadatas = []
-                extra_metadata = {}
                 try:
-                    media_item_meta = media_content.get("media_item", {})
-                    if isinstance(media_item_meta, dict):
-                        extra_metadata = media_item_meta.get("metadata") or {}
-                except _MEDIA_EMBEDDINGS_NONCRITICAL_EXCEPTIONS:
-                    extra_metadata = {}
-                for _i, chunk in enumerate(chunks):
-                    metadata = {
-                        "media_id": str(media_id),
-                        "chunk_index": chunk["index"],
-                        "chunk_start": chunk["start"],
-                        "chunk_end": chunk["end"],
-                        "chunk_type": _chunk_type_for_metadata(chunk),
-                        "title": media_content["media_item"].get("title", ""),
-                        "author": media_content["media_item"].get("author", ""),
-                        "embedding_model": FALLBACK_EMBEDDING_MODEL,
-                        "embedding_provider": "huggingface"
-                    }
-                    if isinstance(extra_metadata, dict) and extra_metadata:
-                        metadata["extra"] = dict(extra_metadata)
-                    metadatas.append(metadata)
-
-                ids = [f"media_{media_id}_chunk_{i}" for i in range(len(chunks))]
-
-                # Convert embeddings to list format if they're numpy arrays
-                if embeddings and hasattr(embeddings[0], 'tolist'):
-                    embeddings_list = [emb.tolist() for emb in embeddings]
-                else:
-                    embeddings_list = embeddings
-
-                manager = ChromaDBManager(
-                    user_id=str(user_id),
-                    user_embedding_config=_user_embedding_config(),
-                )
-                manager.store_in_chroma(
-                    collection_name=collection_name,
-                    texts=chunk_texts,
-                    embeddings=embeddings_list,
-                    ids=ids,
-                    metadatas=metadatas,
-                    embedding_model_id_for_dim_check=FALLBACK_EMBEDDING_MODEL,
-                )
+                    _store_embeddings(
+                        model_name=FALLBACK_EMBEDDING_MODEL,
+                        provider_name="huggingface",
+                        embeddings_to_store=embeddings,
+                    )
+                except Exception as exc:
+                    logger.error(f"Error storing fallback embeddings: {exc}")
+                    return _storage_failure_result(exc, len(embeddings) if embeddings else 0)
 
                 return {
                     "status": "success",
                     "message": f"Generated embeddings using fallback model {FALLBACK_EMBEDDING_MODEL}",
                     "embedding_count": len(embeddings),
-                    "chunks_processed": len(chunks)
+                    "chunks_processed": len(chunks),
                 }
-            else:
-                raise
+            raise
+
+        validation_error = _validate_embeddings_result(embeddings, len(chunk_texts))
+        if validation_error:
+            return {
+                "status": "error",
+                "message": validation_error,
+                "error": validation_error,
+                "embedding_count": len(embeddings) if embeddings else 0,
+                "chunks_processed": len(chunks),
+            }
+
+        try:
+            _store_embeddings(
+                model_name=embedding_model,
+                provider_name=embedding_provider,
+                embeddings_to_store=embeddings,
+            )
+        except Exception as exc:
+            logger.error(f"Error storing primary embeddings: {exc}")
+            return _storage_failure_result(exc, len(embeddings) if embeddings else 0)
+
+        return {
+            "status": "success",
+            "message": f"Successfully generated {len(embeddings)} embeddings",
+            "embedding_count": len(embeddings),
+            "chunks_processed": len(chunks),
+        }
 
     except _MEDIA_EMBEDDINGS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Error generating embeddings: {e}")
@@ -826,17 +827,26 @@ async def generate_embeddings_batch(
                 f"(user_id={user_id}, media_id={media_id}, reason={type(exc).__name__}: {exc})"
             )
 
-    if failed_media_ids:
+    if failed_media_ids and not job_ids:
         detail = {
             "error": "batch_enqueue_failed",
             "message": "Failed to queue one or more embedding jobs",
-            "submitted": len(job_ids),
+            "submitted": 0,
             "failed_media_ids": failed_media_ids,
             "failure_reasons": failure_reasons,
         }
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=detail,
+        )
+
+    if failed_media_ids:
+        return BatchMediaEmbeddingsResponse(
+            status="partial",
+            job_ids=job_ids,
+            submitted=len(job_ids),
+            failed_media_ids=failed_media_ids,
+            failure_reasons=failure_reasons,
         )
 
     return BatchMediaEmbeddingsResponse(

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
@@ -7,11 +7,11 @@ class RecordingCache:
         self.get_keys: list[str] = []
         self.set_keys: list[str] = []
 
-    async def get(self, key):
+    async def get(self, key: str) -> object | None:
         self.get_keys.append(key)
         return self.data.get(key)
 
-    async def set(self, key, value):
+    async def set(self, key: str, value: object) -> None:
         self.set_keys.append(key)
         self.data[key] = value
 

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
@@ -1,0 +1,84 @@
+import pytest
+
+
+class RecordingCache:
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+        self.get_keys: list[str] = []
+        self.set_keys: list[str] = []
+
+    async def get(self, key):
+        self.get_keys.append(key)
+        return self.data.get(key)
+
+    async def set(self, key, value):
+        self.set_keys.append(key)
+        self.data[key] = value
+
+
+def test_local_api_backend_identity_strips_credentials_and_query():
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
+
+    clean_url = "http://backend-one.example:8080/v1"
+    secret_url = "http://user:pass@backend-one.example:8080/v1?token=abc#fragment"
+
+    clean_identity = mod._normalize_cache_backend_identity({"api_url": clean_url}, "local_api")
+    secret_identity = mod._normalize_cache_backend_identity({"api_url": secret_url}, "local_api")
+
+    assert clean_identity == "http://backend-one.example:8080/v1"
+    assert secret_identity == clean_identity
+    assert "user" not in secret_identity
+    assert "pass" not in secret_identity
+    assert "token" not in secret_identity
+
+    clean_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=clean_identity)
+    secret_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=secret_identity)
+
+    assert secret_cache_key == clean_cache_key
+
+
+@pytest.mark.asyncio
+async def test_local_api_url_participates_in_cache_identity(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
+
+    cache = RecordingCache()
+    api_urls: list[str | None] = []
+
+    async def fake_create_embeddings_with_circuit_breaker(
+        texts,
+        provider,
+        model_id,
+        config,
+        metadata=None,
+        dimensions=None,
+    ):
+        _ = (texts, provider, model_id, metadata, dimensions)
+        api_url = config["api_url"]
+        api_urls.append(api_url)
+        marker = 1.0 if api_url == "http://backend-one/v1" else 2.0
+        return [[marker, marker]]
+
+    monkeypatch.setattr(mod, "embedding_cache", cache)
+    monkeypatch.setattr(mod, "create_embeddings_with_circuit_breaker", fake_create_embeddings_with_circuit_breaker)
+
+    first = await mod.create_embeddings_batch_async(
+        texts=["cache me"],
+        provider="local_api",
+        model_id="test-model",
+        api_url="http://backend-one/v1",
+    )
+    second = await mod.create_embeddings_batch_async(
+        texts=["cache me"],
+        provider="local_api",
+        model_id="test-model",
+        api_url="http://backend-two/v1",
+    )
+
+    assert first == [[1.0, 1.0]]
+    assert second == [[2.0, 2.0]]
+    assert api_urls == ["http://backend-one/v1", "http://backend-two/v1"]
+    assert len(cache.get_keys) == 2
+    assert len(cache.set_keys) == 2
+    assert cache.get_keys[0] != cache.get_keys[1]
+    assert cache.set_keys[0] != cache.set_keys[1]
+    assert cache.get_keys == cache.set_keys

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
@@ -20,21 +20,21 @@ def test_local_api_backend_identity_strips_credentials_and_query():
     import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
 
     clean_url = "http://backend-one.example:8080/v1"
-    secret_url = "http://user:pass@backend-one.example:8080/v1?token=abc#fragment"
+    credentialed_url = "http://alice:s3cret@backend-one.example:8080/v1?token=abc#fragment"
 
     clean_identity = mod._normalize_cache_backend_identity({"api_url": clean_url}, "local_api")
-    secret_identity = mod._normalize_cache_backend_identity({"api_url": secret_url}, "local_api")
+    credentialed_identity = mod._normalize_cache_backend_identity({"api_url": credentialed_url}, "local_api")
 
     assert clean_identity == "http://backend-one.example:8080/v1"
-    assert secret_identity == clean_identity
-    assert "user" not in secret_identity
-    assert "pass" not in secret_identity
-    assert "token" not in secret_identity
+    assert credentialed_identity == clean_identity
+    assert "alice" not in credentialed_identity
+    assert "s3cret" not in credentialed_identity
+    assert "token" not in credentialed_identity
 
     clean_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=clean_identity)
-    secret_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=secret_identity)
+    credentialed_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=credentialed_identity)
 
-    assert secret_cache_key == clean_cache_key
+    assert credentialed_cache_key == clean_cache_key
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
@@ -16,7 +16,7 @@ class RecordingCache:
         self.data[key] = value
 
 
-def test_local_api_backend_identity_strips_credentials_and_query():
+def test_local_api_backend_identity_strips_credentials_and_sensitive_params():
     import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
 
     clean_url = "http://backend-one.example:8080/v1"
@@ -35,6 +35,42 @@ def test_local_api_backend_identity_strips_credentials_and_query():
     credentialed_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=credentialed_identity)
 
     assert credentialed_cache_key == clean_cache_key
+
+
+def test_local_api_backend_identity_preserves_nonsensitive_query_params():
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
+
+    url_tenant_a = "http://backend-one.example:8080/v1?tenant=a"
+    url_tenant_b = "http://backend-one.example:8080/v1?tenant=b"
+    url_no_query = "http://backend-one.example:8080/v1"
+
+    identity_a = mod._normalize_cache_backend_identity({"api_url": url_tenant_a}, "local_api")
+    identity_b = mod._normalize_cache_backend_identity({"api_url": url_tenant_b}, "local_api")
+    identity_none = mod._normalize_cache_backend_identity({"api_url": url_no_query}, "local_api")
+
+    # Non-sensitive query params produce distinct identities
+    assert identity_a != identity_b
+    assert identity_a != identity_none
+    assert "tenant=a" in identity_a
+    assert "tenant=b" in identity_b
+
+    # Cache keys are therefore distinct
+    key_a = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=identity_a)
+    key_b = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=identity_b)
+    assert key_a != key_b
+
+
+def test_local_api_backend_identity_strips_sensitive_but_keeps_nonsensitive():
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
+
+    url_mixed = "http://backend.example:8080/v1?tenant=prod&token=secret123&region=us-east"
+
+    identity = mod._normalize_cache_backend_identity({"api_url": url_mixed}, "local_api")
+
+    assert "tenant=prod" in identity
+    assert "region=us-east" in identity
+    assert "token" not in identity
+    assert "secret123" not in identity
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_token_arrays.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_token_arrays.py
@@ -2,7 +2,7 @@ import os
 import base64
 import numpy as np
 import pytest
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 from fastapi.testclient import TestClient
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
@@ -92,7 +92,7 @@ def test_token_array_uses_raw_token_length_for_limits(client, monkeypatch):
 
 
 @pytest.mark.unit
-def test_tokens_to_texts_logs_decode_failure(monkeypatch):
+def test_tokens_to_texts_decode_failure_raises_value_error(monkeypatch):
     import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as emb_mod
 
     class _BadEncoder:
@@ -103,11 +103,38 @@ def test_tokens_to_texts_logs_decode_failure(monkeypatch):
     warn = Mock()
     monkeypatch.setattr(emb_mod.logger, "warning", warn)
 
-    texts, total, lengths = emb_mod.tokens_to_texts([1, 2], "text-embedding-3-small")
-    assert texts == [""]
-    assert total == 2
-    assert lengths == [2]
+    with pytest.raises(ValueError, match="Invalid token array input"):
+        emb_mod.tokens_to_texts([1, 2], "text-embedding-3-small")
     assert warn.called
+
+
+@pytest.mark.unit
+def test_embeddings_endpoint_decode_failure_short_circuits_downstream_creation(client, monkeypatch):
+    async def override_user():
+        from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+        return User(id=1, username="u", email="u@x", is_active=True, is_admin=False)
+
+    app.dependency_overrides[get_request_user] = override_user
+
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as emb_mod
+
+    class _BadEncoder:
+        def decode(self, _tokens):
+            raise ValueError("boom")
+
+    monkeypatch.setattr(emb_mod, "get_tokenizer", lambda _model: _BadEncoder())
+    create_embeddings_mock = AsyncMock()
+    monkeypatch.setattr(emb_mod, "create_embeddings_batch_async", create_embeddings_mock)
+
+    payload = {
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "input": [101, 102, 103, 104],
+    }
+    r = client.post("/api/v1/embeddings", json=payload, headers={"x-provider": "huggingface"})
+
+    assert r.status_code == 400
+    assert r.json()["detail"] == "Invalid token array input"
+    create_embeddings_mock.assert_not_awaited()
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings/test_media_embedding_jobs.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embedding_jobs.py
@@ -1,6 +1,9 @@
 import os
 import time
+import pytest
 from fastapi.testclient import TestClient
+import redis
+import redis.asyncio as aioredis
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
@@ -20,8 +23,28 @@ class _FakeMediaDB:
             for media_id in ids
         }
 
-    def get_media_by_id(self, media_id: int):
+    def get_media_by_id(self, media_id: int, **_kwargs):
         return self._items.get(media_id)
+
+
+class _FakeRedisClient:
+    async def ping(self):
+        return True
+
+    async def close(self):
+        return None
+
+    async def aclose(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_redis_clients(monkeypatch):
+    def _make_client(*_args, **_kwargs):
+        return _FakeRedisClient()
+
+    monkeypatch.setattr(aioredis, "from_url", _make_client)
+    monkeypatch.setattr(redis, "from_url", _make_client, raising=False)
 
 
 from contextlib import contextmanager
@@ -133,7 +156,7 @@ def test_media_embedding_job_returns_500_when_job_id_missing(monkeypatch):
         app.dependency_overrides.pop(get_media_db_for_user, None)
 
 
-def test_media_embedding_batch_returns_500_on_partial_enqueue_failure(monkeypatch):
+def test_media_embedding_batch_returns_partial_on_partial_enqueue_failure(monkeypatch):
     os.environ["TESTING"] = "true"
     try:
         from tldw_Server_API.app.api.v1.endpoints import media_embeddings as media_embeddings_endpoint
@@ -155,31 +178,30 @@ def test_media_embedding_batch_returns_500_on_partial_enqueue_failure(monkeypatc
                 json={"media_ids": [123, 456]},
                 headers={"X-API-KEY": api_key},
             )
-            assert resp.status_code == 500
+            assert resp.status_code == 202
             body = resp.json()
-            detail = body.get("detail") or {}
-            assert detail.get("error") == "batch_enqueue_failed"
-            assert detail.get("submitted") == 1
-            assert detail.get("failed_media_ids") == [456]
+            assert body.get("status") == "partial"
+            assert body.get("job_ids") == ["job-123"]
+            assert body.get("submitted") == 1
+            assert body.get("failed_media_ids") == [456]
+            assert body.get("failure_reasons") == ["media_id=456: RuntimeError"]
     finally:
         os.environ.pop("TESTING", None)
         app.dependency_overrides.pop(get_media_db_for_user, None)
 
 
-def test_media_embedding_batch_returns_500_when_job_id_missing(monkeypatch):
+def test_media_embedding_batch_returns_accepted_with_empty_failure_lists(monkeypatch):
     os.environ["TESTING"] = "true"
     try:
         from tldw_Server_API.app.api.v1.endpoints import media_embeddings as media_embeddings_endpoint
 
-        class _MissingIdAdapter:
+        class _SuccessfulAdapter:
             def create_job(self, **kwargs):
                 media_id = int(kwargs["media_id"])
-                if media_id == 456:
-                    return {}
                 return {"uuid": f"job-{media_id}"}
 
         app.dependency_overrides[get_media_db_for_user] = lambda: _FakeMediaDB(media_ids=[123, 456])
-        monkeypatch.setattr(media_embeddings_endpoint, "EmbeddingsJobsAdapter", _MissingIdAdapter)
+        monkeypatch.setattr(media_embeddings_endpoint, "EmbeddingsJobsAdapter", _SuccessfulAdapter)
 
         with _client() as client:
             api_key = get_settings().SINGLE_USER_API_KEY
@@ -188,10 +210,73 @@ def test_media_embedding_batch_returns_500_when_job_id_missing(monkeypatch):
                 json={"media_ids": [123, 456]},
                 headers={"X-API-KEY": api_key},
             )
+            assert resp.status_code == 202
+            body = resp.json()
+            assert body.get("status") == "accepted"
+            assert body.get("job_ids") == ["job-123", "job-456"]
+            assert body.get("submitted") == 2
+            assert body.get("failed_media_ids") == []
+            assert body.get("failure_reasons") == []
+    finally:
+        os.environ.pop("TESTING", None)
+        app.dependency_overrides.pop(get_media_db_for_user, None)
+
+
+def test_media_embedding_batch_returns_500_when_nothing_queued(monkeypatch):
+    os.environ["TESTING"] = "true"
+    try:
+        from tldw_Server_API.app.api.v1.endpoints import media_embeddings as media_embeddings_endpoint
+
+        class _FailingAdapter:
+            def create_job(self, **_kwargs):
+                raise RuntimeError("enqueue failed")
+
+        app.dependency_overrides[get_media_db_for_user] = lambda: _FakeMediaDB(media_ids=[456])
+        monkeypatch.setattr(media_embeddings_endpoint, "EmbeddingsJobsAdapter", _FailingAdapter)
+
+        with _client() as client:
+            api_key = get_settings().SINGLE_USER_API_KEY
+            resp = client.post(
+                "/api/v1/media/embeddings/batch",
+                json={"media_ids": [456]},
+                headers={"X-API-KEY": api_key},
+            )
             assert resp.status_code == 500
             detail = (resp.json() or {}).get("detail") or {}
             assert detail.get("error") == "batch_enqueue_failed"
+            assert detail.get("submitted") == 0
             assert detail.get("failed_media_ids") == [456]
+            assert detail.get("failure_reasons") == ["media_id=456: RuntimeError"]
+    finally:
+        os.environ.pop("TESTING", None)
+        app.dependency_overrides.pop(get_media_db_for_user, None)
+
+
+def test_media_embedding_batch_returns_500_when_batch_job_id_missing(monkeypatch):
+    os.environ["TESTING"] = "true"
+    try:
+        from tldw_Server_API.app.api.v1.endpoints import media_embeddings as media_embeddings_endpoint
+
+        class _MissingIdAdapter:
+            def create_job(self, **_kwargs):
+                return {}
+
+        app.dependency_overrides[get_media_db_for_user] = lambda: _FakeMediaDB(media_ids=[456])
+        monkeypatch.setattr(media_embeddings_endpoint, "EmbeddingsJobsAdapter", _MissingIdAdapter)
+
+        with _client() as client:
+            api_key = get_settings().SINGLE_USER_API_KEY
+            resp = client.post(
+                "/api/v1/media/embeddings/batch",
+                json={"media_ids": [456]},
+                headers={"X-API-KEY": api_key},
+            )
+            assert resp.status_code == 500
+            detail = (resp.json() or {}).get("detail") or {}
+            assert detail.get("error") == "batch_enqueue_failed"
+            assert detail.get("submitted") == 0
+            assert detail.get("failed_media_ids") == [456]
+            assert detail.get("failure_reasons") == ["media_id=456: ValueError"]
     finally:
         os.environ.pop("TESTING", None)
         app.dependency_overrides.pop(get_media_db_for_user, None)

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py
@@ -4,7 +4,7 @@ from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanc
 
 
 @pytest.mark.asyncio
-async def test_storage_failure_after_successful_primary_generation_returns_storage_error_and_skips_fallback(monkeypatch):
+async def test_storage_failure_after_successful_primary_generation_returns_storage_error_and_skips_fallback(monkeypatch, tmp_path):
     calls: list[tuple[str, str]] = []
 
     async def fake_create_embeddings_batch_async(*, texts, provider, model_id, metadata):
@@ -27,7 +27,7 @@ async def test_storage_failure_after_successful_primary_generation_returns_stora
     )
     monkeypatch.setattr(media_embeddings, "chunk_media_content", lambda *_args, **_kwargs: [{"text": "hello", "index": 0, "start": 0, "end": 5}])
     monkeypatch.setattr(media_embeddings, "ChromaDBManager", FakeChromaDBManager)
-    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": "/tmp/test"})  # nosec B108
+    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": str(tmp_path / "user-db")})
 
     result = await media_embeddings.generate_embeddings_for_media(
         media_id=9,
@@ -49,7 +49,7 @@ async def test_storage_failure_after_successful_primary_generation_returns_stora
 
 
 @pytest.mark.asyncio
-async def test_generation_failure_can_fall_back_and_succeed(monkeypatch):
+async def test_generation_failure_can_fall_back_and_succeed(monkeypatch, tmp_path):
     calls: list[tuple[str, str]] = []
     stores: list[str] = []
 
@@ -75,7 +75,7 @@ async def test_generation_failure_can_fall_back_and_succeed(monkeypatch):
     )
     monkeypatch.setattr(media_embeddings, "chunk_media_content", lambda *_args, **_kwargs: [{"text": "hello", "index": 0, "start": 0, "end": 5}])
     monkeypatch.setattr(media_embeddings, "ChromaDBManager", FakeChromaDBManager)
-    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": "/tmp/test"})  # nosec B108
+    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": str(tmp_path / "user-db")})
 
     result = await media_embeddings.generate_embeddings_for_media(
         media_id=10,

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py
@@ -1,0 +1,99 @@
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced, media_embeddings
+
+
+@pytest.mark.asyncio
+async def test_storage_failure_after_successful_primary_generation_returns_storage_error_and_skips_fallback(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    async def fake_create_embeddings_batch_async(*, texts, provider, model_id, metadata):
+        calls.append((provider, model_id))
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    class FakeChromaDBManager:
+        def __init__(self, *, user_id, user_embedding_config):
+            self.user_id = user_id
+            self.user_embedding_config = user_embedding_config
+
+        def store_in_chroma(self, *args, **kwargs):
+            raise RuntimeError("chroma write failed")
+
+    monkeypatch.setattr(
+        embeddings_v5_production_enhanced,
+        "create_embeddings_batch_async",
+        fake_create_embeddings_batch_async,
+        raising=True,
+    )
+    monkeypatch.setattr(media_embeddings, "chunk_media_content", lambda *_args, **_kwargs: [{"text": "hello", "index": 0, "start": 0, "end": 5}])
+    monkeypatch.setattr(media_embeddings, "ChromaDBManager", FakeChromaDBManager)
+    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": "/tmp/test"})  # nosec B108
+
+    result = await media_embeddings.generate_embeddings_for_media(
+        media_id=9,
+        media_content={
+            "media_item": {"title": "Doc", "author": "Author", "metadata": {}},
+            "content": {"content": "hello"},
+        },
+        embedding_model="primary-model",
+        embedding_provider="primary-provider",
+        chunk_size=1000,
+        chunk_overlap=200,
+        user_id="tenant-1",
+    )
+
+    assert result["status"] == "error"
+    assert "storage" in result["message"].lower() or "storage" in result["error"].lower()
+    assert "chroma" in result["message"].lower() or "chroma" in result["error"].lower()
+    assert calls == [("primary-provider", "primary-model")]
+
+
+@pytest.mark.asyncio
+async def test_generation_failure_can_fall_back_and_succeed(monkeypatch):
+    calls: list[tuple[str, str]] = []
+    stores: list[str] = []
+
+    async def fake_create_embeddings_batch_async(*, texts, provider, model_id, metadata):
+        calls.append((provider, model_id))
+        if provider == "primary-provider":
+            raise RuntimeError("primary provider failed")
+        return [[0.4, 0.5, 0.6] for _ in texts]
+
+    class FakeChromaDBManager:
+        def __init__(self, *, user_id, user_embedding_config):
+            self.user_id = user_id
+            self.user_embedding_config = user_embedding_config
+
+        def store_in_chroma(self, *, collection_name, texts, embeddings, ids, metadatas, embedding_model_id_for_dim_check=None):
+            stores.append(embedding_model_id_for_dim_check)
+
+    monkeypatch.setattr(
+        embeddings_v5_production_enhanced,
+        "create_embeddings_batch_async",
+        fake_create_embeddings_batch_async,
+        raising=True,
+    )
+    monkeypatch.setattr(media_embeddings, "chunk_media_content", lambda *_args, **_kwargs: [{"text": "hello", "index": 0, "start": 0, "end": 5}])
+    monkeypatch.setattr(media_embeddings, "ChromaDBManager", FakeChromaDBManager)
+    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": "/tmp/test"})  # nosec B108
+
+    result = await media_embeddings.generate_embeddings_for_media(
+        media_id=10,
+        media_content={
+            "media_item": {"title": "Doc", "author": "Author", "metadata": {}},
+            "content": {"content": "hello"},
+        },
+        embedding_model="primary-model",
+        embedding_provider="primary-provider",
+        chunk_size=1000,
+        chunk_overlap=200,
+        user_id="tenant-2",
+    )
+
+    assert result["status"] == "success"
+    assert result["embedding_count"] == 1
+    assert calls == [
+        ("primary-provider", "primary-model"),
+        ("huggingface", media_embeddings.FALLBACK_EMBEDDING_MODEL),
+    ]
+    assert stores == [media_embeddings.FALLBACK_EMBEDDING_MODEL]

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
@@ -90,6 +90,54 @@ async def test_generate_embeddings_batch_returns_partial_response_on_partial_enq
 
 
 @pytest.mark.asyncio
+async def test_generate_embeddings_batch_returns_partial_when_some_media_ids_missing(monkeypatch):
+    class _OkAdapter:
+        def create_job(self, **kwargs):
+            return {"uuid": f"job-{kwargs['media_id']}"}
+
+    monkeypatch.setattr(media_embeddings, "_embeddings_jobs_backend", lambda: "jobs")
+    monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
+    monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _OkAdapter)
+
+    # _FakeMediaDB only knows about media_id 123; 999 is missing
+    response = await media_embeddings.generate_embeddings_batch(
+        request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[123, 999]),
+        db=_FakeMediaDB([123]),
+        current_user=_user(),
+    )
+
+    assert response.status == "partial"
+    assert response.job_ids == ["job-123"]
+    assert response.submitted == 1
+    assert response.failed_media_ids == [999]
+    assert response.failure_reasons == ["media_id=999: not found"]
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_batch_raises_when_all_media_ids_missing(monkeypatch):
+    class _OkAdapter:
+        def create_job(self, **kwargs):
+            return {"uuid": f"job-{kwargs['media_id']}"}
+
+    monkeypatch.setattr(media_embeddings, "_embeddings_jobs_backend", lambda: "jobs")
+    monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
+    monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _OkAdapter)
+
+    # _FakeMediaDB is empty — both IDs are missing
+    with pytest.raises(HTTPException) as excinfo:
+        await media_embeddings.generate_embeddings_batch(
+            request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[888, 999]),
+            db=_FakeMediaDB([]),
+            current_user=_user(),
+        )
+
+    assert excinfo.value.status_code == 500
+    assert isinstance(excinfo.value.detail, dict)
+    assert excinfo.value.detail.get("error") == "batch_enqueue_failed"
+    assert excinfo.value.detail.get("failed_media_ids") == [888, 999]
+
+
+@pytest.mark.asyncio
 async def test_generate_embeddings_batch_raises_when_all_enqueues_fail_before_any_success(monkeypatch):
     class _AlwaysFailingAdapter:
         def create_job(self, **kwargs):

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
@@ -9,7 +9,7 @@ class _FakeMediaDB:
     def __init__(self, media_ids: list[int]):
         self._ids = set(int(media_id) for media_id in media_ids)
 
-    def get_media_by_id(self, media_id: int):
+    def get_media_by_id(self, media_id: int, **_kwargs):
         if int(media_id) in self._ids:
             return {"id": int(media_id), "title": "Doc", "author": "A"}
         return None
@@ -64,7 +64,7 @@ async def test_generate_embeddings_fails_when_job_id_missing(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_generate_embeddings_batch_fails_on_partial_enqueue_error(monkeypatch):
+async def test_generate_embeddings_batch_returns_partial_response_on_partial_enqueue_error(monkeypatch):
     class _PartialAdapter:
         def create_job(self, **kwargs):
             media_id = int(kwargs["media_id"])
@@ -76,28 +76,24 @@ async def test_generate_embeddings_batch_fails_on_partial_enqueue_error(monkeypa
     monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
     monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _PartialAdapter)
 
-    with pytest.raises(HTTPException) as excinfo:
-        await media_embeddings.generate_embeddings_batch(
-            request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[123, 456]),
-            db=_FakeMediaDB([123, 456]),
-            current_user=_user(),
-        )
+    response = await media_embeddings.generate_embeddings_batch(
+        request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[123, 456]),
+        db=_FakeMediaDB([123, 456]),
+        current_user=_user(),
+    )
 
-    assert excinfo.value.status_code == 500
-    assert isinstance(excinfo.value.detail, dict)
-    assert excinfo.value.detail.get("error") == "batch_enqueue_failed"
-    assert excinfo.value.detail.get("submitted") == 1
-    assert excinfo.value.detail.get("failed_media_ids") == [456]
+    assert response.status == "partial"
+    assert response.job_ids == ["job-123"]
+    assert response.submitted == 1
+    assert response.failed_media_ids == [456]
+    assert response.failure_reasons == ["media_id=456: RuntimeError"]
 
 
 @pytest.mark.asyncio
-async def test_generate_embeddings_batch_fails_when_job_id_missing(monkeypatch):
+async def test_generate_embeddings_batch_raises_when_all_enqueues_fail_before_any_success(monkeypatch):
     class _MissingIdAdapter:
         def create_job(self, **kwargs):
-            media_id = int(kwargs["media_id"])
-            if media_id == 456:
-                return {}
-            return {"uuid": f"job-{media_id}"}
+            raise RuntimeError("enqueue failed")
 
     monkeypatch.setattr(media_embeddings, "_embeddings_jobs_backend", lambda: "jobs")
     monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
@@ -105,12 +101,13 @@ async def test_generate_embeddings_batch_fails_when_job_id_missing(monkeypatch):
 
     with pytest.raises(HTTPException) as excinfo:
         await media_embeddings.generate_embeddings_batch(
-            request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[123, 456]),
-            db=_FakeMediaDB([123, 456]),
+            request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[456]),
+            db=_FakeMediaDB([456]),
             current_user=_user(),
         )
 
     assert excinfo.value.status_code == 500
     assert isinstance(excinfo.value.detail, dict)
     assert excinfo.value.detail.get("error") == "batch_enqueue_failed"
+    assert excinfo.value.detail.get("submitted") == 0
     assert excinfo.value.detail.get("failed_media_ids") == [456]

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
@@ -91,13 +91,13 @@ async def test_generate_embeddings_batch_returns_partial_response_on_partial_enq
 
 @pytest.mark.asyncio
 async def test_generate_embeddings_batch_raises_when_all_enqueues_fail_before_any_success(monkeypatch):
-    class _MissingIdAdapter:
+    class _AlwaysFailingAdapter:
         def create_job(self, **kwargs):
             raise RuntimeError("enqueue failed")
 
     monkeypatch.setattr(media_embeddings, "_embeddings_jobs_backend", lambda: "jobs")
     monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
-    monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _MissingIdAdapter)
+    monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _AlwaysFailingAdapter)
 
     with pytest.raises(HTTPException) as excinfo:
         await media_embeddings.generate_embeddings_batch(


### PR DESCRIPTION
## Summary
- reject invalid embeddings token-array decode failures with HTTP 400 instead of silently embedding empty content
- scope embeddings cache identity by sanitized local backend URL and stop leaking URL credentials into cache identity
- classify media embedding storage failures separately from generation failures, and make batch media enqueue semantics truthful for partial and zero-queued cases
- add focused regression coverage for decode rejection, backend-sensitive cache identity, storage-failure-no-fallback, partial enqueue, zero-queued failure, and missing batch job ids

## Test Plan
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Embeddings/test_embeddings_token_arrays.py tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py tldw_Server_API/tests/Embeddings/test_media_embeddings_storage_scope.py tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py tldw_Server_API/tests/Embeddings/test_media_embedding_jobs.py tldw_Server_API/tests/Embeddings/test_embeddings_dimensions_policy.py tldw_Server_API/tests/Embeddings/test_l2_normalization_policy.py -v
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py tldw_Server_API/app/api/v1/endpoints/media_embeddings.py -f json -o /tmp/bandit_embeddings_remediation_dev_pr.json
