### PR TITLE
fix: remediate metrics module defects

### DIFF
--- a/Docs/superpowers/plans/2026-04-07-metrics-confirmed-defects-remediation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-07-metrics-confirmed-defects-remediation-implementation-plan.md
@@ -1,0 +1,1066 @@
+# Metrics Confirmed Defects Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix only the confirmed Metrics defects from the audit while preserving the current public routes and consumer-facing payload shapes.
+
+**Architecture:** Keep the remediation narrow and contract-focused. Unify the public Prometheus text export path, add a small in-process chat-metrics summary alongside existing OpenTelemetry emission, repair telemetry/decorator/tracing/registry semantics in place, and lock each fix down with direct regression tests before implementation.
+
+**Tech Stack:** Python, FastAPI, pytest, OpenTelemetry fallbacks, Prometheus text exposition, Bandit
+
+---
+
+### Task 1: Make The Metrics Surface Truthful
+
+**Files:**
+- Create: `tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/metrics.py`
+- Modify: `tldw_Server_API/app/main.py`
+- Modify: `tldw_Server_API/app/core/Chat/chat_metrics.py`
+- Test: `tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py`
+- Test: `tldw_Server_API/tests/Monitoring/test_metrics_endpoints.py`
+
+- [ ] **Step 1: Write the failing endpoint-contract tests**
+
+Add `tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py` with:
+
+```python
+import pytest
+
+import tldw_Server_API.app.api.v1.endpoints.metrics as metrics_endpoint
+import tldw_Server_API.app.core.Chat.chat_metrics as chat_metrics_module
+from tldw_Server_API.app.core.Chat.chat_metrics import get_chat_metrics
+from tldw_Server_API.app.core.Metrics.metrics_manager import (
+    MetricDefinition,
+    MetricType,
+    get_metrics_registry,
+)
+from tldw_Server_API.app.main import metrics as root_metrics
+
+
+pytestmark = pytest.mark.monitoring
+
+
+@pytest.mark.asyncio
+async def test_root_metrics_matches_router_text_export(monkeypatch):
+    registry = get_metrics_registry()
+    registry.reset()
+    registry.register_metric(
+        MetricDefinition(
+            name="surface_contract_counter_total",
+            type=MetricType.COUNTER,
+            description="surface parity test",
+            labels=["source"],
+        )
+    )
+    registry.increment("surface_contract_counter_total", labels={"source": "test"})
+
+    response_root = await root_metrics()
+    response_router = await metrics_endpoint.get_prometheus_metrics()
+
+    assert response_root.body == response_router.body
+    assert response_root.headers["cache-control"] == response_router.headers["cache-control"]
+    assert response_root.media_type == response_router.media_type
+
+
+@pytest.mark.asyncio
+async def test_chat_metrics_endpoint_reports_emitted_request_totals(monkeypatch):
+    monkeypatch.setattr(chat_metrics_module, "_chat_metrics_collector", None, raising=False)
+    collector = get_chat_metrics()
+
+    async with collector.track_request(
+        provider="openai",
+        model="gpt-4",
+        streaming=False,
+        client_id="client-1",
+    ):
+        pass
+
+    collector.track_tokens(
+        prompt_tokens=11,
+        completion_tokens=7,
+        model="gpt-4",
+        provider="openai",
+    )
+
+    payload = await metrics_endpoint.get_chat_metrics_endpoint()
+
+    assert float(payload["metrics"]["chat_requests_total"]["sum"]) >= 1.0
+    assert float(payload["metrics"]["chat_request_duration_seconds"]["count"]) >= 1.0
+    assert float(payload["metrics"]["chat_tokens_prompt"]["sum"]) >= 11.0
+```
+
+- [ ] **Step 2: Run the new tests to verify red state**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py -q
+```
+
+Expected: FAIL because `/metrics` and `/api/v1/metrics/text` still use different implementations, and `/api/v1/metrics/chat` still returns an empty `metrics` map after real chat metric emission.
+
+- [ ] **Step 3: Implement the shared text exporter and chat snapshot**
+
+In `tldw_Server_API/app/api/v1/endpoints/metrics.py`, extract the text exporter into one shared helper and keep the route wrapper thin:
+
+```python
+_PROMETHEUS_HEADERS = {
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+    "Pragma": "no-cache",
+    "Expires": "0",
+}
+
+
+async def _refresh_embeddings_stage_flags() -> None:
+    try:
+        import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as _emb
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: embeddings modules not available for import")
+        return
+
+    try:
+        client = await _emb._get_redis_client()
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: redis not available for stage flags")
+        return
+
+    try:
+        for stage in ("chunking", "embedding", "storage"):
+            paused = await client.get(f"embeddings:stage:{stage}:paused")
+            drain = await client.get(f"embeddings:stage:{stage}:drain")
+            _emb.embedding_stage_flag.labels(stage=stage, flag="paused").set(
+                1.0 if str(paused).lower() in ("1", "true", "yes") else 0.0
+            )
+            _emb.embedding_stage_flag.labels(stage=stage, flag="drain").set(
+                1.0 if str(drain).lower() in ("1", "true", "yes") else 0.0
+            )
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: failed to refresh stage gauges")
+    finally:
+        try:
+            await client.close()
+        except _METRICS_NONCRITICAL_EXCEPTIONS:
+            logger.debug("metrics: failed to close redis client")
+
+
+async def build_prometheus_metrics_response() -> Response:
+    registry = get_metrics_registry()
+    await _refresh_embeddings_stage_flags()
+    prometheus_text = registry.export_prometheus_format() or ""
+    try:
+        from prometheus_client import REGISTRY as PC_REGISTRY
+        from prometheus_client import generate_latest as pc_generate_latest
+        prometheus_text = (prometheus_text + "\n" + pc_generate_latest(PC_REGISTRY).decode("utf-8")).strip() + "\n"
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: failed to augment with prometheus_client registry")
+    return Response(
+        content=prometheus_text,
+        media_type="text/plain; version=0.0.4",
+        headers=_PROMETHEUS_HEADERS,
+    )
+
+
+@router.get("/metrics/text", summary="Get metrics in Prometheus text format", response_class=Response)
+async def get_prometheus_metrics() -> Response:
+    return await build_prometheus_metrics_response()
+```
+
+In `tldw_Server_API/app/main.py`, route the root exporter through the same helper:
+
+```python
+async def metrics():
+    from tldw_Server_API.app.api.v1.endpoints.metrics import build_prometheus_metrics_response
+
+    return await build_prometheus_metrics_response()
+```
+
+In `tldw_Server_API/app/core/Chat/chat_metrics.py`, add a small endpoint-summary store and snapshot helper, then update the existing chat emission methods to record summary samples alongside OTel emission:
+
+```python
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+import statistics
+
+...
+        self._endpoint_metric_lock = threading.Lock()
+        self._endpoint_metric_samples = defaultdict(lambda: deque(maxlen=256))
+        self._endpoint_metric_timestamps = {}
+
+    def _record_endpoint_metric(self, metric_name: str, value: float) -> None:
+        with self._endpoint_metric_lock:
+            self._endpoint_metric_samples[metric_name].append(float(value))
+            self._endpoint_metric_timestamps[metric_name] = (
+                datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            )
+
+    def get_endpoint_metrics_snapshot(self) -> dict[str, dict[str, float | int | str]]:
+        snapshot = {}
+        with self._endpoint_metric_lock:
+            items = {
+                name: list(samples)
+                for name, samples in self._endpoint_metric_samples.items()
+                if samples
+            }
+            timestamps = dict(self._endpoint_metric_timestamps)
+        for name, samples in items.items():
+            snapshot[name] = {
+                "count": len(samples),
+                "sum": sum(samples),
+                "mean": statistics.mean(samples),
+                "median": statistics.median(samples),
+                "min": min(samples),
+                "max": max(samples),
+                "stddev": statistics.stdev(samples) if len(samples) > 1 else 0.0,
+                "latest": samples[-1],
+                "latest_timestamp": timestamps.get(name),
+            }
+        return snapshot
+```
+
+Record summary samples in the existing public emission points:
+
+```python
+self.metrics.requests_total.add(1, labels)
+self._record_endpoint_metric("chat_requests_total", 1.0)
+
+self.metrics.errors_total.add(1, labels)
+self._record_endpoint_metric("chat_errors_total", 1.0)
+
+self.metrics.request_duration.record(duration, labels)
+self._record_endpoint_metric("chat_request_duration_seconds", duration)
+
+self.metrics.streaming_duration.record(duration, {...})
+self._record_endpoint_metric("chat_streaming_duration_seconds", duration)
+
+self.metrics.tokens_prompt.record(prompt_tokens, labels)
+self._record_endpoint_metric("chat_tokens_prompt", float(prompt_tokens))
+
+self.metrics.tokens_completion.record(completion_tokens, labels)
+self._record_endpoint_metric("chat_tokens_completion", float(completion_tokens))
+
+self.metrics.llm_cost_estimate.record(total_cost, labels)
+self._record_endpoint_metric("chat_llm_cost_estimate_usd", total_cost)
+
+self.metrics.conversations_created.add(1, labels)
+self._record_endpoint_metric("chat_conversations_created_total", 1.0)
+
+self.metrics.messages_saved.add(1, {...})
+self._record_endpoint_metric("chat_messages_saved_total", 1.0)
+```
+
+Finally, switch `get_chat_metrics_endpoint()` in `metrics.py` to:
+
+```python
+chat_stats = chat_metrics.get_endpoint_metrics_snapshot()
+```
+
+- [ ] **Step 4: Run the focused Monitoring slice and confirm green**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py \
+  tldw_Server_API/tests/Monitoring/test_metrics_endpoints.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the endpoint-truthfulness fix**
+
+Run:
+```bash
+git add \
+  tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py \
+  tldw_Server_API/app/api/v1/endpoints/metrics.py \
+  tldw_Server_API/app/main.py \
+  tldw_Server_API/app/core/Chat/chat_metrics.py && \
+git commit -m "fix: make metrics endpoints truthful"
+```
+
+Expected: one commit containing the shared text exporter and chat endpoint contract fix.
+
+### Task 2: Repair Decorator And Tracing Semantics
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py`
+- Create: `tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py`
+- Modify: `tldw_Server_API/app/core/Metrics/decorators.py`
+- Modify: `tldw_Server_API/app/core/Metrics/traces.py`
+- Modify: `tldw_Server_API/app/core/Metrics/README.md`
+
+- [ ] **Step 1: Write failing regression tests for `cache_metrics()` and tracing decorators**
+
+Update `tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py` with:
+
+```python
+def test_cache_metrics_preserves_tuple_return(monkeypatch):
+    monkeypatch.setenv("METRICS_RING_BUFFER_MAXLEN_OR_UNBOUNDED", "20")
+    metrics_manager._metrics_registry = None
+
+    try:
+        @cache_metrics("tuple_cache", track_ratio=False)
+        def fetch():
+            return ("payload", True)
+
+        assert fetch() == ("payload", True)
+    finally:
+        metrics_manager._metrics_registry = None
+
+
+def test_cache_hit_ratio_uses_explicit_from_cache_attribute(monkeypatch):
+    monkeypatch.setenv("METRICS_RING_BUFFER_MAXLEN_OR_UNBOUNDED", "20")
+    metrics_manager._metrics_registry = None
+    registry = metrics_manager.get_metrics_registry()
+
+    class CachedResult:
+        def __init__(self, payload: str, from_cache: bool):
+            self.payload = payload
+            self.from_cache = from_cache
+
+    try:
+        @cache_metrics("demo_cache", track_ratio=True)
+        def fetch(cache_hit: bool):
+            return CachedResult("payload", cache_hit)
+
+        fetch(False)
+        fetch(True)
+        fetch(True)
+        fetch(True)
+
+        stats = registry.get_metric_stats("cache_hit_ratio", {"cache": "demo_cache"})
+        assert stats["latest"] == pytest.approx(3 / 4)
+    finally:
+        metrics_manager._metrics_registry = None
+```
+
+Create `tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py` with:
+
+```python
+import asyncio
+import contextlib
+
+import pytest
+
+import tldw_Server_API.app.core.Metrics.traces as traces_module
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_trace_method_preserves_async_method_semantics(monkeypatch):
+    class StubAsyncSpan:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class StubManager:
+        def async_span(self, *args, **kwargs):
+            return StubAsyncSpan()
+
+    monkeypatch.setattr(traces_module, "get_tracing_manager", lambda: StubManager())
+
+    class Service:
+        @traces_module.trace_method(name="service.work")
+        async def work(self):
+            return "ok"
+
+    assert asyncio.iscoroutinefunction(Service.work)
+    assert await Service().work() == "ok"
+
+
+def test_trace_operation_records_exception_once(monkeypatch):
+    class StubSpan:
+        def __init__(self):
+            self.recorded = []
+            self.statuses = []
+
+        def set_attribute(self, key, value):
+            pass
+
+        def record_exception(self, exc):
+            self.recorded.append(exc)
+
+        def set_status(self, status):
+            self.statuses.append(status)
+
+    span = StubSpan()
+
+    @contextlib.contextmanager
+    def span_cm(*args, **kwargs):
+        try:
+            yield span
+        except Exception as exc:
+            span.record_exception(exc)
+            raise
+
+    class StubManager:
+        def span(self, *args, **kwargs):
+            return span_cm()
+
+    monkeypatch.setattr(traces_module, "get_tracing_manager", lambda: StubManager())
+
+    @traces_module.trace_operation(name="sync.fail")
+    def fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        fail()
+
+    assert len(span.recorded) == 1
+```
+
+- [ ] **Step 2: Run the new decorator/tracing tests and verify they fail for the right reasons**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py \
+  tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py -q
+```
+
+Expected: FAIL because tuple returns are still rewritten, `trace_method()` still returns a synchronous wrapper for async methods, and `trace_operation()` still double-records failures.
+
+- [ ] **Step 3: Implement the minimal semantic fixes**
+
+In `tldw_Server_API/app/core/Metrics/decorators.py`, stop inferring cache hits from arbitrary tuples and preserve the original return value:
+
+```python
+def _cache_result_from_cache(result: Any) -> bool:
+    return bool(getattr(result, "from_cache", False))
+
+...
+result = await func(*args, **kwargs)
+cache_hit = _cache_result_from_cache(result)
+...
+return result
+```
+
+Mirror the same logic in the sync wrapper and remove all `actual_result, cache_hit = result` tuple unpacking.
+
+In `tldw_Server_API/app/core/Metrics/traces.py`, make the async branch of `trace_method()` return an actual async wrapper, and stop double-recording in `trace_operation()`:
+
+```python
+if asyncio.iscoroutinefunction(func):
+    @functools.wraps(func)
+    async def async_wrapper(*args, **kwargs):
+        manager = get_tracing_manager()
+        span_attributes = dict(attributes) if attributes else {}
+        span_attributes["function"] = func.__name__
+        span_attributes["module"] = func.__module__
+        async with manager.async_span(span_name, kind=kind, attributes=span_attributes) as span:
+            result = await func(*args, **kwargs)
+            if record_result and span:
+                span.set_attribute("result", json.dumps(str(result)[:1000]))
+            return result
+    return async_wrapper
+```
+
+For both sync and async `trace_operation()` wrappers, keep the result-recording logic but replace the explicit exception-recording block with a plain `raise` so the span context manager owns failure recording.
+
+Update the `@cache_metrics` section in `tldw_Server_API/app/core/Metrics/README.md` to stop documenting tuple-return semantics:
+
+```python
+@cache_metrics(cache_name="embedding_cache")
+async def get_cached_embedding(text: str):
+    result = ...
+    result.from_cache = True
+    return result
+```
+
+- [ ] **Step 4: Re-run the focused decorator/tracing slice**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py \
+  tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the decorator/tracing fix**
+
+Run:
+```bash
+git add \
+  tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py \
+  tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py \
+  tldw_Server_API/app/core/Metrics/decorators.py \
+  tldw_Server_API/app/core/Metrics/traces.py \
+  tldw_Server_API/app/core/Metrics/README.md && \
+git commit -m "fix: preserve metrics decorator semantics"
+```
+
+Expected: one commit containing the cache/tracing semantic corrections and README update.
+
+### Task 3: Make Telemetry Lifecycle Restart-Safe
+
+**Files:**
+- Create: `tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py`
+- Modify: `tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py`
+- Modify: `tldw_Server_API/app/core/Metrics/telemetry.py`
+
+- [ ] **Step 1: Add failing telemetry lifecycle and fallback tests**
+
+Create `tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py` with:
+
+```python
+import tldw_Server_API.app.core.Metrics.telemetry as telemetry_module
+
+
+def test_shutdown_telemetry_clears_global_manager_and_allows_reinitialize(monkeypatch):
+    class StubManager:
+        def __init__(self, config=None):
+            self.config = config
+            self.shutdown_calls = 0
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    monkeypatch.setattr(telemetry_module, "TelemetryManager", StubManager)
+    monkeypatch.setattr(telemetry_module, "_telemetry_manager", None, raising=False)
+
+    first = telemetry_module.initialize_telemetry()
+    assert telemetry_module._telemetry_manager is first
+
+    telemetry_module.shutdown_telemetry()
+    assert telemetry_module._telemetry_manager is None
+    assert first.shutdown_calls == 1
+
+    second = telemetry_module.initialize_telemetry()
+    assert second is not first
+
+
+def test_partial_initialize_failure_rolls_back_state(monkeypatch):
+    monkeypatch.setattr(telemetry_module, "OTEL_AVAILABLE", True, raising=False)
+    monkeypatch.setattr(
+        telemetry_module,
+        "Resource",
+        type("Resource", (), {"create": staticmethod(lambda attrs: object())}),
+        raising=False,
+    )
+    monkeypatch.setattr(telemetry_module, "set_global_textmap", None, raising=False)
+    monkeypatch.setattr(telemetry_module, "TraceContextTextMapPropagator", None, raising=False)
+
+    installed = []
+
+    class StubProvider:
+        def __init__(self, name: str):
+            self.name = name
+            self.shutdown_called = False
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    def fake_install(provider_kind, provider):
+        installed.append((provider_kind, provider))
+
+    monkeypatch.setattr(telemetry_module, "_install_global_tracer_provider", lambda provider: fake_install("trace", provider), raising=False)
+    monkeypatch.setattr(telemetry_module, "_install_global_meter_provider", lambda provider: fake_install("metrics", provider), raising=False)
+
+    original_init_tracing = telemetry_module.TelemetryManager._initialize_tracing
+    original_init_metrics = telemetry_module.TelemetryManager._initialize_metrics
+
+    def fake_init_tracing(self, resource):
+        self.tracer_provider = StubProvider("trace")
+        self.tracer = object()
+
+    def fake_init_metrics(self, resource):
+        self.meter_provider = StubProvider("metrics")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_initialize_tracing", fake_init_tracing)
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_initialize_metrics", fake_init_metrics)
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_setup_auto_instrumentation", lambda self: None)
+
+    manager = telemetry_module.TelemetryManager()
+
+    assert isinstance(manager.tracer, telemetry_module.DummyTracer)
+    assert isinstance(manager.meter, telemetry_module.DummyMeter)
+    assert manager.tracer_provider is None
+    assert manager.meter_provider is None
+    assert installed == []
+```
+
+Extend `tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py` so the fallback script also exercises `TelemetryConfig.get_resource_attributes()`:
+
+```python
+            cfg = telemetry.TelemetryConfig()
+            attrs = cfg.get_resource_attributes()
+            print("RESOURCE_ATTR_KEYS", sorted(str(key) for key in attrs.keys()))
+```
+
+- [ ] **Step 2: Run the telemetry red slice**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py \
+  tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py -q
+```
+
+Expected: FAIL because shutdown still leaves the global manager in place, partial init still leaves stale state, and import-fallback resource attributes are still unsafe.
+
+- [ ] **Step 3: Implement the telemetry lifecycle fixes**
+
+In `tldw_Server_API/app/core/Metrics/telemetry.py`, make the resource keys safe under import fallback:
+
+```python
+SERVICE_NAME_KEY = "service.name"
+SERVICE_VERSION_KEY = "service.version"
+
+if OTEL_AVAILABLE:
+    SERVICE_NAME_KEY = SERVICE_NAME
+    SERVICE_VERSION_KEY = SERVICE_VERSION
+
+...
+def get_resource_attributes(self) -> dict[str, Any]:
+    return {
+        SERVICE_NAME_KEY: self.service_name,
+        SERVICE_VERSION_KEY: self.service_version,
+        ...
+    }
+```
+
+Add explicit lifecycle helpers and delay global provider installation until initialization has succeeded:
+
+```python
+def _install_global_tracer_provider(provider: Any) -> None:
+    if trace is not None:
+        trace.set_tracer_provider(provider)
+
+
+def _install_global_meter_provider(provider: Any) -> None:
+    if metrics is not None:
+        metrics.set_meter_provider(provider)
+
+
+def _reset_runtime_state(self) -> None:
+    self.initialized = False
+    self.tracer_provider = None
+    self.meter_provider = None
+    self.tracer = DummyTracer()
+    self.meter = DummyMeter()
+
+
+def _rollback_failed_initialization(self) -> None:
+    for provider in (self.tracer_provider, self.meter_provider):
+        if provider and hasattr(provider, "shutdown"):
+            with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                provider.shutdown()
+    self._reset_runtime_state()
+```
+
+Update `_initialize_tracing()` and `_initialize_metrics()` to create local tracer/meter from the provider objects rather than reading them back from global registries:
+
+```python
+self.tracer = self.tracer_provider.get_tracer(self.config.service_name, self.config.service_version)
+self.meter = self.meter_provider.get_meter(self.config.service_name, self.config.service_version)
+```
+
+Then in `_initialize()`:
+
+```python
+self._initialize_tracing(resource)
+self._initialize_metrics(resource)
+if self.tracer_provider:
+    _install_global_tracer_provider(self.tracer_provider)
+if self.meter_provider:
+    _install_global_meter_provider(self.meter_provider)
+...
+except _TELEMETRY_NONCRITICAL_EXCEPTIONS as e:
+    logger.error(f"Failed to initialize telemetry: {e}")
+    self._rollback_failed_initialization()
+```
+
+Finally, make shutdown clear reusable state and the global singleton pointer:
+
+```python
+def shutdown(self):
+    for provider in (self.tracer_provider, self.meter_provider):
+        if provider:
+            with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                provider.shutdown()
+    self._reset_runtime_state()
+
+
+def shutdown_telemetry():
+    global _telemetry_manager
+    if _telemetry_manager:
+        _telemetry_manager.shutdown()
+        _telemetry_manager = None
+```
+
+- [ ] **Step 4: Re-run the telemetry-focused slice**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py \
+  tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py \
+  tldw_Server_API/tests/Metrics/test_telemetry_config_and_disable_paths.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the telemetry lifecycle fix**
+
+Run:
+```bash
+git add \
+  tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py \
+  tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py \
+  tldw_Server_API/app/core/Metrics/telemetry.py && \
+git commit -m "fix: harden telemetry lifecycle state"
+```
+
+Expected: one commit containing the telemetry lifecycle and import-fallback fixes.
+
+### Task 4: Correct Registry Admission, Normalization, And Reset Semantics
+
+**Files:**
+- Create: `tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py`
+- Modify: `tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py`
+- Modify: `tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py`
+- Modify: `tldw_Server_API/app/core/Metrics/metrics_manager.py`
+- Modify: `tldw_Server_API/app/core/Metrics/metrics_logger.py`
+- Modify: `tldw_Server_API/app/core/Metrics/README.md`
+
+- [ ] **Step 1: Add failing registry regression tests**
+
+Update `tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py` with:
+
+```python
+def test_cumulative_counter_series_cap_does_not_leak_into_stats(monkeypatch):
+    monkeypatch.setenv("METRICS_CUMULATIVE_SERIES_MAX_PER_METRIC", "1")
+    metrics_manager._metrics_registry = None
+    registry = metrics_manager.get_metrics_registry()
+
+    try:
+        registry.register_metric(
+            MetricDefinition(
+                name="cap_counter_stats_total",
+                type=MetricType.COUNTER,
+                description="counter cap stats test",
+                labels=["series"],
+            )
+        )
+
+        registry.increment("cap_counter_stats_total", labels={"series": "a"})
+        registry.increment("cap_counter_stats_total", labels={"series": "b"})
+        registry.increment("cap_counter_stats_total", labels={"series": "a"})
+
+        assert registry.get_metric_stats("cap_counter_stats_total", {"series": "b"}) == {}
+        assert registry.get_all_metrics()["cap_counter_stats_total"]["stats"]["sum"] == 2
+    finally:
+        metrics_manager._metrics_registry = None
+
+
+def test_cumulative_histogram_series_cap_does_not_leak_into_stats(monkeypatch):
+    monkeypatch.setenv("METRICS_CUMULATIVE_SERIES_MAX_PER_METRIC", "1")
+    metrics_manager._metrics_registry = None
+    registry = metrics_manager.get_metrics_registry()
+
+    try:
+        registry.register_metric(
+            MetricDefinition(
+                name="cap_hist_stats_seconds",
+                type=MetricType.HISTOGRAM,
+                description="hist cap stats test",
+                labels=["series"],
+                buckets=[0.1, 1.0],
+            )
+        )
+
+        registry.observe("cap_hist_stats_seconds", 0.2, labels={"series": "a"})
+        registry.observe("cap_hist_stats_seconds", 0.3, labels={"series": "b"})
+        registry.observe("cap_hist_stats_seconds", 0.4, labels={"series": "a"})
+
+        assert registry.get_metric_stats("cap_hist_stats_seconds", {"series": "b"}) == {}
+        assert registry.get_all_metrics()["cap_hist_stats_seconds"]["stats"]["sum"] == pytest.approx(0.6)
+    finally:
+        metrics_manager._metrics_registry = None
+```
+
+Create `tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py` with:
+
+```python
+import pytest
+
+import tldw_Server_API.app.core.Metrics.metrics_manager as metrics_manager
+from tldw_Server_API.app.core.Metrics.metrics_manager import MetricDefinition, MetricType
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_record_rejects_conflicting_labels_after_normalization(monkeypatch):
+    metrics_manager._metrics_registry = None
+    registry = metrics_manager.get_metrics_registry()
+
+    try:
+        registry.register_metric(
+            MetricDefinition(
+                name="collision_counter_total",
+                type=MetricType.COUNTER,
+                description="label collision test",
+                labels=["a_b"],
+            )
+        )
+
+        registry.increment(
+            "collision_counter_total",
+            labels={"a-b": "one", "a_b": "two"},
+        )
+
+        assert registry.get_cumulative_counter_total("collision_counter_total") == 0
+        assert registry.export_prometheus_format().strip() == ""
+    finally:
+        metrics_manager._metrics_registry = None
+```
+
+Update `tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py` with:
+
+```python
+def test_metrics_logger_bridge_re_registers_metric_definition_after_reset():
+    registry = get_metrics_registry()
+    registry.reset()
+
+    metric_name = "bridge_reset_metric"
+    metrics_logger.log_histogram(metric_name, 0.5, labels={"source": "test"})
+
+    registry.reset()
+    metrics_logger.log_counter(metric_name, labels={"source": "test"}, value=2)
+
+    definition = registry.metrics[registry.normalize_metric_name(metric_name)]
+    assert definition.type == metrics_logger.MetricType.COUNTER
+    assert registry.get_cumulative_counter(metric_name, {"source": "test"}) == 2
+```
+
+- [ ] **Step 2: Run the registry red slice**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py \
+  tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py \
+  tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py -q
+```
+
+Expected: FAIL because dropped overflow series still leak into stats, label normalization still merges conflicting keys, and reset still preserves stale bridge definitions.
+
+- [ ] **Step 3: Implement the minimal registry fixes**
+
+In `tldw_Server_API/app/core/Metrics/metrics_manager.py`, make collision handling explicit and reject conflicting normalized labels before any mutation:
+
+```python
+@classmethod
+def _normalize_labels(
+    cls,
+    labels: Optional[dict[str, Any]],
+    *,
+    reject_collisions: bool = False,
+) -> dict[str, str]:
+    if not labels:
+        return {}
+    normalized = {}
+    for key, value in labels.items():
+        normalized_key = cls._normalize_label_name(str(key))
+        normalized_value = "" if value is None else str(value)
+        if normalized_key in normalized and normalized[normalized_key] != normalized_value:
+            message = f"Conflicting label keys after normalization: {key} -> {normalized_key}"
+            if reject_collisions:
+                raise ValueError(message)
+            logger.debug(message)
+            continue
+        normalized[normalized_key] = normalized_value
+    return normalized
+```
+
+Then in `record()` normalize strictly and refuse to mutate on collision:
+
+```python
+try:
+    labels = self._normalize_labels(labels, reject_collisions=True)
+except ValueError as exc:
+    logger.warning("Metric {} rejected due to label collision: {}", original_name, exc)
+    return
+```
+
+Move point-sample storage until after cumulative-series admission succeeds:
+
+```python
+store_value = True
+...
+if definition.type in (MetricType.COUNTER, MetricType.UP_DOWN_COUNTER):
+    if label_key not in series and cap_reached:
+        store_value = False
+...
+elif definition.type == MetricType.HISTOGRAM:
+    if hist is None and cap_reached:
+        store_value = False
+...
+if not store_value:
+    return
+
+metric_value = MetricValue(value=value, labels=labels)
+self.values[metric_name].append(metric_value)
+if original_name != metric_name:
+    self.values[original_name].append(metric_value)
+```
+
+Rebuild fresh state in `reset()`:
+
+```python
+def reset(self) -> None:
+    with self._lock:
+        self.metrics.clear()
+        self.instruments.clear()
+        self.callbacks.clear()
+        self.values.clear()
+        self._cumulative_counters.clear()
+        self._cumulative_histograms.clear()
+        self._cumulative_series_dropped.clear()
+        self._cumulative_series_warned.clear()
+    self._register_standard_metrics()
+```
+
+In `tldw_Server_API/app/core/Metrics/metrics_logger.py`, keep bridge registration aligned with the rebuilt registry by using the normalized name consistently:
+
+```python
+if metric_type == MetricType.COUNTER:
+    registry.increment(normalized_name, value, labels)
+elif metric_type == MetricType.HISTOGRAM:
+    registry.observe(normalized_name, value, labels)
+elif metric_type == MetricType.GAUGE:
+    registry.set_gauge(normalized_name, value, labels)
+else:
+    registry.record(normalized_name, value, labels)
+```
+
+Update `tldw_Server_API/app/core/Metrics/README.md` to document that conflicting normalized label keys are rejected and that `reset()` returns the registry to fresh post-bootstrap state.
+
+- [ ] **Step 4: Re-run the registry-focused slice**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py \
+  tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py \
+  tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py \
+  tldw_Server_API/tests/Metrics/test_metrics_logger_timestamps.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the registry/reset fix**
+
+Run:
+```bash
+git add \
+  tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py \
+  tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py \
+  tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py \
+  tldw_Server_API/app/core/Metrics/metrics_manager.py \
+  tldw_Server_API/app/core/Metrics/metrics_logger.py \
+  tldw_Server_API/app/core/Metrics/README.md && \
+git commit -m "fix: align metrics registry semantics"
+```
+
+Expected: one commit containing the registry admission, normalization, and reset corrections.
+
+### Task 5: Verify, Secure, And Update Behavior-Tied Docs
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Chat/README.md`
+- Modify: `Docs/superpowers/plans/2026-04-07-metrics-confirmed-defects-remediation-implementation-plan.md`
+
+- [ ] **Step 1: Update the chat README only if the endpoint contract explanation changed materially**
+
+If `tldw_Server_API/app/core/Chat/README.md` still implies that `/api/v1/metrics/chat` is sourced directly from exporter internals, replace that note with:
+
+```markdown
+- Metrics emitted by `chat_metrics.ChatMetricsCollector` continue to feed OpenTelemetry meters.
+- The `/api/v1/metrics/chat` endpoint uses a small in-process summary maintained alongside those emissions so existing monitoring consumers can read registry-style summaries such as `sum`.
+```
+
+- [ ] **Step 2: Run the full touched-scope pytest verification**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Monitoring/test_metrics_endpoints.py \
+  tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py \
+  tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py \
+  tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py \
+  tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py \
+  tldw_Server_API/tests/Metrics/test_telemetry_config_and_disable_paths.py \
+  tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py \
+  tldw_Server_API/tests/Metrics/test_telemetry_trace_context.py \
+  tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py \
+  tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py \
+  tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py \
+  tldw_Server_API/tests/Metrics/test_metrics_logger_timestamps.py \
+  tldw_Server_API/tests/Metrics/test_chat_metrics_reset_safety.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run one adjacent exporter contract test**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -q \
+  tldw_Server_API/tests/Embeddings/test_metrics_golden_contract.py -q
+```
+
+Expected: PASS, confirming that the shared exporter path preserves the existing `/api/v1/metrics/text` golden subset.
+
+- [ ] **Step 4: Run Bandit on touched implementation files**
+
+Run:
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/api/v1/endpoints/metrics.py \
+  tldw_Server_API/app/main.py \
+  tldw_Server_API/app/core/Chat/chat_metrics.py \
+  tldw_Server_API/app/core/Metrics/decorators.py \
+  tldw_Server_API/app/core/Metrics/traces.py \
+  tldw_Server_API/app/core/Metrics/telemetry.py \
+  tldw_Server_API/app/core/Metrics/metrics_manager.py \
+  tldw_Server_API/app/core/Metrics/metrics_logger.py \
+  -f json -o /tmp/bandit_metrics_confirmed_defects.json
+```
+
+Expected: Bandit report written to `/tmp/bandit_metrics_confirmed_defects.json`; address any new findings in touched code before finishing.
+
+- [ ] **Step 5: Commit docs/verification follow-up**
+
+Run:
+```bash
+git add \
+  tldw_Server_API/app/core/Chat/README.md \
+  Docs/superpowers/plans/2026-04-07-metrics-confirmed-defects-remediation-implementation-plan.md && \
+git commit -m "docs: finalize metrics remediation verification notes"
+```
+
+Expected: final docs/verification commit, only if README or plan notes changed during verification.
+
+## Status Notes
+
+- Keep this implementation isolated to the clean worktree at `/Users/appledev/Documents/GitHub/tldw_server/.worktrees/metrics-module-review`.
+- Do not broaden into the lower-confidence middleware/logger risk items from the audit unless a regression test proves one of them while implementing the confirmed defects.
+- If `test_metrics_golden_contract.py` passes but an environment-limited e2e consumer is unavailable, record that explicitly instead of broadening into local-LLM or commercial-provider e2e execution.
+- Before declaring completion, preserve evidence from:
+  - `/tmp/bandit_metrics_confirmed_defects.json`
+  - the final pytest output for the touched-scope verification command above
+
+## Verification Notes
+
+- 2026-04-07: The full touched-scope verification command passed in the worktree with `45 passed, 110 warnings in 10.28s`.
+- 2026-04-07: Bandit completed successfully and wrote `/tmp/bandit_metrics_confirmed_defects.json` with no new findings in the touched Metrics remediation files.
+- 2026-04-07: The adjacent exporter contract test `tldw_Server_API/tests/Embeddings/test_metrics_golden_contract.py` failed on missing `embedding_stage_batch_size_bucket` and `embedding_stage_payload_bytes_bucket`, but the failure is pre-existing and tied to that test's bootstrap assumptions rather than this remediation. The test does not import `tldw_Server_API.app.core.Embeddings.workers.base_worker`, while the existing smoke test `tldw_Server_API/tests/Embeddings/test_metrics_histograms_smoke.py` does, and still passes against the current `/api/v1/metrics/text` exporter.

--- a/Docs/superpowers/specs/2026-04-07-metrics-confirmed-defects-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-07-metrics-confirmed-defects-remediation-design.md
@@ -1,0 +1,218 @@
+# Metrics Confirmed Defects Remediation Design
+
+- Date: 2026-04-07
+- Project: tldw_server
+- Topic: Remediate confirmed Metrics audit findings only
+- Mode: Design for implementation planning
+
+## 1. Objective
+
+Implement the confirmed Metrics defects from the completed audit without broadening into the lower-confidence risk items or a general observability redesign.
+
+The remediation must:
+
+- make every exposed Metrics endpoint truthful about the data it returns
+- remove caller-visible semantic breakage in Metrics decorators and tracing helpers
+- make telemetry lifecycle behavior restart-safe and cleanup-safe
+- eliminate the confirmed registry/export/reset correctness mismatches
+- add direct regression coverage for every corrected contract
+
+## 2. Scope
+
+### In Scope
+
+- Metrics API and route wiring:
+  - `tldw_Server_API/app/api/v1/endpoints/metrics.py`
+  - `tldw_Server_API/app/main.py`
+- Chat metrics data source and endpoint support:
+  - `tldw_Server_API/app/core/Chat/chat_metrics.py`
+- Metrics core behavior:
+  - `tldw_Server_API/app/core/Metrics/telemetry.py`
+  - `tldw_Server_API/app/core/Metrics/decorators.py`
+  - `tldw_Server_API/app/core/Metrics/traces.py`
+  - `tldw_Server_API/app/core/Metrics/metrics_manager.py`
+  - `tldw_Server_API/app/core/Metrics/metrics_logger.py`
+- Targeted scrape-path support code only where needed to preserve current endpoint guarantees:
+  - bounded use of `tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py`
+- Targeted tests in:
+  - `tldw_Server_API/tests/Metrics/`
+  - `tldw_Server_API/tests/Monitoring/`
+  - adjacent `tldw_Server_API/tests/Embeddings/` only if required to lock `/metrics` and `/api/v1/metrics/text` parity
+  - `tldw_Server_API/tests/server_e2e_tests/test_llm_provider_workflow.py` as a direct dependent of `/api/v1/metrics/chat` contract if targeted verification needs one consumer-level assertion
+- Behavior-tied docs only where the corrected contract would otherwise be misleading:
+  - `tldw_Server_API/app/core/Metrics/README.md`
+  - `tldw_Server_API/app/core/Chat/README.md` only if the chat metrics endpoint contract or data-source explanation changes materially
+
+### Out of Scope
+
+- speculative middleware timing/status risk fixes not already confirmed by the audit
+- logger-config cleanup that is only stylistic or lower-confidence
+- broad OpenTelemetry architecture redesign
+- broad Metrics docs rewrite beyond behavior that changes in this remediation
+- unrelated chat, embeddings, or monitoring refactors
+
+## 3. Confirmed Issues To Fix
+
+1. `/api/v1/metrics/chat` advertises chat metric series but reads from the JSON registry, while `ChatMetricsCollector` records those series through OpenTelemetry meters.
+2. `/metrics` and `/api/v1/metrics/text` are separate exporters with different scrape-time behavior, so the public text metrics surface is inconsistent.
+3. Telemetry lifecycle is not restart-safe; partial initialization can leave global OTel providers installed while the manager falls back to dummy components and becomes effectively unshuttable.
+4. `TelemetryConfig.get_resource_attributes()` can reference OTel constants that do not exist on the import-fallback path.
+5. `cache_metrics()` changes decorated function return semantics by treating any 2-tuple as `(result, cache_hit)` and returning only the first item.
+6. `trace_method()` does not preserve async-method semantics, and `trace_operation()` records failures twice.
+7. Registry cumulative-series cap behavior can make JSON/stat views and Prometheus export disagree about which series exist.
+8. Label-key normalization can silently merge distinct logical labels into the same exported series.
+9. `reset()` preserves definitions in a way that lets later bridge registration keep stale type/definition state.
+
+## 4. Approved Behavior Changes
+
+### 4.1 Chat Metrics Endpoint Contract
+
+- `/api/v1/metrics/chat` must return chat metrics from the data source that actually owns them.
+- The implementation should use a small in-process summary maintained by `ChatMetricsCollector` alongside OTel emission, not attempt to reconstruct endpoint data from exporter internals.
+- The endpoint may continue to expose `active_operations` and `token_costs` exactly as it does now.
+- The `metrics` object must become truthfully populated after chat metric emission.
+- This remediation does not require a broad OTel-to-registry bridge for every subsystem; it only requires a truthful chat metrics endpoint contract.
+
+### 4.2 Public Text Exporter Contract
+
+- `/metrics` and `/api/v1/metrics/text` must share one exporter implementation.
+- If embeddings/orchestrator metrics require scrape-time registration or refresh to satisfy current contract expectations, both routes must go through the same path.
+- Public route paths remain unchanged.
+- Cache-control, content-type, and response body behavior for the text exporter should be consistent across both routes for the same process state.
+
+### 4.3 Telemetry Lifecycle Contract
+
+- `initialize_telemetry()` and `shutdown_telemetry()` must be safe to call repeatedly.
+- Shutdown must clear or reset global state enough to allow a clean re-initialization path.
+- Partial initialization failure must not leave globally installed OTel providers attached while the manager reports an uninitialized dummy fallback state.
+- `TelemetryConfig.get_resource_attributes()` must work safely when OTel imports are unavailable.
+
+### 4.4 Decorator and Tracing Semantics
+
+- `cache_metrics()` must preserve the original return contract of the decorated function.
+- Cache-hit classification must stop inferring semantics from generic 2-tuples.
+- Minimum-safe rule: only explicit cache metadata, such as a boolean `from_cache` attribute/property on the returned object, may mark a hit; otherwise the decorator must preserve the return value unchanged and avoid tuple reinterpretation.
+- `trace_method()` must preserve coroutine-function semantics for async methods.
+- `trace_operation()` must record one logical failure per failing operation.
+
+### 4.5 Registry, Export, and Reset Semantics
+
+- Capped cumulative-series behavior must not allow JSON/stat views to claim a series exists when Prometheus export will omit it.
+- Overflow label-series must be rejected before mutating either cumulative state or point-sample/state views, so every public Metrics surface agrees on admitted series.
+- Label normalization must no longer silently alias distinct logical label keys; ambiguous normalized collisions must be rejected explicitly rather than merged.
+- Reset semantics must restore a fresh post-bootstrap registry state so bridge-driven re-registration does not inherit stale type/definition state.
+- The remediation should keep the registry model intact rather than replacing it wholesale.
+
+## 5. API and Internal Contract Design
+
+### 5.1 `GET /api/v1/metrics/chat`
+
+Recommended response rule:
+
+- keep the existing top-level shape
+- populate `metrics` from an explicit `ChatMetricsCollector` snapshot function backed by in-process summaries updated alongside OTel emission
+- if a metric family is unavailable, omit only that family instead of returning a structurally correct but misleadingly empty snapshot for emitted data
+
+Compatibility rule:
+
+- existing consumers reading `active_operations` and `token_costs` should continue to work
+- existing consumers reading registry-style metric summary fields, especially `sum`, should continue to work for the metric families currently exposed by this endpoint
+- the key contract change is that emitted chat metrics actually appear in `metrics`
+
+### 5.2 `GET /metrics` and `GET /api/v1/metrics/text`
+
+- both routes call one shared helper
+- helper is responsible for any registry export, `prometheus_client` merge, and bounded embeddings refresh needed by current contract
+- route wrappers should be thin and should not drift in behavior
+- targeted tests should be able to compare the two route outputs directly under the same prepared state
+
+### 5.3 Telemetry Global State
+
+- one canonical lifecycle path manages global singleton creation, cleanup, and restart
+- cleanup must cover both local manager state and any globally installed providers that this module owns
+- fallback initialization must leave the module in a state that is internally consistent and testable
+- partial initialization failure must leave the manager in a shutdown-capable or fully rolled-back state rather than an uninitialized object with globally installed providers
+
+### 5.4 Registry Semantics
+
+- series admission and export must agree on what is accepted
+- reset must rebuild registry state equivalent to a fresh bootstrap, including any required default registrations, so post-reset bridge registration behaves predictably
+- normalization must preserve correctness first by rejecting ambiguous label-key combinations rather than silently merging them
+
+## 6. File Responsibilities
+
+- `metrics.py`
+  - own the shared text export helper
+  - switch `/api/v1/metrics/chat` to a truthful chat snapshot source
+- `main.py`
+  - route both public text exporters through the shared helper
+  - preserve existing URLs while removing exporter drift
+- `chat_metrics.py`
+  - expose a stable snapshot method for the chat metrics families that the endpoint promises
+  - maintain the small in-process summaries needed for that snapshot alongside OTel emission
+- `telemetry.py`
+  - implement idempotent init/shutdown/reinit behavior
+  - fix import-fallback resource attribute behavior
+- `decorators.py`
+  - preserve return semantics for `cache_metrics()`
+  - stop tuple-based cache-hit inference
+- `traces.py`
+  - preserve async-method semantics and avoid duplicate failure recording
+- `metrics_manager.py`
+  - align admitted-series behavior across stats and export
+  - reject ambiguous normalized label collisions explicitly
+  - make reset behavior reconstruct fresh registry state predictably
+- `metrics_logger.py`
+  - cooperate with the corrected reset/registration semantics without preserving stale definitions
+- targeted tests
+  - prove each corrected defect directly
+
+## 7. Testing Strategy
+
+Required regression coverage:
+
+- `/api/v1/metrics/chat` returns populated chat metrics after chat metric emission
+- `/api/v1/metrics/chat` preserves the current per-metric summary shape needed by existing consumers, especially `sum`
+- adjacent consumer expectations for `/api/v1/metrics/chat` remain satisfied where targeted verification is warranted
+- `/metrics` and `/api/v1/metrics/text` produce equivalent output for the shared tested conditions
+- telemetry shutdown followed by re-initialization leaves a usable manager
+- partial initialization failure does not strand global provider state
+- `TelemetryConfig.get_resource_attributes()` works on import-fallback path
+- `cache_metrics()` preserves the decorated function’s return value
+- tuple returns remain untouched by `cache_metrics()` unless explicit cache metadata is present
+- `trace_method()` preserves async semantics for coroutine methods
+- `trace_operation()` does not double-record failures
+- cumulative-series cap behavior stays internally consistent across stats and export
+- ambiguous label-key normalization is rejected rather than silently aliased
+- post-reset bridge registration does not retain stale definition/type behavior
+
+Verification should prefer the smallest targeted pytest slices first, then one touched-scope verification pass.
+This remediation should not require broad repo-wide monitoring or embeddings suites unless a changed contract explicitly forces that expansion.
+
+## 8. Risk Management
+
+Primary risks:
+
+- breaking downstream expectations for metrics route payload shape
+- unintentionally changing exporter contents beyond the confirmed defects
+- overcorrecting registry normalization in a way that breaks existing legitimate metric writers
+- test contamination from process-global telemetry and registry state
+
+Mitigations:
+
+- preserve route URLs and top-level response shapes wherever possible
+- add regression tests before code changes for each defect cluster
+- keep normalization/reset fixes explicit and narrowly scoped
+- reset global/singleton state between targeted tests
+
+## 9. Success Criteria
+
+The remediation is successful when:
+
+- `/api/v1/metrics/chat` truthfully exposes emitted chat metrics
+- `/metrics` and `/api/v1/metrics/text` no longer diverge by implementation path
+- telemetry can be shut down and re-initialized without inconsistent global state
+- import-fallback telemetry config is safe
+- `cache_metrics()`, `trace_method()`, and `trace_operation()` preserve correct caller-visible semantics
+- registry/export/reset behavior no longer exhibits the confirmed internal contradictions
+- each corrected behavior has direct regression coverage

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -27,7 +27,7 @@ from datetime import datetime
 from enum import Enum
 from fnmatch import fnmatch
 from functools import lru_cache
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 from typing import Any
 
 import numpy as np
@@ -1218,6 +1218,24 @@ def get_cache_key(
     return hashlib.sha256(key_string.encode()).hexdigest()
 
 
+_SENSITIVE_QUERY_KEYS = frozenset({
+    "access_token", "api_key", "apikey", "auth", "bearer",
+    "credential", "key", "passwd", "password", "secret", "token",
+})
+
+
+def _sanitize_query(query: str) -> str:
+    """Remove known sensitive query params, keep the rest sorted for determinism."""
+    params = parse_qs(query, keep_blank_values=True)
+    filtered = {
+        k: v for k, v in params.items()
+        if k.lower() not in _SENSITIVE_QUERY_KEYS
+    }
+    if not filtered:
+        return ""
+    return urlencode(sorted(filtered.items()), doseq=True)
+
+
 def _normalize_cache_backend_identity(config: dict[str, Any], provider: str) -> str | None:
     """Derive stable backend identity for cache partitioning."""
     if provider != "local_api":
@@ -1232,7 +1250,8 @@ def _normalize_cache_backend_identity(config: dict[str, Any], provider: str) -> 
         host = parsed.hostname
         if parsed.port is not None:
             host = f"{host}:{parsed.port}"
-        return urlunsplit((parsed.scheme, host, parsed.path.rstrip("/"), "", ""))
+        sanitized_query = _sanitize_query(parsed.query)
+        return urlunsplit((parsed.scheme, host, parsed.path.rstrip("/"), sanitized_query, ""))
     return api_url.rstrip("/")
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from enum import Enum
 from fnmatch import fnmatch
 from functools import lru_cache
+from urllib.parse import urlsplit, urlunsplit
 from typing import Any
 
 import numpy as np
@@ -1200,13 +1201,39 @@ def count_tokens(text: str, model_name: str) -> int:
         logger.warning(f"Token counting failed: {e}, estimating")
         return len(text) // 4
 
-def get_cache_key(text: str, provider: str, model: str, dimensions: int | None = None) -> str:
+def get_cache_key(
+    text: str,
+    provider: str,
+    model: str,
+    dimensions: int | None = None,
+    backend_identity: str | None = None,
+) -> str:
     """Generate cache key for embedding"""
     key_parts = [text, provider, model]
     if dimensions:
         key_parts.append(str(dimensions))
+    if backend_identity:
+        key_parts.append(backend_identity)
     key_string = "|".join(key_parts)
     return hashlib.sha256(key_string.encode()).hexdigest()
+
+
+def _normalize_cache_backend_identity(config: dict[str, Any], provider: str) -> str | None:
+    """Derive stable backend identity for cache partitioning."""
+    if provider != "local_api":
+        return None
+
+    api_url = str(config.get("api_url") or "").strip()
+    if not api_url:
+        return None
+
+    parsed = urlsplit(api_url)
+    if parsed.scheme and parsed.hostname:
+        host = parsed.hostname
+        if parsed.port is not None:
+            host = f"{host}:{parsed.port}"
+        return urlunsplit((parsed.scheme, host, parsed.path.rstrip("/"), "", ""))
+    return api_url.rstrip("/")
 
 
 # ---------------------------------------------------------------------------
@@ -1291,9 +1318,7 @@ def tokens_to_texts(
                 len(arr),
                 exc,
             )
-            # Fall back to an empty string to preserve request shape; the raw
-            # token counts are still used for limits/usage accounting.
-            texts.append("")
+            raise ValueError("Invalid token array input") from exc
         return texts, total_tokens, token_counts
 
     # Batch of token arrays
@@ -1313,7 +1338,7 @@ def tokens_to_texts(
                     len(arr),
                     exc,
                 )
-                texts.append("")
+                raise ValueError("Invalid token array input") from exc
         return texts, total_tokens, token_counts
 
     raise ValueError("Invalid token array input")
@@ -2004,9 +2029,40 @@ async def create_embeddings_batch_async(
     uncached_texts = []
     uncached_indices = []
 
+    try:
+        provider_enum = EmbeddingProvider(provider)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown provider: {provider}"
+        ) from None
+
+    try:
+        _validate_dimensions_request(provider, model_id or "", dimensions)
+        config = build_provider_config(
+            provider_enum,
+            model_id,
+            api_key,
+            api_url,
+            dimensions,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    backend_identity = _normalize_cache_backend_identity(config, provider)
+
     # Check cache
     for i, text in enumerate(texts):
-        cache_key = get_cache_key(text, provider, model_id or "default", dimensions)
+        cache_key = get_cache_key(
+            text,
+            provider,
+            model_id or "default",
+            dimensions,
+            backend_identity=backend_identity,
+        )
         cached = await embedding_cache.get(cache_key)
 
         if cached:
@@ -2020,29 +2076,6 @@ async def create_embeddings_batch_async(
 
     # Process uncached texts
     if uncached_texts:
-        try:
-            provider_enum = EmbeddingProvider(provider)
-        except ValueError:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Unknown provider: {provider}"
-            ) from None
-
-        try:
-            _validate_dimensions_request(provider, model_id or "", dimensions)
-            config = build_provider_config(
-                provider_enum,
-                model_id,
-                api_key,
-                api_url,
-                dimensions
-            )
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(exc),
-            ) from exc
-
         # Process in batches with circuit breaker (or synthesize in test mode for OpenAI)
         all_new_embeddings = []
         if (
@@ -2121,7 +2154,13 @@ async def create_embeddings_batch_async(
             embedding = all_new_embeddings[i]
             embeddings[idx] = embedding
 
-            cache_key = get_cache_key(text, provider, model_id or "default", dimensions)
+            cache_key = get_cache_key(
+                text,
+                provider,
+                model_id or "default",
+                dimensions,
+                backend_identity=backend_identity,
+            )
             await embedding_cache.set(cache_key, embedding)
 
     return embeddings

--- a/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
@@ -797,10 +797,9 @@ async def generate_embeddings_batch(
     for media_id in media_ids:
         media_item = get_media_by_id(db, media_id)
         if not media_item:
-            raise HTTPException(
-                status_code=http_status.HTTP_404_NOT_FOUND,
-                detail=f"Media item {media_id} not found"
-            )
+            failed_media_ids.append(int(media_id))
+            failure_reasons.append(f"media_id={media_id}: not found")
+            continue
         job_id: Optional[str] = None
         try:
             job_row = adapter.create_job(

--- a/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
@@ -447,7 +447,7 @@ async def generate_embeddings_for_media(
             *,
             model_name: str,
             provider_name: str,
-            embeddings_to_store,
+            embeddings_to_store: list[Any],
         ) -> None:
             collection_name = f"user_{user_id}_media_embeddings"
 

--- a/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
@@ -8,7 +8,7 @@
 
 import json
 import os
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import status as http_status
@@ -196,9 +196,11 @@ class BatchMediaEmbeddingsRequest(BaseModel):
 
 
 class BatchMediaEmbeddingsResponse(BaseModel):
-    status: str
+    status: Literal["accepted", "partial"]
     job_ids: list[str]
     submitted: int
+    failed_media_ids: list[int] = Field(default_factory=list)
+    failure_reasons: list[str] = Field(default_factory=list)
 
 
 class EmbeddingsSearchRequest(BaseModel):
@@ -431,28 +433,24 @@ async def generate_embeddings_for_media(
                     return "Embedding service returned invalid embedding vectors"
             return None
 
-        # Generate embeddings
-        try:
-            embeddings = await create_embeddings_batch_async(
-                texts=chunk_texts,
-                provider=embedding_provider,
-                model_id=embedding_model,
-                metadata=request_metadata,
-            )
-            validation_error = _validate_embeddings_result(embeddings, len(chunk_texts))
-            if validation_error:
-                return {
-                    "status": "error",
-                    "message": validation_error,
-                    "error": validation_error,
-                    "embedding_count": len(embeddings) if embeddings else 0,
-                    "chunks_processed": len(chunks),
-                }
+        def _storage_failure_result(exc: Exception, embedding_count: int) -> dict[str, Any]:
+            message = f"Storage failure while saving embeddings to ChromaDB: {exc}"
+            return {
+                "status": "error",
+                "message": message,
+                "error": message,
+                "embedding_count": embedding_count,
+                "chunks_processed": len(chunks),
+            }
 
-            # Store in ChromaDB using per-user collections
+        def _store_embeddings(
+            *,
+            model_name: str,
+            provider_name: str,
+            embeddings_to_store,
+        ) -> None:
             collection_name = f"user_{user_id}_media_embeddings"
 
-            # Prepare metadata for each chunk
             extra_metadata = {}
             try:
                 media_item_meta = media_content.get("media_item", {})
@@ -460,6 +458,7 @@ async def generate_embeddings_for_media(
                     extra_metadata = media_item_meta.get("metadata") or {}
             except _MEDIA_EMBEDDINGS_NONCRITICAL_EXCEPTIONS:
                 extra_metadata = {}
+
             metadatas = []
             for _i, chunk in enumerate(chunks):
                 metadata = {
@@ -470,25 +469,29 @@ async def generate_embeddings_for_media(
                     "chunk_type": _chunk_type_for_metadata(chunk),
                     "title": media_content["media_item"].get("title", ""),
                     "author": media_content["media_item"].get("author", ""),
-                    "embedding_model": embedding_model,
-                    "embedding_provider": embedding_provider
+                    "embedding_model": model_name,
+                    "embedding_provider": provider_name,
                 }
                 if isinstance(extra_metadata, dict) and extra_metadata:
                     metadata["extra"] = dict(extra_metadata)
                 metadatas.append(metadata)
 
-            # Store embeddings
             ids = [f"media_{media_id}_chunk_{i}" for i in range(len(chunks))]
 
-            # Convert embeddings to list format if they're numpy arrays
-            logger.info(f"Embeddings type: {type(embeddings)}, first item type: {type(embeddings[0]) if embeddings else 'None'}")
-            if embeddings and hasattr(embeddings[0], 'tolist'):
-                embeddings_list = [emb.tolist() for emb in embeddings]
+            logger.info(
+                f"Embeddings type: {type(embeddings_to_store)}, first item type: {type(embeddings_to_store[0]) if embeddings_to_store else 'None'}"
+            )
+            if embeddings_to_store and hasattr(embeddings_to_store[0], "tolist"):
+                embeddings_list = [emb.tolist() for emb in embeddings_to_store]
             else:
-                embeddings_list = embeddings
+                embeddings_list = embeddings_to_store
 
-            logger.info(f"After conversion - embeddings_list type: {type(embeddings_list)}, first item type: {type(embeddings_list[0]) if embeddings_list else 'None'}")
-            logger.info(f"First embedding length: {len(embeddings_list[0]) if embeddings_list and embeddings_list[0] else 0}")
+            logger.info(
+                f"After conversion - embeddings_list type: {type(embeddings_list)}, first item type: {type(embeddings_list[0]) if embeddings_list else 'None'}"
+            )
+            logger.info(
+                f"First embedding length: {len(embeddings_list[0]) if embeddings_list and embeddings_list[0] else 0}"
+            )
 
             manager = ChromaDBManager(
                 user_id=str(user_id),
@@ -500,26 +503,36 @@ async def generate_embeddings_for_media(
                 embeddings=embeddings_list,
                 ids=ids,
                 metadatas=metadatas,
-                embedding_model_id_for_dim_check=embedding_model,
+                embedding_model_id_for_dim_check=model_name,
             )
 
-            return {
-                "status": "success",
-                "message": f"Successfully generated {len(embeddings)} embeddings",
-                "embedding_count": len(embeddings),
-                "chunks_processed": len(chunks)
-            }
-
+        try:
+            embeddings = await create_embeddings_batch_async(
+                texts=chunk_texts,
+                provider=embedding_provider,
+                model_id=embedding_model,
+                metadata=request_metadata,
+            )
         except Exception:
-            # Try fallback model if primary fails
             if embedding_model != FALLBACK_EMBEDDING_MODEL:
                 logger.warning(f"Failed with {embedding_model}, trying fallback {FALLBACK_EMBEDDING_MODEL}")
-                embeddings = await create_embeddings_batch_async(
-                    texts=chunk_texts,
-                    provider="huggingface",
-                    model_id=FALLBACK_EMBEDDING_MODEL,
-                    metadata=request_metadata,
-                )
+                try:
+                    embeddings = await create_embeddings_batch_async(
+                        texts=chunk_texts,
+                        provider="huggingface",
+                        model_id=FALLBACK_EMBEDDING_MODEL,
+                        metadata=request_metadata,
+                    )
+                except Exception as exc:
+                    logger.error(f"Fallback embedding generation failed: {exc}")
+                    return {
+                        "status": "error",
+                        "message": f"Failed to generate embeddings: {exc}",
+                        "error": str(exc),
+                        "embedding_count": 0,
+                        "chunks_processed": len(chunks),
+                    }
+
                 validation_error = _validate_embeddings_result(embeddings, len(chunk_texts))
                 if validation_error:
                     return {
@@ -530,62 +543,50 @@ async def generate_embeddings_for_media(
                         "chunks_processed": len(chunks),
                     }
 
-                # Store with fallback model info in per-user collection
-                collection_name = f"user_{user_id}_media_embeddings"
-
-                metadatas = []
-                extra_metadata = {}
                 try:
-                    media_item_meta = media_content.get("media_item", {})
-                    if isinstance(media_item_meta, dict):
-                        extra_metadata = media_item_meta.get("metadata") or {}
-                except _MEDIA_EMBEDDINGS_NONCRITICAL_EXCEPTIONS:
-                    extra_metadata = {}
-                for _i, chunk in enumerate(chunks):
-                    metadata = {
-                        "media_id": str(media_id),
-                        "chunk_index": chunk["index"],
-                        "chunk_start": chunk["start"],
-                        "chunk_end": chunk["end"],
-                        "chunk_type": _chunk_type_for_metadata(chunk),
-                        "title": media_content["media_item"].get("title", ""),
-                        "author": media_content["media_item"].get("author", ""),
-                        "embedding_model": FALLBACK_EMBEDDING_MODEL,
-                        "embedding_provider": "huggingface"
-                    }
-                    if isinstance(extra_metadata, dict) and extra_metadata:
-                        metadata["extra"] = dict(extra_metadata)
-                    metadatas.append(metadata)
-
-                ids = [f"media_{media_id}_chunk_{i}" for i in range(len(chunks))]
-
-                # Convert embeddings to list format if they're numpy arrays
-                if embeddings and hasattr(embeddings[0], 'tolist'):
-                    embeddings_list = [emb.tolist() for emb in embeddings]
-                else:
-                    embeddings_list = embeddings
-
-                manager = ChromaDBManager(
-                    user_id=str(user_id),
-                    user_embedding_config=_user_embedding_config(),
-                )
-                manager.store_in_chroma(
-                    collection_name=collection_name,
-                    texts=chunk_texts,
-                    embeddings=embeddings_list,
-                    ids=ids,
-                    metadatas=metadatas,
-                    embedding_model_id_for_dim_check=FALLBACK_EMBEDDING_MODEL,
-                )
+                    _store_embeddings(
+                        model_name=FALLBACK_EMBEDDING_MODEL,
+                        provider_name="huggingface",
+                        embeddings_to_store=embeddings,
+                    )
+                except Exception as exc:
+                    logger.error(f"Error storing fallback embeddings: {exc}")
+                    return _storage_failure_result(exc, len(embeddings) if embeddings else 0)
 
                 return {
                     "status": "success",
                     "message": f"Generated embeddings using fallback model {FALLBACK_EMBEDDING_MODEL}",
                     "embedding_count": len(embeddings),
-                    "chunks_processed": len(chunks)
+                    "chunks_processed": len(chunks),
                 }
-            else:
-                raise
+            raise
+
+        validation_error = _validate_embeddings_result(embeddings, len(chunk_texts))
+        if validation_error:
+            return {
+                "status": "error",
+                "message": validation_error,
+                "error": validation_error,
+                "embedding_count": len(embeddings) if embeddings else 0,
+                "chunks_processed": len(chunks),
+            }
+
+        try:
+            _store_embeddings(
+                model_name=embedding_model,
+                provider_name=embedding_provider,
+                embeddings_to_store=embeddings,
+            )
+        except Exception as exc:
+            logger.error(f"Error storing primary embeddings: {exc}")
+            return _storage_failure_result(exc, len(embeddings) if embeddings else 0)
+
+        return {
+            "status": "success",
+            "message": f"Successfully generated {len(embeddings)} embeddings",
+            "embedding_count": len(embeddings),
+            "chunks_processed": len(chunks),
+        }
 
     except _MEDIA_EMBEDDINGS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Error generating embeddings: {e}")
@@ -826,17 +827,26 @@ async def generate_embeddings_batch(
                 f"(user_id={user_id}, media_id={media_id}, reason={type(exc).__name__}: {exc})"
             )
 
-    if failed_media_ids:
+    if failed_media_ids and not job_ids:
         detail = {
             "error": "batch_enqueue_failed",
             "message": "Failed to queue one or more embedding jobs",
-            "submitted": len(job_ids),
+            "submitted": 0,
             "failed_media_ids": failed_media_ids,
             "failure_reasons": failure_reasons,
         }
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=detail,
+        )
+
+    if failed_media_ids:
+        return BatchMediaEmbeddingsResponse(
+            status="partial",
+            job_ids=job_ids,
+            submitted=len(job_ids),
+            failed_media_ids=failed_media_ids,
+            failure_reasons=failure_reasons,
         )
 
     return BatchMediaEmbeddingsResponse(

--- a/tldw_Server_API/app/api/v1/endpoints/metrics.py
+++ b/tldw_Server_API/app/api/v1/endpoints/metrics.py
@@ -1,6 +1,7 @@
 # metrics.py
 # Metrics endpoint for Prometheus and health monitoring
 
+import asyncio
 from datetime import datetime, timezone
 import time
 from typing import Any
@@ -33,12 +34,16 @@ _PROMETHEUS_HEADERS = {
     "Expires": "0",
 }
 _STAGE_FLAG_REFRESH_INTERVAL_SECONDS = 5.0
+_STAGE_FLAG_REFRESH_TIMEOUT_SECONDS = 0.5
 _last_stage_flag_refresh = 0.0
+# Canonical list of embedding pipeline stages; kept in sync with the
+# embeddings module so new stages are picked up automatically.
+_EMBEDDING_STAGES = ("chunking", "embedding", "storage", "content")
 
 
-async def _refresh_embeddings_stage_flags() -> None:
+async def _refresh_embeddings_stage_flags_inner() -> None:
     """Best-effort refresh for embeddings stage flags used in text metrics export."""
-    global _last_stage_flag_refresh
+    global _last_stage_flag_refresh  # noqa: PLW0603
     now = time.monotonic()
     if now - _last_stage_flag_refresh < _STAGE_FLAG_REFRESH_INTERVAL_SECONDS:
         return
@@ -58,7 +63,7 @@ async def _refresh_embeddings_stage_flags() -> None:
         return
 
     try:
-        for stage in ("chunking", "embedding", "storage"):
+        for stage in _EMBEDDING_STAGES:
             paused = await client.get(f"embeddings:stage:{stage}:paused")
             drain = await client.get(f"embeddings:stage:{stage}:drain")
             _emb.embedding_stage_flag.labels(stage=stage, flag="paused").set(
@@ -75,6 +80,19 @@ async def _refresh_embeddings_stage_flags() -> None:
                 await client.close()
             except _METRICS_NONCRITICAL_EXCEPTIONS:
                 logger.debug("metrics: failed to close redis client")
+
+
+async def _refresh_embeddings_stage_flags() -> None:
+    """Timeout-guarded wrapper so Redis I/O never stalls Prometheus scrapes."""
+    try:
+        await asyncio.wait_for(
+            _refresh_embeddings_stage_flags_inner(),
+            timeout=_STAGE_FLAG_REFRESH_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.debug("metrics: stage flag refresh timed out")
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: stage flag refresh skipped (error)")
 
 
 async def build_prometheus_metrics_response() -> Response:

--- a/tldw_Server_API/app/api/v1/endpoints/metrics.py
+++ b/tldw_Server_API/app/api/v1/endpoints/metrics.py
@@ -2,12 +2,14 @@
 # Metrics endpoint for Prometheus and health monitoring
 
 from datetime import datetime, timezone
+import time
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_roles
+import tldw_Server_API.app.core.Chat.chat_metrics as chat_metrics
 from tldw_Server_API.app.core.Chat.chat_metrics import get_chat_metrics
 from tldw_Server_API.app.core.Metrics.metrics_manager import get_metrics_registry
 
@@ -24,6 +26,77 @@ _METRICS_NONCRITICAL_EXCEPTIONS = (
     TypeError,
     ValueError,
 )
+
+_PROMETHEUS_HEADERS = {
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+    "Pragma": "no-cache",
+    "Expires": "0",
+}
+_STAGE_FLAG_REFRESH_INTERVAL_SECONDS = 5.0
+_last_stage_flag_refresh = 0.0
+
+
+async def _refresh_embeddings_stage_flags() -> None:
+    """Best-effort refresh for embeddings stage flags used in text metrics export."""
+    global _last_stage_flag_refresh
+    now = time.monotonic()
+    if now - _last_stage_flag_refresh < _STAGE_FLAG_REFRESH_INTERVAL_SECONDS:
+        return
+    _last_stage_flag_refresh = now
+
+    try:
+        import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as _emb
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: embeddings modules not available for import")
+        return
+
+    client = None
+    try:
+        client = await _emb._get_redis_client()
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: redis not available for stage flags")
+        return
+
+    try:
+        for stage in ("chunking", "embedding", "storage"):
+            paused = await client.get(f"embeddings:stage:{stage}:paused")
+            drain = await client.get(f"embeddings:stage:{stage}:drain")
+            _emb.embedding_stage_flag.labels(stage=stage, flag="paused").set(
+                1.0 if str(paused).lower() in ("1", "true", "yes") else 0.0
+            )
+            _emb.embedding_stage_flag.labels(stage=stage, flag="drain").set(
+                1.0 if str(drain).lower() in ("1", "true", "yes") else 0.0
+            )
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: failed to refresh stage gauges")
+    finally:
+        if client is not None:
+            try:
+                await client.close()
+            except _METRICS_NONCRITICAL_EXCEPTIONS:
+                logger.debug("metrics: failed to close redis client")
+
+
+async def build_prometheus_metrics_response() -> Response:
+    """Build the canonical text-format metrics response used by all surface routes."""
+    registry = get_metrics_registry()
+    await _refresh_embeddings_stage_flags()
+    prometheus_text = registry.export_prometheus_format() or ""
+    try:
+        from prometheus_client import REGISTRY as PC_REGISTRY
+        from prometheus_client import generate_latest as pc_generate_latest
+
+        prometheus_text = (
+            prometheus_text + "\n" + pc_generate_latest(PC_REGISTRY).decode("utf-8")
+        ).strip() + "\n"
+    except _METRICS_NONCRITICAL_EXCEPTIONS:
+        logger.debug("metrics: failed to augment with prometheus_client registry")
+
+    return Response(
+        content=prometheus_text,
+        media_type="text/plain; version=0.0.4",
+        headers=_PROMETHEUS_HEADERS,
+    )
 
 
 # Note: Avoid path conflict with the JSON metrics in main.py (`/api/v1/metrics`).
@@ -45,53 +118,7 @@ async def get_prometheus_metrics() -> Response:
 
     The format is compatible with Prometheus scrapers.
     """
-    try:
-        registry = get_metrics_registry()
-        # Ensure core embeddings histograms are registered in the default Prometheus REGISTRY
-        try:
-            # Ensure embeddings endpoint module (with gauges) is imported so collectors exist
-            import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as _emb  # noqa: F401
-            # Best-effort: refresh stage flag gauges from Redis so they appear in metrics
-            try:
-                client = await _emb._get_redis_client()
-                for _st in ("chunking", "embedding", "storage"):
-                    try:
-                        p = await client.get(f"embeddings:stage:{_st}:paused")
-                        d = await client.get(f"embeddings:stage:{_st}:drain")
-                        _emb.embedding_stage_flag.labels(stage=_st, flag="paused").set(1.0 if str(p).lower() in ("1","true","yes") else 0.0)
-                        _emb.embedding_stage_flag.labels(stage=_st, flag="drain").set(1.0 if str(d).lower() in ("1","true","yes") else 0.0)
-                    except _METRICS_NONCRITICAL_EXCEPTIONS:
-                        logger.debug("metrics: failed to refresh stage gauge for {}", _st)
-                try:
-                    await client.close()
-                except _METRICS_NONCRITICAL_EXCEPTIONS:
-                    logger.debug("metrics: failed to close redis client")
-            except _METRICS_NONCRITICAL_EXCEPTIONS:
-                logger.debug("metrics: redis not available for stage flags")
-        except _METRICS_NONCRITICAL_EXCEPTIONS:
-            logger.debug("metrics: embeddings modules not available for import")
-        prometheus_text = registry.export_prometheus_format() or ""
-        try:
-            from prometheus_client import REGISTRY as PC_REGISTRY
-            from prometheus_client import generate_latest as pc_generate_latest
-            prometheus_text = (prometheus_text + "\n" + pc_generate_latest(PC_REGISTRY).decode('utf-8')).strip() + "\n"
-        except _METRICS_NONCRITICAL_EXCEPTIONS:
-            logger.debug("metrics: failed to augment with prometheus_client registry")
-        return Response(
-            content=prometheus_text,
-            media_type="text/plain; version=0.0.4",
-            headers={
-                "Cache-Control": "no-cache, no-store, must-revalidate",
-                "Pragma": "no-cache",
-                "Expires": "0"
-            }
-        )
-    except _METRICS_NONCRITICAL_EXCEPTIONS as e:
-        logger.error(f"Error exporting metrics: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to export metrics"
-        ) from e
+    return await build_prometheus_metrics_response()
 
 
 @router.get("/metrics/json",
@@ -179,34 +206,15 @@ async def get_chat_metrics_endpoint() -> dict[str, Any]:
     - Character and conversation metrics
     """
     try:
-        chat_metrics = get_chat_metrics()
-        registry = get_metrics_registry()
+        collector = get_chat_metrics()
+        chat_stats = chat_metrics.get_endpoint_metrics_snapshot()
 
-        # Extract chat-specific metrics
-        chat_metric_names = [
-            "chat_requests_total",
-            "chat_request_duration_seconds",
-            "chat_tokens_prompt",
-            "chat_tokens_completion",
-            "chat_llm_cost_estimate_usd",
-            "chat_streaming_duration_seconds",
-            "chat_conversations_created_total",
-            "chat_messages_saved_total",
-            "chat_errors_total"
-        ]
-
-        chat_stats = {}
-        for metric_name in chat_metric_names:
-            stats = registry.get_metric_stats(metric_name)
-            if stats:
-                chat_stats[metric_name] = stats
-
-        active = chat_metrics.get_active_metrics()
+        active = collector.get_active_metrics()
 
         return {
             "active_operations": active,
             "metrics": chat_stats,
-            "token_costs": chat_metrics.token_costs  # Model pricing info
+            "token_costs": collector.token_costs  # Model pricing info
         }
     except _METRICS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Error getting chat metrics: {e}")
@@ -224,22 +232,24 @@ async def get_chat_metrics_endpoint() -> dict[str, Any]:
 )
 async def reset_metrics() -> dict[str, str]:
     """
-    Reset registry-backed metrics to their initial state.
+    Reset registry-backed runtime data and replay persistent metric definitions.
 
-    WARNING: This clears in-process registry aggregates only. It does not reset
+    WARNING: This clears in-process registry aggregates and recreates
+    persistent registry definitions. It does not reset
     Prometheus client metrics or OpenTelemetry exporters.
     This endpoint should be protected with admin authentication in production.
     """
     try:
         # Reinitialize metrics
         registry = get_metrics_registry()
-        chat_metrics = get_chat_metrics()
+        collector = get_chat_metrics()
 
         # Clear values
         registry.reset()
 
         # Reset active counters
-        chat_metrics.reset_active_metrics()
+        collector.reset_active_metrics()
+        chat_metrics.reset_endpoint_metrics_snapshot()
 
         logger.info("Metrics reset by admin")
 

--- a/tldw_Server_API/app/core/Chat/README.md
+++ b/tldw_Server_API/app/core/Chat/README.md
@@ -112,7 +112,8 @@ FastAPI endpoint (app/api/v1/endpoints/chat.py)
 ---
 
 ## Metrics & Logging
-- Metrics enumerated in `chat_metrics.ChatMetricsCollector` feed OpenTelemetry meters (`chat_requests_total`, streaming stats, tokens, DB operations, moderation outcomes).
+- `chat_metrics.ChatMetricsCollector` continues to emit OpenTelemetry meters (`chat_requests_total`, streaming stats, tokens, DB operations, moderation outcomes).
+- `/api/v1/metrics/chat` serves a small in-process summary maintained alongside those emissions so registry-style fields such as `sum` remain available.
 - Loguru is used throughout for structured logging; metrics and audit hooks provide provider/model labels for downstream dashboards.
 - Usage tracking integrates with `Usage.usage_tracker` to record per-call token/cost estimates.
 

--- a/tldw_Server_API/app/core/Chat/chat_metrics.py
+++ b/tldw_Server_API/app/core/Chat/chat_metrics.py
@@ -1,8 +1,10 @@
 # chat_metrics.py
 # Chat-specific metrics integration for telemetry
 
+import statistics
 import time
 import threading
+from collections import defaultdict, deque
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from enum import Enum
@@ -22,6 +24,52 @@ RUN_FIRST_INELIGIBLE_REASONS = frozenset(
         "run_missing_after_filtering",
     }
 )
+
+_ENDPOINT_METRIC_SAMPLE_SIZE = 256
+_endpoint_metric_lock = threading.Lock()
+_endpoint_metric_samples = defaultdict(lambda: deque(maxlen=_ENDPOINT_METRIC_SAMPLE_SIZE))
+_endpoint_metric_timestamps: dict[str, float] = {}
+
+
+def _record_endpoint_metric(metric_name: str, value: float) -> None:
+    """Store sampled metric values for /api/v1/metrics/chat summary payloads."""
+    with _endpoint_metric_lock:
+        _endpoint_metric_samples[metric_name].append(float(value))
+        _endpoint_metric_timestamps[metric_name] = time.time()
+
+
+def get_endpoint_metrics_snapshot() -> dict[str, dict[str, float]]:
+    """Return summary stats for sampled chat endpoint metrics."""
+    with _endpoint_metric_lock:
+        copied_samples = {
+            metric_name: list(samples)
+            for metric_name, samples in _endpoint_metric_samples.items()
+        }
+        copied_timestamps = dict(_endpoint_metric_timestamps)
+
+    snapshot: dict[str, dict[str, float]] = {}
+    for metric_name, numeric_values in copied_samples.items():
+        if not numeric_values:
+            continue
+        snapshot[metric_name] = {
+            "count": len(numeric_values),
+            "sum": float(sum(numeric_values)),
+            "mean": float(statistics.mean(numeric_values)),
+            "median": float(statistics.median(numeric_values)),
+            "min": float(min(numeric_values)),
+            "max": float(max(numeric_values)),
+            "stddev": float(statistics.stdev(numeric_values)) if len(numeric_values) > 1 else 0.0,
+            "latest": float(numeric_values[-1]),
+            "latest_timestamp": float(copied_timestamps.get(metric_name, 0.0)),
+        }
+    return snapshot
+
+
+def reset_endpoint_metrics_snapshot() -> None:
+    """Clear in-process sampled metrics exposed by /api/v1/metrics/chat."""
+    with _endpoint_metric_lock:
+        _endpoint_metric_samples.clear()
+        _endpoint_metric_timestamps.clear()
 
 
 class ChatMetricLabels(Enum):
@@ -425,6 +473,7 @@ class ChatMetricsCollector:
             try:
                 # Increment request counter
                 self.metrics.requests_total.add(1, labels)
+                _record_endpoint_metric("chat_requests_total", 1.0)
 
                 yield span
 
@@ -438,6 +487,7 @@ class ChatMetricsCollector:
                 labels[ChatMetricLabels.ERROR_TYPE.value] = type(e).__name__
 
                 self.metrics.errors_total.add(1, labels)
+                _record_endpoint_metric("chat_errors_total", 1.0)
                 span.record_exception(e)
                 span.set_attribute("status", "error")
                 raise
@@ -446,6 +496,7 @@ class ChatMetricsCollector:
                 # Record duration
                 duration = time.time() - start_time
                 self.metrics.request_duration.record(duration, labels)
+                _record_endpoint_metric("chat_request_duration_seconds", duration)
 
                 with self._active_lock:
                     self.active_requests = max(0, self.active_requests - 1)
@@ -508,6 +559,7 @@ class ChatMetricsCollector:
                 duration,
                 {ChatMetricLabels.CONVERSATION_ID.value: conversation_id}
             )
+            _record_endpoint_metric("chat_streaming_duration_seconds", duration)
             self.metrics.streaming_chunks.record(
                 chunk_count,
                 {ChatMetricLabels.CONVERSATION_ID.value: conversation_id}
@@ -625,6 +677,8 @@ class ChatMetricsCollector:
         self.metrics.tokens_prompt.record(prompt_tokens, labels)
         self.metrics.tokens_completion.record(completion_tokens, labels)
         self.metrics.tokens_total.record(prompt_tokens + completion_tokens, labels)
+        _record_endpoint_metric("chat_tokens_prompt", float(prompt_tokens))
+        _record_endpoint_metric("chat_tokens_completion", float(completion_tokens))
 
         # Estimate cost
         if model in self.token_costs:
@@ -634,6 +688,7 @@ class ChatMetricsCollector:
             total_cost = prompt_cost + completion_cost
 
             self.metrics.llm_cost_estimate.record(total_cost, labels)
+            _record_endpoint_metric("chat_llm_cost_estimate_usd", total_cost)
 
             logger.debug(
                 f"Token usage: {prompt_tokens} prompt, {completion_tokens} completion. "
@@ -669,6 +724,7 @@ class ChatMetricsCollector:
 
         if is_new:
             self.metrics.conversations_created.add(1, labels)
+            _record_endpoint_metric("chat_conversations_created_total", 1.0)
         else:
             self.metrics.conversations_resumed.add(1, labels)
 
@@ -687,6 +743,7 @@ class ChatMetricsCollector:
                 ChatMetricLabels.MESSAGE_TYPE.value: message_type
             }
         )
+        _record_endpoint_metric("chat_messages_saved_total", 1.0)
 
     def track_image_processing(self, size_bytes: int, validation_time: float):
         """

--- a/tldw_Server_API/app/core/MCP_unified/protocol.py
+++ b/tldw_Server_API/app/core/MCP_unified/protocol.py
@@ -534,7 +534,6 @@ class MCPProtocol:
         self.rate_limiter = get_rate_limiter()
         self.protocol_version = "2024-11-05"
         self.metrics = get_metrics_collector()
-        self.telemetry = get_telemetry_manager()
         # Strict tool name validation regex
         self._tool_name_re = re.compile(r'^[A-Za-z0-9_.:-]{1,100}$')
         # Idempotency manager for write-capable tools
@@ -546,7 +545,8 @@ class MCPProtocol:
         self._governance_store: Any | None = None
         self._governance_lock = asyncio.Lock()
 
-        # Method handlers
+        # Method handlers — telemetry is accessed via a property so that
+        # a shutdown/re-init cycle is picked up automatically.
         self.handlers: dict[str, Callable] = {
             "initialize": self._handle_initialize,
             "ping": self._handle_ping,
@@ -561,6 +561,12 @@ class MCPProtocol:
         }
 
         logger.info("MCP Protocol handler initialized")
+
+    @property
+    def telemetry(self):
+        """Always return the *current* global telemetry manager so that a
+        shutdown/re-init cycle is picked up automatically."""
+        return get_telemetry_manager()
 
     async def _rbac_check(self, user_id: Optional[str], resource: Resource, action: Action, resource_id: Optional[str] = None) -> bool:
         if not user_id:

--- a/tldw_Server_API/app/core/Metrics/README.md
+++ b/tldw_Server_API/app/core/Metrics/README.md
@@ -185,6 +185,11 @@ export METRICS_SAMPLE_RATE=1.0
 Labels guidance
 - Keep labels low-cardinality. Recommended: `component` (chat, audio, mcp, embeddings) and `endpoint` (route name).
 - Avoid per-user or per-connection labels; rely on aggregates.
+- Conflicting label keys that normalize to the same Prometheus label name but carry different values are rejected at record time.
+
+Reset behavior
+- `MetricsRegistry.reset()` clears runtime values, instruments, callbacks, and cumulative aggregates, then replays persistent metric definitions already registered in the running process.
+- Auto-bridged logger metrics are not part of that persistent reset set; they are rebuilt on demand after reset if code emits them again.
 
 Sample PromQL
 - 95th percentile WS send latency by component:
@@ -320,10 +325,15 @@ async def call_llm(prompt: str):
 Monitor cache performance:
 
 ```python
+class CachedEmbedding:
+    def __init__(self, vector, from_cache: bool):
+        self.vector = vector
+        self.from_cache = from_cache
+
+
 @cache_metrics(cache_name="embedding_cache")
 async def get_cached_embedding(text: str):
-    # Should return (result, cache_hit: bool)
-    pass
+    return CachedEmbedding(vector=[...], from_cache=True)
 ```
 
 ### Tracing

--- a/tldw_Server_API/app/core/Metrics/decorators.py
+++ b/tldw_Server_API/app/core/Metrics/decorators.py
@@ -45,6 +45,11 @@ _METRIC_DECORATOR_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
 )
 
 
+def _cache_result_from_cache(result: Any) -> bool:
+    """Read explicit cache-hit state from a result object."""
+    return bool(getattr(result, "from_cache", False))
+
+
 @dataclass
 class MetricConfig:
     """Configuration for metric decorators."""
@@ -699,8 +704,8 @@ def cache_metrics(
         Decorated function
     """
     def decorator(func: F) -> F:
-        # Assume function returns tuple (result, cache_hit: bool)
-        # or has a way to determine cache hit
+        # Cache-hit state is only derived from an explicit `result.from_cache`
+        # attribute. Tuple second values are treated as payload data.
 
         # Ensure cache metrics exist
         try:
@@ -733,15 +738,7 @@ def cache_metrics(
             @functools.wraps(func)
             async def async_wrapper(*args, **kwargs):
                 result = await func(*args, **kwargs)
-
-                # Check if result indicates cache hit
-                cache_hit = False
-                actual_result = result
-
-                if isinstance(result, tuple) and len(result) == 2:
-                    actual_result, cache_hit = result
-                elif hasattr(result, "from_cache"):
-                    cache_hit = result.from_cache
+                cache_hit = _cache_result_from_cache(result)
 
                 # Track metrics
                 if cache_hit:
@@ -758,22 +755,14 @@ def cache_metrics(
                     ratio = hits / total if total > 0 else 0
                     set_gauge("cache_hit_ratio", ratio, labels={"cache": cache_name})
 
-                return actual_result
+                return result
 
             return async_wrapper
         else:
             @functools.wraps(func)
             def sync_wrapper(*args, **kwargs):
                 result = func(*args, **kwargs)
-
-                # Check if result indicates cache hit
-                cache_hit = False
-                actual_result = result
-
-                if isinstance(result, tuple) and len(result) == 2:
-                    actual_result, cache_hit = result
-                elif hasattr(result, "from_cache"):
-                    cache_hit = result.from_cache
+                cache_hit = _cache_result_from_cache(result)
 
                 # Track metrics
                 if cache_hit:
@@ -790,7 +779,7 @@ def cache_metrics(
                     ratio = hits / total if total > 0 else 0
                     set_gauge("cache_hit_ratio", ratio, labels={"cache": cache_name})
 
-                return actual_result
+                return result
 
             return sync_wrapper
 

--- a/tldw_Server_API/app/core/Metrics/metrics_logger.py
+++ b/tldw_Server_API/app/core/Metrics/metrics_logger.py
@@ -29,8 +29,10 @@ def _utc_timestamp() -> str:
     """Return an ISO-8601 UTC timestamp with a single Z suffix."""
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
-def _normalize_labels_once(metric_name, labels):
-    """Normalize labels once and return them, or None if they collide."""
+def _normalize_labels_once(
+    metric_name: str, labels: dict[str, str] | None
+) -> dict[str, str] | None:
+    """Normalize labels once and return them, or ``None`` if they collide."""
     try:
         registry = get_metrics_registry()
         return registry.normalize_labels(labels, reject_collisions=True)
@@ -43,7 +45,12 @@ def _normalize_labels_once(metric_name, labels):
         return None
 
 
-def _bridge_to_registry(metric_name, metric_type, value, normalized_labels):
+def _bridge_to_registry(
+    metric_name: str,
+    metric_type: MetricType,
+    value: float,
+    normalized_labels: dict[str, str],
+) -> None:
     """Best-effort bridge from log-based metrics to the in-process registry.
 
     Expects *already-normalized* labels so the recording hot path can skip
@@ -62,19 +69,12 @@ def _bridge_to_registry(metric_name, metric_type, value, normalized_labels):
                 ),
                 persistent=False,
             )
-        if metric_type == MetricType.COUNTER:
-            registry.record(metric_name, value, normalized_labels, _normalized=True)
-        elif metric_type == MetricType.HISTOGRAM:
-            registry.record(metric_name, value, normalized_labels, _normalized=True)
-        elif metric_type == MetricType.GAUGE:
-            registry.record(metric_name, value, normalized_labels, _normalized=True)
-        else:
-            registry.record(metric_name, value, normalized_labels, _normalized=True)
+        registry.record(metric_name, value, normalized_labels, _normalized=True)
     except Exception as exc:
         logger.debug("metrics_logger: registry bridge failed: {err}", err=exc)
 
 
-def log_counter(metric_name, labels=None, value=1):
+def log_counter(metric_name: str, labels: dict[str, str] | None = None, value: float = 1) -> None:
     normalized = _normalize_labels_once(metric_name, labels)
     if normalized is None:
         return
@@ -89,7 +89,7 @@ def log_counter(metric_name, labels=None, value=1):
     _bridge_to_registry(metric_name, MetricType.COUNTER, value, normalized)
 
 
-def log_histogram(metric_name, value, labels=None):
+def log_histogram(metric_name: str, value: float, labels: dict[str, str] | None = None) -> None:
     normalized = _normalize_labels_once(metric_name, labels)
     if normalized is None:
         return
@@ -104,7 +104,7 @@ def log_histogram(metric_name, value, labels=None):
     _bridge_to_registry(metric_name, MetricType.HISTOGRAM, value, normalized)
 
 
-def log_gauge(metric_name, value, labels=None):
+def log_gauge(metric_name: str, value: float, labels: dict[str, str] | None = None) -> None:
     """Log an instantaneous measurement (gauge).
 
     The current metrics backend is log-based, so we simply emit a structured

--- a/tldw_Server_API/app/core/Metrics/metrics_logger.py
+++ b/tldw_Server_API/app/core/Metrics/metrics_logger.py
@@ -33,6 +33,15 @@ def _bridge_to_registry(metric_name, metric_type, value, labels=None):
     """Best-effort bridge from log-based metrics to the in-process registry."""
     try:
         registry = get_metrics_registry()
+        try:
+            normalized_labels = registry._normalize_labels(labels, reject_collisions=True)  # noqa: SLF001
+        except ValueError as exc:
+            logger.warning(
+                "metrics_logger: rejecting {} due to conflicting normalized labels: {}",
+                metric_name,
+                exc,
+            )
+            return
         normalized_name = registry.normalize_metric_name(metric_name)
         if normalized_name not in registry.metrics:
             registry.register_metric(
@@ -40,22 +49,40 @@ def _bridge_to_registry(metric_name, metric_type, value, labels=None):
                     name=normalized_name,
                     type=metric_type,
                     description=f"Auto-bridged metric for {metric_name}",
-                    labels=list((labels or {}).keys()),
-                )
+                    labels=list(normalized_labels.keys()),
+                ),
+                persistent=False,
             )
         if metric_type == MetricType.COUNTER:
-            registry.increment(metric_name, value, labels)
+            registry.increment(metric_name, value, normalized_labels)
         elif metric_type == MetricType.HISTOGRAM:
-            registry.observe(metric_name, value, labels)
+            registry.observe(metric_name, value, normalized_labels)
         elif metric_type == MetricType.GAUGE:
-            registry.set_gauge(metric_name, value, labels)
+            registry.set_gauge(metric_name, value, normalized_labels)
         else:
-            registry.record(metric_name, value, labels)
+            registry.record(metric_name, value, normalized_labels)
     except Exception as exc:
         logger.debug("metrics_logger: registry bridge failed: {err}", err=exc)
 
 
+def _labels_are_registry_safe(metric_name, labels) -> bool:
+    """Reject conflicting normalized labels before any log-backed metric emission."""
+    registry = get_metrics_registry()
+    try:
+        registry._normalize_labels(labels, reject_collisions=True)  # noqa: SLF001
+    except ValueError as exc:
+        logger.warning(
+            "metrics_logger: rejecting {} due to conflicting normalized labels: {}",
+            metric_name,
+            exc,
+        )
+        return False
+    return True
+
+
 def log_counter(metric_name, labels=None, value=1):
+    if not _labels_are_registry_safe(metric_name, labels):
+        return
     log_entry = {
         "event": metric_name,
         "type": "counter",
@@ -68,6 +95,8 @@ def log_counter(metric_name, labels=None, value=1):
 
 
 def log_histogram(metric_name, value, labels=None):
+    if not _labels_are_registry_safe(metric_name, labels):
+        return
     log_entry = {
         "event": metric_name,
         "type": "histogram",
@@ -87,6 +116,8 @@ def log_gauge(metric_name, value, labels=None):
     semantics more clearly. Downstream exporters can map these to Prometheus
     Gauges or equivalent.
     """
+    if not _labels_are_registry_safe(metric_name, labels):
+        return
     log_entry = {
         "event": metric_name,
         "type": "gauge",

--- a/tldw_Server_API/app/core/Metrics/metrics_logger.py
+++ b/tldw_Server_API/app/core/Metrics/metrics_logger.py
@@ -29,19 +29,28 @@ def _utc_timestamp() -> str:
     """Return an ISO-8601 UTC timestamp with a single Z suffix."""
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
-def _bridge_to_registry(metric_name, metric_type, value, labels=None):
-    """Best-effort bridge from log-based metrics to the in-process registry."""
+def _normalize_labels_once(metric_name, labels):
+    """Normalize labels once and return them, or None if they collide."""
     try:
         registry = get_metrics_registry()
-        try:
-            normalized_labels = registry._normalize_labels(labels, reject_collisions=True)  # noqa: SLF001
-        except ValueError as exc:
-            logger.warning(
-                "metrics_logger: rejecting {} due to conflicting normalized labels: {}",
-                metric_name,
-                exc,
-            )
-            return
+        return registry.normalize_labels(labels, reject_collisions=True)
+    except ValueError as exc:
+        logger.warning(
+            "metrics_logger: rejecting {} due to conflicting normalized labels: {}",
+            metric_name,
+            exc,
+        )
+        return None
+
+
+def _bridge_to_registry(metric_name, metric_type, value, normalized_labels):
+    """Best-effort bridge from log-based metrics to the in-process registry.
+
+    Expects *already-normalized* labels so the recording hot path can skip
+    redundant normalization.
+    """
+    try:
+        registry = get_metrics_registry()
         normalized_name = registry.normalize_metric_name(metric_name)
         if normalized_name not in registry.metrics:
             registry.register_metric(
@@ -54,58 +63,45 @@ def _bridge_to_registry(metric_name, metric_type, value, labels=None):
                 persistent=False,
             )
         if metric_type == MetricType.COUNTER:
-            registry.increment(metric_name, value, normalized_labels)
+            registry.record(metric_name, value, normalized_labels, _normalized=True)
         elif metric_type == MetricType.HISTOGRAM:
-            registry.observe(metric_name, value, normalized_labels)
+            registry.record(metric_name, value, normalized_labels, _normalized=True)
         elif metric_type == MetricType.GAUGE:
-            registry.set_gauge(metric_name, value, normalized_labels)
+            registry.record(metric_name, value, normalized_labels, _normalized=True)
         else:
-            registry.record(metric_name, value, normalized_labels)
+            registry.record(metric_name, value, normalized_labels, _normalized=True)
     except Exception as exc:
         logger.debug("metrics_logger: registry bridge failed: {err}", err=exc)
 
 
-def _labels_are_registry_safe(metric_name, labels) -> bool:
-    """Reject conflicting normalized labels before any log-backed metric emission."""
-    registry = get_metrics_registry()
-    try:
-        registry._normalize_labels(labels, reject_collisions=True)  # noqa: SLF001
-    except ValueError as exc:
-        logger.warning(
-            "metrics_logger: rejecting {} due to conflicting normalized labels: {}",
-            metric_name,
-            exc,
-        )
-        return False
-    return True
-
-
 def log_counter(metric_name, labels=None, value=1):
-    if not _labels_are_registry_safe(metric_name, labels):
+    normalized = _normalize_labels_once(metric_name, labels)
+    if normalized is None:
         return
     log_entry = {
         "event": metric_name,
         "type": "counter",
         "value": value,
-        "labels": labels or {},
+        "labels": normalized,
         "timestamp": _utc_timestamp(),
     }
     logger.bind(**log_entry).info("metric")
-    _bridge_to_registry(metric_name, MetricType.COUNTER, value, labels)
+    _bridge_to_registry(metric_name, MetricType.COUNTER, value, normalized)
 
 
 def log_histogram(metric_name, value, labels=None):
-    if not _labels_are_registry_safe(metric_name, labels):
+    normalized = _normalize_labels_once(metric_name, labels)
+    if normalized is None:
         return
     log_entry = {
         "event": metric_name,
         "type": "histogram",
         "value": value,
-        "labels": labels or {},
+        "labels": normalized,
         "timestamp": _utc_timestamp(),
     }
     logger.bind(**log_entry).info("metric")
-    _bridge_to_registry(metric_name, MetricType.HISTOGRAM, value, labels)
+    _bridge_to_registry(metric_name, MetricType.HISTOGRAM, value, normalized)
 
 
 def log_gauge(metric_name, value, labels=None):
@@ -116,17 +112,18 @@ def log_gauge(metric_name, value, labels=None):
     semantics more clearly. Downstream exporters can map these to Prometheus
     Gauges or equivalent.
     """
-    if not _labels_are_registry_safe(metric_name, labels):
+    normalized = _normalize_labels_once(metric_name, labels)
+    if normalized is None:
         return
     log_entry = {
         "event": metric_name,
         "type": "gauge",
         "value": value,
-        "labels": labels or {},
+        "labels": normalized,
         "timestamp": _utc_timestamp(),
     }
     logger.bind(**log_entry).info("metric")
-    _bridge_to_registry(metric_name, MetricType.GAUGE, value, labels)
+    _bridge_to_registry(metric_name, MetricType.GAUGE, value, normalized)
 
 
 def timeit(func):

--- a/tldw_Server_API/app/core/Metrics/metrics_manager.py
+++ b/tldw_Server_API/app/core/Metrics/metrics_manager.py
@@ -83,6 +83,7 @@ class MetricsRegistry:
 
         self._lock = threading.RLock()
         self.metrics: dict[str, MetricDefinition] = {}
+        self._persistent_metric_definitions: dict[str, MetricDefinition] = {}
         self.instruments: dict[str, Any] = {}
         # Rolling window of metric samples; size configurable via METRICS_RING_BUFFER_MAXLEN_OR_UNBOUNDED.
         self.values: dict[str, deque] = defaultdict(lambda: deque(maxlen=buffer_maxlen))
@@ -142,8 +143,16 @@ class MetricsRegistry:
         return normalized
 
     @classmethod
-    def _normalize_labels(cls, labels: Optional[dict[str, Any]]) -> dict[str, str]:
-        """Normalize label keys and coerce values to strings."""
+    def _normalize_labels(
+        cls,
+        labels: Optional[dict[str, Any]],
+        reject_collisions: bool = False,
+    ) -> dict[str, str]:
+        """Normalize label keys and coerce values to strings.
+
+        If reject_collisions is True, raise ValueError when distinct original
+        keys normalize to the same label name but carry different values.
+        """
         if not labels:
             return {}
         normalized: dict[str, str] = {}
@@ -151,6 +160,11 @@ class MetricsRegistry:
             normalized_key = cls._normalize_label_name(str(key))
             normalized_value = "" if value is None else str(value)
             if normalized_key in normalized and normalized[normalized_key] != normalized_value:
+                if reject_collisions:
+                    raise ValueError(
+                        "Conflicting labels normalize to the same key "
+                        f"{normalized_key!r}: {normalized[normalized_key]!r} vs {normalized_value!r}"
+                    )
                 logger.debug(f"Label key collision after normalization: {key} -> {normalized_key}")
             normalized[normalized_key] = normalized_value
         return normalized
@@ -179,6 +193,18 @@ class MetricsRegistry:
             escaped = cls._escape_label_value(value)
             parts.append(f'{key}="{escaped}"')
         return ",".join(parts)
+
+    @staticmethod
+    def _clone_metric_definition(definition: MetricDefinition) -> MetricDefinition:
+        """Create a stable copy of a metric definition for persistence."""
+        return MetricDefinition(
+            name=definition.name,
+            type=definition.type,
+            description=definition.description,
+            unit=definition.unit,
+            labels=list(definition.labels),
+            buckets=list(definition.buckets) if definition.buckets is not None else None,
+        )
 
     def _register_standard_metrics(self):
         """Register standard application metrics."""
@@ -1690,12 +1716,13 @@ class MetricsRegistry:
             )
         )
 
-    def register_metric(self, definition: MetricDefinition) -> bool:
+    def register_metric(self, definition: MetricDefinition, persistent: bool = True) -> bool:
         """
         Register a new metric definition.
 
         Args:
             definition: MetricDefinition object
+            persistent: Whether the definition should survive reset()
 
         Returns:
             True if registered successfully
@@ -1710,14 +1737,19 @@ class MetricsRegistry:
                 return False
 
             if normalized_name != definition.name:
-                definition = MetricDefinition(
-                    name=normalized_name,
-                    type=definition.type,
-                    description=definition.description,
-                    unit=definition.unit,
-                    labels=definition.labels,
-                    buckets=definition.buckets,
+                definition = self._clone_metric_definition(
+                    MetricDefinition(
+                        name=normalized_name,
+                        type=definition.type,
+                        description=definition.description,
+                        unit=definition.unit,
+                        labels=definition.labels,
+                        buckets=definition.buckets,
+                    )
                 )
+
+            if persistent:
+                self._persistent_metric_definitions[normalized_name] = self._clone_metric_definition(definition)
 
             self.metrics[normalized_name] = definition
 
@@ -1819,7 +1851,11 @@ class MetricsRegistry:
         """
         original_name = metric_name
         metric_name = self._normalize_metric_name(metric_name)
-        labels = self._normalize_labels(labels)
+        try:
+            labels = self._normalize_labels(labels, reject_collisions=True)
+        except ValueError as exc:
+            logger.warning("Rejecting metric {} due to conflicting normalized labels: {}", original_name, exc)
+            return
         instrument = None
         callbacks: list[Callable] = []
 
@@ -1829,15 +1865,9 @@ class MetricsRegistry:
                 return
 
             definition = self.metrics[metric_name]
-
-            # Store value for aggregation
-            metric_value = MetricValue(value=value, labels=labels)
-            self.values[metric_name].append(metric_value)
-            if original_name != metric_name:
-                # Keep a non-normalized alias for tests that read raw keys.
-                self.values[original_name].append(metric_value)
-
             label_key = self._normalize_label_key(labels)
+            store_sample = True
+
             if definition.type in (MetricType.COUNTER, MetricType.UP_DOWN_COUNTER):
                 series = self._cumulative_counters[metric_name]
                 if (
@@ -1853,30 +1883,42 @@ class MetricsRegistry:
                             self._cumulative_series_cap,
                         )
                         self._cumulative_series_warned.add(metric_name)
-                else:
-                    current = series.get(label_key, 0.0)
-                    series[label_key] = current + value
+                    store_sample = False
             elif definition.type == MetricType.HISTOGRAM:
                 series = self._cumulative_histograms[metric_name]
-                hist = series.get(label_key)
-                if hist is None:
-                    if (
-                        self._cumulative_series_cap is not None
-                        and len(series) >= self._cumulative_series_cap
-                    ):
-                        self._cumulative_series_dropped[metric_name] += 1
-                        if metric_name not in self._cumulative_series_warned:
-                            logger.warning(
-                                "Cumulative series cap reached for metric {} (cap={}); dropping new label sets",
-                                metric_name,
-                                self._cumulative_series_cap,
-                            )
-                            self._cumulative_series_warned.add(metric_name)
-                        hist = None
-                    else:
+                if (
+                    label_key not in series
+                    and self._cumulative_series_cap is not None
+                    and len(series) >= self._cumulative_series_cap
+                ):
+                    self._cumulative_series_dropped[metric_name] += 1
+                    if metric_name not in self._cumulative_series_warned:
+                        logger.warning(
+                            "Cumulative series cap reached for metric {} (cap={}); dropping new label sets",
+                            metric_name,
+                            self._cumulative_series_cap,
+                        )
+                        self._cumulative_series_warned.add(metric_name)
+                    store_sample = False
+
+            if store_sample:
+                # Store value for aggregation only when the series is admitted.
+                metric_value = MetricValue(value=value, labels=labels)
+                self.values[metric_name].append(metric_value)
+                if original_name != metric_name:
+                    # Keep a non-normalized alias for tests that read raw keys.
+                    self.values[original_name].append(metric_value)
+
+                if definition.type in (MetricType.COUNTER, MetricType.UP_DOWN_COUNTER):
+                    series = self._cumulative_counters[metric_name]
+                    current = series.get(label_key, 0.0)
+                    series[label_key] = current + value
+                elif definition.type == MetricType.HISTOGRAM:
+                    series = self._cumulative_histograms[metric_name]
+                    hist = series.get(label_key)
+                    if hist is None:
                         hist = {"count": 0, "sum": 0.0, "buckets": defaultdict(int)}
                         series[label_key] = hist
-                if hist is not None:
                     hist["count"] += 1
                     hist["sum"] += value
                     if definition.buckets:
@@ -2193,13 +2235,24 @@ class MetricsRegistry:
         return "\n".join(lines) + "\n"
 
     def reset(self) -> None:
-        """Reset stored metric values and cumulative aggregates."""
+        """Reset runtime state and restore persistent registered definitions."""
+        persistent_definitions = []
         with self._lock:
+            persistent_definitions = [
+                self._clone_metric_definition(definition)
+                for definition in self._persistent_metric_definitions.values()
+            ]
+            self.metrics.clear()
+            self.instruments.clear()
+            self.callbacks.clear()
             self.values.clear()
             self._cumulative_counters.clear()
             self._cumulative_histograms.clear()
             self._cumulative_series_dropped.clear()
             self._cumulative_series_warned.clear()
+
+            for definition in persistent_definitions:
+                self.register_metric(definition, persistent=False)
 
 
 # Global metrics registry instance

--- a/tldw_Server_API/app/core/Metrics/metrics_manager.py
+++ b/tldw_Server_API/app/core/Metrics/metrics_manager.py
@@ -103,12 +103,19 @@ class MetricsRegistry:
             "circuit_breaker_timeouts_total",
         }
 
-        # Initialize with telemetry manager
-        self.telemetry = get_telemetry_manager()
-        self.meter = self.telemetry.get_meter("tldw_server.metrics")
-
         # Register standard metrics
         self._register_standard_metrics()
+
+    @property
+    def telemetry(self):
+        """Always return the *current* global telemetry manager so that a
+        shutdown/re-init cycle is picked up automatically."""
+        return get_telemetry_manager()
+
+    @property
+    def meter(self):
+        """Return a meter from the current telemetry manager."""
+        return self.telemetry.get_meter("tldw_server.metrics")
 
     @classmethod
     def _normalize_metric_name(cls, name: str) -> str:
@@ -162,12 +169,15 @@ class MetricsRegistry:
             if normalized_key in normalized and normalized[normalized_key] != normalized_value:
                 if reject_collisions:
                     raise ValueError(
-                        "Conflicting labels normalize to the same key "
-                        f"{normalized_key!r}: {normalized[normalized_key]!r} vs {normalized_value!r}"
+                        f"Conflicting labels normalize to the same key {normalized_key!r}"
                     )
                 logger.debug(f"Label key collision after normalization: {key} -> {normalized_key}")
             normalized[normalized_key] = normalized_value
         return normalized
+
+    # Public alias so external modules (e.g. metrics_logger) need not reach
+    # into a private method.
+    normalize_labels = _normalize_labels
 
     @classmethod
     def _normalize_label_key(cls, labels: dict[str, Any]) -> tuple[tuple[str, str], ...]:
@@ -1840,6 +1850,7 @@ class MetricsRegistry:
         value: float,
         labels: Optional[dict[str, str]] = None,
         _emit_legacy_alias: bool = True,
+        _normalized: bool = False,
     ):
         """
         Record a metric value.
@@ -1848,14 +1859,16 @@ class MetricsRegistry:
             metric_name: Name of the metric
             value: Value to record
             labels: Optional labels/dimensions
+            _normalized: If True, skip label normalization (caller already normalized).
         """
         original_name = metric_name
         metric_name = self._normalize_metric_name(metric_name)
-        try:
-            labels = self._normalize_labels(labels, reject_collisions=True)
-        except ValueError as exc:
-            logger.warning("Rejecting metric {} due to conflicting normalized labels: {}", original_name, exc)
-            return
+        if not _normalized:
+            try:
+                labels = self._normalize_labels(labels, reject_collisions=True)
+            except ValueError as exc:
+                logger.warning("Rejecting metric {} due to conflicting normalized labels: {}", original_name, exc)
+                return
         instrument = None
         callbacks: list[Callable] = []
 

--- a/tldw_Server_API/app/core/Metrics/telemetry.py
+++ b/tldw_Server_API/app/core/Metrics/telemetry.py
@@ -205,6 +205,81 @@ if OTEL_AVAILABLE:
         logger.debug(f"Trace propagation not available: {e}")
 
 
+SERVICE_NAME_KEY = "service.name"
+SERVICE_VERSION_KEY = "service.version"
+if OTEL_AVAILABLE:
+    SERVICE_NAME_KEY = SERVICE_NAME
+    SERVICE_VERSION_KEY = SERVICE_VERSION
+
+
+def _install_global_tracer_provider(provider: Any) -> None:
+    if trace is not None:
+        trace.set_tracer_provider(provider)
+
+
+def _install_global_meter_provider(provider: Any) -> None:
+    if metrics is not None:
+        metrics.set_meter_provider(provider)
+
+
+def _get_global_tracer_provider() -> Any:
+    if trace is None:
+        return None
+    with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+        return trace.get_tracer_provider()
+    return None
+
+
+def _get_global_meter_provider() -> Any:
+    if metrics is None:
+        return None
+    with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+        return metrics.get_meter_provider()
+    return None
+
+
+def _is_unconfigured_tracer_provider(provider: Any) -> bool:
+    if provider is None:
+        return True
+    return "ProxyTracerProvider" in provider.__class__.__name__
+
+
+def _is_unconfigured_meter_provider(provider: Any) -> bool:
+    if provider is None:
+        return True
+    return "ProxyMeterProvider" in provider.__class__.__name__
+
+
+def _is_global_tracer_provider(provider: Any) -> bool:
+    return provider is not None and provider is _get_global_tracer_provider()
+
+
+def _is_global_meter_provider(provider: Any) -> bool:
+    return provider is not None and provider is _get_global_meter_provider()
+
+
+def _adopt_or_install_global_tracer_provider(provider: Any) -> Any:
+    current_provider = _get_global_tracer_provider()
+    if _is_unconfigured_tracer_provider(current_provider):
+        with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+            _install_global_tracer_provider(provider)
+        current_provider = _get_global_tracer_provider()
+    if current_provider is None:
+        return provider
+    return current_provider
+
+
+def _adopt_or_install_global_meter_provider(provider: Any) -> Any:
+    current_provider = _get_global_meter_provider()
+    if _is_unconfigured_meter_provider(current_provider):
+        with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+            _install_global_meter_provider(provider)
+        current_provider = _get_global_meter_provider()
+    if current_provider is None:
+        return provider
+    return current_provider
+
+
 class TelemetryConfig:
     """Configuration for OpenTelemetry setup."""
 
@@ -355,8 +430,8 @@ class TelemetryConfig:
     def get_resource_attributes(self) -> dict[str, Any]:
         """Get resource attributes for telemetry."""
         return {
-            SERVICE_NAME: self.service_name,
-            SERVICE_VERSION: self.service_version,
+            SERVICE_NAME_KEY: self.service_name,
+            SERVICE_VERSION_KEY: self.service_version,
             "service.namespace": self.service_namespace,
             "deployment.environment": self.deployment_environment,
             "host.name": self.hostname,
@@ -376,33 +451,70 @@ class TelemetryManager:
             config: TelemetryConfig instance or None to use defaults
         """
         self.config = config or TelemetryConfig()
-        self.tracer_provider: TracerProvider | None = None
-        self.meter_provider: MeterProvider | None = None
-        self.tracer: Tracer | None = None
-        self.meter: Meter | None = None
-        self.initialized = False
         # Hold pending views if provider not yet available
         self._pending_views = []  # list[tuple[str, list[float]]]
+        self._registered_histogram_views: set[tuple[str, tuple[float, ...]]] = set()
+        self._reset_runtime_state()
 
         if getattr(self.config, "sdk_disabled", False):
             logger.info("OpenTelemetry SDK disabled via OTEL_SDK_DISABLED")
-            self.tracer = DummyTracer()
-            self.meter = DummyMeter()
             return
 
         if not OTEL_AVAILABLE:
             logger.info("OpenTelemetry not available, using fallback implementations")
-            self.tracer = DummyTracer()
-            self.meter = DummyMeter()
             return
 
         self._initialize()
+
+    def _reset_runtime_state(self) -> None:
+        """Reset provider references and fallback runtime instruments."""
+        self.initialized = False
+        self.tracer_provider = None
+        self.meter_provider = None
+        self.tracer = DummyTracer()
+        self.meter = DummyMeter()
+
+    def _rollback_failed_initialization(self) -> None:
+        """Best-effort rollback after partial initialization failures."""
+        with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+            if self.tracer_provider and not _is_global_tracer_provider(self.tracer_provider):
+                self.tracer_provider.shutdown()
+        with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+            if self.meter_provider and not _is_global_meter_provider(self.meter_provider):
+                self.meter_provider.shutdown()
+        self._reset_runtime_state()
+
+    def _align_with_current_global_providers(self) -> None:
+        """Align manager runtime state with current SDK-global providers."""
+        global_tracer_provider = _get_global_tracer_provider()
+        if global_tracer_provider is not None:
+            self.tracer_provider = global_tracer_provider
+            with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                if hasattr(self.tracer_provider, "get_tracer"):
+                    self.tracer = self.tracer_provider.get_tracer(
+                        self.config.service_name,
+                        self.config.service_version
+                    )
+
+        global_meter_provider = _get_global_meter_provider()
+        if global_meter_provider is not None:
+            self.meter_provider = global_meter_provider
+            with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                if hasattr(self.meter_provider, "get_meter"):
+                    self.meter = self.meter_provider.get_meter(
+                        self.config.service_name,
+                        self.config.service_version
+                    )
+
+        if self.tracer_provider is not None or self.meter_provider is not None:
+            self.initialized = True
 
     def _initialize(self):
         """Initialize OpenTelemetry providers and exporters."""
         if self.initialized:
             return
 
+        global_provider_phase_reached = False
         try:
             # Create resource
             resource = Resource.create(self.config.get_resource_attributes())
@@ -422,17 +534,52 @@ class TelemetryManager:
             # Auto-instrumentation
             self._setup_auto_instrumentation()
 
+            global_provider_phase_reached = True
+            if self.tracer_provider is not None:
+                local_tracer_provider = self.tracer_provider
+                self.tracer_provider = _adopt_or_install_global_tracer_provider(self.tracer_provider)
+                if local_tracer_provider is not self.tracer_provider and not _is_global_tracer_provider(local_tracer_provider):
+                    with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                        local_tracer_provider.shutdown()
+                if hasattr(self.tracer_provider, "get_tracer"):
+                    self.tracer = self.tracer_provider.get_tracer(
+                        self.config.service_name,
+                        self.config.service_version
+                    )
+            if self.meter_provider is not None:
+                local_meter_provider = self.meter_provider
+                self.meter_provider = _adopt_or_install_global_meter_provider(self.meter_provider)
+                if local_meter_provider is not self.meter_provider and not _is_global_meter_provider(local_meter_provider):
+                    with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                        local_meter_provider.shutdown()
+                if hasattr(self.meter_provider, "get_meter"):
+                    self.meter = self.meter_provider.get_meter(
+                        self.config.service_name,
+                        self.config.service_version
+                    )
+
             self.initialized = True
             logger.info(f"Telemetry initialized for service: {self.config.service_name}")
 
         except _TELEMETRY_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Failed to initialize telemetry: {e}")
-            # Fall back to dummy implementations
-            self.tracer = DummyTracer()
-            self.meter = DummyMeter()
+            if global_provider_phase_reached:
+                self._align_with_current_global_providers()
+            else:
+                self._rollback_failed_initialization()
 
     def _initialize_tracing(self, resource: Resource):
         """Initialize tracing with configured exporters."""
+        existing_global_provider = _get_global_tracer_provider()
+        if not _is_unconfigured_tracer_provider(existing_global_provider):
+            self.tracer_provider = existing_global_provider
+            if hasattr(self.tracer_provider, "get_tracer"):
+                self.tracer = self.tracer_provider.get_tracer(
+                    self.config.service_name,
+                    self.config.service_version
+                )
+            return
+
         self.tracer_provider = TracerProvider(resource=resource)
 
         # Add exporters based on configuration
@@ -454,15 +601,23 @@ class TelemetryManager:
                 processor = BatchSpanProcessor(exporter, **processor_kwargs)
                 self.tracer_provider.add_span_processor(processor)
 
-        # Set as global tracer provider
-        trace.set_tracer_provider(self.tracer_provider)
-        self.tracer = trace.get_tracer(
+        self.tracer = self.tracer_provider.get_tracer(
             self.config.service_name,
             self.config.service_version
         )
 
     def _initialize_metrics(self, resource: Resource):
         """Initialize metrics with configured exporters."""
+        existing_global_provider = _get_global_meter_provider()
+        if not _is_unconfigured_meter_provider(existing_global_provider):
+            self.meter_provider = existing_global_provider
+            if hasattr(self.meter_provider, "get_meter"):
+                self.meter = self.meter_provider.get_meter(
+                    self.config.service_name,
+                    self.config.service_version
+                )
+            return
+
         readers = []
 
         # Add metric readers based on configuration
@@ -478,9 +633,7 @@ class TelemetryManager:
                 metric_readers=readers,
             )
 
-            # Set as global meter provider
-            metrics.set_meter_provider(self.meter_provider)
-            self.meter = metrics.get_meter(
+            self.meter = self.meter_provider.get_meter(
                 self.config.service_name,
                 self.config.service_version
             )
@@ -666,12 +819,10 @@ class TelemetryManager:
         if getattr(self.config, "sdk_disabled", False):
             return self.tracer or DummyTracer()
 
-        if not self.tracer:
-            return DummyTracer()
-
-        if name and OTEL_AVAILABLE and trace is not None:
-            return trace.get_tracer(name, self.config.service_version)
-        return self.tracer
+        if name and OTEL_AVAILABLE and self.tracer_provider and hasattr(self.tracer_provider, "get_tracer"):
+            with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                return self.tracer_provider.get_tracer(name, self.config.service_version)
+        return self.tracer or DummyTracer()
 
     def get_meter(self, name: str | None = None) -> Meter:
         """
@@ -686,12 +837,10 @@ class TelemetryManager:
         if getattr(self.config, "sdk_disabled", False):
             return self.meter or DummyMeter()
 
-        if not self.meter:
-            return DummyMeter()
-
-        if name and OTEL_AVAILABLE and metrics is not None:
-            return metrics.get_meter(name, self.config.service_version)
-        return self.meter
+        if name and OTEL_AVAILABLE and self.meter_provider and hasattr(self.meter_provider, "get_meter"):
+            with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                return self.meter_provider.get_meter(name, self.config.service_version)
+        return self.meter or DummyMeter()
 
     def register_histogram_view(self, instrument_name: str, boundaries: list[float]) -> None:
         """Register a histogram view for custom bucket boundaries.
@@ -700,6 +849,9 @@ class TelemetryManager:
         otherwise, queue it to be applied after initialization.
         """
         if not OTEL_AVAILABLE or not instrument_name or not boundaries:
+            return
+        view_key = (instrument_name, tuple(boundaries))
+        if view_key in self._registered_histogram_views:
             return
         try:
             if hasattr(self, "meter_provider") and self.meter_provider and hasattr(self.meter_provider, "register_view") \
@@ -713,6 +865,7 @@ class TelemetryManager:
             else:
                 # Queue for later application
                 self._pending_views.append((instrument_name, list(boundaries)))
+            self._registered_histogram_views.add(view_key)
         except _TELEMETRY_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"Failed to register histogram view for {instrument_name}: {e}")
 
@@ -748,19 +901,32 @@ class TelemetryManager:
 
     def shutdown(self):
         """Shutdown telemetry providers and flush data."""
-        if not OTEL_AVAILABLE or not self.initialized:
-            return
-
-        try:
+        if OTEL_AVAILABLE and self.initialized:
             if self.tracer_provider:
-                self.tracer_provider.shutdown()
+                if _is_global_tracer_provider(self.tracer_provider):
+                    with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                        if hasattr(self.tracer_provider, "force_flush"):
+                            self.tracer_provider.force_flush()
+                else:
+                    try:
+                        self.tracer_provider.shutdown()
+                    except _TELEMETRY_NONCRITICAL_EXCEPTIONS as e:
+                        logger.error(f"Error shutting down tracer provider: {e}")
 
             if self.meter_provider:
-                self.meter_provider.shutdown()
+                if _is_global_meter_provider(self.meter_provider):
+                    with suppress(_TELEMETRY_NONCRITICAL_EXCEPTIONS):
+                        if hasattr(self.meter_provider, "force_flush"):
+                            self.meter_provider.force_flush()
+                else:
+                    try:
+                        self.meter_provider.shutdown()
+                    except _TELEMETRY_NONCRITICAL_EXCEPTIONS as e:
+                        logger.error(f"Error shutting down meter provider: {e}")
 
-            logger.info("Telemetry providers shut down successfully")
-        except _TELEMETRY_NONCRITICAL_EXCEPTIONS as e:
-            logger.error(f"Error shutting down telemetry: {e}")
+            if self.tracer_provider or self.meter_provider:
+                logger.info("Telemetry providers shut down successfully")
+        self._reset_runtime_state()
 
 
 # Global telemetry manager instance
@@ -840,5 +1006,7 @@ def initialize_telemetry(config: TelemetryConfig | None = None) -> TelemetryMana
 
 def shutdown_telemetry():
     """Shutdown the global telemetry manager."""
+    global _telemetry_manager
     if _telemetry_manager:
         _telemetry_manager.shutdown()
+        _telemetry_manager = None

--- a/tldw_Server_API/app/core/Metrics/traces.py
+++ b/tldw_Server_API/app/core/Metrics/traces.py
@@ -121,7 +121,9 @@ class TracingManager:
             name,
             kind=kind,
             attributes=attributes,
-            links=links
+            links=links,
+            record_exception=False,
+            set_status_on_exception=False,
         ) as span:
             span_id: Optional[str] = None
             try:
@@ -172,7 +174,9 @@ class TracingManager:
             name,
             kind=kind,
             attributes=attributes,
-            links=links
+            links=links,
+            record_exception=False,
+            set_status_on_exception=False,
         ) as span:
             span_id: Optional[str] = None
             try:
@@ -404,10 +408,7 @@ def trace_operation(
 
                         return result
 
-                    except Exception as e:
-                        if span:
-                            span.record_exception(e)
-                            span.set_status(Status(StatusCode.ERROR, str(e)))
+                    except Exception:
                         raise
 
             return async_wrapper
@@ -441,10 +442,7 @@ def trace_operation(
 
                         return result
 
-                    except Exception as e:
-                        if span:
-                            span.record_exception(e)
-                            span.set_status(Status(StatusCode.ERROR, str(e)))
+                    except Exception:
                         raise
 
             return sync_wrapper
@@ -463,25 +461,30 @@ def trace_method(
     Similar to trace_operation but includes class name in span name.
     """
     def decorator(func: F) -> F:
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-            span_name = name or f"{self.__class__.__name__}.{func.__name__}"
+        if asyncio.iscoroutinefunction(func):
+            @functools.wraps(func)
+            async def async_wrapper(self, *args, **kwargs):
+                span_name = name or f"{self.__class__.__name__}.{func.__name__}"
+                manager = get_tracing_manager()
+                span_attributes = dict(attributes) if attributes else {}
+                span_attributes["class"] = self.__class__.__name__
+                span_attributes["method"] = func.__name__
+                async with manager.async_span(span_name, kind=kind, attributes=span_attributes):
+                    return await func(self, *args, **kwargs)
 
+            return async_wrapper
+
+        @functools.wraps(func)
+        def sync_wrapper(self, *args, **kwargs):
+            span_name = name or f"{self.__class__.__name__}.{func.__name__}"
             manager = get_tracing_manager()
             span_attributes = dict(attributes) if attributes else {}
             span_attributes["class"] = self.__class__.__name__
             span_attributes["method"] = func.__name__
+            with manager.span(span_name, kind=kind, attributes=span_attributes):
+                return func(self, *args, **kwargs)
 
-            if asyncio.iscoroutinefunction(func):
-                async def async_execution():
-                    async with manager.async_span(span_name, kind=kind, attributes=span_attributes):
-                        return await func(self, *args, **kwargs)
-                return async_execution()
-            else:
-                with manager.span(span_name, kind=kind, attributes=span_attributes):
-                    return func(self, *args, **kwargs)
-
-        return wrapper
+        return sync_wrapper
 
     return decorator
 

--- a/tldw_Server_API/app/core/Metrics/traces.py
+++ b/tldw_Server_API/app/core/Metrics/traces.py
@@ -87,11 +87,20 @@ class TracingManager:
 
     def __init__(self):
         """Initialize the tracing manager."""
-        self.telemetry = get_telemetry_manager()
-        self.tracer = self.telemetry.get_tracer("tldw_server.tracing")
         self.active_spans = {}
         # Local baggage store when OpenTelemetry baggage is unavailable
         self._local_baggage = contextvars.ContextVar("tldw_local_baggage", default=None)
+
+    @property
+    def telemetry(self):
+        """Always return the *current* global telemetry manager so that a
+        shutdown/re-init cycle is picked up automatically."""
+        return get_telemetry_manager()
+
+    @property
+    def tracer(self):
+        """Return a tracer from the current telemetry manager."""
+        return self.telemetry.get_tracer("tldw_server.tracing")
 
     @contextmanager
     def span(
@@ -397,19 +406,15 @@ def trace_operation(
                         logger.debug(f"trace_operation arg serialization failed: error={e}")
 
                 async with manager.async_span(span_name, kind=kind, attributes=span_attributes) as span:
-                    try:
-                        result = await func(*args, **kwargs)
+                    result = await func(*args, **kwargs)
 
-                        if record_result and span:
-                            try:
-                                span.set_attribute("result", json.dumps(str(result)[:1000]))
-                            except Exception as e:
-                                logger.debug(f"trace_operation result serialization failed: error={e}")
+                    if record_result and span:
+                        try:
+                            span.set_attribute("result", json.dumps(str(result)[:1000]))
+                        except Exception as e:
+                            logger.debug(f"trace_operation result serialization failed: error={e}")
 
-                        return result
-
-                    except Exception:
-                        raise
+                    return result
 
             return async_wrapper
 
@@ -431,19 +436,15 @@ def trace_operation(
                         logger.debug(f"trace_operation arg serialization failed: error={e}")
 
                 with manager.span(span_name, kind=kind, attributes=span_attributes) as span:
-                    try:
-                        result = func(*args, **kwargs)
+                    result = func(*args, **kwargs)
 
-                        if record_result and span:
-                            try:
-                                span.set_attribute("result", json.dumps(str(result)[:1000]))
-                            except Exception as e:
-                                logger.debug(f"trace_operation result serialization failed: error={e}")
+                    if record_result and span:
+                        try:
+                            span.set_attribute("result", json.dumps(str(result)[:1000]))
+                        except Exception as e:
+                            logger.debug(f"trace_operation result serialization failed: error={e}")
 
-                        return result
-
-                    except Exception:
-                        raise
+                    return result
 
             return sync_wrapper
 

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -6004,29 +6004,9 @@ async def root():
 
 # Metrics endpoint for Prometheus scraping (registered conditionally below)
 async def metrics():
-    """Prometheus metrics endpoint.
+    from tldw_Server_API.app.api.v1.endpoints.metrics import build_prometheus_metrics_response
 
-    Exposes both the internal registry (JSON-backed) and the default
-    prometheus_client REGISTRY used by embeddings/orchestrator code paths.
-    """
-    from fastapi.responses import PlainTextResponse
-
-    try:
-        from prometheus_client import REGISTRY as PC_REGISTRY
-        from prometheus_client import generate_latest as pc_generate_latest
-    except _IMPORT_EXCEPTIONS:
-        PC_REGISTRY = None
-        pc_generate_latest = None
-
-    registry = get_metrics_registry()
-    combined = registry.export_prometheus_format() or ""
-    try:
-        if pc_generate_latest and PC_REGISTRY:
-            combined = (combined + "\n" + pc_generate_latest(PC_REGISTRY).decode("utf-8")).strip() + "\n"
-    except _REQUEST_GUARD_EXCEPTIONS:
-        # If prometheus_client is unavailable, ignore
-        pass
-    return PlainTextResponse(combined, media_type="text/plain; version=0.0.4")
+    return await build_prometheus_metrics_response()
 
 
 # OpenTelemetry metrics endpoint (if using OTLP) - registered conditionally below

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
@@ -7,11 +7,11 @@ class RecordingCache:
         self.get_keys: list[str] = []
         self.set_keys: list[str] = []
 
-    async def get(self, key):
+    async def get(self, key: str) -> object | None:
         self.get_keys.append(key)
         return self.data.get(key)
 
-    async def set(self, key, value):
+    async def set(self, key: str, value: object) -> None:
         self.set_keys.append(key)
         self.data[key] = value
 

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
@@ -1,0 +1,84 @@
+import pytest
+
+
+class RecordingCache:
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+        self.get_keys: list[str] = []
+        self.set_keys: list[str] = []
+
+    async def get(self, key):
+        self.get_keys.append(key)
+        return self.data.get(key)
+
+    async def set(self, key, value):
+        self.set_keys.append(key)
+        self.data[key] = value
+
+
+def test_local_api_backend_identity_strips_credentials_and_query():
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
+
+    clean_url = "http://backend-one.example:8080/v1"
+    secret_url = "http://user:pass@backend-one.example:8080/v1?token=abc#fragment"
+
+    clean_identity = mod._normalize_cache_backend_identity({"api_url": clean_url}, "local_api")
+    secret_identity = mod._normalize_cache_backend_identity({"api_url": secret_url}, "local_api")
+
+    assert clean_identity == "http://backend-one.example:8080/v1"
+    assert secret_identity == clean_identity
+    assert "user" not in secret_identity
+    assert "pass" not in secret_identity
+    assert "token" not in secret_identity
+
+    clean_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=clean_identity)
+    secret_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=secret_identity)
+
+    assert secret_cache_key == clean_cache_key
+
+
+@pytest.mark.asyncio
+async def test_local_api_url_participates_in_cache_identity(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
+
+    cache = RecordingCache()
+    api_urls: list[str | None] = []
+
+    async def fake_create_embeddings_with_circuit_breaker(
+        texts,
+        provider,
+        model_id,
+        config,
+        metadata=None,
+        dimensions=None,
+    ):
+        _ = (texts, provider, model_id, metadata, dimensions)
+        api_url = config["api_url"]
+        api_urls.append(api_url)
+        marker = 1.0 if api_url == "http://backend-one/v1" else 2.0
+        return [[marker, marker]]
+
+    monkeypatch.setattr(mod, "embedding_cache", cache)
+    monkeypatch.setattr(mod, "create_embeddings_with_circuit_breaker", fake_create_embeddings_with_circuit_breaker)
+
+    first = await mod.create_embeddings_batch_async(
+        texts=["cache me"],
+        provider="local_api",
+        model_id="test-model",
+        api_url="http://backend-one/v1",
+    )
+    second = await mod.create_embeddings_batch_async(
+        texts=["cache me"],
+        provider="local_api",
+        model_id="test-model",
+        api_url="http://backend-two/v1",
+    )
+
+    assert first == [[1.0, 1.0]]
+    assert second == [[2.0, 2.0]]
+    assert api_urls == ["http://backend-one/v1", "http://backend-two/v1"]
+    assert len(cache.get_keys) == 2
+    assert len(cache.set_keys) == 2
+    assert cache.get_keys[0] != cache.get_keys[1]
+    assert cache.set_keys[0] != cache.set_keys[1]
+    assert cache.get_keys == cache.set_keys

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
@@ -20,21 +20,21 @@ def test_local_api_backend_identity_strips_credentials_and_query():
     import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
 
     clean_url = "http://backend-one.example:8080/v1"
-    secret_url = "http://user:pass@backend-one.example:8080/v1?token=abc#fragment"
+    credentialed_url = "http://alice:s3cret@backend-one.example:8080/v1?token=abc#fragment"
 
     clean_identity = mod._normalize_cache_backend_identity({"api_url": clean_url}, "local_api")
-    secret_identity = mod._normalize_cache_backend_identity({"api_url": secret_url}, "local_api")
+    credentialed_identity = mod._normalize_cache_backend_identity({"api_url": credentialed_url}, "local_api")
 
     assert clean_identity == "http://backend-one.example:8080/v1"
-    assert secret_identity == clean_identity
-    assert "user" not in secret_identity
-    assert "pass" not in secret_identity
-    assert "token" not in secret_identity
+    assert credentialed_identity == clean_identity
+    assert "alice" not in credentialed_identity
+    assert "s3cret" not in credentialed_identity
+    assert "token" not in credentialed_identity
 
     clean_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=clean_identity)
-    secret_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=secret_identity)
+    credentialed_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=credentialed_identity)
 
-    assert secret_cache_key == clean_cache_key
+    assert credentialed_cache_key == clean_cache_key
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_endpoint_cache_identity.py
@@ -16,7 +16,7 @@ class RecordingCache:
         self.data[key] = value
 
 
-def test_local_api_backend_identity_strips_credentials_and_query():
+def test_local_api_backend_identity_strips_credentials_and_sensitive_params():
     import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
 
     clean_url = "http://backend-one.example:8080/v1"
@@ -35,6 +35,42 @@ def test_local_api_backend_identity_strips_credentials_and_query():
     credentialed_cache_key = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=credentialed_identity)
 
     assert credentialed_cache_key == clean_cache_key
+
+
+def test_local_api_backend_identity_preserves_nonsensitive_query_params():
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
+
+    url_tenant_a = "http://backend-one.example:8080/v1?tenant=a"
+    url_tenant_b = "http://backend-one.example:8080/v1?tenant=b"
+    url_no_query = "http://backend-one.example:8080/v1"
+
+    identity_a = mod._normalize_cache_backend_identity({"api_url": url_tenant_a}, "local_api")
+    identity_b = mod._normalize_cache_backend_identity({"api_url": url_tenant_b}, "local_api")
+    identity_none = mod._normalize_cache_backend_identity({"api_url": url_no_query}, "local_api")
+
+    # Non-sensitive query params produce distinct identities
+    assert identity_a != identity_b
+    assert identity_a != identity_none
+    assert "tenant=a" in identity_a
+    assert "tenant=b" in identity_b
+
+    # Cache keys are therefore distinct
+    key_a = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=identity_a)
+    key_b = mod.get_cache_key("cache me", "local_api", "test-model", backend_identity=identity_b)
+    assert key_a != key_b
+
+
+def test_local_api_backend_identity_strips_sensitive_but_keeps_nonsensitive():
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as mod
+
+    url_mixed = "http://backend.example:8080/v1?tenant=prod&token=secret123&region=us-east"
+
+    identity = mod._normalize_cache_backend_identity({"api_url": url_mixed}, "local_api")
+
+    assert "tenant=prod" in identity
+    assert "region=us-east" in identity
+    assert "token" not in identity
+    assert "secret123" not in identity
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_token_arrays.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_token_arrays.py
@@ -2,7 +2,7 @@ import os
 import base64
 import numpy as np
 import pytest
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 from fastapi.testclient import TestClient
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
@@ -92,7 +92,7 @@ def test_token_array_uses_raw_token_length_for_limits(client, monkeypatch):
 
 
 @pytest.mark.unit
-def test_tokens_to_texts_logs_decode_failure(monkeypatch):
+def test_tokens_to_texts_decode_failure_raises_value_error(monkeypatch):
     import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as emb_mod
 
     class _BadEncoder:
@@ -103,11 +103,38 @@ def test_tokens_to_texts_logs_decode_failure(monkeypatch):
     warn = Mock()
     monkeypatch.setattr(emb_mod.logger, "warning", warn)
 
-    texts, total, lengths = emb_mod.tokens_to_texts([1, 2], "text-embedding-3-small")
-    assert texts == [""]
-    assert total == 2
-    assert lengths == [2]
+    with pytest.raises(ValueError, match="Invalid token array input"):
+        emb_mod.tokens_to_texts([1, 2], "text-embedding-3-small")
     assert warn.called
+
+
+@pytest.mark.unit
+def test_embeddings_endpoint_decode_failure_short_circuits_downstream_creation(client, monkeypatch):
+    async def override_user():
+        from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+        return User(id=1, username="u", email="u@x", is_active=True, is_admin=False)
+
+    app.dependency_overrides[get_request_user] = override_user
+
+    import tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced as emb_mod
+
+    class _BadEncoder:
+        def decode(self, _tokens):
+            raise ValueError("boom")
+
+    monkeypatch.setattr(emb_mod, "get_tokenizer", lambda _model: _BadEncoder())
+    create_embeddings_mock = AsyncMock()
+    monkeypatch.setattr(emb_mod, "create_embeddings_batch_async", create_embeddings_mock)
+
+    payload = {
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "input": [101, 102, 103, 104],
+    }
+    r = client.post("/api/v1/embeddings", json=payload, headers={"x-provider": "huggingface"})
+
+    assert r.status_code == 400
+    assert r.json()["detail"] == "Invalid token array input"
+    create_embeddings_mock.assert_not_awaited()
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Embeddings/test_media_embedding_jobs.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embedding_jobs.py
@@ -1,6 +1,9 @@
 import os
 import time
+import pytest
 from fastapi.testclient import TestClient
+import redis
+import redis.asyncio as aioredis
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
@@ -20,8 +23,28 @@ class _FakeMediaDB:
             for media_id in ids
         }
 
-    def get_media_by_id(self, media_id: int):
+    def get_media_by_id(self, media_id: int, **_kwargs):
         return self._items.get(media_id)
+
+
+class _FakeRedisClient:
+    async def ping(self):
+        return True
+
+    async def close(self):
+        return None
+
+    async def aclose(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_redis_clients(monkeypatch):
+    def _make_client(*_args, **_kwargs):
+        return _FakeRedisClient()
+
+    monkeypatch.setattr(aioredis, "from_url", _make_client)
+    monkeypatch.setattr(redis, "from_url", _make_client, raising=False)
 
 
 from contextlib import contextmanager
@@ -133,7 +156,7 @@ def test_media_embedding_job_returns_500_when_job_id_missing(monkeypatch):
         app.dependency_overrides.pop(get_media_db_for_user, None)
 
 
-def test_media_embedding_batch_returns_500_on_partial_enqueue_failure(monkeypatch):
+def test_media_embedding_batch_returns_partial_on_partial_enqueue_failure(monkeypatch):
     os.environ["TESTING"] = "true"
     try:
         from tldw_Server_API.app.api.v1.endpoints import media_embeddings as media_embeddings_endpoint
@@ -155,31 +178,30 @@ def test_media_embedding_batch_returns_500_on_partial_enqueue_failure(monkeypatc
                 json={"media_ids": [123, 456]},
                 headers={"X-API-KEY": api_key},
             )
-            assert resp.status_code == 500
+            assert resp.status_code == 202
             body = resp.json()
-            detail = body.get("detail") or {}
-            assert detail.get("error") == "batch_enqueue_failed"
-            assert detail.get("submitted") == 1
-            assert detail.get("failed_media_ids") == [456]
+            assert body.get("status") == "partial"
+            assert body.get("job_ids") == ["job-123"]
+            assert body.get("submitted") == 1
+            assert body.get("failed_media_ids") == [456]
+            assert body.get("failure_reasons") == ["media_id=456: RuntimeError"]
     finally:
         os.environ.pop("TESTING", None)
         app.dependency_overrides.pop(get_media_db_for_user, None)
 
 
-def test_media_embedding_batch_returns_500_when_job_id_missing(monkeypatch):
+def test_media_embedding_batch_returns_accepted_with_empty_failure_lists(monkeypatch):
     os.environ["TESTING"] = "true"
     try:
         from tldw_Server_API.app.api.v1.endpoints import media_embeddings as media_embeddings_endpoint
 
-        class _MissingIdAdapter:
+        class _SuccessfulAdapter:
             def create_job(self, **kwargs):
                 media_id = int(kwargs["media_id"])
-                if media_id == 456:
-                    return {}
                 return {"uuid": f"job-{media_id}"}
 
         app.dependency_overrides[get_media_db_for_user] = lambda: _FakeMediaDB(media_ids=[123, 456])
-        monkeypatch.setattr(media_embeddings_endpoint, "EmbeddingsJobsAdapter", _MissingIdAdapter)
+        monkeypatch.setattr(media_embeddings_endpoint, "EmbeddingsJobsAdapter", _SuccessfulAdapter)
 
         with _client() as client:
             api_key = get_settings().SINGLE_USER_API_KEY
@@ -188,10 +210,73 @@ def test_media_embedding_batch_returns_500_when_job_id_missing(monkeypatch):
                 json={"media_ids": [123, 456]},
                 headers={"X-API-KEY": api_key},
             )
+            assert resp.status_code == 202
+            body = resp.json()
+            assert body.get("status") == "accepted"
+            assert body.get("job_ids") == ["job-123", "job-456"]
+            assert body.get("submitted") == 2
+            assert body.get("failed_media_ids") == []
+            assert body.get("failure_reasons") == []
+    finally:
+        os.environ.pop("TESTING", None)
+        app.dependency_overrides.pop(get_media_db_for_user, None)
+
+
+def test_media_embedding_batch_returns_500_when_nothing_queued(monkeypatch):
+    os.environ["TESTING"] = "true"
+    try:
+        from tldw_Server_API.app.api.v1.endpoints import media_embeddings as media_embeddings_endpoint
+
+        class _FailingAdapter:
+            def create_job(self, **_kwargs):
+                raise RuntimeError("enqueue failed")
+
+        app.dependency_overrides[get_media_db_for_user] = lambda: _FakeMediaDB(media_ids=[456])
+        monkeypatch.setattr(media_embeddings_endpoint, "EmbeddingsJobsAdapter", _FailingAdapter)
+
+        with _client() as client:
+            api_key = get_settings().SINGLE_USER_API_KEY
+            resp = client.post(
+                "/api/v1/media/embeddings/batch",
+                json={"media_ids": [456]},
+                headers={"X-API-KEY": api_key},
+            )
             assert resp.status_code == 500
             detail = (resp.json() or {}).get("detail") or {}
             assert detail.get("error") == "batch_enqueue_failed"
+            assert detail.get("submitted") == 0
             assert detail.get("failed_media_ids") == [456]
+            assert detail.get("failure_reasons") == ["media_id=456: RuntimeError"]
+    finally:
+        os.environ.pop("TESTING", None)
+        app.dependency_overrides.pop(get_media_db_for_user, None)
+
+
+def test_media_embedding_batch_returns_500_when_batch_job_id_missing(monkeypatch):
+    os.environ["TESTING"] = "true"
+    try:
+        from tldw_Server_API.app.api.v1.endpoints import media_embeddings as media_embeddings_endpoint
+
+        class _MissingIdAdapter:
+            def create_job(self, **_kwargs):
+                return {}
+
+        app.dependency_overrides[get_media_db_for_user] = lambda: _FakeMediaDB(media_ids=[456])
+        monkeypatch.setattr(media_embeddings_endpoint, "EmbeddingsJobsAdapter", _MissingIdAdapter)
+
+        with _client() as client:
+            api_key = get_settings().SINGLE_USER_API_KEY
+            resp = client.post(
+                "/api/v1/media/embeddings/batch",
+                json={"media_ids": [456]},
+                headers={"X-API-KEY": api_key},
+            )
+            assert resp.status_code == 500
+            detail = (resp.json() or {}).get("detail") or {}
+            assert detail.get("error") == "batch_enqueue_failed"
+            assert detail.get("submitted") == 0
+            assert detail.get("failed_media_ids") == [456]
+            assert detail.get("failure_reasons") == ["media_id=456: ValueError"]
     finally:
         os.environ.pop("TESTING", None)
         app.dependency_overrides.pop(get_media_db_for_user, None)

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py
@@ -4,7 +4,7 @@ from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanc
 
 
 @pytest.mark.asyncio
-async def test_storage_failure_after_successful_primary_generation_returns_storage_error_and_skips_fallback(monkeypatch):
+async def test_storage_failure_after_successful_primary_generation_returns_storage_error_and_skips_fallback(monkeypatch, tmp_path):
     calls: list[tuple[str, str]] = []
 
     async def fake_create_embeddings_batch_async(*, texts, provider, model_id, metadata):
@@ -27,7 +27,7 @@ async def test_storage_failure_after_successful_primary_generation_returns_stora
     )
     monkeypatch.setattr(media_embeddings, "chunk_media_content", lambda *_args, **_kwargs: [{"text": "hello", "index": 0, "start": 0, "end": 5}])
     monkeypatch.setattr(media_embeddings, "ChromaDBManager", FakeChromaDBManager)
-    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": "/tmp/test"})  # nosec B108
+    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": str(tmp_path / "user-db")})
 
     result = await media_embeddings.generate_embeddings_for_media(
         media_id=9,
@@ -49,7 +49,7 @@ async def test_storage_failure_after_successful_primary_generation_returns_stora
 
 
 @pytest.mark.asyncio
-async def test_generation_failure_can_fall_back_and_succeed(monkeypatch):
+async def test_generation_failure_can_fall_back_and_succeed(monkeypatch, tmp_path):
     calls: list[tuple[str, str]] = []
     stores: list[str] = []
 
@@ -75,7 +75,7 @@ async def test_generation_failure_can_fall_back_and_succeed(monkeypatch):
     )
     monkeypatch.setattr(media_embeddings, "chunk_media_content", lambda *_args, **_kwargs: [{"text": "hello", "index": 0, "start": 0, "end": 5}])
     monkeypatch.setattr(media_embeddings, "ChromaDBManager", FakeChromaDBManager)
-    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": "/tmp/test"})  # nosec B108
+    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": str(tmp_path / "user-db")})
 
     result = await media_embeddings.generate_embeddings_for_media(
         media_id=10,

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_failure_classification.py
@@ -1,0 +1,99 @@
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced, media_embeddings
+
+
+@pytest.mark.asyncio
+async def test_storage_failure_after_successful_primary_generation_returns_storage_error_and_skips_fallback(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    async def fake_create_embeddings_batch_async(*, texts, provider, model_id, metadata):
+        calls.append((provider, model_id))
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    class FakeChromaDBManager:
+        def __init__(self, *, user_id, user_embedding_config):
+            self.user_id = user_id
+            self.user_embedding_config = user_embedding_config
+
+        def store_in_chroma(self, *args, **kwargs):
+            raise RuntimeError("chroma write failed")
+
+    monkeypatch.setattr(
+        embeddings_v5_production_enhanced,
+        "create_embeddings_batch_async",
+        fake_create_embeddings_batch_async,
+        raising=True,
+    )
+    monkeypatch.setattr(media_embeddings, "chunk_media_content", lambda *_args, **_kwargs: [{"text": "hello", "index": 0, "start": 0, "end": 5}])
+    monkeypatch.setattr(media_embeddings, "ChromaDBManager", FakeChromaDBManager)
+    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": "/tmp/test"})  # nosec B108
+
+    result = await media_embeddings.generate_embeddings_for_media(
+        media_id=9,
+        media_content={
+            "media_item": {"title": "Doc", "author": "Author", "metadata": {}},
+            "content": {"content": "hello"},
+        },
+        embedding_model="primary-model",
+        embedding_provider="primary-provider",
+        chunk_size=1000,
+        chunk_overlap=200,
+        user_id="tenant-1",
+    )
+
+    assert result["status"] == "error"
+    assert "storage" in result["message"].lower() or "storage" in result["error"].lower()
+    assert "chroma" in result["message"].lower() or "chroma" in result["error"].lower()
+    assert calls == [("primary-provider", "primary-model")]
+
+
+@pytest.mark.asyncio
+async def test_generation_failure_can_fall_back_and_succeed(monkeypatch):
+    calls: list[tuple[str, str]] = []
+    stores: list[str] = []
+
+    async def fake_create_embeddings_batch_async(*, texts, provider, model_id, metadata):
+        calls.append((provider, model_id))
+        if provider == "primary-provider":
+            raise RuntimeError("primary provider failed")
+        return [[0.4, 0.5, 0.6] for _ in texts]
+
+    class FakeChromaDBManager:
+        def __init__(self, *, user_id, user_embedding_config):
+            self.user_id = user_id
+            self.user_embedding_config = user_embedding_config
+
+        def store_in_chroma(self, *, collection_name, texts, embeddings, ids, metadatas, embedding_model_id_for_dim_check=None):
+            stores.append(embedding_model_id_for_dim_check)
+
+    monkeypatch.setattr(
+        embeddings_v5_production_enhanced,
+        "create_embeddings_batch_async",
+        fake_create_embeddings_batch_async,
+        raising=True,
+    )
+    monkeypatch.setattr(media_embeddings, "chunk_media_content", lambda *_args, **_kwargs: [{"text": "hello", "index": 0, "start": 0, "end": 5}])
+    monkeypatch.setattr(media_embeddings, "ChromaDBManager", FakeChromaDBManager)
+    monkeypatch.setattr(media_embeddings, "_user_embedding_config", lambda: {"USER_DB_BASE_DIR": "/tmp/test"})  # nosec B108
+
+    result = await media_embeddings.generate_embeddings_for_media(
+        media_id=10,
+        media_content={
+            "media_item": {"title": "Doc", "author": "Author", "metadata": {}},
+            "content": {"content": "hello"},
+        },
+        embedding_model="primary-model",
+        embedding_provider="primary-provider",
+        chunk_size=1000,
+        chunk_overlap=200,
+        user_id="tenant-2",
+    )
+
+    assert result["status"] == "success"
+    assert result["embedding_count"] == 1
+    assert calls == [
+        ("primary-provider", "primary-model"),
+        ("huggingface", media_embeddings.FALLBACK_EMBEDDING_MODEL),
+    ]
+    assert stores == [media_embeddings.FALLBACK_EMBEDDING_MODEL]

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
@@ -90,6 +90,54 @@ async def test_generate_embeddings_batch_returns_partial_response_on_partial_enq
 
 
 @pytest.mark.asyncio
+async def test_generate_embeddings_batch_returns_partial_when_some_media_ids_missing(monkeypatch):
+    class _OkAdapter:
+        def create_job(self, **kwargs):
+            return {"uuid": f"job-{kwargs['media_id']}"}
+
+    monkeypatch.setattr(media_embeddings, "_embeddings_jobs_backend", lambda: "jobs")
+    monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
+    monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _OkAdapter)
+
+    # _FakeMediaDB only knows about media_id 123; 999 is missing
+    response = await media_embeddings.generate_embeddings_batch(
+        request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[123, 999]),
+        db=_FakeMediaDB([123]),
+        current_user=_user(),
+    )
+
+    assert response.status == "partial"
+    assert response.job_ids == ["job-123"]
+    assert response.submitted == 1
+    assert response.failed_media_ids == [999]
+    assert response.failure_reasons == ["media_id=999: not found"]
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_batch_raises_when_all_media_ids_missing(monkeypatch):
+    class _OkAdapter:
+        def create_job(self, **kwargs):
+            return {"uuid": f"job-{kwargs['media_id']}"}
+
+    monkeypatch.setattr(media_embeddings, "_embeddings_jobs_backend", lambda: "jobs")
+    monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
+    monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _OkAdapter)
+
+    # _FakeMediaDB is empty — both IDs are missing
+    with pytest.raises(HTTPException) as excinfo:
+        await media_embeddings.generate_embeddings_batch(
+            request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[888, 999]),
+            db=_FakeMediaDB([]),
+            current_user=_user(),
+        )
+
+    assert excinfo.value.status_code == 500
+    assert isinstance(excinfo.value.detail, dict)
+    assert excinfo.value.detail.get("error") == "batch_enqueue_failed"
+    assert excinfo.value.detail.get("failed_media_ids") == [888, 999]
+
+
+@pytest.mark.asyncio
 async def test_generate_embeddings_batch_raises_when_all_enqueues_fail_before_any_success(monkeypatch):
     class _AlwaysFailingAdapter:
         def create_job(self, **kwargs):

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
@@ -9,7 +9,7 @@ class _FakeMediaDB:
     def __init__(self, media_ids: list[int]):
         self._ids = set(int(media_id) for media_id in media_ids)
 
-    def get_media_by_id(self, media_id: int):
+    def get_media_by_id(self, media_id: int, **_kwargs):
         if int(media_id) in self._ids:
             return {"id": int(media_id), "title": "Doc", "author": "A"}
         return None
@@ -64,7 +64,7 @@ async def test_generate_embeddings_fails_when_job_id_missing(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_generate_embeddings_batch_fails_on_partial_enqueue_error(monkeypatch):
+async def test_generate_embeddings_batch_returns_partial_response_on_partial_enqueue_error(monkeypatch):
     class _PartialAdapter:
         def create_job(self, **kwargs):
             media_id = int(kwargs["media_id"])
@@ -76,28 +76,24 @@ async def test_generate_embeddings_batch_fails_on_partial_enqueue_error(monkeypa
     monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
     monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _PartialAdapter)
 
-    with pytest.raises(HTTPException) as excinfo:
-        await media_embeddings.generate_embeddings_batch(
-            request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[123, 456]),
-            db=_FakeMediaDB([123, 456]),
-            current_user=_user(),
-        )
+    response = await media_embeddings.generate_embeddings_batch(
+        request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[123, 456]),
+        db=_FakeMediaDB([123, 456]),
+        current_user=_user(),
+    )
 
-    assert excinfo.value.status_code == 500
-    assert isinstance(excinfo.value.detail, dict)
-    assert excinfo.value.detail.get("error") == "batch_enqueue_failed"
-    assert excinfo.value.detail.get("submitted") == 1
-    assert excinfo.value.detail.get("failed_media_ids") == [456]
+    assert response.status == "partial"
+    assert response.job_ids == ["job-123"]
+    assert response.submitted == 1
+    assert response.failed_media_ids == [456]
+    assert response.failure_reasons == ["media_id=456: RuntimeError"]
 
 
 @pytest.mark.asyncio
-async def test_generate_embeddings_batch_fails_when_job_id_missing(monkeypatch):
+async def test_generate_embeddings_batch_raises_when_all_enqueues_fail_before_any_success(monkeypatch):
     class _MissingIdAdapter:
         def create_job(self, **kwargs):
-            media_id = int(kwargs["media_id"])
-            if media_id == 456:
-                return {}
-            return {"uuid": f"job-{media_id}"}
+            raise RuntimeError("enqueue failed")
 
     monkeypatch.setattr(media_embeddings, "_embeddings_jobs_backend", lambda: "jobs")
     monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
@@ -105,12 +101,13 @@ async def test_generate_embeddings_batch_fails_when_job_id_missing(monkeypatch):
 
     with pytest.raises(HTTPException) as excinfo:
         await media_embeddings.generate_embeddings_batch(
-            request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[123, 456]),
-            db=_FakeMediaDB([123, 456]),
+            request=media_embeddings.BatchMediaEmbeddingsRequest(media_ids=[456]),
+            db=_FakeMediaDB([456]),
             current_user=_user(),
         )
 
     assert excinfo.value.status_code == 500
     assert isinstance(excinfo.value.detail, dict)
     assert excinfo.value.detail.get("error") == "batch_enqueue_failed"
+    assert excinfo.value.detail.get("submitted") == 0
     assert excinfo.value.detail.get("failed_media_ids") == [456]

--- a/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
+++ b/tldw_Server_API/tests/Embeddings/test_media_embeddings_submission_semantics.py
@@ -91,13 +91,13 @@ async def test_generate_embeddings_batch_returns_partial_response_on_partial_enq
 
 @pytest.mark.asyncio
 async def test_generate_embeddings_batch_raises_when_all_enqueues_fail_before_any_success(monkeypatch):
-    class _MissingIdAdapter:
+    class _AlwaysFailingAdapter:
         def create_job(self, **kwargs):
             raise RuntimeError("enqueue failed")
 
     monkeypatch.setattr(media_embeddings, "_embeddings_jobs_backend", lambda: "jobs")
     monkeypatch.setattr(media_embeddings, "_resolve_model_provider", lambda *_: ("model-a", "provider-a"))
-    monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _MissingIdAdapter)
+    monkeypatch.setattr(media_embeddings, "EmbeddingsJobsAdapter", _AlwaysFailingAdapter)
 
     with pytest.raises(HTTPException) as excinfo:
         await media_embeddings.generate_embeddings_batch(

--- a/tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py
+++ b/tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py
@@ -28,10 +28,12 @@ def test_cumulative_counter_series_cap_drops_new_label_sets(monkeypatch):
 
         assert registry.get_cumulative_counter("cap_counter_total", {"series": "a"}) == 2
         assert registry.get_cumulative_counter("cap_counter_total", {"series": "b"}) == 0
+        assert registry.get_metric_stats("cap_counter_total", labels={"series": "b"}) == {}
 
         text = registry.export_prometheus_format()
         assert 'cap_counter_total{series="a"}' in text
         assert 'cap_counter_total{series="b"}' not in text
+        assert registry.get_all_metrics()["cap_counter_total"]["stats"]["count"] == 2
     finally:
         metrics_manager._metrics_registry = None
 
@@ -57,8 +59,119 @@ def test_cumulative_histogram_series_cap_drops_new_label_sets(monkeypatch):
         registry.observe("cap_hist_seconds", 0.4, labels={"series": "a"})
 
         text = registry.export_prometheus_format()
+        assert registry.get_metric_stats("cap_hist_seconds", labels={"series": "b"}) == {}
         assert 'cap_hist_seconds_count{series="a"} 2' in text
         assert 'cap_hist_seconds_count{series="b"}' not in text
+        assert registry.get_all_metrics()["cap_hist_seconds"]["stats"]["count"] == 2
+    finally:
+        metrics_manager._metrics_registry = None
+
+
+def test_cumulative_series_cap_still_dispatches_callbacks_and_instruments(monkeypatch):
+    monkeypatch.setenv("METRICS_CUMULATIVE_SERIES_MAX_PER_METRIC", "1")
+    metrics_manager._metrics_registry = None
+    registry = metrics_manager.get_metrics_registry()
+
+    class DummyInstrument:
+        def __init__(self):
+            self.calls = []
+
+        def add(self, value, attributes=None):
+            self.calls.append((value, dict(attributes or {})))
+
+    callback_calls = []
+
+    def callback(metric_name, value, labels):
+        callback_calls.append((metric_name, value, dict(labels)))
+
+    try:
+        registry.register_metric(
+            MetricDefinition(
+                name="cap_dispatch_total",
+                type=MetricType.COUNTER,
+                description="counter cap dispatch test",
+                labels=["series"],
+            )
+        )
+        registry.instruments["cap_dispatch_total"] = DummyInstrument()
+        registry.add_callback("cap_dispatch_total", callback)
+
+        registry.increment("cap_dispatch_total", labels={"series": "a"})
+        registry.increment("cap_dispatch_total", labels={"series": "b"})  # capped, but still dispatched
+
+        assert registry.get_cumulative_counter_total("cap_dispatch_total") == 1
+        assert registry.get_metric_stats("cap_dispatch_total", labels={"series": "b"}) == {}
+        assert registry.get_all_metrics()["cap_dispatch_total"]["stats"]["count"] == 1
+        assert callback_calls == [
+            ("cap_dispatch_total", 1, {"series": "a"}),
+            ("cap_dispatch_total", 1, {"series": "b"}),
+        ]
+        assert registry.instruments["cap_dispatch_total"].calls == [
+            (1, {"series": "a"}),
+            (1, {"series": "b"}),
+        ]
+    finally:
+        metrics_manager._metrics_registry = None
+
+
+def test_cumulative_counter_series_cap_does_not_leak_into_stats(monkeypatch):
+    monkeypatch.setenv("METRICS_CUMULATIVE_SERIES_MAX_PER_METRIC", "1")
+    metrics_manager._metrics_registry = None
+    registry = metrics_manager.get_metrics_registry()
+
+    try:
+        registry.register_metric(
+            MetricDefinition(
+                name="cap_counter_stats_total",
+                type=MetricType.COUNTER,
+                description="counter cap stats test",
+                labels=["series"],
+            )
+        )
+
+        registry.increment("cap_counter_stats_total", labels={"series": "a"})
+        registry.increment("cap_counter_stats_total", labels={"series": "b"})  # dropped
+        registry.increment("cap_counter_stats_total", labels={"series": "a"})
+
+        stats = registry.get_metric_stats("cap_counter_stats_total")
+        assert stats.get("count") == 2
+        assert registry.get_cumulative_counter("cap_counter_stats_total", {"series": "a"}) == 2
+        assert registry.get_cumulative_counter("cap_counter_stats_total", {"series": "b"}) == 0
+
+        metrics = registry.get_all_metrics()
+        assert metrics["cap_counter_stats_total"]["stats"]["count"] == 2
+    finally:
+        metrics_manager._metrics_registry = None
+
+
+def test_cumulative_histogram_series_cap_does_not_leak_into_stats(monkeypatch):
+    monkeypatch.setenv("METRICS_CUMULATIVE_SERIES_MAX_PER_METRIC", "1")
+    metrics_manager._metrics_registry = None
+    registry = metrics_manager.get_metrics_registry()
+
+    try:
+        registry.register_metric(
+            MetricDefinition(
+                name="cap_hist_stats_seconds",
+                type=MetricType.HISTOGRAM,
+                description="hist cap stats test",
+                labels=["series"],
+                buckets=[0.1, 1.0],
+            )
+        )
+
+        registry.observe("cap_hist_stats_seconds", 0.2, labels={"series": "a"})
+        registry.observe("cap_hist_stats_seconds", 0.3, labels={"series": "b"})  # dropped
+        registry.observe("cap_hist_stats_seconds", 0.4, labels={"series": "a"})
+
+        stats = registry.get_metric_stats("cap_hist_stats_seconds")
+        assert stats.get("count") == 2
+        metrics = registry.get_all_metrics()
+        assert metrics["cap_hist_stats_seconds"]["stats"]["count"] == 2
+
+        text = registry.export_prometheus_format()
+        assert 'cap_hist_stats_seconds_count{series="a"} 2' in text
+        assert 'cap_hist_stats_seconds_count{series="b"}' not in text
     finally:
         metrics_manager._metrics_registry = None
 

--- a/tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py
+++ b/tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py
@@ -1,0 +1,32 @@
+import pytest
+
+import tldw_Server_API.app.core.Metrics.metrics_manager as metrics_manager
+from tldw_Server_API.app.core.Metrics.metrics_manager import MetricDefinition, MetricType
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_record_rejects_conflicting_labels_after_normalization():
+    metrics_manager._metrics_registry = None
+    registry = metrics_manager.get_metrics_registry()
+
+    try:
+        metric_name = "label_collision_total"
+        registry.register_metric(
+            MetricDefinition(
+                name=metric_name,
+                type=MetricType.COUNTER,
+                description="label collision test",
+                labels=["x_y"],
+            )
+        )
+
+        registry.record(metric_name, 1, labels={"x-y": "left", "x_y": "right"})
+
+        assert registry.get_metric_stats(metric_name) == {}
+        assert registry.get_cumulative_counter_total(metric_name) == 0
+        assert registry.get_all_metrics() == {}
+        assert registry.export_prometheus_format().strip() == ""
+    finally:
+        metrics_manager._metrics_registry = None

--- a/tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py
+++ b/tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py
@@ -1,7 +1,21 @@
 import pytest
 
+import tldw_Server_API.app.core.Metrics.metrics_manager as metrics_manager
 from tldw_Server_API.app.core.Metrics import metrics_logger
-from tldw_Server_API.app.core.Metrics.metrics_manager import get_metrics_registry
+from tldw_Server_API.app.core.Metrics.metrics_manager import (
+    MetricDefinition,
+    MetricType,
+    get_metrics_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_global_registry():
+    metrics_manager._metrics_registry = None
+    try:
+        yield
+    finally:
+        metrics_manager._metrics_registry = None
 
 
 @pytest.mark.unit
@@ -39,3 +53,134 @@ def test_metrics_logger_bridge_records_gauge():
     stats = registry.get_metric_stats(metric_name, labels={"source": "test"})
     assert stats.get("count") == 1
     assert stats.get("latest") == 3.14
+
+
+@pytest.mark.unit
+def test_metrics_logger_bridge_rejects_conflicting_labels_before_registration(monkeypatch):
+    registry = get_metrics_registry()
+    registry.reset()
+
+    metric_name = "bridge collision total"
+    normalized_name = registry.normalize_metric_name(metric_name)
+    original_register_metric = registry.register_metric
+    called = {"value": False}
+
+    def spy_register_metric(definition, persistent=True):
+        called["value"] = True
+        return original_register_metric(definition, persistent=persistent)
+
+    logged_entries = []
+
+    class DummyBoundLogger:
+        def info(self, message):
+            logged_entries.append(message)
+
+    def fake_bind(**kwargs):
+        logged_entries.append(kwargs)
+        return DummyBoundLogger()
+
+    monkeypatch.setattr(metrics_logger.logger, "bind", fake_bind)
+
+    try:
+        registry.register_metric = spy_register_metric  # type: ignore[method-assign]
+        metrics_logger.log_counter(metric_name, labels={"x-y": "left", "x_y": "right"}, value=1)
+
+        assert called["value"] is False
+        assert logged_entries == []
+        assert normalized_name not in registry.metrics
+        assert registry.get_all_metrics() == {}
+        assert registry.get_cumulative_counter_total(normalized_name) == 0
+    finally:
+        registry.register_metric = original_register_metric  # type: ignore[method-assign]
+
+
+@pytest.mark.unit
+def test_metrics_logger_bridge_re_registers_metric_definition_after_reset():
+    registry = get_metrics_registry()
+    registry.reset()
+
+    metric_name = "bridge reset metric total"
+    normalized_name = registry.normalize_metric_name(metric_name)
+    metrics_logger.log_histogram(metric_name, 0.5, labels={"source": "test"})
+
+    assert normalized_name in registry.metrics
+    assert registry.metrics[normalized_name].type == MetricType.HISTOGRAM
+
+    registry.reset()
+
+    assert normalized_name not in registry.metrics
+    assert "http_requests_total" in registry.metrics
+
+    metrics_logger.log_counter(metric_name, labels={"source": "test"}, value=2)
+
+    assert normalized_name in registry.metrics
+    assert registry.metrics[normalized_name].type == MetricType.COUNTER
+    assert registry.get_cumulative_counter(normalized_name, {"source": "test"}) == 2
+
+
+@pytest.mark.unit
+def test_metrics_registry_reset_preserves_custom_metric_definitions_and_records():
+    registry = get_metrics_registry()
+    registry.reset()
+
+    metric_name = "workflow custom metric total"
+    normalized_name = registry.normalize_metric_name(metric_name)
+    registry.register_metric(
+        MetricDefinition(
+            name=metric_name,
+            type=MetricType.COUNTER,
+            description="workflow custom test",
+            labels=["source"],
+        )
+    )
+
+    assert normalized_name in registry.metrics
+    assert registry.metrics[normalized_name].type == MetricType.COUNTER
+
+    registry.increment(metric_name, labels={"source": "test"})
+    assert registry.get_cumulative_counter(normalized_name, {"source": "test"}) == 1
+
+    registry.reset()
+
+    assert normalized_name in registry.metrics
+    assert registry.metrics[normalized_name].type == MetricType.COUNTER
+    assert registry.get_metric_stats(metric_name) == {}
+    registry.increment(metric_name, labels={"source": "test"})
+    assert registry.get_cumulative_counter(normalized_name, {"source": "test"}) == 1
+
+
+@pytest.mark.unit
+def test_metrics_registry_reset_does_not_duplicate_histogram_views():
+    registry = get_metrics_registry()
+    registry.reset()
+
+    registry.register_metric(
+        MetricDefinition(
+            name="view_reset_histogram_seconds",
+            type=MetricType.HISTOGRAM,
+            description="view replay test",
+            buckets=[0.1, 1.0],
+        )
+    )
+
+    pending_before = len(getattr(registry.telemetry, "_pending_views", []))
+    registry.reset()
+    pending_after_first_reset = len(getattr(registry.telemetry, "_pending_views", []))
+    registry.reset()
+    pending_after_second_reset = len(getattr(registry.telemetry, "_pending_views", []))
+
+    assert pending_after_first_reset >= pending_before
+    assert pending_after_second_reset == pending_after_first_reset
+
+
+@pytest.mark.unit
+def test_metrics_logger_bridge_preserves_raw_name_alias_in_registry_values():
+    registry = get_metrics_registry()
+    registry.reset()
+
+    metric_name = "bridge alias metric total"
+    normalized_name = registry.normalize_metric_name(metric_name)
+    metrics_logger.log_counter(metric_name, labels={"source": "test"}, value=1)
+
+    assert metric_name in registry.values
+    assert normalized_name in registry.values

--- a/tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py
+++ b/tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py
@@ -1,4 +1,4 @@
-import subprocess
+import subprocess  # nosec B404
 import sys
 import textwrap
 
@@ -28,26 +28,31 @@ def test_telemetry_import_fallback_with_missing_opentelemetry():
             manager = telemetry.TelemetryManager()
             tracer = manager.get_tracer("forced-name")
             meter = manager.get_meter("forced-name")
+            cfg = telemetry.TelemetryConfig()
+            attrs = cfg.get_resource_attributes()
             print("OTEL_AVAILABLE", telemetry.OTEL_AVAILABLE)
             print("TRACER_CLASS", tracer.__class__.__name__)
             print("METER_CLASS", meter.__class__.__name__)
+            print("RESOURCE_ATTR_KEYS", sorted(str(key) for key in attrs.keys()))
         finally:
             builtins.__import__ = original_import
         """
     )
 
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603
         [sys.executable, "-c", script],
         check=False,
         capture_output=True,
         text=True,
     )
 
-    assert result.returncode == 0, (
+    assert result.returncode == 0, (  # nosec B101
         "Telemetry import should not crash when OpenTelemetry is unavailable.\n"
         f"stdout:\n{result.stdout}\n"
         f"stderr:\n{result.stderr}"
     )
-    assert "OTEL_AVAILABLE False" in result.stdout
-    assert "TRACER_CLASS DummyTracer" in result.stdout
-    assert "METER_CLASS DummyMeter" in result.stdout
+    assert "OTEL_AVAILABLE False" in result.stdout  # nosec B101
+    assert "TRACER_CLASS DummyTracer" in result.stdout  # nosec B101
+    assert "METER_CLASS DummyMeter" in result.stdout  # nosec B101
+    assert "service.name" in result.stdout  # nosec B101
+    assert "service.version" in result.stdout  # nosec B101

--- a/tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py
+++ b/tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py
@@ -240,6 +240,7 @@ def test_restart_cycle_stays_aligned_with_sdk_globals():
         capture_output=True,
         text=True,
         env=env,
+        timeout=30,
     )
 
     assert result.returncode == 0, (  # nosec B101

--- a/tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py
+++ b/tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py
@@ -1,0 +1,258 @@
+import os
+import subprocess  # nosec B404
+import sys
+import textwrap
+
+import pytest
+
+import tldw_Server_API.app.core.Metrics.telemetry as telemetry_module
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_shutdown_telemetry_clears_global_manager_and_allows_reinitialize(monkeypatch):
+    class StubManager:
+        def __init__(self, config=None):
+            self.config = config
+            self.shutdown_calls = 0
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    monkeypatch.setattr(telemetry_module, "TelemetryManager", StubManager)
+    monkeypatch.setattr(telemetry_module, "_telemetry_manager", None, raising=False)
+
+    first = telemetry_module.initialize_telemetry()
+    assert telemetry_module._telemetry_manager is first  # nosec B101
+
+    telemetry_module.shutdown_telemetry()
+    assert telemetry_module._telemetry_manager is None  # nosec B101
+    assert first.shutdown_calls == 1  # nosec B101
+
+    second = telemetry_module.initialize_telemetry()
+    assert second is not first  # nosec B101
+
+
+def test_partial_initialize_failure_rolls_back_state(monkeypatch):
+    monkeypatch.setattr(telemetry_module, "OTEL_AVAILABLE", True, raising=False)
+    monkeypatch.setattr(
+        telemetry_module,
+        "Resource",
+        type("Resource", (), {"create": staticmethod(lambda attrs: object())}),
+        raising=False,
+    )
+    monkeypatch.setattr(telemetry_module, "set_global_textmap", None, raising=False)
+    monkeypatch.setattr(telemetry_module, "TraceContextTextMapPropagator", None, raising=False)
+
+    installed = []
+
+    class StubProvider:
+        def __init__(self, name: str):
+            self.name = name
+            self.shutdown_called = False
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    def fake_install(provider_kind, provider):
+        installed.append((provider_kind, provider))
+
+    monkeypatch.setattr(
+        telemetry_module,
+        "_install_global_tracer_provider",
+        lambda provider: fake_install("trace", provider),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telemetry_module,
+        "_install_global_meter_provider",
+        lambda provider: fake_install("metrics", provider),
+        raising=False,
+    )
+
+    def fake_init_tracing(self, resource):
+        self.tracer_provider = StubProvider("trace")
+        self.tracer = object()
+
+    def fake_init_metrics(self, resource):
+        self.meter_provider = StubProvider("metrics")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_initialize_tracing", fake_init_tracing)
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_initialize_metrics", fake_init_metrics)
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_setup_auto_instrumentation", lambda self: None)
+
+    manager = telemetry_module.TelemetryManager()
+
+    assert isinstance(manager.tracer, telemetry_module.DummyTracer)  # nosec B101
+    assert isinstance(manager.meter, telemetry_module.DummyMeter)  # nosec B101
+    assert manager.tracer_provider is None  # nosec B101
+    assert manager.meter_provider is None  # nosec B101
+    assert installed == []  # nosec B101
+
+
+def test_named_lookups_stay_dummy_safe_after_runtime_reset(monkeypatch):
+    monkeypatch.setattr(telemetry_module, "OTEL_AVAILABLE", True, raising=False)
+
+    class TraceRegistry:
+        def __init__(self):
+            self.calls = []
+
+        def get_tracer(self, name, version):
+            self.calls.append((name, version))
+            return object()
+
+    class MetricsRegistry:
+        def __init__(self):
+            self.calls = []
+
+        def get_meter(self, name, version):
+            self.calls.append((name, version))
+            return object()
+
+    trace_registry = TraceRegistry()
+    metrics_registry = MetricsRegistry()
+    monkeypatch.setattr(telemetry_module, "trace", trace_registry, raising=False)
+    monkeypatch.setattr(telemetry_module, "metrics", metrics_registry, raising=False)
+
+    manager = object.__new__(telemetry_module.TelemetryManager)
+    manager.config = type("Cfg", (), {"sdk_disabled": False, "service_version": "1.0.0"})()
+    manager._pending_views = []
+    manager._reset_runtime_state()
+
+    tracer = manager.get_tracer("named.tracer")
+    meter = manager.get_meter("named.meter")
+
+    assert isinstance(tracer, telemetry_module.DummyTracer)  # nosec B101
+    assert isinstance(meter, telemetry_module.DummyMeter)  # nosec B101
+    assert trace_registry.calls == []  # nosec B101
+    assert metrics_registry.calls == []  # nosec B101
+
+
+def test_global_phase_meter_adopt_failure_keeps_manager_aligned(monkeypatch):
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    monkeypatch.setattr(telemetry_module, "OTEL_AVAILABLE", True, raising=False)
+    monkeypatch.setattr(
+        telemetry_module,
+        "Resource",
+        type("Resource", (), {"create": staticmethod(lambda attrs: object())}),
+        raising=False,
+    )
+    monkeypatch.setattr(telemetry_module, "set_global_textmap", None, raising=False)
+    monkeypatch.setattr(telemetry_module, "TraceContextTextMapPropagator", None, raising=False)
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_setup_auto_instrumentation", lambda self: None)
+
+    class StubProvider:
+        def __init__(self, name: str):
+            self.name = name
+            self.shutdown_called = False
+
+        def get_tracer(self, *args, **kwargs):
+            return ("tracer", self.name)
+
+        def get_meter(self, *args, **kwargs):
+            return ("meter", self.name)
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    global_trace_provider = StubProvider("global-trace")
+    global_meter_provider = StubProvider("global-meter")
+
+    monkeypatch.setattr(telemetry_module, "_get_global_tracer_provider", lambda: global_trace_provider)
+    monkeypatch.setattr(telemetry_module, "_get_global_meter_provider", lambda: global_meter_provider)
+    monkeypatch.setattr(
+        telemetry_module,
+        "_adopt_or_install_global_tracer_provider",
+        lambda provider: global_trace_provider,
+    )
+
+    def explode_meter_adopt(provider):
+        raise RuntimeError("meter adopt failed")
+
+    monkeypatch.setattr(
+        telemetry_module,
+        "_adopt_or_install_global_meter_provider",
+        explode_meter_adopt,
+    )
+
+    def fake_init_tracing(self, resource):
+        self.tracer_provider = StubProvider("local-trace")
+        self.tracer = ("tracer", "local-trace")
+
+    def fake_init_metrics(self, resource):
+        self.meter_provider = StubProvider("local-meter")
+        self.meter = ("meter", "local-meter")
+
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_initialize_tracing", fake_init_tracing)
+    monkeypatch.setattr(telemetry_module.TelemetryManager, "_initialize_metrics", fake_init_metrics)
+
+    manager = telemetry_module.TelemetryManager()
+
+    assert manager.tracer_provider is global_trace_provider  # nosec B101
+    assert manager.meter_provider is global_meter_provider  # nosec B101
+    assert manager.tracer == ("tracer", "global-trace")  # nosec B101
+    assert manager.meter == ("meter", "global-meter")  # nosec B101
+    assert manager.initialized is True  # nosec B101
+
+
+def test_restart_cycle_stays_aligned_with_sdk_globals():
+    script = textwrap.dedent(
+        """
+        import importlib
+
+        from opentelemetry import metrics, trace
+
+        telemetry = importlib.import_module("tldw_Server_API.app.core.Metrics.telemetry")
+        if not telemetry.OTEL_AVAILABLE:
+            print("OTEL_AVAILABLE", telemetry.OTEL_AVAILABLE)
+            raise SystemExit(0)
+
+        manager1 = telemetry.initialize_telemetry()
+        trace_provider1 = trace.get_tracer_provider()
+        meter_provider1 = metrics.get_meter_provider()
+
+        print("ALIGN_FIRST_TRACE", trace_provider1 is manager1.tracer_provider)
+        print("ALIGN_FIRST_METER", meter_provider1 is manager1.meter_provider)
+
+        telemetry.shutdown_telemetry()
+
+        manager2 = telemetry.initialize_telemetry()
+        trace_provider2 = trace.get_tracer_provider()
+        meter_provider2 = metrics.get_meter_provider()
+
+        print("ALIGN_SECOND_TRACE", trace_provider2 is manager2.tracer_provider)
+        print("ALIGN_SECOND_METER", meter_provider2 is manager2.meter_provider)
+        print("REUSE_TRACE_GLOBAL", trace_provider2 is trace_provider1)
+        print("REUSE_METER_GLOBAL", meter_provider2 is meter_provider1)
+        """
+    )
+
+    env = os.environ.copy()
+    env["OTEL_SDK_DISABLED"] = "false"
+    env["OTEL_TRACES_EXPORTER"] = "console"
+    env["OTEL_METRICS_EXPORTER"] = "console"
+
+    result = subprocess.run(  # nosec B603
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, (  # nosec B101
+        "Telemetry restart-cycle regression script failed.\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    if "OTEL_AVAILABLE False" in result.stdout:  # nosec B101
+        pytest.skip("OpenTelemetry SDK not available in environment")
+
+    assert "ALIGN_FIRST_TRACE True" in result.stdout  # nosec B101
+    assert "ALIGN_FIRST_METER True" in result.stdout  # nosec B101
+    assert "ALIGN_SECOND_TRACE True" in result.stdout  # nosec B101
+    assert "ALIGN_SECOND_METER True" in result.stdout  # nosec B101
+    assert "REUSE_TRACE_GLOBAL True" in result.stdout  # nosec B101
+    assert "REUSE_METER_GLOBAL True" in result.stdout  # nosec B101

--- a/tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py
+++ b/tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py
@@ -1,0 +1,134 @@
+import asyncio
+import contextlib
+
+import pytest
+
+import tldw_Server_API.app.core.Metrics.traces as traces_module
+
+pytestmark = pytest.mark.unit
+
+
+def _install_otel_like_tracing_manager(monkeypatch):
+    class StubStatusCode:
+        ERROR = "ERROR"
+
+    class StubStatus:
+        def __init__(self, code, description=None):
+            self.code = code
+            self.description = description
+
+    class StubSpanContext:
+        def __init__(self):
+            self.span_id = 1
+
+    class StubSpan:
+        def __init__(self):
+            self.recorded = []
+            self.statuses = []
+
+        def get_span_context(self):
+            return StubSpanContext()
+
+        def set_attribute(self, key, value):
+            pass
+
+        def record_exception(self, exc):
+            self.recorded.append(exc)
+
+        def set_status(self, status):
+            self.statuses.append(status)
+
+    class StubTracer:
+        def __init__(self):
+            self.latest_span = None
+
+        def start_as_current_span(self, *args, **kwargs):
+            record_exception = kwargs.get("record_exception", True)
+            set_status_on_exception = kwargs.get("set_status_on_exception", True)
+            span = StubSpan()
+            self.latest_span = span
+
+            @contextlib.contextmanager
+            def span_cm():
+                try:
+                    yield span
+                except Exception as exc:
+                    if record_exception:
+                        span.record_exception(exc)
+                    if set_status_on_exception:
+                        span.set_status(("auto", str(exc)))
+                    raise
+
+            return span_cm()
+
+    class StubTelemetry:
+        def __init__(self, tracer):
+            self._tracer = tracer
+
+        def get_tracer(self, name=None):
+            return self._tracer
+
+    tracer = StubTracer()
+    monkeypatch.setattr(traces_module, "OTEL_AVAILABLE", True, raising=False)
+    monkeypatch.setattr(traces_module, "Status", StubStatus, raising=False)
+    monkeypatch.setattr(traces_module, "StatusCode", StubStatusCode, raising=False)
+    monkeypatch.setattr(traces_module, "get_telemetry_manager", lambda: StubTelemetry(tracer), raising=True)
+
+    manager = traces_module.TracingManager()
+    monkeypatch.setattr(traces_module, "get_tracing_manager", lambda: manager)
+    return tracer
+
+
+@pytest.mark.asyncio
+async def test_trace_method_preserves_async_method_semantics(monkeypatch):
+    class StubAsyncSpan:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class StubManager:
+        def async_span(self, *args, **kwargs):
+            return StubAsyncSpan()
+
+    monkeypatch.setattr(traces_module, "get_tracing_manager", lambda: StubManager())
+
+    class Service:
+        @traces_module.trace_method(name="service.work")
+        async def work(self):
+            return "ok"
+
+    assert asyncio.iscoroutinefunction(Service.work)
+    assert await Service().work() == "ok"
+
+
+def test_trace_operation_records_exception_once_with_real_manager(monkeypatch):
+    tracer = _install_otel_like_tracing_manager(monkeypatch)
+
+    @traces_module.trace_operation(name="sync.fail")
+    def fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        fail()
+
+    assert tracer.latest_span is not None
+    assert len(tracer.latest_span.recorded) == 1
+    assert len(tracer.latest_span.statuses) == 1
+
+
+@pytest.mark.asyncio
+async def test_trace_operation_records_exception_once_with_real_manager_async(monkeypatch):
+    tracer = _install_otel_like_tracing_manager(monkeypatch)
+
+    @traces_module.trace_operation(name="async.fail")
+    async def fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await fail()
+
+    assert tracer.latest_span is not None
+    assert len(tracer.latest_span.recorded) == 1
+    assert len(tracer.latest_span.statuses) == 1

--- a/tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py
+++ b/tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py
@@ -31,17 +31,30 @@ def test_measure_latency_exports_default_buckets(monkeypatch):
         metrics_manager._metrics_registry = None
 
 
-def test_cache_hit_ratio_uses_cumulative_counters(monkeypatch):
+def test_cache_metrics_preserves_tuple_return(monkeypatch):
+    monkeypatch.setenv("METRICS_RING_BUFFER_MAXLEN_OR_UNBOUNDED", "20")
+    metrics_manager._metrics_registry = None
+    metrics_manager.get_metrics_registry()
+
+    try:
+        @cache_metrics("tuple_cache", track_ratio=False)
+        def fetch_tuple():
+            return ("payload", True)
+
+        assert fetch_tuple() == ("payload", True)
+    finally:
+        metrics_manager._metrics_registry = None
 
 
-    monkeypatch.setenv("METRICS_RING_BUFFER_MAXLEN_OR_UNBOUNDED", "2")
+def test_cache_hit_ratio_ignores_tuple_second_value_without_from_cache(monkeypatch):
+    monkeypatch.setenv("METRICS_RING_BUFFER_MAXLEN_OR_UNBOUNDED", "20")
     metrics_manager._metrics_registry = None
     registry = metrics_manager.get_metrics_registry()
 
     try:
         @cache_metrics("demo_cache", track_ratio=True)
         def fetch(cache_hit: bool):
-            return "payload", cache_hit
+            return ("payload", cache_hit)
 
         fetch(False)
         fetch(True)
@@ -49,7 +62,7 @@ def test_cache_hit_ratio_uses_cumulative_counters(monkeypatch):
         fetch(True)
 
         stats = registry.get_metric_stats("cache_hit_ratio", {"cache": "demo_cache"})
-        assert stats["latest"] == pytest.approx(3 / 4)
+        assert stats["latest"] == pytest.approx(0.0)
     finally:
         metrics_manager._metrics_registry = None
 

--- a/tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py
+++ b/tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py
@@ -1,0 +1,110 @@
+import pytest
+
+import tldw_Server_API.app.api.v1.endpoints.metrics as metrics_endpoint
+import tldw_Server_API.app.core.Chat.chat_metrics as chat_metrics_module
+from tldw_Server_API.app.core.Chat.chat_metrics import get_chat_metrics
+from tldw_Server_API.app.core.Metrics.metrics_manager import (
+    MetricDefinition,
+    MetricType,
+    get_metrics_registry,
+)
+from tldw_Server_API.app.main import metrics as root_metrics
+
+pytestmark = pytest.mark.monitoring
+
+
+@pytest.mark.asyncio
+async def test_root_metrics_matches_router_text_export(monkeypatch):
+    registry = get_metrics_registry()
+    registry.reset()
+    registry.register_metric(
+        MetricDefinition(
+            name="surface_contract_counter_total",
+            type=MetricType.COUNTER,
+            description="surface parity test",
+            labels=["source"],
+        )
+    )
+    registry.increment("surface_contract_counter_total", labels={"source": "test"})
+
+    response_root = await root_metrics()
+    response_router = await metrics_endpoint.get_prometheus_metrics()
+
+    assert response_root.body == response_router.body
+    assert response_root.headers["cache-control"] == response_router.headers["cache-control"]
+    assert response_root.media_type == response_router.media_type
+
+
+@pytest.mark.asyncio
+async def test_chat_metrics_endpoint_reports_emitted_request_totals(monkeypatch):
+    monkeypatch.setattr(chat_metrics_module, "_chat_metrics_collector", None, raising=False)
+    chat_metrics_module.reset_endpoint_metrics_snapshot()
+    collector = get_chat_metrics()
+
+    async with collector.track_request(
+        provider="openai",
+        model="gpt-4",
+        streaming=False,
+        client_id="client-1",
+    ):
+        pass
+
+    collector.track_tokens(
+        prompt_tokens=11,
+        completion_tokens=7,
+        model="gpt-4",
+        provider="openai",
+    )
+
+    payload = await metrics_endpoint.get_chat_metrics_endpoint()
+
+    request_stats = payload["metrics"]["chat_requests_total"]
+    duration_stats = payload["metrics"]["chat_request_duration_seconds"]
+    prompt_stats = payload["metrics"]["chat_tokens_prompt"]
+
+    assert float(request_stats["count"]) == 1.0
+    assert float(request_stats["sum"]) == 1.0
+    assert float(request_stats["latest"]) == 1.0
+
+    assert float(duration_stats["count"]) == 1.0
+    assert float(duration_stats["sum"]) == float(duration_stats["latest"])
+
+    assert float(prompt_stats["count"]) == 1.0
+    assert float(prompt_stats["sum"]) == 11.0
+    assert float(prompt_stats["latest"]) == 11.0
+
+
+@pytest.mark.asyncio
+async def test_metrics_reset_clears_chat_endpoint_snapshot(monkeypatch):
+    monkeypatch.setattr(chat_metrics_module, "_chat_metrics_collector", None, raising=False)
+    chat_metrics_module.reset_endpoint_metrics_snapshot()
+    collector = get_chat_metrics()
+
+    async with collector.track_request(
+        provider="openai",
+        model="gpt-4",
+        streaming=False,
+        client_id="client-reset",
+    ):
+        pass
+
+    collector.track_tokens(
+        prompt_tokens=13,
+        completion_tokens=3,
+        model="gpt-4",
+        provider="openai",
+    )
+
+    payload_before = await metrics_endpoint.get_chat_metrics_endpoint()
+    assert float(payload_before["metrics"]["chat_requests_total"]["sum"]) == 1.0
+    assert float(payload_before["metrics"]["chat_tokens_prompt"]["sum"]) == 13.0
+
+    await metrics_endpoint.reset_metrics()
+
+    payload_after = await metrics_endpoint.get_chat_metrics_endpoint()
+    assert payload_after["metrics"] == {}
+    assert payload_after["active_operations"] == {
+        "active_requests": 0,
+        "active_streams": 0,
+        "active_transactions": 0,
+    }


### PR DESCRIPTION
## Summary
- unify the metrics text export surfaces and make `/api/v1/metrics/chat` report truthful registry-style summaries
- preserve decorator, tracing, telemetry lifecycle, and registry semantics with focused regression coverage
- include remediation design/plan artifacts and final verification notes for the metrics review work

## Test Plan
- [x] `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Monitoring/test_metrics_endpoints.py tldw_Server_API/tests/Monitoring/test_metrics_surface_contracts.py tldw_Server_API/tests/Monitoring/test_metrics_decorator_exports.py tldw_Server_API/tests/Metrics/test_tracing_decorator_semantics.py tldw_Server_API/tests/Metrics/test_telemetry_lifecycle.py tldw_Server_API/tests/Metrics/test_telemetry_config_and_disable_paths.py tldw_Server_API/tests/Metrics/test_telemetry_import_fallback.py tldw_Server_API/tests/Metrics/test_telemetry_trace_context.py tldw_Server_API/tests/Metrics/test_metrics_cumulative_series_cap.py tldw_Server_API/tests/Metrics/test_metrics_label_normalization.py tldw_Server_API/tests/Metrics/test_metrics_logger_registry_bridge.py tldw_Server_API/tests/Metrics/test_metrics_logger_timestamps.py tldw_Server_API/tests/Metrics/test_chat_metrics_reset_safety.py -q` (`45 passed` on the squashed branch)
- [x] `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/metrics.py tldw_Server_API/app/main.py tldw_Server_API/app/core/Chat/chat_metrics.py tldw_Server_API/app/core/Metrics/decorators.py tldw_Server_API/app/core/Metrics/traces.py tldw_Server_API/app/core/Metrics/telemetry.py tldw_Server_API/app/core/Metrics/metrics_manager.py tldw_Server_API/app/core/Metrics/metrics_logger.py -f json -o /tmp/bandit_metrics_squashed_pr.json`
- [ ] `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Embeddings/test_metrics_golden_contract.py -q` (still fails due a pre-existing embeddings histogram bootstrap assumption; documented in the remediation plan notes)