### PR TITLE
feat(ocr): add llama.cpp and chatllm OCR backends

### DIFF
--- a/Docs/API-related/OCR_API_Documentation.md
+++ b/Docs/API-related/OCR_API_Documentation.md
@@ -15,7 +15,8 @@ The OCR module integrates with media ingestion to extract text from scanned PDFs
 
 1) GET `/api/v1/ocr/backends`
    - Lists available OCR backends with basic health info.
-   - Returns a map keyed by backend name (e.g., `mineru`, `points`, `dots`) including minimal configuration details and reachability checks.
+   - Returns a map keyed by backend name (e.g., `mineru`, `points`, `dots`, `llamacpp`, `chatllm`) including lightweight backend-specific configuration details.
+   - Field shape varies by backend. Today `llamacpp` exposes `mode`, `configured_mode`, `configured`, `supports_structured_output`, `supports_json`, `model`, `configured_flags`, auto-eligibility flags, `backend_concurrency_cap`, and mode-specific flags such as `url_configured`, `managed_configured`, `managed_running`, `allow_managed_start`, and `cli_configured`; `chatllm` exposes a similar capability set with its own mode-specific details, but not every field is identical.
    - Code: `tldw_Server_API/app/api/v1/endpoints/ocr.py:router.get("/backends")`
 
 2) POST `/api/v1/ocr/points/preload`
@@ -35,6 +36,8 @@ OCR is typically enabled via the media ingestion request options. Key fields (se
 - `ocr_min_page_text_chars` (int) - threshold to treat a page as “no text” for fallback OCR
 - `ocr_output_format` (str | null) - `text|markdown|json` (controls structured OCR output)
 - `ocr_prompt_preset` (str | null) - `general|doc|table|spotting|json` (backend-specific presets)
+- The PDF pipeline stores structured OCR data under `analysis_details.ocr.structured` when the backend returns it.
+- Per-page OCR concurrency is capped by the smaller of `OCR_PAGE_CONCURRENCY` and the backend profile's `max_page_concurrency`.
 
 Reference (code): `tldw_Server_API/app/api/v1/schemas/media_request_models.py`.
 
@@ -45,6 +48,13 @@ Reference (code): `tldw_Server_API/app/api/v1/schemas/media_request_models.py`.
 - MinerU appears in `GET /api/v1/ocr/backends` with capability flags such as `pdf_only`, `document_level`, and `opt_in_only`.
 - MinerU is excluded from `auto`, `auto_high_quality`, and `OCR.backend_priority` in v1.
 - `ocr_lang` and `ocr_dpi` are advisory for MinerU and are currently recorded in metadata but not used to drive the CLI invocation.
+
+### Llama.cpp and ChatLLM behavior
+
+- `ocr_backend=llamacpp` and `ocr_backend=chatllm` are server-owned OCR profiles that can run in `remote`, `managed`, `cli`, or `auto` mode.
+- Both backends use explicit auto-eligibility flags. They only participate in `auto` / `auto_high_quality` when the flag is enabled and the backend is locally available.
+- Managed mode is single-process only in v1. For multi-worker deployments, use `remote` or `cli`.
+- The PDF pipeline records the effective page concurrency it actually used, not just the global cap.
 
 ## Quick Examples
 
@@ -141,7 +151,9 @@ Example MinerU discovery response excerpt (truncated)
 
 - MinerU: document-level PDF OCR with bounded structured artifacts (`pages`, `tables`, artifact excerpts)
 - POINTS Reader: documentation coming soon
-- OCR Providers overview: documentation coming soon
+- Llama.cpp OCR: see `Docs/OCR/LlamaCpp-OCR.md`
+- ChatLLM OCR: see `Docs/OCR/ChatLLM-OCR.md`
+- OCR Providers overview: see `Docs/OCR/OCR_Providers.md`
 
 ## Roadmap (Placeholder)
 

--- a/Docs/OCR/ChatLLM-OCR.md
+++ b/Docs/OCR/ChatLLM-OCR.md
@@ -1,0 +1,81 @@
+# ChatLLM OCR
+
+This guide covers the `chatllm` OCR backend. Like `llamacpp`, it keeps OCR server-owned: the client selects `ocr_backend=chatllm`, while the server decides the runtime mode, model, binary, and concurrency cap.
+
+## Modes
+
+- `remote`: call an OpenAI-compatible ChatLLM endpoint.
+- `managed`: let the server own a private OCR process.
+- `cli`: run a one-shot local command for each OCR request.
+- `auto`: choose the best configured mode from the server profile.
+
+Managed mode is single-process only in v1. Use remote mode if you need multi-worker or externally managed deployments.
+
+## Required Settings
+
+- `CHATLLM_OCR_MODE=auto|remote|managed|cli`
+- `CHATLLM_OCR_ALLOW_MANAGED_START=true|false`
+- `CHATLLM_OCR_AUTO_ELIGIBLE=true|false`
+- `CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE=true|false`
+- `CHATLLM_OCR_MAX_PAGE_CONCURRENCY`
+
+The PDF pipeline uses `min(OCR_PAGE_CONCURRENCY, CHATLLM_OCR_MAX_PAGE_CONCURRENCY)` when dispatching page OCR work.
+
+## Remote Mode
+
+Use remote mode when ChatLLM is already exposed as an OpenAI-compatible service.
+
+Typical settings:
+
+- `CHATLLM_OCR_URL`
+- `CHATLLM_OCR_MODEL`
+- `CHATLLM_OCR_API_KEY`
+
+The backend should preserve backend metadata in `analysis_details.ocr` and normalize OCR results into the existing `OCRResult` contract, including `analysis_details.ocr.structured` when structured output is available.
+
+## Managed Mode
+
+Managed mode owns a private OCR process and is only intended for single-API-process deployments in v1.
+
+Typical settings:
+
+- `CHATLLM_OCR_SERVER_BINARY`
+- `CHATLLM_OCR_MODEL_PATH`
+- `CHATLLM_OCR_HOST`
+- `CHATLLM_OCR_PORT`
+- `CHATLLM_OCR_STARTUP_TIMEOUT_SEC`
+- `CHATLLM_OCR_SERVER_ARGS_JSON`
+- `CHATLLM_OCR_HEALTHCHECK_URL`
+
+The server should not auto-start this process unless `CHATLLM_OCR_ALLOW_MANAGED_START=true`.
+
+## CLI Mode
+
+CLI mode runs a single OCR invocation and exits.
+
+Typical settings:
+
+- `CHATLLM_OCR_CLI_BINARY`
+- `CHATLLM_OCR_MODEL_PATH`
+- `CHATLLM_OCR_CLI_ARGS_JSON`
+
+Use JSON argv arrays rather than shell strings. Example:
+
+```json
+["--model", "{model_path}", "--image", "{image_path}", "--prompt", "{prompt}"]
+```
+
+## Auto Selection
+
+`chatllm` participates in `auto` and `auto_high_quality` only when:
+
+- the backend is locally available
+- the matching auto-eligibility flag is enabled
+
+The operator can still force the backend explicitly with `ocr_backend=chatllm`.
+
+## Operational Notes
+
+- Keep `CHATLLM_OCR_MAX_PAGE_CONCURRENCY` low unless you have validated higher parallelism.
+- Keep temporary image files ephemeral and server-owned.
+- Do not expose request-level overrides for model paths, server paths, or ports.

--- a/Docs/OCR/LlamaCpp-OCR.md
+++ b/Docs/OCR/LlamaCpp-OCR.md
@@ -1,0 +1,82 @@
+# Llama.cpp OCR
+
+This guide covers the `llamacpp` OCR backend. It keeps OCR server-owned: the client selects `ocr_backend=llamacpp`, while the server decides the runtime mode, model, binary, and concurrency cap.
+
+## Modes
+
+- `remote`: call an existing OpenAI-compatible llama.cpp endpoint.
+- `managed`: let the server own a private OCR process.
+- `cli`: run a one-shot local command for each OCR request.
+- `auto`: choose the best configured mode from the server profile.
+
+Managed mode is single-process only in v1. Use remote mode if you need multi-worker or externally managed deployments.
+
+## Required Settings
+
+- `LLAMACPP_OCR_MODE=auto|remote|managed|cli`
+- `LLAMACPP_OCR_ALLOW_MANAGED_START=true|false`
+- `LLAMACPP_OCR_AUTO_ELIGIBLE=true|false`
+- `LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE=true|false`
+- `LLAMACPP_OCR_MAX_PAGE_CONCURRENCY`
+
+The PDF pipeline uses `min(OCR_PAGE_CONCURRENCY, LLAMACPP_OCR_MAX_PAGE_CONCURRENCY)` when dispatching page OCR work.
+
+## Remote Mode
+
+Use remote mode when you already have a llama.cpp endpoint or when another service manages the server process.
+
+Typical settings:
+
+- `LLAMACPP_OCR_HOST`
+- `LLAMACPP_OCR_PORT`
+- `LLAMACPP_OCR_MODEL_PATH`
+- `LLAMACPP_OCR_USE_DATA_URL=true|false`
+
+The endpoint should be OpenAI-compatible. This backend expects structured OCR output to be represented through the existing `OCRResult` contract and stored under `analysis_details.ocr.structured`.
+
+## Managed Mode
+
+Managed mode owns a private OCR process and is only intended for single-API-process deployments in v1.
+
+Typical settings:
+
+- `LLAMACPP_OCR_ARGV`
+- `LLAMACPP_OCR_MODEL_PATH`
+- `LLAMACPP_OCR_HOST` (optional; defaults to `127.0.0.1`)
+- `LLAMACPP_OCR_PORT`
+- `LLAMACPP_OCR_STARTUP_TIMEOUT_SEC`
+
+`LLAMACPP_OCR_ARGV` must be a JSON argv array for the private server process, using placeholders such as `{model_path}`, `{host}`, and `{port}`.
+
+The server should not auto-start this process unless `LLAMACPP_OCR_ALLOW_MANAGED_START=true`. In `auto`, a configured managed startup profile is preferred over `remote`; set `LLAMACPP_OCR_MODE=remote` to force an external endpoint instead.
+
+## CLI Mode
+
+CLI mode runs a single OCR invocation and exits.
+
+Typical settings:
+
+- `LLAMACPP_OCR_ARGV`
+- `LLAMACPP_OCR_MODEL_PATH`
+
+`LLAMACPP_OCR_ARGV` must be a JSON argv array for the one-shot OCR command. Use JSON argv arrays rather than shell strings. Example:
+
+```json
+["--model", "{model_path}", "--image", "{image_path}", "--prompt", "{prompt}"]
+```
+
+## Auto Selection
+
+`llamacpp` participates in `auto` and `auto_high_quality` only when:
+
+- the backend is locally available
+- the matching auto-eligibility flag is enabled
+
+The operator can still force the backend explicitly with `ocr_backend=llamacpp`.
+
+## Operational Notes
+
+- `LLAMACPP_OCR_ARGV` is the current local-runtime command surface for both managed and CLI modes. Configure the mode you actually intend to run; do not assume separate server/CLI env vars exist in v1.
+- Keep `LLAMACPP_OCR_MAX_PAGE_CONCURRENCY` low unless you have validated higher parallelism.
+- Keep temporary image files ephemeral and server-owned.
+- Do not expose request-level overrides for model paths, server paths, or ports.

--- a/Docs/OCR/OCR_Providers.md
+++ b/Docs/OCR/OCR_Providers.md
@@ -10,15 +10,17 @@ Supported backends
 - deepseek (DeepSeek-OCR, Transformers)
 - hunyuan (Tencent HunyuanOCR, vLLM + Transformers)
 - dolphin (ByteDance Dolphin-v2, Transformers + remote server)
+- llamacpp (OCR-capable llama.cpp deployment, remote/managed/cli)
+- chatllm (OCR-capable ChatLLM deployment, remote/managed/cli)
 
 Common usage
-- Set `enable_ocr=true` and choose `ocr_backend` (`mineru`, `tesseract`, `dots`, `points`, `deepseek`, `hunyuan`, or `dolphin`).
+- Set `enable_ocr=true` and choose `ocr_backend` (`mineru`, `tesseract`, `dots`, `points`, `deepseek`, `hunyuan`, `dolphin`, `llamacpp`, or `chatllm`).
 - `ocr_mode`: `fallback` (only pages lacking text) or `always` (force OCR).
 - `ocr_dpi`: 200-300 is a good balance.
 - Structured outputs:
   - `ocr_output_format`: `text|markdown|json`
   - `ocr_prompt_preset`: `general|doc|table|spotting|json`
-- Parallelism: `OCR_PAGE_CONCURRENCY` controls per-page OCR concurrency (default 1). Keep small (1-2) for GPU-backed models.
+- Parallelism: `OCR_PAGE_CONCURRENCY` controls the global per-page OCR concurrency cap (default 1). The PDF pipeline now uses `min(OCR_PAGE_CONCURRENCY, backend profile max_page_concurrency)`, so backend-local caps are respected too. Keep both values small for GPU-backed models unless you have validated higher throughput.
 - Config override: `Config_Files/config.txt` supports `[OCR] backend_priority` (comma-separated list or JSON array) to control auto selection order.
 
 MinerU-specific notes
@@ -50,6 +52,67 @@ Behavior
 Notes
 - MinerU does not participate in generic image OCR flows in v1.
 - The CLI output directory may be nested; the adapter resolves the primary artifact directory automatically.
+
+## Llama.cpp OCR (backend: `llamacpp`)
+
+Summary
+- OCR-capable llama.cpp deployments can run in `remote`, `managed`, `cli`, or `auto` mode.
+- Remote mode is the preferred path when you already have a llama.cpp/OpenAI-compatible endpoint or an existing server managed elsewhere.
+- Managed mode is OCR-private and single-process only in v1.
+
+Environment
+- `LLAMACPP_OCR_MODE`: `auto|remote|managed|cli`.
+- `LLAMACPP_OCR_AUTO_ELIGIBLE`: opt-in flag for `auto`.
+- `LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE`: opt-in flag for `auto_high_quality`.
+- `LLAMACPP_OCR_MAX_PAGE_CONCURRENCY`: backend-local page concurrency cap. The PDF pipeline uses the smaller of this and `OCR_PAGE_CONCURRENCY`.
+
+Remote
+- `LLAMACPP_OCR_HOST`, `LLAMACPP_OCR_PORT`, `LLAMACPP_OCR_MODEL_PATH`, `LLAMACPP_OCR_USE_DATA_URL`.
+
+Managed
+- `LLAMACPP_OCR_ARGV`, `LLAMACPP_OCR_MODEL_PATH`, `LLAMACPP_OCR_HOST`, `LLAMACPP_OCR_PORT`, `LLAMACPP_OCR_STARTUP_TIMEOUT_SEC`.
+- `LLAMACPP_OCR_ALLOW_MANAGED_START=true|false` controls whether the server may start the managed process itself.
+- In `auto`, a configured managed startup profile is preferred over `remote`; set `LLAMACPP_OCR_MODE=remote` to force an external endpoint.
+
+CLI
+- `LLAMACPP_OCR_ARGV`, `LLAMACPP_OCR_MODEL_PATH`.
+
+Docs
+- See [Docs/OCR/LlamaCpp-OCR.md](./LlamaCpp-OCR.md) for the backend-specific setup guide.
+
+Notes
+- `llamacpp` supports the existing OCR presets and structured output contract.
+- Managed mode should be used only in single-API-process deployments in v1.
+
+## ChatLLM OCR (backend: `chatllm`)
+
+Summary
+- ChatLLM OCR mirrors the same OCR contract as llama.cpp, but with ChatLLM-specific runtime configuration.
+- Supported modes are `remote`, `managed`, `cli`, and `auto`.
+- Managed mode is OCR-private and single-process only in v1.
+
+Environment
+- `CHATLLM_OCR_MODE`: `auto|remote|managed|cli`.
+- `CHATLLM_OCR_AUTO_ELIGIBLE`: opt-in flag for `auto`.
+- `CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE`: opt-in flag for `auto_high_quality`.
+- `CHATLLM_OCR_MAX_PAGE_CONCURRENCY`: backend-local page concurrency cap. The PDF pipeline uses the smaller of this and `OCR_PAGE_CONCURRENCY`.
+
+Remote
+- `CHATLLM_OCR_URL`, `CHATLLM_OCR_MODEL`, `CHATLLM_OCR_API_KEY`.
+
+Managed
+- `CHATLLM_OCR_SERVER_BINARY`, `CHATLLM_OCR_MODEL_PATH`, `CHATLLM_OCR_HOST`, `CHATLLM_OCR_PORT`, `CHATLLM_OCR_STARTUP_TIMEOUT_SEC`, `CHATLLM_OCR_SERVER_ARGS_JSON`, `CHATLLM_OCR_HEALTHCHECK_URL`.
+- `CHATLLM_OCR_ALLOW_MANAGED_START=true|false` controls whether the server may start the managed process itself.
+
+CLI
+- `CHATLLM_OCR_CLI_BINARY`, `CHATLLM_OCR_MODEL_PATH`, `CHATLLM_OCR_CLI_ARGS_JSON`.
+
+Docs
+- See [Docs/OCR/ChatLLM-OCR.md](./ChatLLM-OCR.md) for the backend-specific setup guide.
+
+Notes
+- `chatllm` supports the existing OCR presets and structured output contract.
+- Managed mode should be used only in single-API-process deployments in v1.
 
 ## dots.ocr (backend: `dots`)
 
@@ -212,5 +275,7 @@ Notes
 | points    | Transformers/SGLang | OCR + HTML tables + Markdown text | trust_remote_code required; SGLang ideal |
 | deepseek  | Transformers      | Layout-rich OCR to Markdown       | Heavy GPU stack; trust_remote_code required |
 | hunyuan   | vLLM/Transformers | Structured OCR + JSON outputs     | vLLM recommended for quality/speed     |
+| llamacpp  | Remote/Managed/CLI | Server-owned OCR-capable llama.cpp | Backend-local page concurrency cap 1 by default |
+| chatllm   | Remote/Managed/CLI | Server-owned ChatLLM OCR          | Backend-local page concurrency cap 1 by default |
 
 Note: VCS installs (extras) require `git` and network. For airgapped deployments, install upstream repos manually, then install this project without the extras.

--- a/Docs/Operations/Env_Vars.md
+++ b/Docs/Operations/Env_Vars.md
@@ -43,7 +43,27 @@ Operational notes:
 - If `CIRCUIT_BREAKER_HALF_OPEN_LEASE_TTL_SECONDS` is too high, abandoned probe slots take longer to self-heal; if too low, long-running probes can lose their lease before completion.
 
 ## OCR (PDF pipeline)
-- `OCR_PAGE_CONCURRENCY`: Per-page OCR concurrency (default `1`).
+- `OCR_PAGE_CONCURRENCY`: Global per-page OCR concurrency cap (default `1`). The PDF pipeline applies `min(OCR_PAGE_CONCURRENCY, backend profile max_page_concurrency)` before dispatching page OCR work.
+
+### Llama.cpp OCR
+- `LLAMACPP_OCR_MODE`: `auto|remote|managed|cli`.
+- `LLAMACPP_OCR_ALLOW_MANAGED_START`: `true|false`. Managed mode is single-process only in v1.
+- `LLAMACPP_OCR_AUTO_ELIGIBLE`: Enables participation in `auto` when the backend is configured and locally available.
+- `LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE`: Enables participation in `auto_high_quality` when the backend is configured and locally available.
+- `LLAMACPP_OCR_MAX_PAGE_CONCURRENCY`: Backend-local per-page cap; defaults to `1` unless you raise it explicitly.
+- Remote: `LLAMACPP_OCR_HOST`, `LLAMACPP_OCR_PORT`, `LLAMACPP_OCR_MODEL_PATH`, `LLAMACPP_OCR_USE_DATA_URL`.
+- Managed: `LLAMACPP_OCR_ARGV`, `LLAMACPP_OCR_MODEL_PATH`, optional `LLAMACPP_OCR_HOST`, `LLAMACPP_OCR_PORT`, `LLAMACPP_OCR_STARTUP_TIMEOUT_SEC`. Managed startup in `auto` is preferred over `remote` when `LLAMACPP_OCR_ALLOW_MANAGED_START=true` and the managed profile is configured.
+- CLI: `LLAMACPP_OCR_ARGV`, `LLAMACPP_OCR_MODEL_PATH`.
+
+### ChatLLM OCR
+- `CHATLLM_OCR_MODE`: `auto|remote|managed|cli`.
+- `CHATLLM_OCR_ALLOW_MANAGED_START`: `true|false`. Managed mode is single-process only in v1.
+- `CHATLLM_OCR_AUTO_ELIGIBLE`: Enables participation in `auto` when the backend is configured and locally available.
+- `CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE`: Enables participation in `auto_high_quality` when the backend is configured and locally available.
+- `CHATLLM_OCR_MAX_PAGE_CONCURRENCY`: Backend-local per-page cap; defaults to `1` unless you raise it explicitly.
+- Remote: `CHATLLM_OCR_URL`, `CHATLLM_OCR_MODEL`, `CHATLLM_OCR_API_KEY`.
+- Managed: `CHATLLM_OCR_SERVER_BINARY`, `CHATLLM_OCR_MODEL_PATH`, `CHATLLM_OCR_HOST`, `CHATLLM_OCR_PORT`, `CHATLLM_OCR_STARTUP_TIMEOUT_SEC`, `CHATLLM_OCR_SERVER_ARGS_JSON`, `CHATLLM_OCR_HEALTHCHECK_URL`.
+- CLI: `CHATLLM_OCR_CLI_BINARY`, `CHATLLM_OCR_MODEL_PATH`, `CHATLLM_OCR_CLI_ARGS_JSON`.
 
 ### MinerU OCR
 - `MINERU_CMD`: Command used to launch MinerU for document-level PDF OCR. Defaults to `mineru`. The command is tokenized safely and executed without a shell.

--- a/tldw_Server_API/app/api/v1/endpoints/ocr.py
+++ b/tldw_Server_API/app/api/v1/endpoints/ocr.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from fastapi import APIRouter
 
+from tldw_Server_API.app.api.v1.schemas.ocr_schemas import OCRBackendsResponse
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import (
     list_backends as _list_backends,
 )
@@ -55,7 +56,7 @@ def _record_backend_discovery_error(
     out[backend_name]["error"] = str(exc)
 
 
-@router.get("/backends")
+@router.get("/backends", response_model=OCRBackendsResponse)
 def list_ocr_backends() -> dict[str, Any]:
     """List available OCR backends with lightweight health information."""
     out = _list_backends()

--- a/tldw_Server_API/app/api/v1/endpoints/ocr.py
+++ b/tldw_Server_API/app/api/v1/endpoints/ocr.py
@@ -115,6 +115,61 @@ def list_ocr_backends() -> dict[str, Any]:
         pass
 
     try:
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+            LlamaCppOCRBackend,
+        )
+
+        llamacpp_desc = LlamaCppOCRBackend().describe()
+        out.setdefault("llamacpp", {}).update(
+            {
+                "mode": llamacpp_desc.get("mode"),
+                "configured_mode": llamacpp_desc.get("configured_mode"),
+                "model": llamacpp_desc.get("model"),
+                "configured": llamacpp_desc.get("configured"),
+                "supports_structured_output": llamacpp_desc.get("supports_structured_output"),
+                "supports_json": llamacpp_desc.get("supports_json"),
+                "configured_flags": llamacpp_desc.get("configured_flags"),
+                "auto_eligible": llamacpp_desc.get("auto_eligible"),
+                "auto_high_quality_eligible": llamacpp_desc.get("auto_high_quality_eligible"),
+                "url_configured": llamacpp_desc.get("url_configured"),
+                "managed_configured": llamacpp_desc.get("managed_configured"),
+                "managed_running": llamacpp_desc.get("managed_running"),
+                "allow_managed_start": llamacpp_desc.get("allow_managed_start"),
+                "cli_configured": llamacpp_desc.get("cli_configured"),
+                "backend_concurrency_cap": llamacpp_desc.get("backend_concurrency_cap"),
+            }
+        )
+    except _OCR_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    try:
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+            ChatLLMOCRBackend,
+        )
+
+        chatllm_desc = ChatLLMOCRBackend().describe()
+        out.setdefault("chatllm", {}).update(
+            {
+                "mode": chatllm_desc.get("mode"),
+                "configured": chatllm_desc.get("configured"),
+                "supports_structured_output": chatllm_desc.get("supports_structured_output"),
+                "supports_json": chatllm_desc.get("supports_json"),
+                "auto_eligible": chatllm_desc.get("auto_eligible"),
+                "auto_high_quality_eligible": chatllm_desc.get("auto_high_quality_eligible"),
+                "managed_configured": chatllm_desc.get("managed_configured"),
+                "managed_running": chatllm_desc.get("managed_running"),
+                "allow_managed_start": chatllm_desc.get("allow_managed_start"),
+                "url_configured": chatllm_desc.get("url_configured"),
+                "healthcheck_url_configured": chatllm_desc.get("healthcheck_url_configured"),
+                "cli_configured": chatllm_desc.get("cli_configured"),
+                "backend_concurrency_cap": chatllm_desc.get("backend_concurrency_cap"),
+                "model": chatllm_desc.get("model"),
+            }
+        )
+    except _OCR_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    try:
         from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse import (
             NemotronParseBackend,
         )

--- a/tldw_Server_API/app/api/v1/endpoints/ocr.py
+++ b/tldw_Server_API/app/api/v1/endpoints/ocr.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import (
     list_backends as _list_backends,
 )
+from tldw_Server_API.app.core.Utils.Utils import logging
 
 router = APIRouter(prefix="/ocr", tags=["ocr"])
 
@@ -42,6 +43,16 @@ def _describe_mineru_backend_error(exc: Exception) -> dict[str, Any]:
         "mode": "cli",
         "error": str(exc),
     }
+
+
+def _record_backend_discovery_error(
+    out: dict[str, Any],
+    backend_name: str,
+    exc: Exception,
+) -> None:
+    logging.error(f"OCR backend discovery failed for {backend_name}: {exc}", exc_info=True)
+    out.setdefault(backend_name, {})
+    out[backend_name]["error"] = str(exc)
 
 
 @router.get("/backends")
@@ -139,8 +150,8 @@ def list_ocr_backends() -> dict[str, Any]:
                 "backend_concurrency_cap": llamacpp_desc.get("backend_concurrency_cap"),
             }
         )
-    except _OCR_NONCRITICAL_EXCEPTIONS:
-        pass
+    except _OCR_NONCRITICAL_EXCEPTIONS as exc:
+        _record_backend_discovery_error(out, "llamacpp", exc)
 
     try:
         from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
@@ -166,8 +177,8 @@ def list_ocr_backends() -> dict[str, Any]:
                 "model": chatllm_desc.get("model"),
             }
         )
-    except _OCR_NONCRITICAL_EXCEPTIONS:
-        pass
+    except _OCR_NONCRITICAL_EXCEPTIONS as exc:
+        _record_backend_discovery_error(out, "chatllm", exc)
 
     try:
         from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse import (

--- a/tldw_Server_API/app/api/v1/schemas/ocr_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/ocr_schemas.py
@@ -1,0 +1,56 @@
+"""Schemas for OCR discovery and management endpoints."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, RootModel
+
+
+class OCRBackendDiscoveryEntry(BaseModel):
+    """Document the lightweight discovery metadata returned for an OCR backend."""
+
+    available: Optional[bool] = None
+    mode: Optional[str] = None
+    configured_mode: Optional[str] = None
+    model: Optional[str] = None
+    configured: Optional[bool] = None
+    supports_structured_output: Optional[bool] = None
+    supports_json: Optional[bool] = None
+    configured_flags: Optional[str] = None
+    auto_eligible: Optional[bool] = None
+    auto_high_quality_eligible: Optional[bool] = None
+    url_configured: Optional[bool] = None
+    managed_configured: Optional[bool] = None
+    managed_running: Optional[bool] = None
+    allow_managed_start: Optional[bool] = None
+    cli_configured: Optional[bool] = None
+    backend_concurrency_cap: Optional[int] = None
+    healthcheck_url_configured: Optional[bool] = None
+    prompt: Optional[str] = None
+    prompt_preset: Optional[str] = None
+    text_format: Optional[str] = None
+    table_format: Optional[str] = None
+    remote_mode: Optional[str] = None
+    sglang_reachable: Optional[bool] = None
+    vllm_reachable: Optional[bool] = None
+    pdf_only: Optional[bool] = None
+    document_level: Optional[bool] = None
+    opt_in_only: Optional[bool] = None
+    supports_per_page_metrics: Optional[bool] = None
+    timeout_sec: Optional[int] = None
+    max_concurrency: Optional[int] = None
+    tmp_root: Optional[str] = None
+    debug_save_raw: Optional[bool] = None
+    model_id: Optional[str] = None
+    base_size: Optional[int] = None
+    image_size: Optional[int] = None
+    crop_mode: Optional[bool | str] = None
+    device: Optional[str] = None
+    dtype: Optional[str] = None
+    attn_impl: Optional[str] = None
+    error: Optional[str] = None
+
+
+class OCRBackendsResponse(RootModel[dict[str, OCRBackendDiscoveryEntry]]):
+    """Map backend names to their discovery metadata."""

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/chatllm_ocr.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/chatllm_ocr.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess  # nosec B404
+import tempfile
+from threading import RLock
+from typing import Any
+from urllib.parse import urlparse
+
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.base import OCRBackend
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+    cleanup_managed_process,
+    get_managed_process_record,
+    managed_process_running,
+    register_managed_process,
+    render_argv_template,
+    terminate_process,
+    wait_for_managed_http_ready,
+)
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.types import (
+    OCRResult,
+    normalize_ocr_format,
+)
+from tldw_Server_API.app.core.Utils.Utils import logging
+
+_CHATLLM_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    AttributeError,
+    ConnectionError,
+    FileNotFoundError,
+    OSError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+    json.JSONDecodeError,
+)
+_MANAGED_LIFECYCLE_LOCK = RLock()
+_PROMPT_PRESETS: dict[str, str] = {
+    "general": "Extract all visible text from the image.",
+    "doc": "Parse the document and return all text in Markdown. Preserve document structure.",
+    "table": "Extract tables faithfully in Markdown. Return all other text in Markdown.",
+    "spotting": "Return JSON only with text spans and bounding boxes for each detected region.",
+    "json": "Return JSON only with fields: text and blocks.",
+}
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_json_list(name: str) -> tuple[str, ...]:
+    raw = os.getenv(name)
+    if not raw:
+        return ()
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    return tuple(str(item) for item in parsed)
+
+
+def _startup_timeout_seconds() -> float:
+    raw = os.getenv("CHATLLM_OCR_STARTUP_TIMEOUT_SEC") or "30"
+    try:
+        return max(float(raw), 0.1)
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _resolve_mode() -> str:
+    return (os.getenv("CHATLLM_OCR_MODE") or "remote").strip().lower()
+
+
+def _active_mode() -> str:
+    mode = _resolve_mode()
+    if mode != "auto":
+        return mode
+    if _remote_configured():
+        return "remote"
+    if managed_process_running(ChatLLMOCRBackend.name) or _managed_start_configured():
+        return "managed"
+    if _cli_configured():
+        return "cli"
+    return "auto"
+
+
+def _resolve_prompt(prompt_preset: str | None, output_format: str | None) -> str:
+    preset = (prompt_preset or os.getenv("CHATLLM_OCR_PROMPT_PRESET_DEFAULT") or "").strip().lower()
+    if not preset:
+        fmt = normalize_ocr_format(output_format)
+        if fmt == "json":
+            preset = "json"
+        elif fmt == "markdown":
+            preset = "doc"
+        else:
+            preset = "general"
+    return _PROMPT_PRESETS.get(preset, _PROMPT_PRESETS["general"])
+
+
+def _structured_preset_requested(prompt_preset: str | None) -> bool:
+    return (prompt_preset or "").strip().lower() in {"spotting", "json"}
+
+
+def _extract_message_content(payload: dict[str, Any]) -> str:
+    content = payload.get("choices", [{}])[0].get("message", {}).get("content", "")
+    if isinstance(content, list):
+        pieces: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                pieces.append(str(item.get("text", "")))
+            elif isinstance(item, str):
+                pieces.append(item)
+        return "\n".join(piece for piece in pieces if piece)
+    if isinstance(content, str):
+        return content
+    return str(content or "")
+
+
+def _extract_text_from_json(payload: Any) -> str:
+    if isinstance(payload, dict):
+        for key in ("text", "markdown", "content", "output"):
+            value = payload.get(key)
+            if isinstance(value, str) and value:
+                return value
+        blocks = payload.get("blocks")
+        if isinstance(blocks, list):
+            block_text = [
+                str(block.get("text", "")).strip()
+                for block in blocks
+                if isinstance(block, dict) and str(block.get("text", "")).strip()
+            ]
+            if block_text:
+                return "\n".join(block_text)
+    if isinstance(payload, list):
+        items = [str(item).strip() for item in payload if str(item).strip()]
+        return "\n".join(items)
+    if isinstance(payload, str):
+        return payload
+    return ""
+
+
+def _parse_cli_json(stdout: str) -> Any | None:
+    text = stdout.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        pass
+
+    for line in reversed(text.splitlines()):
+        candidate = line.strip()
+        if not candidate:
+            continue
+        try:
+            return json.loads(candidate)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+    return None
+
+
+def _resolve_remote_url() -> str:
+    url = (os.getenv("CHATLLM_OCR_URL") or "").strip()
+    if not url:
+        raise RuntimeError("CHATLLM_OCR_URL is required for remote mode")
+    if url.endswith("/v1/chat/completions"):
+        return url
+    if url.rstrip("/").endswith("/v1"):
+        return url.rstrip("/") + "/chat/completions"
+    return url.rstrip("/") + "/v1/chat/completions"
+
+
+def _remote_configured() -> bool:
+    return bool((os.getenv("CHATLLM_OCR_URL") or "").strip()) and bool((os.getenv("CHATLLM_OCR_MODEL") or "").strip())
+
+
+def _cli_binary() -> str | None:
+    raw = (os.getenv("CHATLLM_OCR_CLI_BINARY") or "").strip()
+    return raw or None
+
+
+def _cli_argv() -> tuple[str, ...]:
+    return _env_json_list("CHATLLM_OCR_CLI_ARGS_JSON")
+
+
+def _cli_configured() -> bool:
+    return bool(_cli_binary()) and bool(_cli_argv())
+
+
+def _managed_server_binary() -> str | None:
+    raw = (os.getenv("CHATLLM_OCR_SERVER_BINARY") or "").strip()
+    return raw or None
+
+
+def _managed_server_argv() -> tuple[str, ...]:
+    return _env_json_list("CHATLLM_OCR_SERVER_ARGS_JSON")
+
+
+def _resolve_managed_endpoint() -> tuple[str, int]:
+    host = (os.getenv("CHATLLM_OCR_HOST") or "127.0.0.1").strip() or "127.0.0.1"
+    port = _env_int("CHATLLM_OCR_PORT", 0)
+    if port <= 0:
+        raise RuntimeError("CHATLLM managed OCR requires CHATLLM_OCR_PORT")
+    return host, port
+
+
+def _healthcheck_url_configured() -> bool:
+    return bool((os.getenv("CHATLLM_OCR_HEALTHCHECK_URL") or "").strip())
+
+
+def _managed_configured() -> bool:
+    if not _managed_server_binary() or not _managed_server_argv() or not _healthcheck_url_configured():
+        return False
+    try:
+        _resolve_managed_endpoint()
+    except RuntimeError:
+        return False
+    return True
+
+
+def _managed_start_configured() -> bool:
+    return _env_bool("CHATLLM_OCR_ALLOW_MANAGED_START", False) and _managed_configured()
+
+
+def _wait_for_healthcheck(timeout_total: float) -> bool:
+    configured_url = (os.getenv("CHATLLM_OCR_HEALTHCHECK_URL") or "").strip()
+    if configured_url:
+        parsed = urlparse(configured_url)
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        path = parsed.path or "/"
+        return wait_for_managed_http_ready(
+            host=host,
+            port=port,
+            timeout_total=timeout_total,
+            paths=(path,),
+        )
+
+    host, port = _resolve_managed_endpoint()
+    return wait_for_managed_http_ready(host=host, port=port, timeout_total=timeout_total)
+
+
+def _build_openai_payload(image_bytes: bytes, prompt: str) -> dict[str, Any]:
+    return {
+        "model": os.getenv("CHATLLM_OCR_MODEL") or os.getenv("CHATLLM_OCR_MODEL_PATH") or "chatllm-ocr",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:image/png;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+                        },
+                    },
+                ],
+            }
+        ],
+        "temperature": float(os.getenv("CHATLLM_OCR_TEMPERATURE", "0")),
+        "max_tokens": _env_int("CHATLLM_OCR_MAX_TOKENS", 2048),
+    }
+
+
+def _request_headers() -> dict[str, str] | None:
+    api_key = (os.getenv("CHATLLM_OCR_API_KEY") or "").strip()
+    if not api_key:
+        return None
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _ocr_via_remote(image_bytes: bytes, prompt: str) -> str:
+    from tldw_Server_API.app.core.http_client import fetch_json
+
+    response = fetch_json(
+        method="POST",
+        url=_resolve_remote_url(),
+        json=_build_openai_payload(image_bytes, prompt),
+        timeout=_env_int("CHATLLM_OCR_TIMEOUT_SEC", 60),
+        headers=_request_headers(),
+        require_json_ct=False,
+    )
+    return _extract_message_content(response)
+
+
+def _ensure_managed_runtime() -> tuple[str, int]:
+    with _MANAGED_LIFECYCLE_LOCK:
+        timeout_total = _startup_timeout_seconds()
+        record = get_managed_process_record(ChatLLMOCRBackend.name)
+        if record is not None and record.host and record.port is not None:
+            if _wait_for_healthcheck(min(timeout_total, 1.0)):
+                return record.host, record.port
+            cleanup_managed_process(ChatLLMOCRBackend.name)
+
+        host, port = _resolve_managed_endpoint()
+        if not _env_bool("CHATLLM_OCR_ALLOW_MANAGED_START", False):
+            raise RuntimeError("managed OCR startup is disabled")
+        binary = _managed_server_binary()
+        argv = _managed_server_argv()
+        if not binary or not argv:
+            raise RuntimeError("managed OCR startup requires CHATLLM_OCR_SERVER_BINARY and CHATLLM_OCR_SERVER_ARGS_JSON")
+
+        command = [binary, *render_argv_template(
+            argv,
+            model_path=os.getenv("CHATLLM_OCR_MODEL_PATH"),
+            image_path=None,
+            prompt=None,
+            host=host,
+            port=port,
+        )]
+        process = subprocess.Popen(  # nosec B603
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        if _wait_for_healthcheck(timeout_total):
+            register_managed_process(
+                ChatLLMOCRBackend.name,
+                process,
+                host=host,
+                port=port,
+                argv=command,
+            )
+            return host, port
+
+        terminate_process(process)
+        raise RuntimeError(f"managed OCR runtime did not become ready at {host}:{port}")
+
+
+def _ocr_via_managed(image_bytes: bytes, prompt: str) -> str:
+    from tldw_Server_API.app.core.http_client import fetch_json
+
+    host, port = _ensure_managed_runtime()
+    response = fetch_json(
+        method="POST",
+        url=f"http://{host}:{port}/v1/chat/completions",
+        json=_build_openai_payload(image_bytes, prompt),
+        timeout=_env_int("CHATLLM_OCR_TIMEOUT_SEC", 60),
+        headers=_request_headers(),
+        require_json_ct=False,
+    )
+    return _extract_message_content(response)
+
+
+def _ocr_via_cli(image_bytes: bytes, prompt: str) -> str:
+    binary = _cli_binary()
+    argv = _cli_argv()
+    if not binary or not argv:
+        raise RuntimeError("CHATLLM CLI OCR requires binary and args")
+
+    with tempfile.TemporaryDirectory(prefix="chatllm_ocr_") as tmpdir:
+        image_path = os.path.join(tmpdir, "page.png")
+        with open(image_path, "wb") as handle:
+            handle.write(image_bytes)
+        command = [binary, *render_argv_template(
+            argv,
+            model_path=os.getenv("CHATLLM_OCR_MODEL_PATH"),
+            image_path=image_path,
+            prompt=prompt,
+            host=None,
+            port=None,
+        )]
+        completed = subprocess.run(  # nosec B603
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_env_int("CHATLLM_OCR_TIMEOUT_SEC", 60),
+        )
+    return completed.stdout or ""
+
+
+class ChatLLMOCRBackend(OCRBackend):
+    name = "chatllm"
+
+    @classmethod
+    def available(cls) -> bool:
+        mode = _active_mode()
+        try:
+            if mode == "remote":
+                return _remote_configured()
+            if mode == "managed":
+                return managed_process_running(cls.name) or _managed_start_configured()
+            if mode == "cli":
+                return _cli_configured()
+        except _CHATLLM_NONCRITICAL_EXCEPTIONS:
+            return False
+        return False
+
+    def describe(self) -> dict[str, Any]:
+        mode = _active_mode()
+        return {
+            "mode": mode,
+            "model": os.getenv("CHATLLM_OCR_MODEL_PATH") or os.getenv("CHATLLM_OCR_MODEL"),
+            "configured": _remote_configured() or _cli_configured() or _managed_configured() or managed_process_running(self.name),
+            "supports_structured_output": True,
+            "supports_json": True,
+            "auto_eligible": _env_bool("CHATLLM_OCR_AUTO_ELIGIBLE", False),
+            "auto_high_quality_eligible": _env_bool("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", False),
+            "managed_configured": mode == "managed" and _managed_configured(),
+            "managed_running": managed_process_running(self.name),
+            "allow_managed_start": _env_bool("CHATLLM_OCR_ALLOW_MANAGED_START", False),
+            "url_configured": _remote_configured(),
+            "healthcheck_url_configured": _healthcheck_url_configured(),
+            "cli_configured": _cli_configured(),
+            "backend_concurrency_cap": _env_int("CHATLLM_OCR_MAX_PAGE_CONCURRENCY", 1),
+        }
+
+    def ocr_image(self, image_bytes: bytes, lang: str | None = None) -> str:
+        result = self.ocr_image_structured(image_bytes, lang=lang, output_format="text")
+        return result.text or ""
+
+    def ocr_image_structured(
+        self,
+        image_bytes: bytes,
+        lang: str | None = None,
+        output_format: str | None = None,
+        prompt_preset: str | None = None,
+    ) -> OCRResult:
+        fmt = normalize_ocr_format(output_format)
+        if fmt == "unknown":
+            fmt = "text"
+
+        mode = _active_mode()
+        prompt = _resolve_prompt(prompt_preset, output_format)
+        if not self.available():
+            if mode == "managed":
+                _ensure_managed_runtime()
+            else:
+                logging.warning("ChatLLM OCR backend not available: configure CHATLLM_OCR runtime settings.")
+                return OCRResult(text="", format=fmt, meta={"backend": self.name, "mode": mode})
+
+        try:
+            if mode == "remote":
+                raw_output = _ocr_via_remote(image_bytes, prompt)
+            elif mode == "managed":
+                raw_output = _ocr_via_managed(image_bytes, prompt)
+            elif mode == "cli":
+                raw_output = _ocr_via_cli(image_bytes, prompt)
+            else:
+                logging.warning("ChatLLM OCR mode is unsupported.")
+                return OCRResult(text="", format=fmt, meta={"backend": self.name, "mode": mode})
+        except _CHATLLM_NONCRITICAL_EXCEPTIONS as exc:
+            if mode == "managed" and isinstance(exc, RuntimeError):
+                raise
+            logging.error(f"ChatLLM OCR failed: {exc}", exc_info=True)
+            return OCRResult(text="", format=fmt, meta={"backend": self.name, "mode": mode})
+
+        meta = {
+            "backend": self.name,
+            "mode": mode,
+            "prompt_preset": prompt_preset,
+            "output_format": output_format,
+            "model": self.describe().get("model"),
+        }
+        parse_structured = fmt == "json" or _structured_preset_requested(prompt_preset)
+        if parse_structured:
+            parsed = _parse_cli_json(raw_output)
+            if parsed is not None:
+                return OCRResult(
+                    text=_extract_text_from_json(parsed),
+                    format="json",
+                    raw=parsed,
+                    meta=meta,
+                )
+            warning = "JSON output requested but CLI output could not be parsed; returning plain text."
+            if fmt == "json":
+                return OCRResult(
+                    text=raw_output.strip(),
+                    format="text",
+                    raw={"raw_output": raw_output.strip()},
+                    meta=meta,
+                    warnings=[warning],
+                )
+            return OCRResult(
+                text=raw_output.strip(),
+                format=fmt,
+                raw={"raw_output": raw_output.strip()},
+                meta=meta,
+                warnings=[warning],
+            )
+
+        return OCRResult(
+            text=raw_output.strip(),
+            format=fmt,
+            raw=None,
+            meta=meta,
+        )

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/chatllm_ocr.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/chatllm_ocr.py
@@ -119,7 +119,19 @@ def _structured_preset_requested(prompt_preset: str | None) -> bool:
 
 
 def _extract_message_content(payload: dict[str, Any]) -> str:
-    content = payload.get("choices", [{}])[0].get("message", {}).get("content", "")
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        return str(first_choice or "")
+
+    message = first_choice.get("message", {})
+    if not isinstance(message, dict):
+        return str(message or "")
+
+    content = message.get("content", "")
     if isinstance(content, list):
         pieces: list[str] = []
         for item in content:
@@ -246,9 +258,12 @@ def _wait_for_healthcheck(timeout_total: float) -> bool:
         host = parsed.hostname or "127.0.0.1"
         port = parsed.port or (443 if parsed.scheme == "https" else 80)
         path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
         return wait_for_managed_http_ready(
             host=host,
             port=port,
+            scheme=parsed.scheme or "http",
             timeout_total=timeout_total,
             paths=(path,),
         )

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/chatllm_ocr.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/chatllm_ocr.py
@@ -1,3 +1,5 @@
+"""ChatLLM OCR backend with remote, managed, and CLI execution modes."""
+
 from __future__ import annotations
 
 import base64
@@ -102,7 +104,11 @@ def _active_mode() -> str:
 
 
 def _resolve_prompt(prompt_preset: str | None, output_format: str | None) -> str:
-    preset = (prompt_preset or os.getenv("CHATLLM_OCR_PROMPT_PRESET_DEFAULT") or "").strip().lower()
+    preset = (
+        prompt_preset
+        or os.getenv("CHATLLM_OCR_PROMPT_PRESET_DEFAULT")
+        or ""
+    ).strip().lower()
     if not preset:
         fmt = normalize_ocr_format(output_format)
         if fmt == "json":
@@ -200,7 +206,9 @@ def _resolve_remote_url() -> str:
 
 
 def _remote_configured() -> bool:
-    return bool((os.getenv("CHATLLM_OCR_URL") or "").strip()) and bool((os.getenv("CHATLLM_OCR_MODEL") or "").strip())
+    return bool((os.getenv("CHATLLM_OCR_URL") or "").strip()) and bool(
+        (os.getenv("CHATLLM_OCR_MODEL") or "").strip()
+    )
 
 
 def _cli_binary() -> str | None:
@@ -238,7 +246,11 @@ def _healthcheck_url_configured() -> bool:
 
 
 def _managed_configured() -> bool:
-    if not _managed_server_binary() or not _managed_server_argv() or not _healthcheck_url_configured():
+    if (
+        not _managed_server_binary()
+        or not _managed_server_argv()
+        or not _healthcheck_url_configured()
+    ):
         return False
     try:
         _resolve_managed_endpoint()
@@ -274,7 +286,11 @@ def _wait_for_healthcheck(timeout_total: float) -> bool:
 
 def _build_openai_payload(image_bytes: bytes, prompt: str) -> dict[str, Any]:
     return {
-        "model": os.getenv("CHATLLM_OCR_MODEL") or os.getenv("CHATLLM_OCR_MODEL_PATH") or "chatllm-ocr",
+        "model": (
+            os.getenv("CHATLLM_OCR_MODEL")
+            or os.getenv("CHATLLM_OCR_MODEL_PATH")
+            or "chatllm-ocr"
+        ),
         "messages": [
             {
                 "role": "user",
@@ -283,7 +299,10 @@ def _build_openai_payload(image_bytes: bytes, prompt: str) -> dict[str, Any]:
                     {
                         "type": "image_url",
                         "image_url": {
-                            "url": f"data:image/png;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+                            "url": (
+                                "data:image/png;base64,"
+                                f"{base64.b64encode(image_bytes).decode('ascii')}"
+                            )
                         },
                     },
                 ],
@@ -330,7 +349,10 @@ def _ensure_managed_runtime() -> tuple[str, int]:
         binary = _managed_server_binary()
         argv = _managed_server_argv()
         if not binary or not argv:
-            raise RuntimeError("managed OCR startup requires CHATLLM_OCR_SERVER_BINARY and CHATLLM_OCR_SERVER_ARGS_JSON")
+            raise RuntimeError(
+                "managed OCR startup requires CHATLLM_OCR_SERVER_BINARY and "
+                "CHATLLM_OCR_SERVER_ARGS_JSON"
+            )
 
         command = [binary, *render_argv_template(
             argv,
@@ -405,6 +427,8 @@ def _ocr_via_cli(image_bytes: bytes, prompt: str) -> str:
 
 
 class ChatLLMOCRBackend(OCRBackend):
+    """OCR backend that can use ChatLLM through an endpoint, managed runtime, or CLI."""
+
     name = "chatllm"
 
     @classmethod
@@ -426,11 +450,19 @@ class ChatLLMOCRBackend(OCRBackend):
         return {
             "mode": mode,
             "model": os.getenv("CHATLLM_OCR_MODEL_PATH") or os.getenv("CHATLLM_OCR_MODEL"),
-            "configured": _remote_configured() or _cli_configured() or _managed_configured() or managed_process_running(self.name),
+            "configured": (
+                _remote_configured()
+                or _cli_configured()
+                or _managed_configured()
+                or managed_process_running(self.name)
+            ),
             "supports_structured_output": True,
             "supports_json": True,
             "auto_eligible": _env_bool("CHATLLM_OCR_AUTO_ELIGIBLE", False),
-            "auto_high_quality_eligible": _env_bool("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", False),
+            "auto_high_quality_eligible": _env_bool(
+                "CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE",
+                False,
+            ),
             "managed_configured": mode == "managed" and _managed_configured(),
             "managed_running": managed_process_running(self.name),
             "allow_managed_start": _env_bool("CHATLLM_OCR_ALLOW_MANAGED_START", False),
@@ -461,7 +493,10 @@ class ChatLLMOCRBackend(OCRBackend):
             if mode == "managed":
                 _ensure_managed_runtime()
             else:
-                logging.warning("ChatLLM OCR backend not available: configure CHATLLM_OCR runtime settings.")
+                logging.warning(
+                    "ChatLLM OCR backend not available: configure CHATLLM_OCR "
+                    "runtime settings."
+                )
                 return OCRResult(text="", format=fmt, meta={"backend": self.name, "mode": mode})
 
         try:
@@ -497,7 +532,10 @@ class ChatLLMOCRBackend(OCRBackend):
                     raw=parsed,
                     meta=meta,
                 )
-            warning = "JSON output requested but CLI output could not be parsed; returning plain text."
+            warning = (
+                "JSON output requested but CLI output could not be parsed; "
+                "returning plain text."
+            )
             if fmt == "json":
                 return OCRResult(
                     text=raw_output.strip(),

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/llamacpp_ocr.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/llamacpp_ocr.py
@@ -1,0 +1,568 @@
+from __future__ import annotations
+
+import base64
+import contextlib
+from dataclasses import replace
+import json
+import os
+import subprocess  # nosec B404
+import tempfile
+from threading import RLock
+from typing import Any
+
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.base import OCRBackend
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+    get_managed_process_record,
+    is_profile_available,
+    load_ocr_runtime_profiles,
+    managed_process_running,
+    register_managed_process,
+    render_argv_template,
+    terminate_process,
+    wait_for_managed_http_ready,
+)
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.types import (
+    OCRResult,
+    normalize_ocr_format,
+)
+from tldw_Server_API.app.core.Utils.Utils import logging
+
+_LLAMACPP_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    AttributeError,
+    ConnectionError,
+    FileNotFoundError,
+    OSError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+    json.JSONDecodeError,
+)
+
+_PROMPT_PRESETS: dict[str, str] = {
+    "general": "Extract all visible text from the image.",
+    "doc": "Parse the document and return all text in Markdown. Preserve document structure.",
+    "table": "Extract tables faithfully in Markdown. Return all other text in Markdown.",
+    "spotting": "Return JSON only with text spans and bounding boxes for each detected region.",
+    "json": "Return JSON only with fields: text and blocks.",
+}
+_MANAGED_LIFECYCLE_LOCK = RLock()
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _resolve_profiles():
+    return load_ocr_runtime_profiles("LLAMACPP")
+
+
+def _configured_mode() -> str:
+    mode = (os.getenv("LLAMACPP_OCR_MODE") or "cli").strip().lower() or "cli"
+    if mode in {"auto", "remote", "managed", "cli"}:
+        return mode
+    return "cli"
+
+
+def _profile_for_mode(mode: str):
+    profiles = _resolve_profiles()
+    if mode == "remote":
+        return replace(profiles.remote, mode="remote")
+    if mode == "managed":
+        return replace(profiles.managed, mode="managed")
+    return replace(profiles.cli, mode="cli")
+
+
+def _active_profile():
+    mode = _configured_mode()
+    if mode == "remote":
+        return _profile_for_mode("remote")
+    if mode == "managed":
+        return _profile_for_mode("managed")
+    if mode == "cli":
+        return _profile_for_mode("cli")
+    candidates = [
+        _profile_for_mode("remote"),
+        _profile_for_mode("managed"),
+        _profile_for_mode("cli"),
+    ]
+    if managed_process_running(LlamaCppOCRBackend.name) or _managed_start_configured():
+        candidates = [
+            _profile_for_mode("managed"),
+            _profile_for_mode("remote"),
+            _profile_for_mode("cli"),
+        ]
+    for candidate in candidates:
+        if is_profile_available(candidate, backend_name=LlamaCppOCRBackend.name):
+            return candidate
+    return None
+
+
+def _active_mode() -> str:
+    profile = _active_profile()
+    if profile is None:
+        return _configured_mode()
+    return profile.normalized_mode()
+
+
+def _wait_for_managed_http_ready(host: str, port: int, timeout_total: float) -> bool:
+    return wait_for_managed_http_ready(host=host, port=port, timeout_total=timeout_total)
+
+
+def _startup_timeout_seconds() -> float:
+    raw = os.getenv("LLAMACPP_OCR_STARTUP_TIMEOUT_SEC") or os.getenv("LLAMACPP_OCR_STARTUP_TIMEOUT") or "30"
+    try:
+        return max(float(raw), 0.1)
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _resolve_prompt(prompt_preset: str | None, output_format: str | None) -> str:
+    env_prompt = os.getenv("LLAMACPP_OCR_PROMPT")
+    if env_prompt:
+        return env_prompt
+
+    preset = (prompt_preset or "").strip().lower()
+    if not preset:
+        fmt = normalize_ocr_format(output_format)
+        if fmt == "json":
+            preset = "json"
+        elif fmt == "markdown":
+            preset = "doc"
+        else:
+            preset = "general"
+    return _PROMPT_PRESETS.get(preset, _PROMPT_PRESETS["general"])
+
+
+def _structured_preset_requested(prompt_preset: str | None) -> bool:
+    preset = (prompt_preset or "").strip().lower()
+    return preset in {"spotting", "json"}
+
+
+def _extract_message_content(payload: dict[str, Any]) -> str:
+    content = payload.get("choices", [{}])[0].get("message", {}).get("content", "")
+    if isinstance(content, list):
+        pieces: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                pieces.append(str(item.get("text", "")))
+            elif isinstance(item, str):
+                pieces.append(item)
+        return "\n".join(piece for piece in pieces if piece)
+    if isinstance(content, str):
+        return content
+    return str(content or "")
+
+
+def _extract_text_from_json(payload: Any) -> str:
+    if isinstance(payload, dict):
+        for key in ("text", "markdown", "content", "output"):
+            value = payload.get(key)
+            if isinstance(value, str) and value:
+                return value
+        blocks = payload.get("blocks")
+        if isinstance(blocks, list):
+            block_text = [
+                str(block.get("text", "")).strip()
+                for block in blocks
+                if isinstance(block, dict) and str(block.get("text", "")).strip()
+            ]
+            if block_text:
+                return "\n".join(block_text)
+    if isinstance(payload, list):
+        items = [str(item).strip() for item in payload if str(item).strip()]
+        return "\n".join(items)
+    if isinstance(payload, str):
+        return payload
+    return ""
+
+
+def _parse_cli_json(stdout: str) -> Any | None:
+    text = stdout.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        pass
+
+    for line in reversed(text.splitlines()):
+        candidate = line.strip()
+        if not candidate:
+            continue
+        try:
+            return json.loads(candidate)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+    return None
+
+
+def _ocr_via_remote(image_bytes: bytes, prompt: str) -> str:
+    profile = _resolve_profiles().remote
+    host = getattr(profile, "host", None) or os.getenv("LLAMACPP_OCR_HOST")
+    port = getattr(profile, "port", None)
+    if port is None:
+        port = _env_int("LLAMACPP_OCR_PORT", 0)
+    if not host or not port:
+        raise RuntimeError("LLAMACPP remote OCR requires LLAMACPP_OCR_HOST and LLAMACPP_OCR_PORT")
+
+    model = getattr(profile, "model_path", None) or os.getenv("LLAMACPP_OCR_MODEL_PATH") or "llamacpp-ocr"
+    timeout = _env_int("LLAMACPP_OCR_TIMEOUT", 60)
+    use_data_url = _env_bool("LLAMACPP_OCR_USE_DATA_URL", True)
+
+    temp_path: str | None = None
+    try:
+        if use_data_url:
+            image_url = f"data:image/png;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+        else:
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as handle:
+                handle.write(image_bytes)
+                image_url = handle.name
+                temp_path = handle.name
+
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {"type": "image_url", "image_url": {"url": image_url}},
+                    ],
+                }
+            ],
+            "temperature": float(os.getenv("LLAMACPP_OCR_TEMPERATURE", "0")),
+            "max_tokens": _env_int("LLAMACPP_OCR_MAX_TOKENS", 2048),
+        }
+
+        from tldw_Server_API.app.core.http_client import fetch_json
+
+        response = fetch_json(
+            method="POST",
+            url=f"http://{host}:{port}/v1/chat/completions",
+            json=payload,
+            timeout=timeout,
+        )
+        return _extract_message_content(response)
+    finally:
+        if temp_path:
+            with contextlib.suppress(OSError):
+                os.unlink(temp_path)
+
+
+def _resolve_managed_endpoint() -> tuple[str, int]:
+    profile = _resolve_profiles().managed
+    host = profile.host or os.getenv("LLAMACPP_OCR_HOST") or "127.0.0.1"
+    port = profile.port
+    if port is None:
+        port = _env_int("LLAMACPP_OCR_PORT", 0)
+    if port <= 0:
+        raise RuntimeError("LLAMACPP managed OCR requires LLAMACPP_OCR_PORT")
+    admin_port = _env_int("LLAMACPP_SERVER_PORT", 0)
+    if admin_port <= 0:
+        admin_port = _env_int("LLAMACPP_PORT", 0)
+    if admin_port > 0 and port == admin_port:
+        raise RuntimeError("LLAMACPP managed OCR requires an OCR-private port distinct from the admin server port")
+    return host, port
+
+
+def _managed_runtime_configured() -> bool:
+    profile = _resolve_profiles().managed
+    if not profile.argv:
+        return False
+    try:
+        _resolve_managed_endpoint()
+    except RuntimeError:
+        return False
+    return True
+
+
+def _managed_start_configured() -> bool:
+    profile = _resolve_profiles().managed
+    return profile.allow_managed_start and _managed_runtime_configured()
+
+
+def _ensure_managed_runtime() -> tuple[str, int]:
+    with _MANAGED_LIFECYCLE_LOCK:
+        timeout_total = _startup_timeout_seconds()
+        record = get_managed_process_record(LlamaCppOCRBackend.name)
+        if record is not None:
+            record_host = record.host
+            record_port = record.port
+            if record_host and record_port is not None:
+                _wait_for_managed_http_ready(record_host, record_port, min(timeout_total, 1.0))
+                return record_host, record_port
+        profile = _resolve_profiles().managed
+        host, port = _resolve_managed_endpoint()
+        if not profile.allow_managed_start:
+            raise RuntimeError("managed OCR startup is disabled")
+        if not profile.argv:
+            raise RuntimeError("managed OCR startup requires LLAMACPP_OCR_ARGV")
+
+        command = render_argv_template(
+            profile.argv,
+            model_path=profile.model_path,
+            image_path=None,
+            prompt=profile.prompt,
+            host=host,
+            port=port,
+        )
+        process = subprocess.Popen(  # nosec B603
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+        if _wait_for_managed_http_ready(host, port, timeout_total):
+            register_managed_process(
+                LlamaCppOCRBackend.name,
+                process,
+                host=host,
+                port=port,
+                argv=command,
+            )
+            return host, port
+
+        terminate_process(process)
+        raise RuntimeError(f"managed OCR runtime did not become ready at {host}:{port}")
+
+
+def _ocr_via_managed(image_bytes: bytes, prompt: str) -> str:
+    host, port = _ensure_managed_runtime()
+    model = _resolve_profiles().managed.model_path or os.getenv("LLAMACPP_OCR_MODEL_PATH") or "llamacpp-ocr"
+    timeout = _env_int("LLAMACPP_OCR_TIMEOUT", 60)
+    use_data_url = _env_bool("LLAMACPP_OCR_USE_DATA_URL", True)
+
+    temp_path: str | None = None
+    try:
+        if use_data_url:
+            image_url = f"data:image/png;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+        else:
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as handle:
+                handle.write(image_bytes)
+                image_url = handle.name
+                temp_path = handle.name
+
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {"type": "image_url", "image_url": {"url": image_url}},
+                    ],
+                }
+            ],
+            "temperature": float(os.getenv("LLAMACPP_OCR_TEMPERATURE", "0")),
+            "max_tokens": _env_int("LLAMACPP_OCR_MAX_TOKENS", 2048),
+        }
+
+        from tldw_Server_API.app.core.http_client import fetch_json
+
+        response = fetch_json(
+            method="POST",
+            url=f"http://{host}:{port}/v1/chat/completions",
+            json=payload,
+            timeout=timeout,
+        )
+        return _extract_message_content(response)
+    finally:
+        if temp_path:
+            with contextlib.suppress(OSError):
+                os.unlink(temp_path)
+
+
+def _remote_configured() -> bool:
+    profile = _resolve_profiles().remote
+    host = getattr(profile, "host", None) or os.getenv("LLAMACPP_OCR_HOST")
+    port = getattr(profile, "port", None)
+    if port is None:
+        port = _env_int("LLAMACPP_OCR_PORT", 0)
+    return bool(host) and bool(port and port > 0)
+
+
+def _cli_configured() -> bool:
+    return bool(_resolve_profiles().cli.argv)
+
+
+def _ocr_via_cli(image_bytes: bytes, prompt: str) -> str:
+    profile = _resolve_profiles().cli
+    with tempfile.TemporaryDirectory(prefix="llamacpp_ocr_") as tmpdir:
+        image_path = os.path.join(tmpdir, "page.png")
+        with open(image_path, "wb") as handle:
+            handle.write(image_bytes)
+        command = render_argv_template(
+            profile.argv,
+            model_path=profile.model_path,
+            image_path=image_path,
+            prompt=prompt,
+            host=None,
+            port=None,
+        )
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )  # nosec B603
+    return completed.stdout or ""
+
+
+class LlamaCppOCRBackend(OCRBackend):
+    name = "llamacpp"
+
+    @classmethod
+    def available(cls) -> bool:
+        try:
+            active = _active_profile()
+            if active is None:
+                return False
+            return is_profile_available(active, backend_name=cls.name)
+        except _LLAMACPP_NONCRITICAL_EXCEPTIONS:
+            return False
+
+    def describe(self) -> dict[str, Any]:
+        profiles = _resolve_profiles()
+        active = _active_profile()
+        active_mode = _active_mode()
+        if active is None:
+            mode = _configured_mode()
+            if mode == "remote":
+                active = _profile_for_mode("remote")
+            elif mode == "managed":
+                active = _profile_for_mode("managed")
+            else:
+                active = _profile_for_mode("cli")
+        host = getattr(active, "host", None)
+        port = getattr(active, "port", None)
+        description: dict[str, Any] = {
+            "mode": active_mode,
+            "configured_mode": _configured_mode(),
+            "model": getattr(active, "model_path", None),
+            "configured": _remote_configured() or _cli_configured() or _managed_runtime_configured() or managed_process_running(self.name),
+            "supports_structured_output": True,
+            "supports_json": True,
+            "prompt": getattr(active, "prompt", None) or os.getenv("LLAMACPP_OCR_PROMPT"),
+            "configured_flags": os.getenv("LLAMACPP_OCR_CONFIGURED_FLAGS"),
+            "auto_eligible": _env_bool("LLAMACPP_OCR_AUTO_ELIGIBLE", False),
+            "auto_high_quality_eligible": _env_bool("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", False),
+            "backend_concurrency_cap": active.max_page_concurrency,
+            "allow_managed_start": profiles.managed.allow_managed_start,
+            "url_configured": _remote_configured(),
+            "managed_configured": _managed_runtime_configured(),
+            "managed_running": managed_process_running(self.name),
+            "cli_configured": _cli_configured(),
+            "argv": list(active.argv),
+        }
+        if host:
+            description["host"] = host
+        if port is not None:
+            description["port"] = port
+            description["url"] = f"http://{host}:{port}/v1/chat/completions" if host else None
+        return description
+
+    def ocr_image(self, image_bytes: bytes, lang: str | None = None) -> str:
+        result = self.ocr_image_structured(image_bytes, lang=lang, output_format="text")
+        return result.text or ""
+
+    def ocr_image_structured(
+        self,
+        image_bytes: bytes,
+        lang: str | None = None,
+        output_format: str | None = None,
+        prompt_preset: str | None = None,
+    ) -> OCRResult:
+        fmt = normalize_ocr_format(output_format)
+        if fmt == "unknown":
+            fmt = "text"
+
+        prompt = _resolve_prompt(prompt_preset, output_format)
+        mode = _active_mode()
+        raw_output = ""
+        warnings: list[str] = []
+
+        if not self.available():
+            if mode == "managed":
+                _ensure_managed_runtime()
+            else:
+                logging.warning("LlamaCppOCRBackend not available: configure LLAMACPP_OCR runtime settings.")
+                return OCRResult(text="", format=fmt, meta={"backend": self.name, "mode": mode})
+
+        try:
+            if mode == "remote":
+                raw_output = _ocr_via_remote(image_bytes, prompt)
+            elif mode == "cli":
+                raw_output = _ocr_via_cli(image_bytes, prompt)
+            elif mode == "managed":
+                raw_output = _ocr_via_managed(image_bytes, prompt)
+            else:
+                logging.warning("LlamaCpp OCR mode is unsupported.")
+                return OCRResult(text="", format=fmt, meta={"backend": self.name, "mode": mode})
+        except _LLAMACPP_NONCRITICAL_EXCEPTIONS as exc:
+            if mode == "managed" and isinstance(exc, RuntimeError):
+                raise
+            logging.error(f"LlamaCpp OCR failed: {exc}", exc_info=True)
+            return OCRResult(text="", format=fmt, meta={"backend": self.name, "mode": mode})
+
+        meta = {
+            "backend": self.name,
+            "mode": mode,
+            "prompt_preset": prompt_preset,
+            "output_format": output_format,
+            "model": self.describe().get("model"),
+            "configured_flags": os.getenv("LLAMACPP_OCR_CONFIGURED_FLAGS"),
+            "auto_eligible": _env_bool("LLAMACPP_OCR_AUTO_ELIGIBLE", False),
+            "auto_high_quality_eligible": _env_bool("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", False),
+            "backend_concurrency_cap": (_active_profile() or _resolve_profiles().cli).max_page_concurrency,
+        }
+
+        parse_structured = fmt == "json" or _structured_preset_requested(prompt_preset)
+        if parse_structured:
+            parsed = _parse_cli_json(raw_output)
+            if parsed is not None:
+                return OCRResult(
+                    text=_extract_text_from_json(parsed),
+                    format="json",
+                    raw=parsed,
+                    meta=meta,
+                )
+            warning = "JSON output requested but CLI output could not be parsed; returning plain text."
+            if fmt == "json":
+                return OCRResult(
+                    text=raw_output.strip(),
+                    format="text",
+                    raw={"raw_output": raw_output.strip()},
+                    meta=meta,
+                    warnings=[warning],
+                )
+            return OCRResult(
+                text=raw_output.strip(),
+                format=fmt,
+                raw={"raw_output": raw_output.strip()},
+                meta=meta,
+                warnings=[warning],
+            )
+
+        return OCRResult(
+            text=raw_output.strip(),
+            format=fmt,
+            raw=None,
+            meta=meta,
+            warnings=warnings,
+        )

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/llamacpp_ocr.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/llamacpp_ocr.py
@@ -1,3 +1,5 @@
+"""Llama.cpp OCR backend with auto, remote, managed, and CLI runtime support."""
+
 from __future__ import annotations
 
 import base64
@@ -12,6 +14,10 @@ from typing import Any
 
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.base import OCRBackend
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+    CLIOCRProfile,
+    ManagedOCRProfile,
+    OCRRuntimeProfiles,
+    RemoteOCRProfile,
     cleanup_managed_process,
     get_managed_process_record,
     is_profile_available,
@@ -28,6 +34,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.types import (
 )
 from tldw_Server_API.app.core.Utils.Utils import logging
 
+_LlamaCppProfile = RemoteOCRProfile | ManagedOCRProfile | CLIOCRProfile
 _LLAMACPP_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     AttributeError,
     ConnectionError,
@@ -67,7 +74,7 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-def _resolve_profiles():
+def _resolve_profiles() -> OCRRuntimeProfiles:
     return load_ocr_runtime_profiles("LLAMACPP")
 
 
@@ -78,7 +85,7 @@ def _configured_mode() -> str:
     return "cli"
 
 
-def _profile_for_mode(mode: str):
+def _profile_for_mode(mode: str) -> _LlamaCppProfile:
     profiles = _resolve_profiles()
     if mode == "remote":
         return replace(profiles.remote, mode="remote")
@@ -87,7 +94,7 @@ def _profile_for_mode(mode: str):
     return replace(profiles.cli, mode="cli")
 
 
-def _active_profile():
+def _active_profile() -> _LlamaCppProfile | None:
     mode = _configured_mode()
     if mode == "remote":
         return _profile_for_mode("remote")
@@ -124,7 +131,11 @@ def _wait_for_managed_http_ready(host: str, port: int, timeout_total: float) -> 
 
 
 def _startup_timeout_seconds() -> float:
-    raw = os.getenv("LLAMACPP_OCR_STARTUP_TIMEOUT_SEC") or os.getenv("LLAMACPP_OCR_STARTUP_TIMEOUT") or "30"
+    raw = (
+        os.getenv("LLAMACPP_OCR_STARTUP_TIMEOUT_SEC")
+        or os.getenv("LLAMACPP_OCR_STARTUP_TIMEOUT")
+        or "30"
+    )
     try:
         return max(float(raw), 0.1)
     except (TypeError, ValueError):
@@ -232,7 +243,11 @@ def _ocr_via_remote(image_bytes: bytes, prompt: str) -> str:
     if not host or not port:
         raise RuntimeError("LLAMACPP remote OCR requires LLAMACPP_OCR_HOST and LLAMACPP_OCR_PORT")
 
-    model = getattr(profile, "model_path", None) or os.getenv("LLAMACPP_OCR_MODEL_PATH") or "llamacpp-ocr"
+    model = (
+        getattr(profile, "model_path", None)
+        or os.getenv("LLAMACPP_OCR_MODEL_PATH")
+        or "llamacpp-ocr"
+    )
     timeout = _env_int("LLAMACPP_OCR_TIMEOUT", 60)
     use_data_url = _env_bool("LLAMACPP_OCR_USE_DATA_URL", True)
 
@@ -288,7 +303,10 @@ def _resolve_managed_endpoint() -> tuple[str, int]:
     if admin_port <= 0:
         admin_port = _env_int("LLAMACPP_PORT", 0)
     if admin_port > 0 and port == admin_port:
-        raise RuntimeError("LLAMACPP managed OCR requires an OCR-private port distinct from the admin server port")
+        raise RuntimeError(
+            "LLAMACPP managed OCR requires an OCR-private port distinct from "
+            "the admin server port"
+        )
     return host, port
 
 
@@ -358,7 +376,11 @@ def _ensure_managed_runtime() -> tuple[str, int]:
 
 def _ocr_via_managed(image_bytes: bytes, prompt: str) -> str:
     host, port = _ensure_managed_runtime()
-    model = _resolve_profiles().managed.model_path or os.getenv("LLAMACPP_OCR_MODEL_PATH") or "llamacpp-ocr"
+    model = (
+        _resolve_profiles().managed.model_path
+        or os.getenv("LLAMACPP_OCR_MODEL_PATH")
+        or "llamacpp-ocr"
+    )
     timeout = _env_int("LLAMACPP_OCR_TIMEOUT", 60)
     use_data_url = _env_bool("LLAMACPP_OCR_USE_DATA_URL", True)
 
@@ -450,6 +472,8 @@ def _ocr_via_cli(image_bytes: bytes, prompt: str) -> str:
 
 
 class LlamaCppOCRBackend(OCRBackend):
+    """OCR backend that can call llama.cpp remotely, via a managed server, or via CLI."""
+
     name = "llamacpp"
 
     @classmethod
@@ -480,13 +504,21 @@ class LlamaCppOCRBackend(OCRBackend):
             "mode": active_mode,
             "configured_mode": _configured_mode(),
             "model": getattr(active, "model_path", None),
-            "configured": _remote_configured() or _cli_configured() or _managed_runtime_configured() or managed_process_running(self.name),
+            "configured": (
+                _remote_configured()
+                or _cli_configured()
+                or _managed_runtime_configured()
+                or managed_process_running(self.name)
+            ),
             "supports_structured_output": True,
             "supports_json": True,
             "prompt": getattr(active, "prompt", None) or os.getenv("LLAMACPP_OCR_PROMPT"),
             "configured_flags": os.getenv("LLAMACPP_OCR_CONFIGURED_FLAGS"),
             "auto_eligible": _env_bool("LLAMACPP_OCR_AUTO_ELIGIBLE", False),
-            "auto_high_quality_eligible": _env_bool("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", False),
+            "auto_high_quality_eligible": _env_bool(
+                "LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE",
+                False,
+            ),
             "backend_concurrency_cap": active.max_page_concurrency,
             "allow_managed_start": profiles.managed.allow_managed_start,
             "url_configured": _remote_configured(),
@@ -526,7 +558,10 @@ class LlamaCppOCRBackend(OCRBackend):
             if mode == "managed":
                 _ensure_managed_runtime()
             else:
-                logging.warning("LlamaCppOCRBackend not available: configure LLAMACPP_OCR runtime settings.")
+                logging.warning(
+                    "LlamaCppOCRBackend not available: configure LLAMACPP_OCR "
+                    "runtime settings."
+                )
                 return OCRResult(text="", format=fmt, meta={"backend": self.name, "mode": mode})
 
         try:
@@ -553,8 +588,13 @@ class LlamaCppOCRBackend(OCRBackend):
             "model": self.describe().get("model"),
             "configured_flags": os.getenv("LLAMACPP_OCR_CONFIGURED_FLAGS"),
             "auto_eligible": _env_bool("LLAMACPP_OCR_AUTO_ELIGIBLE", False),
-            "auto_high_quality_eligible": _env_bool("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", False),
-            "backend_concurrency_cap": (_active_profile() or _resolve_profiles().cli).max_page_concurrency,
+            "auto_high_quality_eligible": _env_bool(
+                "LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE",
+                False,
+            ),
+            "backend_concurrency_cap": (
+                _active_profile() or _resolve_profiles().cli
+            ).max_page_concurrency,
         }
 
         parse_structured = fmt == "json" or _structured_preset_requested(prompt_preset)
@@ -567,7 +607,10 @@ class LlamaCppOCRBackend(OCRBackend):
                     raw=parsed,
                     meta=meta,
                 )
-            warning = "JSON output requested but CLI output could not be parsed; returning plain text."
+            warning = (
+                "JSON output requested but CLI output could not be parsed; "
+                "returning plain text."
+            )
             if fmt == "json":
                 return OCRResult(
                     text=raw_output.strip(),

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/llamacpp_ocr.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/llamacpp_ocr.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.base import OCRBackend
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+    cleanup_managed_process,
     get_managed_process_record,
     is_profile_available,
     load_ocr_runtime_profiles,
@@ -153,7 +154,19 @@ def _structured_preset_requested(prompt_preset: str | None) -> bool:
 
 
 def _extract_message_content(payload: dict[str, Any]) -> str:
-    content = payload.get("choices", [{}])[0].get("message", {}).get("content", "")
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        return str(first_choice or "")
+
+    message = first_choice.get("message", {})
+    if not isinstance(message, dict):
+        return str(message or "")
+
+    content = message.get("content", "")
     if isinstance(content, list):
         pieces: list[str] = []
         for item in content:
@@ -303,8 +316,9 @@ def _ensure_managed_runtime() -> tuple[str, int]:
             record_host = record.host
             record_port = record.port
             if record_host and record_port is not None:
-                _wait_for_managed_http_ready(record_host, record_port, min(timeout_total, 1.0))
-                return record_host, record_port
+                if _wait_for_managed_http_ready(record_host, record_port, min(timeout_total, 1.0)):
+                    return record_host, record_port
+                cleanup_managed_process(LlamaCppOCRBackend.name, timeout=min(timeout_total, 1.0))
         profile = _resolve_profiles().managed
         host, port = _resolve_managed_endpoint()
         if not profile.allow_managed_start:
@@ -403,6 +417,7 @@ def _cli_configured() -> bool:
 
 def _ocr_via_cli(image_bytes: bytes, prompt: str) -> str:
     profile = _resolve_profiles().cli
+    timeout_seconds = _env_int("LLAMACPP_OCR_TIMEOUT", 60)
     with tempfile.TemporaryDirectory(prefix="llamacpp_ocr_") as tmpdir:
         image_path = os.path.join(tmpdir, "page.png")
         with open(image_path, "wb") as handle:
@@ -415,12 +430,22 @@ def _ocr_via_cli(image_bytes: bytes, prompt: str) -> str:
             host=None,
             port=None,
         )
-        completed = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            check=False,
-        )  # nosec B603
+        try:
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout_seconds,
+            )  # nosec B603
+        except subprocess.TimeoutExpired as exc:
+            logging.error(
+                "Llama.cpp OCR CLI timed out after %ss for model=%r image_path=%r",
+                timeout_seconds,
+                profile.model_path,
+                image_path,
+            )
+            raise RuntimeError(f"llama.cpp CLI OCR timed out after {timeout_seconds}s") from exc
     return completed.stdout or ""
 
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/registry.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/registry.py
@@ -117,17 +117,44 @@ def get_backend(name: str | None = None) -> OCRBackend | None:
     if name == "auto_high_quality":
         preferred_order = _resolve_priority_from_config()
         if not preferred_order:
-            preferred_order = ["llamacpp", "chatllm", "nemotron_parse", "hunyuan", "deepseek", "points", "dots", "dolphin", "tesseract"]
+            preferred_order = [
+                "llamacpp",
+                "chatllm",
+                "nemotron_parse",
+                "hunyuan",
+                "deepseek",
+                "points",
+                "dots",
+                "dolphin",
+                "tesseract",
+            ]
     else:
         # Try config override for normal auto
         preferred_order = _resolve_priority_from_config()
         if not preferred_order:
-            preferred_order = ["tesseract", "nemotron_parse", "points", "deepseek", "hunyuan", "dots", "dolphin", "llamacpp", "chatllm"]
+            preferred_order = [
+                "tesseract",
+                "nemotron_parse",
+                "points",
+                "deepseek",
+                "hunyuan",
+                "dots",
+                "dolphin",
+                "llamacpp",
+                "chatllm",
+            ]
 
     if preferred_order:
         for key in preferred_order:
             cls = _BACKENDS.get(key)
-            if cls and _is_auto_eligible(key, high_quality=name == "auto_high_quality") and cls.available():
+            if (
+                cls
+                and _is_auto_eligible(
+                    key,
+                    high_quality=name == "auto_high_quality",
+                )
+                and cls.available()
+            ):
                 return cls()
         # fallback to discovery order below
 
@@ -135,7 +162,10 @@ def get_backend(name: str | None = None) -> OCRBackend | None:
     for cls in _BACKENDS.values():
         if getattr(cls, "name", None) in _AUTO_EXCLUDE:
             continue
-        if not _is_auto_eligible(getattr(cls, "name", ""), high_quality=name == "auto_high_quality"):
+        if not _is_auto_eligible(
+            getattr(cls, "name", ""),
+            high_quality=name == "auto_high_quality",
+        ):
             continue
         if cls.available():
             candidates.append(cls)

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/registry.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/registry.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr import (
     DeepSeekOCRBackend,
 )
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+    ChatLLMOCRBackend,
+)
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr import (
     DolphinOCRBackend,
 )
@@ -11,6 +14,9 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr i
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr import (
     HunyuanOCRBackend,
+)
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+    LlamaCppOCRBackend,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse import (
     NemotronParseBackend,
@@ -22,6 +28,7 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_
     TesseractCLIBackend,
 )
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.base import OCRBackend
+import os
 
 try:
     # Optional config override
@@ -34,11 +41,13 @@ _BACKENDS: dict[str, type[OCRBackend]] = {
     # Keep Tesseract first for a lightweight default, but users can force 'dots'
     TesseractCLIBackend.name: TesseractCLIBackend,
     NemotronParseBackend.name: NemotronParseBackend,
-    DotsOCRBackend.name: DotsOCRBackend,
     PointsReaderBackend.name: PointsReaderBackend,
     DeepSeekOCRBackend.name: DeepSeekOCRBackend,
     HunyuanOCRBackend.name: HunyuanOCRBackend,
+    DotsOCRBackend.name: DotsOCRBackend,
     DolphinOCRBackend.name: DolphinOCRBackend,
+    LlamaCppOCRBackend.name: LlamaCppOCRBackend,
+    ChatLLMOCRBackend.name: ChatLLMOCRBackend,
 }
 
 _AUTO_EXCLUDE = {
@@ -65,6 +74,25 @@ def _resolve_priority_from_config() -> list[str] | None:
         return None
 
 
+def _env_flag(name: str) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_auto_eligible(backend_name: str, *, high_quality: bool) -> bool:
+    if backend_name == "llamacpp":
+        if high_quality:
+            return _env_flag("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE")
+        return _env_flag("LLAMACPP_OCR_AUTO_ELIGIBLE")
+    if backend_name == "chatllm":
+        if high_quality:
+            return _env_flag("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE")
+        return _env_flag("CHATLLM_OCR_AUTO_ELIGIBLE")
+    return True
+
+
 def get_backend(name: str | None = None) -> OCRBackend | None:
     """
     Resolve an OCR backend instance by name or choose the first available.
@@ -89,21 +117,25 @@ def get_backend(name: str | None = None) -> OCRBackend | None:
     if name == "auto_high_quality":
         preferred_order = _resolve_priority_from_config()
         if not preferred_order:
-            preferred_order = ["nemotron_parse", "hunyuan", "deepseek", "points", "dots", "tesseract"]
+            preferred_order = ["llamacpp", "chatllm", "nemotron_parse", "hunyuan", "deepseek", "points", "dots", "dolphin", "tesseract"]
     else:
         # Try config override for normal auto
         preferred_order = _resolve_priority_from_config()
+        if not preferred_order:
+            preferred_order = ["tesseract", "nemotron_parse", "points", "deepseek", "hunyuan", "dots", "dolphin", "llamacpp", "chatllm"]
 
     if preferred_order:
         for key in preferred_order:
             cls = _BACKENDS.get(key)
-            if cls and cls.available():
+            if cls and _is_auto_eligible(key, high_quality=name == "auto_high_quality") and cls.available():
                 return cls()
         # fallback to discovery order below
 
     # Default: first available in registration order
     for cls in _BACKENDS.values():
         if getattr(cls, "name", None) in _AUTO_EXCLUDE:
+            continue
+        if not _is_auto_eligible(getattr(cls, "name", ""), high_quality=name == "auto_high_quality"):
             continue
         if cls.available():
             candidates.append(cls)

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/runtime_support.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/runtime_support.py
@@ -345,6 +345,7 @@ def wait_for_managed_http_ready(
     *,
     host: str,
     port: int,
+    scheme: str = "http",
     timeout_total: float = 30.0,
     interval: float = 0.5,
     paths: tuple[str, ...] = ("/health", "/v1/models"),
@@ -352,7 +353,8 @@ def wait_for_managed_http_ready(
     deadline = time.monotonic() + max(timeout_total, 0.0)
     while time.monotonic() < deadline:
         for path in paths:
-            connection = http.client.HTTPConnection(host, port, timeout=min(5.0, max(interval, 0.1)))
+            connection_cls = http.client.HTTPSConnection if str(scheme).strip().lower() == "https" else http.client.HTTPConnection
+            connection = connection_cls(host, port, timeout=min(5.0, max(interval, 0.1)))
             try:
                 connection.request("GET", path)
                 response = connection.getresponse()

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/runtime_support.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/runtime_support.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import http.client
+import json
+import os
+import platform
+import re
+import signal
+from threading import RLock
+import time
+from typing import Any, Mapping, Sequence
+
+
+def _parse_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return default
+    return normalized in {"1", "true", "yes", "on"}
+
+
+def _parse_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return parsed
+
+
+def _parse_argv_json(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value)
+    raw = str(value).strip()
+    if not raw:
+        return ()
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    return tuple(str(item) for item in parsed)
+
+
+def _pick_positive_cap(*caps: int | None) -> int | None:
+    values = [cap for cap in caps if isinstance(cap, int) and cap > 0]
+    if not values:
+        return None
+    return min(values)
+
+
+def effective_page_concurrency(global_cap: int | None, backend_cap: int | None) -> int:
+    """
+    Resolve the page concurrency budget from the global and backend-specific caps.
+    """
+
+    return _pick_positive_cap(global_cap, backend_cap) or 1
+
+
+def render_argv_template(
+    argv: Sequence[str],
+    *,
+    model_path: str | None = None,
+    image_path: str | None = None,
+    prompt: str | None = None,
+    host: str | None = None,
+    port: int | str | None = None,
+) -> list[str]:
+    """
+    Render argv placeholders without invoking a shell.
+    """
+
+    pattern = re.compile(r"\{model_path\}|\{image_path\}|\{prompt\}|\{host\}|\{port\}")
+    replacements = {
+        "{model_path}": "" if model_path is None else str(model_path),
+        "{image_path}": "" if image_path is None else str(image_path),
+        "{prompt}": "" if prompt is None else str(prompt),
+        "{host}": "" if host is None else str(host),
+        "{port}": "" if port is None else str(port),
+    }
+
+    rendered: list[str] = []
+    for part in argv:
+        value = str(part)
+        rendered.append(pattern.sub(lambda match: replacements[match.group(0)], value))
+    return rendered
+
+
+def is_profile_available(profile: Any, backend_name: str | None = None) -> bool:
+    """
+    Cheap/local availability check for a runtime profile.
+
+    This only consults in-memory/profile state and never performs reachability
+    checks or subprocess probing.
+    """
+
+    if profile is None:
+        return False
+
+    if hasattr(profile, "is_available"):
+        try:
+            if backend_name is not None:
+                return bool(profile.is_available(backend_name=backend_name))
+            return bool(profile.is_available())
+        except TypeError:
+            return bool(profile.is_available())
+
+    return False
+
+
+@dataclass(frozen=True, slots=True)
+class _BaseOCRProfile:
+    mode: str
+    allow_managed_start: bool = False
+    max_page_concurrency: int | None = None
+    argv: tuple[str, ...] = field(default_factory=tuple)
+
+    def normalized_mode(self) -> str:
+        return self.mode.strip().lower()
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteOCRProfile(_BaseOCRProfile):
+    host: str | None = None
+    port: int | None = None
+    model_path: str | None = None
+    prompt: str | None = None
+
+    def is_available(self) -> bool:
+        return self.normalized_mode() == "remote" and bool(self.host) and self.port is not None
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedOCRProfile(_BaseOCRProfile):
+    host: str | None = None
+    port: int | None = None
+    model_path: str | None = None
+    prompt: str | None = None
+
+    def is_available(self, backend_name: str | None = None) -> bool:
+        if _lookup_managed_process(backend_name) is not None:
+            return True
+        return (
+            self.normalized_mode() == "managed"
+            and self.allow_managed_start
+            and bool(self.argv)
+            and isinstance(self.port, int)
+            and self.port > 0
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CLIOCRProfile(_BaseOCRProfile):
+    model_path: str | None = None
+    prompt: str | None = None
+
+    def is_available(self) -> bool:
+        return self.normalized_mode() == "cli" and bool(self.argv)
+
+
+@dataclass(frozen=True, slots=True)
+class OCRRuntimeProfiles:
+    remote: RemoteOCRProfile
+    managed: ManagedOCRProfile
+    cli: CLIOCRProfile
+    active: _BaseOCRProfile
+
+
+@dataclass(slots=True)
+class ManagedProcessRecord:
+    process: Any
+    host: str | None = None
+    port: int | None = None
+    argv: tuple[str, ...] = field(default_factory=tuple)
+
+    def is_running(self) -> bool:
+        return is_process_running(self.process)
+
+    @property
+    def base_url(self) -> str | None:
+        if not self.host or self.port is None:
+            return None
+        return f"http://{self.host}:{self.port}"
+
+
+_MANAGED_PROCESS_REGISTRY: dict[str, ManagedProcessRecord] = {}
+_MANAGED_PROCESS_LOCK = RLock()
+
+
+def register_managed_process(
+    backend_name: str,
+    process: Any,
+    *,
+    host: str | None = None,
+    port: int | None = None,
+    argv: Sequence[str] | None = None,
+) -> Any:
+    with _MANAGED_PROCESS_LOCK:
+        _MANAGED_PROCESS_REGISTRY[backend_name] = ManagedProcessRecord(
+            process=process,
+            host=host,
+            port=port,
+            argv=tuple(str(item) for item in (argv or ())),
+        )
+    return process
+
+
+def get_managed_process(backend_name: str) -> Any | None:
+    with _MANAGED_PROCESS_LOCK:
+        record = _MANAGED_PROCESS_REGISTRY.get(backend_name)
+    if record is None:
+        return None
+    if not record.is_running():
+        clear_managed_process(backend_name)
+        return None
+    return record.process
+
+
+def get_managed_process_record(backend_name: str) -> ManagedProcessRecord | None:
+    with _MANAGED_PROCESS_LOCK:
+        record = _MANAGED_PROCESS_REGISTRY.get(backend_name)
+    if record is None:
+        return None
+    if not record.is_running():
+        clear_managed_process(backend_name)
+        return None
+    return record
+
+
+def clear_managed_process(backend_name: str) -> Any | None:
+    with _MANAGED_PROCESS_LOCK:
+        record = _MANAGED_PROCESS_REGISTRY.pop(backend_name, None)
+    if record is None:
+        return None
+    return record.process
+
+
+def reset_managed_process_registry() -> None:
+    with _MANAGED_PROCESS_LOCK:
+        _MANAGED_PROCESS_REGISTRY.clear()
+
+
+def _lookup_managed_process(backend_name: str | None) -> Any | None:
+    if backend_name is None:
+        return None
+    return get_managed_process(backend_name)
+
+
+def is_process_running(process: Any) -> bool:
+    if process is None:
+        return False
+    try:
+        poll = getattr(process, "poll", None)
+        if callable(poll):
+            return poll() is None
+        return getattr(process, "returncode", None) is None
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+        return False
+
+
+def managed_process_running(backend_name: str) -> bool:
+    return get_managed_process_record(backend_name) is not None
+
+
+def cleanup_managed_process(backend_name: str, *, timeout: float = 5.0) -> bool:
+    process = clear_managed_process(backend_name)
+    return terminate_process(process, timeout=timeout)
+
+
+def terminate_process(process: Any, *, timeout: float = 5.0) -> bool:
+    if process is None or not is_process_running(process):
+        return True
+
+    is_windows = platform.system().lower().startswith("win")
+    try:
+        if is_windows:
+            terminate = getattr(process, "terminate", None)
+            if callable(terminate):
+                terminate()
+        else:
+            pid = getattr(process, "pid", None)
+            if pid:
+                os.killpg(os.getpgid(pid), signal.SIGTERM)
+            else:
+                terminate = getattr(process, "terminate", None)
+                if callable(terminate):
+                    terminate()
+    except (AttributeError, OSError, ProcessLookupError, RuntimeError, ValueError):
+        terminate = getattr(process, "terminate", None)
+        if callable(terminate):
+            try:
+                terminate()
+            except (AttributeError, OSError, RuntimeError, ValueError):
+                pass
+
+    wait = getattr(process, "wait", None)
+    if callable(wait):
+        deadline = time.monotonic() + max(timeout, 0.0)
+        while time.monotonic() < deadline:
+            try:
+                wait(timeout=0.1)
+                return True
+            except TypeError:
+                break
+            except Exception:
+                if not is_process_running(process):
+                    return True
+        try:
+            wait(timeout=max(timeout, 0.0))
+            return True
+        except TypeError:
+            pass
+        except Exception:
+            if not is_process_running(process):
+                return True
+
+    if is_process_running(process):
+        kill = getattr(process, "kill", None)
+        if callable(kill):
+            try:
+                kill()
+            except (AttributeError, OSError, RuntimeError, ValueError):
+                return False
+        wait = getattr(process, "wait", None)
+        if callable(wait):
+            try:
+                wait(timeout=max(timeout, 0.0))
+                return True
+            except (TypeError, Exception):
+                pass
+    return not is_process_running(process)
+
+
+def wait_for_managed_http_ready(
+    *,
+    host: str,
+    port: int,
+    timeout_total: float = 30.0,
+    interval: float = 0.5,
+    paths: tuple[str, ...] = ("/health", "/v1/models"),
+) -> bool:
+    deadline = time.monotonic() + max(timeout_total, 0.0)
+    while time.monotonic() < deadline:
+        for path in paths:
+            connection = http.client.HTTPConnection(host, port, timeout=min(5.0, max(interval, 0.1)))
+            try:
+                connection.request("GET", path)
+                response = connection.getresponse()
+                if 200 <= int(response.status) < 300:
+                    response.read()
+                    return True
+                response.read()
+            except (ConnectionError, OSError, TimeoutError, http.client.HTTPException):
+                pass
+            finally:
+                connection.close()
+        time.sleep(max(interval, 0.05))
+    return False
+
+
+def load_ocr_runtime_profiles(
+    prefix: str,
+    env: Mapping[str, Any] | None = None,
+) -> OCRRuntimeProfiles:
+    """
+    Parse shared OCR runtime configuration for a backend namespace.
+    """
+
+    source = os.environ if env is None else env
+    normalized_prefix = prefix.strip().upper().rstrip("_")
+
+    def key(suffix: str) -> str:
+        return f"{normalized_prefix}_OCR_{suffix}"
+
+    mode = str(source.get(key("MODE"), "cli")).strip().lower() or "cli"
+    allow_managed_start = _parse_bool(source.get(key("ALLOW_MANAGED_START")), False)
+    max_page_concurrency = _parse_int(source.get(key("MAX_PAGE_CONCURRENCY")))
+    if max_page_concurrency is None or max_page_concurrency < 1:
+        max_page_concurrency = 1
+    argv = _parse_argv_json(source.get(key("ARGV")))
+    host = source.get(key("HOST"))
+    port = _parse_int(source.get(key("PORT")))
+    model_path = source.get(key("MODEL_PATH"))
+    prompt = source.get(key("PROMPT"))
+
+    remote = RemoteOCRProfile(
+        mode=mode,
+        allow_managed_start=allow_managed_start,
+        max_page_concurrency=max_page_concurrency,
+        argv=argv,
+        host=None if host is None else str(host),
+        port=port,
+        model_path=None if model_path is None else str(model_path),
+        prompt=None if prompt is None else str(prompt),
+    )
+    managed = ManagedOCRProfile(
+        mode=mode,
+        allow_managed_start=allow_managed_start,
+        max_page_concurrency=max_page_concurrency,
+        argv=argv,
+        host=None if host is None else str(host),
+        port=port,
+        model_path=None if model_path is None else str(model_path),
+        prompt=None if prompt is None else str(prompt),
+    )
+    cli = CLIOCRProfile(
+        mode=mode,
+        allow_managed_start=allow_managed_start,
+        max_page_concurrency=max_page_concurrency,
+        argv=argv,
+        model_path=None if model_path is None else str(model_path),
+        prompt=None if prompt is None else str(prompt),
+    )
+
+    if mode == "remote":
+        active: _BaseOCRProfile = remote
+    elif mode == "managed":
+        active = managed
+    else:
+        active = cli
+
+    return OCRRuntimeProfiles(remote=remote, managed=managed, cli=cli, active=active)

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/runtime_support.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/runtime_support.py
@@ -1,3 +1,5 @@
+"""Shared helpers for OCR runtime configuration, managed processes, and readiness probes."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/PDF/PDF_Processing_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/PDF/PDF_Processing_Lib.py
@@ -29,6 +29,9 @@ import pymupdf4llm
 # Import Local
 from tldw_Server_API.app.core.config import loaded_config_data
 from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend as _get_ocr_backend
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+    effective_page_concurrency as _effective_ocr_page_concurrency,
+)
 from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import resolve_safe_local_path
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter, log_histogram
@@ -83,6 +86,20 @@ _CJK_CHAR_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff\uac00-\ud7a
 #######################################################################################################################
 # Function Definitions
 #
+
+
+def _ocr_min_text_threshold(value: int) -> int:
+    return max(value, 1)
+
+
+def _should_replace_ocr_content(
+    content_text_len: int,
+    ocr_mode: Optional[str],
+    ocr_min_page_text_chars: int,
+) -> bool:
+    return (ocr_mode or "fallback").lower() == "always" or content_text_len < _ocr_min_text_threshold(
+        ocr_min_page_text_chars
+    )
 
 
 def _is_usable_torch_module_for_docling() -> bool:
@@ -661,7 +678,7 @@ def process_pdf(
                 should_ocr = False
                 if enable_ocr:
                     mode = (ocr_mode or "fallback").lower()
-                    if mode == "always" or content_text_len < max(ocr_min_page_text_chars, 1):
+                    if mode == "always" or content_text_len < _ocr_min_text_threshold(ocr_min_page_text_chars):
                         should_ocr = True
 
                 if should_ocr:
@@ -728,7 +745,28 @@ def process_pdf(
                                 "OCR requested but no backend available"
                             ]
                         else:
-                            # Determine small concurrency for OCR if configured
+                            backend_details: dict[str, Any] = {}
+                            backend_page_concurrency: Optional[int] = None
+                            try:
+                                if hasattr(backend, "describe") and callable(backend.describe):
+                                    extra = backend.describe() or {}
+                                    if isinstance(extra, dict):
+                                        backend_details = dict(extra)
+                                        raw_backend_page_concurrency = backend_details.get("backend_concurrency_cap")
+                                        if raw_backend_page_concurrency is None:
+                                            raw_backend_page_concurrency = backend_details.get("max_page_concurrency")
+                                        if raw_backend_page_concurrency is None:
+                                            raw_backend_page_concurrency = backend_details.get("page_concurrency")
+                                        if raw_backend_page_concurrency is not None:
+                                            try:
+                                                backend_page_concurrency = max(1, int(raw_backend_page_concurrency))
+                                            except (TypeError, ValueError):
+                                                backend_page_concurrency = None
+                            except _PDF_NONCRITICAL_EXCEPTIONS:
+                                backend_details = {}
+                                backend_page_concurrency = None
+
+                            # Determine OCR concurrency using the global cap and any backend-local cap.
                             try:
                                 import os as _os
                                 concurrency_env = _os.getenv("OCR_PAGE_CONCURRENCY")
@@ -740,6 +778,10 @@ def process_pdf(
                                     concurrency_env = int(cfg.get('page_concurrency_default', 1))
                             except _PDF_NONCRITICAL_EXCEPTIONS:
                                 concurrency_env = 1
+                            effective_page_concurrency = _effective_ocr_page_concurrency(
+                                concurrency_env,
+                                backend_page_concurrency,
+                            )
 
                             ocr_text, page_count, ocr_pages, structured_pages = _ocr_pdf_pages(
                                 pdf_path=path_for_processing,
@@ -748,7 +790,7 @@ def process_pdf(
                                 backend=backend,
                                 per_page_min_text=ocr_min_page_text_chars,
                                 per_page_check=True,
-                                concurrency=max(1, concurrency_env),
+                                concurrency=effective_page_concurrency,
                                 output_format=ocr_output_format,
                                 prompt_preset=ocr_prompt_preset,
                             )
@@ -760,18 +802,33 @@ def process_pdf(
                                 "lang": ocr_lang or "eng",
                                 "total_pages": page_count,
                                 "ocr_pages": ocr_pages,
-                                "page_concurrency": max(1, concurrency_env),
                                 "output_format": ocr_output_format,
                                 "prompt_preset": ocr_prompt_preset,
                             }
-                            # Attach backend-specific metadata if available
+                            refreshed_backend_details = backend_details
                             try:
                                 if hasattr(backend, "describe") and callable(backend.describe):
-                                    extra = backend.describe() or {}
-                                    if isinstance(extra, dict):
-                                        details.update(extra)
+                                    refreshed = backend.describe() or {}
+                                    if isinstance(refreshed, dict):
+                                        refreshed_backend_details = dict(refreshed)
                             except _PDF_NONCRITICAL_EXCEPTIONS:
-                                pass
+                                refreshed_backend_details = backend_details
+
+                            if refreshed_backend_details:
+                                refreshed_backend_details = dict(refreshed_backend_details)
+                                if backend_page_concurrency is None:
+                                    refreshed_backend_details.pop("backend_concurrency_cap", None)
+                                    refreshed_backend_details.pop("max_page_concurrency", None)
+                                else:
+                                    refreshed_backend_details["backend_concurrency_cap"] = backend_page_concurrency
+
+                            # Attach backend-specific metadata if available.
+                            if refreshed_backend_details:
+                                details.update(refreshed_backend_details)
+                            details["page_concurrency"] = effective_page_concurrency
+                            details["effective_page_concurrency"] = effective_page_concurrency
+                            if backend_page_concurrency is not None:
+                                details.setdefault("backend_concurrency_cap", backend_page_concurrency)
                             if structured_pages is not None:
                                 try:
                                     from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.types import (
@@ -797,7 +854,11 @@ def process_pdf(
                             result["analysis_details"]["ocr"] = details
 
                             if ocr_text and ocr_text.strip():
-                                if (ocr_mode or "fallback").lower() == "always" or content_text_len < max(ocr_min_page_text_chars, 1):
+                                if _should_replace_ocr_content(
+                                    content_text_len,
+                                    ocr_mode,
+                                    ocr_min_page_text_chars,
+                                ):
                                     result["content"] = ocr_text
                                     result["parser_used"] = f"{result['parser_used']}+ocr"
                                 else:

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/PDF/PDF_Processing_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/PDF/PDF_Processing_Lib.py
@@ -82,6 +82,7 @@ _INLINE_WHITESPACE_RE = re.compile(r"[ \t]+")
 _PUNCTUATION_RE = re.compile(r"[^\w\s]")
 _LIST_CONTINUATION_RE = re.compile(r"^\s{2,}\S")
 _CJK_CHAR_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff\uac00-\ud7af]")
+_OCR_BACKEND_OUTPUT_DENYLIST = {"argv", "host", "port", "url", "prompt", "model"}
 #
 #######################################################################################################################
 # Function Definitions
@@ -100,6 +101,14 @@ def _should_replace_ocr_content(
     return (ocr_mode or "fallback").lower() == "always" or content_text_len < _ocr_min_text_threshold(
         ocr_min_page_text_chars
     )
+
+
+def _sanitize_ocr_backend_details_for_output(details: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in details.items()
+        if key not in _OCR_BACKEND_OUTPUT_DENYLIST
+    }
 
 
 def _is_usable_torch_module_for_docling() -> bool:
@@ -815,7 +824,9 @@ def process_pdf(
                                 refreshed_backend_details = backend_details
 
                             if refreshed_backend_details:
-                                refreshed_backend_details = dict(refreshed_backend_details)
+                                refreshed_backend_details = _sanitize_ocr_backend_details_for_output(
+                                    dict(refreshed_backend_details)
+                                )
                                 if backend_page_concurrency is None:
                                     refreshed_backend_details.pop("backend_concurrency_cap", None)
                                     refreshed_backend_details.pop("max_page_concurrency", None)

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_chatllm_ocr_backend.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_chatllm_ocr_backend.py
@@ -10,6 +10,17 @@ import pytest
 
 
 @pytest.mark.unit
+def test_chatllm_extract_message_content_returns_empty_when_choices_missing_or_empty():
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        _extract_message_content,
+    )
+
+    assert _extract_message_content({"choices": []}) == ""  # nosec B101
+    assert _extract_message_content({"choices": None}) == ""  # nosec B101
+    assert _extract_message_content({}) == ""  # nosec B101
+
+
+@pytest.mark.unit
 def test_chatllm_available_is_local_only_for_remote_mode(monkeypatch):
     from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
         ChatLLMOCRBackend,
@@ -50,6 +61,31 @@ def test_chatllm_managed_availability_requires_explicit_healthcheck_url(monkeypa
     monkeypatch.delenv("CHATLLM_OCR_HEALTHCHECK_URL", raising=False)
 
     assert ChatLLMOCRBackend.available() is False  # nosec B101
+
+
+@pytest.mark.unit
+def test_chatllm_wait_for_healthcheck_uses_https_scheme_and_query(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        _wait_for_healthcheck,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_wait_for_managed_http_ready(**kwargs):
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setenv("CHATLLM_OCR_HEALTHCHECK_URL", "https://chatllm.local:9443/ready/status?full=1")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.wait_for_managed_http_ready",
+        fake_wait_for_managed_http_ready,
+    )
+
+    assert _wait_for_healthcheck(2.5) is True  # nosec B101
+    assert captured["host"] == "chatllm.local"  # nosec B101
+    assert captured["port"] == 9443  # nosec B101
+    assert captured["scheme"] == "https"  # nosec B101
+    assert captured["paths"] == ("/ready/status?full=1",)  # nosec B101
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_chatllm_ocr_backend.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_chatllm_ocr_backend.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import types
+
+import pytest
+
+
+@pytest.mark.unit
+def test_chatllm_available_is_local_only_for_remote_mode(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "remote")
+    monkeypatch.setenv("CHATLLM_OCR_URL", "http://127.0.0.1:8081/v1/chat/completions")
+    monkeypatch.setenv("CHATLLM_OCR_MODEL", "chatllm-vision")
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("availability must stay local-only")
+
+    monkeypatch.setattr(socket, "create_connection", _fail)
+    monkeypatch.setattr("subprocess.run", _fail)
+
+    assert ChatLLMOCRBackend.available() is True  # nosec B101
+
+
+@pytest.mark.unit
+def test_chatllm_managed_availability_requires_explicit_healthcheck_url(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "managed")
+    monkeypatch.setenv("CHATLLM_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("CHATLLM_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("CHATLLM_OCR_PORT", "19091")
+    monkeypatch.setenv("CHATLLM_OCR_SERVER_BINARY", "chatllm-server")
+    monkeypatch.setenv(
+        "CHATLLM_OCR_SERVER_ARGS_JSON",
+        json.dumps(["--model", "{model_path}", "--port", "{port}"]),
+    )
+    monkeypatch.delenv("CHATLLM_OCR_HEALTHCHECK_URL", raising=False)
+
+    assert ChatLLMOCRBackend.available() is False  # nosec B101
+
+
+@pytest.mark.unit
+def test_chatllm_remote_uses_openai_compatible_payload(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "remote")
+    monkeypatch.setenv("CHATLLM_OCR_URL", "http://127.0.0.1:8081/v1/chat/completions")
+    monkeypatch.setenv("CHATLLM_OCR_MODEL", "chatllm-vision")
+    monkeypatch.setenv("CHATLLM_OCR_API_KEY", "secret-token")
+    monkeypatch.setenv("CHATLLM_OCR_MAX_TOKENS", "1024")
+    monkeypatch.setenv("CHATLLM_OCR_TEMPERATURE", "0.25")
+
+    captured: dict[str, object] = {}
+
+    def fake_fetch_json(*, method, url, json, timeout, headers=None, **kwargs):
+        captured.update(
+            {
+                "method": method,
+                "url": url,
+                "json": json,
+                "timeout": timeout,
+                "headers": headers,
+            }
+        )
+        return {"choices": [{"message": {"content": "remote markdown"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.http_client.fetch_json",
+        fake_fetch_json,
+    )
+
+    result = ChatLLMOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+        prompt_preset="doc",
+    )
+
+    payload = captured["json"]
+    assert captured["method"] == "POST"  # nosec B101
+    assert captured["url"] == "http://127.0.0.1:8081/v1/chat/completions"  # nosec B101
+    assert captured["headers"] == {"Authorization": "Bearer secret-token"}  # nosec B101
+    assert payload["model"] == "chatllm-vision"  # nosec B101  # type: ignore[index]
+    assert payload["messages"][0]["content"][0]["text"].startswith("Parse the document")  # nosec B101  # type: ignore[index]
+    image_url = payload["messages"][0]["content"][1]["image_url"]["url"]  # type: ignore[index]
+    assert image_url == f"data:image/png;base64,{base64.b64encode(b'png-bytes').decode('ascii')}"  # nosec B101
+    assert result.text == "remote markdown"  # nosec B101
+    assert result.format == "markdown"  # nosec B101
+    assert result.meta["backend"] == "chatllm"  # nosec B101
+
+
+@pytest.mark.unit
+def test_chatllm_remote_base_url_appends_chat_completions_once(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "remote")
+    monkeypatch.setenv("CHATLLM_OCR_URL", "http://127.0.0.1:8081/v1")
+    monkeypatch.setenv("CHATLLM_OCR_MODEL", "chatllm-vision")
+
+    captured: dict[str, object] = {}
+
+    def fake_fetch_json(*, method, url, json, timeout, headers=None, **kwargs):
+        captured["url"] = url
+        return {"choices": [{"message": {"content": "remote markdown"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.http_client.fetch_json",
+        fake_fetch_json,
+    )
+
+    result = ChatLLMOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+    )
+
+    assert captured["url"] == "http://127.0.0.1:8081/v1/chat/completions"  # nosec B101
+    assert result.text == "remote markdown"  # nosec B101
+
+
+@pytest.mark.unit
+def test_chatllm_cli_json_output_falls_back_to_trailing_json_line(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "cli")
+    monkeypatch.setenv("CHATLLM_OCR_CLI_BINARY", "chatllm")
+    monkeypatch.setenv(
+        "CHATLLM_OCR_CLI_ARGS_JSON",
+        json.dumps(["ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check, timeout):
+        assert cmd[:2] == ["chatllm", "ocr"]  # nosec B101
+        assert os.path.exists(cmd[3]) is True  # nosec B101
+        assert timeout == 60  # nosec B101
+        return types.SimpleNamespace(
+            stdout='markdown prelude\n{"text":"fallback text","blocks":[{"text":"fallback text"}]}',
+            returncode=0,
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = ChatLLMOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="json",
+    )
+
+    assert result.format == "json"  # nosec B101
+    assert result.text == "fallback text"  # nosec B101
+    assert result.raw["blocks"][0]["text"] == "fallback text"  # nosec B101  # type: ignore[index]
+
+
+@pytest.mark.unit
+def test_chatllm_managed_restarts_unhealthy_existing_runtime(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        register_managed_process,
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "managed")
+    monkeypatch.setenv("CHATLLM_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("CHATLLM_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("CHATLLM_OCR_PORT", "19091")
+    monkeypatch.setenv("CHATLLM_OCR_MODEL_PATH", "/models/chatllm.gguf")
+    monkeypatch.setenv("CHATLLM_OCR_SERVER_BINARY", "chatllm-server")
+    monkeypatch.setenv(
+        "CHATLLM_OCR_SERVER_ARGS_JSON",
+        json.dumps(["serve", "--model", "{model_path}", "--port", "{port}"]),
+    )
+    monkeypatch.setenv("CHATLLM_OCR_HEALTHCHECK_URL", "http://127.0.0.1:19091/ready")
+
+    class _ExistingProcess:
+        pid = None
+        returncode = None
+
+        def __init__(self):
+            self.terminated = False
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminated = True
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                raise TimeoutError("still running")
+            return self.returncode
+
+    class _NewProcess:
+        pid = None
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            return 0
+
+    existing = _ExistingProcess()
+    register_managed_process("chatllm", existing, host="127.0.0.1", port=19091)
+
+    readiness = iter([False, True])
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr._wait_for_healthcheck",
+        lambda timeout_total: next(readiness),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.subprocess.Popen",
+        lambda *args, **kwargs: _NewProcess(),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.http_client.fetch_json",
+        lambda **kwargs: {"choices": [{"message": {"content": "managed text"}}]},
+    )
+
+    result = ChatLLMOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="text",
+    )
+
+    assert existing.terminated is True  # nosec B101
+    assert result.text == "managed text"  # nosec B101
+
+
+@pytest.mark.unit
+def test_chatllm_structured_preset_parses_json_without_json_output_format(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "cli")
+    monkeypatch.setenv("CHATLLM_OCR_CLI_BINARY", "chatllm")
+    monkeypatch.setenv(
+        "CHATLLM_OCR_CLI_ARGS_JSON",
+        json.dumps(["ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check, timeout):
+        assert timeout == 60  # nosec B101
+        return types.SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "text": "detected text",
+                    "blocks": [{"text": "detected text", "bbox": [10, 11, 12, 13]}],
+                }
+            ),
+            returncode=0,
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    spotting_result = ChatLLMOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="text",
+        prompt_preset="spotting",
+    )
+    json_result = ChatLLMOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+        prompt_preset="json",
+    )
+
+    assert spotting_result.format == "json"  # nosec B101
+    assert spotting_result.raw["blocks"][0]["bbox"] == [10, 11, 12, 13]  # nosec B101  # type: ignore[index]
+    assert json_result.format == "json"  # nosec B101
+    assert json_result.text == "detected text"  # nosec B101
+
+
+@pytest.mark.unit
+def test_chatllm_cli_json_failure_degrades_with_warning(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "cli")
+    monkeypatch.setenv("CHATLLM_OCR_CLI_BINARY", "chatllm")
+    monkeypatch.setenv(
+        "CHATLLM_OCR_CLI_ARGS_JSON",
+        json.dumps(["ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check, timeout):
+        assert timeout == 60  # nosec B101
+        return types.SimpleNamespace(stdout="plain extracted text", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = ChatLLMOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="json",
+    )
+
+    assert result.format == "text"  # nosec B101
+    assert result.text == "plain extracted text"  # nosec B101
+    assert result.raw == {"raw_output": "plain extracted text"}  # nosec B101
+    assert "could not be parsed" in result.warnings[0]  # nosec B101
+
+
+@pytest.mark.unit
+def test_chatllm_describe_reports_managed_metadata(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr import (
+        ChatLLMOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("CHATLLM_OCR_MODE", "managed")
+    monkeypatch.setenv("CHATLLM_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("CHATLLM_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("CHATLLM_OCR_PORT", "19091")
+    monkeypatch.setenv("CHATLLM_OCR_MODEL_PATH", "/models/chatllm.gguf")
+    monkeypatch.setenv("CHATLLM_OCR_SERVER_BINARY", "chatllm-server")
+    monkeypatch.setenv("CHATLLM_OCR_SERVER_ARGS_JSON", json.dumps(["--model", "{model_path}", "--port", "{port}"]))
+    monkeypatch.setenv("CHATLLM_OCR_HEALTHCHECK_URL", "http://127.0.0.1:19091/ready")
+    monkeypatch.setenv("CHATLLM_OCR_MAX_PAGE_CONCURRENCY", "2")
+    monkeypatch.setenv("CHATLLM_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.setenv("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", "false")
+
+    description = ChatLLMOCRBackend().describe()
+
+    assert description["mode"] == "managed"  # nosec B101
+    assert description["model"] == "/models/chatllm.gguf"  # nosec B101
+    assert description["managed_configured"] is True  # nosec B101
+    assert description["allow_managed_start"] is True  # nosec B101
+    assert description["managed_running"] is False  # nosec B101
+    assert description["healthcheck_url_configured"] is True  # nosec B101
+    assert description["backend_concurrency_cap"] == 2  # nosec B101
+    assert description["auto_eligible"] is True  # nosec B101
+    assert description["auto_high_quality_eligible"] is False  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_llamacpp_ocr_backend.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_llamacpp_ocr_backend.py
@@ -4,9 +4,21 @@ import base64
 import json
 import os
 import socket
+import subprocess
 import types
 
 import pytest
+
+
+@pytest.mark.unit
+def test_llamacpp_extract_message_content_returns_empty_when_choices_missing_or_empty():
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        _extract_message_content,
+    )
+
+    assert _extract_message_content({"choices": []}) == ""  # nosec B101
+    assert _extract_message_content({"choices": None}) == ""  # nosec B101
+    assert _extract_message_content({}) == ""  # nosec B101
 
 
 @pytest.mark.unit
@@ -47,11 +59,85 @@ def test_llamacpp_available_is_true_for_managed_mode_when_managed_start_is_confi
 
 
 @pytest.mark.unit
+def test_llamacpp_managed_restarts_unhealthy_existing_runtime(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        _ensure_managed_runtime,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        register_managed_process,
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "19090")
+    monkeypatch.setenv("LLAMACPP_OCR_MODEL_PATH", "vision.gguf")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--serve", "--host", "{host}", "--port", "{port}"]),
+    )
+
+    class _ExistingProcess:
+        pid = None
+        returncode = None
+
+        def __init__(self):
+            self.terminated = False
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminated = True
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                raise TimeoutError("still running")
+            return self.returncode
+
+    class _NewProcess:
+        pid = None
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            return 0
+
+    existing = _ExistingProcess()
+    register_managed_process("llamacpp", existing, host="127.0.0.1", port=19090)
+
+    readiness = iter([False, True])
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr._wait_for_managed_http_ready",
+        lambda host, port, timeout_total: next(readiness),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.subprocess.Popen",
+        lambda *args, **kwargs: _NewProcess(),
+    )
+
+    host, port = _ensure_managed_runtime()
+
+    assert existing.terminated is True  # nosec B101
+    assert (host, port) == ("127.0.0.1", 19090)  # nosec B101
+    reset_managed_process_registry()
+
+
+@pytest.mark.unit
 def test_llamacpp_auto_mode_prefers_remote_for_invocation(monkeypatch):
     from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
         LlamaCppOCRBackend,
     )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
 
+    reset_managed_process_registry()
     monkeypatch.setenv("LLAMACPP_OCR_MODE", "auto")
     monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
     monkeypatch.setenv("LLAMACPP_OCR_PORT", "8080")
@@ -85,6 +171,7 @@ def test_llamacpp_auto_mode_prefers_remote_for_invocation(monkeypatch):
     assert captured["method"] == "POST"  # nosec B101
     assert captured["url"] == "http://127.0.0.1:8080/v1/chat/completions"  # nosec B101
     assert result.text == "auto remote text"  # nosec B101
+    reset_managed_process_registry()
 
 
 @pytest.mark.unit
@@ -146,7 +233,8 @@ def test_llamacpp_auto_mode_falls_back_to_cli_when_only_cli_is_configured(monkey
         json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
     )
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output, text, check, timeout):
+        assert timeout == 60  # nosec B101
         return types.SimpleNamespace(stdout="auto cli text", returncode=0)
 
     monkeypatch.setattr("subprocess.run", fake_run)
@@ -294,11 +382,12 @@ def test_llamacpp_cli_json_output_prefers_full_json_stdout(monkeypatch):
         json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
     )
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output, text, check, timeout):
         assert cmd[0] == "llama-ocr"  # nosec B101
         assert "{image_path}" not in cmd  # nosec B101
         assert any(str(part).endswith(".png") for part in cmd)  # nosec B101
         assert check is False  # nosec B101
+        assert timeout == 60  # nosec B101
         return types.SimpleNamespace(
             stdout=json.dumps(
                 {
@@ -334,11 +423,12 @@ def test_llamacpp_cli_uses_closed_temp_image_path(monkeypatch):
 
     seen: dict[str, str] = {}
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output, text, check, timeout):
         image_path = cmd[2]
         seen["image_path"] = image_path
         assert image_path.endswith(".png")  # nosec B101
         assert os.path.exists(image_path) is True  # nosec B101
+        assert timeout == 60  # nosec B101
         return types.SimpleNamespace(stdout="plain text", returncode=0)
 
     monkeypatch.setattr("subprocess.run", fake_run)
@@ -353,6 +443,37 @@ def test_llamacpp_cli_uses_closed_temp_image_path(monkeypatch):
 
 
 @pytest.mark.unit
+def test_llamacpp_cli_timeout_returns_empty_result(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "cli")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+    monkeypatch.setenv("LLAMACPP_OCR_TIMEOUT", "7")
+
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, capture_output, text, check, timeout=None):
+        captured["timeout"] = timeout
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="text",
+    )
+
+    assert captured["timeout"] == 7  # nosec B101
+    assert result.text == ""  # nosec B101
+    assert result.format == "text"  # nosec B101
+
+
+@pytest.mark.unit
 def test_llamacpp_structured_preset_parses_json_without_json_output_format(monkeypatch):
     from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
         LlamaCppOCRBackend,
@@ -364,7 +485,8 @@ def test_llamacpp_structured_preset_parses_json_without_json_output_format(monke
         json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
     )
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output, text, check, timeout):
+        assert timeout == 60  # nosec B101
         return types.SimpleNamespace(
             stdout=json.dumps(
                 {
@@ -406,7 +528,8 @@ def test_llamacpp_cli_json_output_falls_back_to_trailing_json_line(monkeypatch):
         json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
     )
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output, text, check, timeout):
+        assert timeout == 60  # nosec B101
         return types.SimpleNamespace(
             stdout='markdown prelude\n{"text":"fallback text","blocks":[{"text":"fallback text"}]}'
         )
@@ -435,8 +558,9 @@ def test_llamacpp_cli_parses_stdout_when_process_exits_nonzero(monkeypatch):
         json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
     )
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output, text, check, timeout):
         assert check is False  # nosec B101
+        assert timeout == 60  # nosec B101
         return types.SimpleNamespace(stdout="best effort markdown", returncode=2)
 
     monkeypatch.setattr("subprocess.run", fake_run)
@@ -462,7 +586,8 @@ def test_llamacpp_cli_json_request_degrades_when_stdout_is_not_json(monkeypatch)
         json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
     )
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output, text, check, timeout):
+        assert timeout == 60  # nosec B101
         return types.SimpleNamespace(stdout="plain extracted text", returncode=0)
 
     monkeypatch.setattr("subprocess.run", fake_run)
@@ -490,7 +615,8 @@ def test_llamacpp_structured_preset_parse_failure_preserves_raw_output(monkeypat
         json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
     )
 
-    def fake_run(cmd, capture_output, text, check):
+    def fake_run(cmd, capture_output, text, check, timeout):
+        assert timeout == 60  # nosec B101
         return types.SimpleNamespace(stdout="plain extracted text", returncode=0)
 
     monkeypatch.setattr("subprocess.run", fake_run)

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_llamacpp_ocr_backend.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_llamacpp_ocr_backend.py
@@ -1,0 +1,588 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import types
+
+import pytest
+
+
+@pytest.mark.unit
+def test_llamacpp_available_is_local_only_for_remote_mode(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "remote")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "8080")
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("availability must stay local-only")
+
+    monkeypatch.setattr(socket, "create_connection", _fail)
+    monkeypatch.setattr("subprocess.run", _fail)
+
+    assert LlamaCppOCRBackend.available() is True  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_available_is_true_for_managed_mode_when_managed_start_is_configured(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "19090")
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["llama-ocr", "--serve"]')
+
+    assert LlamaCppOCRBackend.available() is True  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_auto_mode_prefers_remote_for_invocation(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "auto")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "8080")
+    monkeypatch.setenv("LLAMACPP_OCR_MODEL_PATH", "vision.gguf")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_fetch_json(*, method, url, json, timeout):
+        captured["method"] = method
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return {"choices": [{"message": {"content": "auto remote text"}}]}
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("cli path must not run when remote auto mode is usable")
+
+    monkeypatch.setattr("tldw_Server_API.app.core.http_client.fetch_json", fake_fetch_json)
+    monkeypatch.setattr("subprocess.run", _fail)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+    )
+
+    assert LlamaCppOCRBackend.available() is True  # nosec B101
+    assert LlamaCppOCRBackend().describe()["mode"] == "remote"  # nosec B101
+    assert captured["method"] == "POST"  # nosec B101
+    assert captured["url"] == "http://127.0.0.1:8080/v1/chat/completions"  # nosec B101
+    assert result.text == "auto remote text"  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_auto_mode_prefers_managed_when_managed_start_is_configured(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "auto")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "19090")
+    monkeypatch.setenv("LLAMACPP_OCR_MODEL_PATH", "vision.gguf")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--serve", "--host", "{host}", "--port", "{port}"]),
+    )
+
+    managed_calls = {"count": 0}
+
+    def _fake_ensure_managed_runtime():
+        managed_calls["count"] += 1
+        return ("127.0.0.1", 19090)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr._ensure_managed_runtime",
+        _fake_ensure_managed_runtime,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_fetch_json(*, method, url, json, timeout):
+        captured["url"] = url
+        return {"choices": [{"message": {"content": "auto managed text"}}]}
+
+    monkeypatch.setattr("tldw_Server_API.app.core.http_client.fetch_json", fake_fetch_json)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+    )
+
+    assert LlamaCppOCRBackend.available() is True  # nosec B101
+    assert LlamaCppOCRBackend().describe()["mode"] == "managed"  # nosec B101
+    assert managed_calls["count"] == 1  # nosec B101
+    assert captured["url"] == "http://127.0.0.1:19090/v1/chat/completions"  # nosec B101
+    assert result.text == "auto managed text"  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_auto_mode_falls_back_to_cli_when_only_cli_is_configured(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "auto")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check):
+        return types.SimpleNamespace(stdout="auto cli text", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="text",
+    )
+
+    assert LlamaCppOCRBackend.available() is True  # nosec B101
+    assert LlamaCppOCRBackend().describe()["mode"] == "cli"  # nosec B101
+    assert result.text == "auto cli text"  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_available_is_false_for_managed_mode_without_private_port(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.delenv("LLAMACPP_OCR_PORT", raising=False)
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["llama-ocr", "--serve"]')
+
+    assert LlamaCppOCRBackend.available() is False  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_remote_request_uses_openai_compatible_data_url(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "remote")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "8080")
+    monkeypatch.setenv("LLAMACPP_OCR_MODEL_PATH", "vision.gguf")
+    monkeypatch.setenv("LLAMACPP_OCR_USE_DATA_URL", "true")
+
+    captured: dict[str, object] = {}
+
+    def fake_fetch_json(*, method, url, json, timeout):
+        captured.update(
+            {
+                "method": method,
+                "url": url,
+                "json": json,
+                "timeout": timeout,
+            }
+        )
+        return {"choices": [{"message": {"content": "remote text"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.http_client.fetch_json",
+        fake_fetch_json,
+    )
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+        prompt_preset="doc",
+    )
+
+    payload = captured["json"]
+    assert captured["method"] == "POST"  # nosec B101
+    assert captured["url"] == "http://127.0.0.1:8080/v1/chat/completions"  # nosec B101
+    assert payload["model"] == "vision.gguf"  # nosec B101  # type: ignore[index]
+    assert payload["messages"][0]["content"][0]["text"].startswith("Parse the document")  # nosec B101  # type: ignore[index]
+    image_url = payload["messages"][0]["content"][1]["image_url"]["url"]  # type: ignore[index]
+    assert image_url == f"data:image/png;base64,{base64.b64encode(b'png-bytes').decode('ascii')}"  # nosec B101
+    assert result.text == "remote text"  # nosec B101
+    assert result.format == "markdown"  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_remote_request_cleans_up_temp_file_when_not_using_data_url(monkeypatch, tmp_path):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "remote")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "8080")
+    monkeypatch.setenv("LLAMACPP_OCR_MODEL_PATH", "vision.gguf")
+    monkeypatch.setenv("LLAMACPP_OCR_USE_DATA_URL", "false")
+
+    created_path = tmp_path / "remote-image.png"
+
+    class _TempFile:
+        name = str(created_path)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def write(self, data):
+            created_path.write_bytes(data)
+
+    captured: dict[str, object] = {}
+
+    def fake_tempfile(*args, **kwargs):
+        return _TempFile()
+
+    def fake_fetch_json(*, method, url, json, timeout):
+        captured["image_url"] = json["messages"][0]["content"][1]["image_url"]["url"]
+        assert created_path.exists()  # nosec B101
+        return {"choices": [{"message": {"content": "remote text"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.tempfile.NamedTemporaryFile",
+        fake_tempfile,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.http_client.fetch_json",
+        fake_fetch_json,
+    )
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+        prompt_preset="doc",
+    )
+
+    assert captured["image_url"] == str(created_path)  # nosec B101
+    assert created_path.exists() is False  # nosec B101
+    assert result.text == "remote text"  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_cli_json_output_prefers_full_json_stdout(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "cli")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check):
+        assert cmd[0] == "llama-ocr"  # nosec B101
+        assert "{image_path}" not in cmd  # nosec B101
+        assert any(str(part).endswith(".png") for part in cmd)  # nosec B101
+        assert check is False  # nosec B101
+        return types.SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "text": "json text",
+                    "blocks": [{"text": "json text", "bbox": [1, 2, 3, 4]}],
+                }
+            )
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="json",
+    )
+
+    assert result.format == "json"  # nosec B101
+    assert result.text == "json text"  # nosec B101
+    assert result.raw["blocks"][0]["bbox"] == [1, 2, 3, 4]  # nosec B101  # type: ignore[index]
+
+
+@pytest.mark.unit
+def test_llamacpp_cli_uses_closed_temp_image_path(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "cli")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    seen: dict[str, str] = {}
+
+    def fake_run(cmd, capture_output, text, check):
+        image_path = cmd[2]
+        seen["image_path"] = image_path
+        assert image_path.endswith(".png")  # nosec B101
+        assert os.path.exists(image_path) is True  # nosec B101
+        return types.SimpleNamespace(stdout="plain text", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="text",
+    )
+
+    assert result.text == "plain text"  # nosec B101
+    assert os.path.exists(seen["image_path"]) is False  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_structured_preset_parses_json_without_json_output_format(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "cli")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check):
+        return types.SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "text": "detected text",
+                    "blocks": [{"text": "detected text", "bbox": [10, 11, 12, 13]}],
+                }
+            ),
+            returncode=0,
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    spotting_result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="text",
+        prompt_preset="spotting",
+    )
+    json_result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+        prompt_preset="json",
+    )
+
+    assert spotting_result.format == "json"  # nosec B101
+    assert spotting_result.raw["blocks"][0]["bbox"] == [10, 11, 12, 13]  # nosec B101  # type: ignore[index]
+    assert json_result.format == "json"  # nosec B101
+    assert json_result.text == "detected text"  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_cli_json_output_falls_back_to_trailing_json_line(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "cli")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check):
+        return types.SimpleNamespace(
+            stdout='markdown prelude\n{"text":"fallback text","blocks":[{"text":"fallback text"}]}'
+        )
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="json",
+    )
+
+    assert result.format == "json"  # nosec B101
+    assert result.text == "fallback text"  # nosec B101
+    assert result.raw["blocks"][0]["text"] == "fallback text"  # nosec B101  # type: ignore[index]
+
+
+@pytest.mark.unit
+def test_llamacpp_cli_parses_stdout_when_process_exits_nonzero(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "cli")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check):
+        assert check is False  # nosec B101
+        return types.SimpleNamespace(stdout="best effort markdown", returncode=2)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+    )
+
+    assert result.format == "markdown"  # nosec B101
+    assert result.text == "best effort markdown"  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_cli_json_request_degrades_when_stdout_is_not_json(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "cli")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check):
+        return types.SimpleNamespace(stdout="plain extracted text", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="json",
+    )
+
+    assert result.format == "text"  # nosec B101
+    assert result.text == "plain extracted text"  # nosec B101
+    assert result.raw == {"raw_output": "plain extracted text"}  # nosec B101
+    assert "could not be parsed" in result.warnings[0]  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_structured_preset_parse_failure_preserves_raw_output(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "cli")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        json.dumps(["llama-ocr", "--image", "{image_path}", "--prompt", "{prompt}"]),
+    )
+
+    def fake_run(cmd, capture_output, text, check):
+        return types.SimpleNamespace(stdout="plain extracted text", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = LlamaCppOCRBackend().ocr_image_structured(
+        b"png-bytes",
+        output_format="markdown",
+        prompt_preset="json",
+    )
+
+    assert result.format == "markdown"  # nosec B101
+    assert result.text == "plain extracted text"  # nosec B101
+    assert result.raw == {"raw_output": "plain extracted text"}  # nosec B101
+    assert "could not be parsed" in result.warnings[0]  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_describe_reports_runtime_and_auto_metadata(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "remote")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "8080")
+    monkeypatch.setenv("LLAMACPP_OCR_MODEL_PATH", "vision.gguf")
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["llama-ocr"]')
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "false")
+    monkeypatch.setenv("LLAMACPP_OCR_MAX_PAGE_CONCURRENCY", "6")
+    monkeypatch.setenv("LLAMACPP_OCR_CONFIGURED_FLAGS", "--ctx-size 4096 --temp 0")
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", "false")
+
+    description = LlamaCppOCRBackend().describe()
+
+    assert description["mode"] == "remote"  # nosec B101
+    assert description["model"] == "vision.gguf"  # nosec B101
+    assert description["configured_flags"] == "--ctx-size 4096 --temp 0"  # nosec B101
+    assert description["auto_eligible"] is True  # nosec B101
+    assert description["auto_high_quality_eligible"] is False  # nosec B101
+    assert description["backend_concurrency_cap"] == 6  # nosec B101
+    assert description["configured"] is True  # nosec B101
+    assert description["supports_structured_output"] is True  # nosec B101
+    assert description["supports_json"] is True  # nosec B101
+    assert description["configured_mode"] == "remote"  # nosec B101
+    assert description["url_configured"] is True  # nosec B101
+    assert description["cli_configured"] is True  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_describe_reports_managed_configuration_state(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "19090")
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["llama-ocr", "--serve"]')
+
+    description = LlamaCppOCRBackend().describe()
+
+    assert description["mode"] == "managed"  # nosec B101
+    assert description["allow_managed_start"] is True  # nosec B101
+    assert description["managed_configured"] is True  # nosec B101
+    assert description["managed_running"] is False  # nosec B101
+
+
+@pytest.mark.unit
+def test_llamacpp_describe_reports_active_managed_runtime(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        register_managed_process,
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "false")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "19090")
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["llama-ocr", "--serve"]')
+    register_managed_process("llamacpp", types.SimpleNamespace(pid=101, poll=lambda: None, returncode=None))
+
+    description = LlamaCppOCRBackend().describe()
+
+    assert description["managed_configured"] is True  # nosec B101
+    assert description["managed_running"] is True  # nosec B101
+    assert description["allow_managed_start"] is False  # nosec B101
+    reset_managed_process_registry()

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_adapter.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_adapter.py
@@ -16,8 +16,8 @@ def test_registry_selects_tesseract_when_available(monkeypatch):
     # Simulate tesseract binary present
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/tesseract" if name == "tesseract" else None)
     backend = get_backend(None)  # auto
-    assert backend is not None
-    assert isinstance(backend, TesseractCLIBackend)
+    assert backend is not None  # nosec B101
+    assert isinstance(backend, TesseractCLIBackend)  # nosec B101
 
 
 @pytest.mark.unit
@@ -34,21 +34,33 @@ def test_tesseract_cli_ocr_invocation(monkeypatch):
 
     def fake_run(cmd, capture_output, text, check):
 
-        assert cmd[0] == "tesseract"
-        assert "stdout" in cmd
+        assert cmd[0] == "tesseract"  # nosec B101
+        assert "stdout" in cmd  # nosec B101
         return DummyCompleted(stdout="Hello OCR")
 
     monkeypatch.setattr("subprocess.run", fake_run)
 
     backend = get_backend("tesseract")
-    assert backend is not None
+    assert backend is not None  # nosec B101
     text = backend.ocr_image(b"\x89PNG\r\n....")
-    assert text == "Hello OCR"
+    assert text == "Hello OCR"  # nosec B101
 
 
 @pytest.mark.unit
 def test_registry_resolves_nemotron_parse_when_configured(monkeypatch):
     monkeypatch.setenv("NEMOTRON_VLLM_URL", "http://127.0.0.1:8001/v1/chat/completions")
     backend = get_backend("nemotron_parse")
-    assert backend is not None
-    assert getattr(backend, "name", None) == "nemotron_parse"
+    assert backend is not None  # nosec B101
+    assert getattr(backend, "name", None) == "nemotron_parse"  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_resolves_llamacpp_when_configured(monkeypatch):
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "remote")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "8080")
+
+    backend = get_backend("llamacpp")
+
+    assert backend is not None  # nosec B101
+    assert getattr(backend, "name", None) == "llamacpp"  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_llamacpp_chatllm_pdf_pipeline.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_llamacpp_chatllm_pdf_pipeline.py
@@ -185,6 +185,59 @@ async def test_process_pdf_task_ignores_invalid_backend_concurrency_cap(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_process_pdf_task_filters_internal_backend_details_from_output(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF import PDF_Processing_Lib as pdf_lib
+
+    class _SensitiveBackend(_StubLLMOCROBackend):
+        def describe(self) -> dict[str, Any]:
+            return {
+                "mode": "managed",
+                "configured": True,
+                "runtime": self.name,
+                "backend_concurrency_cap": self.backend_concurrency_cap,
+                "argv": ["llama-server", "--model", "/models/private.gguf"],
+                "host": "127.0.0.1",
+                "port": 19090,
+                "url": "http://127.0.0.1:19090/v1/chat/completions",
+                "prompt": "internal prompt",
+                "model": "/models/private.gguf",
+            }
+
+    stub_backend = _SensitiveBackend(name="llamacpp", backend_concurrency_cap=2)
+
+    monkeypatch.setattr(pdf_lib, "_get_ocr_backend", lambda name=None: stub_backend)
+    monkeypatch.setattr(
+        pdf_lib,
+        "_ocr_pdf_pages",
+        lambda **kwargs: ("OCR PAGE TEXT", 1, 1, [{"text": "OCR PAGE TEXT", "raw": {"page": 1}}]),
+    )
+    monkeypatch.setattr(pdf_lib, "pymupdf4llm_parse_pdf", lambda path: "parser text")
+    monkeypatch.setenv("OCR_PAGE_CONCURRENCY", "4")
+
+    result = await pdf_lib.process_pdf_task(
+        file_bytes=_build_minimal_pdf_bytes(),
+        filename="llamacpp-sensitive.pdf",
+        parser="pymupdf4llm",
+        perform_chunking=False,
+        perform_analysis=False,
+        enable_ocr=True,
+        ocr_backend="llamacpp",
+        ocr_mode="always",
+    )
+
+    ocr_details = result["analysis_details"]["ocr"]
+    assert ocr_details["runtime"] == "llamacpp"  # nosec B101
+    assert ocr_details["backend_concurrency_cap"] == 2  # nosec B101
+    assert "argv" not in ocr_details  # nosec B101
+    assert "host" not in ocr_details  # nosec B101
+    assert "port" not in ocr_details  # nosec B101
+    assert "url" not in ocr_details  # nosec B101
+    assert "prompt" not in ocr_details  # nosec B101
+    assert "model" not in ocr_details  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 @pytest.mark.parametrize("backend_name", ["llamacpp", "chatllm"])
 async def test_process_pdf_task_appends_ocr_text_when_append_branch_is_taken(
     monkeypatch, backend_name: str

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_llamacpp_chatllm_pdf_pipeline.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_llamacpp_chatllm_pdf_pipeline.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.types import OCRResult
+
+
+def _build_minimal_pdf_bytes() -> bytes:
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page(width=300, height=200)
+    page.insert_text((72, 72), "Hello from parser")
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+@dataclass
+class _StubLLMOCROBackend:
+    name: str
+    backend_concurrency_cap: Any
+
+    @classmethod
+    def available(cls) -> bool:
+        return True
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "mode": "remote",
+            "configured": True,
+            "runtime": self.name,
+            "backend_concurrency_cap": self.backend_concurrency_cap,
+        }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_name", ["llamacpp", "chatllm"])
+async def test_process_pdf_task_attaches_structured_ocr_and_preserves_backend_metadata(
+    monkeypatch, backend_name: str
+):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF import PDF_Processing_Lib as pdf_lib
+
+    stub_backend = _StubLLMOCROBackend(name=backend_name, backend_concurrency_cap=2)
+    captured: dict[str, Any] = {}
+
+    def _fake_get_backend(name=None):
+        assert name == backend_name  # nosec B101
+        return stub_backend
+
+    def _fake_ocr_pdf_pages(**kwargs):
+        captured.update(kwargs)
+        return (
+            "OCR PAGE TEXT",
+            2,
+            2,
+            [
+                {
+                    "text": "OCR PAGE TEXT",
+                    "raw": {"backend": backend_name, "page": 1},
+                },
+                {
+                    "text": "OCR PAGE TEXT",
+                    "raw": {"backend": backend_name, "page": 2},
+                },
+            ],
+        )
+
+    monkeypatch.setattr(pdf_lib, "_get_ocr_backend", _fake_get_backend)
+    monkeypatch.setattr(pdf_lib, "_ocr_pdf_pages", _fake_ocr_pdf_pages)
+    monkeypatch.setattr(pdf_lib, "pymupdf4llm_parse_pdf", lambda path: "parser text")
+    monkeypatch.setenv("OCR_PAGE_CONCURRENCY", "8")
+
+    result = await pdf_lib.process_pdf_task(
+        file_bytes=_build_minimal_pdf_bytes(),
+        filename=f"{backend_name}.pdf",
+        parser="pymupdf4llm",
+        perform_chunking=False,
+        perform_analysis=False,
+        enable_ocr=True,
+        ocr_backend=backend_name,
+        ocr_mode="always",
+        ocr_output_format="json",
+        ocr_prompt_preset="json",
+    )
+
+    assert captured["concurrency"] == 2  # nosec B101
+    assert result["content"] == "OCR PAGE TEXT"  # nosec B101
+
+    ocr_details = result["analysis_details"]["ocr"]
+    assert ocr_details["backend"] == backend_name  # nosec B101
+    assert ocr_details["runtime"] == backend_name  # nosec B101
+    assert ocr_details["page_concurrency"] == 2  # nosec B101
+    assert ocr_details["backend_concurrency_cap"] == 2  # nosec B101
+    assert ocr_details["structured"]["pages"][0]["raw"] == {"backend": backend_name, "page": 1}  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_name", ["llamacpp", "chatllm"])
+async def test_process_pdf_task_preserves_parser_text_when_ocr_not_triggered(
+    monkeypatch, backend_name: str
+):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF import PDF_Processing_Lib as pdf_lib
+
+    stub_backend = _StubLLMOCROBackend(name=backend_name, backend_concurrency_cap=1)
+    ocr_calls = {"count": 0}
+
+    def _fake_get_backend(name=None):
+        assert name == backend_name  # nosec B101
+        return stub_backend
+
+    def _fake_ocr_pdf_pages(**kwargs):
+        ocr_calls["count"] += 1
+        return ("unexpected", 1, 1, [OCRResult(text="unexpected", raw={"backend": backend_name}).as_dict()])
+
+    monkeypatch.setattr(pdf_lib, "_get_ocr_backend", _fake_get_backend)
+    monkeypatch.setattr(pdf_lib, "_ocr_pdf_pages", _fake_ocr_pdf_pages)
+    monkeypatch.setattr(pdf_lib, "pymupdf4llm_parse_pdf", lambda path: "parser text is already long enough")
+
+    result = await pdf_lib.process_pdf_task(
+        file_bytes=_build_minimal_pdf_bytes(),
+        filename=f"{backend_name}.pdf",
+        parser="pymupdf4llm",
+        perform_chunking=False,
+        perform_analysis=False,
+        enable_ocr=True,
+        ocr_backend=backend_name,
+        ocr_mode="fallback",
+        ocr_min_page_text_chars=5,
+    )
+
+    assert ocr_calls["count"] == 0  # nosec B101
+    assert result["content"] == "parser text is already long enough"  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_name", ["llamacpp", "chatllm"])
+async def test_process_pdf_task_ignores_invalid_backend_concurrency_cap(
+    monkeypatch, backend_name: str
+):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF import PDF_Processing_Lib as pdf_lib
+
+    stub_backend = _StubLLMOCROBackend(name=backend_name, backend_concurrency_cap="invalid")
+    captured: dict[str, Any] = {}
+
+    def _fake_get_backend(name=None):
+        assert name == backend_name  # nosec B101
+        return stub_backend
+
+    def _fake_ocr_pdf_pages(**kwargs):
+        captured.update(kwargs)
+        return (
+            "OCR PAGE TEXT",
+            1,
+            1,
+            [{"text": "OCR PAGE TEXT", "raw": {"backend": backend_name, "page": 1}}],
+        )
+
+    monkeypatch.setattr(pdf_lib, "_get_ocr_backend", _fake_get_backend)
+    monkeypatch.setattr(pdf_lib, "_ocr_pdf_pages", _fake_ocr_pdf_pages)
+    monkeypatch.setattr(pdf_lib, "pymupdf4llm_parse_pdf", lambda path: "")
+    monkeypatch.setenv("OCR_PAGE_CONCURRENCY", "4")
+
+    result = await pdf_lib.process_pdf_task(
+        file_bytes=_build_minimal_pdf_bytes(),
+        filename=f"{backend_name}.pdf",
+        parser="pymupdf4llm",
+        perform_chunking=False,
+        perform_analysis=False,
+        enable_ocr=True,
+        ocr_backend=backend_name,
+        ocr_mode="always",
+    )
+
+    assert captured["concurrency"] == 4  # nosec B101
+    assert result["analysis_details"]["ocr"]["page_concurrency"] == 4  # nosec B101
+    assert "backend_concurrency_cap" not in result["analysis_details"]["ocr"]  # nosec B101
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_name", ["llamacpp", "chatllm"])
+async def test_process_pdf_task_appends_ocr_text_when_append_branch_is_taken(
+    monkeypatch, backend_name: str
+):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF import PDF_Processing_Lib as pdf_lib
+
+    stub_backend = _StubLLMOCROBackend(name=backend_name, backend_concurrency_cap=2)
+    ocr_calls = {"count": 0}
+    def _fake_get_backend(name=None):
+        assert name == backend_name  # nosec B101
+        return stub_backend
+
+    def _fake_ocr_pdf_pages(**kwargs):
+        ocr_calls["count"] += 1
+        return (
+            "OCR PAGE TEXT",
+            1,
+            1,
+            [{"text": "OCR PAGE TEXT", "raw": {"backend": backend_name, "page": 1}}],
+        )
+
+    monkeypatch.setattr(pdf_lib, "_get_ocr_backend", _fake_get_backend)
+    monkeypatch.setattr(pdf_lib, "_ocr_pdf_pages", _fake_ocr_pdf_pages)
+    monkeypatch.setattr(pdf_lib, "pymupdf4llm_parse_pdf", lambda path: "parser text")
+    monkeypatch.setattr(
+        pdf_lib,
+        "_should_replace_ocr_content",
+        lambda content_text_len, ocr_mode, ocr_min_page_text_chars: False,
+        raising=False,
+    )
+
+    result = await pdf_lib.process_pdf_task(
+        file_bytes=_build_minimal_pdf_bytes(),
+        filename=f"{backend_name}.pdf",
+        parser="pymupdf4llm",
+        perform_chunking=False,
+        perform_analysis=False,
+        enable_ocr=True,
+        ocr_backend=backend_name,
+        ocr_mode="fallback",
+        ocr_min_page_text_chars=20,
+    )
+
+    assert ocr_calls["count"] == 1  # nosec B101
+    assert result["content"] == "parser text\n\nOCR PAGE TEXT"  # nosec B101
+    assert result["parser_used"].endswith("+ocr-appended") is True  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_auto_selection.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_auto_selection.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_registry_auto_requires_llamacpp_auto_eligible(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.delenv("LLAMACPP_OCR_AUTO_ELIGIBLE", raising=False)
+    monkeypatch.delenv("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    assert get_backend("auto") is None  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_selects_llamacpp_when_opted_in(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.delenv("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    backend = get_backend("auto")
+
+    assert backend is not None  # nosec B101
+    assert getattr(backend, "name", None) == "llamacpp"  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_high_quality_requires_high_quality_opt_in(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.delenv("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    assert get_backend("auto_high_quality") is None  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_high_quality_selects_llamacpp_when_opted_in(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", "true")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    backend = get_backend("auto_high_quality")
+
+    assert backend is not None  # nosec B101
+    assert getattr(backend, "name", None) == "llamacpp"  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_high_quality_prefers_llamacpp_in_default_priority(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", "true")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry._resolve_priority_from_config",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    backend = get_backend("auto_high_quality")
+
+    assert backend is not None  # nosec B101
+    assert getattr(backend, "name", None) == "llamacpp"  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_requires_chatllm_auto_eligible(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.delenv("CHATLLM_OCR_AUTO_ELIGIBLE", raising=False)
+    monkeypatch.delenv("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.ChatLLMOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    assert get_backend("auto") is None  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_selects_chatllm_when_opted_in(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.setenv("CHATLLM_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.delenv("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.ChatLLMOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    backend = get_backend("auto")
+
+    assert backend is not None  # nosec B101
+    assert getattr(backend, "name", None) == "chatllm"  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_high_quality_requires_chatllm_high_quality_opt_in(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.setenv("CHATLLM_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.delenv("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", raising=False)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.ChatLLMOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    assert get_backend("auto_high_quality") is None  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_high_quality_selects_chatllm_when_opted_in(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.setenv("CHATLLM_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.setenv("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", "true")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.ChatLLMOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: False),
+    )
+
+    backend = get_backend("auto_high_quality")
+
+    assert backend is not None  # nosec B101
+    assert getattr(backend, "name", None) == "chatllm"  # nosec B101
+
+
+@pytest.mark.unit
+def test_registry_auto_high_quality_prefers_llamacpp_before_chatllm(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry import get_backend
+
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", "true")
+    monkeypatch.setenv("CHATLLM_OCR_AUTO_ELIGIBLE", "true")
+    monkeypatch.setenv("CHATLLM_OCR_AUTO_HIGH_QUALITY_ELIGIBLE", "true")
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.registry._resolve_priority_from_config",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.ChatLLMOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.nemotron_parse.NemotronParseBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.hunyuan_ocr.HunyuanOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.deepseek_ocr.DeepSeekOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.points_reader.PointsReaderBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.tesseract_cli.TesseractCLIBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dots_ocr.DotsOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.dolphin_ocr.DolphinOCRBackend.available",
+        classmethod(lambda cls: True),
+    )
+
+    backend = get_backend("auto_high_quality")
+
+    assert backend is not None  # nosec B101
+    assert getattr(backend, "name", None) == "llamacpp"  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_discovery.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_discovery.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+
+def test_list_ocr_backends_enriches_llamacpp_discovery(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import ocr as ocr_mod
+
+    class _StubLlamaCppBackend:
+        def describe(self):
+            return {
+                "mode": "remote",
+                "configured_mode": "auto",
+                "model": "vision.gguf",
+                "configured": True,
+                "supports_structured_output": True,
+                "supports_json": True,
+                "configured_flags": "--ctx-size 4096",
+                "auto_eligible": True,
+                "auto_high_quality_eligible": True,
+                "url_configured": True,
+                "managed_configured": False,
+                "managed_running": False,
+                "allow_managed_start": False,
+                "cli_configured": True,
+                "backend_concurrency_cap": 3,
+            }
+
+    monkeypatch.setattr(
+        ocr_mod,
+        "_list_backends",
+        lambda: {"llamacpp": {"available": True}},
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend",
+        _StubLlamaCppBackend,
+    )
+
+    payload = ocr_mod.list_ocr_backends()
+
+    assert payload["llamacpp"]["available"] is True  # nosec B101
+    assert payload["llamacpp"]["mode"] == "remote"  # nosec B101
+    assert payload["llamacpp"]["configured_mode"] == "auto"  # nosec B101
+    assert payload["llamacpp"]["model"] == "vision.gguf"  # nosec B101
+    assert payload["llamacpp"]["configured"] is True  # nosec B101
+    assert payload["llamacpp"]["supports_structured_output"] is True  # nosec B101
+    assert payload["llamacpp"]["supports_json"] is True  # nosec B101
+    assert payload["llamacpp"]["configured_flags"] == "--ctx-size 4096"  # nosec B101
+    assert payload["llamacpp"]["auto_eligible"] is True  # nosec B101
+    assert payload["llamacpp"]["auto_high_quality_eligible"] is True  # nosec B101
+    assert payload["llamacpp"]["url_configured"] is True  # nosec B101
+    assert payload["llamacpp"]["managed_configured"] is False  # nosec B101
+    assert payload["llamacpp"]["cli_configured"] is True  # nosec B101
+    assert payload["llamacpp"]["backend_concurrency_cap"] == 3  # nosec B101
+
+
+def test_list_ocr_backends_enriches_chatllm_discovery(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import ocr as ocr_mod
+
+    class _StubChatLLMBackend:
+        def describe(self):
+            return {
+                "mode": "managed",
+                "configured": True,
+                "supports_structured_output": True,
+                "supports_json": True,
+                "auto_eligible": True,
+                "auto_high_quality_eligible": False,
+                "managed_configured": True,
+                "managed_running": False,
+                "allow_managed_start": True,
+                "url_configured": False,
+                "healthcheck_url_configured": True,
+                "cli_configured": False,
+                "backend_concurrency_cap": 2,
+                "model": "/models/chatllm.gguf",
+            }
+
+    monkeypatch.setattr(
+        ocr_mod,
+        "_list_backends",
+        lambda: {"chatllm": {"available": True}},
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.ChatLLMOCRBackend",
+        _StubChatLLMBackend,
+    )
+
+    payload = ocr_mod.list_ocr_backends()
+
+    assert payload["chatllm"]["available"] is True  # nosec B101
+    assert payload["chatllm"]["mode"] == "managed"  # nosec B101
+    assert payload["chatllm"]["configured"] is True  # nosec B101
+    assert payload["chatllm"]["supports_structured_output"] is True  # nosec B101
+    assert payload["chatllm"]["supports_json"] is True  # nosec B101
+    assert payload["chatllm"]["auto_eligible"] is True  # nosec B101
+    assert payload["chatllm"]["auto_high_quality_eligible"] is False  # nosec B101
+    assert payload["chatllm"]["managed_configured"] is True  # nosec B101
+    assert payload["chatllm"]["healthcheck_url_configured"] is True  # nosec B101
+    assert payload["chatllm"]["backend_concurrency_cap"] == 2  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_discovery.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_discovery.py
@@ -1,6 +1,42 @@
 from __future__ import annotations
 
 
+def test_list_ocr_backends_matches_response_schema(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import ocr as ocr_mod
+    from tldw_Server_API.app.api.v1.schemas.ocr_schemas import OCRBackendsResponse
+
+    monkeypatch.setattr(
+        ocr_mod,
+        "_list_backends",
+        lambda: {
+            "llamacpp": {"available": True},
+            "mineru": {"available": False},
+        },
+    )
+    monkeypatch.setattr(
+        ocr_mod,
+        "_describe_mineru_backend",
+        lambda: {
+            "available": False,
+            "pdf_only": True,
+            "document_level": True,
+            "opt_in_only": True,
+            "supports_per_page_metrics": True,
+            "mode": "cli",
+            "timeout_sec": 30,
+            "max_concurrency": 2,
+            "tmp_root": "/tmp/mineru",
+            "debug_save_raw": False,
+        },
+    )
+
+    payload = ocr_mod.list_ocr_backends()
+    validated = OCRBackendsResponse.model_validate(payload)
+
+    assert validated.root["llamacpp"].available is True  # nosec B101
+    assert validated.root["mineru"].timeout_sec == 30  # nosec B101
+
+
 def test_list_ocr_backends_enriches_llamacpp_discovery(monkeypatch):
     from tldw_Server_API.app.api.v1.endpoints import ocr as ocr_mod
 

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_discovery.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_discovery.py
@@ -96,3 +96,49 @@ def test_list_ocr_backends_enriches_chatllm_discovery(monkeypatch):
     assert payload["chatllm"]["managed_configured"] is True  # nosec B101
     assert payload["chatllm"]["healthcheck_url_configured"] is True  # nosec B101
     assert payload["chatllm"]["backend_concurrency_cap"] == 2  # nosec B101
+
+
+def test_list_ocr_backends_records_llamacpp_discovery_errors(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import ocr as ocr_mod
+
+    class _BrokenLlamaCppBackend:
+        def describe(self):
+            raise ValueError("llama describe failed")
+
+    monkeypatch.setattr(
+        ocr_mod,
+        "_list_backends",
+        lambda: {"llamacpp": {"available": True}},
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.LlamaCppOCRBackend",
+        _BrokenLlamaCppBackend,
+    )
+
+    payload = ocr_mod.list_ocr_backends()
+
+    assert payload["llamacpp"]["available"] is True  # nosec B101
+    assert payload["llamacpp"]["error"] == "llama describe failed"  # nosec B101
+
+
+def test_list_ocr_backends_records_chatllm_discovery_errors(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import ocr as ocr_mod
+
+    class _BrokenChatLLMBackend:
+        def describe(self):
+            raise ValueError("chatllm describe failed")
+
+    monkeypatch.setattr(
+        ocr_mod,
+        "_list_backends",
+        lambda: {"chatllm": {"available": False}},
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.chatllm_ocr.ChatLLMOCRBackend",
+        _BrokenChatLLMBackend,
+    )
+
+    payload = ocr_mod.list_ocr_backends()
+
+    assert payload["chatllm"]["available"] is False  # nosec B101
+    assert payload["chatllm"]["error"] == "chatllm describe failed"  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_managed.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_managed.py
@@ -68,7 +68,7 @@ def test_managed_mode_reuses_existing_ocr_process(monkeypatch):
     )
     monkeypatch.setattr(
         "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr._wait_for_managed_http_ready",
-        lambda host, port, timeout_total: False,
+        lambda host, port, timeout_total: True,
     )
     monkeypatch.setattr(
         "tldw_Server_API.app.core.http_client.fetch_json",

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_managed.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_managed.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+@pytest.mark.unit
+def test_managed_mode_refuses_start_when_disabled(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "false")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "18080")
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["llama-ocr", "--host", "{host}", "--port", "{port}"]')
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("managed startup should be refused before spawning")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.subprocess.Popen",
+        _fail,
+    )
+
+    with pytest.raises(RuntimeError, match="managed OCR startup is disabled"):
+        LlamaCppOCRBackend().ocr_image_structured(b"png-bytes", output_format="text")
+
+    reset_managed_process_registry()
+
+
+@pytest.mark.unit
+def test_managed_mode_reuses_existing_ocr_process(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        register_managed_process,
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+
+    process = types.SimpleNamespace(pid=999, poll=lambda: None, returncode=None)
+    register_managed_process("llamacpp", process, host="127.0.0.1", port=18081)
+
+    spawned: list[object] = []
+
+    def fake_popen(*args, **kwargs):
+        spawned.append((args, kwargs))
+        raise AssertionError("existing OCR-managed process should be reused")
+
+    def fake_fetch_json(*, method, url, json, timeout):
+        assert url == "http://127.0.0.1:18081/v1/chat/completions"  # nosec B101
+        return {"choices": [{"message": {"content": "managed text"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.subprocess.Popen",
+        fake_popen,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr._wait_for_managed_http_ready",
+        lambda host, port, timeout_total: False,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.http_client.fetch_json",
+        fake_fetch_json,
+    )
+
+    result = LlamaCppOCRBackend().ocr_image_structured(b"png-bytes", output_format="text")
+
+    assert spawned == []  # nosec B101
+    assert result.text == "managed text"  # nosec B101
+    reset_managed_process_registry()
+
+
+@pytest.mark.unit
+def test_managed_mode_uses_private_ocr_port_not_admin_port(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "19090")
+    monkeypatch.setenv("LLAMACPP_SERVER_PORT", "8080")
+    monkeypatch.setenv(
+        "LLAMACPP_OCR_ARGV",
+        '["llama-ocr", "--host", "{host}", "--port", "{port}", "--model", "{model_path}"]',
+    )
+    monkeypatch.setenv("LLAMACPP_OCR_MODEL_PATH", "vision.gguf")
+
+    spawned: list[list[str]] = []
+
+    class _Process:
+        pid = 1234
+        returncode = None
+
+        def poll(self):
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        spawned.append(list(cmd))
+        return _Process()
+
+    def fake_wait_for_ready(host, port, timeout_total):
+        assert host == "127.0.0.1"  # nosec B101
+        assert port == 19090  # nosec B101
+        assert timeout_total > 0  # nosec B101
+        return True
+
+    def fake_fetch_json(*, method, url, json, timeout):
+        assert url == "http://127.0.0.1:19090/v1/chat/completions"  # nosec B101
+        return {"choices": [{"message": {"content": "managed text"}}]}
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.subprocess.Popen",
+        fake_popen,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr._wait_for_managed_http_ready",
+        fake_wait_for_ready,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.http_client.fetch_json",
+        fake_fetch_json,
+    )
+
+    result = LlamaCppOCRBackend().ocr_image_structured(b"png-bytes", output_format="text")
+
+    assert result.text == "managed text"  # nosec B101
+    assert "--port" in spawned[0]  # nosec B101
+    assert "19090" in spawned[0]  # nosec B101
+    assert "8080" not in spawned[0]  # nosec B101
+    reset_managed_process_registry()
+
+
+@pytest.mark.unit
+def test_managed_mode_rejects_admin_port_reuse(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "8080")
+    monkeypatch.setenv("LLAMACPP_SERVER_PORT", "8080")
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["llama-ocr", "--host", "{host}", "--port", "{port}"]')
+
+    with pytest.raises(RuntimeError, match="OCR-private port"):
+        LlamaCppOCRBackend().ocr_image_structured(b"png-bytes", output_format="text")
+
+    reset_managed_process_registry()
+
+
+@pytest.mark.unit
+def test_managed_startup_failure_terminates_process_and_leaves_no_registry_entry(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr import (
+        LlamaCppOCRBackend,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+        get_managed_process_record,
+        reset_managed_process_registry,
+    )
+
+    reset_managed_process_registry()
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_HOST", "127.0.0.1")
+    monkeypatch.setenv("LLAMACPP_OCR_PORT", "19091")
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["llama-ocr", "--host", "{host}", "--port", "{port}"]')
+
+    class _Process:
+        pid = None
+        returncode = None
+
+        def __init__(self):
+            self.terminated = False
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminated = True
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                raise TimeoutError("still starting")
+            return self.returncode
+
+    process = _Process()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr.subprocess.Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.backends.llamacpp_ocr._wait_for_managed_http_ready",
+        lambda host, port, timeout_total: False,
+    )
+
+    with pytest.raises(RuntimeError, match="did not become ready"):
+        LlamaCppOCRBackend().ocr_image_structured(b"png-bytes", output_format="text")
+
+    assert process.terminated is True  # nosec B101
+    assert get_managed_process_record("llamacpp") is None  # nosec B101
+    reset_managed_process_registry()

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_support.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_support.py
@@ -181,3 +181,61 @@ def test_managed_process_registry_is_keyed_by_backend_name():
     assert clear_managed_process("llamacpp") is process_a  # nosec B101
     assert get_managed_process("llamacpp") is None  # nosec B101
     assert get_managed_process("chatllm") is process_b  # nosec B101
+
+
+@pytest.mark.unit
+def test_wait_for_managed_http_ready_uses_https_connection_when_requested(monkeypatch):
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR import runtime_support as runtime_mod
+
+    captured: dict[str, object] = {"https_calls": 0, "http_calls": 0}
+
+    class _Response:
+        status = 200
+
+        def read(self):
+            return b""
+
+    class _HTTPSConnection:
+        def __init__(self, host, port, timeout):
+            captured["https_calls"] = captured.get("https_calls", 0) + 1
+            captured["host"] = host
+            captured["port"] = port
+            captured["timeout"] = timeout
+
+        def request(self, method, path):
+            captured["method"] = method
+            captured["path"] = path
+
+        def getresponse(self):
+            return _Response()
+
+        def close(self):
+            return None
+
+    class _HTTPConnection:
+        def __init__(self, host, port, timeout):
+            captured["http_calls"] = captured.get("http_calls", 0) + 1
+
+        def request(self, method, path):
+            raise AssertionError("HTTPConnection should not be used for https probes")
+
+        def getresponse(self):
+            raise AssertionError("HTTPConnection should not be used for https probes")
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(runtime_mod.http.client, "HTTPSConnection", _HTTPSConnection)
+    monkeypatch.setattr(runtime_mod.http.client, "HTTPConnection", _HTTPConnection)
+
+    assert runtime_mod.wait_for_managed_http_ready(
+        host="chatllm.local",
+        port=9443,
+        scheme="https",
+        timeout_total=0.5,
+        interval=0.1,
+        paths=("/ready",),
+    ) is True  # nosec B101
+    assert captured["https_calls"] == 1  # nosec B101
+    assert captured["http_calls"] == 0  # nosec B101
+    assert captured["path"] == "/ready"  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_support.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_support.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from tldw_Server_API.app.core.Ingestion_Media_Processing.OCR.runtime_support import (
+    CLIOCRProfile,
+    ManagedOCRProfile,
+    RemoteOCRProfile,
+    clear_managed_process,
+    effective_page_concurrency,
+    get_managed_process,
+    is_profile_available,
+    load_ocr_runtime_profiles,
+    register_managed_process,
+    render_argv_template,
+    reset_managed_process_registry,
+)
+
+
+@pytest.mark.unit
+def test_remote_availability_depends_on_config_only(monkeypatch):
+    profile = RemoteOCRProfile(
+        mode="remote",
+        host="127.0.0.1",
+        port=9999,
+        allow_managed_start=False,
+        max_page_concurrency=4,
+        argv=("{model_path}", "{image_path}"),
+    )
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("reachability probes are not allowed")
+
+    monkeypatch.setattr(socket, "create_connection", _fail)
+    monkeypatch.setattr("subprocess.run", _fail)
+
+    assert is_profile_available(profile) is True  # nosec B101
+
+
+@pytest.mark.unit
+def test_is_profile_available_uses_managed_registry_when_backend_matches():
+    reset_managed_process_registry()
+    profile = ManagedOCRProfile(
+        mode="managed",
+        allow_managed_start=False,
+        max_page_concurrency=2,
+        argv=(),
+    )
+    process = object()
+    register_managed_process("llamacpp", process)
+
+    assert is_profile_available(profile) is False  # nosec B101
+    assert is_profile_available(profile, backend_name="llamacpp") is True  # nosec B101
+    assert is_profile_available(profile, backend_name="chatllm") is False  # nosec B101
+
+
+@pytest.mark.unit
+def test_effective_page_concurrency_uses_global_and_backend_caps():
+    assert effective_page_concurrency(8, 3) == 3  # nosec B101
+    assert effective_page_concurrency(3, 8) == 3  # nosec B101
+    assert effective_page_concurrency(None, 5) == 5  # nosec B101
+    assert effective_page_concurrency(5, None) == 5  # nosec B101
+    assert effective_page_concurrency(None, None) == 1  # nosec B101
+
+
+@pytest.mark.unit
+def test_render_argv_template_replaces_placeholders_without_shell_execution():
+    rendered = render_argv_template(
+        [
+            "ocr-bin",
+            "--model",
+            "{model_path}",
+            "--image",
+            "{image_path}",
+            "--prompt",
+            "{prompt}",
+            "--host",
+            "{host}",
+            "--port",
+            "{port}",
+        ],
+        model_path="/opt/models/ocr model.bin",
+        image_path="/var/run/ocr/input 01.png;rm -rf /",
+        prompt='read literally $(echo pwned) & "quoted"',
+        host="127.0.0.1",
+        port=8123,
+    )
+
+    expected = [
+        "ocr-bin",
+        "--model",
+        "/opt/models/ocr model.bin",
+        "--image",
+        "/var/run/ocr/input 01.png;rm -rf /",
+        "--prompt",
+        'read literally $(echo pwned) & "quoted"',
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8123",
+    ]
+    assert rendered == expected  # nosec B101
+
+
+@pytest.mark.unit
+def test_render_argv_template_treats_replacement_values_literally():
+    rendered = render_argv_template(
+        ["ocr-bin", "--prompt", "{prompt}", "--host", "{host}", "--port", "{port}"],
+        prompt="mention {host} and {port} literally",
+        host="alpha",
+        port=8123,
+    )
+
+    assert rendered == [
+        "ocr-bin",
+        "--prompt",
+        "mention {host} and {port} literally",
+        "--host",
+        "alpha",
+        "--port",
+        "8123",
+    ]  # nosec B101
+
+
+@pytest.mark.unit
+def test_load_ocr_runtime_profiles_defaults_to_os_environ(monkeypatch):
+    monkeypatch.setenv("LLAMACPP_OCR_MODE", "managed")
+    monkeypatch.setenv("LLAMACPP_OCR_ALLOW_MANAGED_START", "true")
+    monkeypatch.setenv("LLAMACPP_OCR_MAX_PAGE_CONCURRENCY", "12")
+    monkeypatch.setenv("LLAMACPP_OCR_ARGV", '["ocr-cli", "{image_path}", "{prompt}"]')
+
+    profiles = load_ocr_runtime_profiles("LLAMACPP")
+
+    assert isinstance(profiles.active, ManagedOCRProfile)  # nosec B101
+    assert profiles.active.allow_managed_start is True  # nosec B101
+    assert profiles.active.max_page_concurrency == 12  # nosec B101
+    assert profiles.active.argv == ("ocr-cli", "{image_path}", "{prompt}")  # nosec B101
+
+
+@pytest.mark.unit
+def test_load_ocr_runtime_profiles_parses_env_inputs():
+    env = {
+        "LLAMACPP_OCR_MODE": "managed",
+        "LLAMACPP_OCR_ALLOW_MANAGED_START": "true",
+        "LLAMACPP_OCR_MAX_PAGE_CONCURRENCY": "12",
+        "LLAMACPP_OCR_ARGV": '["ocr-cli", "{image_path}", "{prompt}"]',
+    }
+
+    profiles = load_ocr_runtime_profiles("LLAMACPP", env=env)
+
+    assert isinstance(profiles.active, ManagedOCRProfile)  # nosec B101
+    assert profiles.active.allow_managed_start is True  # nosec B101
+    assert profiles.active.max_page_concurrency == 12  # nosec B101
+    assert profiles.active.argv == ("ocr-cli", "{image_path}", "{prompt}")  # nosec B101
+
+
+@pytest.mark.unit
+def test_load_ocr_runtime_profiles_defaults_page_concurrency_to_one():
+    profiles = load_ocr_runtime_profiles(
+        "LLAMACPP",
+        env={"LLAMACPP_OCR_MODE": "remote"},
+    )
+
+    assert profiles.active.max_page_concurrency == 1  # nosec B101
+
+
+@pytest.mark.unit
+def test_managed_process_registry_is_keyed_by_backend_name():
+    reset_managed_process_registry()
+    process_a = object()
+    process_b = object()
+
+    register_managed_process("llamacpp", process_a)
+    register_managed_process("chatllm", process_b)
+
+    assert get_managed_process("llamacpp") is process_a  # nosec B101
+    assert get_managed_process("chatllm") is process_b  # nosec B101
+
+    assert clear_managed_process("llamacpp") is process_a  # nosec B101
+    assert get_managed_process("llamacpp") is None  # nosec B101
+    assert get_managed_process("chatllm") is process_b  # nosec B101


### PR DESCRIPTION
## Summary
- add shared OCR runtime support plus llama.cpp and ChatLLM OCR backends with remote, managed, cli, and auto selection behavior
- integrate backend-local OCR concurrency caps into the PDF pipeline and surface richer OCR backend discovery metadata
- add OCR docs and targeted runtime/PDF regression coverage for llama.cpp and ChatLLM

## Test Plan
- source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_support.py tldw_Server_API/tests/Media_Ingestion_Modification/test_llamacpp_ocr_backend.py tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_discovery.py tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_llamacpp_chatllm_pdf_pipeline.py tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_structured_output.py tldw_Server_API/tests/Media_Ingestion_Modification/test_mineru_pdf_pipeline.py
- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/runtime_support.py tldw_Server_API/app/core/Ingestion_Media_Processing/OCR/backends/llamacpp_ocr.py tldw_Server_API/app/api/v1/endpoints/ocr.py tldw_Server_API/app/core/Ingestion_Media_Processing/PDF/PDF_Processing_Lib.py tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_support.py tldw_Server_API/tests/Media_Ingestion_Modification/test_llamacpp_ocr_backend.py tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_runtime_discovery.py tldw_Server_API/tests/Media_Ingestion_Modification/test_ocr_llamacpp_chatllm_pdf_pipeline.py -f json -o /tmp/bandit_ocr_task5.json
- git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/ocr-llamacpp-chatllm-backends diff --check