### PR TITLE
fix: remediate character full-stack findings

### DIFF
--- a/Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md
+++ b/Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md
@@ -1,0 +1,873 @@
+# AuthNZ Full Module Review Execution Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Execute the approved full AuthNZ review and deliver one findings-first, evidence-backed report plus staged review artifacts covering core AuthNZ, immediate API integration points, representative claim-first consumers, tests, and documentation contracts.
+
+**Architecture:** This is a read-first, boundary-aware audit plan. Execution starts by locking the current workspace baseline, creating staged review artifacts under `Docs/superpowers/reviews/authnz-full-module/`, and fixing the final report contract before deep reading begins. It then inspects runtime authentication and authorization behavior, persistence and configuration safety, and test or documentation alignment, using only the smallest targeted verification needed to confirm or weaken specific claims. Narrow proof-of-fix patches are not pre-authored in this plan; if a critical localized issue is confirmed, preserve the pre-fix evidence and write a dedicated remediation plan for that exact defect instead of improvising code changes from the review plan.
+
+**Tech Stack:** Python 3, FastAPI, pytest, git, ripgrep, sed, Markdown
+
+---
+
+## Scope Lock
+
+Keep these decisions fixed during execution:
+
+- review the current working tree by default, not only `HEAD`
+- label any finding that depends on uncommitted local changes
+- keep code scope centered on `tldw_Server_API/app/core/AuthNZ`, `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`, and `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- inspect representative admin or control-surface endpoints only when they directly use claim-first AuthNZ dependencies, are high-fan-out consumers of AuthNZ behavior, or emerge as regression hotspots from current evidence
+- use `tldw_Server_API/tests/AuthNZ`, `tldw_Server_API/tests/AuthNZ_SQLite`, `tldw_Server_API/tests/AuthNZ_Postgres`, `tldw_Server_API/tests/AuthNZ_Unit`, and `tldw_Server_API/tests/AuthNZ_Federation` as the primary test evidence set
+- start documentation review from the bounded seed set in the approved spec and expand only when a seed document points to another behavior-defining contract
+- separate `Confirmed finding`, `Probable risk`, `Improvement`, and `Open question`
+- keep pre-fix evidence in the stage artifacts before any remediation branch is considered
+- do not modify repository source files during this review execution plan
+- do not run broad blanket suites; use the smallest targeted verification needed to answer a concrete claim
+- keep blind spots explicit instead of implying unreviewed enterprise, federation, or secret-backend paths are safe
+- if a dedicated review worktree is not already available, execute this plan in the current workspace and rely on the Stage 1 baseline to distinguish pre-existing local changes from reviewed behavior
+
+## Review File Map
+
+**Create during execution:**
+- `Docs/superpowers/reviews/authnz-full-module/README.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage5-final-synthesis-roadmap-and-patch-decisions.md`
+
+**Spec and plan inputs:**
+- `Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md`
+- `Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md`
+
+**Primary documentation and contract references:**
+- `tldw_Server_API/app/core/AuthNZ/README.md`
+- `Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md`
+- `Docs/API-related/User_Registration_API_Documentation.md`
+- `Docs/Operations/Env_Vars.md`
+- `Docs/Getting_Started/QUICKSTART.md`
+- `Docs/Getting_Started/TROUBLESHOOTING.md`
+
+**Primary source files to inspect first:**
+- `tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py`
+- `tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py`
+- `tldw_Server_API/app/core/AuthNZ/jwt_service.py`
+- `tldw_Server_API/app/core/AuthNZ/session_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/token_blacklist.py`
+- `tldw_Server_API/app/core/AuthNZ/password_service.py`
+- `tldw_Server_API/app/core/AuthNZ/mfa_service.py`
+- `tldw_Server_API/app/core/AuthNZ/lockout_tracker.py`
+- `tldw_Server_API/app/core/AuthNZ/auth_governor.py`
+- `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/virtual_keys.py`
+- `tldw_Server_API/app/core/AuthNZ/permissions.py`
+- `tldw_Server_API/app/core/AuthNZ/rbac.py`
+- `tldw_Server_API/app/core/AuthNZ/org_rbac.py`
+- `tldw_Server_API/app/core/AuthNZ/orgs_teams.py`
+- `tldw_Server_API/app/core/AuthNZ/settings.py`
+- `tldw_Server_API/app/core/AuthNZ/database.py`
+- `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- `tldw_Server_API/app/core/AuthNZ/initialize.py`
+- `tldw_Server_API/app/core/AuthNZ/migrate_to_multiuser.py`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/auth.py`
+
+**Representative integration consumers to inspect only if selected by Stage 1 criteria:**
+- `tldw_Server_API/app/api/v1/endpoints/users.py`
+- `tldw_Server_API/app/api/v1/endpoints/privileges.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_sessions_mfa.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_orgs.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_registration.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_system.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_settings.py`
+
+**Representative repository files to inspect during persistence review:**
+- `tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/sessions_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/token_blacklist_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/users_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/mfa_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/rbac_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/orgs_teams_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/quotas_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/rate_limits_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/user_provider_secrets_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/org_provider_secrets_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/byok_oauth_state_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/identity_provider_repo.py`
+
+**High-value existing tests to reuse during the review:**
+- `tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_jwt_service_rs256.py`
+- `tldw_Server_API/tests/AuthNZ/property/test_jwt_service_property.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_session_manager_configured_key.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_session_revocation_blacklist.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_session_manager_token_metadata.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_session_refresh_cache.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_lockout_tracker.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_api_keys.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_jwt_membership.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_auth_deps_precedence.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_jwt_happy_path.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_api_key_happy_path.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_state_consistency.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_real_rate_limiter.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_jwt_refresh_rotation_blacklist.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_single_user_claims_permissions.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_rbac_effective_permissions.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_mfa_service.py`
+- `tldw_Server_API/tests/AuthNZ_Postgres/test_auth_enhanced_mfa.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_deps.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_route_level.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_permissions_claim_first.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_claim_first_single_user_mode_guardrail.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_admin_roles_single_user_claims.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_api_keys.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_lockout_scope.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_usage_truthiness.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_migrate_to_multiuser_review_fixes.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_api_keys_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_sessions_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_token_blacklist_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_quotas_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_rate_limits_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_orgs_teams_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_sessions_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_token_blacklist_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_quotas_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_rate_limits_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_orgs_teams_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_virtual_keys_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_byok_runtime_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_byok_rotation_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_api_keys_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_token_blacklist_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_quotas_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_rate_limits_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_orgs_teams_repo_postgres.py`
+
+**Scratch artifacts allowed during execution:**
+- `/tmp/authnz_full_review_inventory.txt`
+- `/tmp/authnz_full_runtime_pytest.log`
+- `/tmp/authnz_full_persistence_pytest.log`
+- `/tmp/authnz_full_contract_pytest.log`
+- `/tmp/authnz_full_verification_notes.md`
+
+## Stage Overview
+
+## Stage 1: Baseline and Boundary Inventory
+**Goal:** Lock the current workspace baseline, create stable review artifacts, inventory the exact scoped files, and fix the final findings contract before deep reading begins.
+**Success Criteria:** Review artifacts exist under `Docs/superpowers/reviews/authnz-full-module/`, the baseline and inventory are recorded, the representative endpoint selection rule is operationalized, and the final response contract is frozen.
+**Tests:** No pytest execution in this stage.
+**Status:** Not Started
+
+## Stage 2: Runtime Authentication and Authorization Analysis
+**Goal:** Inspect credential resolution, JWT and session behavior, endpoint dependency chains, claim-first authorization, and stateful login security controls first.
+**Success Criteria:** Runtime and authz candidate findings are tied to exact files, tests, and verification commands, with confirmed findings separated cleanly from probable risks.
+**Tests:** Run only the smallest runtime and authz test slices listed below that materially confirm or weaken candidate findings.
+**Status:** Not Started
+
+## Stage 3: Persistence, Migrations, and Configuration Safety
+**Goal:** Review settings precedence, database routing, migration safety, initialization paths, and backend-specific repository behavior.
+**Success Criteria:** SQLite or PostgreSQL divergence, schema or migration hazards, and fail-open or fail-closed configuration issues are documented with direct code evidence and representative test coverage.
+**Tests:** Run only the smallest persistence, repo, migration, or backend-selection test slices needed to settle specific claims.
+**Status:** Not Started
+
+## Stage 4: Tests, Docs Drift, and Verification Gaps
+**Goal:** Compare the reviewed runtime behavior against documentation claims and the actual AuthNZ test surface, then identify missing, weak, or misleading coverage.
+**Success Criteria:** Documentation drift and test gaps are ranked by operational or regression risk, and unverified enterprise or federation paths are explicitly downgraded when direct validation is not available.
+**Tests:** Run only the narrow contract tests needed to reconcile code, docs, and existing test claims.
+**Status:** Not Started
+
+## Stage 5: Final Synthesis, Roadmap, and Patch Decisions
+**Goal:** Deduplicate findings across stages, produce the final findings-first report and roadmap, and decide whether any issue warrants a separate remediation branch.
+**Success Criteria:** The final review output follows the approved structure, every major claim is backed by code inspection, test inspection, verification, or an explicit confidence downgrade, and any patch candidate is either rejected or spun into a separate remediation plan with pre-fix evidence preserved.
+**Tests:** No new blanket suites. Reuse earlier verification output and run only one last narrow slice if a single claim remains unresolved.
+**Status:** Not Started
+
+### Task 1: Prepare Review Artifacts and Capture the Baseline
+
+**Files:**
+- Create: `Docs/superpowers/reviews/authnz-full-module/README.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage5-final-synthesis-roadmap-and-patch-decisions.md`
+- Inspect: `Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md`
+- Inspect: `Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md`
+- Test: none
+
+- [ ] **Step 1: Create the review output directory**
+
+Run:
+```bash
+mkdir -p Docs/superpowers/reviews/authnz-full-module
+```
+
+Expected: the `Docs/superpowers/reviews/authnz-full-module` directory exists and no application source files change.
+
+- [ ] **Step 2: Create one markdown file per stage with a fixed evidence template**
+
+Use these exact title lines and section headings:
+```markdown
+# Stage 1: Baseline and Boundary Inventory
+# Stage 2: Runtime Authentication and Authorization Analysis
+# Stage 3: Persistence, Migrations, and Configuration Safety
+# Stage 4: Tests, Docs Drift, and Verification Gaps
+# Stage 5: Final Synthesis, Roadmap, and Patch Decisions
+
+## Scope
+## Files Reviewed
+## Tests Reviewed
+## Docs Reviewed
+## Validation Commands
+## Confirmed Findings
+## Probable Risks
+## Improvements
+## Open Questions
+## Exit Note
+```
+
+- [ ] **Step 3: Write `Docs/superpowers/reviews/authnz-full-module/README.md`**
+
+Document:
+- the stage order `1 -> 2 -> 3 -> 4 -> 5`
+- the path to each stage report
+- the rule that confirmed findings come before probable risks and improvements
+- the rule that issues fixed later in a separate remediation branch must still remain visible in the review record
+- the rule that enterprise, federation, and secret-backend paths need explicit confidence downgrades when direct verification is unavailable
+- the canonical final response structure from Step 7
+
+- [ ] **Step 4: Capture the workspace baseline**
+
+Run:
+```bash
+git status --short
+git rev-parse --short HEAD
+git log --oneline -n 20 -- tldw_Server_API/app/core/AuthNZ tldw_Server_API/app/api/v1/API_Deps/auth_deps.py tldw_Server_API/app/api/v1/endpoints/auth.py
+```
+
+Expected: a clear baseline showing the current dirty-worktree state, the short `HEAD` hash, and the recent churn window for the scoped AuthNZ surface.
+
+- [ ] **Step 5: Capture the exact scoped inventory**
+
+Run:
+```bash
+{
+  rg --files tldw_Server_API/app/core/AuthNZ
+  printf '%s\n' \
+    tldw_Server_API/app/api/v1/API_Deps/auth_deps.py \
+    tldw_Server_API/app/api/v1/endpoints/auth.py \
+    tldw_Server_API/app/core/AuthNZ/README.md \
+    Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md \
+    Docs/API-related/User_Registration_API_Documentation.md \
+    Docs/Operations/Env_Vars.md \
+    Docs/Getting_Started/QUICKSTART.md \
+    Docs/Getting_Started/TROUBLESHOOTING.md
+  rg --files tldw_Server_API/tests/AuthNZ tldw_Server_API/tests/AuthNZ_SQLite tldw_Server_API/tests/AuthNZ_Postgres tldw_Server_API/tests/AuthNZ_Unit tldw_Server_API/tests/AuthNZ_Federation
+} | sort | tee /tmp/authnz_full_review_inventory.txt
+```
+
+Expected: one stable inventory file containing the scoped implementation, seed docs, and AuthNZ-focused test surface.
+
+- [ ] **Step 6: Select the representative integration consumers before deep reading**
+
+Run:
+```bash
+rg -n "get_auth_principal|require_permissions\\(|require_roles\\(" \
+  tldw_Server_API/app/api/v1/endpoints/users.py \
+  tldw_Server_API/app/api/v1/endpoints/privileges.py \
+  tldw_Server_API/app/api/v1/endpoints/admin \
+  | head -n 200
+```
+
+Expected: a bounded candidate list of claim-first consumers to sample later, without expanding into a general endpoint audit.
+
+- [ ] **Step 7: Freeze the final user-facing review output contract**
+
+Use this exact final response structure:
+```markdown
+## Findings
+### Confirmed findings
+- severity, confidence, file references, impact, and fix direction when clear
+
+### Probable risks
+- material issues not fully proven, with explicit confidence limits
+
+### Improvements
+- lower-priority hardening or maintainability suggestions
+
+## Open Questions
+- only unresolved ambiguities that materially affect confidence
+
+## Verification
+- files and docs inspected, tests run, and what remains unverified
+
+## Remediation Roadmap
+- immediate fixes
+- near-term hardening
+- structural refactors worth scheduling
+```
+
+- [ ] **Step 8: Write the Stage 1 baseline note**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md` must record:
+- the dirty-worktree baseline from Step 4
+- the short `HEAD` hash from Step 4
+- the inventory from Step 5
+- the candidate integration-consumer list from Step 6
+- the fixed final response structure from Step 7
+- the explicit statement that this review plan does not authorize source patches
+
+- [ ] **Step 9: Commit the review scaffold**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md
+git commit -m "docs: scaffold AuthNZ full-module review artifacts"
+```
+
+Expected: one docs-only commit captures the review workspace before stage findings are added.
+
+### Task 2: Execute Stage 2 Runtime Authentication and Authorization Analysis
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/jwt_service.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/session_manager.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/token_blacklist.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/password_service.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/mfa_service.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/lockout_tracker.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/auth_governor.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/virtual_keys.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/permissions.py`
+- Inspect: `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_jwt_service_rs256.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_session_manager_configured_key.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_session_revocation_blacklist.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_lockout_tracker.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_api_keys.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_jwt_membership.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_auth_deps_precedence.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_deps.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_route_level.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_permissions_claim_first.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_jwt_happy_path.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_api_key_happy_path.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_state_consistency.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_real_rate_limiter.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_jwt_refresh_rotation_blacklist.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_mfa_service.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Postgres/test_auth_enhanced_mfa.py`
+
+- [ ] **Step 1: Read the runtime auth source files in one bounded pass**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
+sed -n '1,260p' tldw_Server_API/app/api/v1/endpoints/auth.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/permissions.py
+```
+
+Expected: the credential-resolution order, endpoint dependency chain, and claim-first enforcement entry points are visible before deeper subsystem reading begins.
+
+- [ ] **Step 2: Read the stateful identity and token files**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/jwt_service.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/session_manager.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/token_blacklist.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/password_service.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/mfa_service.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/lockout_tracker.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/auth_governor.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/api_key_manager.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/virtual_keys.py
+```
+
+Expected: JWT handling, session lifecycle, lockout state, API-key validation, and MFA flow assumptions are visible enough to record candidate findings.
+
+- [ ] **Step 3: Read the highest-value runtime and authz tests before running anything**
+
+Run:
+```bash
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_session_revocation_blacklist.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_permissions_claim_first.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_state_consistency.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_jwt_refresh_rotation_blacklist.py
+```
+
+Expected: the strongest existing runtime contracts are visible before verification commands are chosen.
+
+- [ ] **Step 4: Write the Stage 2 artifact before executing tests**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md` must record:
+- the exact files reviewed
+- the tests reviewed from Steps 1 through 3
+- candidate findings grouped as confirmed only when code evidence is already conclusive
+- any likely runtime risks that still need verification
+- the exact verification commands selected in Steps 5 and 6
+
+- [ ] **Step 5: Run the smallest unit-level runtime verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_jwt_service_rs256.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_session_manager_configured_key.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_session_revocation_blacklist.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_lockout_tracker.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_api_keys.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_jwt_membership.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_deps_precedence.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_deps.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_route_level.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_permissions_claim_first.py \
+  | tee /tmp/authnz_full_runtime_pytest.log
+```
+
+Expected: primarily `PASSED`; any `FAILED` or `SKIPPED` result must be treated as evidence to investigate, not as a pass by implication.
+
+- [ ] **Step 6: Run the smallest integration-level runtime verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_jwt_happy_path.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_api_key_happy_path.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_state_consistency.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_real_rate_limiter.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_jwt_refresh_rotation_blacklist.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_mfa_service.py \
+  tldw_Server_API/tests/AuthNZ_Postgres/test_auth_enhanced_mfa.py \
+  | tee -a /tmp/authnz_full_runtime_pytest.log
+```
+
+Expected: passing or explicitly skipped backend-sensitive results; any skip reason must be copied into the stage artifact as a confidence limit.
+
+- [ ] **Step 7: Update and commit the Stage 2 artifact**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md` must be updated with:
+- the executed commands from Steps 5 and 6
+- the observed pass, fail, or skip outcomes
+- confidence upgrades or downgrades based on those results
+- the exact line-level file references supporting each finding
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md
+git commit -m "docs: record AuthNZ runtime and authz review stage"
+```
+
+Expected: one docs-only commit preserves the runtime-auth stage findings before later stages reinterpret them.
+
+### Task 3: Execute Stage 3 Persistence, Migrations, and Configuration Safety
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/settings.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/database.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/initialize.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/migrate_to_multiuser.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/sessions_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/token_blacklist_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/users_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/mfa_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/rbac_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/orgs_teams_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/quotas_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/rate_limits_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/user_provider_secrets_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/org_provider_secrets_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/byok_oauth_state_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/identity_provider_repo.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_api_keys.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_lockout_scope.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_usage_truthiness.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_migrate_to_multiuser_review_fixes.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_api_keys_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_sessions_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_token_blacklist_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_quotas_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_rate_limits_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_orgs_teams_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_initialize_single_user_invariant_repo_routing.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_sessions_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_token_blacklist_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_quotas_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_rate_limits_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_orgs_teams_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_virtual_keys_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_byok_runtime_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_byok_rotation_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_api_keys_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_token_blacklist_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_quotas_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_rate_limits_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_orgs_teams_repo_postgres.py`
+
+- [ ] **Step 1: Read the configuration and bootstrap files**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/settings.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/database.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/initialize.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/migrate_to_multiuser.py
+```
+
+Expected: settings precedence, mode handling, DB initialization, and migration-entry assumptions are visible before repo or schema details are judged.
+
+- [ ] **Step 2: Read the migration and representative repository files**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/migrations.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/sessions_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/token_blacklist_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/rate_limits_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/quotas_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/orgs_teams_repo.py
+```
+
+Expected: representative persistence routing, schema evolution, and backend-selection patterns are visible enough to classify candidate risks.
+
+- [ ] **Step 3: Read the highest-value persistence and backend-selection tests before running them**
+
+Run:
+```bash
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_api_keys.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_migrate_to_multiuser_review_fixes.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_authnz_api_keys_repo_backend_selection.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_authnz_api_keys_repo_postgres.py
+```
+
+Expected: the strongest schema and repo-routing expectations are visible before verification commands are chosen.
+
+- [ ] **Step 4: Write the Stage 3 artifact before executing tests**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md` must record:
+- the exact files and docs reviewed
+- any suspected fail-open or fail-closed branches
+- any backend divergence questions that require verification
+- the exact verification commands selected in Steps 5 and 6
+
+- [ ] **Step 5: Run the smallest unit-level persistence verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_api_keys.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_lockout_scope.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_usage_truthiness.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_migrate_to_multiuser_review_fixes.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_api_keys_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_sessions_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_token_blacklist_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_quotas_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_rate_limits_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_orgs_teams_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_initialize_single_user_invariant_repo_routing.py \
+  | tee /tmp/authnz_full_persistence_pytest.log
+```
+
+Expected: primarily `PASSED`; any backend-selection or migration failure becomes direct evidence to investigate, not a reason to skip the area.
+
+- [ ] **Step 6: Run the smallest backend-sensitive persistence verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_sessions_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_token_blacklist_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_quotas_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_rate_limits_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_orgs_teams_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_virtual_keys_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_byok_runtime_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_byok_rotation_sqlite.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_api_keys_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_token_blacklist_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_quotas_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_rate_limits_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_orgs_teams_repo_postgres.py \
+  | tee -a /tmp/authnz_full_persistence_pytest.log
+```
+
+Expected: passing or explicitly skipped backend-sensitive results; any skip or environment limitation must be copied into the stage artifact as a confidence downgrade.
+
+- [ ] **Step 7: Update and commit the Stage 3 artifact**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md` must be updated with:
+- the executed commands from Steps 5 and 6
+- the observed pass, fail, or skip outcomes
+- any backend-specific confidence limits
+- exact line-level file references supporting each persistence finding
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md
+git commit -m "docs: record AuthNZ persistence and configuration review stage"
+```
+
+Expected: one docs-only commit preserves the persistence stage before test-gap synthesis begins.
+
+### Task 4: Execute Stage 4 Tests, Docs Drift, and Verification Gaps
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/README.md`
+- Inspect: `Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md`
+- Inspect: `Docs/API-related/User_Registration_API_Documentation.md`
+- Inspect: `Docs/Operations/Env_Vars.md`
+- Inspect: `Docs/Getting_Started/QUICKSTART.md`
+- Inspect: `Docs/Getting_Started/TROUBLESHOOTING.md`
+- Inspect: `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`
+- Test: `tldw_Server_API/tests/AuthNZ/property/test_auth_endpoints_property.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_legacy_admin_shim_removed.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_optional_current_user_shim_removed.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_db_adapter_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver_mode_shim_removed.py`
+- Test: `tldw_Server_API/tests/Resource_Governance/test_auth_route_map_coverage.py`
+
+- [ ] **Step 1: Read the documentation seed set in one bounded pass**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/README.md
+sed -n '1,260p' Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md
+sed -n '1,260p' Docs/API-related/User_Registration_API_Documentation.md
+sed -n '1,260p' Docs/Operations/Env_Vars.md
+sed -n '1,260p' Docs/Getting_Started/QUICKSTART.md
+sed -n '1,260p' Docs/Getting_Started/TROUBLESHOOTING.md
+```
+
+Expected: the currently documented auth contracts are visible before code-vs-doc drift is classified.
+
+- [ ] **Step 2: Map the doc claims back to code and test anchors**
+
+Run:
+```bash
+rg -n "AUTH_MODE|single-user|single_user|multi-user|multi_user|JWT|X-API-KEY|virtual key|virtual keys|claim-first|get_auth_principal|require_permissions|require_roles" \
+  tldw_Server_API/app/core/AuthNZ/README.md \
+  Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md \
+  Docs/API-related/User_Registration_API_Documentation.md \
+  Docs/Operations/Env_Vars.md \
+  Docs/Getting_Started/QUICKSTART.md \
+  Docs/Getting_Started/TROUBLESHOOTING.md \
+  tldw_Server_API/app/api/v1/API_Deps/auth_deps.py \
+  tldw_Server_API/app/api/v1/endpoints/auth.py
+```
+
+Expected: a concrete claim map that makes documentation drift and contract mismatches actionable instead of impressionistic.
+
+- [ ] **Step 3: Read the strongest contract and hardening tests before running them**
+
+Run:
+```bash
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/property/test_auth_endpoints_property.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_legacy_admin_shim_removed.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_optional_current_user_shim_removed.py
+sed -n '1,240p' tldw_Server_API/tests/Resource_Governance/test_auth_route_map_coverage.py
+```
+
+Expected: documented endpoint and dependency behavior is cross-checked against the tests that claim to enforce it before verification commands are chosen.
+
+- [ ] **Step 4: Write the Stage 4 artifact before executing tests**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md` must record:
+- the exact docs reviewed
+- candidate documentation drifts and test-gap hypotheses
+- which claims are already proven by code alone
+- which claims need the verification commands from Steps 5 and 6
+
+- [ ] **Step 5: Run the smallest contract-level verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py \
+  tldw_Server_API/tests/AuthNZ/property/test_auth_endpoints_property.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_legacy_admin_shim_removed.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_optional_current_user_shim_removed.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_db_adapter_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver_mode_shim_removed.py \
+  | tee /tmp/authnz_full_contract_pytest.log
+```
+
+Expected: passing or explicitly skipped contract checks; any failures or skips become direct evidence for drift, not noise to ignore.
+
+- [ ] **Step 6: Run the route-coverage verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/Resource_Governance/test_auth_route_map_coverage.py | tee -a /tmp/authnz_full_contract_pytest.log
+```
+
+Expected: one targeted confirmation of route-map coverage for auth surfaces, or a clear failure that must be recorded as a contract gap.
+
+- [ ] **Step 7: Update and commit the Stage 4 artifact**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md` must be updated with:
+- the executed commands from Steps 5 and 6
+- the observed pass, fail, or skip outcomes
+- ranked documentation drifts
+- ranked missing or weak test invariants
+- explicit blind spots for enterprise, federation, or secret-backend paths that were not strongly validated
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md
+git commit -m "docs: record AuthNZ docs and test-gap review stage"
+```
+
+Expected: one docs-only commit preserves the docs and coverage assessment before final synthesis begins.
+
+### Task 5: Execute Stage 5 Final Synthesis, Roadmap, and Patch Decisions
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage5-final-synthesis-roadmap-and-patch-decisions.md`
+- Inspect: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md`
+- Inspect: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md`
+- Inspect: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md`
+- Inspect: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md`
+- Test: none by default
+
+- [ ] **Step 1: Read and deduplicate the stage findings**
+
+Run:
+```bash
+sed -n '1,260p' Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md
+sed -n '1,260p' Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md
+sed -n '1,260p' Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md
+sed -n '1,260p' Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md
+```
+
+Expected: one consolidated set of findings without duplicate issues or conflicting severity labels.
+
+- [ ] **Step 2: Write the Stage 5 synthesis artifact**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage5-final-synthesis-roadmap-and-patch-decisions.md` must contain:
+```markdown
+# Stage 5 Final Synthesis
+
+## Highest-Confidence Findings
+## Probable Risks
+## Improvements
+## Open Questions
+## Verification Summary
+## Remediation Roadmap
+## Patch-Gate Decisions
+## Blind Spots / Not Reviewed
+```
+
+- [ ] **Step 3: Bucket the remediation roadmap**
+
+Use these exact roadmap buckets:
+- `Immediate fixes`
+- `Near-term hardening`
+- `Structural refactors worth scheduling`
+
+Every roadmap item must name the exact file or file group affected and state why the item belongs in that bucket.
+
+- [ ] **Step 4: Make the patch-gate decision explicitly**
+
+Use this exact decision matrix:
+```markdown
+- Not confirmed: no remediation branch
+- Confirmed but broad or product-dependent: roadmap only
+- Confirmed, critical, localized, and verifiable: preserve pre-fix evidence and write a separate remediation plan before any code change
+```
+
+Expected: the review does not silently drift into patching. Any code-fix branch is either rejected or broken into a fresh remediation plan with pre-fix evidence preserved.
+
+- [ ] **Step 5: Run one last verification command only if a single claim remains unresolved**
+
+Reuse exactly one already-defined command from Task 2 Step 5, Task 2 Step 6, Task 3 Step 5, Task 3 Step 6, Task 4 Step 5, or Task 4 Step 6. If no unresolved claim remains, record `No additional verification required` in the Stage 5 artifact instead of running more tests.
+
+Expected: no blanket reruns. Either one unresolved claim is settled, or the decision to stop is explicit.
+
+- [ ] **Step 6: Commit the final review artifacts**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module
+git commit -m "docs: finalize AuthNZ full-module review artifacts"
+```
+
+Expected: one docs-only commit preserves the final staged review record.
+
+## Self-Review Checklist
+
+- Verify that every stage from the approved spec maps to a task in this plan.
+- Verify that the stage artifact path and filenames match the approved review workspace contract.
+- Verify that the plan never authorizes ad hoc source patches during the review.
+- Verify that the final response structure in Task 1 matches the approved design.
+- Verify that every verification command is targeted and uses the project virtual environment.
+- Verify that enterprise, federation, and secret-backend blind spots are explicitly preserved if direct validation is weak.

--- a/Docs/superpowers/plans/2026-04-08-chat-module-audit-execution-plan.md
+++ b/Docs/superpowers/plans/2026-04-08-chat-module-audit-execution-plan.md
@@ -1,0 +1,538 @@
+# Chat Module Audit Execution Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Execute the approved Chat audit, gather targeted test evidence, and deliver a severity-ranked review covering the scoped Chat routes and shared `core/Chat` code.
+
+**Architecture:** The audit proceeds in fixed route groups. Each group freezes its route and test inventory first, performs static inspection second, runs targeted tests only where they validate ambiguous or risky behavior third, and records findings immediately in one review artifact so evidence and conclusions stay linked. No production code changes are planned during this execution unless the user explicitly pivots from review to remediation.
+
+**Tech Stack:** Python/FastAPI source inspection, `rg`, `sed`, `pytest`, repo-local markdown docs under `Docs/superpowers/*`
+
+---
+
+## File Map
+
+- Create: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md` - canonical audit artifact with scope, evidence log, route inventory, findings, open questions, and coverage gaps.
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_documents.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_service.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_orchestrator.py`
+- Inspect: `tldw_Server_API/app/core/Chat/streaming_utils.py`
+- Inspect: `tldw_Server_API/app/core/Chat/request_queue.py`
+- Inspect: `tldw_Server_API/app/core/Chat/rate_limiter.py`
+- Inspect: `tldw_Server_API/app/core/Chat/document_generator.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_store.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_approval.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_engine.py`
+- Inspect: `tldw_Server_API/app/core/Chat/validate_dictionary.py`
+- Inspect: `tldw_Server_API/app/core/Chat/README.md`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/provider_resolution.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/request_validation.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/stream_execution.py`
+- Test: `tldw_Server_API/tests/Chat`
+- Test: `tldw_Server_API/tests/Chat_NEW`
+- Test: `tldw_Server_API/tests/Chat_Workflows`
+- Test: `tldw_Server_API/tests/Streaming`
+- Test: `tldw_Server_API/tests/e2e/test_workspace_chat_scope.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_deps.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_permissions.py`
+
+### Task 1: Freeze Inventory And Create The Audit Artifact
+
+**Files:**
+- Create: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_documents.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- Test: `tldw_Server_API/tests/Chat`
+- Test: `tldw_Server_API/tests/Chat_NEW`
+- Test: `tldw_Server_API/tests/Chat_Workflows`
+- Test: `tldw_Server_API/tests/Streaming`
+
+- [ ] **Step 1: Create the review scaffold**
+
+```markdown
+# Chat Module Audit Findings
+
+## Scope
+- Spec: `Docs/superpowers/specs/2026-04-08-chat-module-review-design.md`
+- In scope: `chat.py`, `chat_documents.py`, `chat_loop.py`, `chat_grammars.py`, `chat_dictionaries.py`, `chat_workflows.py`, shared `core/Chat/*`
+- Out of scope: Character Chat, Chatbooks, unrelated provider internals
+
+## Evidence Log
+| Group | Routes | Static review | Targeted tests | Result | Notes |
+| --- | --- | --- | --- | --- | --- |
+
+## Route Inventory
+
+## Critical
+_None._
+
+## High
+_None._
+
+## Medium
+_None._
+
+## Low
+_None._
+
+## Open Questions
+
+## Coverage Gaps
+```
+
+- [ ] **Step 2: Freeze the route inventory**
+
+Run:
+
+```bash
+rg -n "@router\\.(get|post|patch|delete)\\(" \
+  tldw_Server_API/app/api/v1/endpoints/chat.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_documents.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_loop.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_grammars.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_workflows.py
+```
+
+Expected: a concrete decorator list for every scoped endpoint file. Copy the route groupings into the `Route Inventory` section before reading implementation details.
+
+- [ ] **Step 3: Freeze the test inventory**
+
+Run:
+
+```bash
+rg --files tldw_Server_API/tests | rg '(^|/)(Chat|Chat_NEW|Chat_Workflows|Streaming)/|workspace_chat_scope|chat_workflows_(deps|permissions)'
+```
+
+Expected: a bounded evidence list for the scoped review. Map each relevant file into the `Evidence Log`, and write `no direct route test found` for scoped routes that have no direct evidence file.
+
+- [ ] **Step 4: Verify the low-traffic routes are not skipped**
+
+Run:
+
+```bash
+rg -n "async def list_chat_commands|async def validate_chat_dictionary|async def create_chat_completion|async def get_chat_queue_status|async def get_chat_queue_activity|async def list_chat_conversations|async def get_chat_conversation|async def update_chat_conversation|async def get_conversation_tree|async def create_conversation_share_link|async def resolve_conversation_share_token|async def save_chat_knowledge|async def get_chat_analytics|async def persist_rag_context|async def get_rag_context|async def get_messages_with_rag_context|async def get_conversation_citations" \
+  tldw_Server_API/app/api/v1/endpoints/chat.py
+```
+
+Expected: every major `chat.py` route family appears in `Route Inventory` and has either a mapped test file or an explicit `coverage gap candidate` note.
+
+- [ ] **Step 5: Save the artifact before deeper review**
+
+Run:
+
+```bash
+git diff -- Docs/superpowers/reviews/2026-04-08-chat-module-review.md
+```
+
+Expected: the diff shows only the scaffold, route inventory, and evidence-log seed entries.
+
+### Task 2: Audit Main Chat Completion, Queue, And Streaming Behavior
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_service.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_orchestrator.py`
+- Inspect: `tldw_Server_API/app/core/Chat/streaming_utils.py`
+- Inspect: `tldw_Server_API/app/core/Chat/request_queue.py`
+- Inspect: `tldw_Server_API/app/core/Chat/rate_limiter.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/provider_resolution.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/request_validation.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/stream_execution.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_endpoint_helpers.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_service_call_params.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_service_normalization.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_request_queue.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_streaming_utils.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_service_queue_future.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_service_queue_estimate.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_queue_status_endpoint.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_queue_activity_endpoint.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_chat_endpoint_streaming_normalization.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py`
+
+- [ ] **Step 1: Read the command, validation, completion, and queue entry points**
+
+Run:
+
+```bash
+rg -n "async def list_chat_commands|async def validate_chat_dictionary|async def create_chat_completion|async def get_chat_queue_status|async def get_chat_queue_activity" \
+  tldw_Server_API/app/api/v1/endpoints/chat.py
+```
+
+Expected: exact entry-point line numbers for the scoped route group. Read each function body plus the helper calls it delegates to before writing any findings.
+
+- [ ] **Step 2: Read the shared core files behind those routes**
+
+Run:
+
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/Chat/chat_service.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/chat_orchestrator.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/streaming_utils.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/request_queue.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/rate_limiter.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/orchestrator/provider_resolution.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/orchestrator/request_validation.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/orchestrator/stream_execution.py
+```
+
+Expected: enough implementation context to judge auth flow, provider resolution, queue backpressure, streaming lifecycle, and error mapping. If a finding depends on code below these ranges, extend the read around the exact symbol before recording it.
+
+- [ ] **Step 3: Read the matching tests before running them**
+
+Run:
+
+```bash
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_endpoint_helpers.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_service_call_params.py
+sed -n '1,240p' tldw_Server_API/tests/Chat/unit/test_request_queue.py
+sed -n '1,240p' tldw_Server_API/tests/Chat/unit/test_streaming_utils.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/integration/test_chat_endpoint_streaming_normalization.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/unit/test_queue_status_endpoint.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/unit/test_queue_activity_endpoint.py
+```
+
+Expected: a clear view of what the current tests actually assert, not just their filenames.
+
+- [ ] **Step 4: Run the targeted unit tests for this route group**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat/unit/test_chat_endpoint_helpers.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_call_params.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_normalization.py \
+  tldw_Server_API/tests/Chat/unit/test_request_queue.py \
+  tldw_Server_API/tests/Chat/unit/test_streaming_utils.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_queue_future.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_queue_estimate.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_queue_status_endpoint.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_queue_activity_endpoint.py \
+  -v
+```
+
+Expected: tests collect and run. Record pass, fail, flaky, or blocked status in `Evidence Log`, and classify any failures as product defect, coverage gap, or environment issue.
+
+- [ ] **Step 5: Run the targeted integration tests for this route group**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py \
+  tldw_Server_API/tests/Chat/integration/test_chat_endpoint_streaming_normalization.py \
+  tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py \
+  -v
+```
+
+Expected: integration coverage for request normalization, routing, and streaming behavior. Record the outcome exactly; do not treat a pass as proof that the code path is safe if static review still shows a defect.
+
+- [ ] **Step 6: Record route-group findings immediately**
+
+Add findings to `Docs/superpowers/reviews/2026-04-08-chat-module-review.md` using this template:
+
+```markdown
+### High: Streaming branch can leave queue state inconsistent on early disconnect
+- Files: `tldw_Server_API/app/api/v1/endpoints/chat.py:4471`, `tldw_Server_API/app/core/Chat/request_queue.py:1`
+- Why it matters: A primary chat path can leak state or mis-report active work under disconnect pressure.
+- Evidence: Static review of queue commit callback and disconnect path; targeted tests in `tldw_Server_API/tests/Chat/integration/test_chat_endpoint_streaming_normalization.py`
+- Recommendation: Tighten queue cleanup invariants and add an assertion around disconnect-driven cleanup.
+```
+
+- [ ] **Step 7: Promote missing evidence to explicit coverage gaps**
+
+Run:
+
+```bash
+rg -n "queue|stream|routing|disconnect" \
+  tldw_Server_API/tests/Chat \
+  tldw_Server_API/tests/Chat_NEW \
+  tldw_Server_API/tests/Streaming
+```
+
+Expected: enough evidence to say either `covered` or `coverage gap`. Do not leave risky behavior implied but unclassified.
+
+### Task 3: Audit Conversations, Share Links, Knowledge Save, Analytics, And RAG Context Routes
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_history.py`
+- Inspect: `tldw_Server_API/app/core/Chat/conversation_enrichment.py`
+- Inspect: `tldw_Server_API/app/core/Chat/message_utils.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_conversations_api.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_conversations_scope.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_share_links_api.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_knowledge_save.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_conversations_tree_analytics.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_knowledge_save.py`
+- Test: `tldw_Server_API/tests/e2e/test_workspace_chat_scope.py`
+
+- [ ] **Step 1: Read the conversation, sharing, knowledge, and RAG-context entry points**
+
+Run:
+
+```bash
+rg -n "async def save_chat_knowledge|async def list_chat_conversations|async def get_chat_conversation|async def update_chat_conversation|async def get_conversation_tree|async def create_conversation_share_link|async def list_conversation_share_links|async def revoke_conversation_share_link|async def resolve_conversation_share_token|async def get_chat_analytics|async def persist_rag_context|async def get_rag_context|async def get_messages_with_rag_context|async def get_conversation_citations" \
+  tldw_Server_API/app/api/v1/endpoints/chat.py
+```
+
+Expected: exact line numbers for every scoped route in this group. Read each implementation before reviewing the supporting helpers.
+
+- [ ] **Step 2: Read the shared helpers behind conversation and knowledge routes**
+
+Run:
+
+```bash
+sed -n '1,240p' tldw_Server_API/app/core/Chat/chat_history.py
+sed -n '1,240p' tldw_Server_API/app/core/Chat/conversation_enrichment.py
+sed -n '1,240p' tldw_Server_API/app/core/Chat/message_utils.py
+```
+
+Expected: enough context to evaluate ownership checks, persisted metadata shape, share-token handling, and enrichment side effects.
+
+- [ ] **Step 3: Read the direct tests and note missing route coverage**
+
+Run:
+
+```bash
+sed -n '1,240p' tldw_Server_API/tests/Chat/unit/test_chat_conversations_api.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_conversations_scope.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_share_links_api.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_knowledge_save.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_conversations_tree_analytics.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_knowledge_save.py
+sed -n '1,220p' tldw_Server_API/tests/e2e/test_workspace_chat_scope.py
+rg -n "persist_rag_context|get_rag_context|get_messages_with_rag_context|get_conversation_citations" \
+  tldw_Server_API/tests/Chat \
+  tldw_Server_API/tests/Chat_NEW \
+  tldw_Server_API/tests/e2e
+```
+
+Expected: either direct tests for the route or a concrete `no direct route test found` note in `Coverage Gaps`, especially for RAG-context and citations endpoints.
+
+- [ ] **Step 4: Run the targeted tests for this route group**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat/unit/test_chat_conversations_api.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_conversations_scope.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_share_links_api.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_knowledge_save.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_conversations_tree_analytics.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_knowledge_save.py \
+  tldw_Server_API/tests/e2e/test_workspace_chat_scope.py \
+  -v
+```
+
+Expected: direct evidence for conversation ownership, share-link handling, knowledge-save rollback behavior, analytics/tree routes, and workspace scoping. Record exact outcomes in the `Evidence Log`.
+
+- [ ] **Step 5: Record findings and explicit no-test gaps**
+
+Add new findings to `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`, and add a `Coverage Gaps` item for any scoped route that still lacks a direct assertion file after the `rg` check in Step 3.
+
+### Task 4: Audit Documents, Loop, Grammars, Dictionaries, And Workflows
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_documents.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- Inspect: `tldw_Server_API/app/core/Chat/document_generator.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_store.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_approval.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_engine.py`
+- Inspect: `tldw_Server_API/app/core/Chat/validate_dictionary.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_document_generation_endpoints.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_document_generator.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_workflows.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_dictionary_validate_endpoint.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_endpoints.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_dual_emit_compat.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_store.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_store_compaction.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_engine.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_approval.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py`
+- Test: `tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_api.py`
+- Test: `tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_service.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_deps.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_permissions.py`
+
+- [ ] **Step 1: Read the five adjacent endpoint modules**
+
+Run:
+
+```bash
+sed -n '1,260p' tldw_Server_API/app/api/v1/endpoints/chat_documents.py
+sed -n '1,220p' tldw_Server_API/app/api/v1/endpoints/chat_loop.py
+sed -n '1,220p' tldw_Server_API/app/api/v1/endpoints/chat_grammars.py
+sed -n '1,260p' tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py
+sed -n '1,260p' tldw_Server_API/app/api/v1/endpoints/chat_workflows.py
+```
+
+Expected: a route-level view of auth, ownership, exception handling, streaming, and persistence behavior for each adjacent surface.
+
+- [ ] **Step 2: Read the supporting core modules**
+
+Run:
+
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/Chat/document_generator.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/chat_loop_store.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/chat_loop_approval.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/chat_loop_engine.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/validate_dictionary.py
+```
+
+Expected: enough context to judge state lifetime, approval flow, document-generation contract handling, and dictionary validation logic.
+
+- [ ] **Step 3: Read the direct tests before running them**
+
+Run:
+
+```bash
+sed -n '1,220p' tldw_Server_API/tests/Chat/integration/test_document_generation_endpoints.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_workflows.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_endpoints.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_dual_emit_compat.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_dictionary_validate_endpoint.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_api.py
+sed -n '1,220p' tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_permissions.py
+```
+
+Expected: a concrete understanding of what the current tests cover for each adjacent surface, including auth wiring and compatibility expectations.
+
+- [ ] **Step 4: Run the targeted tests for documents, grammars, and dictionaries**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat/integration/test_document_generation_endpoints.py \
+  tldw_Server_API/tests/Chat/unit/test_document_generator.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_dictionary_validate_endpoint.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py \
+  -v
+```
+
+Expected: route-level evidence for document-generation contracts, saved grammar behavior, dictionary CRUD/validation, and llama.cpp grammar bridging.
+
+- [ ] **Step 5: Run the targeted tests for loop and workflows**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_endpoints.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_dual_emit_compat.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_store.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_store_compaction.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_engine.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_approval.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_workflows.py \
+  tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_api.py \
+  tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_service.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_deps.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_permissions.py \
+  -v
+```
+
+Expected: evidence for in-memory loop state behavior, approval flow, workflow route correctness, and permission wiring.
+
+- [ ] **Step 6: Record findings for each adjacent surface separately**
+
+Expected: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md` contains distinct findings or `no issue found in this pass` notes for documents, loop, grammars, dictionaries, and workflows. Do not collapse these into one generic section.
+
+### Task 5: Synthesize Cross-Cutting Risks And Prepare Delivery
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `Docs/superpowers/specs/2026-04-08-chat-module-review-design.md`
+- Inspect: `Docs/superpowers/plans/2026-04-08-chat-module-audit-execution-plan.md`
+
+- [ ] **Step 1: Deduplicate and normalize the findings**
+
+Review `Docs/superpowers/reviews/2026-04-08-chat-module-review.md` and merge duplicate findings that point to the same root cause. Keep the strongest file/line references and preserve route-specific evidence in the bullet text.
+
+- [ ] **Step 2: Re-apply the severity rubric from the spec**
+
+Run:
+
+```bash
+sed -n '94,126p' Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
+```
+
+Expected: every finding in the review doc still matches the agreed `Critical` / `High` / `Medium` / `Low` rules.
+
+- [ ] **Step 3: Verify evidence completeness**
+
+Run:
+
+```bash
+rg -n "^## Evidence Log|^## Route Inventory|^## Critical|^## High|^## Medium|^## Low|^## Open Questions|^## Coverage Gaps" \
+  Docs/superpowers/reviews/2026-04-08-chat-module-review.md
+```
+
+Expected: the review artifact contains all required sections. Every route group from Task 1 should have an `Evidence Log` row and either a finding, a `no issue found in this pass` note, or a `coverage gap` note.
+
+- [ ] **Step 4: Prepare the user-facing review summary**
+
+Copy the final findings into this structure for the terminal response:
+
+```markdown
+## Findings
+### High: ...
+- Files: `path:line`
+- Risk: ...
+- Evidence: ...
+
+## Open Questions
+- ...
+
+## Coverage Gaps
+- ...
+```
+
+Expected: the final terminal response can be written directly from the review doc without re-reading the whole codebase.
+
+- [ ] **Step 5: Leave remediation as a separate follow-on**
+
+Add this line to the bottom of `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`:
+
+```markdown
+Remediation is intentionally out of scope for this audit. If the user wants fixes, create a separate remediation plan from the finalized findings set.
+```
+
+Expected: the review remains an audit artifact, not an implicit refactor plan.

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md
@@ -1,0 +1,21 @@
+# Characters Backend Delta Review
+
+## Scope
+
+## Baseline Artifacts Checked
+
+## Code Paths Reviewed
+
+## Tests Reviewed
+
+## Validation Commands
+
+## Findings
+
+## Residual Risks / Open Questions
+
+## Coverage Gaps
+
+## Improvements
+
+## Exit Note

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md
@@ -2,20 +2,95 @@
 
 ## Scope
 
+- backend Character lifecycle and persistence
+- backend import/export and retrieval
+- backend chat-coupled behavior
+
 ## Baseline Artifacts Checked
+
+- Docs/superpowers/specs/2026-03-23-characters-backend-review-design.md
+- Docs/superpowers/reviews/characters-backend/2026-03-23-stage2-api-crud-versioning.md
+- Docs/superpowers/reviews/characters-backend/2026-03-23-stage3-import-validation-export.md
+- Docs/superpowers/reviews/characters-backend/2026-03-23-stage4-exemplars-worldbooks-search.md
+- Docs/superpowers/reviews/characters-backend/2026-03-23-stage5-chat-rate-limit-synthesis.md
+- Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md
 
 ## Code Paths Reviewed
 
+- tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py: lifecycle, import/export, versions, exemplars, and world-book routes
+- tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py: Character chat session creation, completion prep, greeting injection, memory injection, and routing
+- tldw_Server_API/app/api/v1/endpoints/character_messages.py: Character message persistence and message retrieval paths
+- tldw_Server_API/app/core/Character_Chat/modules/character_db.py: persistence normalization and lifecycle helpers
+- tldw_Server_API/app/core/Character_Chat/modules/character_io.py: import, export, and file-format handling
+- tldw_Server_API/app/core/Character_Chat/modules/character_chat.py: chat-coupled Character behavior
+- tldw_Server_API/app/core/Character_Chat/character_rate_limiter.py and character_limits.py: quota and throttle behavior
+- tldw_Server_API/app/core/Character_Chat/world_book_manager.py and app/core/Chat/chat_characters.py: retrieval and cross-module Character coupling
+- tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py: Character DB invariants, restore, revert, and version history
+- tldw_Server_API/app/api/v1/schemas/character_schemas.py and character_memory_schemas.py: request and response contracts
+
 ## Tests Reviewed
+
+- tldw_Server_API/tests/Characters/test_characters_endpoint.py
+- tldw_Server_API/tests/Characters/test_character_functionality_db.py
+- tldw_Server_API/tests/Characters/test_character_chat_lib.py
+- tldw_Server_API/tests/Characters/test_character_chat_greetings_api.py
+- tldw_Server_API/tests/Characters/test_ccv3_parser.py
+- tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_api.py
+- tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_auto_routing.py
+- tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
+- tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_exemplars_api.py
+- tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
+- tldw_Server_API/tests/Character_Chat_NEW/unit/test_world_book_manager.py
+- tldw_Server_API/tests/unit/test_character_rate_limiter.py
 
 ## Validation Commands
 
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Characters/test_characters_endpoint.py tldw_Server_API/tests/Characters/test_character_functionality_db.py tldw_Server_API/tests/Characters/test_character_chat_lib.py tldw_Server_API/tests/Characters/test_ccv3_parser.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_api.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_png_export.py -q` — fail
+- Failing test: `tldw_Server_API/tests/Characters/test_character_functionality_db.py::TestCharacterCardUpdate::test_empty_update_payload_remains_a_noop` (`TypeError: CharactersRAGDB.get_character_card_by_id() got an unexpected keyword argument 'include_deleted'`). The rest of the lifecycle/import-export slice completed cleanly enough to show no adjacent breakage around the current review findings.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_exemplars_api.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_world_book_manager.py tldw_Server_API/tests/ChaChaNotesDB/test_character_exemplars_db.py tldw_Server_API/tests/RAG/test_dual_backend_characters_retriever.py -q` — pass
+- Confidence gained: the targeted retrieval and world-book slice passed (`67 passed, 2 skipped`), so no new retrieval-sensitive Character regression was reproduced in this Stage 3 sample.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Characters/test_character_chat_greetings_api.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_auto_routing.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py tldw_Server_API/tests/Character_Chat/unit/test_chat_session_character_scope_api.py tldw_Server_API/tests/unit/test_character_rate_limiter.py tldw_Server_API/tests/Streaming/test_character_chat_sse_unified_flag.py -q` — fail
+- Failing tests: `tldw_Server_API/tests/Streaming/test_character_chat_sse_unified_flag.py::test_character_chat_streaming_unified_sse`, `::test_character_chat_streaming_unified_sse_slow_async_heartbeat`, `::test_character_chat_streaming_unified_sse_provider_duplicate_done`, `::test_character_chat_streaming_unified_sse_chunk_limit`, `::test_character_chat_streaming_unified_sse_byte_limit`, and `::test_character_chat_streaming_unified_sse_provider_error_emits_done`, each bootstrapping into `GET /api/v1/characters/` returning `503`. The adjacent persist and rate-limit tests in that slice otherwise passed.
+
 ## Findings
+
+### Confirmed finding: manual character-memory extraction checks a conversation owner field that the conversations table does not store
+
+- Severity: Medium
+- Type: correctness
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/reviews/characters-backend/2026-03-23-stage5-chat-rate-limit-synthesis.md; Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md
+- Why it matters: The newer manual memory-extraction path can reject valid, owned chats before any extraction work starts, which leaves the character-memory feature unusable from its API surface even though the underlying storage and extraction helpers exist.
+- Current evidence: Direct-edge inspection included `tldw_Server_API/app/api/v1/endpoints/character_memory.py:231-235`, where manual extraction authorizes against `conversation.get("user_id")`, and the adjacent unit coverage in `tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py`, which does not exercise the endpoint ownership check. That read was compared against the conversations schema and conversation write/read paths, which store and expose conversation ownership through `client_id` rather than `user_id` (`tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py:744-756`, `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py:19310-19399`). None of the reviewed Character backend tests exercise `/characters/{character_id}/memories/extract`, so this mismatch is currently unguarded.
+- Targeted validation note: None of the executed Stage 3 pytest slices covered `/api/v1/characters/{character_id}/memories/extract` or the endpoint ownership branch in `character_memory.py`, so runtime confirmation was not feasible within this task's prescribed test set.
+- Validation status: environment-limited, confidence unchanged
+
+### Probable risk: streamed assistant persistence skips message-cap enforcement when quota checks fail internally
+
+- Severity: Medium
+- Type: correctness
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/reviews/characters-backend/2026-03-23-stage5-chat-rate-limit-synthesis.md; Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md
+- Why it matters: This candidate is narrower than the March Stage 5 quota issue. The historical finding was about non-atomic count-then-check enforcement under concurrency; this delta item is about a distinct fail-open exception path in the newer streamed-persist write flow, where internal quota-check failures do not stop persistence.
+- Current evidence: `persist_streamed_assistant_message()` catches non-HTTP exceptions around `count_messages_for_conversation()` and `check_message_limit()` and only logs before continuing at `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:6098-6105`. That is a separate failure mode from the March Stage 5 non-atomic enforcement review and it differs from the direct message-send path, which converts the same counting failure into `503` at `tldw_Server_API/app/api/v1/endpoints/character_messages.py:263-281`. The reviewed streaming persistence tests only cover happy-path persistence and speaker metadata, not quota-failure behavior (`tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py`).
+- Targeted validation note: The executed chat slice did hit `/api/v1/chats/{chat_id}/completions/persist` happy-path coverage and nearby limiter coverage, but it did not inject a `count_messages_for_conversation()` or `check_message_limit()` exception through the persist endpoint. The same slice also produced unrelated SSE bootstrap failures from `test_character_chat_sse_unified_flag.py`, where `GET /api/v1/characters/` returned `503` before the streaming assertions ran.
+- Validation status: not reproduced by targeted pytest slice, downgraded to probable risk
 
 ## Residual Risks / Open Questions
 
+- The March review set did not cover the newer character-memory API surface directly, so any broader claims about memory CRUD beyond the ownership mismatch above still need targeted runtime validation.
+- `character_chat_sessions.py` now carries process-local memory-extraction counters, and the static pass cannot tell whether their lifecycle is acceptable under multi-worker or long-running workloads without Stage 3 runtime checks.
+
 ## Coverage Gaps
+
+- No reviewed test exercises `/api/v1/characters/{character_id}/memories/extract`, so the conversation-ownership contract for manual character-memory extraction is currently untested.
+- No reviewed test forces `count_messages_for_conversation()` or rate-limiter failures through `/api/v1/chats/{chat_id}/completions/persist`, so the persist endpoint's fail-open branch is unguarded.
 
 ## Improvements
 
+- Add an endpoint regression test for manual character-memory extraction that uses a real chat session and asserts ownership is checked against the conversation field actually stored by `ChaChaNotes_DB`.
+- Add a persist-endpoint regression test that injects a message-count or limiter failure and asserts the API returns `503` instead of persisting the assistant reply.
+
 ## Exit Note
+
+Backend validation complete. All surviving confirmed findings now have either executed support or a clearly stated reason why runtime confirmation was not feasible in this environment.

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md
@@ -1,0 +1,21 @@
+# Characters Frontend Delta Review
+
+## Scope
+
+## Baseline Artifacts Checked
+
+## Code Paths Reviewed
+
+## Tests Reviewed
+
+## Validation Commands
+
+## Findings
+
+## Residual Risks / Open Questions
+
+## Coverage Gaps
+
+## Improvements
+
+## Exit Note

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md
@@ -2,20 +2,86 @@
 
 ## Scope
 
+- frontend Character workspace
+- frontend Character chat integration
+- frontend Character API client and shared utilities
+
 ## Baseline Artifacts Checked
+
+- Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md
+- Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md
+- Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md
 
 ## Code Paths Reviewed
 
+- apps/tldw-frontend/pages/characters.tsx and pages/settings/characters.tsx: route entry points and dynamic loading
+- apps/packages/ui/src/routes/option-characters.tsx: route-level Character workspace composition
+- apps/packages/ui/src/components/Option/Characters/Manager.tsx, CharactersWorkspace.tsx, CharacterEditorForm.tsx, CharacterDialogs.tsx, CharacterListContent.tsx, and CharacterGalleryCard.tsx: workspace state, editing, list rendering, dialogs, and gallery behavior
+- apps/packages/ui/src/components/Option/Characters/import-state-model.ts, search-utils.ts, and tag-manager-utils.ts: Character workspace state helpers and pure logic
+- apps/packages/ui/src/components/Option/Characters/hooks/useCharacterData.tsx, useCharacterCrud.tsx, useCharacterImportQueue.tsx, useCharacterVersionHistory.tsx, and useCharacterQuickChat.tsx: async data flow and workspace actions
+- apps/packages/ui/src/components/Common/CharacterSelect.tsx and components/Sidepanel/Chat/CharacterSelect.tsx: shared Character selection behavior
+- apps/packages/ui/src/hooks/useSelectedCharacter.ts, useCharacterGreeting.ts, hooks/chat/useCharacterChatMode.ts, hooks/chat/useServerChatLoader.ts, and hooks/chat/useSelectServerChat.ts: Character selection and chat-state synchronization
+- apps/packages/ui/src/services/tldw/domains/characters.ts: frontend API client normalization, fallbacks, and cache behavior
+- apps/packages/ui/src/utils/characters-route.ts, character-greetings.ts, character-mood.ts, default-character-preference.ts, selected-character-storage.ts, and character-export.ts: routing, greeting resolution, persistence helpers, and export shaping
+
 ## Tests Reviewed
+
+- apps/packages/ui/src/components/Option/Characters/__tests__/Manager.first-use.test.tsx
+- apps/packages/ui/src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx
+- apps/packages/ui/src/components/Option/Characters/__tests__/CharacterGalleryCard.test.tsx
+- apps/packages/ui/src/components/Option/Characters/__tests__/import-state-model.test.ts
+- apps/packages/ui/src/components/Option/Characters/__tests__/search-utils.test.ts
+- apps/packages/ui/src/components/Option/Characters/__tests__/tag-manager-utils.test.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.characters-list-all.test.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.characters-delete.test.ts
+- apps/packages/ui/src/hooks/__tests__/useCharacterGreeting.test.tsx
+- apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts
+- apps/packages/ui/src/utils/__tests__/character-greetings.test.ts
+- apps/packages/ui/src/utils/__tests__/character-mood.test.ts
+- apps/packages/ui/src/utils/__tests__/default-character-preference.test.ts
+- apps/packages/ui/src/utils/__tests__/characters-route.test.ts
+- apps/tldw-frontend/e2e/workflows/tier-2-features/characters.spec.ts
+- apps/tldw-frontend/e2e/workflows/journeys/character-chat.spec.ts
 
 ## Validation Commands
 
+- `cd apps/packages/ui && bun run test -- src/components/Option/Characters/__tests__/Manager.first-use.test.tsx src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx src/components/Option/Characters/__tests__/CharacterGalleryCard.test.tsx src/components/Option/Characters/__tests__/import-state-model.test.ts src/components/Option/Characters/__tests__/search-utils.test.ts src/services/__tests__/tldw-api-client.characters-list-all.test.ts src/services/__tests__/tldw-api-client.characters-delete.test.ts src/hooks/__tests__/useCharacterGreeting.test.tsx src/hooks/__tests__/useServerChatLoader.test.ts src/utils/__tests__/character-greetings.test.ts src/utils/__tests__/character-mood.test.ts src/utils/__tests__/default-character-preference.test.ts src/utils/__tests__/characters-route.test.ts --maxWorkers=1` — environment-limited
+- No targeted UI tests executed. This checkout lacks a usable local frontend workspace install for the prescribed `apps/packages/ui` command path, so `bun run test` resolved to `vitest run` but could not execute it cleanly in this workspace and exited with `/bin/bash: vitest: command not found`.
+- `cd apps/tldw-frontend && bun run e2e:pw -- e2e/workflows/tier-2-features/characters.spec.ts e2e/workflows/journeys/character-chat.spec.ts --reporter=line` — environment-limited
+- No Character browser assertions executed. This workspace lacks a usable local frontend tool install for the prescribed `apps/tldw-frontend` command path, so `bun run e2e:pw` fell through to the non-repo binary `/Users/appledev/Documents/GitHub/tldw_server/3.13/bin/playwright`, which reported `unknown command 'test'`.
+
 ## Findings
 
-## Residual Risks / Open Questions
+### Probable risk: Character workspace handoffs store a truncated character selection payload
 
-## Coverage Gaps
+- Severity: Medium
+- Type: correctness
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md; Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md; Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md
+- Why it matters: Before the selected character is replaced with a hydrated server record, cross-surface consumers only see the reduced handoff payload. In that pre-hydration window, alternate greetings and `extensions`-backed mood portraits are unavailable even though downstream chat UI reads those fields from the selected character state.
+- Current evidence: `apps/packages/ui/src/components/Option/Characters/utils.ts:764-782` builds the workspace handoff payload with only `id`, `name`, `system_prompt`, `greeting`, and `avatar_url`; `apps/packages/ui/src/components/Option/Characters/hooks/useCharacterCrud.tsx:483-497` uses that payload for chat entry and `apps/packages/ui/src/components/Option/Characters/hooks/useCharacterQuickChat.tsx:37-54` duplicates it for quick-chat promotion. Downstream, `apps/packages/ui/src/hooks/useCharacterGreeting.ts:331-388` reads greeting variants from `selectedCharacter` first and only later fetches and merges the full record, while `apps/packages/ui/src/components/Common/CharacterSelect.tsx:306-308` and `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx:353-358` derive mood images from `selectedCharacter?.extensions`. The audited baseline artifacts define Character UX goals, but none describe or constrain this selection-payload handoff, so the novelty claim is anchored to current code paths rather than implied recent churn.
+- Validation status: environment-limited, confidence unchanged
 
-## Improvements
+### Probable risk: Quick-chat promotion does not seed server-chat assistant metadata before navigation
+
+- Severity: Medium
+- Type: correctness
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md; Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md; Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md
+- Why it matters: Promoting a quick-chat thread into the main chat route appears to leave a transient pre-hydration window where the server chat id is set but the assistant metadata has not yet been seeded. Any UI that gates character-specific behavior on `serverChatCharacterId` or assistant kind can therefore briefly evaluate against incomplete server-chat metadata before eager metadata loading fills it in.
+- Current evidence: `apps/packages/ui/src/components/Option/Characters/hooks/useCharacterQuickChat.tsx:265-305` sets `serverChatId`, state, topic, cluster/source/externalRef, history, and messages, but does not set `serverChatCharacterId`, `serverChatAssistantKind`, or `serverChatAssistantId`. `apps/packages/ui/src/components/Sidepanel/Chat/body.tsx:237-244` disables character identity whenever `serverChatId` exists and `serverChatCharacterId` is null. The recovery path is also visible statically: `apps/packages/ui/src/hooks/useMessage.tsx:281-305` eagerly reloads chat metadata when `serverChatId` exists and `serverChatMetaLoaded` is false, and `apps/packages/ui/src/hooks/chat/useServerChatLoader.ts:728-737` applies the metadata backfill setters after resolving `getChat(...)` data. The audited baseline artifacts do not contain comparable guidance for quick-chat promotion metadata seeding, so the novelty label is anchored to this currently reviewed frontend path.
+- Validation status: environment-limited, confidence unchanged
+
+### Confirmed finding: The character chat E2E journey does not validate character selection or prompt propagation
+
+- Severity: Medium
+- Type: test gap
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md; Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md; Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md
+- Why it matters: The named journey test currently appears to cover the main create-character to chat flow, but it does not prove that the created character is selected in chat or that its system prompt reaches the completion request. That leaves the primary cross-feature integration path effectively unguarded despite a reassuring spec name.
+- Current evidence: `apps/tldw-frontend/e2e/workflows/journeys/character-chat.spec.ts:1-79` states that it selects the character and verifies system prompt inclusion, yet the body only creates a character, navigates to `/chat`, sends a generic message, and checks request status. No step selects the created character and no assertion inspects the request payload. The adjacent E2E coverage in `apps/tldw-frontend/e2e/workflows/tier-2-features/characters.spec.ts:1-133` covers page load, create, and delete only, so there is no directly relevant browser-level test in the reviewed suite that closes this create-character-to-chat selection and prompt-propagation gap. The audited baseline artifacts describe Character/chat UX goals, but none provide a comparable frontend baseline for this specific journey assertion.
+- Validation status: environment-limited, confidence unchanged
 
 ## Exit Note
+
+Frontend validation complete. All surviving confirmed findings now have either targeted test support or a clearly stated reason why browser-level confirmation was not feasible in this environment.

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md
@@ -1,0 +1,17 @@
+# Characters Full-Stack Delta Synthesis
+
+## Backend Findings
+
+## Frontend Findings
+
+## Cross-Layer Contract Drift
+
+## Open Questions / Residual Risks
+
+## Coverage Gaps
+
+## Improvement Opportunities
+
+## Verification Summary
+
+## Prioritized Next Steps

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md
@@ -2,16 +2,59 @@
 
 ## Backend Findings
 
+- Confirmed finding: manual character-memory extraction authorizes against `conversation.get("user_id")`, while Character conversations are stored and verified against `client_id`. That makes `/api/v1/characters/{character_id}/memories/extract` vulnerable to rejecting valid owned chats until the ownership field is aligned.
+- Probable risk: streamed assistant persistence in [character_chat_sessions.py](/Users/appledev/Documents/GitHub/tldw_server/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py) catches internal quota-check exceptions and continues persisting the assistant reply instead of failing closed. Adjacent targeted pytest slices did not reproduce the branch directly, so it remains a probable backend-only risk.
+
 ## Frontend Findings
+
+- Probable risk: Character workspace handoffs store a truncated selected-character payload with only `id`, `name`, `system_prompt`, `greeting`, and `avatar_url`. Consumers such as greeting resolution and mood portrait rendering also read `selectedCharacter.extensions` and alternate greeting fields, so the pre-hydration window can degrade Character-specific UI state.
+- Probable risk: quick-chat promotion sets `serverChatId` and navigates before seeding `serverChatCharacterId`, `serverChatAssistantKind`, or `serverChatAssistantId`. Frontend recovery depends on a later `getChat()` metadata load, so Character identity can be briefly disabled during the handoff.
+- Confirmed finding: the named Character journey spec still does not select the created character in chat or assert that the Character system prompt reaches `/chat/completions`. The reviewed browser suite therefore leaves the primary Character-to-chat path unguarded even though the spec name implies coverage.
+- Stage 5 frontend validation did not add runtime evidence. This checkout lacks a usable local frontend workspace install for the prescribed `apps/packages/ui` command path, so `bun run test` resolved to `vitest run` but could not execute it cleanly in this workspace. This workspace also lacks a usable local frontend tool install for the prescribed `apps/tldw-frontend` command path, so `bun run e2e:pw` fell through to `/Users/appledev/Documents/GitHub/tldw_server/3.13/bin/playwright`, which reported `unknown command 'test'`.
 
 ## Cross-Layer Contract Drift
 
+- Assistant identity metadata is the highest-risk contract seam. The backend persists and returns `character_id`, `assistant_kind`, and `assistant_id` for chat sessions in [character_chat_sessions.py](/Users/appledev/Documents/GitHub/tldw_server/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py), and the frontend loader in [useServerChatLoader.ts](/Users/appledev/Documents/GitHub/tldw_server/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts) reconstructs Character identity from exactly those fields. Quick-chat promotion bypasses that contract temporarily by only setting `serverChatId`, so the UI falls into a local pre-hydration state that the backend never explicitly models.
+- Selected-character payload shape is another drift seam. The backend `GET /api/v1/characters/{character_id}` contract returns the full character document, while frontend handoff helpers can seed a reduced local object first and rely on later hydration. Any UI path that reads the selected-character cache before hydration is therefore operating on a weaker contract than the backend actually serves.
+- The Character list/query surface is intentionally defensive on the frontend. [characters.ts](/Users/appledev/Documents/GitHub/tldw_server/apps/packages/ui/src/services/tldw/domains/characters.ts) falls back between `/api/v1/characters`, `/api/v1/characters/`, and `/api/v1/characters/query` when it sees 404/405/422 or `path.character_id` parsing errors, while the backend currently exposes both `/` and `/query` plus `versions`, `revert`, `restore`, and `world-books` routes. That fallback reduces breakage but is also evidence that this contract has already been route-order-sensitive enough to require client-side recovery logic.
+- Message speaker metadata looks aligned today but remains drift-sensitive. The backend persists `speaker_character_id` and `speaker_character_name` in streamed/persisted message metadata, and the frontend loader maps those fields back into chat messages for identity and mood rendering. The current review did not find a mismatch there, but there is also no targeted full-stack test covering it.
+
 ## Open Questions / Residual Risks
+
+- It is still unverified whether the truncated selected-character handoff produces a visible user-facing regression in the main chat route before the full character fetch completes, or whether the hydration window is usually too short to notice.
+- It is still unverified whether quick-chat promotion can race badly enough in production for Character identity gating in the sidepanel body to suppress Character-specific rendering during navigation.
+- The manual memory-extraction ownership mismatch remains runtime-unconfirmed because the approved backend slices did not include `/api/v1/characters/{character_id}/memories/extract`.
+- The streamed assistant persistence risk remains branch-unconfirmed because no targeted test injected a `count_messages_for_conversation()` or limiter failure into `/api/v1/chats/{chat_id}/completions/persist`.
 
 ## Coverage Gaps
 
+- The prescribed frontend Vitest slice could not run in `apps/packages/ui` because this checkout lacks a usable local frontend workspace install for that command path, so none of the targeted Character unit/integration tests produced fresh Stage 5 evidence.
+- The prescribed frontend Playwright slice could not run in `apps/tldw-frontend` because this workspace lacks a usable local frontend tool install for that command path and `bun run e2e:pw` fell through to `/Users/appledev/Documents/GitHub/tldw_server/3.13/bin/playwright`, so no browser-level evidence was added for the Character workspace or Character chat flows.
+- The existing Character journey E2E still does not assert Character selection or system-prompt propagation into `/chat/completions`.
+- No reviewed frontend or full-stack test proves that quick-chat promotion seeds assistant metadata before navigation.
+- No reviewed frontend or full-stack test proves that selected-character handoffs preserve alternate greetings, `extensions`, or mood assets before hydration.
+- No reviewed backend test covers the manual memory-extraction ownership branch or the streamed persist fail-open quota path.
+
 ## Improvement Opportunities
+
+- Restore a usable local frontend workspace/tool install for the prescribed `bun run test` and `bun run e2e:pw` command paths in this checkout so the targeted Character validation commands execute against repo-local tooling.
+- Add a narrow frontend regression test around Character handoff payload shape, either by preserving the richer selected-character object up front or by codifying that downstream consumers must tolerate pre-hydration truncation.
+- Add a quick-chat promotion regression that asserts `serverChatCharacterId`, `serverChatAssistantKind`, and `serverChatAssistantId` are seeded before navigation when a server chat id is promoted into the main chat experience.
+- Strengthen the Character journey E2E so it explicitly selects the created character and inspects the `/chat/completions` payload for Character prompt propagation.
+- Add backend endpoint tests for `/api/v1/characters/{character_id}/memories/extract` ownership and `/api/v1/chats/{chat_id}/completions/persist` quota-check failures.
 
 ## Verification Summary
 
+- Frontend targeted validation attempted:
+- `cd apps/packages/ui && bun run test -- src/components/Option/Characters/__tests__/Manager.first-use.test.tsx src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx src/components/Option/Characters/__tests__/CharacterGalleryCard.test.tsx src/components/Option/Characters/__tests__/import-state-model.test.ts src/components/Option/Characters/__tests__/search-utils.test.ts src/services/__tests__/tldw-api-client.characters-list-all.test.ts src/services/__tests__/tldw-api-client.characters-delete.test.ts src/hooks/__tests__/useCharacterGreeting.test.tsx src/hooks/__tests__/useServerChatLoader.test.ts src/utils/__tests__/character-greetings.test.ts src/utils/__tests__/character-mood.test.ts src/utils/__tests__/default-character-preference.test.ts src/utils/__tests__/characters-route.test.ts --maxWorkers=1` failed before discovery because this checkout lacks a usable local frontend workspace install for that command path, so `bun run test` resolved to `vitest run` but could not execute it cleanly in this workspace.
+- `cd apps/tldw-frontend && bun run e2e:pw -- e2e/workflows/tier-2-features/characters.spec.ts e2e/workflows/journeys/character-chat.spec.ts --reporter=line` failed at bootstrap because this workspace lacks a usable local frontend tool install for that command path, so `bun run e2e:pw` fell through to `/Users/appledev/Documents/GitHub/tldw_server/3.13/bin/playwright`, which reported `unknown command 'test'`.
+- Contract comparison executed with `rg -n "/api/v1/characters|/characters/query|character_id|versions|revert|restore|world-books|speaker_character|assistant_kind" ...` across the prescribed backend and frontend files. That comparison confirmed that frontend assistant identity and route fallbacks are explicitly keyed to backend Character/chat response fields.
+- Backend evidence was carried forward from the completed review in [2026-04-08-backend-review.md](/Users/appledev/Documents/GitHub/tldw_server/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md), including one confirmed backend correctness issue and one surviving probable backend risk.
+
 ## Prioritized Next Steps
+
+1. Restore a usable local frontend workspace/tool install for the exact prescribed Vitest and Playwright Character command paths so those slices can run and either confirm or downgrade the two runtime-sensitive frontend risks.
+2. Expand the Character journey E2E to assert actual Character selection and prompt propagation into `/chat/completions`; that closes the largest current full-stack coverage gap.
+3. Add a focused regression for quick-chat promotion metadata seeding, because that is the clearest frontend/backend contract seam around `assistant_kind`, `assistant_id`, and `character_id`.
+4. Add a focused regression for selected-character handoff fidelity or explicitly narrow the supported pre-hydration contract so greeting and mood consumers are not reading fields the handoff does not preserve.
+5. Add backend endpoint tests for manual memory extraction ownership and streamed persistence quota failure so the surviving backend items move from static risk to directly exercised behavior.

--- a/Docs/superpowers/reviews/characters-fullstack-delta/README.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/README.md
@@ -1,0 +1,24 @@
+# Characters Full-Stack Delta Review
+
+## Stage Order
+
+1. Baseline and artifact setup
+2. Backend delta static pass
+3. Backend targeted validation
+4. Frontend delta static pass
+5. Frontend targeted validation and cross-layer synthesis
+6. Final synthesis and handoff
+
+## Review Artifacts
+
+- `Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md`
+
+## Rules
+
+- Findings are written before remediation ideas.
+- Historical findings are not re-reported as current unless they still appear live.
+- Every reported finding includes a baseline artifact note.
+- Uncertain items are labeled as `Probable risk` or `Open question`, not overstated as confirmed defects.
+- Backend, frontend, and cross-layer findings stay separate until the final synthesis.

--- a/Docs/superpowers/specs/2026-04-08-audit-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-audit-module-review-design.md
@@ -1,0 +1,217 @@
+# Audit Module Review Design
+
+Date: 2026-04-08
+Status: Approved for planning
+Owner: Codex brainstorming session
+
+## Summary
+
+Run a deep, reliability-first review of the Audit subsystem in `tldw_server`.
+
+The review covers:
+
+- the core Audit service
+- dependency injection and lifecycle management
+- export and count endpoints
+- storage mode and tenant scoping behavior
+- migration and fallback durability paths
+- representative cross-module audit emitters and adapters
+- dedicated Audit tests plus selected integration tests that exercise audit behavior
+
+The output must prioritize actionable findings over commentary, with bugs and risks clearly separated from hardening suggestions.
+
+## Problem
+
+The Audit subsystem is a compliance and operational reliability surface. If it is wrong, the likely failures are not cosmetic. They are event loss, incomplete shutdown flushes, fallback queue corruption, tenant-boundary mistakes in shared mode, or export behavior that becomes unsafe under load.
+
+The module is also spread across several layers:
+
+- core logic in `tldw_Server_API/app/core/Audit/`
+- DI and lifecycle code in `tldw_Server_API/app/api/v1/API_Deps/`
+- REST endpoints in `tldw_Server_API/app/api/v1/endpoints/`
+- emitters and adapters across AuthNZ, Chat, Embeddings, Evaluations, Jobs, Sharing, MCP, and related backend surfaces
+
+Because the behavior is distributed, a useful review needs explicit slices, an evidence bar, and a narrow definition of what counts as a finding.
+
+## Goals
+
+- Produce a severity-ordered Audit review with actionable findings.
+- Optimize for reliability and operational risk rather than style.
+- Inspect both the Audit core and representative integrations.
+- Use static inspection and targeted test execution as evidence.
+- Separate `Confirmed issue`, `Likely risk`, and `Improvement suggestion`.
+- Identify important testing gaps where reliability-sensitive behavior is weakly protected.
+
+## Non-Goals
+
+- Refactor the Audit module during the review.
+- Expand the pass into a general backend style review.
+- Treat passing tests as proof that a code path is safe.
+- Propose broad architecture rewrites unless needed to explain a concrete issue.
+
+## Scope Confirmed With User
+
+The user approved the broader review scope rather than narrowing to only the Audit core package.
+
+The confirmed scope includes:
+
+- deep review depth
+- reliability and operational risk as the main optimization target
+- findings-first output with separate improvements
+
+## Review Baseline
+
+The review will inspect the current working tree by default.
+
+If a finding depends on uncommitted local changes, the review must say so explicitly instead of presenting the behavior as if it were clean `HEAD`.
+
+## Recommended Approach
+
+Use a risk-led layered review.
+
+Three candidate approaches were considered:
+
+1. Risk-led layered review
+2. Test-led review
+3. Integration-led review
+
+The recommended choice is the risk-led layered review because it is the most reliable way to surface silent-loss, shutdown, tenant-boundary, and export-scaling failures before test coverage biases the outcome.
+
+## Inspection Slices
+
+### 1. Core Service and Migration Reliability
+
+Inspect:
+
+- buffering and flush semantics
+- high-risk immediate flush logic
+- background-task behavior
+- shutdown guarantees
+- schema creation and initialization
+- retention cleanup
+- fallback queue append behavior
+- shared/per-user storage handling
+- migration resumability and partial-failure behavior
+
+Primary files:
+
+- `tldw_Server_API/app/core/Audit/unified_audit_service.py`
+- `tldw_Server_API/app/core/Audit/audit_shared_migration.py`
+
+### 2. DI, Lifecycle, and Tenancy
+
+Inspect:
+
+- per-user instance caching
+- eviction and reuse semantics
+- owner-loop and cross-loop shutdown behavior
+- request user binding
+- shared storage enablement and rollback precedence
+- DB path resolution
+- tenant scoping assumptions
+
+Primary files:
+
+- `tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py`
+- `tldw_Server_API/app/core/DB_Management/db_path_utils.py`
+- `tldw_Server_API/app/core/config.py`
+
+### 3. Export, Filtering, and Admin Access
+
+Inspect:
+
+- timestamp parsing
+- enum and filter mapping
+- stream versus non-stream behavior
+- row-limit and truncation logic
+- filename sanitization
+- access-control assumptions
+- tenant visibility rules in shared mode
+
+Primary file:
+
+- `tldw_Server_API/app/api/v1/endpoints/audit.py`
+
+### 4. Cross-Module Emitters and Adapter Consistency
+
+Sample high-value producers and adapters to find:
+
+- missing or inconsistent `AuditContext`
+- missing or incorrect user scoping
+- unsafe fire-and-forget audit writes
+- swallowed audit failures
+- inconsistent event naming or category mapping
+- brittle behavior in shutdown or error paths
+
+Priority integration areas:
+
+- AuthNZ
+- Chat
+- Embeddings
+- Evaluations
+- Jobs
+- Sharing
+- MCP
+- RAG-adjacent or governance surfaces when they materially rely on unified audit behavior
+
+### 5. Coverage and Drift
+
+Use dedicated Audit tests and selected integration tests to establish what behavior is actually protected, then identify where reliability-sensitive paths appear weakly covered or untested.
+
+Priority gap areas:
+
+- shutdown races
+- fallback durability and locking
+- shared-storage tenant edges
+- large export behavior
+- migration recovery and resumability
+- cross-module contract drift
+
+## Evidence Model
+
+Every review item must be labeled as one of:
+
+- `Confirmed issue`
+- `Likely risk`
+- `Improvement suggestion`
+
+Classification rules:
+
+- `Confirmed issue`: concrete failure mode in code, contract mismatch, or reproducible behavior from tests
+- `Likely risk`: credible concern with weak coverage or configuration-dependent behavior, but not fully proven
+- `Improvement suggestion`: non-bug hardening work that reduces fragility or operator pain
+
+Each finding must include:
+
+- exact file references
+- whether evidence came from static inspection, targeted test execution, or both
+- whether the behavior depends on the dirty worktree rather than only committed code
+
+## Deliverable Shape
+
+The final review should be concise and findings-first, using this structure:
+
+## Findings
+
+- severity-ordered issues and likely risks with file references and evidence notes
+
+## Open Questions / Assumptions
+
+- only unresolved items that materially affect confidence
+
+## Improvements
+
+- non-bug hardening suggestions kept separate from bug findings
+
+## Verification
+
+- baseline reviewed
+- tests run
+- important files inspected
+- anything left unverified
+
+## Verification Strategy
+
+Run the dedicated Audit tests plus selected integration tests that directly exercise audit behavior. Test execution is evidence of covered behavior, not proof of global correctness.
+
+The review should prefer representative test slices over blanket unrelated suite execution.

--- a/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
@@ -55,6 +55,13 @@ Representative endpoint and test entry points should include at least:
 - `tldw_Server_API/tests/AuthNZ/unit/`
 - `tldw_Server_API/tests/AuthNZ/property/`
 
+Representative admin/authz endpoint selection should favor:
+
+- endpoints that issue, refresh, revoke, or invalidate credentials
+- endpoints that mutate RBAC, roles, permissions, or admin-only state
+- endpoints whose protection depends on shared AuthNZ dependencies rather than local ad hoc checks
+- an adjacent non-auth endpoint only when it is needed to confirm that AuthNZ enforcement is actually applied at a real caller boundary
+
 Expansion beyond the initial hotspot set should be justified by one or more of:
 
 - high fan-out into other AuthNZ flows
@@ -168,6 +175,10 @@ The resulting review should be a concise, prioritized audit report with:
 2. Probable risks or open questions that materially affect confidence
 3. Improvements that would reduce future AuthNZ regression risk
 4. Brief residual-risk notes where coverage or runtime verification remains incomplete
+5. A coverage note listing:
+   - hotspot files reviewed directly
+   - files or tests only spot-checked
+   - notable scoped surfaces not reviewed deeply and why
 
 ## Success Criteria
 

--- a/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
@@ -1,5 +1,9 @@
 # AuthNZ Bug And Test-Gap Audit Design
 
+Date: 2026-04-08
+Topic: Bug-and-test-gap audit of AuthNZ runtime behavior
+Status: Revised after spec self-review
+
 ## Overview
 
 This review will audit the AuthNZ subsystem in `tldw_server` for bugs, unsafe edge cases, and missing or weak tests. The goal is not a broad style review. The goal is a prioritized findings report that identifies concrete correctness and security risks, then maps those risks to the test coverage that should exist.
@@ -16,6 +20,7 @@ This review will audit the AuthNZ subsystem in `tldw_server` for bugs, unsafe ed
 - No broad refactor proposal unless it directly addresses a bug pattern or persistent test gap.
 - No style-only review.
 - No review of unrelated modules outside AuthNZ and its directly related auth/admin entry points.
+- No remediation or code changes during the audit unless explicitly requested in a later step.
 
 ## Audit Scope
 
@@ -25,6 +30,38 @@ The audit covers:
 - `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
 - Related auth and admin API endpoints that depend on AuthNZ enforcement paths
 - AuthNZ integration, unit, and property tests that exercise those paths
+
+Initial hotspot files should include at least:
+
+- `tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py`
+- `tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py`
+- `tldw_Server_API/app/core/AuthNZ/jwt_service.py`
+- `tldw_Server_API/app/core/AuthNZ/session_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/permissions.py`
+- `tldw_Server_API/app/core/AuthNZ/rbac.py`
+- `tldw_Server_API/app/core/AuthNZ/settings.py`
+- `tldw_Server_API/app/core/AuthNZ/database.py`
+- `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/auth.py`
+
+Representative endpoint and test entry points should include at least:
+
+- auth endpoints under `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- representative admin/authz endpoints that materially depend on claim-first enforcement
+- `tldw_Server_API/tests/AuthNZ/integration/`
+- `tldw_Server_API/tests/AuthNZ/unit/`
+- `tldw_Server_API/tests/AuthNZ/property/`
+
+Expansion beyond the initial hotspot set should be justified by one or more of:
+
+- high fan-out into other AuthNZ flows
+- recent churn or repeated regressions
+- backend divergence between SQLite and PostgreSQL
+- privileged or externally reachable behavior
+- unusually large or multi-responsibility implementations
 
 The audit will treat the following areas as highest-risk surfaces:
 
@@ -71,6 +108,13 @@ Compare the high-risk behaviors from the first three passes against current Auth
 - tests that mock away the exact logic that should be verified
 - coverage that exists at unit level but not at integration boundaries
 
+### Pass 5: Evidence Cross-Check
+
+Use recent git history, the most relevant docs, and targeted verification only where they materially change confidence in a suspected issue. This pass exists to prevent two failure modes:
+
+- reporting stale-doc mismatches as defects when the runtime contract already changed intentionally
+- reporting probable risks as confirmed bugs when the critical branch or backend divergence has not been validated
+
 ## Prioritization Model
 
 Findings will be ranked by operational impact:
@@ -85,26 +129,45 @@ Each finding should include:
 
 - title
 - severity
+- confidence
+- classification
 - affected file and exact line reference
 - concrete failure mode
 - reason the behavior is risky or incorrect
 - current test coverage status
 - specific test that should be added or strengthened
 
+Classification should be one of:
+
+- Confirmed finding
+- Probable risk
+- Improvement
+
 ## Evidence Standards
 
 - Prefer direct code-path evidence over inference.
 - Use tests to confirm intended behavior when the implementation alone is ambiguous.
 - Treat inconsistencies between endpoint wiring, dependency logic, and test assumptions as findings when they could hide real regressions.
+- Perform targeted runtime verification when a high-risk claim depends on stateful behavior, backend divergence, or ambiguous guard execution and the answer is feasible to verify locally.
+- Be explicit when a conclusion is limited by unavailable runtime verification or fixture constraints.
 - Keep the final output focused on findings first. Any summary should be secondary.
+
+Targeted runtime verification is especially appropriate for:
+
+- refresh rotation and revocation behavior
+- lockout and rate-limit state transitions
+- SQLite versus PostgreSQL divergence on the same reviewed path
+- test-mode or environment-guard branches
+- endpoint-level enforcement where the dependency chain is unclear from static inspection alone
 
 ## Deliverable
 
 The resulting review should be a concise, prioritized audit report with:
 
-1. Findings ordered by severity
-2. Open questions or assumptions that affected confidence
-3. Brief residual-risk notes where coverage or runtime verification remains incomplete
+1. Confirmed findings ordered by severity
+2. Probable risks or open questions that materially affect confidence
+3. Improvements that would reduce future AuthNZ regression risk
+4. Brief residual-risk notes where coverage or runtime verification remains incomplete
 
 ## Success Criteria
 

--- a/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
@@ -1,0 +1,116 @@
+# AuthNZ Bug And Test-Gap Audit Design
+
+## Overview
+
+This review will audit the AuthNZ subsystem in `tldw_server` for bugs, unsafe edge cases, and missing or weak tests. The goal is not a broad style review. The goal is a prioritized findings report that identifies concrete correctness and security risks, then maps those risks to the test coverage that should exist.
+
+## Goals
+
+- Produce a prioritized set of findings focused on real bugs, regressions, and unsafe behavior.
+- Include missing-test and weak-test findings when they materially increase regression risk.
+- Cover the runtime path from request authentication through authorization and stateful session/key handling.
+- Keep findings grounded in exact code references and current project behavior.
+
+## Non-Goals
+
+- No broad refactor proposal unless it directly addresses a bug pattern or persistent test gap.
+- No style-only review.
+- No review of unrelated modules outside AuthNZ and its directly related auth/admin entry points.
+
+## Audit Scope
+
+The audit covers:
+
+- `tldw_Server_API/app/core/AuthNZ/`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- Related auth and admin API endpoints that depend on AuthNZ enforcement paths
+- AuthNZ integration, unit, and property tests that exercise those paths
+
+The audit will treat the following areas as highest-risk surfaces:
+
+- Single-user vs multi-user auth branching
+- JWT parsing, validation, refresh, and revocation
+- Session lifecycle and blacklist behavior
+- API key validation, rotation, and scope enforcement
+- Admin and privileged endpoint protection
+- RBAC and permission resolution
+- Lockout, rate limit, quota, and governor interactions
+- Test mode and environment guardrails
+
+## Review Method
+
+The review will use a risk-driven method with a test-gap overlay.
+
+### Pass 1: Trust Boundary Review
+
+Inspect the request entry points where principals are resolved and privileged routes are gated. Focus on authentication precedence, token/key parsing, mode-specific behavior, and any branches that could bypass intended checks.
+
+### Pass 2: Stateful Flow Review
+
+Trace flows that depend on mutable state:
+
+- login
+- refresh rotation
+- session validation and revocation
+- token blacklist usage
+- API key lifecycle
+- lockout and rate-limit state transitions
+
+The purpose of this pass is to catch correctness bugs that emerge only when state changes across requests.
+
+### Pass 3: Authorization Review
+
+Inspect how permissions are derived, propagated, and enforced across auth/admin endpoints. Focus on privilege escalation risks, incorrect default behavior, inconsistent permission checks, and org/team/admin edge cases.
+
+### Pass 4: Test-Gap Review
+
+Compare the high-risk behaviors from the first three passes against current AuthNZ tests. Flag:
+
+- behavior with no direct test coverage
+- tests that assert happy paths but not failure paths
+- tests that mock away the exact logic that should be verified
+- coverage that exists at unit level but not at integration boundaries
+
+## Prioritization Model
+
+Findings will be ranked by operational impact:
+
+- High: auth bypass, privilege escalation, revocation failure, broken admin enforcement, unsafe test-mode or environment behavior
+- Medium: correctness bugs that deny valid access, break refresh or lockout flows, or create inconsistent authorization outcomes
+- Low: missing tests, brittle abstractions, duplicate enforcement paths, or maintainability issues likely to cause future regressions
+
+## Finding Format
+
+Each finding should include:
+
+- title
+- severity
+- affected file and exact line reference
+- concrete failure mode
+- reason the behavior is risky or incorrect
+- current test coverage status
+- specific test that should be added or strengthened
+
+## Evidence Standards
+
+- Prefer direct code-path evidence over inference.
+- Use tests to confirm intended behavior when the implementation alone is ambiguous.
+- Treat inconsistencies between endpoint wiring, dependency logic, and test assumptions as findings when they could hide real regressions.
+- Keep the final output focused on findings first. Any summary should be secondary.
+
+## Deliverable
+
+The resulting review should be a concise, prioritized audit report with:
+
+1. Findings ordered by severity
+2. Open questions or assumptions that affected confidence
+3. Brief residual-risk notes where coverage or runtime verification remains incomplete
+
+## Success Criteria
+
+This audit is successful if it:
+
+- identifies real, code-backed AuthNZ risks instead of generic advice
+- distinguishes bugs from lower-signal cleanup suggestions
+- maps important gaps in tests to the behaviors they fail to protect
+- gives the maintainer a clear order of operations for follow-up fixes

--- a/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
@@ -1,0 +1,326 @@
+# AuthNZ Full Module Review Design
+
+Date: 2026-04-08
+Topic: Full AuthNZ module deep review with remediation roadmap
+Status: Approved design
+
+## Objective
+
+Review the AuthNZ surface in `tldw_server` for concrete bugs, security issues,
+correctness problems, documentation drift, test gaps, and maintainability risks
+with a deep, evidence-first audit.
+
+The review should produce a ranked findings report and a prioritized remediation
+roadmap. Unlike narrower prior AuthNZ reviews, this run explicitly includes the
+core AuthNZ module, its immediate API integration points, and the tests and docs
+that define or describe current behavior.
+
+This review is allowed to include small proof-of-fix patches, but only for
+confirmed critical issues where the remediation is localized and can be verified
+without forcing a risky redesign during the audit.
+
+## Scope
+
+This review is centered on:
+
+- `tldw_Server_API/app/core/AuthNZ`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- representative admin or control-surface endpoints that materially depend on
+  AuthNZ claim-first enforcement
+- AuthNZ-focused tests and adjacent tests that validate AuthNZ runtime behavior
+- documentation that claims current AuthNZ behavior
+
+This includes:
+
+- authentication entry points and credential resolution
+- authorization and claim-first dependency enforcement
+- JWT issuance, validation, scoping, rotation, and revocation assumptions
+- session lifecycle and blacklist behavior
+- password, reset, email verification, MFA, API key, and virtual key flows
+- rate limit, quota, lockout, and budget guardrails where they are part of the
+  AuthNZ runtime contract
+- settings precedence, mode and profile handling, startup and initialization
+  behavior, and backend-specific persistence paths
+- migration and schema safety across SQLite and PostgreSQL
+- test coverage quality and documentation accuracy for the reviewed behavior
+
+This review excludes:
+
+- a full platform-wide endpoint audit outside AuthNZ-driven behavior
+- broad product UX critique
+- speculative rewrites that are not supported by concrete evidence
+- large remediation refactors during the review itself
+
+## Approaches Considered
+
+### Recommended: Layered risk audit
+
+Map trust boundaries first, then inspect the highest-risk AuthNZ internals and
+their integration points, and finally compare implementation behavior against
+tests and docs before writing findings.
+
+Why this is preferred:
+
+- it matches the user’s request for a deep audit plus roadmap
+- it surfaces security and authz failures before lower-value cleanup
+- it reduces the chance of missing issues hidden between core services and API
+  dependencies
+- it supports selective proof-of-fix patches without turning the review into a
+  rewrite
+
+### Alternative: Surface-first audit
+
+Inspect architecture, the largest files, and representative endpoints, then
+spot-check tests and docs.
+
+Trade-offs:
+
+- faster
+- useful for a quick health scan
+- weaker for edge-case runtime failures and persistence or migration hazards
+
+### Alternative: Endpoint-first behavior audit
+
+Start from `/api/v1/auth*`, `auth_deps.py`, and the current tests, then trace
+back into core AuthNZ services.
+
+Trade-offs:
+
+- strong for externally visible regressions
+- strong for auth and authz contract mismatches
+- weaker for dormant but dangerous internals such as migrations, settings
+  precedence, and backend divergence
+
+## Chosen Method
+
+Use the recommended layered risk audit with five ordered passes:
+
+1. `Boundary map`
+   Identify authentication entry points, authorization gates, trust boundaries,
+   secret and key handling, and mode or profile switches.
+2. `Runtime correctness`
+   Inspect credential resolution, session lifecycle, JWT or API-key behavior,
+   RBAC and claim enforcement, and stateful security controls.
+3. `Persistence and configuration safety`
+   Review settings precedence, startup and initialization behavior, DB
+   abstractions, migrations, and SQLite or PostgreSQL divergence.
+4. `Evidence cross-check`
+   Compare suspicious or high-risk behavior against tests, recent commits, and
+   current docs to distinguish confirmed defects from assumptions, stale docs,
+   or already-covered invariants.
+5. `Findings and remediation synthesis`
+   Produce a ranked review report and roadmap, and apply only narrowly scoped
+   proof-of-fix patches for confirmed critical issues that satisfy the patch
+   gate below.
+
+## Evidence Model
+
+The review will rely on:
+
+- direct source inspection of the scoped AuthNZ code and immediate integration
+  points
+- direct inspection of AuthNZ-focused tests across:
+  - `tldw_Server_API/tests/AuthNZ`
+  - `tldw_Server_API/tests/AuthNZ_SQLite`
+  - `tldw_Server_API/tests/AuthNZ_Postgres`
+  - `tldw_Server_API/tests/AuthNZ_Unit`
+  - `tldw_Server_API/tests/AuthNZ_Federation`
+- targeted caller inspection when an AuthNZ behavior is only meaningful in its
+  API dependency or endpoint context
+- targeted documentation inspection where docs claim current runtime behavior
+- recent git history when it helps explain regression-prone areas or newly
+  changed contracts
+
+The review is evidence-first, not style-first. A concern becomes a reported
+finding only when there is concrete support from code, tests, docs drift that
+creates real risk, or targeted verification.
+
+Runtime verification may be used selectively when it materially strengthens or
+weakens a specific claim. It should answer narrow questions such as:
+
+- whether a suspicious branch is actually exercised
+- whether a contract claimed by docs or tests no longer matches code
+- whether a critical invariant fails under current fixtures
+- whether SQLite and PostgreSQL behavior diverge on a reviewed path
+
+If verification cannot be run, the limitation should be stated explicitly and
+the issue should remain a probable risk unless source evidence is already
+conclusive.
+
+## Review Focus Areas
+
+The review order inside the scoped surface should bias toward:
+
+- credential resolution order and ambiguity between single-user key auth,
+  multi-user JWT auth, API keys, and virtual keys
+- claim-first authorization and the risk of mode-based bypasses
+- token creation, validation, revocation, refresh rotation, and blacklist usage
+- session lifecycle, encrypted token storage, key management, and revocation
+  consistency
+- password, reset, verification, MFA, and lockout behavior
+- API key and virtual key issuance, validation, scoping, quotas, and budgets
+- settings precedence, fail-open or fail-closed behavior, and deployment-mode
+  coordination
+- backend-specific persistence, migration safety, and schema harmonization
+- docs drift and test gaps on high-risk auth and authz contracts
+- maintainability problems in very large files where blurred boundaries are
+  likely to create future defects
+
+Initial hotspot files should include at least:
+
+- `tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py`
+- `tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py`
+- `tldw_Server_API/app/core/AuthNZ/jwt_service.py`
+- `tldw_Server_API/app/core/AuthNZ/session_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/permissions.py`
+- `tldw_Server_API/app/core/AuthNZ/settings.py`
+- `tldw_Server_API/app/core/AuthNZ/database.py`
+- `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/auth.py`
+
+Representative expansion beyond the hotspot set should be driven by one or more
+of these signals:
+
+- high fan-out
+- recent churn or repeated regressions
+- security sensitivity
+- backend divergence
+- unusually large or multi-responsibility implementations
+
+## Findings Model
+
+The final report should present findings first, ordered by severity.
+
+Each observation should be classified as one of:
+
+### Confirmed finding
+
+A concrete bug, vulnerability, contract mismatch, persistence hazard, or design
+problem supported directly by code, tests, docs drift with operational risk, or
+targeted verification.
+
+### Probable risk
+
+Something that appears unsafe, brittle, or likely wrong but depends on
+assumptions that are not fully proven within the reviewed evidence.
+
+### Improvement
+
+A maintainability, hardening, or architectural simplification opportunity that
+would reduce future risk but is not itself strong evidence of a current defect.
+
+Each reported item should include:
+
+- severity
+- confidence
+- concise description of the failure mode or risk
+- why it matters
+- concrete file references
+
+## Severity Model
+
+Severity should be weighted primarily by:
+
+- security and privilege-escalation risk
+- authentication or authorization correctness risk
+- data integrity or session/token safety risk
+- blast radius across modes, backends, or high-fan-out callers
+- probability of recurring regressions caused by maintainability debt
+
+Documentation drift and test gaps are in scope, but they must not outrank a
+real runtime or security defect unless they create direct operational risk.
+
+## Deliverable Contract
+
+The review will produce three outputs:
+
+### 1. Findings report
+
+The final response should be in code-review style, ordered by severity, with
+runtime and security defects first, then correctness issues, then
+maintainability, docs drift, and test gaps.
+
+### 2. Remediation roadmap
+
+The roadmap should group work into:
+
+- immediate fixes
+- near-term hardening
+- structural refactors worth scheduling
+
+The roadmap should be concrete and minimal. It should recommend the smallest
+defensible change that addresses the real issue rather than broad rewrites.
+
+### 3. Proof-of-fix patches for confirmed critical issues only
+
+Patches are allowed only when all of these are true:
+
+- the issue is confirmed, not speculative
+- severity is critical or otherwise urgent enough to justify interrupting the
+  review flow
+- the fix is localized and low-risk
+- the change can be verified with targeted tests or other concrete checks
+
+If a safe fix requires a broader redesign, the review should stop at the
+finding plus roadmap item and not force a risky patch during the audit.
+
+## Patch Gate
+
+A proof-of-fix patch is permitted only if it satisfies this decision rule:
+
+1. The bug is real and supported by direct evidence.
+2. The touched area can be changed without broad coordination or endpoint-wide
+   redesign.
+3. The likely fix does not depend on unresolved product choices.
+4. Verification can be run against the changed behavior.
+
+If any of these are false, the issue stays in the report and roadmap only.
+
+## Testing And Verification Strategy
+
+Testing effort during the review should remain targeted, not exhaustive.
+
+Verification should prefer the smallest useful command set that can answer a
+specific question. When code changes are made, the review must verify them with
+focused tests or equivalent concrete checks before claiming success.
+
+Because touched code may include security-sensitive paths, completion for any
+proof-of-fix patch should also include Bandit on the touched scope using the
+project virtual environment.
+
+## Execution Boundaries
+
+- Stay focused on AuthNZ and its immediate integration surface.
+- Do not silently expand into a full application review.
+- Do not present speculation as a confirmed bug.
+- Do not let large-file maintainability commentary crowd out higher-signal auth
+  and authz failures.
+- Do not turn the deep audit into a large remediation project during the same
+  pass.
+
+## Success Criteria
+
+The review is successful when:
+
+- the full approved AuthNZ surface is covered with risk-weighted depth
+- findings are evidence-based and ordered by severity
+- code and security defects are clearly separated from softer risks and
+  maintainability issues
+- docs drift and test gaps are treated as first-class findings when they create
+  meaningful operational or regression risk
+- the final report is immediately usable for triage
+- any proof-of-fix patches are narrow, justified, and verified
+- unresolved blind spots are made explicit instead of being mistaken for clean
+  health
+
+## Expected Outcome
+
+This design yields a deep, boundary-aware AuthNZ audit that is broad enough to
+cover core services, API integration points, tests, and documentation contracts
+without losing prioritization. The result should be a high-signal findings
+report, a practical remediation roadmap, and only those small critical patches
+that can be made safely and verified during the review.

--- a/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
@@ -52,6 +52,18 @@ This review excludes:
 - speculative rewrites that are not supported by concrete evidence
 - large remediation refactors during the review itself
 
+Representative admin or control-surface endpoints are in scope only when at
+least one of these is true:
+
+- they directly use `get_auth_principal`, `require_permissions(...)`,
+  `require_roles(...)`, or related AuthNZ claim-first dependencies
+- they are a high-fan-out or high-risk consumer of AuthNZ authentication or
+  authorization behavior
+- recent churn or prior findings suggest they are a likely regression surface
+
+This keeps the integration review focused on AuthNZ contract boundaries rather
+than drifting into a general endpoint audit.
+
 ## Approaches Considered
 
 ### Recommended: Layered risk audit
@@ -132,6 +144,16 @@ The review will rely on:
 - recent git history when it helps explain regression-prone areas or newly
   changed contracts
 
+Documentation review should start from a bounded seed set and expand only when
+those docs point to another behavior-defining source. The seed set is:
+
+- `tldw_Server_API/app/core/AuthNZ/README.md`
+- `Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md`
+- `Docs/API-related/User_Registration_API_Documentation.md`
+- `Docs/Operations/Env_Vars.md`
+- relevant quickstart or troubleshooting docs only when they claim current auth
+  behavior that may affect runtime expectations
+
 The review is evidence-first, not style-first. A concern becomes a reported
 finding only when there is concrete support from code, tests, docs drift that
 creates real risk, or targeted verification.
@@ -147,6 +169,11 @@ weakens a specific claim. It should answer narrow questions such as:
 If verification cannot be run, the limitation should be stated explicitly and
 the issue should remain a probable risk unless source evidence is already
 conclusive.
+
+Feature-flagged, enterprise, federation, or secret-backend paths remain in
+scope, but any path that cannot be exercised or strongly validated from local
+evidence must be reported as a probable risk unless the source alone proves a
+confirmed defect.
 
 ## Review Focus Areas
 
@@ -190,6 +217,25 @@ of these signals:
 - security sensitivity
 - backend divergence
 - unusually large or multi-responsibility implementations
+
+## Review Artifact Contract
+
+The audit should leave a traceable review workspace under:
+
+- `Docs/superpowers/reviews/authnz-full-module/`
+
+That workspace should contain:
+
+- a `README.md` that fixes the stage order and links the stage reports
+- stage artifacts that separate inventory, runtime and authz analysis,
+  persistence/config review, and test/docs synthesis
+- a final synthesis artifact that captures the highest-confidence findings,
+  open questions, and verification limits before the final user-facing report is
+  written
+
+The user-facing final response should be based on those staged artifacts rather
+than on ad hoc notes. This keeps the audit resumable and preserves pre-fix
+evidence when narrow proof-of-fix patches are applied later in the review.
 
 ## Findings Model
 
@@ -280,6 +326,15 @@ A proof-of-fix patch is permitted only if it satisfies this decision rule:
 
 If any of these are false, the issue stays in the report and roadmap only.
 
+Before any proof-of-fix patch is applied, the review must first preserve the
+pre-fix evidence in the stage artifacts or review notes so the final report can
+describe the original defect and not just the repaired state.
+
+Proof-of-fix patches should generally be applied after the relevant stage has
+gathered enough surrounding context to avoid masking a broader pattern. If a
+patch would interfere with continued evidence gathering, defer it and keep the
+issue in the roadmap.
+
 ## Testing And Verification Strategy
 
 Testing effort during the review should remain targeted, not exhaustive.
@@ -291,6 +346,12 @@ focused tests or equivalent concrete checks before claiming success.
 Because touched code may include security-sensitive paths, completion for any
 proof-of-fix patch should also include Bandit on the touched scope using the
 project virtual environment.
+
+The final report should include a short verification section summarizing:
+
+- files and docs inspected
+- tests or checks run
+- what remains unverified
 
 ## Execution Boundaries
 

--- a/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
@@ -237,6 +237,17 @@ The user-facing final response should be based on those staged artifacts rather
 than on ad hoc notes. This keeps the audit resumable and preserves pre-fix
 evidence when narrow proof-of-fix patches are applied later in the review.
 
+The default stage order should be:
+
+1. `Stage 1: Baseline and boundary inventory`
+2. `Stage 2: Runtime authentication and authorization analysis`
+3. `Stage 3: Persistence, migrations, and configuration safety`
+4. `Stage 4: Tests, docs drift, and verification gaps`
+5. `Stage 5: Final synthesis, roadmap, and patch decisions`
+
+If the review needs to branch, it should still preserve this canonical sequence
+in the workspace so the evidence trail is easy to follow.
+
 ## Findings Model
 
 The final report should present findings first, ordered by severity.
@@ -289,6 +300,21 @@ The review will produce three outputs:
 The final response should be in code-review style, ordered by severity, with
 runtime and security defects first, then correctness issues, then
 maintainability, docs drift, and test gaps.
+
+The canonical final response structure should be:
+
+1. `Findings`
+2. `Open Questions` only when unresolved ambiguity materially affects confidence
+3. `Verification`
+4. `Remediation Roadmap`
+
+Inside `Findings`:
+
+- confirmed findings come before probable risks
+- probable risks come before improvements
+- any issue fixed during the review must still be listed, clearly marked as
+  `fixed during review`, with the original failure mode and the verification
+  evidence preserved
 
 ### 2. Remediation roadmap
 

--- a/Docs/superpowers/specs/2026-04-08-characters-fullstack-delta-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-characters-fullstack-delta-review-design.md
@@ -29,18 +29,29 @@ synthesis.
 - `tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py`
 - `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
 - `tldw_Server_API/app/api/v1/endpoints/character_messages.py`
+- `tldw_Server_API/app/api/v1/schemas/character_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/character_memory_schemas.py`
 - `tldw_Server_API/app/core/Character_Chat/Character_Chat_Lib_facade.py`
 - `tldw_Server_API/app/core/Character_Chat/character_limits.py`
 - `tldw_Server_API/app/core/Character_Chat/character_rate_limiter.py`
 - `tldw_Server_API/app/core/Character_Chat/modules/character_db.py`
 - `tldw_Server_API/app/core/Character_Chat/modules/character_io.py`
 - `tldw_Server_API/app/core/Character_Chat/modules/character_chat.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_validation.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_memory_extraction.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_templates.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_prompt_presets.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_generation_presets.py`
+- `tldw_Server_API/app/core/Character_Chat/world_book_manager.py`
+- `tldw_Server_API/app/core/Chat/chat_characters.py`
 - related Character retrieval, exemplar, and world-book logic touched by the
   current Character API and chat flows
 - backend Character tests under `tldw_Server_API/tests/Characters/`,
   `tldw_Server_API/tests/Character_Chat*`, `tldw_Server_API/tests/ChaChaNotesDB/`,
   and nearby integration/property/e2e suites where Character behavior is
   exercised
+- any additional backend module directly imported by the in-scope Character
+  entry points when that dependency materially affects Character behavior
 
 ### Frontend in scope
 
@@ -52,11 +63,22 @@ synthesis.
 - `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx`
 - `apps/packages/ui/src/hooks/useSelectedCharacter.ts`
 - `apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts`
+- `apps/packages/ui/src/hooks/chat/useServerChatLoader.ts`
+- `apps/packages/ui/src/hooks/chat/useSelectServerChat.ts`
+- `apps/packages/ui/src/utils/selected-character-storage.ts`
+- `apps/packages/ui/src/utils/characters-route.ts`
+- `apps/packages/ui/src/utils/character-greetings.ts`
+- `apps/packages/ui/src/utils/character-mood.ts`
+- `apps/packages/ui/src/utils/default-character-preference.ts`
+- `apps/packages/ui/src/utils/character-export.ts`
 - nearby Character-related selection, storage, server-chat loader, greeting, and
   workspace hooks/utilities
 - `apps/packages/ui/src/services/tldw/domains/characters.ts`
 - Character-focused frontend tests, including unit, integration, and e2e
   coverage where current Character behavior is exercised
+- any additional frontend hook, utility, or adapter directly imported by the
+  in-scope Character entry points when that dependency materially affects
+  Character behavior
 
 ## Non-Goals
 
@@ -81,6 +103,9 @@ Primary baseline artifacts:
 - `Docs/superpowers/specs/2026-03-23-characters-backend-review-design.md`
 - `Docs/superpowers/plans/2026-03-23-characters-backend-sequential-review.md`
 - `Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md`
+- `Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md`
+- `Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md`
+- `Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md`
 - related Character review and remediation docs created from that work
 
 Rule:
@@ -91,6 +116,14 @@ Rule:
   appears affected or has drifted back into the same failure mode
 - `historical only`: already known and apparently remediated; do not report as a
   current finding except as brief context
+
+Novelty rule:
+
+- each reported finding must note which historical artifacts were checked before
+  it was classified as net-new or a regression
+- if no comparable frontend baseline artifact exists for a frontend finding,
+  state that explicitly instead of implying stronger novelty confidence than the
+  evidence supports
 
 ## Approaches Considered
 
@@ -320,7 +353,10 @@ For each suspected issue:
 
 Permitted validation:
 
-- focused `pytest` invocations for the exact Character behavior under review
+- focused `pytest` invocations for backend Character behavior under review
+- focused frontend test commands for the exact Character behavior under review,
+  including package-scoped unit or integration tests and narrow Playwright or
+  e2e runs when that is the smallest reliable validation path
 - small read-oriented commands that clarify code paths, references, or coverage
 - minimal execution to confirm a suspected branch mismatch or regression
 
@@ -347,9 +383,14 @@ inspect, validation commands, and review artifacts to write.
 
 Write separate review artifacts for:
 
-- backend findings
-- frontend findings
-- final synthesis and cross-layer drift
+- `Docs/superpowers/reviews/characters-fullstack-delta/README.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/YYYY-MM-DD-backend-review.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/YYYY-MM-DD-frontend-review.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/YYYY-MM-DD-synthesis.md`
+
+If an existing directory or filename would create ambiguity with older Character
+reviews, prefer the dated `characters-fullstack-delta` path over reusing the
+older `characters-backend` location.
 
 ### 4. Final Findings Format
 
@@ -361,12 +402,15 @@ Findings first, ordered by severity. Each finding should include:
 - impact
 - concrete reasoning
 - file reference(s)
+- baseline artifact note
 - validation note when a command or targeted test was used
 
 Then include:
 
 - open questions or residual risks
 - coverage gaps
+- improvement opportunities that are worth addressing even when they are not
+  confirmed bugs
 - short cross-layer contract drift section
 
 ## Severity Model
@@ -401,3 +445,5 @@ This design is successful if the eventual audit:
   into unrelated chat or UI subsystems.
 - If a suspected issue cannot be validated confidently, it must be labeled as an
   open question or residual risk instead of a confirmed defect.
+- The execution plan must assume a dirty workspace is possible and should avoid
+  staging or committing unrelated files when writing review artifacts.

--- a/Docs/superpowers/specs/2026-04-08-characters-fullstack-delta-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-characters-fullstack-delta-review-design.md
@@ -1,0 +1,403 @@
+# Characters Full-Stack Delta Review Design
+
+Date: 2026-04-08
+Topic: Staged full-stack Characters review for `tldw_server`
+
+## Goal
+
+Produce an evidence-based staged review of the Characters module across backend
+and frontend surfaces that identifies:
+
+- net-new bugs and edge-case failures
+- still-open regressions previously thought to be remediated
+- backend or frontend contract drift
+- maintainability and performance risks
+- missing or misleading automated tests
+
+The review is intentionally delta-oriented. It should not re-report historical
+findings that were already documented and remediated unless the current code
+still appears affected.
+
+## Scope
+
+This review covers the Character surface across both backend and frontend,
+organized into separate backend and frontend stages plus a cross-layer
+synthesis.
+
+### Backend in scope
+
+- `tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py`
+- `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+- `tldw_Server_API/app/api/v1/endpoints/character_messages.py`
+- `tldw_Server_API/app/core/Character_Chat/Character_Chat_Lib_facade.py`
+- `tldw_Server_API/app/core/Character_Chat/character_limits.py`
+- `tldw_Server_API/app/core/Character_Chat/character_rate_limiter.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_db.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_io.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_chat.py`
+- related Character retrieval, exemplar, and world-book logic touched by the
+  current Character API and chat flows
+- backend Character tests under `tldw_Server_API/tests/Characters/`,
+  `tldw_Server_API/tests/Character_Chat*`, `tldw_Server_API/tests/ChaChaNotesDB/`,
+  and nearby integration/property/e2e suites where Character behavior is
+  exercised
+
+### Frontend in scope
+
+- `apps/tldw-frontend/pages/characters.tsx`
+- `apps/tldw-frontend/pages/settings/characters.tsx`
+- `apps/packages/ui/src/routes/option-characters.tsx`
+- `apps/packages/ui/src/components/Option/Characters/`
+- `apps/packages/ui/src/components/Common/CharacterSelect.tsx`
+- `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx`
+- `apps/packages/ui/src/hooks/useSelectedCharacter.ts`
+- `apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts`
+- nearby Character-related selection, storage, server-chat loader, greeting, and
+  workspace hooks/utilities
+- `apps/packages/ui/src/services/tldw/domains/characters.ts`
+- Character-focused frontend tests, including unit, integration, and e2e
+  coverage where current Character behavior is exercised
+
+## Non-Goals
+
+This review does not cover:
+
+- implementing fixes during the audit
+- broad unrelated chat or UI subsystems that do not materially depend on
+  Character behavior
+- re-documenting historical Character findings that are already covered and no
+  longer appear live
+- purely visual or stylistic frontend commentary unless it indicates a state,
+  correctness, or contract problem
+
+## Baseline Artifacts
+
+Earlier Character review and remediation artifacts are the baseline for deciding
+whether a finding is net-new or a regression. The audit should consult them
+before claiming novelty.
+
+Primary baseline artifacts:
+
+- `Docs/superpowers/specs/2026-03-23-characters-backend-review-design.md`
+- `Docs/superpowers/plans/2026-03-23-characters-backend-sequential-review.md`
+- `Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md`
+- related Character review and remediation docs created from that work
+
+Rule:
+
+- `net-new finding`: not already covered by the historical review or
+  remediation docs
+- `possible regression`: historically covered, but the current code still
+  appears affected or has drifted back into the same failure mode
+- `historical only`: already known and apparently remediated; do not report as a
+  current finding except as brief context
+
+## Approaches Considered
+
+### 1. Recommended: Staged Delta Audit With Targeted Validation
+
+Review backend first, frontend second, using the earlier Character review and
+remediation artifacts as the baseline. Run a small set of focused validation
+commands only when code inspection alone is not strong enough to support a
+claim.
+
+Strengths:
+
+- strongest fit for the user's request for net-new findings
+- keeps findings attributable to either backend, frontend, or contract drift
+- avoids repeating already-resolved review material
+- allows stronger evidence without broad noisy suite runs
+
+Weaknesses:
+
+- depends on accurate interpretation of the earlier artifacts
+- requires discipline to avoid drifting into a fresh full audit
+
+### 2. Fresh Full Audit Then Dedupe
+
+Review the entire Character surface from scratch, then subtract anything already
+covered historically.
+
+Strengths:
+
+- highest independent confidence
+- less risk of missing a resurfaced issue because of documentation bias
+
+Weaknesses:
+
+- slower
+- likely to repeat large amounts of already-known material
+
+### 3. Fast Hot-Path Audit
+
+Inspect only the highest-risk flows: import/export, CRUD/versioning, chat
+session coupling, frontend state sync, and API client adapters.
+
+Strengths:
+
+- fastest route to high-severity findings
+- good if time is tightly constrained
+
+Weaknesses:
+
+- likely to miss lower-frequency correctness issues and test gaps
+- weaker final coverage story
+
+## Recommended Approach
+
+Use the staged delta audit with targeted validation.
+
+Execution order:
+
+1. establish the prior-review baseline
+2. run a backend delta pass
+3. run a frontend delta pass
+4. perform a cross-layer synthesis for contract drift
+5. support ambiguous findings with small focused validation only when it
+   materially improves confidence
+
+## Review Architecture
+
+The audit proceeds in three passes.
+
+### Pass 1: Backend Delta Review
+
+Review the current backend Character surfaces against the historical review and
+remediation artifacts.
+
+Focus:
+
+- CRUD, restore, revert, versioning, and persistence integrity
+- import/export and image handling contracts
+- rate limiting, chat/session coupling, greeting or memory injection, and
+  completion persistence
+- exemplar, world-book, search, and related retrieval behavior
+- test coverage around risky backend branches
+
+Output:
+
+- backend-only findings, residual risks, and coverage gaps
+
+### Pass 2: Frontend Delta Review
+
+Review the current frontend Character surfaces against the current backend
+contracts and the historical Character artifacts.
+
+Focus:
+
+- Character workspace state ownership and edit flows
+- selection, storage, and identity synchronization
+- chat integration and server-chat restoration behavior
+- API client normalization, fallback logic, caching, and invalidation
+- test coverage around risky frontend branches
+
+Output:
+
+- frontend-only findings, residual risks, and coverage gaps
+
+### Pass 3: Cross-Layer Synthesis
+
+Compare backend and frontend assumptions to identify Character-specific contract
+drift or boundary mismatches.
+
+Focus:
+
+- path or schema mismatches
+- stale fallback assumptions
+- inconsistent identity or version semantics
+- backend responses that the frontend currently tolerates but should not rely on
+
+Output:
+
+- short cross-layer findings section plus a combined synthesis
+
+## Review Slices
+
+To keep the audit bounded and attributable, use these six slices.
+
+### 1. Backend Lifecycle and Persistence
+
+Primary files:
+
+- `characters_endpoint.py`
+- `character_db.py`
+- `Character_Chat_Lib_facade.py`
+- `ChaChaNotes_DB.py`
+- related schemas and helpers
+
+Primary questions:
+
+- do CRUD, delete, restore, revert, and version flows preserve Character
+  invariants
+- are normalization and concurrency checks consistent
+- do current tests still cover the highest-risk persistence branches
+
+### 2. Backend Chat-Coupled Behavior
+
+Primary files:
+
+- `character_chat_sessions.py`
+- `character_messages.py`
+- `character_chat.py`
+- `character_rate_limiter.py`
+- `character_limits.py`
+
+Primary questions:
+
+- does Character-specific chat behavior still align with backend contracts
+- are quotas, greeting injection, memory injection, and completion persistence
+  coherent under current code
+- are there state-coupled regressions not covered by prior remediation
+
+### 3. Backend Retrieval Surfaces
+
+Primary areas:
+
+- exemplars
+- world books
+- Character search and retrieval fallbacks
+
+Primary questions:
+
+- do returned contracts still match current behavior
+- are fallback paths semantically correct
+- are there net-new correctness, performance, or permission risks
+
+### 4. Frontend Character Workspace
+
+Primary areas:
+
+- `CharactersWorkspace`
+- editor, list, dialog, inline-edit, bulk-ops, import, and version-history hooks
+
+Primary questions:
+
+- is state ownership clear and robust
+- can edits, import, bulk actions, or version flows desynchronize UI state
+- are there avoidable performance traps or missing tests
+
+### 5. Frontend Chat Integration
+
+Primary areas:
+
+- `useCharacterChatMode`
+- Character selection and storage hooks
+- shared Character selection components
+- server chat loader and synchronization helpers
+
+Primary questions:
+
+- can Character identity or session state drift between local UI and server
+- are greeting and chat-start flows robust
+- do frontend assumptions still match backend chat/session behavior
+
+### 6. Frontend API Client and Domain Layer
+
+Primary areas:
+
+- `apps/packages/ui/src/services/tldw/domains/characters.ts`
+- nearby Character routing and normalization utilities
+
+Primary questions:
+
+- are path fallbacks still necessary and correct
+- is cache invalidation coherent for create, update, revert, import, and delete
+- are payload normalization and error mapping defensible under current API
+
+## Evidence and Validation Rules
+
+The audit should be evidence-driven and conservative about claims.
+
+For each suspected issue:
+
+1. trace the current code path end to end
+2. inspect nearby tests and relevant historical Character artifacts
+3. classify the issue as `net-new`, `possible regression`, or `historical only`
+4. run targeted validation only when it materially increases confidence
+5. report uncertainty explicitly when a claim cannot be proven locally
+
+### Targeted Validation Rules
+
+Permitted validation:
+
+- focused `pytest` invocations for the exact Character behavior under review
+- small read-oriented commands that clarify code paths, references, or coverage
+- minimal execution to confirm a suspected branch mismatch or regression
+
+Avoid:
+
+- broad suite runs that add noise without improving confidence
+- speculative findings based only on style or code shape
+- presenting ambiguous concerns as confirmed bugs
+
+## Deliverables
+
+The audit should produce a compact review package.
+
+### 1. Design Spec
+
+This document defines scope, evidence rules, and deliverables before execution.
+
+### 2. Execution Plan
+
+A follow-on implementation plan should enumerate the stage order, files to
+inspect, validation commands, and review artifacts to write.
+
+### 3. Stage Review Docs
+
+Write separate review artifacts for:
+
+- backend findings
+- frontend findings
+- final synthesis and cross-layer drift
+
+### 4. Final Findings Format
+
+Findings first, ordered by severity. Each finding should include:
+
+- severity
+- type
+- whether it is net-new or a regression
+- impact
+- concrete reasoning
+- file reference(s)
+- validation note when a command or targeted test was used
+
+Then include:
+
+- open questions or residual risks
+- coverage gaps
+- short cross-layer contract drift section
+
+## Severity Model
+
+- `High`: likely bug, data loss/corruption risk, security issue, or major
+  behavioral regression risk
+- `Medium`: correctness edge case, contract inconsistency, meaningful
+  maintainability/performance issue, or important state-synchronization risk
+- `Low`: localized cleanup, smaller code smell, or minor missing-test issue
+
+## Success Criteria
+
+This design is successful if the eventual audit:
+
+- covers the full Character surface requested by the user while reporting only
+  net-new findings and still-open regressions
+- keeps backend findings separate from frontend findings
+- includes a short but concrete cross-layer synthesis
+- uses targeted validation only where it materially improves confidence
+- clearly separates confirmed defects, likely risks, open questions, and test
+  gaps
+- leaves review artifacts specific enough for later remediation work to pick up
+  individual findings without redoing the investigation
+
+## Boundaries
+
+- This phase remains review-only; no Character fixes are implemented during the
+  audit.
+- Previously resolved historical findings are not re-reported just for
+  completeness.
+- The audit stays focused on Character-dependent behavior and does not expand
+  into unrelated chat or UI subsystems.
+- If a suspected issue cannot be validated confidently, it must be labeled as an
+  open question or residual risk instead of a confirmed defect.

--- a/Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
@@ -28,9 +28,13 @@ Included:
   - `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
   - `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
   - `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
-  - `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
 - Primary test evidence under `tldw_Server_API/tests/Chat`
-- Directly relevant newer chat tests when they cover the same scoped routes or shared helpers
+- Additional evidence suites when they directly exercise the scoped routes or shared helpers:
+  - `tldw_Server_API/tests/Chat_NEW`
+  - `tldw_Server_API/tests/Chat_Workflows`
+  - `tldw_Server_API/tests/Streaming`
+  - targeted auth or adapter suites when the risk being checked is permission wiring or scoped SSE behavior rather than generic provider internals
 
 Excluded unless a shared defect crosses the boundary:
 
@@ -41,6 +45,8 @@ Excluded unless a shared defect crosses the boundary:
 ## Review Method
 
 The review will use an endpoint-by-endpoint sweep rather than a shared-subsystem-first audit.
+
+Before reviewing each group, freeze the concrete route and matching-test inventory so low-traffic endpoints such as queue, analytics, share-link, and loop routes are not skipped by accident.
 
 Planned review order:
 
@@ -82,6 +88,8 @@ Evidence rules:
 - Passing tests do not overrule a concrete code-level defect.
 - Failing or flaky tests count as findings when they imply product risk or weak coverage.
 - The review will not claim safety for untouched paths just because adjacent tests pass.
+- Environment or fixture failures will be reported separately from product defects unless the scoped code is responsible for the fragility.
+- For each targeted test run, record whether it passed, failed, was flaky, or could not be run, plus the reason.
 
 ## Success Criteria
 
@@ -91,6 +99,15 @@ The review is successful when it produces:
 - clear distinction between implementation bugs, test gaps, and lower-severity maintenance risks
 - targeted test evidence for ambiguous or high-risk paths
 - a short synthesis of recurring structural risks across the scoped Chat surfaces
+
+## Severity Rubric
+
+Use a consistent severity model in the final review:
+
+- Critical: cross-user data exposure, authz bypass, destructive persistence corruption, or similarly severe security failures
+- High: primary-path correctness failures, streaming contract breaks, serious resource or concurrency hazards, or information leakage with meaningful user impact
+- Medium: narrower endpoint bugs, incomplete validation, non-fatal persistence inconsistencies, or important missing coverage around risky behavior
+- Low: maintainability, observability, or cleanup issues that have limited immediate user impact but raise future defect risk
 
 ## Deliverable
 

--- a/Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
@@ -1,0 +1,109 @@
+# Chat Module Review Design
+
+Date: 2026-04-08
+Topic: Core Chat module review with adjacent chat endpoints and tests
+Status: Approved for review planning
+
+## Goal
+
+Run an endpoint-by-endpoint engineering review of the Chat module in `tldw_server` to identify:
+
+- correctness bugs
+- security and authorization issues
+- async/concurrency hazards
+- persistence and state consistency problems
+- error-handling and information-leakage risks
+- test coverage gaps and maintainability issues that materially increase future defect risk
+
+This is a review spec, not an implementation spec. The output of the review will be findings, not code changes.
+
+## Scope
+
+Included:
+
+- `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Shared dependencies used by the main chat routes under `tldw_Server_API/app/core/Chat/`
+- Adjacent chat endpoints:
+  - `tldw_Server_API/app/api/v1/endpoints/chat_documents.py`
+  - `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
+  - `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+  - `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+  - `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- Primary test evidence under `tldw_Server_API/tests/Chat`
+- Directly relevant newer chat tests when they cover the same scoped routes or shared helpers
+
+Excluded unless a shared defect crosses the boundary:
+
+- Character Chat
+- Chatbooks
+- Unrelated provider-adapter internals beyond what is necessary to validate Chat route behavior
+
+## Review Method
+
+The review will use an endpoint-by-endpoint sweep rather than a shared-subsystem-first audit.
+
+Planned review order:
+
+1. `chat.py` command discovery and dictionary-validation routes
+2. `chat.py` main completion path
+3. `chat.py` conversation, message, analytics, and share-link routes
+4. `chat.py` knowledge and RAG-context routes
+5. `chat_documents.py`
+6. `chat_loop.py`
+7. `chat_grammars.py`
+8. `chat_dictionaries.py`
+9. `chat_workflows.py`
+10. Shared-risk synthesis across `core/Chat/*` and the matching tests
+
+Each route group will be reviewed for:
+
+- behavior and contract correctness
+- authn, authz, and ownership enforcement
+- async boundaries, task lifecycle, and concurrency safety
+- queueing, rate limiting, and streaming behavior
+- persistence consistency and failure handling
+- error mapping, client-visible leakage, and operational observability
+- test quality, missing coverage, and brittle assertions
+
+## Evidence Model
+
+Static code review is the primary evidence source for all included route groups.
+
+Targeted tests are supporting evidence for high-risk or ambiguous behavior, especially:
+
+- streaming
+- auth and ownership checks
+- persistence semantics
+- queue and rate-limiter interactions
+- endpoint response contracts
+
+Evidence rules:
+
+- Passing tests do not overrule a concrete code-level defect.
+- Failing or flaky tests count as findings when they imply product risk or weak coverage.
+- The review will not claim safety for untouched paths just because adjacent tests pass.
+
+## Success Criteria
+
+The review is successful when it produces:
+
+- a severity-ordered findings list tied to concrete files and lines
+- clear distinction between implementation bugs, test gaps, and lower-severity maintenance risks
+- targeted test evidence for ambiguous or high-risk paths
+- a short synthesis of recurring structural risks across the scoped Chat surfaces
+
+## Deliverable
+
+The final review output will be structured as:
+
+1. findings first, ordered by severity, with file references
+2. open questions or assumptions
+3. short summary of coverage gaps and maintainability risks
+
+The review should stay focused on concrete, defensible issues. Broad refactor ideas are only included when they are justified by repeated risk patterns discovered during the sweep.
+
+## Assumptions
+
+- The user wants a broad audit, not only high-severity bugs.
+- Targeted test execution is allowed and should be used as supporting evidence.
+- The scoped review should remain centered on the chat-facing API family and shared `core/Chat` behavior, not expand into neighboring subsystems without a concrete cross-boundary issue.

--- a/Docs/superpowers/specs/2026-04-08-mcp-unified-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-mcp-unified-module-review-design.md
@@ -44,6 +44,7 @@ This review excludes:
 - broad product or UX critique
 - speculative architecture rewrites that are not justified by concrete defects
 - remediation work during the review unless explicitly requested later
+- generated artifacts such as `__pycache__` bytecode files
 
 ## Approaches Considered
 
@@ -120,11 +121,29 @@ traceable. The review will use these slices:
   `external_servers/*`, `command_runtime/*`, and related runtime configuration
   or adapter boundaries
 - governance and operations:
-  `governance_packs/*`, `monitoring/*`, `config.py`, `README.md`, and package
-  boundary files where they shape runtime expectations
+  `governance_packs/*`, `monitoring/*`, `config.py`, `README.md`,
+  `docker/Dockerfile`, and package boundary files where they shape runtime
+  expectations
 
-Every source file in `tldw_Server_API/app/core/MCP_unified` must be inspected,
-even if a given file ends up contributing no reportable issue.
+Every tracked, non-generated implementation or runtime artifact in
+`tldw_Server_API/app/core/MCP_unified` must be inspected, even if a given file
+ends up contributing no reportable issue. Tests remain supporting evidence
+rather than primary source files for the file-by-file audit.
+
+## Coverage Ledger
+
+To keep the file-by-file promise auditable, the review should maintain a
+working coverage ledger during execution.
+
+The ledger should list:
+
+- every inspected implementation or runtime file in scope
+- the review slice that owned it
+- whether it produced a finding, a probable risk, or no reportable issue
+- any tests or docs consulted for that file when relevant
+
+The final user-facing report may stay compact, but the review process should
+not rely on memory or an informal checklist.
 
 ## Evidence Model
 
@@ -144,6 +163,11 @@ The review will rely on:
 
 The review is source-first, not test-first. Tests and docs are supporting
 evidence, not substitutes for direct code inspection.
+
+Targeted runtime verification may be used selectively when static inspection
+alone leaves an important claim unresolved, especially for concurrency,
+transport divergence, or safety-guard behavior. It should stay narrow and
+evidence-driven rather than turning the audit into broad execution work.
 
 ## Findings Model
 
@@ -165,6 +189,15 @@ finding instead of repeated per file.
 
 If a file or slice does not contribute any meaningful issue, it should not be
 given filler commentary. The review should stay high-signal.
+
+Observations should be labeled as one of:
+
+- `Confirmed finding`: supported directly by source, tests, or tightly bounded
+  verification
+- `Probable risk`: a likely issue where the impact or trigger cannot be fully
+  proven from available local evidence
+- `Improvement`: a concrete change that is not strong evidence of a current
+  defect but would reduce future risk or maintenance friction
 
 ## Review Focus Areas
 
@@ -215,5 +248,7 @@ The canonical output will be one findings report in code-review style with:
 - explicit test-gap notes tied to those findings
 - a compact appendix listing the reviewed slices and files so the review is
   visibly file-by-file rather than sampled
+- a note on any selective runtime verification used to confirm or narrow a
+  claim
 
 The final response should prioritize bugs, risks, and weak spots over summary.

--- a/Docs/superpowers/specs/2026-04-08-mcp-unified-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-mcp-unified-module-review-design.md
@@ -1,0 +1,219 @@
+# MCP Unified Module Review Design
+
+Date: 2026-04-08
+Topic: MCP Unified module full file-by-file review with findings and fixes
+Status: Approved design
+
+## Objective
+
+Review the MCP Unified subsystem in `tldw_server` for concrete bugs,
+correctness issues, security weaknesses, operational hazards, test gaps, and
+maintainability problems using a full file-by-file audit.
+
+The review should produce a code-review-style findings report with concrete fix
+guidance for each issue. The emphasis is on actionable, evidence-backed
+problems rather than broad redesign advice or generic style commentary.
+
+## Scope
+
+This review is centered on:
+
+- `tldw_Server_API/app/core/MCP_unified`
+- `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py`
+- MCP Unified tests used to confirm intended behavior or expose coverage gaps
+
+This includes:
+
+- transport and request lifecycle behavior across HTTP and WebSocket entry
+  points
+- protocol parsing, request validation, response shaping, batching, and
+  idempotency behavior
+- auth, RBAC, rate limiting, request guards, persona and scope handling
+- module framework behavior including registry, base interfaces, and module
+  implementations
+- external server integration including manager, transports, config schema, and
+  runtime credential handling
+- governance packs, monitoring, config defaults, and operational safety
+- tests and documentation only when they materially define or claim current MCP
+  Unified behavior
+
+This review excludes:
+
+- the broader MCP Hub management surface under `/api/v1/mcp/hub`
+- unrelated platform endpoints that only mention MCP incidentally
+- broad product or UX critique
+- speculative architecture rewrites that are not justified by concrete defects
+- remediation work during the review unless explicitly requested later
+
+## Approaches Considered
+
+### Chosen: Full file-by-file audit
+
+Read every source file in the scoped MCP Unified tree, then synthesize findings
+across the subsystem with concrete fix guidance.
+
+Why this is preferred:
+
+- it matches the user’s explicit request for a full file-by-file review
+- it reduces the chance that low-visibility helpers or safety checks are missed
+- it supports subsystem-wide findings without depending on sampling assumptions
+- it produces a stronger basis for calling out test gaps and cross-file risks
+
+### Alternative: Entry-point-first audit
+
+Start from endpoint, server, protocol, and config files, then trace only into
+high-risk dependencies and hotspot modules.
+
+Trade-offs:
+
+- faster
+- better early signal for integration problems
+- weaker assurance that every module file actually received direct inspection
+
+### Alternative: Test-led audit
+
+Use the current MCP tests as the map of intended behavior, then inspect the
+code paths behind important or weakly covered behaviors.
+
+Trade-offs:
+
+- efficient for regressions and contract drift
+- good at exposing missing tests
+- risks normalizing existing blind spots in the test suite
+
+## Chosen Method
+
+Use the full file-by-file audit with five ordered passes:
+
+1. `Inventory and boundary map`
+   Enumerate the scoped files, identify trust boundaries, major runtime seams,
+   and hotspot areas likely to carry cross-file risk.
+2. `Direct file inspection`
+   Read every scoped source file, recording concrete concerns and cross-file
+   dependencies as they appear.
+3. `Behavior cross-check`
+   Use MCP-focused tests and targeted docs to confirm intended behavior,
+   distinguish confirmed defects from probable risks, and identify missing
+   coverage.
+4. `Finding synthesis`
+   Consolidate duplicate symptoms into single findings when they reflect one
+   underlying problem spanning multiple files.
+5. `Fix guidance`
+   Attach concrete remediation guidance and likely test additions to each
+   finding without turning the review into a speculative redesign roadmap.
+
+## Review Slices
+
+The file-by-file pass should still be organized so the findings remain
+traceable. The review will use these slices:
+
+- transport and request lifecycle:
+  `mcp_unified_endpoint.py`, `server.py`, `protocol.py`,
+  `security/request_guards.py`, `security/ip_filter.py`
+- auth and policy:
+  `auth/*`, `persona_scope.py`, and any scope-enforcement logic on the MCP
+  request path
+- module framework:
+  `modules/base.py`, `modules/registry.py`, `modules/disk_space.py`, and all
+  files under `modules/implementations/`
+- external integration:
+  `external_servers/*`, `command_runtime/*`, and related runtime configuration
+  or adapter boundaries
+- governance and operations:
+  `governance_packs/*`, `monitoring/*`, `config.py`, `README.md`, and package
+  boundary files where they shape runtime expectations
+
+Every source file in `tldw_Server_API/app/core/MCP_unified` must be inspected,
+even if a given file ends up contributing no reportable issue.
+
+## Evidence Model
+
+The review will rely on:
+
+- direct source inspection of every scoped MCP Unified source file
+- direct inspection of the main MCP endpoint surface in
+  `mcp_unified_endpoint.py`
+- targeted test inspection across:
+  - `tldw_Server_API/app/core/MCP_unified/tests`
+  - `tldw_Server_API/tests/MCP_unified` when those tests clarify intended
+    runtime behavior for the scoped subsystem
+- targeted documentation inspection where docs claim current MCP Unified
+  behavior and materially affect review conclusions
+- recent git history only when a suspicious area appears churn-heavy or
+  regression-prone
+
+The review is source-first, not test-first. Tests and docs are supporting
+evidence, not substitutes for direct code inspection.
+
+## Findings Model
+
+The review output should be organized as a code review with findings first,
+ordered by severity.
+
+Each finding should include:
+
+- severity
+- confidence
+- affected files with line references
+- the concrete bug, risk, or design weakness
+- why it matters in practice
+- the specific fix that is recommended
+- the tests that should be added, tightened, or updated
+
+When one issue spans multiple files, it should be reported once as a single
+finding instead of repeated per file.
+
+If a file or slice does not contribute any meaningful issue, it should not be
+given filler commentary. The review should stay high-signal.
+
+## Review Focus Areas
+
+The audit should bias toward:
+
+- authentication and authorization boundary mistakes
+- unsafe config defaults or confusing configuration precedence
+- request validation gaps and malformed input handling
+- state, concurrency, cache, or idempotency errors
+- transport inconsistencies between HTTP and WebSocket paths
+- credential leakage or redaction failures
+- fragile fallbacks and fail-open behavior
+- module registry and tool execution trust boundaries
+- external process or transport safety
+- operational hazards in metrics, health, or breaker behavior
+- maintainability risks in large or multi-responsibility files when they create
+  plausible defect pressure
+
+## Success Criteria
+
+Success for this review means:
+
+- every source file under `tldw_Server_API/app/core/MCP_unified` is inspected
+- `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py` is included
+- findings are actionable enough to become implementation tasks without
+  rediscovering the issue
+- fix guidance is concrete and paired with likely test actions
+- obvious gaps in tests, validation, auth boundaries, state handling, or config
+  safety are called out explicitly
+
+## Execution Boundaries
+
+- The review remains non-invasive and should not silently turn into
+  remediation work.
+- Improvements should be proposed only when they address a concrete defect,
+  risk, or repeated maintenance hazard.
+- Runtime safety should not be claimed unless justified by source and available
+  tests.
+- Residual-risk notes are allowed at the end for complex areas that appear
+  acceptable by inspection but remain hard to fully validate statically.
+
+## Final Deliverable
+
+The canonical output will be one findings report in code-review style with:
+
+- findings first, ordered by severity
+- concrete remediation guidance for each finding
+- explicit test-gap notes tied to those findings
+- a compact appendix listing the reviewed slices and files so the review is
+  visibly file-by-file rather than sampled
+
+The final response should prioritize bugs, risks, and weak spots over summary.

--- a/Docs/superpowers/specs/2026-04-09-characters-fullstack-findings-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-09-characters-fullstack-findings-remediation-design.md
@@ -1,0 +1,269 @@
+# Characters Full-Stack Findings Remediation Design
+
+**Date:** 2026-04-09
+
+**Goal:** Fix the approved Character audit findings and improvements across backend correctness, frontend behavior, frontend workspace tooling, and regression coverage, then verify the fixes with the same targeted validation slices that informed the review.
+
+## Problem Statement
+
+The completed Character full-stack delta review identified five live implementation issues plus one enabling infrastructure gap:
+
+- backend manual memory extraction authorizes against `user_id` even though conversations are stored with `client_id`
+- backend streamed assistant persistence can skip hard validation when internal quota/count checks fail
+- frontend Character handoff payloads are narrower than the fields downstream consumers already read before hydration
+- frontend quick-chat promotion seeds `serverChatId` before assistant identity metadata
+- the Character journey E2E does not actually validate Character selection or prompt propagation
+- the prescribed frontend Vitest and Playwright command paths do not currently resolve through usable repo-local tooling in this checkout
+
+These findings should be remediated as one coordinated effort because the frontend behavior fixes and their regression coverage depend on making the workspace toolchain runnable first.
+
+## Scope
+
+### In Scope
+
+- normalize frontend workspace tooling so the prescribed Character Vitest and Playwright commands execute against repo-local tooling
+- fix manual Character memory-extraction ownership validation
+- change streamed Character assistant persistence to save once, then return `503` on internal quota/count-check failure without duplicating the assistant reply on retry
+- widen Character handoff payloads so existing pre-hydration consumers receive the fields they already read
+- seed assistant identity metadata during quick-chat promotion before navigation when the data is already available
+- add backend, frontend, and browser regressions for the reviewed findings
+- rerun the targeted review validation slices after implementation
+
+### Out of Scope
+
+- unrelated Character UI redesign or workflow changes
+- broad chat-storage architecture changes outside the streamed Character persist path
+- generic cross-module deduplication frameworks
+- refactoring unrelated dirty-worktree files
+
+## Approved Decisions
+
+### Delivery Order
+
+Use a staged verification-first sequence:
+
+1. repair frontend workspace/tool resolution
+2. fix backend correctness
+3. fix frontend handoff behavior
+4. add and run regression coverage
+
+This order reduces risk because the frontend fixes should be verified with the same commands that previously failed for environment reasons.
+
+### Frontend Behavior Strategy
+
+Preserve fast navigation. Do not delay route changes just to wait for full Character hydration.
+
+Instead:
+
+- seed richer selected-character state immediately
+- seed quick-chat assistant metadata before navigation when already available
+- keep later hydration as the fallback path, not the primary source of truth
+
+### Streamed Persist Failure Strategy
+
+For internal quota/count-check failures in the streamed assistant persist path:
+
+- save the assistant reply
+- return `503` to signal degraded validation
+- prevent duplicate assistant persistence on retry of the same streamed reply
+
+This is intentionally different from the direct-send path, which still fails closed before persistence.
+
+## Architecture
+
+The remediation is split into four workstreams.
+
+### Workstream 1: Frontend Workspace Tooling
+
+Repair the shared `apps/` frontend workspace so the existing commands already named in the review execute against repo-local tools:
+
+- `cd apps/packages/ui && bun run test -- ...`
+- `cd apps/tldw-frontend && bun run e2e:pw -- ...`
+
+The fix should address command resolution, workspace dependency visibility, and runner invocation so the checkout does not fall back to broken or non-repo binaries.
+
+The target is broader than the Character module alone: the shared frontend workspace install should be normalized so sibling frontend test commands resolve through repo-local tooling too, even if the implementation validates only the Character slices immediately.
+
+### Workstream 2: Backend Correctness
+
+#### Manual Memory Extraction Ownership
+
+Align the memory-extraction endpoint with the ownership field actually stored and surfaced by conversation persistence. The endpoint should:
+
+- accept chats owned by the current user via stored conversation ownership
+- reject foreign chats
+- preserve the rest of the extraction flow unchanged
+
+#### Streamed Persist Save-Then-503
+
+Keep assistant persistence in the Character streamed persist path, but treat internal quota/count-check failures as degraded validation rather than as permission to silently continue.
+
+Required behavior:
+
+- assistant reply persists once
+- response returns `503`
+- retry of the same streamed reply does not write a duplicate assistant message
+
+### Workstream 3: Frontend Handoff Correctness
+
+#### Selected-Character Payload Fidelity
+
+The shared Character handoff payload should preserve the fields current pre-hydration consumers already read, including:
+
+- greeting variants
+- `extensions`
+- image-related fields
+- other existing Character identity fields already present on the source record
+
+The purpose is not to create a new canonical frontend Character shape. It is to stop handing downstream consumers a knowingly weaker temporary object than the data already available at the handoff point.
+
+#### Quick-Chat Assistant Metadata Seeding
+
+Quick-chat promotion should set:
+
+- `serverChatCharacterId`
+- `serverChatAssistantKind`
+- `serverChatAssistantId`
+
+before navigation whenever the promoted state already has enough information to do so.
+
+Later `getChat()`-based hydration remains the fallback for incomplete or stale state.
+
+### Workstream 4: Regression Coverage
+
+Add the minimal targeted regressions that directly encode the reviewed findings:
+
+- backend endpoint regression for memory-extraction ownership
+- backend persist regression for save-once, `503`, and no duplicate on retry
+- frontend regression for Character handoff payload richness
+- frontend regression for quick-chat metadata seeding before navigation
+- browser journey regression for Character selection and prompt propagation into `/chat/completions`
+
+## Data and Idempotency Strategy
+
+Duplicate suppression for streamed persist should remain narrow and local to the Character persist endpoint.
+
+Recommended contract:
+
+- derive or reuse a stable per-reply persist identity
+- scope that identity to the same conversation and same assistant reply
+- store the identity in persisted assistant-message metadata
+- on retry, detect an existing assistant message for the same persist identity and return the existing logical outcome instead of writing a second assistant reply
+
+Identity source preference:
+
+1. reuse an existing stable per-turn or per-message reference if the request already carries one across retries
+2. otherwise derive a deterministic fingerprint from conversation id, parent/user message id, and assistant reply payload
+
+This should be narrow enough to avoid blocking legitimate repeated assistant turns while still preventing duplicates when the initial save succeeded but the endpoint responded with `503`.
+
+## Testing Strategy
+
+### Frontend Tooling Verification
+
+First, make these exact commands runnable in this checkout:
+
+```bash
+cd apps/packages/ui && bun run test -- \
+  src/components/Option/Characters/__tests__/Manager.first-use.test.tsx \
+  src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx \
+  src/components/Option/Characters/__tests__/CharacterGalleryCard.test.tsx \
+  src/components/Option/Characters/__tests__/import-state-model.test.ts \
+  src/components/Option/Characters/__tests__/search-utils.test.ts \
+  src/services/__tests__/tldw-api-client.characters-list-all.test.ts \
+  src/services/__tests__/tldw-api-client.characters-delete.test.ts \
+  src/hooks/__tests__/useCharacterGreeting.test.tsx \
+  src/hooks/__tests__/useServerChatLoader.test.ts \
+  src/utils/__tests__/character-greetings.test.ts \
+  src/utils/__tests__/character-mood.test.ts \
+  src/utils/__tests__/default-character-preference.test.ts \
+  src/utils/__tests__/characters-route.test.ts \
+  --maxWorkers=1
+```
+
+```bash
+cd apps/tldw-frontend && bun run e2e:pw -- \
+  e2e/workflows/tier-2-features/characters.spec.ts \
+  e2e/workflows/journeys/character-chat.spec.ts \
+  --reporter=line
+```
+
+### Backend Regression Verification
+
+After backend fixes:
+
+- run focused backend tests for the new endpoint and streamed-persist behaviors
+- rerun the previously reviewed backend slices to confirm no local regression
+
+### Frontend Regression Verification
+
+After frontend fixes:
+
+- add targeted unit/integration tests for payload fidelity and quick-chat metadata seeding
+- rerun the prescribed Character frontend Vitest slice
+
+### Browser Verification
+
+After E2E changes:
+
+- rerun the Character Playwright slice
+- verify the journey test now asserts actual Character selection and `/chat/completions` prompt propagation
+
+### Security and Completion Verification
+
+Before completion:
+
+- run Bandit on touched Python paths from the project virtual environment
+- rerun the affected validation commands and capture exact outcomes
+
+## Risks and Mitigations
+
+### Risk: Toolchain repair bleeds into unrelated frontend setup
+
+Mitigation:
+
+- keep the goal narrowly tied to repo-local command resolution for the shared `apps/` workspace
+- prefer the smallest install/config change that restores workspace-local Vitest and Playwright resolution
+
+### Risk: Persist duplicate suppression blocks legitimate repeated turns
+
+Mitigation:
+
+- scope dedupe by conversation and stable reply identity
+- apply it only to the streamed Character persist path
+- cover retry and non-retry cases in tests
+
+### Risk: Richer handoff payloads drift from canonical Character normalization
+
+Mitigation:
+
+- keep the handoff change additive and field-preserving
+- avoid inventing new semantics
+- rely on later hydration to remain canonical
+
+### Risk: Fast-navigation quick-chat fix still misses edge timing
+
+Mitigation:
+
+- seed metadata before navigation when the data is already present
+- keep existing hydration paths intact
+- verify with targeted tests and the Character journey E2E
+
+## Success Criteria
+
+The remediation is complete when all of the following are true:
+
+- the shared frontend workspace resolves the prescribed Character Vitest and Playwright commands through repo-local tooling
+- manual memory extraction authorizes owned chats correctly
+- streamed Character persist saves once, returns `503` on internal quota/count-check failure, and does not duplicate on retry
+- Character handoff payloads include the fields already consumed before hydration
+- quick-chat promotion seeds assistant metadata before navigation when possible
+- backend, frontend, and browser regressions exist for the reviewed findings
+- the previously prescribed backend/frontend validation slices run successfully or fail only for clearly unrelated reasons
+
+## Implementation Notes
+
+- keep commits scoped by logical workstream where practical
+- do not touch unrelated dirty-worktree files
+- if dependency installation or lockfile changes are required, isolate them and verify they are intentional
+- preserve existing user-facing navigation speed while improving first-paint correctness

--- a/Docs/superpowers/specs/2026-04-09-characters-fullstack-findings-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-09-characters-fullstack-findings-remediation-design.md
@@ -24,6 +24,7 @@ These findings should be remediated as one coordinated effort because the fronte
 - normalize frontend workspace tooling so the prescribed Character Vitest and Playwright commands execute against repo-local tooling
 - fix manual Character memory-extraction ownership validation
 - change streamed Character assistant persistence to save once, then return `503` on internal quota/count-check failure without duplicating the assistant reply on retry
+- update Character streamed-persist callers so a saved-but-degraded `503` does not trigger duplicate fallback persistence
 - widen Character handoff payloads so existing pre-hydration consumers receive the fields they already read
 - seed assistant identity metadata during quick-chat promotion before navigation when the data is already available
 - add backend, frontend, and browser regressions for the reviewed findings
@@ -103,6 +104,8 @@ Required behavior:
 - assistant reply persists once
 - response returns `503`
 - retry of the same streamed reply does not write a duplicate assistant message
+- the degraded `503` exposes a machine-detectable saved outcome in error details so Character clients can distinguish "saved but validation degraded" from "not saved"
+- Character callers that currently fall back to `addChatMessage()` treat that saved-degraded outcome as terminal and do not perform duplicate fallback persistence
 
 ### Workstream 3: Frontend Handoff Correctness
 
@@ -117,6 +120,8 @@ The shared Character handoff payload should preserve the fields current pre-hydr
 
 The purpose is not to create a new canonical frontend Character shape. It is to stop handing downstream consumers a knowingly weaker temporary object than the data already available at the handoff point.
 
+Implement this through one shared field-preserving builder/helper used by both normal Character selection and quick-chat promotion, so the handoff contract cannot drift immediately across duplicate mappers.
+
 #### Quick-Chat Assistant Metadata Seeding
 
 Quick-chat promotion should set:
@@ -129,12 +134,15 @@ before navigation whenever the promoted state already has enough information to 
 
 Later `getChat()`-based hydration remains the fallback for incomplete or stale state.
 
+Pre-seeding must not mark server-chat metadata as fully loaded by itself. Keep `serverChatMetaLoaded` false unless the promoted state is already equivalent to authoritative server-chat metadata, so the later `getChat()` hydration path can still correct stale or incomplete assistant identity.
+
 ### Workstream 4: Regression Coverage
 
 Add the minimal targeted regressions that directly encode the reviewed findings:
 
 - backend endpoint regression for memory-extraction ownership
 - backend persist regression for save-once, `503`, and no duplicate on retry
+- frontend streamed-persist regression for saved-degraded `503` handling without `addChatMessage()` duplication
 - frontend regression for Character handoff payload richness
 - frontend regression for quick-chat metadata seeding before navigation
 - browser journey regression for Character selection and prompt propagation into `/chat/completions`
@@ -150,10 +158,19 @@ Recommended contract:
 - store the identity in persisted assistant-message metadata
 - on retry, detect an existing assistant message for the same persist identity and return the existing logical outcome instead of writing a second assistant reply
 
+Because the current streamed-persist request schema does not carry a dedicated idempotency key, server-side deterministic fingerprinting should be the default identity source.
+
+Fingerprint inputs should include the smallest stable fields that identify the same streamed reply:
+
+- conversation id
+- parent/user message id when present
+- speaker Character identity when present
+- normalized assistant reply payload
+
 Identity source preference:
 
-1. reuse an existing stable per-turn or per-message reference if the request already carries one across retries
-2. otherwise derive a deterministic fingerprint from conversation id, parent/user message id, and assistant reply payload
+1. derive the deterministic server-side fingerprint above
+2. reuse an existing stable per-turn or per-message reference only if the implementation confirms the request already carries one consistently across retries
 
 This should be narrow enough to avoid blocking legitimate repeated assistant turns while still preventing duplicates when the initial save succeeded but the endpoint responded with `503`.
 
@@ -199,7 +216,7 @@ After backend fixes:
 
 After frontend fixes:
 
-- add targeted unit/integration tests for payload fidelity and quick-chat metadata seeding
+- add targeted unit/integration tests for payload fidelity, quick-chat metadata seeding, and saved-degraded streamed-persist handling
 - rerun the prescribed Character frontend Vitest slice
 
 ### Browser Verification
@@ -256,6 +273,7 @@ The remediation is complete when all of the following are true:
 - the shared frontend workspace resolves the prescribed Character Vitest and Playwright commands through repo-local tooling
 - manual memory extraction authorizes owned chats correctly
 - streamed Character persist saves once, returns `503` on internal quota/count-check failure, and does not duplicate on retry
+- Character streamed-persist callers recognize the saved-degraded `503` outcome and do not fall back to duplicate `addChatMessage()` persistence
 - Character handoff payloads include the fields already consumed before hydration
 - quick-chat promotion seeds assistant metadata before navigation when possible
 - backend, frontend, and browser regressions exist for the reviewed findings

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx
@@ -169,10 +169,59 @@ const makeUseQueryResult = (value: Record<string, unknown>) => ({
   ...value
 })
 
+const ensureLocalStorageApi = () => {
+  const existing = window.localStorage as {
+    getItem?: (key: string) => string | null
+    setItem?: (key: string, value: string) => void
+    removeItem?: (key: string) => void
+    clear?: () => void
+    key?: (index: number) => string | null
+    length?: number
+  }
+  if (
+    typeof existing?.getItem === "function" &&
+    typeof existing?.setItem === "function" &&
+    typeof existing?.removeItem === "function" &&
+    typeof existing?.clear === "function" &&
+    typeof existing?.key === "function"
+  ) {
+    return existing
+  }
+
+  const storage = new Map<string, string>()
+  const shim = {
+    getItem: vi.fn((key: string) => storage.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      storage.set(key, String(value))
+    }),
+    removeItem: vi.fn((key: string) => {
+      storage.delete(key)
+    }),
+    clear: vi.fn(() => {
+      storage.clear()
+    }),
+    key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+    get length() {
+      return storage.size
+    }
+  }
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: shim
+  })
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: shim
+  })
+
+  return shim
+}
+
 describe("CharactersManager cross-feature integration stage-1", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    window.localStorage.clear()
+    ensureLocalStorageApi().clear()
     window.history.replaceState(
       {},
       "",

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/Manager.first-use.test.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/Manager.first-use.test.tsx
@@ -32,6 +32,7 @@ const {
   setSelectedCharacterMock,
   focusComposerMock,
   notificationMock,
+  storeSetters,
   tldwClientMock,
   templateData
 } = vi.hoisted(() => ({
@@ -58,6 +59,21 @@ const {
   navigateMock: vi.fn(),
   setSelectedCharacterMock: vi.fn(),
   focusComposerMock: vi.fn(),
+  storeSetters: {
+    setHistory: vi.fn(),
+    setMessages: vi.fn(),
+    setHistoryId: vi.fn(),
+    setServerChatId: vi.fn(),
+    setServerChatState: vi.fn(),
+    setServerChatTopic: vi.fn(),
+    setServerChatClusterId: vi.fn(),
+    setServerChatSource: vi.fn(),
+    setServerChatExternalRef: vi.fn(),
+    setServerChatCharacterId: vi.fn(),
+    setServerChatAssistantKind: vi.fn(),
+    setServerChatAssistantId: vi.fn(),
+    setServerChatMetaLoaded: vi.fn()
+  },
   notificationMock: {
     success: vi.fn(),
     info: vi.fn(),
@@ -229,17 +245,7 @@ vi.mock("@/hooks/useComposerFocus", () => ({
 
 vi.mock("@/store/option", () => ({
   useStoreMessageOption: (selector: any) =>
-    selector({
-      setHistory: vi.fn(),
-      setMessages: vi.fn(),
-      setHistoryId: vi.fn(),
-      setServerChatId: vi.fn(),
-      setServerChatState: vi.fn(),
-      setServerChatTopic: vi.fn(),
-      setServerChatClusterId: vi.fn(),
-      setServerChatSource: vi.fn(),
-      setServerChatExternalRef: vi.fn()
-    })
+    selector(storeSetters)
 }))
 
 vi.mock("@plasmohq/storage/hook", () => ({
@@ -309,10 +315,80 @@ const findEditSubmitButton = async (timeout = 15000) =>
     return candidate as HTMLElement
   }, { timeout })
 
+const ensureLocalStorageApi = () => {
+  const existing = window.localStorage as {
+    getItem?: (key: string) => string | null
+    setItem?: (key: string, value: string) => void
+    removeItem?: (key: string) => void
+    clear?: () => void
+    key?: (index: number) => string | null
+    length?: number
+  }
+  if (
+    typeof existing?.getItem === "function" &&
+    typeof existing?.setItem === "function" &&
+    typeof existing?.removeItem === "function" &&
+    typeof existing?.clear === "function" &&
+    typeof existing?.key === "function"
+  ) {
+    return existing
+  }
+
+  const storage = new Map<string, string>()
+  const shim = {
+    getItem: vi.fn((key: string) => storage.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      storage.set(key, String(value))
+    }),
+    removeItem: vi.fn((key: string) => {
+      storage.delete(key)
+    }),
+    clear: vi.fn(() => {
+      storage.clear()
+    }),
+    key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+    get length() {
+      return storage.size
+    }
+  }
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: shim
+  })
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: shim
+  })
+
+  return shim
+}
+
 describe("CharactersManager first-use onboarding", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    window.localStorage.clear()
+    const storage = ensureLocalStorageApi() as {
+      clear?: () => void
+      key?: (index: number) => string | null
+      length?: number
+      removeItem?: (key: string) => void
+    }
+    if (typeof storage.clear === "function") {
+      storage.clear()
+    } else if (
+      typeof storage.key === "function" &&
+      typeof storage.length === "number" &&
+      typeof storage.removeItem === "function"
+    ) {
+      const keys: string[] = []
+      for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index)
+        if (typeof key === "string" && key.length > 0) {
+          keys.push(key)
+        }
+      }
+      keys.forEach((key) => storage.removeItem?.(key))
+    }
     window.history.replaceState({}, "", "/")
     useNavigateMock.mockReturnValue(navigateMock)
     confirmDangerMock.mockResolvedValue(true)
@@ -3733,6 +3809,8 @@ describe("CharactersManager first-use onboarding", () => {
       system_prompt: "Promotion prompt",
       greeting: "Promotion greeting",
       description: "Promotion test",
+      alternate_greetings: ["Backup greeting"],
+      extensions: { tone: "steady" },
       version: 1
     }
 
@@ -3791,9 +3869,15 @@ describe("CharactersManager first-use onboarding", () => {
     expect(setSelectedCharacterMock).toHaveBeenCalled()
     expect(setSelectedCharacterMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: "Promote Quick Chat Character"
+        name: "Promote Quick Chat Character",
+        alternate_greetings: expect.any(Array),
+        extensions: expect.anything()
       })
     )
+    expect(storeSetters.setServerChatCharacterId).toHaveBeenCalledWith("303")
+    expect(storeSetters.setServerChatAssistantKind).toHaveBeenCalledWith("character")
+    expect(storeSetters.setServerChatAssistantId).toHaveBeenCalledWith("303")
+    expect(storeSetters.setServerChatMetaLoaded).toHaveBeenCalledWith(false)
     expect(tldwClientMock.deleteChat).not.toHaveBeenCalled()
   }, 30000)
 

--- a/apps/packages/ui/src/components/Option/Characters/__tests__/selection-payload.test.ts
+++ b/apps/packages/ui/src/components/Option/Characters/__tests__/selection-payload.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import { buildCharacterSelectionPayload } from "../utils"
+
+describe("buildCharacterSelectionPayload", () => {
+  it("preserves greeting variants, extensions, and image fields for pre-hydration consumers", () => {
+    const payload = buildCharacterSelectionPayload({
+      id: "char-123",
+      name: "Payload Bot",
+      greeting: "Primary greeting",
+      alternate_greetings: ["Alt one", "Alt two"],
+      extensions: { voice: "calm" },
+      image_base64: "AAAA",
+      image_mime: "image/png",
+      avatar_url: "",
+      system_prompt: "System prompt",
+      description: "Description",
+      version: 7
+    })
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        id: "char-123",
+        name: "Payload Bot",
+        greeting: "Primary greeting",
+        alternate_greetings: ["Alt one", "Alt two"],
+        extensions: { voice: "calm" },
+        image_base64: "AAAA",
+        image_mime: "image/png",
+        version: 7
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/Characters/hooks/useCharacterQuickChat.tsx
+++ b/apps/packages/ui/src/components/Option/Characters/hooks/useCharacterQuickChat.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from "react-router-dom"
 import { useSelectedCharacter } from "@/hooks/useSelectedCharacter"
 import { focusComposer } from "@/hooks/useComposerFocus"
 import { normalizeChatRole } from "@/utils/normalize-chat-role"
-import { validateAndCreateImageDataUrl } from "@/utils/image-utils"
+import { buildCharacterSelectionPayload } from "../utils"
 
 type CharacterQuickChatMessage = {
   id: string
@@ -34,25 +34,6 @@ const resolveCharacterNumericId = (record: any): number | null => {
   return parsed
 }
 
-const buildCharacterSelectionPayload = (record: any) => ({
-  id: record.id || record.slug || record.name,
-  name: record.name || record.title || record.slug,
-  system_prompt:
-    record.system_prompt ||
-    record.systemPrompt ||
-    record.instructions ||
-    "",
-  greeting:
-    record.greeting ||
-    record.first_message ||
-    record.greet ||
-    "",
-  avatar_url:
-    record.avatar_url ||
-    validateAndCreateImageDataUrl(record.image_base64) ||
-    ""
-})
-
 export interface UseCharacterQuickChatDeps {
   /** i18n translator */
   t: (key: string, opts?: Record<string, any>) => string
@@ -71,6 +52,10 @@ export function useCharacterQuickChat(deps: UseCharacterQuickChatDeps) {
     setMessages,
     setHistoryId,
     setServerChatId,
+    setServerChatCharacterId,
+    setServerChatAssistantKind,
+    setServerChatAssistantId,
+    setServerChatMetaLoaded,
     setServerChatState,
     setServerChatTopic,
     setServerChatClusterId,
@@ -82,6 +67,10 @@ export function useCharacterQuickChat(deps: UseCharacterQuickChatDeps) {
       setMessages: state.setMessages,
       setHistoryId: state.setHistoryId,
       setServerChatId: state.setServerChatId,
+      setServerChatCharacterId: state.setServerChatCharacterId,
+      setServerChatAssistantKind: state.setServerChatAssistantKind,
+      setServerChatAssistantId: state.setServerChatAssistantId,
+      setServerChatMetaLoaded: state.setServerChatMetaLoaded,
       setServerChatState: state.setServerChatState,
       setServerChatTopic: state.setServerChatTopic,
       setServerChatClusterId: state.setServerChatClusterId,
@@ -292,6 +281,10 @@ export function useCharacterQuickChat(deps: UseCharacterQuickChatDeps) {
 
     setHistoryId(null)
     setServerChatId(quickChatSessionId)
+    setServerChatCharacterId(characterSelection.id ?? null)
+    setServerChatAssistantKind("character")
+    setServerChatAssistantId(characterSelection.id ?? null)
+    setServerChatMetaLoaded(false)
     setServerChatState("in-progress")
     setServerChatTopic(null)
     setServerChatClusterId(null)
@@ -315,9 +308,13 @@ export function useCharacterQuickChat(deps: UseCharacterQuickChatDeps) {
     setHistoryId,
     setMessages,
     setSelectedCharacter,
+    setServerChatAssistantId,
+    setServerChatAssistantKind,
+    setServerChatCharacterId,
     setServerChatClusterId,
     setServerChatExternalRef,
     setServerChatId,
+    setServerChatMetaLoaded,
     setServerChatSource,
     setServerChatState,
     setServerChatTopic,

--- a/apps/packages/ui/src/components/Option/Characters/utils.ts
+++ b/apps/packages/ui/src/components/Option/Characters/utils.ts
@@ -775,10 +775,25 @@ export const buildCharacterSelectionPayload = (record: any) => {
       record.first_message ||
       record.greet ||
       "",
+    alternate_greetings: Array.isArray(record.alternate_greetings)
+      ? record.alternate_greetings
+      : [],
+    extensions:
+      record.extensions &&
+      typeof record.extensions === "object" &&
+      !Array.isArray(record.extensions)
+        ? record.extensions
+        : null,
+    image_base64:
+      typeof record.image_base64 === "string" ? record.image_base64 : null,
+    image_mime:
+      typeof record.image_mime === "string" ? record.image_mime : null,
     avatar_url:
       record.avatar_url ||
       validateAndCreateImageDataUrl(record.image_base64) ||
-      ""
+      "",
+    description: record.description || "",
+    version: typeof record.version === "number" ? record.version : undefined
   }
 }
 

--- a/apps/packages/ui/src/hooks/chat/__tests__/characterPersistOutcome.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/characterPersistOutcome.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveSavedDegradedCharacterPersist } from "../characterPersistOutcome"
+
+describe("resolveSavedDegradedCharacterPersist", () => {
+  it("extracts a saved degraded outcome from a 503 error payload", () => {
+    const error = Object.assign(new Error("degraded"), {
+      status: 503,
+      details: {
+        detail: {
+          code: "persist_validation_degraded",
+          saved: true,
+          assistant_message_id: "assistant-server-1"
+        }
+      }
+    })
+
+    expect(resolveSavedDegradedCharacterPersist(error)).toEqual({
+      saved: true,
+      assistantMessageId: "assistant-server-1",
+      version: undefined
+    })
+  })
+
+  it("returns null for ordinary persistence errors", () => {
+    const error = Object.assign(new Error("boom"), {
+      status: 500,
+      details: { detail: "boom" }
+    })
+
+    expect(resolveSavedDegradedCharacterPersist(error)).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.error-recovery.guard.test.ts
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.error-recovery.guard.test.ts
@@ -35,5 +35,6 @@ describe("useChatActions interruption recovery guard", () => {
     expect(source).toContain("attemptCharacterStreamRecoveryPersist")
     expect(source).toContain("streamTransportInterrupted")
     expect(source).toContain("partialResponseSaved")
+    expect(source).toContain("resolveSavedDegradedCharacterPersist")
   })
 })

--- a/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.image-event-sync.integration.test.tsx
+++ b/apps/packages/ui/src/hooks/chat/__tests__/useChatActions.image-event-sync.integration.test.tsx
@@ -577,4 +577,59 @@ describe("useChatActions character stream throttling integration", () => {
       .at(-1)
     expect(finalAssistant?.message).toBe("x".repeat(180))
   })
+
+  it("does not fall back to addChatMessage when persistCharacterCompletion reports saved degraded state", async () => {
+    persistCharacterCompletionMock.mockRejectedValueOnce(
+      Object.assign(new Error("degraded"), {
+        status: 503,
+        details: {
+          detail: {
+            code: "persist_validation_degraded",
+            saved: true,
+            assistant_message_id: "assistant-server-99"
+          }
+        }
+      })
+    )
+    streamCharacterChatCompletionMock.mockImplementation(async function* () {
+      yield {
+        choices: [
+          {
+            delta: {
+              content: "saved degraded reply"
+            }
+          }
+        ]
+      }
+    })
+
+    const { options } = createHookOptions([])
+    options.serverChatId = "server-chat-1"
+    options.selectedCharacter = {
+      id: 101,
+      name: "Stream Character",
+      avatar_url: ""
+    }
+
+    const { result } = renderHook(() => useChatActions(options))
+
+    await act(async () => {
+      await result.current.onSubmit({
+        message: "persist but degrade",
+        image: ""
+      })
+    })
+
+    expect(persistCharacterCompletionMock).toHaveBeenCalledTimes(1)
+    expect(persistCharacterCompletionMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        assistant_message_id: expect.any(String)
+      })
+    )
+    expect(addChatMessageMock).not.toHaveBeenCalledWith(
+      "server-chat-1",
+      expect.objectContaining({ role: "assistant" })
+    )
+  })
 })

--- a/apps/packages/ui/src/hooks/chat/characterPersistOutcome.ts
+++ b/apps/packages/ui/src/hooks/chat/characterPersistOutcome.ts
@@ -1,0 +1,35 @@
+type PersistOutcome = {
+  saved: true
+  assistantMessageId?: string
+  version?: number
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null
+
+export const resolveSavedDegradedCharacterPersist = (
+  error: unknown
+): PersistOutcome | null => {
+  if (!isRecord(error) || error.status !== 503) {
+    return null
+  }
+
+  const details = isRecord(error.details) ? error.details : null
+  const detail = details && isRecord(details.detail) ? details.detail : null
+  if (
+    !detail ||
+    detail.code !== "persist_validation_degraded" ||
+    detail.saved !== true
+  ) {
+    return null
+  }
+
+  return {
+    saved: true,
+    assistantMessageId:
+      typeof detail.assistant_message_id === "string"
+        ? detail.assistant_message_id
+        : undefined,
+    version: typeof detail.version === "number" ? detail.version : undefined
+  }
+}

--- a/apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts
+++ b/apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts
@@ -35,6 +35,7 @@ import {
 import {
   discardAbortedTurnIfRequested,
 } from "@/hooks/chat/abort-turn-cleanup";
+import { resolveSavedDegradedCharacterPersist } from "@/hooks/chat/characterPersistOutcome";
 import type { Character } from "@/types/character";
 import type { ChatScope } from "@/types/chat-scope";
 import type { ChatHistory, Message } from "@/store/option";
@@ -803,6 +804,7 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
 
           const persistPayload: Record<string, unknown> = {
             assistant_content: finalPersistedContent,
+            assistant_message_id: generateMessageId,
             speaker_character_id: speakerCharacterId,
             speaker_character_name: characterName,
           };
@@ -818,6 +820,13 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
           if (persistedUserServerMessageId) {
             persistPayload.user_message_id = persistedUserServerMessageId;
           }
+          const metadataExtra = {
+            speaker_character_id: speakerCharacterId ?? null,
+            speaker_character_name: characterName,
+            mood_label: resolvedMoodLabel,
+            mood_confidence: resolvedMoodConfidence ?? null,
+            mood_topic: resolvedMoodTopic ?? null,
+          };
 
           const persisted = (await tldwClient.persistCharacterCompletion(
             chatId,
@@ -835,13 +844,6 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
             persisted?.id;
           const createdAsstVersion = persisted?.version;
           assistantPersistedToServer = createdAsstServerId != null;
-          const metadataExtra = {
-            speaker_character_id: speakerCharacterId ?? null,
-            speaker_character_name: characterName,
-            mood_label: resolvedMoodLabel,
-            mood_confidence: resolvedMoodConfidence ?? null,
-            mood_topic: resolvedMoodTopic ?? null,
-          };
           setMessages(
             (prev) =>
               (prev as any[]).map((m) => {
@@ -867,35 +869,61 @@ export const createCharacterChatMode = (deps: CharacterChatModeDeps) => {
             "Failed to persist assistant message via completions/persist:",
             e,
           );
-          try {
-            const createdAsst = (await tldwClient.addChatMessage(
-              chatId,
-              {
-                role: "assistant",
-                content: finalPersistedContent,
-              },
-              scope ? { scope } : undefined,
-            )) as { id?: string | number; version?: number } | null;
-            assistantPersistedToServer = createdAsst?.id != null;
+          const savedOutcome = resolveSavedDegradedCharacterPersist(e);
+          if (savedOutcome?.saved) {
+            assistantPersistedToServer =
+              savedOutcome.assistantMessageId != null;
             setMessages(
               (prev) =>
                 (prev as any[]).map((m) => {
                   if (m.id !== generateMessageId) return m;
                   const serverMessageId =
-                    createdAsst?.id != null
-                      ? String(createdAsst.id)
+                    savedOutcome.assistantMessageId != null
+                      ? String(savedOutcome.assistantMessageId)
                       : undefined;
                   return updateActiveVariant(m, {
                     serverMessageId,
-                    serverMessageVersion: createdAsst?.version,
+                    serverMessageVersion: savedOutcome.version,
+                    metadataExtra,
+                    speakerCharacterId: speakerCharacterId ?? null,
+                    speakerCharacterName: characterName,
+                    moodLabel: resolvedMoodLabel,
+                    moodConfidence: resolvedMoodConfidence ?? null,
+                    moodTopic: resolvedMoodTopic ?? null,
                   });
                 }) as Message[],
             );
-          } catch (fallbackError) {
-            console.error(
-              "Failed fallback assistant persistence with addChatMessage:",
-              fallbackError,
-            );
+          } else {
+            try {
+              const createdAsst = (await tldwClient.addChatMessage(
+                chatId,
+                {
+                  role: "assistant",
+                  content: finalPersistedContent,
+                },
+                scope ? { scope } : undefined,
+              )) as { id?: string | number; version?: number } | null;
+              assistantPersistedToServer = createdAsst?.id != null;
+              setMessages(
+                (prev) =>
+                  (prev as any[]).map((m) => {
+                    if (m.id !== generateMessageId) return m;
+                    const serverMessageId =
+                      createdAsst?.id != null
+                        ? String(createdAsst.id)
+                        : undefined;
+                    return updateActiveVariant(m, {
+                      serverMessageId,
+                      serverMessageVersion: createdAsst?.version,
+                    });
+                  }) as Message[],
+              );
+            } catch (fallbackError) {
+              console.error(
+                "Failed fallback assistant persistence with addChatMessage:",
+                fallbackError,
+              );
+            }
           }
         }
       } else {

--- a/apps/packages/ui/src/hooks/chat/useChatActions.ts
+++ b/apps/packages/ui/src/hooks/chat/useChatActions.ts
@@ -90,6 +90,7 @@ import {
   discardAbortedTurnIfRequested,
   isAbortLikeError
 } from "@/hooks/chat/abort-turn-cleanup"
+import { resolveSavedDegradedCharacterPersist } from "@/hooks/chat/characterPersistOutcome"
 import { ensurePersonaServerChat } from "@/hooks/chat/personaServerChat"
 import {
   isPersonaAssistantSelection,
@@ -1595,6 +1596,7 @@ export const useChatActions = ({
 
           const persistPayload: Record<string, unknown> = {
             assistant_content: finalPersistedContent,
+            assistant_message_id: generateMessageId,
             speaker_character_id: speakerCharacterId,
             speaker_character_name: characterName
           }
@@ -1609,6 +1611,13 @@ export const useChatActions = ({
           }
           if (persistedUserServerMessageId) {
             persistPayload.user_message_id = persistedUserServerMessageId
+          }
+          const metadataExtra = {
+            speaker_character_id: speakerCharacterId ?? null,
+            speaker_character_name: characterName,
+            mood_label: resolvedMoodLabel,
+            mood_confidence: resolvedMoodConfidence ?? null,
+            mood_topic: resolvedMoodTopic ?? null
           }
 
           const persisted = (await tldwClient.persistCharacterCompletion(
@@ -1628,13 +1637,6 @@ export const useChatActions = ({
             persisted?.id
           const createdAsstVersion = persisted?.version
           assistantPersistedToServer = createdAsstServerId != null
-          const metadataExtra = {
-            speaker_character_id: speakerCharacterId ?? null,
-            speaker_character_name: characterName,
-            mood_label: resolvedMoodLabel,
-            mood_confidence: resolvedMoodConfidence ?? null,
-            mood_topic: resolvedMoodTopic ?? null
-          }
           setMessages((prev) =>
             ((prev as any[]).map((m) => {
               if (m.id !== generateMessageId) return m
@@ -1659,28 +1661,52 @@ export const useChatActions = ({
             "Failed to persist assistant message via completions/persist:",
             e
           )
-          try {
-            const createdAsst = (await tldwClient.addChatMessage(chatId, {
-              role: "assistant",
-              content: finalPersistedContent
-            })) as { id?: string | number; version?: number } | null
-            assistantPersistedToServer = createdAsst?.id != null
+          const savedOutcome = resolveSavedDegradedCharacterPersist(e)
+          if (savedOutcome?.saved) {
+            assistantPersistedToServer = savedOutcome.assistantMessageId != null
             setMessages((prev) =>
               ((prev as any[]).map((m) => {
                 if (m.id !== generateMessageId) return m
                 const serverMessageId =
-                  createdAsst?.id != null ? String(createdAsst.id) : undefined
+                  savedOutcome.assistantMessageId != null
+                    ? String(savedOutcome.assistantMessageId)
+                    : undefined
                 return updateActiveVariant(m, {
                   serverMessageId,
-                  serverMessageVersion: createdAsst?.version
+                  serverMessageVersion: savedOutcome.version,
+                  metadataExtra,
+                  speakerCharacterId: speakerCharacterId ?? null,
+                  speakerCharacterName: characterName,
+                  moodLabel: resolvedMoodLabel,
+                  moodConfidence: resolvedMoodConfidence ?? null,
+                  moodTopic: resolvedMoodTopic ?? null
                 })
               }) as Message[])
             )
-          } catch (fallbackError) {
-            console.error(
-              "Failed fallback assistant persistence with addChatMessage:",
-              fallbackError
-            )
+          } else {
+            try {
+              const createdAsst = (await tldwClient.addChatMessage(chatId, {
+                role: "assistant",
+                content: finalPersistedContent
+              })) as { id?: string | number; version?: number } | null
+              assistantPersistedToServer = createdAsst?.id != null
+              setMessages((prev) =>
+                ((prev as any[]).map((m) => {
+                  if (m.id !== generateMessageId) return m
+                  const serverMessageId =
+                    createdAsst?.id != null ? String(createdAsst.id) : undefined
+                  return updateActiveVariant(m, {
+                    serverMessageId,
+                    serverMessageVersion: createdAsst?.version
+                  })
+                }) as Message[])
+              )
+            } catch (fallbackError) {
+              console.error(
+                "Failed fallback assistant persistence with addChatMessage:",
+                fallbackError
+              )
+            }
           }
         }
       } else {

--- a/apps/packages/ui/src/hooks/useMessage.tsx
+++ b/apps/packages/ui/src/hooks/useMessage.tsx
@@ -76,6 +76,7 @@ import { applyMcpModuleDisclosureFromToolCalls } from "@/utils/mcp-disclosure";
 import { normalizeChatModelId } from "@/utils/chat-model-availability";
 import { validateSelectedChatModelAvailability } from "@/utils/chat-model-validation";
 import { discardAbortedTurnIfRequested } from "@/hooks/chat/abort-turn-cleanup";
+import { resolveSavedDegradedCharacterPersist } from "@/hooks/chat/characterPersistOutcome";
 import {
   collectGreetings,
   isGreetingMessageType,
@@ -1629,6 +1630,7 @@ export const useMessage = () => {
               : undefined;
           const persistPayload: Record<string, unknown> = {
             assistant_content: finalPersistedContent,
+            assistant_message_id: generateMessageId,
             speaker_character_id: speakerCharacterId,
             speaker_character_name: characterName,
           };
@@ -1644,6 +1646,13 @@ export const useMessage = () => {
           if (persistedUserServerMessageId) {
             persistPayload.user_message_id = persistedUserServerMessageId;
           }
+          const metadataExtra = {
+            speaker_character_id: speakerCharacterId ?? null,
+            speaker_character_name: characterName,
+            mood_label: resolvedMoodLabel,
+            mood_confidence: resolvedMoodConfidence ?? null,
+            mood_topic: resolvedMoodTopic ?? null,
+          };
           const persisted = (await tldwClient.persistCharacterCompletion(
             chatId,
             persistPayload,
@@ -1658,13 +1667,6 @@ export const useMessage = () => {
             persisted?.message_id ??
             persisted?.id;
           const createdAsstVersion = persisted?.version;
-          const metadataExtra = {
-            speaker_character_id: speakerCharacterId ?? null,
-            speaker_character_name: characterName,
-            mood_label: resolvedMoodLabel,
-            mood_confidence: resolvedMoodConfidence ?? null,
-            mood_topic: resolvedMoodTopic ?? null,
-          };
           setMessages(
             (prev) =>
               (prev as ServerBackedMessage[]).map((m) => {
@@ -1690,30 +1692,54 @@ export const useMessage = () => {
             "Failed to persist assistant message via completions/persist:",
             e,
           );
-          try {
-            const createdAsst = (await tldwClient.addChatMessage(chatId, {
-              role: "assistant",
-              content: finalPersistedContent,
-            })) as { id?: string | number; version?: number } | null;
+          const savedOutcome = resolveSavedDegradedCharacterPersist(e);
+          if (savedOutcome?.saved) {
             setMessages(
               (prev) =>
                 (prev as ServerBackedMessage[]).map((m) => {
                   if (m.id !== generateMessageId) return m;
                   const serverMessageId =
-                    createdAsst?.id != null
-                      ? String(createdAsst.id)
+                    savedOutcome.assistantMessageId != null
+                      ? String(savedOutcome.assistantMessageId)
                       : undefined;
                   return updateActiveVariant(m, {
                     serverMessageId,
-                    serverMessageVersion: createdAsst?.version,
+                    serverMessageVersion: savedOutcome.version,
+                    metadataExtra,
+                    speakerCharacterId: speakerCharacterId ?? null,
+                    speakerCharacterName: characterName,
+                    moodLabel: resolvedMoodLabel,
+                    moodConfidence: resolvedMoodConfidence ?? null,
+                    moodTopic: resolvedMoodTopic ?? null,
                   });
                 }) as Message[],
             );
-          } catch (fallbackError) {
-            console.error(
-              "Failed fallback assistant persistence with addChatMessage:",
-              fallbackError,
-            );
+          } else {
+            try {
+              const createdAsst = (await tldwClient.addChatMessage(chatId, {
+                role: "assistant",
+                content: finalPersistedContent,
+              })) as { id?: string | number; version?: number } | null;
+              setMessages(
+                (prev) =>
+                  (prev as ServerBackedMessage[]).map((m) => {
+                    if (m.id !== generateMessageId) return m;
+                    const serverMessageId =
+                      createdAsst?.id != null
+                        ? String(createdAsst.id)
+                        : undefined;
+                    return updateActiveVariant(m, {
+                      serverMessageId,
+                      serverMessageVersion: createdAsst?.version,
+                    });
+                  }) as Message[],
+              );
+            } catch (fallbackError) {
+              console.error(
+                "Failed fallback assistant persistence with addChatMessage:",
+                fallbackError,
+              );
+            }
           }
         }
       } else {

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.character-persist.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.character-persist.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bgRequest: vi.fn(),
+  bgUpload: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: (...args: unknown[]) => mocks.bgRequest(...args),
+  bgUpload: (...args: unknown[]) => mocks.bgUpload(...args),
+  bgStream: vi.fn()
+}))
+
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => ({
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    remove: vi.fn(async () => undefined)
+  }),
+  safeStorageSerde: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value
+  }
+}))
+
+import { TldwApiClient } from "@/services/tldw/TldwApiClient"
+
+describe("TldwApiClient character persist cache invalidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("invalidates cached chat messages when persist reports saved degraded state", async () => {
+    const error = Object.assign(new Error("degraded"), {
+      status: 503,
+      details: {
+        detail: {
+          code: "persist_validation_degraded",
+          saved: true,
+          assistant_message_id: "assistant-server-99"
+        }
+      }
+    })
+    mocks.bgRequest.mockRejectedValue(error)
+
+    const client = new TldwApiClient()
+    const invalidateSpy = vi.spyOn(client, "invalidateChatMessagesCache")
+
+    await expect(
+      client.persistCharacterCompletion("chat-1", {
+        assistant_content: "saved degraded reply"
+      })
+    ).rejects.toBe(error)
+
+    expect(invalidateSpy).toHaveBeenCalledWith("chat-1")
+  })
+
+  it("does not invalidate chat messages for unrelated persist failures", async () => {
+    const error = Object.assign(new Error("broken"), {
+      status: 500,
+      details: { detail: "server error" }
+    })
+    mocks.bgRequest.mockRejectedValue(error)
+
+    const client = new TldwApiClient()
+    const invalidateSpy = vi.spyOn(client, "invalidateChatMessagesCache")
+
+    await expect(
+      client.persistCharacterCompletion("chat-1", {
+        assistant_content: "normal failure"
+      })
+    ).rejects.toBe(error)
+
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -59,6 +59,15 @@ const CHAT_COMPLETION_ERROR_MESSAGE = "Chat completion failed."
 const CHAT_COMPLETION_ERRORS_MESSAGE =
   "One or more internal errors were suppressed."
 
+const isSavedDegradedCharacterPersistError = (error: unknown): boolean => {
+  const detail = (
+    error as {
+      details?: { detail?: { code?: unknown; saved?: unknown } }
+    } | null
+  )?.details?.detail
+  return detail?.code === "persist_validation_degraded" && detail?.saved === true
+}
+
 const isSuspiciousChatCompletionString = (value: string): boolean =>
   /traceback|stack(?:\s*trace)?|exception|error|\/Users\/|[A-Za-z]:\\|\.py:\d+/i.test(
     value
@@ -5025,14 +5034,21 @@ export class TldwApiClient {
     payload: Record<string, any>
   ): Promise<any> {
     const cid = String(chat_id)
-    const res = await bgRequest<any>({
-      path: `/api/v1/chats/${cid}/completions/persist`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: payload
-    })
-    this.invalidateChatMessagesCache(cid)
-    return res
+    try {
+      const res = await bgRequest<any>({
+        path: `/api/v1/chats/${cid}/completions/persist`,
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload
+      })
+      this.invalidateChatMessagesCache(cid)
+      return res
+    } catch (error) {
+      if (isSavedDegradedCharacterPersistError(error)) {
+        this.invalidateChatMessagesCache(cid)
+      }
+      throw error
+    }
   }
 
   async *streamCharacterChatCompletion(

--- a/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
+++ b/apps/packages/ui/src/services/tldw/domains/chat-rag.ts
@@ -28,6 +28,15 @@ const isConnectionErrorMessage = (message: string): boolean =>
 const isTimeoutErrorMessage = (message: string): boolean =>
   /timeout|timed out|etimedout/i.test(message)
 
+const isSavedDegradedCharacterPersistError = (error: unknown): boolean => {
+  const detail = (
+    error as {
+      details?: { detail?: { code?: unknown; saved?: unknown } }
+    } | null
+  )?.details?.detail
+  return detail?.code === "persist_validation_degraded" && detail?.saved === true
+}
+
 const buildSanitizedRagSearchError = (
   error: unknown
 ): Error & { status?: number; code?: string } => {
@@ -1003,14 +1012,21 @@ export const chatRagMethods = {
   ): Promise<any> {
     const cid = String(chat_id)
     const query = buildQuery(toChatScopeParams(options?.scope))
-    const res = await bgRequest<any>({
-      path: appendPathQuery(`/api/v1/chats/${cid}/completions/persist`, query),
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: payload
-    })
-    this.invalidateChatMessagesCache(cid)
-    return res
+    try {
+      const res = await bgRequest<any>({
+        path: appendPathQuery(`/api/v1/chats/${cid}/completions/persist`, query),
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload
+      })
+      this.invalidateChatMessagesCache(cid)
+      return res
+    } catch (error) {
+      if (isSavedDegradedCharacterPersistError(error)) {
+        this.invalidateChatMessagesCache(cid)
+      }
+      throw error
+    }
   },
 
   async *streamCharacterChatCompletion(

--- a/apps/tldw-frontend/e2e/utils/page-objects/ChatPage.ts
+++ b/apps/tldw-frontend/e2e/utils/page-objects/ChatPage.ts
@@ -264,6 +264,64 @@ export class ChatPage {
     }
   }
 
+  async selectCharacter(name: string): Promise<void> {
+    const triggerCandidates = [
+      this.page.getByTestId("character-selector").first(),
+      this.page.getByRole("button", { name: /character/i }).first(),
+      this.page.locator(".character-select").first(),
+    ]
+
+    let trigger: Locator | null = null
+    await expect
+      .poll(
+        async () => {
+          for (const candidate of triggerCandidates) {
+            if (await candidate.isVisible().catch(() => false)) {
+              trigger = candidate
+              return true
+            }
+          }
+          return false
+        },
+        { timeout: 10_000, message: "Timed out waiting for character selector trigger" }
+      )
+      .toBe(true)
+
+    if (!trigger) {
+      throw new Error("Character selector trigger not found")
+    }
+
+    await trigger.click()
+
+    const optionCandidates = [
+      this.page.getByRole("option", { name }).first(),
+      this.page.getByRole("menuitem", { name }).first(),
+      this.page.getByText(name, { exact: true }).first(),
+    ]
+
+    let option: Locator | null = null
+    await expect
+      .poll(
+        async () => {
+          for (const candidate of optionCandidates) {
+            if (await candidate.isVisible().catch(() => false)) {
+              option = candidate
+              return true
+            }
+          }
+          return false
+        },
+        { timeout: 10_000, message: `Timed out waiting for character option ${name}` }
+      )
+      .toBe(true)
+
+    if (!option) {
+      throw new Error(`Character option not found: ${name}`)
+    }
+
+    await option.click()
+  }
+
   /**
    * Wait for a response to appear
    */

--- a/apps/tldw-frontend/e2e/workflows/journeys/character-chat.spec.ts
+++ b/apps/tldw-frontend/e2e/workflows/journeys/character-chat.spec.ts
@@ -61,10 +61,12 @@ test.describe("Create Character -> Chat journey", () => {
       // Set up capture to verify the system prompt is in the API call
       const capture = captureAllApiCalls(page)
 
+      await chatPage.selectCharacter(characterName)
       await chatPage.sendMessage("Hello, who are you?")
 
       // Wait for the response
       await waitForStreamComplete(page)
+      await chatPage.waitForResponse()
 
       const calls = await capture.stop()
 
@@ -74,9 +76,9 @@ test.describe("Create Character -> Chat journey", () => {
       )
 
       // If a chat call was made, verify it went through
-      if (chatCall) {
-        expect(chatCall.status).toBeLessThan(500)
-      }
+      expect(chatCall).toBeTruthy()
+      expect(chatCall?.status).toBeLessThan(500)
+      expect(JSON.stringify(chatCall?.requestBody || {})).toContain(systemPrompt)
     })
   })
 })

--- a/apps/tldw-frontend/lib/i18n-web.ts
+++ b/apps/tldw-frontend/lib/i18n-web.ts
@@ -77,8 +77,17 @@ const LANGUAGE_ALIASES: Record<string, string> = {
 const RTL_LANGUAGES = ["ar", "fa", "he"]
 
 const getStoredLanguage = (): string => {
-  if (typeof localStorage === "undefined") return "en"
-  return localStorage.getItem("i18nextLng") || "en"
+  if (
+    typeof localStorage === "undefined"
+    || typeof localStorage?.getItem !== "function"
+  ) {
+    return "en"
+  }
+  try {
+    return localStorage.getItem("i18nextLng") || "en"
+  } catch {
+    return "en"
+  }
 }
 
 const normalizeLanguage = (lng: string): string => {

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -534,6 +534,145 @@ def _validate_and_truncate_tool_calls(tool_calls: Any) -> Optional[list]:
 
     return tool_calls
 
+
+def _build_stream_persist_fingerprint(
+    chat_id: str,
+    assistant_content: str,
+    user_message_id: str | None,
+    speaker_character_id: int | None,
+) -> str:
+    """Build a deterministic fingerprint for streamed persist retries."""
+    payload = {
+        "chat_id": chat_id,
+        "assistant_content": assistant_content.strip(),
+        "user_message_id": user_message_id,
+        "speaker_character_id": speaker_character_id,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def _load_existing_stream_persist_message_by_id(
+    db: CharactersRAGDB,
+    chat_id: str,
+    assistant_message_id: str,
+    *,
+    assistant_content: str,
+    parent_message_id: str | None,
+    speaker_name: str,
+) -> tuple[str, dict[str, Any]] | None:
+    """Return an existing persisted assistant message by stable message id."""
+    message = db.get_message_by_id(assistant_message_id)
+    if not message:
+        return None
+    if str(message.get("conversation_id") or "").strip() != str(chat_id).strip():
+        raise ConflictError("assistant_message_id already exists in another conversation")
+    if message.get("deleted"):
+        raise ConflictError("assistant_message_id references a deleted message")
+    if str(message.get("sender") or "") != speaker_name:
+        raise ConflictError("assistant_message_id already exists for a different speaker")
+    if str(message.get("content") or "") != assistant_content:
+        raise ConflictError("assistant_message_id already exists for different content")
+    existing_parent_message_id = str(message.get("parent_message_id") or "").strip() or None
+    expected_parent_message_id = str(parent_message_id or "").strip() or None
+    if existing_parent_message_id != expected_parent_message_id:
+        raise ConflictError("assistant_message_id already exists for a different parent message")
+    metadata = db.get_message_metadata(assistant_message_id) or {}
+    extra = metadata.get("extra") or {}
+    return assistant_message_id, extra
+
+
+def _find_existing_stream_persist_message(
+    db: CharactersRAGDB,
+    chat_id: str,
+    fingerprint: str,
+) -> tuple[str, dict[str, Any]] | None:
+    """Find a previously persisted assistant turn for the same streamed payload."""
+    for message in db.get_messages_for_conversation(
+        chat_id,
+        limit=100,
+        offset=0,
+        order_by_timestamp="DESC",
+    ) or []:
+        if message.get("deleted") or message.get("sender") == "user":
+            continue
+        metadata = db.get_message_metadata(str(message["id"])) or {}
+        extra = metadata.get("extra") or {}
+        if extra.get("stream_persist_fingerprint") == fingerprint:
+            return str(message["id"]), extra
+    return None
+
+
+def _build_persist_validation_degraded_detail(assistant_message_id: str) -> dict[str, Any]:
+    """Build the structured 503 detail used when persistence succeeds but validation degrades."""
+    return {
+        "code": "persist_validation_degraded",
+        "saved": True,
+        "assistant_message_id": assistant_message_id,
+    }
+
+
+def _build_stream_persist_metadata_extra(
+    *,
+    speaker_character_id: int | None,
+    speaker_character_name: str,
+    turn_taking_mode: str,
+    validation_degraded: bool,
+    persist_fingerprint: str | None,
+    mood_label: str | None,
+    mood_confidence: float | None,
+    mood_topic: str | None,
+    usage: dict[str, Any] | None,
+) -> dict[str, Any]:
+    metadata_extra: dict[str, Any] = {
+        "speaker_character_id": speaker_character_id,
+        "speaker_character_name": speaker_character_name,
+        "turn_taking_mode": turn_taking_mode,
+        "persist_validation_degraded": validation_degraded,
+    }
+    if persist_fingerprint:
+        metadata_extra["stream_persist_fingerprint"] = persist_fingerprint
+    if isinstance(mood_label, str):
+        trimmed_label = mood_label.strip()
+        if trimmed_label:
+            metadata_extra["mood_label"] = trimmed_label
+    if mood_confidence is not None:
+        metadata_extra["mood_confidence"] = float(mood_confidence)
+    if isinstance(mood_topic, str):
+        trimmed_topic = mood_topic.strip()
+        if trimmed_topic:
+            metadata_extra["mood_topic"] = trimmed_topic
+    if usage is not None:
+        metadata_extra["usage"] = usage
+    return metadata_extra
+
+
+def _try_store_stream_persist_metadata(
+    db: CharactersRAGDB,
+    *,
+    assistant_message_id: str,
+    tool_calls: Any,
+    metadata_extra: dict[str, Any],
+) -> None:
+    try:
+        validated_tool_calls = _validate_and_truncate_tool_calls(tool_calls)
+        stored = db.add_message_metadata(
+            assistant_message_id,
+            tool_calls=validated_tool_calls,
+            extra=metadata_extra,
+        )
+        if not stored:
+            logger.debug(
+                "Non-fatal: failed to persist metadata for message {}",
+                assistant_message_id,
+            )
+    except _CHAR_CHAT_SESSIONS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.debug(
+            "Non-fatal: failed to persist metadata for message {}: {}",
+            assistant_message_id,
+            exc,
+        )
+
+
 # Legacy local SSE helpers removed — unified streams handle normalization
 
 
@@ -6093,16 +6232,19 @@ async def persist_streamed_assistant_message(
             char_card = db.get_character_card_by_id(conversation.get("character_id")) or {}
             resolved_speaker_name = str(char_card.get("name") or "Assistant").strip() or "Assistant"
         resolved_turn_mode = str(turn_context.get("turn_taking_mode") or "single").strip() or "single"
-
-        # Enforce message cap (+1 assistant)
-        try:
-            current_count = db.count_messages_for_conversation(chat_id)
-            limiter = get_character_rate_limiter()
-            await limiter.check_message_limit(chat_id, current_count + 1)
-        except HTTPException:
-            raise
-        except _CHAR_CHAT_SESSIONS_NONCRITICAL_EXCEPTIONS:
-            logger.debug("Non-fatal: message cap check skipped in persist endpoint")
+        requested_assistant_message_id = (
+            body.assistant_message_id.strip()
+            if isinstance(body.assistant_message_id, str)
+            else ""
+        ) or None
+        persist_fingerprint = None
+        if not requested_assistant_message_id and getattr(body, "user_message_id", None):
+            persist_fingerprint = _build_stream_persist_fingerprint(
+                chat_id,
+                body.assistant_content,
+                body.user_message_id,
+                resolved_speaker_id,
+            )
 
         # Validate optional parent message belongs to this conversation
         if getattr(body, "user_message_id", None):
@@ -6118,50 +6260,108 @@ async def persist_streamed_assistant_message(
                     detail="Parent message must belong to the same conversation"
                 )
 
-        # Persist assistant response via Character_Chat guardrails
-        assistant_msg_id = post_message_to_conversation(
-            db=db,
-            conversation_id=chat_id,
-            character_name=resolved_speaker_name,
-            message_content=body.assistant_content,
-            is_user_message=False,
-            parent_message_id=body.user_message_id,
-            ranking=body.ranking if getattr(body, "ranking", None) is not None else None,
+        existing_persist = None
+        if requested_assistant_message_id:
+            existing_persist = _load_existing_stream_persist_message_by_id(
+                db,
+                chat_id,
+                requested_assistant_message_id,
+                assistant_content=body.assistant_content,
+                parent_message_id=body.user_message_id,
+                speaker_name=resolved_speaker_name,
+            )
+        elif persist_fingerprint is not None:
+            existing_persist = _find_existing_stream_persist_message(db, chat_id, persist_fingerprint)
+        if existing_persist is not None:
+            existing_id, existing_extra = existing_persist
+            if existing_extra.get("persist_validation_degraded"):
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=_build_persist_validation_degraded_detail(existing_id),
+                )
+            return CharacterChatStreamPersistResponse(
+                chat_id=chat_id,
+                assistant_message_id=existing_id,
+                saved=True,
+            )
+
+        # Enforce message cap (+1 assistant)
+        validation_degraded: Exception | None = None
+        try:
+            current_count = db.count_messages_for_conversation(chat_id)
+            limiter = get_character_rate_limiter()
+            await limiter.check_message_limit(chat_id, current_count + 1)
+        except HTTPException:
+            raise
+        except _CHAR_CHAT_SESSIONS_NONCRITICAL_EXCEPTIONS as exc:
+            validation_degraded = exc
+            logger.debug("Non-fatal: message cap check degraded in persist endpoint: {}", exc)
+
+        metadata_extra = _build_stream_persist_metadata_extra(
+            speaker_character_id=resolved_speaker_id,
+            speaker_character_name=resolved_speaker_name,
+            turn_taking_mode=resolved_turn_mode,
+            validation_degraded=validation_degraded is not None,
+            persist_fingerprint=persist_fingerprint,
+            mood_label=body.mood_label,
+            mood_confidence=body.mood_confidence,
+            mood_topic=body.mood_topic,
+            usage=getattr(body, "usage", None),
         )
+
+        # Persist assistant response via Character_Chat guardrails
+        try:
+            assistant_msg_id = post_message_to_conversation(
+                db=db,
+                conversation_id=chat_id,
+                character_name=resolved_speaker_name,
+                message_content=body.assistant_content,
+                is_user_message=False,
+                message_id=requested_assistant_message_id,
+                parent_message_id=body.user_message_id,
+                ranking=body.ranking if getattr(body, "ranking", None) is not None else None,
+            )
+        except ConflictError:
+            if not requested_assistant_message_id:
+                raise
+            existing_persist = _load_existing_stream_persist_message_by_id(
+                db,
+                chat_id,
+                requested_assistant_message_id,
+                assistant_content=body.assistant_content,
+                parent_message_id=body.user_message_id,
+                speaker_name=resolved_speaker_name,
+            )
+            if existing_persist is None:
+                raise
+            existing_id, existing_extra = existing_persist
+            _try_store_stream_persist_metadata(
+                db,
+                assistant_message_id=existing_id,
+                tool_calls=getattr(body, "tool_calls", None),
+                metadata_extra=metadata_extra,
+            )
+            if existing_extra.get("persist_validation_degraded"):
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=_build_persist_validation_degraded_detail(existing_id),
+                )
+            return CharacterChatStreamPersistResponse(
+                chat_id=chat_id,
+                assistant_message_id=existing_id,
+                saved=True,
+            )
         if not assistant_msg_id:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to persist assistant message"
             )
-        # Persist metadata: tool_calls and usage
-        try:
-            metadata_extra: dict[str, Any] = {
-                "speaker_character_id": resolved_speaker_id,
-                "speaker_character_name": resolved_speaker_name,
-                "turn_taking_mode": resolved_turn_mode,
-            }
-            if isinstance(body.mood_label, str):
-                mood_label = body.mood_label.strip()
-                if mood_label:
-                    metadata_extra["mood_label"] = mood_label
-            if body.mood_confidence is not None:
-                metadata_extra["mood_confidence"] = float(body.mood_confidence)
-            if isinstance(body.mood_topic, str):
-                mood_topic = body.mood_topic.strip()
-                if mood_topic:
-                    metadata_extra["mood_topic"] = mood_topic
-            if getattr(body, 'usage', None) is not None:
-                metadata_extra["usage"] = body.usage
-            validated_tool_calls = _validate_and_truncate_tool_calls(getattr(body, 'tool_calls', None))
-            db.add_message_metadata(
-                assistant_msg_id,
-                tool_calls=validated_tool_calls,
-                extra=metadata_extra,
-            )
-        except _CHAR_CHAT_SESSIONS_NONCRITICAL_EXCEPTIONS as exc:
-            logger.debug(
-                f"Non-fatal: failed to persist metadata for message {assistant_msg_id}: {exc}"
-            )
+        _try_store_stream_persist_metadata(
+            db,
+            assistant_message_id=assistant_msg_id,
+            tool_calls=getattr(body, "tool_calls", None),
+            metadata_extra=metadata_extra,
+        )
 
         # Optionally update chat rating
         if getattr(body, 'chat_rating', None) is not None:
@@ -6181,6 +6381,12 @@ async def persist_streamed_assistant_message(
                     e,
                     exc_info=True,
                 )
+
+        if validation_degraded is not None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=_build_persist_validation_degraded_detail(assistant_msg_id),
+            )
 
         return CharacterChatStreamPersistResponse(chat_id=chat_id, assistant_message_id=assistant_msg_id, saved=True)
     except HTTPException:

--- a/tldw_Server_API/app/api/v1/endpoints/character_memory.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_memory.py
@@ -231,8 +231,17 @@ async def extract_character_memories_endpoint(
     conversation = db.get_conversation_by_id(body.chat_id)
     if not conversation:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat session not found")
-    if str(conversation.get("user_id")) != user_id:
+    stored_client_id = str(conversation.get("client_id") or "").strip()
+    request_user_id = str(current_user.id).strip()
+    if stored_client_id != request_user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your chat session")
+    conversation_character_id = str(conversation.get("character_id") or "").strip()
+    requested_character_id = str(card.get("id") or character_id).strip()
+    if conversation_character_id != requested_character_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Chat session must belong to the requested character",
+        )
 
     user_name = conversation.get("user_name", "User")
     persona_id = get_or_create_character_persona_profile(db, character_id, char_name, user_id)

--- a/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
@@ -538,6 +538,12 @@ class CharacterChatStreamPersistRequest(BaseModel):
     Use after a streamed completion where the assistant content was not persisted.
     """
     assistant_content: str = Field(..., min_length=1, max_length=1_000_000, description="Assistant text to persist (max 1MB)")
+    assistant_message_id: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=255,
+        description="Optional stable assistant message ID used for idempotent persist retries.",
+    )
     user_message_id: Optional[str] = Field(None, description="Optional parent user message id to link threading")
     speaker_character_id: Optional[int] = Field(
         None,

--- a/tldw_Server_API/app/core/Character_Chat/modules/character_chat.py
+++ b/tldw_Server_API/app/core/Character_Chat/modules/character_chat.py
@@ -1146,6 +1146,7 @@ def post_message_to_conversation(
     character_name: str,
     message_content: str,
     is_user_message: bool,
+    message_id: Optional[str] = None,
     parent_message_id: Optional[str] = None,
     ranking: Optional[int] = None,
     image_data: Optional[bytes] = None,
@@ -1197,6 +1198,7 @@ def post_message_to_conversation(
             raise InputError(f"Image attachment exceeds maximum size of {max_bytes} bytes")
 
     msg_payload = {
+        "id": message_id,
         "conversation_id": conversation_id,
         "sender": sender_name,
         "content": message_content,

--- a/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
@@ -219,6 +219,141 @@ def test_persist_streamed_message_preserves_active_speaker_identity(test_client:
     }
 
 
+def test_persist_streamed_message_saves_then_returns_503_when_counting_degrades(
+    test_client: TestClient,
+    auth_headers,
+    character_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    original_count = character_db.count_messages_for_conversation
+
+    def broken_count(_chat_id: str):
+        raise RuntimeError("count unavailable")
+
+    monkeypatch.setattr(character_db, "count_messages_for_conversation", broken_count)
+
+    response = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "saved once despite degraded validation",
+            "assistant_message_id": "assistant-count-degraded-1",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 503
+    payload = response.json()["detail"]
+    assert payload["code"] == "persist_validation_degraded"
+    assert payload["saved"] is True
+    assert payload["assistant_message_id"]
+
+    monkeypatch.setattr(character_db, "count_messages_for_conversation", original_count)
+    messages = test_client.get(f"/api/v1/chats/{chat_id}/messages", headers=auth_headers).json()["messages"]
+    assert [m["content"] for m in messages].count("saved once despite degraded validation") == 1
+
+
+def test_persist_streamed_message_retry_reuses_saved_degraded_outcome(
+    test_client: TestClient,
+    auth_headers,
+    character_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+    monkeypatch.setattr(
+        character_db,
+        "count_messages_for_conversation",
+        lambda _chat_id: (_ for _ in ()).throw(RuntimeError("count unavailable")),
+    )
+
+    first = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "duplicate guard text",
+            "assistant_message_id": "assistant-retry-guard-1",
+            "user_message_id": None,
+        },
+        headers=auth_headers,
+    )
+    second = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={
+            "assistant_content": "duplicate guard text",
+            "assistant_message_id": "assistant-retry-guard-1",
+            "user_message_id": None,
+        },
+        headers=auth_headers,
+    )
+
+    assert first.status_code == 503
+    assert second.status_code == 503
+    assert first.json()["detail"]["assistant_message_id"] == second.json()["detail"]["assistant_message_id"]
+
+    messages = test_client.get(f"/api/v1/chats/{chat_id}/messages", headers=auth_headers).json()["messages"]
+    assert [m["content"] for m in messages].count("duplicate guard text") == 1
+
+
+def test_persist_streamed_message_retry_reuses_assistant_message_id_when_metadata_write_fails(
+    test_client: TestClient,
+    auth_headers,
+    character_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+    monkeypatch.setattr(character_db, "add_message_metadata", lambda *args, **kwargs: False)
+
+    payload = {
+        "assistant_content": "metadata failure duplicate guard",
+        "assistant_message_id": "assistant-metadata-failure-1",
+        "user_message_id": None,
+    }
+
+    first = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json=payload,
+        headers=auth_headers,
+    )
+    second = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json=payload,
+        headers=auth_headers,
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["assistant_message_id"] == payload["assistant_message_id"]
+    assert second.json()["assistant_message_id"] == payload["assistant_message_id"]
+
+    messages = test_client.get(f"/api/v1/chats/{chat_id}/messages", headers=auth_headers).json()["messages"]
+    assert [m["content"] for m in messages].count("metadata failure duplicate guard") == 1
+
+
+def test_persist_streamed_message_allows_duplicate_content_without_idempotency_key(
+    test_client: TestClient,
+    auth_headers,
+):
+    _, chat_id = _create_character_and_chat(test_client, auth_headers)
+
+    first = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={"assistant_content": "same visible reply", "user_message_id": None},
+        headers=auth_headers,
+    )
+    second = test_client.post(
+        f"/api/v1/chats/{chat_id}/completions/persist",
+        json={"assistant_content": "same visible reply", "user_message_id": None},
+        headers=auth_headers,
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["assistant_message_id"] != second.json()["assistant_message_id"]
+
+    messages = test_client.get(f"/api/v1/chats/{chat_id}/messages", headers=auth_headers).json()["messages"]
+    assert [m["content"] for m in messages].count("same visible reply") == 2
+
+
 def test_persist_streamed_message_requires_request_body(test_client: TestClient, auth_headers):
     """Persist endpoint should return 422 when request body is missing."""
     _, chat_id = _create_character_and_chat(test_client, auth_headers)

--- a/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
@@ -1,0 +1,135 @@
+"""Integration regressions for manual character memory extraction ownership."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.tests.Character_Chat_NEW.integration.test_character_chat_stream_and_persist import (
+    _create_character_and_chat,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_extract_character_memories_allows_owned_chat_by_client_id(
+    test_client: TestClient,
+    auth_headers,
+    character_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    character_id, chat_id = _create_character_and_chat(test_client, auth_headers)
+    character_db.execute_query(
+        "UPDATE conversations SET client_id = ? WHERE id = ?",
+        ("1", chat_id),
+        commit=True,
+    )
+
+    user_message_id = character_db.add_message(
+        {
+            "id": str(uuid.uuid4()),
+            "conversation_id": chat_id,
+            "sender": "user",
+            "content": "Remember that I like tea.",
+            "client_id": "1",
+            "version": 1,
+        }
+    )
+    character_db.add_message(
+        {
+            "id": str(uuid.uuid4()),
+            "conversation_id": chat_id,
+            "sender": "assistant",
+            "content": "I will remember that.",
+            "parent_message_id": user_message_id,
+            "client_id": "1",
+            "version": 1,
+        }
+    )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_memory_extraction.extract_character_memories",
+        lambda **_: SimpleNamespace(unique=[], total_parsed=0, duplicates_skipped=0),
+    )
+
+    response = test_client.post(
+        f"/api/v1/characters/{character_id}/memories/extract",
+        json={"chat_id": chat_id, "provider": "openai", "model": "test-model"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"extracted": 0, "skipped_duplicates": 0, "memories": []}
+
+
+def test_extract_character_memories_rejects_foreign_chat(
+    test_client: TestClient,
+    auth_headers,
+    character_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    character_id, chat_id = _create_character_and_chat(test_client, auth_headers)
+    character_db.execute_query(
+        "UPDATE conversations SET client_id = ? WHERE id = ?",
+        ("999", chat_id),
+        commit=True,
+    )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_memory_extraction.extract_character_memories",
+        lambda **_: SimpleNamespace(unique=[], total_parsed=0, duplicates_skipped=0),
+    )
+
+    response = test_client.post(
+        f"/api/v1/characters/{character_id}/memories/extract",
+        json={"chat_id": chat_id, "provider": "openai", "model": "test-model"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not your chat session"
+
+
+def test_extract_character_memories_rejects_chat_for_different_character(
+    test_client: TestClient,
+    auth_headers,
+    character_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    character_id, chat_id = _create_character_and_chat(test_client, auth_headers)
+    other_character_response = test_client.post(
+        "/api/v1/characters/",
+        json={
+            "name": "Other Character",
+            "description": "Secondary character",
+            "personality": "Reserved",
+            "first_message": "Hello there",
+        },
+        headers=auth_headers,
+    )
+    assert other_character_response.status_code == 201
+    other_character_id = other_character_response.json()["id"]
+
+    character_db.execute_query(
+        "UPDATE conversations SET client_id = ?, character_id = ? WHERE id = ?",
+        ("1", character_id, chat_id),
+        commit=True,
+    )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Character_Chat.modules.character_memory_extraction.extract_character_memories",
+        lambda **_: SimpleNamespace(unique=[], total_parsed=0, duplicates_skipped=0),
+    )
+
+    response = test_client.post(
+        f"/api/v1/characters/{other_character_id}/memories/extract",
+        json={"chat_id": chat_id, "provider": "openai", "model": "test-model"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Chat session must belong to the requested character"


### PR DESCRIPTION
## Summary
- fix character memory extraction ownership and reject cross-character memory imports
- make streamed character persist idempotent with stable assistant message IDs, safer retry handling, and degraded-response cache invalidation
- preserve character handoff and quick-chat identity while tightening backend, frontend, and browser regressions

## Test Plan
- source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py -q
- bun run test -- src/hooks/chat/__tests__/characterPersistOutcome.test.ts src/hooks/chat/__tests__/useChatActions.image-event-sync.integration.test.tsx src/hooks/chat/__tests__/useChatActions.error-recovery.guard.test.ts src/components/Option/Characters/__tests__/selection-payload.test.ts src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx src/services/__tests__/tldw-api-client.character-persist.test.ts src/services/__tests__/tldw-api-client.characters-list-all.test.ts src/services/__tests__/tldw-api-client.characters-delete.test.ts src/hooks/__tests__/useCharacterGreeting.test.tsx src/hooks/__tests__/useServerChatLoader.test.ts --maxWorkers=1
- bun run test -- src/components/Option/Characters/__tests__/Manager.first-use.test.tsx -t "promotes quick chat into full chat flow without route changes until promoted" --maxWorkers=1
- bun run e2e:pw -- e2e/workflows/tier-2-features/characters.spec.ts e2e/workflows/journeys/character-chat.spec.ts --reporter=line