### PR TITLE
fix: add missing ACP privilege scopes to catalog

### DIFF
--- a/tldw_Server_API/Config_Files/privilege_catalog.yaml
+++ b/tldw_Server_API/Config_Files/privilege_catalog.yaml
@@ -1174,6 +1174,68 @@ scopes:
     ownership_predicates:
       - same_org
     doc_url: https://docs.example.com/privileges/acp-agents-health
+  - id: acp.sessions.prompt_async
+    description: Submit an ACP prompt for asynchronous execution via the scheduler.
+    resource_tags:
+      - acp
+      - sessions
+      - async
+    sensitivity_tier: restricted
+    rate_limit_class: admin
+    default_roles:
+      - admin
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/acp-sessions-prompt-async
+  - id: acp.tasks.status
+    description: Poll status and results of async ACP tasks.
+    resource_tags:
+      - acp
+      - tasks
+      - read
+    sensitivity_tier: high
+    rate_limit_class: elevated
+    default_roles:
+      - admin
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/acp-tasks-status
+  - id: acp.runs.list
+    description: Query ACP run history with optional filters.
+    resource_tags:
+      - acp
+      - runs
+      - read
+    sensitivity_tier: high
+    rate_limit_class: elevated
+    default_roles:
+      - admin
+      - analyst
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/acp-runs-list
+  - id: acp.runs.aggregate
+    description: Aggregate token usage and costs across ACP runs.
+    resource_tags:
+      - acp
+      - runs
+      - analytics
+    sensitivity_tier: high
+    rate_limit_class: elevated
+    default_roles:
+      - admin
+      - analyst
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/acp-runs-aggregate
   - id: sharing.create
     description: Share workspaces with teams or organizations.
     resource_tags:


### PR DESCRIPTION
## Summary
- Adds 4 missing privilege scope entries (`acp.sessions.prompt_async`, `acp.tasks.status`, `acp.runs.list`, `acp.runs.aggregate`) to `privilege_catalog.yaml`
- These scopes are referenced by new ACP endpoints added in dev but were never registered in the catalog
- This caused startup validation to reject the app, failing all 36 e2e-smoke tests in PR #1010

## Test plan
- [x] Verified YAML parses correctly with all 4 new scopes present (90 total)
- [x] Verified `validate_privilege_metadata_on_startup()` passes locally with the fix
- [ ] CI e2e-smoke checks should pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)