### PR TITLE
fix: complete web scraping ingest review remediation

### DIFF
--- a/Docs/superpowers/plans/2026-04-07-web-scraping-ingest-review-execution-plan.md
+++ b/Docs/superpowers/plans/2026-04-07-web-scraping-ingest-review-execution-plan.md
@@ -1,0 +1,586 @@
+# Web_Scraping Ingest Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Execute the approved `Web_Scraping` ingest-path audit and deliver one consolidated, evidence-backed review covering both public ingest routes, service orchestration, fallback behavior, persistence modes, request safety, validation coverage, and remediation priorities.
+
+**Architecture:** This is a read-first, call-graph-driven audit plan. Execution starts from the two public ingest entrypoints and their request models, follows only reachable code paths into services and core fetch or extraction helpers, records stage findings under `Docs/superpowers/reviews/web-scraping-ingest/`, uses targeted tests and a narrow Bandit supplement to confirm high-risk claims, and finishes with one ranked synthesis that separates confirmed defects, probable risks, and improvements.
+
+**Tech Stack:** Python 3, FastAPI, pytest, Bandit, ripgrep, git, Markdown
+
+---
+
+## Review File Map
+
+**Create during execution:**
+- `Docs/superpowers/reviews/web-scraping-ingest/README.md`
+- `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage1-inventory-and-callgraph.md`
+- `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage2-public-entrypoints-and-schema.md`
+- `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage3-services-fallback-and-persistence.md`
+- `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage4-reachable-core-and-request-safety.md`
+- `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage5-validation-gaps-and-synthesis.md`
+
+**Primary source files to inspect during the review:**
+- `tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py`
+- `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+- `tldw_Server_API/app/api/v1/schemas/media_request_models.py`
+- `tldw_Server_API/app/services/web_scraping_service.py`
+- `tldw_Server_API/app/services/enhanced_web_scraping_service.py`
+- `tldw_Server_API/app/services/ephemeral_store.py`
+- `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py`
+- `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+- `tldw_Server_API/app/core/Web_Scraping/scraper_router.py`
+- `tldw_Server_API/app/core/Web_Scraping/filters.py`
+- `tldw_Server_API/app/core/Web_Scraping/scoring.py`
+- `tldw_Server_API/app/core/http_client.py`
+- `tldw_Server_API/app/core/Security/egress.py`
+
+**High-value existing tests to reuse during the review:**
+- `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- `tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py`
+- `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+- `tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py`
+- `tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py`
+- `tldw_Server_API/tests/Web_Scraping/test_persistence_crawl_metadata.py`
+- `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+- `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+- `tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py`
+- `tldw_Server_API/tests/Web_Scraping/test_router_validation.py`
+- `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- `tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py`
+
+## Stage Overview
+
+## Stage 1: Review Artifact Setup and Call-Graph Inventory
+**Goal:** Create stable review artifacts, capture the exact scoped source and test surface, and freeze the audit output structure before deep reading begins.
+**Success Criteria:** Review files exist under `Docs/superpowers/reviews/web-scraping-ingest/`, the scoped source and test inventory is recorded, and the initial ingest call graph is documented.
+**Tests:** Tooling/version checks only
+**Status:** Complete
+
+## Stage 2: Public Entrypoints and Request-Model Contract Review
+**Goal:** Review both public ingest routes and their request-shaping logic for validation, coercion, cookie parsing, forwarding, and client-facing error semantics.
+**Success Criteria:** The public contract for `/api/v1/media/ingest-web-content` and `/api/v1/media/process-web-scraping` is documented with confirmed findings or explicit no-finding notes, backed by targeted request-path tests.
+**Tests:** Friendly ingest, cookie parsing, strategy validation, usage logging, and custom-header tests
+**Status:** Complete
+
+## Stage 3: Service Orchestration, Fallback, and Persistence-Mode Review
+**Goal:** Review the orchestration layer for normalization, mode-specific behavior, fallback gating, persistence metadata, and error translation.
+**Success Criteria:** The enhanced path, fallback path, `ephemeral` mode, and `persist` mode are traced end to end and any contract mismatches or reliability issues are documented with evidence.
+**Tests:** Config precedence, legacy fallback behavior, persistence crawl metadata
+**Status:** Complete
+
+## Stage 4: Reachable Core Fetch Path and Request-Safety Review
+**Goal:** Follow only the reachable fetch or extraction helpers from the ingest path and verify request safety, robots behavior, header and cookie propagation, and outbound policy enforcement.
+**Success Criteria:** Every reachable outbound path reviewed in this stage is classified as confirmed-safe, confirmed-unsafe, or probable-risk with evidence, and Bandit output is triaged rather than dumped verbatim.
+**Tests:** HTTP client, robots, and optional filter or router validations when required to settle a claim
+**Status:** Complete
+
+## Stage 5: Final Validation Pass, Coverage Gaps, and Ranked Synthesis
+**Goal:** Compare the reviewed code paths against the existing test surface, run only the narrowest extra validations needed to settle disputed claims, and produce the final ranked review.
+**Success Criteria:** Findings are de-duplicated, coverage gaps are prioritized, remediation is grouped by urgency, and the final review matches the approved output model.
+**Tests:** Optional e2e smoke when the environment supports it, plus any narrow follow-up commands needed to confirm unresolved claims
+**Status:** Complete
+
+### Task 1: Prepare Review Artifacts and Baseline Inventory
+
+**Files:**
+- Create: `Docs/superpowers/reviews/web-scraping-ingest/README.md`
+- Create: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage1-inventory-and-callgraph.md`
+- Create: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage2-public-entrypoints-and-schema.md`
+- Create: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage3-services-fallback-and-persistence.md`
+- Create: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage4-reachable-core-and-request-safety.md`
+- Create: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage5-validation-gaps-and-synthesis.md`
+- Modify: `Docs/superpowers/plans/2026-04-07-web-scraping-ingest-review-execution-plan.md`
+- Test: none
+
+- [ ] **Step 1: Create the review output directory**
+
+Run:
+```bash
+mkdir -p Docs/superpowers/reviews/web-scraping-ingest
+```
+
+Expected: the `Docs/superpowers/reviews/web-scraping-ingest` directory exists and no source files under `tldw_Server_API/app/` change.
+
+- [ ] **Step 2: Create one markdown file per stage with a fixed review template**
+
+Each stage file should contain:
+```markdown
+# Stage N Title
+
+## Scope
+## Code Paths Reviewed
+## Tests Reviewed
+## Validation Commands
+## Findings
+## Coverage Gaps
+## Improvements
+## Exit Note
+```
+
+- [ ] **Step 3: Write `Docs/superpowers/reviews/web-scraping-ingest/README.md`**
+
+Document:
+```markdown
+# Web_Scraping Ingest Review Artifacts
+
+## Stage Order
+1. Inventory and call graph
+2. Public entrypoints and schema
+3. Services, fallback, and persistence
+4. Reachable core and request safety
+5. Validation gaps and synthesis
+
+## Review Rules
+- Findings come before remediation ideas.
+- Uncertain claims must be labeled as assumptions or probable risks.
+- Security-sensitive claims require direct path proof, targeted validation, or an explicit confidence downgrade.
+- Only reachable code paths from the approved ingest scope belong in this review.
+```
+
+- [ ] **Step 4: Verify the execution environment before deep reading**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest --version
+python -m bandit --version
+```
+
+Expected: `pytest` and `bandit` print version information. If `bandit` is unavailable, stop and record that blocker in `2026-04-07-stage1-inventory-and-callgraph.md` before continuing with static security review only.
+
+- [ ] **Step 5: Capture the scoped source and test inventory**
+
+Run:
+```bash
+source .venv/bin/activate
+rg --files \
+  tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py \
+  tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py \
+  tldw_Server_API/app/api/v1/schemas/media_request_models.py \
+  tldw_Server_API/app/services/web_scraping_service.py \
+  tldw_Server_API/app/services/enhanced_web_scraping_service.py \
+  tldw_Server_API/app/services/ephemeral_store.py \
+  tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py \
+  tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py \
+  tldw_Server_API/app/core/Web_Scraping/scraper_router.py \
+  tldw_Server_API/app/core/Web_Scraping/filters.py \
+  tldw_Server_API/app/core/Web_Scraping/scoring.py \
+  tldw_Server_API/app/core/http_client.py \
+  tldw_Server_API/app/core/Security/egress.py \
+  tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py \
+  tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py \
+  tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py \
+  tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py \
+  tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py \
+  tldw_Server_API/tests/Web_Scraping/test_persistence_crawl_metadata.py \
+  tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py \
+  tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py \
+  tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py \
+  tldw_Server_API/tests/Web_Scraping/test_router_validation.py \
+  tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py \
+  tldw_Server_API/tests/WebScraping/test_custom_headers_support.py \
+  tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py | sort
+```
+
+Expected: a stable inventory that includes the approved ingest-path files and targeted test modules without expanding into unrelated application areas beyond directly referenced helpers.
+
+- [ ] **Step 6: Capture the recent churn baseline for the ingest path**
+
+Run:
+```bash
+git log --oneline -n 20 -- \
+  tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py \
+  tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py \
+  tldw_Server_API/app/services/web_scraping_service.py \
+  tldw_Server_API/app/services/enhanced_web_scraping_service.py \
+  tldw_Server_API/app/core/Web_Scraping
+```
+
+Expected: a first-pass change window that highlights recent refactors around fallback, persistence, and crawl behavior without requiring full-history archaeology.
+
+- [ ] **Step 7: Record the initial call-graph and final output structure in the stage 1 report**
+
+Write:
+```markdown
+## Initial Ingest Call Graph
+- `/api/v1/media/ingest-web-content` -> `ingest_web_content_orchestrate()` -> reachable scrape helpers
+- `/api/v1/media/process-web-scraping` -> `process_web_scraping_task()` -> enhanced service or legacy fallback
+
+## Final Review Output Shape
+## Findings
+1. Severity: concise finding with file references and impact
+
+## Open Questions
+- only unresolved assumptions
+```
+
+- [ ] **Step 8: Commit the review scaffold**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/web-scraping-ingest Docs/superpowers/plans/2026-04-07-web-scraping-ingest-review-execution-plan.md
+git commit -m "docs: scaffold web scraping ingest review artifacts"
+```
+
+Expected: one docs-only commit captures the review workspace before substantive findings are added.
+
+### Task 2: Execute Stage 2 Public Entrypoints and Request-Model Review
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage2-public-entrypoints-and-schema.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+- Inspect: `tldw_Server_API/app/api/v1/schemas/media_request_models.py`
+- Inspect: `tldw_Server_API/app/services/web_scraping_service.py:517`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+- Test: `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- Test: `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+
+- [ ] **Step 1: Read the route definitions, request models, and route-to-service glue**
+
+Run:
+```bash
+sed -n '1,240p' tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
+sed -n '1,220p' tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+rg -n "class IngestWebContentRequest|class WebScrapingRequest|field_validator|use_cookies|cookies|custom_headers|crawl_strategy|include_external|score_threshold" tldw_Server_API/app/api/v1/schemas/media_request_models.py
+rg -n "ingest_web_content_orchestrate|process_web_scraping_task" tldw_Server_API/app/services/web_scraping_service.py
+```
+
+Expected: a compact map of request validation, coercion, forwarding, and the exact service entrypoints for each public route.
+
+- [ ] **Step 2: Write the public contract table into the stage 2 report**
+
+Write:
+```markdown
+## Public Contract Table
+| Route | Request model | Key coercions or validators | Downstream service | Error translation notes |
+| --- | --- | --- | --- | --- |
+| `/api/v1/media/ingest-web-content` | `IngestWebContentRequest` | cookies, scrape-method aliasing, URL presence | `ingest_web_content_orchestrate()` | preserves `HTTPException`, wraps unexpected errors |
+| `/api/v1/media/process-web-scraping` | `WebScrapingRequest` | crawl strategy, headers, cookies, mode | `process_web_scraping_task()` | preserves downstream `HTTPException`, wraps unexpected errors |
+```
+
+- [ ] **Step 3: Run the request-path and forwarding tests**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py \
+  tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py \
+  tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py \
+  tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py \
+  tldw_Server_API/tests/WebScraping/test_custom_headers_support.py
+```
+
+Expected: PASS, or a clearly documented runtime-backed finding if any request-path contract fails. Any failure here is high-value because it directly weakens the public ingest contract or its observability.
+
+- [ ] **Step 4: Record findings with explicit evidence labels**
+
+Use this finding template in the stage 2 report:
+```markdown
+## Findings
+1. **Severity | Confidence | Route or schema boundary**
+   - Files: `path:line`
+   - Evidence: failing test | runtime proof | direct code-path proof | probable risk
+   - Why it matters: one production-facing sentence
+   - Recommended fix direction: one sentence
+```
+
+- [ ] **Step 5: Record explicit no-finding notes for validated boundaries**
+
+Write:
+```markdown
+## Exit Note
+- Verified cookie parsing behavior for friendly ingest.
+- Verified `process-web-scraping` preserves 400s for invalid crawl strategy.
+- Verified usage logging coverage.
+- Either verified custom-header forwarding coverage or recorded the reproducible failure that blocked that verification.
+```
+
+- [ ] **Step 6: Commit the stage 2 review notes**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage2-public-entrypoints-and-schema.md
+git commit -m "docs: add stage 2 web scraping ingest review notes"
+```
+
+Expected: one docs-only commit captures the public contract review before service-level notes begin.
+
+### Task 3: Execute Stage 3 Service Orchestration, Fallback, and Persistence Review
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage3-services-fallback-and-persistence.md`
+- Inspect: `tldw_Server_API/app/services/web_scraping_service.py`
+- Inspect: `tldw_Server_API/app/services/enhanced_web_scraping_service.py`
+- Inspect: `tldw_Server_API/app/services/ephemeral_store.py`
+- Inspect: `tldw_Server_API/app/core/DB_Management/media_db/api.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_persistence_crawl_metadata.py`
+
+- [ ] **Step 1: Read the orchestration, fallback, and storage entrypoints**
+
+Run:
+```bash
+rg -n "async def process_web_scraping_task|async def ingest_web_content_orchestrate|_store_ephemeral|_store_persistent|_legacy_web_scraping_fallback_enabled|_collect_fallback_unsupported_controls" tldw_Server_API/app/services/web_scraping_service.py tldw_Server_API/app/services/enhanced_web_scraping_service.py
+sed -n '133,940p' tldw_Server_API/app/services/web_scraping_service.py
+sed -n '1,760p' tldw_Server_API/app/services/enhanced_web_scraping_service.py
+```
+
+Expected: a readable map of normalization, enhanced dispatch, fallback gating, task-id handling, and mode-specific storage behavior.
+
+- [ ] **Step 2: Write the service control-flow summary into the stage 3 report**
+
+Write:
+```markdown
+## Service Control Flow
+- `process_web_scraping_task()` validates crawl controls, then dispatches to the enhanced service.
+- Enhanced-service failures may trigger the legacy fallback depending on environment gating.
+- `mode="ephemeral"` and `mode="persist"` diverge in storage shape, metadata persistence, and response payload details.
+
+## Failure-Seam Checklist
+- input normalization
+- fallback eligibility
+- degraded-control handling
+- metadata persistence
+- error translation
+```
+
+- [ ] **Step 3: Run the service-layer validation tests**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py \
+  tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py \
+  tldw_Server_API/tests/Web_Scraping/test_persistence_crawl_metadata.py
+```
+
+Expected: PASS. Any failure here is a high-confidence contract or reliability issue in the ingest orchestration layer.
+
+- [ ] **Step 4: Inspect the exact storage helpers only if a stage 3 claim depends on them**
+
+Run:
+```bash
+rg -n "class EphemeralStorage|store_data|get_data|managed_media_database|get_media_repository" tldw_Server_API/app/services/ephemeral_store.py tldw_Server_API/app/core/DB_Management/media_db/api.py
+sed -n '1,260p' tldw_Server_API/app/services/ephemeral_store.py
+sed -n '1,260p' tldw_Server_API/app/core/DB_Management/media_db/api.py
+```
+
+Expected: enough context to confirm or downgrade claims about TTL behavior, persistence lifecycle, or repository ownership without expanding into a full DB-management audit.
+
+- [ ] **Step 5: Record confirmed findings, probable risks, and explicit no-finding notes**
+
+Write:
+```markdown
+## Exit Note
+- Confirmed behavior for config-default versus request-override precedence.
+- Confirmed or downgraded claims around fallback gating and degraded controls.
+- Confirmed or downgraded claims around crawl metadata persistence in `persist` mode.
+```
+
+- [ ] **Step 6: Commit the stage 3 review notes**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage3-services-fallback-and-persistence.md
+git commit -m "docs: add stage 3 web scraping ingest review notes"
+```
+
+Expected: one docs-only commit captures the orchestration and persistence review.
+
+### Task 4: Execute Stage 4 Reachable Core and Request-Safety Review
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage4-reachable-core-and-request-safety.md`
+- Inspect: `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py`
+- Inspect: `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+- Inspect: `tldw_Server_API/app/core/Web_Scraping/scraper_router.py`
+- Inspect: `tldw_Server_API/app/core/Web_Scraping/filters.py`
+- Inspect: `tldw_Server_API/app/core/Web_Scraping/scoring.py`
+- Inspect: `tldw_Server_API/app/core/http_client.py`
+- Inspect: `tldw_Server_API/app/core/Security/egress.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_router_validation.py`
+
+- [ ] **Step 1: Trace the reachable outbound fetch path from the services into the core helpers**
+
+Run:
+```bash
+rg -n "scrape_article|recursive_scrape|scrape_from_sitemap|scrape_by_url_level|http_fetch|fetch\\(|evaluate_url_policy|is_allowed_by_robots" \
+  tldw_Server_API/app/services/web_scraping_service.py \
+  tldw_Server_API/app/services/enhanced_web_scraping_service.py \
+  tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py \
+  tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py \
+  tldw_Server_API/app/core/http_client.py \
+  tldw_Server_API/app/core/Security/egress.py
+```
+
+Expected: a concrete list of reachable fetch and policy functions to inspect, with no need to review unrelated web-search code.
+
+- [ ] **Step 2: Read the request-safety and policy enforcement points**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/http_client.py
+sed -n '1,260p' tldw_Server_API/app/core/Security/egress.py
+rg -n "robots|cookie|custom_headers|user_agent|evaluate_url_policy|http_fetch|fetch\\(" tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
+```
+
+Expected: enough evidence to classify each reachable outbound path as enforced, bypassable, or ambiguous.
+
+- [ ] **Step 3: Run the direct request-safety validation tests**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py \
+  tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py
+```
+
+Expected: PASS. Any failure here weakens confidence in outbound safety or robots behavior.
+
+- [ ] **Step 4: Run the narrow follow-up tests only if a stage 4 claim depends on filter or router semantics**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py \
+  tldw_Server_API/tests/Web_Scraping/test_router_validation.py
+```
+
+Expected: PASS when executed. Skip this step only if stage 4 findings do not rely on filter or router semantics, and record that skip decision in the stage 4 report.
+
+- [ ] **Step 5: Run Bandit on the touched review scope and capture machine-readable output**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py \
+  tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py \
+  tldw_Server_API/app/api/v1/schemas/media_request_models.py \
+  tldw_Server_API/app/services/web_scraping_service.py \
+  tldw_Server_API/app/services/enhanced_web_scraping_service.py \
+  tldw_Server_API/app/core/http_client.py \
+  tldw_Server_API/app/core/Web_Scraping \
+  -f json -o /tmp/bandit_web_scraping_ingest_review.json
+```
+
+Expected: `/tmp/bandit_web_scraping_ingest_review.json` is written when `bandit` is available. If `bandit` is still unavailable in the shared project venv, record that blocker in the Stage 4 note and continue with static request-safety review only. When the JSON is available, findings are triaged and summarized in prose; the JSON file itself is not the final review.
+
+- [ ] **Step 6: Record security findings and confidence downgrades**
+
+Write:
+```markdown
+## Findings
+1. **Severity | Confidence | Request-safety issue**
+   - Files: `path:line`
+   - Evidence: direct code-path proof | failing test | Bandit + manual triage
+   - Why it matters: one sentence
+   - Confidence downgrade note: include this only when enforcement is ambiguous rather than proven weak
+```
+
+- [ ] **Step 7: Commit the stage 4 review notes**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage4-reachable-core-and-request-safety.md
+git commit -m "docs: add stage 4 web scraping request-safety review notes"
+```
+
+Expected: one docs-only commit captures the reachable core and security review.
+
+### Task 5: Execute Stage 5 Final Validation, Coverage-Gap Review, and Synthesis
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/web-scraping-ingest/README.md`
+- Modify: `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage5-validation-gaps-and-synthesis.md`
+- Inspect: all stage reports for de-duplication
+- Test: `tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py`
+
+- [ ] **Step 1: Run the optional end-to-end smoke only when the environment supports it**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -m e2e -v tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py
+```
+
+Expected: the local workflow passes when the e2e server fixtures are available; the external workflow may skip unless `TLDW_E2E_EXTERNAL_WEB_SCRAPE=1` is set. If the e2e environment is unavailable, record the skip condition rather than forcing the test.
+
+- [ ] **Step 2: Write the final synthesis document**
+
+Use this exact structure in `2026-04-07-stage5-validation-gaps-and-synthesis.md`:
+```markdown
+# Stage 5 Validation Gaps and Synthesis
+
+## Findings
+1. Severity-ranked, evidence-backed findings only
+
+## Open Questions
+- only unresolved assumptions that affect confidence
+
+## Coverage Gaps
+- covered and failing
+- covered but weak
+- uncovered
+
+## Remediation Roadmap
+- fix now
+- fix soon
+- opportunistic cleanup
+```
+
+- [ ] **Step 3: Cross-check the final synthesis against the approved spec**
+
+Run:
+```bash
+rg -n "Goal|Primary Scope|Review Questions|Targeted Validation|Security And Request-Safety Audit|Evidence Rules" Docs/superpowers/specs/2026-04-07-web-scraping-ingest-review-design.md
+```
+
+Expected: every spec section maps to at least one stage report or explicit no-finding note. Add missing synthesis coverage before closing the review.
+
+- [ ] **Step 4: Perform a placeholder and duplication scan across the review artifacts**
+
+Run:
+```bash
+rg -n "TODO|TBD|fix later|implement later|placeholder|similar to|add appropriate|write tests for the above" Docs/superpowers/reviews/web-scraping-ingest
+```
+
+Expected: no placeholder language remains. If duplicates exist across stage files, collapse them into the strongest evidence location and cross-reference rather than repeating them.
+
+- [ ] **Step 5: Update the review README with the final artifact status**
+
+Write:
+```markdown
+## Final Status
+- Stage 1 complete
+- Stage 2 complete
+- Stage 3 complete
+- Stage 4 complete
+- Stage 5 complete
+
+## Final Ranked Review
+- See `2026-04-07-stage5-validation-gaps-and-synthesis.md`
+```
+
+- [ ] **Step 6: Commit the final synthesis and README updates**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/web-scraping-ingest/README.md Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage5-validation-gaps-and-synthesis.md
+git commit -m "docs: finalize web scraping ingest review"
+```
+
+Expected: one docs-only commit captures the final ranked review and coverage-gap analysis.

--- a/Docs/superpowers/plans/2026-04-08-web-scraping-remediation-execution-plan.md
+++ b/Docs/superpowers/plans/2026-04-08-web-scraping-remediation-execution-plan.md
@@ -1,0 +1,752 @@
+# Web Scraping Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the web scraping ingest remediation complete by stabilizing the `/process-web-scraping` endpoint tests, hardening centralized curl redirect and egress enforcement, rerouting the enhanced curl path through the centralized HTTP client, and locking in the current best-effort robots contract with direct regression coverage.
+
+**Architecture:** Keep the existing friendly-ingest compatibility seam in `media.__init__` and `web_scraping_service.py`, but stop relying on it for the `/process-web-scraping` endpoint tests. Centralize curl request-safety in `http_client.fetch()`, then make `EnhancedWebScraper._fetch_html_curl()` delegate to that path instead of owning its own curl request logic. Cover the enhanced robots branch directly with focused unit tests rather than changing runtime behavior.
+
+**Tech Stack:** Python 3.14, FastAPI, pytest, httpx, curl_cffi adapter seam, Bandit
+
+---
+
+## File Map
+
+**Primary code files**
+- `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+  Endpoint-local task resolution seam for `/process-web-scraping`.
+- `tldw_Server_API/app/core/http_client.py`
+  Central simple fetch redirect and egress behavior for `backend="curl"`.
+- `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+  Enhanced scraper curl delegation and robots branch clarification.
+
+**Primary test files**
+- `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+  Usage-events endpoint test updated to patch the endpoint-local seam.
+- `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+  Deterministic request-path custom-headers test using the same client style as usage-events.
+- `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+  Curl redirect and egress policy regression tests.
+- `tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py`
+  New focused enhanced-scraper guard tests for curl delegation and robots behavior.
+- `tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py`
+  Compatibility assertion updated for the new endpoint-local seam.
+
+**Validation-only test files**
+- `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+
+**Inspection-only compatibility file**
+- `tldw_Server_API/app/services/web_scraping_service.py`
+  Preserve existing `media.process_web_scraping_task` compatibility behavior for friendly-ingest callers.
+
+## Stage 1: Endpoint Determinism
+**Goal:** Remove the order-sensitive `/process-web-scraping` test failure by standardizing the endpoint tests on one lifecycle-safe client strategy and patch target.
+**Success Criteria:** The usage-events and custom-header endpoint tests pass together in one pytest invocation, and friendly-ingest tests that still patch `media.process_web_scraping_task` remain green.
+**Tests:** `test_webscraping_usage_events.py`, `test_custom_headers_support.py`, `test_friendly_ingest_crawl_flags.py`, `test_media_compat_patchpoints.py`
+**Status:** Not Started
+
+## Stage 2: Central Curl Policy
+**Goal:** Make the centralized simple curl fetch path enforce redirect and egress policy in the same shape as the existing simple httpx path.
+**Success Criteria:** Same-host redirects still succeed, blocked redirect hops are not followed, and curl requests never rely on implicit redirect following.
+**Tests:** `test_http_client_fetch.py`
+**Status:** Not Started
+
+## Stage 3: Enhanced Scraper Delegation And Robots Coverage
+**Goal:** Route the enhanced curl path through the centralized HTTP client and add direct enhanced-scraper regression coverage for curl delegation and the current robots best-effort contract.
+**Success Criteria:** `_fetch_html_curl()` uses `http_client.fetch()` with `backend="curl"`, enhanced robots fail-open and explicit-disallow behavior is covered, Bandit passes on the touched scope, and the final targeted batch is green.
+**Tests:** `test_enhanced_web_scraping_guards.py`, `test_http_client_fetch.py`, `test_robots_enforcement.py`, final targeted batch
+**Status:** Not Started
+
+### Task 1: Stabilize `/process-web-scraping` Endpoint Tests
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+- Modify: `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- Modify: `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- Modify: `tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py`
+- Test: `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- Test: `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- Test: `tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py`
+
+- [ ] **Step 1: Write failing deterministic endpoint tests against an endpoint-local seam**
+
+Update the two endpoint test files so they patch a resolver on `process_web_scraping.py` and so the custom-headers request uses the same `TestClient` lifecycle style as the usage-events test.
+
+```python
+# tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def client_with_ws_overrides(monkeypatch, client_with_single_user):
+    client, usage_logger = client_with_single_user
+
+    import tldw_Server_API.app.api.v1.endpoints.media.process_web_scraping as endpoint_mod
+
+    async def stub_process_web_scraping_task(**kwargs):
+        return {"status": "ok", "results": []}
+
+    monkeypatch.setattr(
+        endpoint_mod,
+        "_resolve_process_web_scraping_task",
+        lambda: stub_process_web_scraping_task,
+    )
+
+    yield client, usage_logger
+```
+
+```python
+# tldw_Server_API/tests/WebScraping/test_custom_headers_support.py
+from unittest.mock import MagicMock
+
+import pytest
+
+from tldw_Server_API.app.core.Web_Scraping.enhanced_web_scraping import CookieManager
+
+
+@pytest.mark.asyncio
+async def test_cookie_manager_stores_and_returns_cookies(tmp_path):
+    manager = CookieManager(storage_path=tmp_path / "cookies.json")
+    manager.add_cookies(
+        "example.com",
+        [{"name": "foo", "value": "bar"}, {"name": "session", "value": "trace-id"}],
+    )
+    cookies = manager.get_cookies("https://example.com/some/path")
+    assert cookies == [{"name": "foo", "value": "bar"}, {"name": "session", "value": "trace-id"}]
+    assert manager.get_cookies("https://other.example") is None
+
+
+def test_process_web_scraping_endpoint_receives_custom_headers(
+    client_with_single_user,
+    monkeypatch,
+):
+    client, _ = client_with_single_user
+
+    from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+    from tldw_Server_API.app.api.v1.endpoints.media import process_web_scraping as endpoint_mod
+    from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
+    from tldw_Server_API.app.main import app
+
+    fake_db = MagicMock(spec=MediaDatabase)
+    app.dependency_overrides[get_media_db_for_user] = lambda: fake_db
+
+    mocked_result = {"status": "success", "message": "ok", "count": 0, "results": []}
+    payload = {
+        "scrape_method": "Individual URLs",
+        "url_input": "https://example.com/article",
+        "max_pages": 5,
+        "max_depth": 1,
+        "summarize_checkbox": False,
+        "mode": "ephemeral",
+        "user_agent": "IntegrationAgent/1.0",
+        "custom_headers": {"X-Test": "true"},
+    }
+
+    async def fake_process_web_scraping_task(**kwargs):
+        return mocked_result
+
+    monkeypatch.setattr(
+        endpoint_mod,
+        "_resolve_process_web_scraping_task",
+        lambda: fake_process_web_scraping_task,
+    )
+
+    try:
+        response = client.post("/api/v1/media/process-web-scraping", json=payload)
+    finally:
+        app.dependency_overrides.pop(get_media_db_for_user, None)
+
+    assert response.status_code == 200
+    assert response.json() == mocked_result
+```
+
+- [ ] **Step 2: Run the endpoint tests to verify the new seam does not exist yet**
+
+Run:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -vv \
+  tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py \
+  tldw_Server_API/tests/WebScraping/test_custom_headers_support.py
+```
+
+Expected: FAIL because `process_web_scraping.py` does not yet expose `_resolve_process_web_scraping_task`.
+
+- [ ] **Step 3: Implement the endpoint-local resolver seam**
+
+Add a module-local resolver in `process_web_scraping.py` and switch the route to use it. Remove the runtime dependency on `media_mod` from this endpoint only.
+
+```python
+# tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+from tldw_Server_API.app.api.v1.schemas.media_request_models import WebScrapingRequest
+from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
+from tldw_Server_API.app.services.web_scraping_service import process_web_scraping_task
+
+
+def _resolve_process_web_scraping_task():
+    return process_web_scraping_task
+```
+
+```python
+# tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+        task = _resolve_process_web_scraping_task()
+        result = await task(
+            scrape_method=payload.scrape_method,
+            url_input=payload.url_input,
+            url_level=payload.url_level,
+            max_pages=payload.max_pages,
+            max_depth=payload.max_depth,
+            summarize_checkbox=payload.summarize_checkbox,
+            custom_prompt=payload.custom_prompt,
+            api_name=payload.api_name,
+            api_key=None,
+            keywords=payload.keywords or "",
+            custom_titles=payload.custom_titles,
+            system_prompt=payload.system_prompt,
+            temperature=payload.temperature,
+            custom_cookies=payload.custom_cookies,
+            mode=payload.mode,
+            user_id=(
+                getattr(getattr(db, "user", None), "id", None)
+                if db is not None
+                else None
+            ),
+            user_agent=payload.user_agent,
+            custom_headers=payload.custom_headers,
+            crawl_strategy=payload.crawl_strategy,
+            include_external=payload.include_external,
+            score_threshold=payload.score_threshold,
+        )
+```
+
+- [ ] **Step 4: Update the compat assertion to reflect the new endpoint seam**
+
+```python
+# tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
+def test_web_scraping_endpoint_resolves_task_without_compat_module():
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "api"
+        / "v1"
+        / "endpoints"
+        / "media"
+        / "process_web_scraping.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+    assert "compat_patchpoints" not in source
+    assert "_resolve_process_web_scraping_task" in source
+    assert 'getattr(media_mod, "process_web_scraping_task"' not in source
+```
+
+- [ ] **Step 5: Run the endpoint and compatibility validation batch**
+
+Run:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py \
+  tldw_Server_API/tests/WebScraping/test_custom_headers_support.py \
+  tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py \
+  tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
+```
+
+Expected: `11 passed`
+
+- [ ] **Step 6: Commit the endpoint determinism changes**
+
+Run:
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py \
+  tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py \
+  tldw_Server_API/tests/WebScraping/test_custom_headers_support.py \
+  tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
+git commit -m "test: stabilize web scraping endpoint request-path tests"
+```
+
+Expected: one commit captures the endpoint-local seam and deterministic request-path tests.
+
+### Task 2: Harden Centralized Curl Redirect And Egress Enforcement
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/http_client.py`
+- Modify: `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+
+- [ ] **Step 1: Write failing curl redirect policy tests**
+
+Extend `test_http_client_fetch.py` so the curl path must manually follow allowed same-host redirects and refuse blocked redirect hops before a second request is issued.
+
+```python
+# tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py
+class DummyResp:
+    def __init__(
+        self,
+        url: str,
+        headers: dict,
+        *,
+        status_code: int = 200,
+        text: str = "<html><body>ok</body></html>",
+    ):
+        self.status_code = status_code
+        self.headers = headers
+        self.text = text
+        self.url = url
+
+
+def test_curl_fetch_follows_same_host_redirects_under_policy(monkeypatch):
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+
+    calls = []
+
+    class DummyCurlSession:
+        def __init__(self, impersonate=None):
+            self.impersonate = impersonate
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            if url == "https://example.com/start":
+                return DummyResp(
+                    url,
+                    {"Location": "/final"},
+                    status_code=302,
+                    text="",
+                )
+            return DummyResp("https://example.com/final", {}, status_code=200, text="<html>final</html>")
+
+    monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
+
+    resp = hc.fetch(
+        "https://example.com/start",
+        headers={"Accept-Encoding": "gzip, br, zstd"},
+        backend="curl",
+        follow_redirects=True,
+    )
+
+    assert [url for url, _ in calls] == [
+        "https://example.com/start",
+        "https://example.com/final",
+    ]
+    assert calls[0][1]["allow_redirects"] is False
+    assert calls[1][1]["allow_redirects"] is False
+    assert resp["status"] == 200
+    assert resp["url"] == "https://example.com/final"
+
+
+def test_curl_fetch_denies_blocked_redirect_hop(monkeypatch):
+    allowed = {
+        "https://example.com/start": True,
+        "https://example.com/final": False,
+    }
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: allowed.get(url, True))
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+
+    calls = []
+
+    class DummyCurlSession:
+        def __init__(self, impersonate=None):
+            self.impersonate = impersonate
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            return DummyResp(
+                url,
+                {"Location": "/final"},
+                status_code=302,
+                text="",
+            )
+
+    monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
+
+    with pytest.raises(ValueError):
+        hc.fetch("https://example.com/start", backend="curl", follow_redirects=True)
+
+    assert [url for url, _ in calls] == ["https://example.com/start"]
+    assert calls[0][1]["allow_redirects"] is False
+```
+
+- [ ] **Step 2: Run the curl-policy tests to verify the current behavior fails**
+
+Run:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -vv tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py
+```
+
+Expected: FAIL because the current curl path still passes `allow_redirects=True` through to the curl session and does not manually apply the same redirect loop used by the simple httpx path.
+
+- [ ] **Step 3: Implement manual redirect handling for the simple curl path**
+
+Keep `_fetch_curl_simple()` as a one-request helper and move redirect policy into the `backend="curl"` branch inside `fetch()`.
+
+```python
+# tldw_Server_API/app/core/http_client.py
+def _fetch_curl_simple(
+    *,
+    url: str,
+    headers: dict[str, str],
+    cookies: dict[str, str] | None,
+    timeout: float | None,
+    impersonate: str | None,
+    proxies: dict[str, str] | None,
+    allow_redirects: bool,
+) -> HttpResponse:
+    CurlSession = _resolve_curl_session()
+    if CurlSession is None:
+        raise RuntimeError("curl_cffi is not installed")  # noqa: TRY003
+    if proxies:
+        _validate_proxies_or_raise(proxies)
+
+    req_kwargs: dict[str, Any] = {
+        "headers": headers,
+        "cookies": cookies,
+        "allow_redirects": False,
+    }
+    if timeout is not None:
+        req_kwargs["timeout"] = timeout
+    if proxies:
+        req_kwargs["proxies"] = proxies
+
+    with CurlSession(impersonate=impersonate) as session:
+        resp = session.get(url, **req_kwargs)
+        return HttpResponse(
+            status=int(getattr(resp, "status_code", 0)),
+            headers=dict(getattr(resp, "headers", {}) or {}),
+            text=str(getattr(resp, "text", "")),
+            url=str(getattr(resp, "url", url)),
+            backend="curl",
+        )
+
+```
+
+```python
+# tldw_Server_API/app/core/http_client.py
+    if backend_norm == "curl":
+        cur_url = url
+        redirects = 0
+
+        while True:
+            if not _is_url_allowed(cur_url):
+                raise ValueError("Egress denied for URL")  # noqa: TRY003
+
+            resp = _fetch_curl_simple(
+                url=cur_url,
+                headers=req_headers,
+                cookies=cookies,
+                timeout=timeout,
+                impersonate=impersonate,
+                proxies=proxies,
+                allow_redirects=False,
+            )
+            status = int(resp["status"])
+
+            if not follow_redirects or status not in (301, 302, 303, 307, 308):
+                return resp
+
+            location = (resp["headers"] or {}).get("location") or (resp["headers"] or {}).get("Location")
+            if not location:
+                return resp
+
+            try:
+                base_url = str(resp["url"] or cur_url)
+                next_url = str(httpx.URL(base_url).join(httpx.URL(location)))
+            except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+                try:
+                    next_url = str(httpx.URL(location))
+                except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+                    return resp
+
+            if not _redirect_allowed(cur_url, next_url):
+                return resp
+
+            redirects += 1
+            if redirects > DEFAULT_MAX_REDIRECTS:
+                return resp
+
+            cur_url = next_url
+```
+
+- [ ] **Step 4: Run the centralized curl-policy tests**
+
+Run:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -vv tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py
+```
+
+Expected: `8 passed`
+
+- [ ] **Step 5: Commit the centralized curl hardening**
+
+Run:
+```bash
+git add \
+  tldw_Server_API/app/core/http_client.py \
+  tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py
+git commit -m "fix: harden curl fetch redirect enforcement"
+```
+
+Expected: one commit captures the centralized curl redirect and egress hardening.
+
+### Task 3: Reroute Enhanced Curl Fetches And Cover Robots Contract
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+- Create: `tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+- Test: `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- Test: `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- Test: `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- Test: `tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py`
+
+- [ ] **Step 1: Write a failing enhanced-scraper guard test module**
+
+Create a focused unit test file that proves `_fetch_html_curl()` must go through `http_client.fetch()` and directly covers the current enhanced robots branch.
+
+```python
+# tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import tldw_Server_API.app.core.Web_Scraping.enhanced_web_scraping as ews
+
+
+def test_fetch_html_curl_routes_through_http_client_fetch(monkeypatch):
+    calls = {}
+
+    def fake_fetch(url, **kwargs):
+        calls["url"] = url
+        calls["kwargs"] = kwargs
+        return {
+            "status": 200,
+            "headers": {"Content-Type": "text/html"},
+            "text": "<html>ok</html>",
+            "url": url,
+            "backend": "curl",
+        }
+
+    monkeypatch.setattr("tldw_Server_API.app.core.http_client.fetch", fake_fetch)
+
+    scraper = ews.EnhancedWebScraper(config={})
+    html = scraper._fetch_html_curl(
+        "https://example.com/article",
+        headers={"X-Test": "true"},
+        cookies={"session": "abc"},
+        timeout=5.0,
+        impersonate="chrome120",
+        proxies=None,
+    )
+
+    assert html == "<html>ok</html>"
+    assert calls["url"] == "https://example.com/article"
+    assert calls["kwargs"]["backend"] == "curl"
+    assert calls["kwargs"]["headers"]["X-Test"] == "true"
+    assert calls["kwargs"]["cookies"] == {"session": "abc"}
+
+
+def _build_scraper(monkeypatch):
+    scraper = ews.EnhancedWebScraper(config={})
+
+    async def _acquire():
+        return None
+
+    scraper.rate_limiter.acquire = _acquire
+
+    plan = SimpleNamespace(
+        respect_robots=True,
+        ua_profile="chrome_120_win",
+        extra_headers={},
+        cookies={},
+        impersonate=None,
+        proxies=None,
+        strategy_order=None,
+        schema_rules=None,
+        llm_settings=None,
+        regex_settings=None,
+        cluster_settings=None,
+        backend="auto",
+    )
+
+    monkeypatch.setattr(scraper, "_resolve_scrape_plan", lambda url: (plan, "httpx", ""))
+    monkeypatch.setattr(scraper, "_run_preflight_analysis", AsyncMock(return_value=None))
+    monkeypatch.setattr(scraper, "_apply_preflight_advice", lambda *args: ("httpx", "trafilatura", []))
+    monkeypatch.setattr("tldw_Server_API.app.core.Security.egress.evaluate_url_policy", lambda url: SimpleNamespace(allowed=True))
+    monkeypatch.setattr(ews, "increment_counter", lambda *args, **kwargs: None)
+
+    return scraper
+
+
+@pytest.mark.asyncio
+async def test_scrape_article_allows_when_robots_check_errors(monkeypatch):
+    scraper = _build_scraper(monkeypatch)
+    fake_scrape = AsyncMock(
+        return_value={
+            "url": "https://example.com/article",
+            "content": "ok",
+            "extraction_successful": True,
+        }
+    )
+    monkeypatch.setattr(scraper, "_scrape_with_trafilatura", fake_scrape)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib.is_allowed_by_robots_async",
+        AsyncMock(side_effect=RuntimeError("robots unavailable")),
+    )
+
+    result = await scraper.scrape_article("https://example.com/article")
+
+    assert result["extraction_successful"] is True
+    fake_scrape.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_scrape_article_blocks_when_robots_disallows(monkeypatch):
+    scraper = _build_scraper(monkeypatch)
+    fake_scrape = AsyncMock()
+    monkeypatch.setattr(scraper, "_scrape_with_trafilatura", fake_scrape)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib.is_allowed_by_robots_async",
+        AsyncMock(return_value=False),
+    )
+
+    result = await scraper.scrape_article("https://example.com/article")
+
+    assert result["extraction_successful"] is False
+    assert result["error"] == "Blocked by robots policy"
+    fake_scrape.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run the enhanced-scraper guard tests to verify the curl delegation is still missing**
+
+Run:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -vv tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py
+```
+
+Expected: `1 failed, 2 passed` because `_fetch_html_curl()` still imports and uses `CurlCffiSession` directly instead of routing through `http_client.fetch()`.
+
+- [ ] **Step 3: Reroute the enhanced curl branch through the centralized HTTP client and clarify robots semantics**
+
+Replace the direct `curl_cffi` call in `enhanced_web_scraping.py` with a delegation to `http_client.fetch()`, and add a short comment above the robots branch to make the fail-open contract explicit.
+
+```python
+# tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
+    @staticmethod
+    def _fetch_html_curl(
+        url: str,
+        *,
+        headers: dict[str, str],
+        cookies: Optional[dict[str, str]],
+        timeout: float,
+        impersonate: Optional[str],
+        proxies: Optional[dict[str, str]],
+    ) -> str:
+        from tldw_Server_API.app.core import http_client as _http_client
+
+        resp = _http_client.fetch(
+            url,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            proxies=proxies,
+            backend="curl",
+            impersonate=impersonate,
+        )
+        return resp["text"]
+```
+
+```python
+# tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
+            # robots.txt enforcement is best-effort: explicit disallow blocks
+            # the scrape, but transient robots retrieval errors do not.
+            if getattr(plan, "respect_robots", True):
+                try:
+                    from tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib import (
+                        is_allowed_by_robots_async,
+                    )
+                    if not await is_allowed_by_robots_async(url, headers.get("User-Agent", DEFAULT_USER_AGENT)):
+                        try:
+                            parsed = urlparse(url)
+                            increment_counter("scrape_blocked_by_robots_total", labels={"domain": parsed.netloc})
+                        except _WEBSCRAPE_NONCRITICAL_EXCEPTIONS:
+                            increment_counter("scrape_blocked_by_robots_total", labels={})
+                        return _attach_preflight({
+                            "url": url,
+                            "error": "Blocked by robots policy",
+                            "extraction_successful": False,
+                        })
+                except _WEBSCRAPE_NONCRITICAL_EXCEPTIONS:
+                    pass
+```
+
+- [ ] **Step 4: Run the final targeted remediation batch**
+
+Run:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py \
+  tldw_Server_API/tests/WebScraping/test_custom_headers_support.py \
+  tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py \
+  tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py \
+  tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py \
+  tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py \
+  tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
+```
+
+Expected: `24 passed`
+
+- [ ] **Step 5: Run Bandit on the touched scope**
+
+Run:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py \
+  tldw_Server_API/app/core/http_client.py \
+  tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py \
+  -f json -o /tmp/bandit_web_scraping_remediation.json
+```
+
+Expected: command exits successfully and writes `/tmp/bandit_web_scraping_remediation.json`; address any new findings in the touched code before committing.
+
+- [ ] **Step 6: Commit the enhanced-scraper and robots changes**
+
+Run:
+```bash
+git add \
+  tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py \
+  tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py
+git add \
+  tldw_Server_API/app/core/http_client.py \
+  tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py \
+  tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py \
+  tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py \
+  tldw_Server_API/tests/WebScraping/test_custom_headers_support.py \
+  tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
+git commit -m "fix: route enhanced curl scraping through http client"
+```
+
+Expected: final remediation commit captures the enhanced curl delegation, robots clarification, and any remaining test adjustments needed to leave the targeted batch green.

--- a/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage1-inventory-and-callgraph.md
+++ b/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage1-inventory-and-callgraph.md
@@ -1,0 +1,106 @@
+# Stage 1 Inventory and Call Graph
+
+## Scope
+Create the review output directory, freeze the report structure, and record the initial Web_Scraping source/test inventory plus the recent-history baseline.
+
+## Code Paths Reviewed
+### Scope Snapshot
+- `tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py`
+- `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+- `tldw_Server_API/app/api/v1/schemas/media_request_models.py`
+- `tldw_Server_API/app/services/web_scraping_service.py`
+- `tldw_Server_API/app/services/enhanced_web_scraping_service.py`
+- `tldw_Server_API/app/services/ephemeral_store.py`
+- `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py`
+- `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+- `tldw_Server_API/app/core/Web_Scraping/scraper_router.py`
+- `tldw_Server_API/app/core/Web_Scraping/filters.py`
+- `tldw_Server_API/app/core/Web_Scraping/scoring.py`
+- `tldw_Server_API/app/core/http_client.py`
+- `tldw_Server_API/app/core/Security/egress.py`
+- `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- `tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py`
+- `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+- `tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py`
+- `tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py`
+- `tldw_Server_API/tests/Web_Scraping/test_persistence_crawl_metadata.py`
+- `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+- `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+- `tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py`
+- `tldw_Server_API/tests/Web_Scraping/test_router_validation.py`
+- `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- `tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py`
+
+## Tests Reviewed
+Stage 1 does not review test behavior in depth. This section freezes the targeted test inventory for later validation stages.
+
+- `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- `tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py`
+- `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+- `tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py`
+- `tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py`
+- `tldw_Server_API/tests/Web_Scraping/test_persistence_crawl_metadata.py`
+- `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+- `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+- `tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py`
+- `tldw_Server_API/tests/Web_Scraping/test_router_validation.py`
+- `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- `tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py`
+
+## Validation Commands
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate`
+- `python -m pytest --version` -> `pytest 9.0.2`
+- `python -m bandit --version` -> `No module named bandit`
+- `rg --files ... | sort` -> scoped inventory captured in this report
+- `git log --oneline -n 20 -- ...` -> recent churn baseline captured below
+
+## Findings
+- None recorded at scaffold time.
+
+## Coverage Gaps
+- Bandit is unavailable in the shared project venv, so security validation is limited to static review until that dependency is installed.
+
+## Improvements
+- Use the fixed stage template to capture subsequent evidence and findings without expanding the scope.
+
+## Exit Note
+- Stage 1 scaffold and baseline inventory captured; deeper review is deferred to later stages.
+
+## Recent Churn Baseline
+```text
+91806e5c3 fix: address non-threaded pr review followups
+8f0279df1 refactor: trim remaining media endpoint shim imports
+b6dd1e7a3 fix media session wrapper listing and trim media endpoint shim imports
+021980919 refactor: manage article extractor db lifecycle
+f2fb4dba1 refactor: use managed media db helper in web scraping services
+eb0852342 refactor: migrate more service callers to media db api
+166fbc2fe refactor: migrate ingestion callers to media db api factory
+41d4f59d4 refactor: expose media db api factory import path
+c31c779a5 refactor: route workflow and scrape ingest through media api
+c2ae77e49 refactor(compat): enforce runtime deprecation registry and fallback gate
+d10e600db refactor(webscraping): remove cookie manager close_all shim
+e2aeac723 refactor(websearch): remove deprecated simple breaker shim
+4769c3dd2 docs(media): remove stale legacy shim wording
+547f51e0c cleanup
+7973e411d refactor(media): reduce legacy ingestion compatibility surface
+40beb3561 bandit+personas
+58312fd53 bandit fixes + UI/UX in webui/extension + Claims fixups
+20bfc9cf4 bugfixes
+7f2596979 fixes
+d0654d0cf colors, themes + splashscreens
+```
+
+## Initial Ingest Call Graph
+- `/api/v1/media/ingest-web-content` -> `ingest_web_content_orchestrate()` -> reachable scrape helpers
+- `/api/v1/media/process-web-scraping` -> `process_web_scraping_task()` -> enhanced service or legacy fallback
+
+## Final Review Output Shape
+```markdown
+## Findings
+1. Severity: concise finding with file references and impact
+
+## Open Questions
+- only unresolved assumptions
+```

--- a/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage2-public-entrypoints-and-schema.md
+++ b/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage2-public-entrypoints-and-schema.md
@@ -1,0 +1,60 @@
+# Stage 2 Public Entrypoints and Schema
+
+## Scope
+- Public request boundary review for `/api/v1/media/ingest-web-content` and `/api/v1/media/process-web-scraping`.
+- Request-model inspection for `IngestWebContentRequest` and `WebScrapingRequest`.
+- Route-to-service glue inspection for `ingest_web_content_orchestrate()` and `process_web_scraping_task()`.
+
+## Code Paths Reviewed
+- `tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py`
+- `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+- `tldw_Server_API/app/api/v1/schemas/media_request_models.py`
+- `tldw_Server_API/app/services/web_scraping_service.py`
+
+## Tests Reviewed
+- `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- `tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py`
+- `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+- `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+
+## Validation Commands
+- `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- Result: `15 passed, 1 failed`
+
+## Public Contract Table
+| Route | Request model | Key coercions or validators | Downstream service | Error translation notes |
+| --- | --- | --- | --- | --- |
+| `/api/v1/media/ingest-web-content` | `IngestWebContentRequest` | `scrape_method` binds to `ScrapeMethod`; `max_pages` enforces `ge=1`; route rejects empty `urls`; orchestrator parses `cookies` into a cookie list and raises `400` on malformed payloads | `ingest_web_content_orchestrate()` | Route preserves downstream `HTTPException` and wraps unexpected failures in `500 Failed to ingest web content` |
+| `/api/v1/media/process-web-scraping` | `WebScrapingRequest` | `max_pages` enforces `ge=1`; service normalizes `crawl_strategy` aliases to `best_first` and validates `score_threshold` into `[0.0, 1.0]`; typed forwarding for `custom_headers`, `custom_cookies`, and `mode` | `process_web_scraping_task()` | Route preserves downstream `HTTPException` and wraps unexpected failures in `500 Web scraping failed due to an internal error.` |
+
+## Findings
+1. **Medium | High | `/api/v1/media/process-web-scraping` end-to-end custom-header contract**
+   - Files: `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py:24`, `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py:25`, `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py:63`
+   - Evidence: failing test
+   - Why it matters: the public route currently fails with `503 Service Unavailable` in the scoped custom-header integration test before the patched task result can be returned, so the endpoint-level custom-header forwarding contract is not presently proven end-to-end.
+   - Recommended fix direction: trace the `503` dependency or pre-route failure in the request path used by `test_process_web_scraping_endpoint_receives_custom_headers` and restore a `200` response so the forwarding assertions can execute.
+
+## Validated Behaviors
+- Cookie parsing for friendly ingest preserves `400` semantics for malformed JSON, invalid cookie object types, and non-dict list members.
+  Files: `tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py:66`, `tldw_Server_API/app/services/web_scraping_service.py:606`
+  Evidence: runtime proof from `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py` and `tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py`
+- `process-web-scraping` preserves downstream `400`s for invalid `crawl_strategy` values and invalid `score_threshold` values instead of translating them to generic `500`s.
+  Files: `tldw_Server_API/app/services/web_scraping_service.py:187`, `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py:91`
+  Evidence: runtime proof from `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+- Usage logging for the public `/api/v1/media/process-web-scraping` route is covered by a passing request-path test.
+  Files: `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py:47`
+  Evidence: runtime proof from `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+
+## Coverage Gaps
+- The failing async integration test prevents a clean runtime confirmation that `/api/v1/media/process-web-scraping` reaches the patched task and forwards `custom_headers` under the current test fixture.
+- `IngestWebContentRequest` itself does not perform cookie-shape validation in the schema; cookie coercion remains service-layer behavior in `ingest_web_content_orchestrate()`.
+
+## Improvements
+- Move cookie parsing and shape validation closer to `IngestWebContentRequest` if the project wants schema-level `422`s instead of service-level `400`s for malformed cookie payloads.
+- Add an endpoint-level regression test that records the actual `503` response body or dependency source when the custom-header path fails, so the failure stays attributable.
+
+## Exit Note
+- Verified cookie parsing behavior for friendly ingest.
+- Verified `process-web-scraping` preserves `400`s for invalid crawl strategy.
+- Verified usage logging coverage; custom-header forwarding coverage is currently blocked by a reproducible `503` in `test_process_web_scraping_endpoint_receives_custom_headers`.

--- a/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage3-services-fallback-and-persistence.md
+++ b/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage3-services-fallback-and-persistence.md
@@ -1,0 +1,84 @@
+# Stage 3 Services Fallback and Persistence
+
+## Scope
+- Service-layer review only.
+- Read path focused on `process_web_scraping_task()`, `ingest_web_content_orchestrate()`, enhanced-service dispatch, fallback gating, and mode-specific storage behavior.
+- No application-code or test changes were made.
+
+## Code Paths Reviewed
+- `tldw_Server_API/app/services/web_scraping_service.py`
+- `tldw_Server_API/app/services/enhanced_web_scraping_service.py`
+- `tldw_Server_API/app/services/ephemeral_store.py`
+- `tldw_Server_API/app/core/DB_Management/media_db/api.py`
+
+## Tests Reviewed
+- `tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py`
+- `tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py`
+- `tldw_Server_API/tests/Web_Scraping/test_persistence_crawl_metadata.py`
+
+## Validation Commands
+```bash
+rg -n "async def process_web_scraping_task|async def ingest_web_content_orchestrate|_store_ephemeral|_store_persistent|_legacy_web_scraping_fallback_enabled|_collect_fallback_unsupported_controls" \
+  tldw_Server_API/app/services/web_scraping_service.py \
+  tldw_Server_API/app/services/enhanced_web_scraping_service.py
+
+sed -n '133,940p' tldw_Server_API/app/services/web_scraping_service.py
+sed -n '1,980p' tldw_Server_API/app/services/enhanced_web_scraping_service.py
+
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py \
+  tldw_Server_API/tests/Web_Scraping/test_legacy_fallback_behavior.py \
+  tldw_Server_API/tests/Web_Scraping/test_persistence_crawl_metadata.py
+
+rg -n "class EphemeralStorage|store_data|get_data|managed_media_database|get_media_repository" \
+  tldw_Server_API/app/services/ephemeral_store.py \
+  tldw_Server_API/app/core/DB_Management/media_db/api.py
+
+sed -n '1,260p' tldw_Server_API/app/services/ephemeral_store.py
+sed -n '1,260p' tldw_Server_API/app/core/DB_Management/media_db/api.py
+```
+
+Result: all 13 targeted tests passed.
+
+## Service Control Flow
+- `process_web_scraping_task()` in `web_scraping_service.py` normalizes `crawl_strategy` and `score_threshold`, computes a coarse priority, and forwards the request to the enhanced service.
+- `WebScrapingService.process_web_scraping_task()` resolves config defaults from `load_and_log_configs()` with explicit request overrides winning for `max_pages`, `crawl_strategy`, `include_external`, and `score_threshold`.
+- Enhanced dispatch generates a `task_id`, routes by scrape method, annotates the result with `crawl_config`, then diverges by mode:
+  - `mode="ephemeral"` calls `_store_ephemeral()` and returns an ephemeral handle plus a preview payload.
+  - `mode="persist"` calls `_store_persistent()` and returns stored media IDs, article counts, and the generated `task_id`.
+- `ingest_web_content_orchestrate()` uses the same service entrypoint for URL-level and recursive ingest, hardcodes `mode="ephemeral"` for those friendly-ingest paths, then maps returned `summary` fields into `analysis`.
+- Enhanced-service failures may trigger the legacy fallback depending on environment gating; successful fallback payloads include `engine="legacy_fallback"` plus `fallback_context`, while disabled fallback raises a contract `400`.
+
+## Failure-Seam Checklist
+- `input normalization`: wrapper-level validation rejects bad `crawl_strategy` and out-of-range `score_threshold` before enhanced dispatch.
+- `fallback eligibility`: legacy fallback is opt-in and rejects unsupported advanced controls instead of silently degrading them.
+- `degraded-control handling`: fallback applies a manual `max_pages` cap for `Sitemap` and `URL Level` results and records that degradation in `fallback_context["degraded_controls_applied"]`.
+- `metadata persistence`: enhanced `persist` mode normalizes crawl traversal metadata and writes it into `safe_metadata`.
+- `error translation`: enhanced-service noncritical failures become `HTTPException(500)` inside the enhanced service; the outer wrapper either falls back or returns an explicit `400` if fallback is disabled or unsupported.
+
+## Findings
+- No Stage 3 contract failure was reproduced in the targeted service-layer tests.
+- Confirmed: config-default versus request-override precedence is explicit and observable through the returned `crawl_config` payload in [`enhanced_web_scraping_service.py:139`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L139) and [`enhanced_web_scraping_service.py:266`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L266). This matches the passing precedence tests in `test_crawl_config_precedence.py`.
+- Confirmed: legacy fallback does not silently ignore unsupported advanced controls. `_collect_fallback_unsupported_controls()` marks `custom_headers`, non-default crawl strategy, `include_external`, and active `score_threshold` as unsupported in [`web_scraping_service.py:70`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/web_scraping_service.py#L70), and the wrapper converts that into a `400` in [`web_scraping_service.py:299`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/web_scraping_service.py#L299). This matches the passing fallback-contract tests in `test_legacy_fallback_behavior.py`.
+- Confirmed: fallback degradation is explicit rather than silent for page-count control. The legacy path truncates `Sitemap` and `URL Level` results and records `"max_pages"` in `fallback_context["degraded_controls_applied"]` in [`web_scraping_service.py:365`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/web_scraping_service.py#L365).
+- Confirmed: enhanced `persist` mode uses `managed_media_database(...)` for lifecycle ownership in [`enhanced_web_scraping_service.py:589`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L589) and the context manager guarantees `close_connection()` on exit in [`api.py:105`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/core/DB_Management/media_db/api.py#L105).
+- Confirmed: enhanced `persist` mode carries crawl traversal fields (`crawl_depth`, `crawl_parent_url`, `crawl_score`) into `safe_metadata`, with best-effort numeric normalization before write, in [`enhanced_web_scraping_service.py:627`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L627) and [`enhanced_web_scraping_service.py:683`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L683). This matches the passing persistence test in `test_persistence_crawl_metadata.py`.
+- Confirmed: enhanced ephemeral storage is process-local and TTL-bound. `_store_ephemeral()` writes a wrapper object into `ephemeral_storage` in [`enhanced_web_scraping_service.py:555`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L555), and the storage implementation prunes expired entries on both write and read in [`ephemeral_store.py:105`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/ephemeral_store.py#L105) and [`ephemeral_store.py:134`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/ephemeral_store.py#L134).
+
+## Probable Risks
+- The earlier Stage 2 custom-header `503` is consistent with a narrow service seam where custom headers require the enhanced scraper path. Enhanced dispatch forwards `custom_headers` into scraper calls in [`enhanced_web_scraping_service.py:323`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L323), [`enhanced_web_scraping_service.py:377`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L377), and [`enhanced_web_scraping_service.py:489`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/enhanced_web_scraping_service.py#L489), but the legacy fallback explicitly treats `custom_headers` as unsupported in [`web_scraping_service.py:89`](/Users/appledev/Documents/GitHub/tldw_server/.worktrees/web-scraping-ingest-review/tldw_Server_API/app/services/web_scraping_service.py#L89). This review did not reproduce the exact endpoint-level `503`, so this remains a bounded inference rather than a confirmed defect.
+
+## Coverage Gaps
+- This pass did not audit the underlying Playwright scraper, queue internals, or endpoint-layer translation around the Stage 2 `503` custom-header failure.
+- This pass did not verify on-disk lifecycle for recursive progress files such as `scrape_progress_<id>.json`.
+- This pass did not perform a broader Media DB audit beyond confirming context-manager ownership and repository adaptation.
+
+## Improvements
+- Add a targeted service or endpoint test that fixes the exact expected status code and payload when `custom_headers` are supplied but the enhanced scraper is unavailable.
+- Add a service test that asserts `task_id` propagation in successful `persist` responses for each enhanced crawl mode.
+- Add a persistence-path test covering traversal metadata sourced from both top-level article fields and nested `metadata` fields across all supported crawl methods.
+
+## Exit Note
+- Confirmed behavior for request-vs-config precedence, fallback gating/degraded controls, and crawl metadata persistence in `persist` mode.
+- Kept the earlier Stage 2 custom-header `503` as a probable-risk note only; this Stage 3 pass did not reproduce or localize the exact endpoint-level failure.

--- a/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage4-reachable-core-and-request-safety.md
+++ b/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage4-reachable-core-and-request-safety.md
@@ -1,0 +1,138 @@
+# Stage 4 Reachable Core and Request Safety
+
+## Scope
+- Reachable outbound fetch and request-safety path for the ingest flow only.
+- Reviewed service entry points and the core helpers they actually call:
+  - `tldw_Server_API/app/services/web_scraping_service.py`
+  - `tldw_Server_API/app/services/enhanced_web_scraping_service.py`
+  - `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py`
+  - `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+  - `tldw_Server_API/app/core/http_client.py`
+  - `tldw_Server_API/app/core/Security/egress.py`
+- Follow-up inspection included `scraper_router.py` and `filters.py` because Stage 4 claims depend on router-controlled `respect_robots` and recursive-discovery `RobotsFilter` semantics.
+
+## Code Paths Reviewed
+- Legacy service individual scrape path:
+  - `web_scraping_service.py:681` -> `Article_Extractor_Lib.scrape_article()`
+- Legacy service sitemap path:
+  - `web_scraping_service.py:703-707` -> `Article_Extractor_Lib.scrape_from_sitemap()`
+- Enhanced service URL-level and recursive paths:
+  - `enhanced_web_scraping_service.py:432-445` and `489-502` -> `EnhancedWebScraper.recursive_scrape()`
+- Legacy core single-article path:
+  - `Article_Extractor_Lib.py:2715-2729` pre-checks `evaluate_url_policy()`
+  - `Article_Extractor_Lib.py:2860-2877` applies robots gating when `plan.respect_robots` is true
+  - `Article_Extractor_Lib.py:2888-2920` fetches through `_fetch_with_curl()` or `http_fetch()`
+- Legacy sitemap/core crawl helpers:
+  - `Article_Extractor_Lib.py:3445-3469` pre-checks sitemap URL then fetches with `http_fetch()`
+  - `Article_Extractor_Lib.py:3518-3535` pre-checks base URL then fetches linked pages with `http_fetch()`
+  - `Article_Extractor_Lib.py:3582-3587` async link collection fetches with `afetch()`
+- Enhanced single-article path:
+  - `enhanced_web_scraping.py:1307-1321` pre-checks `evaluate_url_policy()`
+  - `enhanced_web_scraping.py:1338-1349` builds effective headers from plan + request headers
+  - `enhanced_web_scraping.py:1380-1397` applies robots gating when `plan.respect_robots` is true
+  - `enhanced_web_scraping.py:1406-1413` can route into `_scrape_with_trafilatura(..., backend=backend_choice, custom_headers=headers)`
+  - `enhanced_web_scraping.py:1497-1504` calls `_fetch_html()`
+  - `enhanced_web_scraping.py:1170-1185` routes `backend="curl"` into `_fetch_html_curl()`
+  - `enhanced_web_scraping.py:1208-1236` uses `CurlCffiSession.get()` directly and only clearly reuses proxy validation
+- Enhanced sitemap and recursive crawl path:
+  - `enhanced_web_scraping.py:1950-1975` pre-checks sitemap URL and fetches with `afetch()`
+  - `enhanced_web_scraping.py:2029-2038` pre-checks recursive base URL
+  - `enhanced_web_scraping.py:2143-2150` enables discovery-time `RobotsFilter` from config
+  - `enhanced_web_scraping.py:2266-2267` and `2474-2475` recurse via `scrape_multiple()` -> `scrape_article()`
+- Central egress enforcement:
+  - `egress.py:192-297` rejects unsupported schemes, bad ports, denylisted hosts, strict-profile non-allowlisted hosts, and private/reserved IP resolutions
+  - `http_client.py:947-1010` raises on egress denial and validates proxy hosts
+  - `http_client.py:2072-2183`, `2396-2484`, and `2731-2831` re-check egress before the first request and on each redirect hop
+  - `http_client.py:3058-3164` simple `fetch()` path also re-checks egress and redirect hops
+
+## Tests Reviewed
+- Direct request-safety tests:
+  - `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+  - `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+- Follow-up semantics tests executed because Stage 4 conclusions depend on router/filter behavior:
+  - `tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py`
+  - `tldw_Server_API/tests/Web_Scraping/test_router_validation.py`
+
+## Validation Commands
+- Reachable path trace:
+```bash
+rg -n "scrape_article|recursive_scrape|scrape_from_sitemap|scrape_by_url_level|http_fetch|fetch\(|evaluate_url_policy|is_allowed_by_robots" \
+  tldw_Server_API/app/services/web_scraping_service.py \
+  tldw_Server_API/app/services/enhanced_web_scraping_service.py \
+  tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py \
+  tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py \
+  tldw_Server_API/app/core/http_client.py \
+  tldw_Server_API/app/core/Security/egress.py
+```
+- Enforcement inspection:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/http_client.py
+sed -n '1,260p' tldw_Server_API/app/core/Security/egress.py
+rg -n "robots|cookie|custom_headers|user_agent|evaluate_url_policy|http_fetch|fetch\(" \
+  tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py \
+  tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
+```
+- Direct tests:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py \
+  tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py
+```
+- Follow-up tests:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m pytest -v \
+  tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py \
+  tldw_Server_API/tests/Web_Scraping/test_router_validation.py
+```
+- Bandit:
+```bash
+source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py \
+  tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py \
+  tldw_Server_API/app/api/v1/schemas/media_request_models.py \
+  tldw_Server_API/app/services/web_scraping_service.py \
+  tldw_Server_API/app/services/enhanced_web_scraping_service.py \
+  tldw_Server_API/app/core/http_client.py \
+  tldw_Server_API/app/core/Web_Scraping \
+  -f json -o /tmp/bandit_web_scraping_ingest_review.json
+```
+- Results:
+  - `test_http_client_fetch.py` + `test_robots_enforcement.py`: `8 passed`
+  - `test_filters_and_robots.py` + `test_router_validation.py`: `3 passed`
+  - Bandit JSON written to `/tmp/bandit_web_scraping_ingest_review.json`
+  - No Stage 4 test directly exercised `EnhancedWebScraper._fetch_html_curl()`
+
+## Findings
+1. **Low | High | Robots compliance is not a hard request-safety guarantee on the reachable ingest path**
+   - Files: `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py:2860`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1380`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:2143`, `tldw_Server_API/app/core/Web_Scraping/scraper_router.py:245`, `tldw_Server_API/app/core/Web_Scraping/filters.py:281`
+   - Evidence: direct code-path proof plus passing tests in `test_robots_enforcement.py`, `test_filters_and_robots.py`, and `test_router_validation.py`
+   - Why it matters: the reachable fetch path honors robots only when `respect_robots` remains enabled, and both page-level and discovery-time checks fail open when robots is unreachable or unreadable, so any claim of unconditional robots enforcement should be downgraded to configurable best-effort behavior.
+   - Confidence downgrade note: this is not a confirmed egress bypass; it is a policy-strength limitation caused by explicit configuration and fail-open error handling.
+2. **Medium | Medium | `http_client`-backed paths have strong request-safety evidence, but the reachable enhanced curl branch remains unproven**
+   - Files: `tldw_Server_API/app/core/http_client.py:947`, `tldw_Server_API/app/core/http_client.py:2083`, `tldw_Server_API/app/core/http_client.py:2182`, `tldw_Server_API/app/core/http_client.py:2407`, `tldw_Server_API/app/core/http_client.py:2483`, `tldw_Server_API/app/core/http_client.py:2759`, `tldw_Server_API/app/core/http_client.py:3058`, `tldw_Server_API/app/core/http_client.py:3133`, `tldw_Server_API/app/core/Security/egress.py:192`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1406`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1497`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1170`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1208`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1222`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1235`
+   - Evidence: direct code-path proof plus passing `test_http_client_fetch.py`
+   - Why it matters: the legacy helpers and enhanced `afetch()`/`httpx` branches have strong in-code evidence for pre-request and redirect-hop egress checks, but `scrape_article()` can also reach `_scrape_with_trafilatura()` -> `_fetch_html()` -> `_fetch_html_curl()`, which uses `CurlCffiSession.get()` directly; this file clearly validates proxies but does not clearly route through `http_client.fetch()` or visibly re-check redirect hops, so Stage 4 cannot generalize the tested `http_client` conclusion across that reachable branch.
+   - Confidence downgrade note: this is a probable enforcement gap or at minimum an unproven one, not a confirmed exploitable `custom_headers` security bug from the current evidence.
+3. **Info | Medium | Bandit did not surface a reachable Stage 4 request-safety hit**
+   - Files: `tldw_Server_API/app/core/http_client.py`, `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`, `tldw_Server_API/app/core/Web_Scraping/filters.py`, `tldw_Server_API/app/core/Web_Scraping/scraper_router.py`
+   - Evidence: Bandit JSON at `/tmp/bandit_web_scraping_ingest_review.json`
+   - Why it matters: the broader recursive scan reported 16 low-severity findings, but they were outside this reachable path or not request-safety relevant here; the only touched-file hit in reviewed scope was `B112 try_except_continue` in `scraper_router.py:179`, which does not weaken outbound request enforcement.
+
+## Coverage Gaps
+- `playwright` execution was not dynamically exercised in this stage. The reachable code reviewed here still pre-checks URL policy before that path is selected, but this stage does not include an integration test proving equivalent enforcement after browser launch.
+- The enhanced curl branch was not dynamically exercised in this stage. `test_http_client_fetch.py` proves redirect and egress behavior for `http_client.fetch()`, but no Stage 4 test proves equivalent redirect-hop enforcement for `EnhancedWebScraper._fetch_html_curl()`.
+- `scrape_from_sitemap()` has a deliberate test-mode relaxation at `Article_Extractor_Lib.py:3445-3465` that proceeds after egress denial when pytest/test mode is active. That is not a production-path bypass, but it does mean test behavior is intentionally weaker than runtime behavior for this helper.
+- Bandit scope was broader than the exact Stage 4 path because `-r tldw_Server_API/app/core/Web_Scraping` includes unrelated analyzers and legacy web-search modules. Findings from those files were triaged out of the Stage 4 conclusion.
+
+## Improvements
+- Add an integration test that exercises the enhanced scraper `playwright` fallback and proves the same egress denial behavior before navigation.
+- Add an integration test that exercises the enhanced curl/trafilatura path and verifies redirect-hop behavior against blocked targets.
+- Add an explicit regression test asserting that custom request headers, including `User-Agent`, do not alter egress outcomes on the enhanced service path, and that any curl branch remains policy-equivalent.
+- If stronger compliance is required, change robots handling from fail-open to fail-closed for selected deployments and record that as a configuration contract rather than an implicit assumption.
+
+## Exit Note
+- Stage 4 reachable-path review does not confirm a request-safety bypass in the ingest flow.
+- Confidence is high for the `http_client`-backed paths reviewed here, lower for any claim that robots policy is universally enforced, and downgraded to medium for the reachable enhanced curl branch because equivalent redirect-safe enforcement is not proven by the inspected code or current tests.

--- a/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage5-validation-gaps-and-synthesis.md
+++ b/Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage5-validation-gaps-and-synthesis.md
@@ -1,0 +1,101 @@
+# Stage 5 Validation Gaps and Synthesis
+
+## Scope
+- Consolidate Stage 1 through Stage 4 into one de-duplicated review outcome.
+- Run only the narrow follow-up validations needed to settle the earlier Stage 2 custom-header ambiguity.
+- Record any environment blockers that prevent end-to-end validation from completing in this worktree.
+
+## Code Paths Reviewed
+- Prior review artifacts:
+  - `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage2-public-entrypoints-and-schema.md`
+  - `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage3-services-fallback-and-persistence.md`
+  - `Docs/superpowers/reviews/web-scraping-ingest/2026-04-07-stage4-reachable-core-and-request-safety.md`
+- Endpoint and patch seam:
+  - `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+  - `tldw_Server_API/app/api/v1/endpoints/media/__init__.py`
+- Follow-up validation targets:
+  - `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+  - `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+  - `tldw_Server_API/tests/server_e2e_tests/conftest.py`
+  - `tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py`
+
+## Tests Reviewed
+- Stage 2 targeted batch rerun:
+  - `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+  - `tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py`
+  - `tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py`
+  - `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+  - `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+  - Result: `15 passed, 1 failed`
+- Narrow custom-header follow-up:
+  - `python -m pytest -vv tldw_Server_API/tests/WebScraping/test_custom_headers_support.py::test_process_web_scraping_endpoint_receives_custom_headers`
+  - Result: `1 passed`
+- Minimal reproducer:
+  - `python -m pytest -vv tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+  - Result: `2 passed`
+  - `python -m pytest -vv tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+  - Result: `1 failed, 2 passed`
+- Earlier stage results incorporated into this synthesis:
+  - Stage 3 service tests: `13 passed`
+  - Stage 4 request-safety tests: `11 passed`
+- Optional end-to-end smoke:
+  - `python -m pytest -m e2e -v tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py`
+  - Result: `2 errors` during fixture setup because local port binding is not permitted in this environment
+
+## Validation Commands
+- Spec cross-check:
+  - `rg -n "Goal|Primary Scope|Review Questions|Targeted Validation|Security And Request-Safety Audit|Evidence Rules" Docs/superpowers/specs/2026-04-07-web-scraping-ingest-review-design.md`
+  - Result: all required sections present
+- Placeholder scan:
+  - `rg -n "<marker-scan-pattern>" Docs/superpowers/reviews/web-scraping-ingest`
+  - Result: no matches
+- Stage 2 rerun:
+  - `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py tldw_Server_API/tests/Web_Scraping/test_ingest_cookie_parsing.py tldw_Server_API/tests/Web_Scraping/test_process_web_scraping_strategy_validation.py tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+  - Result: `15 passed, 1 failed`
+- Custom-header isolation:
+  - `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/WebScraping/test_custom_headers_support.py::test_process_web_scraping_endpoint_receives_custom_headers`
+  - Result: `1 passed`
+- Minimal reproducer:
+  - `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+  - Result: `1 failed, 2 passed`
+- Optional e2e smoke:
+  - `source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest -m e2e -v tldw_Server_API/tests/server_e2e_tests/test_web_scraping_workflow.py`
+  - Result: both tests error at `server_e2e_tests/conftest.py:63` while binding `127.0.0.1:0`
+
+## Findings
+1. **Medium | High | `/process-web-scraping` custom-header coverage is affected by a confirmed order-sensitive test-isolation problem**
+   - Files: `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py:8`, `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py:23`, `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py:14`, `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py:61`, `tldw_Server_API/app/api/v1/endpoints/media/__init__.py:82`
+   - Evidence: the endpoint test passes in isolation and when its file runs alone, but fails with `503 Service Unavailable` after `test_webscraping_usage_events.py`; the minimal reproducer is `test_webscraping_usage_events.py` followed by `test_custom_headers_support.py`.
+   - Why it matters: this is no longer best described as a standing route-contract failure. It is a confirmed shared-state or patch-seam instability around the endpoint test surface, which weakens regression confidence for `custom_headers` forwarding and can hide real endpoint regressions behind order-dependent failures.
+   - Confidence note: current evidence proves a test-isolation defect. It does not prove that production requests without that test sequencing would return `503`.
+2. **Medium | Medium | The reachable enhanced curl branch still lacks parity proof with the centralized `http_client` request-safety path**
+   - Files: `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1170`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1208`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1406`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1497`, `tldw_Server_API/app/core/http_client.py:3058`, `tldw_Server_API/app/core/Security/egress.py:192`
+   - Evidence: direct code-path review plus passing `test_http_client_fetch.py`; no Stage 4 test exercised `EnhancedWebScraper._fetch_html_curl()`.
+   - Why it matters: the `http_client`-backed branches have strong evidence for pre-request and redirect-hop egress checks, but the reachable trafilatura or curl path still uses `CurlCffiSession.get()` directly. That leaves request-safety equivalence unproven on a reachable ingest branch.
+   - Confidence note: this remains a probable security or reliability gap, not a confirmed bypass.
+3. **Low | High | Robots handling on the reachable ingest path is configurable best-effort rather than a hard enforcement guarantee**
+   - Files: `tldw_Server_API/app/core/Web_Scraping/Article_Extractor_Lib.py:2860`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:1380`, `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py:2143`, `tldw_Server_API/app/core/Web_Scraping/filters.py:281`, `tldw_Server_API/app/core/Web_Scraping/scraper_router.py:245`
+   - Evidence: direct code-path review plus passing `test_robots_enforcement.py`, `test_filters_and_robots.py`, and `test_router_validation.py`
+   - Why it matters: when robots checks are disabled or when robots retrieval fails, the ingest flow can still proceed. That is acceptable if intentional, but it should be documented as a configurable policy choice rather than assumed universal enforcement.
+
+## Coverage Gaps
+- The exact internal source of the order-sensitive `503` remains unlocalized. The current review proves a cross-test interference seam, but it does not yet identify whether the unstable state lives in app lifespan, dependency overrides, cached router state, or monkeypatched endpoint exports.
+- No dynamic test in this review exercised `EnhancedWebScraper._fetch_html_curl()` or proved redirect-hop parity for that branch.
+- No dynamic test in this review exercised browser-launch or post-launch request policy on the Playwright-backed path.
+- The optional end-to-end workflow smoke could not run to completion in this environment because `server_e2e_tests/conftest.py` binds a local port in `_find_free_port()` and this sandbox denied `bind(("127.0.0.1", 0))`.
+
+## Improvements
+- Make the `/process-web-scraping` endpoint tests deterministic by isolating shared application state between `test_webscraping_usage_events.py` and `test_custom_headers_support.py`.
+  Options to consider: rebuild the app per test, standardize on one patch seam, and ensure any module-level endpoint monkeypatches are fully reset before the next client instance runs.
+- Add a targeted integration test that drives the enhanced trafilatura or curl path and asserts the same egress and redirect-hop behavior already proven for `http_client.fetch()`.
+- Add a targeted integration test for the Playwright-backed scrape path if the project expects browser-mode fetches to match the same outbound policy guarantees.
+- If stricter compliance is required, expose robots handling as an explicit deployment contract and support fail-closed operation for selected environments.
+- Keep cookie-shape validation improvement as a lower-priority ergonomics item only; the current service-layer `400` behavior is covered and consistent enough for now.
+
+## Exit Note
+- Final synthesis outcome:
+  - no confirmed production-path request-safety bypass was proven in the approved ingest scope
+  - one confirmed test-isolation defect weakens endpoint-level regression confidence for `custom_headers`
+  - one medium-confidence request-safety gap remains around the reachable enhanced curl branch
+  - robots handling is configurable best-effort, not universal enforcement
+- End-to-end workflow coverage remains environment-blocked in this sandbox because the e2e fixture cannot bind a local port.

--- a/Docs/superpowers/reviews/web-scraping-ingest/README.md
+++ b/Docs/superpowers/reviews/web-scraping-ingest/README.md
@@ -1,0 +1,25 @@
+# Web_Scraping Ingest Review Artifacts
+
+This directory holds the staged review artifacts for the `Web_Scraping` ingest-path audit.
+
+## Status
+- Stage 1 through Stage 5 are complete in this worktree.
+- Final synthesis: `2026-04-07-stage5-validation-gaps-and-synthesis.md`
+
+## Stage Order
+1. Inventory and call graph
+2. Public entrypoints and schema
+3. Services, fallback, and persistence
+4. Reachable core and request safety
+5. Validation gaps and synthesis
+
+## Highest-Signal Outcomes
+- Confirmed: endpoint-level `custom_headers` coverage has an order-sensitive test-isolation defect, not a stable reproduced production-path contract failure.
+- Probable risk: the reachable enhanced curl branch is not yet proven to enforce the same redirect-safe egress checks as the centralized `http_client` path.
+- Clarification: robots handling on the ingest path is configurable best-effort behavior.
+
+## Review Rules
+- Findings come before remediation ideas.
+- Uncertain claims must be labeled as assumptions or probable risks.
+- Security-sensitive claims require direct path proof, targeted validation, or an explicit confidence downgrade.
+- Only reachable code paths from the approved ingest scope belong in this review.

--- a/Docs/superpowers/specs/2026-04-08-web-scraping-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-08-web-scraping-remediation-design.md
@@ -1,0 +1,193 @@
+# Web Scraping Remediation Design
+
+Date: 2026-04-08
+Topic: `Web_Scraping` ingest remediation
+Status: Proposed design
+
+## Goal
+
+Address the issues found in the `Web_Scraping` ingest review without widening scope into unrelated scraper or lifecycle refactors.
+
+The remediation must:
+
+- remove the order-sensitive endpoint test failure around `/api/v1/media/process-web-scraping`
+- close the reachable enhanced curl request-safety gap by reusing centralized outbound policy enforcement
+- keep robots handling behavior unchanged while making its best-effort contract explicit in tests and nearby code
+
+## Confirmed Problems
+
+1. The `/process-web-scraping` custom-header regression test is order-sensitive.
+   - Root cause: one test uses `TestClient`, which runs app shutdown and leaves the shared app in draining state, while the next test reuses the same app through `ASGITransport` without a fresh lifespan startup.
+   - This produces a real `503 Service Unavailable`, but it is a test-harness isolation defect rather than a proven stable production-path route failure.
+
+2. The enhanced scraper curl path is still a reachable request path that does not clearly prove the same redirect-hop and egress enforcement as the centralized `http_client` path.
+   - Current issue location: `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+   - Relevant central policy path: `tldw_Server_API/app/core/http_client.py`
+
+3. Robots handling is intentionally configurable and fail-open when robots retrieval fails.
+   - This is not a bug to change in this pass.
+   - The problem is incomplete contract clarity and incomplete regression coverage for that behavior.
+
+## Approved Constraints
+
+The remediation will follow these decisions already agreed with the user:
+
+- Keep the current robots best-effort behavior.
+- Prefer a structural fix for the curl path, not test-only evidence.
+- Accept a small production-code cleanup for the endpoint path when it improves determinism, but do not remove compatibility shims still used by friendly-ingest service flows.
+
+## Primary Scope
+
+- `tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py`
+- `tldw_Server_API/app/services/web_scraping_service.py`
+- `tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py`
+- `tldw_Server_API/app/core/http_client.py`
+- `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+- `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+
+Secondary touched scope only if needed:
+
+- `tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py`
+- `tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py`
+- `tldw_Server_API/tests/Web_Scraping/test_router_validation.py`
+
+## Explicit Non-Goals
+
+- No global FastAPI lifecycle redesign.
+- No removal of `media.process_web_scraping_task` as a compatibility seam for friendly-ingest service paths.
+- No fail-closed robots policy change.
+- No broad scraper refactor outside the reachable ingest path.
+- No attempt to make the e2e workflow runnable in this sandbox.
+
+## Design
+
+### 1. Endpoint And Test Determinism
+
+The endpoint fix should be narrow and aimed at the actual failure mode.
+
+The primary fix is test-harness determinism, not a larger production routing change. The confirmed `503` comes from mixing app lifecycle strategies across the two tests, so the first responsibility of this task is to make those tests use one consistent lifecycle-safe client pattern.
+
+`process_web_scraping.py` may gain a module-local resolution seam that defaults to the imported service task, but only if that materially simplifies deterministic patching for the endpoint tests. This keeps the endpoint patch surface local and explicit without widening the change into friendly-ingest or service compatibility paths.
+
+Important constraint:
+
+- Do not remove the `media.process_web_scraping_task` export from `tldw_Server_API/app/api/v1/endpoints/media/__init__.py`.
+- Friendly-ingest service paths in `web_scraping_service.py` still rely on that seam, and those flows are not being refactored in this pass.
+
+The order-sensitive `503` fix should be completed primarily in the tests:
+
+- standardize the affected endpoint tests on one lifecycle-safe client strategy
+- stop mixing `TestClient`-driven lifespan shutdown with direct `ASGITransport(app=app)` reuse for this specific endpoint slice
+- patch one stable endpoint-local target in both usage-events and custom-header tests
+
+Recommended concrete direction:
+
+- keep `test_cookie_manager_stores_and_returns_cookies()` async and independent
+- convert the endpoint custom-header coverage to use the same `client_with_single_user` fixture style as the usage-events test, or a local wrapper around that fixture
+- stop reusing the shared app directly through `ASGITransport(app=app)` for this endpoint slice after a `TestClient`-driven test has run
+- update the compat patchpoint assertion to match the intentional endpoint-local resolution change
+
+Success criteria:
+
+- `test_webscraping_usage_events.py` and `test_custom_headers_support.py` pass together in one pytest invocation
+- header forwarding remains asserted end to end at the route boundary
+- friendly-ingest tests that patch `media.process_web_scraping_task` continue to pass unchanged
+
+### 2. Curl Request-Safety Parity
+
+The curl remediation should centralize policy rather than duplicate it.
+
+The current enhanced curl path in `enhanced_web_scraping.py` should stop calling `CurlCffiSession.get()` directly. Instead, the enhanced scraper should route curl-backed HTML fetches through the centralized simple fetch path in `http_client.py`.
+
+To make that safe enough for this use case, the centralized simple curl path itself must be hardened first:
+
+- disable implicit curl redirect following
+- apply the same lightweight `_is_url_allowed()` gate on the initial URL and on each redirect hop
+- reuse the same redirect policy decisions already used by the simple httpx path:
+  - same-host redirects allowed by default
+  - cross-host redirects configurable
+  - scheme downgrade blocked unless explicitly allowed
+  - max redirect cap enforced
+- keep proxy validation in the central path
+
+After that hardening, `enhanced_web_scraping.py` should call the central fetch helper with `backend="curl"` and adapt the returned mapping into the existing `(html, backend_used, elapsed)` contract.
+
+This keeps outbound policy logic in one place and removes the reachable direct-curl bypass shape from the enhanced scraper.
+
+Success criteria:
+
+- blocked curl URLs fail before fetch
+- blocked redirect hops are not followed
+- allowed same-host redirects still succeed under the central policy defaults
+- successful curl fetches still return HTML content and preserve custom headers and cookies
+- the enhanced scraper no longer owns separate curl redirect or egress logic
+
+### 3. Robots Contract Clarification
+
+Robots behavior should remain functionally unchanged.
+
+This pass should:
+
+- keep fail-open behavior when robots retrieval fails
+- keep explicit block behavior when robots disallows the path
+- add or tighten tests so this contract is visible and deliberate
+- add a short clarifying code comment near the enhanced scraper robots branch to make the policy choice explicit for future readers
+
+This is a contract-clarity change, not a behavior change.
+
+Success criteria:
+
+- robots tests clearly prove fail-open-on-fetch-error and deny-on-explicit-disallow behavior
+- no request path changes from the existing user-visible robots policy
+
+## Testing Strategy
+
+The remediation should be developed test-first.
+
+Minimum required targeted validation after implementation:
+
+- `tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py`
+- `tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- `python -m pytest -v tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py tldw_Server_API/tests/WebScraping/test_custom_headers_support.py`
+- `tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py`
+- `tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py`
+- `tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py`
+
+Run these additional tests if touched by the implementation:
+
+- `tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py`
+- `tldw_Server_API/tests/Web_Scraping/test_filters_and_robots.py`
+- `tldw_Server_API/tests/Web_Scraping/test_router_validation.py`
+
+Security validation:
+
+- run Bandit on the touched web scraping and HTTP client files after the code change
+
+## Risks And Mitigations
+
+- Risk: changing the endpoint seam breaks friendly-ingest or compatibility expectations
+  - Mitigation: keep the `media` shim export in place and limit the resolution change to the endpoint module only
+
+- Risk: hardening curl redirect handling changes successful scrape behavior on legitimate redirect chains
+  - Mitigation: preserve same-host redirects by default and add regression tests for allowed redirect behavior as needed
+
+- Risk: tests become deterministic only by overfitting to current fixtures
+  - Mitigation: standardize on one client pattern for this endpoint slice rather than sprinkling lifecycle resets across unrelated tests
+
+## Implementation Shape
+
+The work should be executed in three implementation tasks:
+
+1. Stabilize endpoint task resolution and the affected endpoint tests.
+2. Harden the centralized simple curl fetch path and reroute the enhanced scraper curl branch through it.
+3. Tighten robots contract tests and add the minimal clarifying comment.
+
+## Expected Outcome
+
+After this remediation:
+
+- the web scraping endpoint tests are deterministic and no longer fail because the shared app was left draining by an earlier test
+- the reachable enhanced curl branch inherits centralized redirect and egress policy enforcement
+- the project explicitly preserves best-effort robots semantics with regression coverage instead of leaving that behavior as an implicit assumption

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
@@ -18,16 +19,18 @@ from tldw_Server_API.app.services.web_scraping_service import process_web_scrapi
 
 router = APIRouter()
 
+WebScrapingTask = Callable[..., Awaitable[Any]]
 
-def _resolve_process_web_scraping_task():
-    with contextlib.suppress(Exception):
-        # Compatibility shim: older integration tests monkeypatch
-        # media.process_web_scraping_task at package scope.
-        from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 
-        shim_task = getattr(media_mod, "process_web_scraping_task", None)
-        if callable(shim_task):
-            return shim_task
+def _resolve_process_web_scraping_task() -> WebScrapingTask:
+    """Return the active web scraping task, honoring the media shim when patched."""
+    # Compatibility shim: older integration tests monkeypatch
+    # media.process_web_scraping_task at package scope.
+    from tldw_Server_API.app.api.v1.endpoints import media as media_mod
+
+    shim_task = getattr(media_mod, "process_web_scraping_task", None)
+    if callable(shim_task):
+        return cast(WebScrapingTask, shim_task)
     return process_web_scraping_task
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
@@ -12,14 +12,23 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
     get_usage_event_logger,
 )
-from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 from tldw_Server_API.app.api.v1.schemas.media_request_models import WebScrapingRequest
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
-from tldw_Server_API.app.services.web_scraping_service import (
-    process_web_scraping_task,
-)
+from tldw_Server_API.app.services.web_scraping_service import process_web_scraping_task
 
 router = APIRouter()
+
+
+def _resolve_process_web_scraping_task():
+    with contextlib.suppress(Exception):
+        # Compatibility shim: older integration tests monkeypatch
+        # media.process_web_scraping_task at package scope.
+        from tldw_Server_API.app.api.v1.endpoints import media as media_mod
+
+        shim_task = getattr(media_mod, "process_web_scraping_task", None)
+        if callable(shim_task):
+            return shim_task
+    return process_web_scraping_task
 
 
 @router.post(
@@ -39,9 +48,8 @@ async def process_web_scraping_endpoint(
     then either store ephemeral or persist in DB.
 
     This is the modular implementation of `/process-web-scraping`, mirroring
-    the legacy behavior while routing through the `media` package and using
-    direct media/service task resolution so tests can patch
-    `media.process_web_scraping_task`.
+    the legacy behavior while routing through a local resolver seam so tests
+    can patch deterministic task resolution.
     """
     try:
         # Usage logging is best-effort; never fail the request.
@@ -56,9 +64,7 @@ async def process_web_scraping_endpoint(
                 },
             )
 
-        # Resolve the scraping task from media first so tests can monkeypatch
-        # `media.process_web_scraping_task` without a separate shim module.
-        task = getattr(media_mod, "process_web_scraping_task", process_web_scraping_task)
+        task = _resolve_process_web_scraping_task()
 
         result = await task(
             scrape_method=payload.scrape_method,

--- a/tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
+++ b/tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
@@ -1214,26 +1214,19 @@ class EnhancedWebScraper:
         impersonate: Optional[str],
         proxies: Optional[dict[str, str]],
     ) -> str:
-        try:
-            from curl_cffi.requests import Session as CurlCffiSession
-        except _WEBSCRAPE_NONCRITICAL_EXCEPTIONS as exc:  # pragma: no cover - optional dependency
-            raise RuntimeError("curl_cffi is not installed") from exc
+        from tldw_Server_API.app.core import http_client as _http_client
 
-        if proxies:
-            from tldw_Server_API.app.core import http_client as _http_client
-            _http_client._validate_proxies_or_raise(proxies)  # type: ignore[attr-defined]
-
-        req_kwargs: dict[str, Any] = {
-            "headers": headers,
-            "cookies": cookies,
-            "timeout": timeout,
-        }
-        if proxies:
-            req_kwargs["proxies"] = proxies
-
-        with CurlCffiSession(impersonate=impersonate) as session:
-            resp = session.get(url, **req_kwargs)
-            return resp.text
+        resp = _http_client.fetch(
+            url,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            proxies=proxies,
+            backend="curl",
+            impersonate=impersonate,
+            follow_redirects=True,
+        )
+        return resp["text"]
 
     @staticmethod
     async def _close_response(resp: Any) -> None:
@@ -1377,7 +1370,8 @@ class EnhancedWebScraper:
                     result.setdefault("preflight_analysis", preflight_payload)
                 return result
 
-            # robots.txt enforcement (fail open if error)
+            # robots.txt enforcement is best-effort: explicit disallow blocks
+            # the scrape, but transient robots retrieval errors do not.
             if getattr(plan, "respect_robots", True):
                 try:
                     from tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib import (

--- a/tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
+++ b/tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py
@@ -1226,7 +1226,10 @@ class EnhancedWebScraper:
             impersonate=impersonate,
             follow_redirects=True,
         )
-        return resp["text"]
+        status = int(resp.get("status", 0))
+        if 200 <= status < 300:
+            return resp["text"]
+        raise ValueError(f"curl fetch did not reach a terminal 2xx response (status={status})")
 
     @staticmethod
     async def _close_response(resp: Any) -> None:

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -2994,7 +2994,6 @@ def _fetch_curl_simple(
     timeout: float | None,
     impersonate: str | None,
     proxies: dict[str, str] | None,
-    allow_redirects: bool,
     session: Any | None = None,
 ) -> HttpResponse:
     CurlSession = None
@@ -3103,21 +3102,51 @@ def fetch(*args, **kwargs):
 
     def _extract_redirect_host(redirect_url: str) -> str:
         try:
-            if httpx is not None:
-                parsed = httpx.URL(redirect_url)
-                return (parsed.host or "").lower()
             parsed = urlparse(redirect_url)
             return (parsed.hostname or "").lower()
+        except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+            return ""
+
+    def _extract_redirect_port(redirect_url: str) -> int | None:
+        try:
+            parsed = urlparse(redirect_url)
+            if parsed.port is not None:
+                return int(parsed.port)
+            scheme = (parsed.scheme or "").lower()
+            if scheme == "https":
+                return 443
+            if scheme == "http":
+                return 80
+            return None
+        except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+            return None
+
+    def _extract_redirect_scheme(redirect_url: str) -> str:
+        try:
+            parsed = urlparse(redirect_url)
+            return (parsed.scheme or "").lower()
         except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
             return ""
 
     def _is_cross_host_redirect(prev: str, nxt: str) -> bool:
         prev_host = _extract_redirect_host(prev)
         next_host = _extract_redirect_host(nxt)
-        return bool(prev_host and next_host and prev_host != next_host)
+        prev_port = _extract_redirect_port(prev)
+        next_port = _extract_redirect_port(nxt)
+        return bool(
+            prev_host
+            and next_host
+            and ((prev_host, prev_port) != (next_host, next_port))
+        )
 
-    def _cross_host_redirect_headers(current_headers: dict[str, str]) -> dict[str, str]:
-        # Preserve only safe transport headers across host boundaries.
+    def _is_scheme_downgrade(prev: str, nxt: str) -> bool:
+        return (
+            _extract_redirect_scheme(prev) == "https"
+            and _extract_redirect_scheme(nxt) == "http"
+        )
+
+    def _redirect_boundary_headers(current_headers: dict[str, str]) -> dict[str, str]:
+        # Preserve only safe transport headers across origin boundaries.
         safe_headers: dict[str, str] = {}
         for header_key, header_value in (current_headers or {}).items():
             key_lc = str(header_key).lower()
@@ -3127,29 +3156,38 @@ def fetch(*args, **kwargs):
                 safe_headers["Accept-Encoding"] = str(header_value)
         return safe_headers
 
+    def _clear_session_cookie_state(session: Any) -> None:
+        for attr_name in ("cookies", "cookie_jar", "jar"):
+            store = getattr(session, attr_name, None)
+            if store is None:
+                continue
+            clear = getattr(store, "clear", None)
+            if callable(clear):
+                with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
+                    clear()
+                continue
+            if isinstance(store, dict):
+                store.clear()
+
     def _redirect_allowed(prev: str, nxt: str) -> bool:
         try:
-            if httpx is not None:
-                pu = httpx.URL(prev)
-                nu = httpx.URL(nxt)
-                prev_scheme = (pu.scheme or "").lower()
-                next_scheme = (nu.scheme or "").lower()
-                prev_host = (pu.host or "").lower()
-                next_host = (nu.host or "").lower()
-            else:
-                pu = urlparse(prev)
-                nu = urlparse(nxt)
-                prev_scheme = (pu.scheme or "").lower()
-                next_scheme = (nu.scheme or "").lower()
-                prev_host = (pu.hostname or "").lower()
-                next_host = (nu.hostname or "").lower()
+            prev_scheme = _extract_redirect_scheme(prev)
+            next_scheme = _extract_redirect_scheme(nxt)
+            prev_host = _extract_redirect_host(prev)
+            next_host = _extract_redirect_host(nxt)
+            prev_port = _extract_redirect_port(prev)
+            next_port = _extract_redirect_port(nxt)
         except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
             return False
         # Disallow scheme downgrade unless explicitly allowed
         if not allow_downgrade and prev_scheme == "https" and next_scheme == "http":
             return False
-        # Same-host redirects are always allowed (subject to egress checks)
-        if prev_host == next_host:
+        same_host = bool(prev_host and next_host and prev_host == next_host)
+        # Same-host scheme changes are governed separately by allow_downgrade.
+        if same_host and prev_scheme != next_scheme:
+            return True
+        # Same-host/same-port redirects are always allowed (subject to egress checks)
+        if (prev_host, prev_port) == (next_host, next_port):
             return True
         # Cross-host redirects configurable (default disabled)
         return bool(allow_cross_host)
@@ -3183,7 +3221,6 @@ def fetch(*args, **kwargs):
                     timeout=timeout,
                     impersonate=impersonate,
                     proxies=proxies,
-                    allow_redirects=False,
                     session=curl_session,
                 )
                 status = int(resp["status"])
@@ -3203,9 +3240,10 @@ def fetch(*args, **kwargs):
                 if not _redirect_allowed(cur_url, next_url):
                     return resp
 
-                if _is_cross_host_redirect(cur_url, next_url):
-                    hop_headers = _cross_host_redirect_headers(hop_headers)
+                if _is_cross_host_redirect(cur_url, next_url) or _is_scheme_downgrade(cur_url, next_url):
+                    hop_headers = _redirect_boundary_headers(hop_headers)
                     hop_cookies = None
+                    _clear_session_cookie_state(curl_session)
 
                 redirects += 1
                 if redirects > DEFAULT_MAX_REDIRECTS:
@@ -3238,21 +3276,18 @@ def fetch(*args, **kwargs):
             if not location:
                 break
 
-            try:
-                base_url = str(getattr(r, "url", cur_url))
-                next_url = str(httpx.URL(base_url).join(httpx.URL(location)))
-            except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
-                try:
-                    next_url = str(httpx.URL(location))
-                except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
-                    break
+            base_url = str(getattr(r, "url", cur_url))
+            next_url = _resolve_redirect_url(base_url, str(location))
+            if not next_url:
+                break
 
             if not _redirect_allowed(cur_url, next_url):
                 break
 
-            if _is_cross_host_redirect(cur_url, next_url):
-                hop_headers = _cross_host_redirect_headers(hop_headers)
+            if _is_cross_host_redirect(cur_url, next_url) or _is_scheme_downgrade(cur_url, next_url):
+                hop_headers = _redirect_boundary_headers(hop_headers)
                 hop_cookies = None
+                _clear_session_cookie_state(sc)
 
             redirects += 1
             if redirects > DEFAULT_MAX_REDIRECTS:

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -2995,22 +2995,35 @@ def _fetch_curl_simple(
     impersonate: str | None,
     proxies: dict[str, str] | None,
     allow_redirects: bool,
+    session: Any | None = None,
 ) -> HttpResponse:
-    CurlSession = _resolve_curl_session()
-    if CurlSession is None:
-        raise RuntimeError("curl_cffi is not installed")  # noqa: TRY003
+    CurlSession = None
+    if session is None:
+        CurlSession = _resolve_curl_session()
+        if CurlSession is None:
+            raise RuntimeError("curl_cffi is not installed")  # noqa: TRY003
     if proxies:
         _validate_proxies_or_raise(proxies)
 
     req_kwargs: dict[str, Any] = {
         "headers": headers,
         "cookies": cookies,
-        "allow_redirects": allow_redirects,
+        "allow_redirects": False,
     }
     if timeout is not None:
         req_kwargs["timeout"] = timeout
     if proxies:
         req_kwargs["proxies"] = proxies
+
+    if session is not None:
+        resp = session.get(url, **req_kwargs)
+        return HttpResponse(
+            status=int(getattr(resp, "status_code", 0)),
+            headers=dict(getattr(resp, "headers", {}) or {}),
+            text=str(getattr(resp, "text", "")),
+            url=str(getattr(resp, "url", url)),
+            backend="curl",
+        )
 
     with CurlSession(impersonate=impersonate) as session:
         resp = session.get(url, **req_kwargs)
@@ -3088,17 +3101,55 @@ def fetch(*args, **kwargs):
     allow_cross_host = is_truthy(os.getenv("HTTP_ALLOW_CROSS_HOST_REDIRECTS", ""))
     allow_downgrade = is_truthy(os.getenv("HTTP_ALLOW_SCHEME_DOWNGRADE", ""))
 
+    def _extract_redirect_host(redirect_url: str) -> str:
+        try:
+            if httpx is not None:
+                parsed = httpx.URL(redirect_url)
+                return (parsed.host or "").lower()
+            parsed = urlparse(redirect_url)
+            return (parsed.hostname or "").lower()
+        except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+            return ""
+
+    def _is_cross_host_redirect(prev: str, nxt: str) -> bool:
+        prev_host = _extract_redirect_host(prev)
+        next_host = _extract_redirect_host(nxt)
+        return bool(prev_host and next_host and prev_host != next_host)
+
+    def _cross_host_redirect_headers(current_headers: dict[str, str]) -> dict[str, str]:
+        # Preserve only safe transport headers across host boundaries.
+        safe_headers: dict[str, str] = {}
+        for header_key, header_value in (current_headers or {}).items():
+            key_lc = str(header_key).lower()
+            if key_lc == "user-agent":
+                safe_headers["User-Agent"] = str(header_value)
+            elif key_lc == "accept-encoding":
+                safe_headers["Accept-Encoding"] = str(header_value)
+        return safe_headers
+
     def _redirect_allowed(prev: str, nxt: str) -> bool:
         try:
-            pu = httpx.URL(prev)
-            nu = httpx.URL(nxt)
+            if httpx is not None:
+                pu = httpx.URL(prev)
+                nu = httpx.URL(nxt)
+                prev_scheme = (pu.scheme or "").lower()
+                next_scheme = (nu.scheme or "").lower()
+                prev_host = (pu.host or "").lower()
+                next_host = (nu.host or "").lower()
+            else:
+                pu = urlparse(prev)
+                nu = urlparse(nxt)
+                prev_scheme = (pu.scheme or "").lower()
+                next_scheme = (nu.scheme or "").lower()
+                prev_host = (pu.hostname or "").lower()
+                next_host = (nu.hostname or "").lower()
         except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
             return False
         # Disallow scheme downgrade unless explicitly allowed
-        if not allow_downgrade and (pu.scheme or "").lower() == "https" and (nu.scheme or "").lower() == "http":
+        if not allow_downgrade and prev_scheme == "https" and next_scheme == "http":
             return False
         # Same-host redirects are always allowed (subject to egress checks)
-        if (pu.host or "").lower() == (nu.host or "").lower():
+        if prev_host == next_host:
             return True
         # Cross-host redirects configurable (default disabled)
         return bool(allow_cross_host)
@@ -3112,21 +3163,63 @@ def fetch(*args, **kwargs):
         client_kwargs["proxies"] = proxies
 
     if backend_norm == "curl":
-        return _fetch_curl_simple(
-            url=url,
-            headers=req_headers,
-            cookies=cookies,
-            timeout=timeout,
-            impersonate=impersonate,
-            proxies=proxies,
-            allow_redirects=follow_redirects,
-        )
+        CurlSession = _resolve_curl_session()
+        if CurlSession is None:
+            raise RuntimeError("curl_cffi is not installed")  # noqa: TRY003
+
+        cur_url = url
+        hop_headers = req_headers
+        hop_cookies = cookies
+        redirects = 0
+        with CurlSession(impersonate=impersonate) as curl_session:
+            while True:
+                if not _is_url_allowed(cur_url):
+                    raise ValueError("Egress denied for URL")  # noqa: TRY003
+
+                resp = _fetch_curl_simple(
+                    url=cur_url,
+                    headers=hop_headers,
+                    cookies=hop_cookies,
+                    timeout=timeout,
+                    impersonate=impersonate,
+                    proxies=proxies,
+                    allow_redirects=False,
+                    session=curl_session,
+                )
+                status = int(resp["status"])
+
+                if not follow_redirects or status not in (301, 302, 303, 307, 308):
+                    return resp
+
+                location = (resp["headers"] or {}).get("location") or (resp["headers"] or {}).get("Location")
+                if not location:
+                    return resp
+
+                base_url = str(resp["url"] or cur_url)
+                next_url = _resolve_redirect_url(base_url, str(location))
+                if not next_url:
+                    return resp
+
+                if not _redirect_allowed(cur_url, next_url):
+                    return resp
+
+                if _is_cross_host_redirect(cur_url, next_url):
+                    hop_headers = _cross_host_redirect_headers(hop_headers)
+                    hop_cookies = None
+
+                redirects += 1
+                if redirects > DEFAULT_MAX_REDIRECTS:
+                    return resp
+
+                cur_url = next_url
 
     # Minimal client lifecycle for simple fetch with explicit redirect handling
     client_cls = getattr(_hx, "Client", object) if _hx is not None else object
     sc = _instantiate_client(client_cls, client_kwargs)
     with sc as sc:
         cur_url = url
+        hop_headers = req_headers
+        hop_cookies = cookies
         redirects = 0
 
         while True:
@@ -3134,7 +3227,7 @@ def fetch(*args, **kwargs):
             if not _is_url_allowed(cur_url):
                 raise ValueError("Egress denied for URL")  # noqa: TRY003
 
-            r = sc.request("GET", cur_url, headers=req_headers, cookies=cookies, follow_redirects=False)
+            r = sc.request("GET", cur_url, headers=hop_headers, cookies=hop_cookies, follow_redirects=False)
             status = int(getattr(r, "status_code", 0))
 
             if not follow_redirects or status not in (301, 302, 303, 307, 308):
@@ -3156,6 +3249,10 @@ def fetch(*args, **kwargs):
 
             if not _redirect_allowed(cur_url, next_url):
                 break
+
+            if _is_cross_host_redirect(cur_url, next_url):
+                hop_headers = _cross_host_redirect_headers(hop_headers)
+                hop_cookies = None
 
             redirects += 1
             if redirects > DEFAULT_MAX_REDIRECTS:

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
@@ -1,3 +1,4 @@
+import inspect
 from pathlib import Path
 import pytest
 
@@ -39,6 +40,11 @@ def test_web_scraping_endpoint_resolves_task_without_compat_module():
     assert "compat_patchpoints" not in source  # nosec B101
     assert "_resolve_process_web_scraping_task" in source  # nosec B101
 
+    from tldw_Server_API.app.api.v1.endpoints.media import process_web_scraping as endpoint_mod
+
+    resolver_source = inspect.getsource(endpoint_mod._resolve_process_web_scraping_task)
+    assert "suppress(Exception)" not in resolver_source  # nosec B101
+
 
 def test_web_scraping_endpoint_resolver_honors_media_shim(monkeypatch):
     import tldw_Server_API.app.api.v1.endpoints.media as media_mod
@@ -56,3 +62,11 @@ def test_web_scraping_endpoint_resolver_honors_media_shim(monkeypatch):
 
     resolved = endpoint_mod._resolve_process_web_scraping_task()
     assert resolved is shim_process_web_scraping_task  # nosec B101
+
+
+def test_web_scraping_endpoint_resolver_is_typed_and_documented():
+    from tldw_Server_API.app.api.v1.endpoints.media import process_web_scraping as endpoint_mod
+
+    signature = inspect.signature(endpoint_mod._resolve_process_web_scraping_task)
+    assert signature.return_annotation is not inspect.Signature.empty  # nosec B101
+    assert endpoint_mod._resolve_process_web_scraping_task.__doc__  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
@@ -15,14 +15,14 @@ def test_compat_patchpoints_module_removed():
         / "media"
         / "compat_patchpoints.py"
     )
-    assert not module_path.exists()
+    assert not module_path.exists()  # nosec B101
 
 
 def test_media_module_drops_legacy_patchpoints():
     from tldw_Server_API.app.api.v1.endpoints import media as media_mod
 
-    assert not hasattr(media_mod, "_download_url_async")
-    assert not hasattr(media_mod, "_save_uploaded_files")
+    assert not hasattr(media_mod, "_download_url_async")  # nosec B101
+    assert not hasattr(media_mod, "_save_uploaded_files")  # nosec B101
 
 
 def test_web_scraping_endpoint_resolves_task_without_compat_module():
@@ -36,5 +36,23 @@ def test_web_scraping_endpoint_resolves_task_without_compat_module():
         / "process_web_scraping.py"
     )
     source = source_path.read_text(encoding="utf-8")
-    assert "compat_patchpoints" not in source
-    assert 'getattr(media_mod, "process_web_scraping_task"' in source
+    assert "compat_patchpoints" not in source  # nosec B101
+    assert "_resolve_process_web_scraping_task" in source  # nosec B101
+
+
+def test_web_scraping_endpoint_resolver_honors_media_shim(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.media as media_mod
+    from tldw_Server_API.app.api.v1.endpoints.media import process_web_scraping as endpoint_mod
+
+    async def shim_process_web_scraping_task(**kwargs):
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        media_mod,
+        "process_web_scraping_task",
+        shim_process_web_scraping_task,
+        raising=True,
+    )
+
+    resolved = endpoint_mod._resolve_process_web_scraping_task()
+    assert resolved is shim_process_web_scraping_task  # nosec B101

--- a/tldw_Server_API/tests/WebScraping/test_custom_headers_support.py
+++ b/tldw_Server_API/tests/WebScraping/test_custom_headers_support.py
@@ -1,15 +1,11 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-from httpx import ASGITransport, AsyncClient
-from tldw_Server_API.app.core.AuthNZ.settings import get_settings
 
 from tldw_Server_API.app.core.Web_Scraping.enhanced_web_scraping import CookieManager
 
 
-pytestmark = pytest.mark.asyncio
-
-
+@pytest.mark.asyncio
 async def test_cookie_manager_stores_and_returns_cookies(tmp_path):
     manager = CookieManager(storage_path=tmp_path / "cookies.json")
     manager.add_cookies(
@@ -17,12 +13,18 @@ async def test_cookie_manager_stores_and_returns_cookies(tmp_path):
         [{"name": "foo", "value": "bar"}, {"name": "session", "value": "trace-id"}],
     )
     cookies = manager.get_cookies("https://example.com/some/path")
-    assert cookies == [{"name": "foo", "value": "bar"}, {"name": "session", "value": "trace-id"}]
-    assert manager.get_cookies("https://other.example") is None
+    assert cookies == [{"name": "foo", "value": "bar"}, {"name": "session", "value": "trace-id"}]  # nosec B101
+    assert manager.get_cookies("https://other.example") is None  # nosec B101
 
 
-async def test_process_web_scraping_endpoint_receives_custom_headers():
+def test_process_web_scraping_endpoint_receives_custom_headers(
+    client_with_single_user,
+    monkeypatch,
+):
+    client, _ = client_with_single_user
+
     from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+    from tldw_Server_API.app.api.v1.endpoints.media import process_web_scraping as endpoint_mod
     from tldw_Server_API.app.core.DB_Management.media_db.native_class import MediaDatabase
     from tldw_Server_API.app.main import app
 
@@ -30,6 +32,7 @@ async def test_process_web_scraping_endpoint_receives_custom_headers():
     app.dependency_overrides[get_media_db_for_user] = lambda: fake_db
 
     mocked_result = {"status": "success", "message": "ok", "count": 0, "results": []}
+    received_kwargs = {}
     payload = {
         "scrape_method": "Individual URLs",
         "url_input": "https://example.com/article",
@@ -41,34 +44,25 @@ async def test_process_web_scraping_endpoint_receives_custom_headers():
         "custom_headers": {"X-Test": "true"},
     }
 
+    async def fake_process_web_scraping_task(**kwargs):
+        received_kwargs.update(kwargs)
+        return mocked_result
+
+    monkeypatch.setattr(
+        endpoint_mod,
+        "_resolve_process_web_scraping_task",
+        lambda: fake_process_web_scraping_task,
+    )
+
     response = None
-    mock_process = None
-
     try:
-        with patch(
-            "tldw_Server_API.app.api.v1.endpoints.media.process_web_scraping_task",
-            new=AsyncMock(return_value=mocked_result),
-        ) as patched_process:
-            mock_process = patched_process
-            headers = {"X-API-KEY": get_settings().SINGLE_USER_API_KEY}
-            async with AsyncClient(
-                transport=ASGITransport(app=app), base_url="http://test", headers=headers
-            ) as client:
-                response = await client.post(
-                    "/api/v1/media/process-web-scraping",
-                    json=payload,
-                )
-
+        response = client.post("/api/v1/media/process-web-scraping", json=payload)
     finally:
-        app.dependency_overrides.clear()
+        app.dependency_overrides.pop(get_media_db_for_user, None)
 
-    assert response is not None
-    assert response.status_code == 200
-    assert response.json() == mocked_result
-
-    assert mock_process is not None
-    assert mock_process.await_count == 1
-    call_kwargs = mock_process.await_args.kwargs
-    assert call_kwargs["user_agent"] == payload["user_agent"]
-    assert call_kwargs["custom_headers"] == payload["custom_headers"]
-    assert call_kwargs["mode"] == "ephemeral"
+    assert response is not None  # nosec B101
+    assert response.status_code == 200  # nosec B101
+    assert response.json() == mocked_result  # nosec B101
+    assert received_kwargs["custom_headers"] == payload["custom_headers"]  # nosec B101
+    assert received_kwargs["user_agent"] == payload["user_agent"]  # nosec B101
+    assert received_kwargs["mode"] == payload["mode"]  # nosec B101

--- a/tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py
+++ b/tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py
@@ -1,5 +1,3 @@
-import asyncio
-import json
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -9,13 +7,16 @@ pytestmark = pytest.mark.unit
 def client_with_ws_overrides(monkeypatch, client_with_single_user):
     client, usage_logger = client_with_single_user
 
-    # Stub the internal service call used by endpoint
-    import tldw_Server_API.app.api.v1.endpoints.media as media_mod
+    import tldw_Server_API.app.api.v1.endpoints.media.process_web_scraping as endpoint_mod
 
     async def stub_process_web_scraping_task(**kwargs):
         return {"status": "ok", "results": []}
 
-    monkeypatch.setattr(media_mod, "process_web_scraping_task", stub_process_web_scraping_task)
+    monkeypatch.setattr(
+        endpoint_mod,
+        "_resolve_process_web_scraping_task",
+        lambda: stub_process_web_scraping_task,
+    )
 
     yield client, usage_logger
 
@@ -30,5 +31,5 @@ def test_webscrape_process_usage_event(client_with_ws_overrides):
         "max_depth": 2,
     }
     r = client.post("/api/v1/media/process-web-scraping", json=payload)
-    assert r.status_code == 200, r.text
-    assert any(e[0] == "webscrape.process" for e in usage_logger.events)
+    assert r.status_code == 200, r.text  # nosec B101
+    assert any(e[0] == "webscrape.process" for e in usage_logger.events)  # nosec B101

--- a/tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py
@@ -5,6 +5,8 @@ import pytest
 
 import tldw_Server_API.app.core.Web_Scraping.enhanced_web_scraping as ews
 
+HTTP_BACKEND = "httpx"
+
 
 def test_fetch_html_curl_routes_through_http_client_fetch(monkeypatch):
     calls: dict[str, object] = {}
@@ -32,14 +34,39 @@ def test_fetch_html_curl_routes_through_http_client_fetch(monkeypatch):
         proxies=None,
     )
 
-    assert html == "<html>ok</html>"
-    assert calls["url"] == "https://example.com/article"
+    assert html == "<html>ok</html>"  # nosec B101
+    assert calls["url"] == "https://example.com/article"  # nosec B101
     kwargs = calls["kwargs"]
-    assert isinstance(kwargs, dict)
-    assert kwargs["backend"] == "curl"
-    assert kwargs["follow_redirects"] is True
-    assert kwargs["headers"]["X-Test"] == "true"
-    assert kwargs["cookies"] == {"session": "abc"}
+    assert isinstance(kwargs, dict)  # nosec B101
+    assert kwargs["backend"] == "curl"  # nosec B101
+    assert kwargs["follow_redirects"] is True  # nosec B101
+    assert kwargs["headers"]["X-Test"] == "true"  # nosec B101
+    assert kwargs["cookies"] == {"session": "abc"}  # nosec B101
+
+
+def test_fetch_html_curl_rejects_non_terminal_responses(monkeypatch):
+    def fake_fetch(url, **kwargs):
+        return {
+            "status": 302,
+            "headers": {"Location": "https://example.com/final"},
+            "text": "",
+            "url": url,
+            "backend": "curl",
+        }
+
+    monkeypatch.setattr("tldw_Server_API.app.core.http_client.fetch", fake_fetch)
+
+    scraper = ews.EnhancedWebScraper(config={})
+
+    with pytest.raises(ValueError, match="terminal 2xx"):
+        scraper._fetch_html_curl(
+            "https://example.com/article",
+            headers={"X-Test": "true"},
+            cookies={"session": "abc"},
+            timeout=5.0,
+            impersonate="chrome120",
+            proxies=None,
+        )
 
 
 def _build_scraper(monkeypatch):
@@ -65,9 +92,9 @@ def _build_scraper(monkeypatch):
         backend="auto",
     )
 
-    monkeypatch.setattr(scraper, "_resolve_scrape_plan", lambda url: (plan, "httpx", ""))
+    monkeypatch.setattr(scraper, "_resolve_scrape_plan", lambda url: (plan, HTTP_BACKEND, ""))
     monkeypatch.setattr(scraper, "_run_preflight_analysis", AsyncMock(return_value=None))
-    monkeypatch.setattr(scraper, "_apply_preflight_advice", lambda *args: ("httpx", "trafilatura", []))
+    monkeypatch.setattr(scraper, "_apply_preflight_advice", lambda *args: (HTTP_BACKEND, "trafilatura", []))
     monkeypatch.setattr(
         "tldw_Server_API.app.core.Security.egress.evaluate_url_policy",
         lambda url: SimpleNamespace(allowed=True),
@@ -95,7 +122,7 @@ async def test_scrape_article_allows_when_robots_check_errors(monkeypatch):
 
     result = await scraper.scrape_article("https://example.com/article")
 
-    assert result["extraction_successful"] is True
+    assert result["extraction_successful"] is True  # nosec B101
     fake_scrape.assert_awaited_once()
 
 
@@ -111,6 +138,6 @@ async def test_scrape_article_blocks_when_robots_disallows(monkeypatch):
 
     result = await scraper.scrape_article("https://example.com/article")
 
-    assert result["extraction_successful"] is False
-    assert result["error"] == "Blocked by robots policy"
+    assert result["extraction_successful"] is False  # nosec B101
+    assert result["error"] == "Blocked by robots policy"  # nosec B101
     fake_scrape.assert_not_awaited()

--- a/tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import tldw_Server_API.app.core.Web_Scraping.enhanced_web_scraping as ews
+
+
+def test_fetch_html_curl_routes_through_http_client_fetch(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_fetch(url, **kwargs):
+        calls["url"] = url
+        calls["kwargs"] = kwargs
+        return {
+            "status": 200,
+            "headers": {"Content-Type": "text/html"},
+            "text": "<html>ok</html>",
+            "url": url,
+            "backend": "curl",
+        }
+
+    monkeypatch.setattr("tldw_Server_API.app.core.http_client.fetch", fake_fetch)
+
+    scraper = ews.EnhancedWebScraper(config={})
+    html = scraper._fetch_html_curl(
+        "https://example.com/article",
+        headers={"X-Test": "true"},
+        cookies={"session": "abc"},
+        timeout=5.0,
+        impersonate="chrome120",
+        proxies=None,
+    )
+
+    assert html == "<html>ok</html>"
+    assert calls["url"] == "https://example.com/article"
+    kwargs = calls["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["backend"] == "curl"
+    assert kwargs["follow_redirects"] is True
+    assert kwargs["headers"]["X-Test"] == "true"
+    assert kwargs["cookies"] == {"session": "abc"}
+
+
+def _build_scraper(monkeypatch):
+    scraper = ews.EnhancedWebScraper(config={})
+
+    async def _acquire():
+        return None
+
+    scraper.rate_limiter.acquire = _acquire
+
+    plan = SimpleNamespace(
+        respect_robots=True,
+        ua_profile="chrome_120_win",
+        extra_headers={},
+        cookies={},
+        impersonate=None,
+        proxies=None,
+        strategy_order=None,
+        schema_rules=None,
+        llm_settings=None,
+        regex_settings=None,
+        cluster_settings=None,
+        backend="auto",
+    )
+
+    monkeypatch.setattr(scraper, "_resolve_scrape_plan", lambda url: (plan, "httpx", ""))
+    monkeypatch.setattr(scraper, "_run_preflight_analysis", AsyncMock(return_value=None))
+    monkeypatch.setattr(scraper, "_apply_preflight_advice", lambda *args: ("httpx", "trafilatura", []))
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Security.egress.evaluate_url_policy",
+        lambda url: SimpleNamespace(allowed=True),
+    )
+    monkeypatch.setattr(ews, "increment_counter", lambda *args, **kwargs: None)
+
+    return scraper
+
+
+@pytest.mark.asyncio
+async def test_scrape_article_allows_when_robots_check_errors(monkeypatch):
+    scraper = _build_scraper(monkeypatch)
+    fake_scrape = AsyncMock(
+        return_value={
+            "url": "https://example.com/article",
+            "content": "ok",
+            "extraction_successful": True,
+        }
+    )
+    monkeypatch.setattr(scraper, "_scrape_with_trafilatura", fake_scrape)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib.is_allowed_by_robots_async",
+        AsyncMock(side_effect=RuntimeError("robots unavailable")),
+    )
+
+    result = await scraper.scrape_article("https://example.com/article")
+
+    assert result["extraction_successful"] is True
+    fake_scrape.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_scrape_article_blocks_when_robots_disallows(monkeypatch):
+    scraper = _build_scraper(monkeypatch)
+    fake_scrape = AsyncMock()
+    monkeypatch.setattr(scraper, "_scrape_with_trafilatura", fake_scrape)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Web_Scraping.Article_Extractor_Lib.is_allowed_by_robots_async",
+        AsyncMock(return_value=False),
+    )
+
+    result = await scraper.scrape_article("https://example.com/article")
+
+    assert result["extraction_successful"] is False
+    assert result["error"] == "Blocked by robots policy"
+    fake_scrape.assert_not_awaited()

--- a/tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py
@@ -48,9 +48,9 @@ def test_httpx_fetch_sanitizes_accept_encoding_and_backend_label(monkeypatch):
 
     headers = {"Accept-Encoding": "gzip, deflate, br, zstd"}
     resp = hc.fetch("https://example.com/", headers=headers, backend="httpx")
-    assert resp["backend"] == "httpx"
+    assert resp["backend"] == "httpx"  # nosec B101
     # zstd should be removed for httpx path
-    assert "zstd" not in resp["headers"].get("Accept-Encoding", "").lower()
+    assert "zstd" not in resp["headers"].get("Accept-Encoding", "").lower()  # nosec B101
 
 
 def test_httpx_fetch_accept_encoding_case_and_params(monkeypatch):
@@ -64,10 +64,10 @@ def test_httpx_fetch_accept_encoding_case_and_params(monkeypatch):
     resp = hc.fetch("https://example.com/", headers=headers, backend="httpx")
 
     # Original exact lower-case key should not remain; canonical should be present
-    assert "accept-encoding" not in resp["headers"].keys()
+    assert "accept-encoding" not in resp["headers"].keys()  # nosec B101
     enc = resp["headers"].get("Accept-Encoding", "")
-    assert "zstd" not in enc.lower()
-    assert "gzip" in enc.lower() and "br" in enc.lower()
+    assert "zstd" not in enc.lower()  # nosec B101
+    assert "gzip" in enc.lower() and "br" in enc.lower()  # nosec B101
 
 
 def test_httpx_fetch_accept_encoding_all_removed(monkeypatch):
@@ -81,7 +81,7 @@ def test_httpx_fetch_accept_encoding_all_removed(monkeypatch):
 
     # Accept-Encoding should be removed entirely if no tokens remain
     keys_lower = {k.lower() for k in resp["headers"].keys()}
-    assert "accept-encoding" not in keys_lower
+    assert "accept-encoding" not in keys_lower  # nosec B101
 
 
 def test_requests_fetch_sanitizes_accept_encoding(monkeypatch):
@@ -94,8 +94,8 @@ def test_requests_fetch_sanitizes_accept_encoding(monkeypatch):
     resp = hc.fetch("https://example.com/", headers=headers, backend="requests")
 
     enc = resp["headers"].get("Accept-Encoding", "").lower()
-    assert "zstd" not in enc
-    assert "br" not in enc
+    assert "zstd" not in enc  # nosec B101
+    assert "br" not in enc  # nosec B101
 
 
 def test_fetch_egress_denied_raises(monkeypatch):
@@ -135,9 +135,9 @@ def test_curl_fetch_uses_curl_session_and_preserves_encodings(monkeypatch):
         impersonate="chrome120",
     )
 
-    assert resp["backend"] == "curl"
-    assert calls["impersonate"] == "chrome120"
-    assert "zstd" in resp["headers"].get("Accept-Encoding", "").lower()
+    assert resp["backend"] == "curl"  # nosec B101
+    assert calls["impersonate"] == "chrome120"  # nosec B101
+    assert "zstd" in resp["headers"].get("Accept-Encoding", "").lower()  # nosec B101
 
 
 def test_curl_fetch_follows_same_host_redirects_under_policy(monkeypatch):
@@ -176,20 +176,20 @@ def test_curl_fetch_follows_same_host_redirects_under_policy(monkeypatch):
         follow_redirects=True,
     )
 
-    assert [url for url, _ in calls] == [
+    assert [url for url, _ in calls] == [  # nosec B101
         "https://example.com/start",
         "https://example.com/final",
     ]
-    assert calls[0][1]["allow_redirects"] is False
-    assert calls[1][1]["allow_redirects"] is False
-    assert resp["status"] == 200
-    assert resp["url"] == "https://example.com/final"
+    assert calls[0][1]["allow_redirects"] is False  # nosec B101
+    assert calls[1][1]["allow_redirects"] is False  # nosec B101
+    assert resp["status"] == 200  # nosec B101
+    assert resp["url"] == "https://example.com/final"  # nosec B101
 
 
 def test_curl_fetch_follows_same_host_redirects_without_httpx(monkeypatch):
     monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
     monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
-    monkeypatch.setattr(hc, "httpx", None)
+    monkeypatch.setattr(hc, "_resolve_httpx", lambda: None)
 
     calls = []
 
@@ -222,14 +222,14 @@ def test_curl_fetch_follows_same_host_redirects_without_httpx(monkeypatch):
         follow_redirects=True,
     )
 
-    assert [url for url, _ in calls] == [
+    assert [url for url, _ in calls] == [  # nosec B101
         "https://example.com/start",
         "https://example.com/final",
     ]
-    assert calls[0][1]["allow_redirects"] is False
-    assert calls[1][1]["allow_redirects"] is False
-    assert resp["status"] == 200
-    assert resp["url"] == "https://example.com/final"
+    assert calls[0][1]["allow_redirects"] is False  # nosec B101
+    assert calls[1][1]["allow_redirects"] is False  # nosec B101
+    assert resp["status"] == 200  # nosec B101
+    assert resp["url"] == "https://example.com/final"  # nosec B101
 
 
 def test_curl_fetch_cross_host_redirect_strips_origin_bound_state(monkeypatch):
@@ -282,19 +282,19 @@ def test_curl_fetch_cross_host_redirect_strips_origin_bound_state(monkeypatch):
         cookies={"session": "origin-cookie"},
     )
 
-    assert [c["url"] for c in calls] == [
+    assert [c["url"] for c in calls] == [  # nosec B101
         "https://source.example/start",
         "https://target.example/final",
     ]
     second_hop_headers = {k.lower(): v for k, v in calls[1]["headers"].items()}
-    assert "authorization" not in second_hop_headers
-    assert "proxy-authorization" not in second_hop_headers
-    assert "x-custom-trace" not in second_hop_headers
-    assert calls[1]["cookies"] == {}
-    assert second_hop_headers.get("user-agent") == "tldw-test-agent/1.0"
-    assert second_hop_headers.get("accept-encoding") == "gzip, br"
-    assert resp["status"] == 200
-    assert resp["url"] == "https://target.example/final"
+    assert "authorization" not in second_hop_headers  # nosec B101
+    assert "proxy-authorization" not in second_hop_headers  # nosec B101
+    assert "x-custom-trace" not in second_hop_headers  # nosec B101
+    assert calls[1]["cookies"] == {}  # nosec B101
+    assert second_hop_headers.get("user-agent") == "tldw-test-agent/1.0"  # nosec B101
+    assert second_hop_headers.get("accept-encoding") == "gzip, br"  # nosec B101
+    assert resp["status"] == 200  # nosec B101
+    assert resp["url"] == "https://target.example/final"  # nosec B101
 
 
 def test_httpx_fetch_cross_host_redirect_strips_origin_bound_state(monkeypatch):
@@ -350,21 +350,160 @@ def test_httpx_fetch_cross_host_redirect_strips_origin_bound_state(monkeypatch):
         cookies={"session": "origin-cookie"},
     )
 
-    assert [c["url"] for c in calls] == [
+    assert [c["url"] for c in calls] == [  # nosec B101
         "https://source.example/start",
         "https://target.example/final",
     ]
     second_hop_headers = {k.lower(): v for k, v in calls[1]["headers"].items()}
-    assert "authorization" not in second_hop_headers
-    assert "proxy-authorization" not in second_hop_headers
-    assert "x-custom-trace" not in second_hop_headers
-    assert calls[1]["cookies"] == {}
-    assert second_hop_headers.get("user-agent") == "tldw-test-agent/1.0"
-    assert second_hop_headers.get("accept-encoding") == "gzip, br"
-    assert calls[0]["follow_redirects"] is False
-    assert calls[1]["follow_redirects"] is False
-    assert resp["status"] == 200
-    assert resp["url"] == "https://target.example/final"
+    assert "authorization" not in second_hop_headers  # nosec B101
+    assert "proxy-authorization" not in second_hop_headers  # nosec B101
+    assert "x-custom-trace" not in second_hop_headers  # nosec B101
+    assert calls[1]["cookies"] == {}  # nosec B101
+    assert second_hop_headers.get("user-agent") == "tldw-test-agent/1.0"  # nosec B101
+    assert second_hop_headers.get("accept-encoding") == "gzip, br"  # nosec B101
+    assert calls[0]["follow_redirects"] is False  # nosec B101
+    assert calls[1]["follow_redirects"] is False  # nosec B101
+    assert resp["status"] == 200  # nosec B101
+    assert resp["url"] == "https://target.example/final"  # nosec B101
+
+
+def test_curl_fetch_same_host_downgrade_strips_state_and_clears_cookie_jar(monkeypatch):
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+    monkeypatch.setenv("HTTP_ALLOW_SCHEME_DOWNGRADE", "true")
+
+    calls = []
+
+    class DummyCurlSession:
+        def __init__(self, impersonate=None):
+            self.impersonate = impersonate
+            self.cookie_jar = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            request_cookies = dict(kwargs.get("cookies") or {})
+            merged_cookies = {**request_cookies, **self.cookie_jar}
+            calls.append(
+                {
+                    "url": url,
+                    "headers": dict(kwargs.get("headers") or {}),
+                    "cookies": merged_cookies,
+                }
+            )
+            if url == "https://example.com/start":
+                self.cookie_jar["challenge"] = "passed"
+                return DummyResp(
+                    url,
+                    {"Location": "http://example.com/final"},
+                    status_code=302,
+                    text="",
+                )
+            return DummyResp(url, {}, status_code=200, text="<html>final</html>")
+
+    monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
+
+    resp = hc.fetch(
+        "https://example.com/start",
+        backend="curl",
+        follow_redirects=True,
+        headers={
+            "Authorization": "Bearer top-secret",
+            "X-Custom-Trace": "origin-bound",
+            "User-Agent": "tldw-test-agent/1.0",
+            "Accept-Encoding": "gzip, br",
+        },
+        cookies={"session": "origin-cookie"},
+    )
+
+    assert [c["url"] for c in calls] == [  # nosec B101
+        "https://example.com/start",
+        "http://example.com/final",
+    ]
+    second_hop_headers = {k.lower(): v for k, v in calls[1]["headers"].items()}
+    assert "authorization" not in second_hop_headers  # nosec B101
+    assert "x-custom-trace" not in second_hop_headers  # nosec B101
+    assert second_hop_headers.get("user-agent") == "tldw-test-agent/1.0"  # nosec B101
+    assert second_hop_headers.get("accept-encoding") == "gzip, br"  # nosec B101
+    assert calls[1]["cookies"] == {}  # nosec B101
+    assert resp["status"] == 200  # nosec B101
+    assert resp["url"] == "http://example.com/final"  # nosec B101
+
+
+def test_httpx_fetch_port_change_strips_state_and_clears_cookie_jar(monkeypatch):
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+    monkeypatch.setenv("HTTP_ALLOW_CROSS_HOST_REDIRECTS", "true")
+
+    calls = []
+
+    class DummyRedirectClient:
+        def __init__(self, timeout=None, trust_env=None, proxies=None):
+            self.timeout = timeout
+            self.trust_env = trust_env
+            self.proxies = proxies
+            self.cookies = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def request(self, method, url, headers=None, cookies=None, follow_redirects=None):
+            request_cookies = dict(cookies or {})
+            merged_cookies = {**request_cookies, **self.cookies}
+            calls.append(
+                {
+                    "url": url,
+                    "headers": dict(headers or {}),
+                    "cookies": merged_cookies,
+                    "follow_redirects": follow_redirects,
+                }
+            )
+            if url == "https://example.com/start":
+                self.cookies["challenge"] = "passed"
+                return DummyResp(
+                    url,
+                    {"Location": "https://example.com:8443/final"},
+                    status_code=302,
+                    text="",
+                )
+            return DummyResp(url, {}, status_code=200, text="<html>final</html>")
+
+    monkeypatch.setattr(hc, "_resolve_httpx", lambda: types.SimpleNamespace(Client=DummyRedirectClient))
+
+    resp = hc.fetch(
+        "https://example.com/start",
+        backend="httpx",
+        follow_redirects=True,
+        headers={
+            "Authorization": "Bearer top-secret",
+            "Proxy-Authorization": "Basic proxy-secret",
+            "X-Custom-Trace": "origin-bound",
+            "User-Agent": "tldw-test-agent/1.0",
+            "Accept-Encoding": "gzip, br",
+        },
+        cookies={"session": "origin-cookie"},
+    )
+
+    assert [c["url"] for c in calls] == [  # nosec B101
+        "https://example.com/start",
+        "https://example.com:8443/final",
+    ]
+    second_hop_headers = {k.lower(): v for k, v in calls[1]["headers"].items()}
+    assert "authorization" not in second_hop_headers  # nosec B101
+    assert "proxy-authorization" not in second_hop_headers  # nosec B101
+    assert "x-custom-trace" not in second_hop_headers  # nosec B101
+    assert second_hop_headers.get("user-agent") == "tldw-test-agent/1.0"  # nosec B101
+    assert second_hop_headers.get("accept-encoding") == "gzip, br"  # nosec B101
+    assert calls[1]["cookies"] == {}  # nosec B101
+    assert resp["status"] == 200  # nosec B101
+    assert resp["url"] == "https://example.com:8443/final"  # nosec B101
 
 
 def test_curl_fetch_denies_blocked_redirect_hop(monkeypatch):
@@ -398,11 +537,11 @@ def test_curl_fetch_denies_blocked_redirect_hop(monkeypatch):
 
     monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Egress denied for URL"):
         hc.fetch("https://example.com/start", backend="curl", follow_redirects=True)
 
-    assert [url for url, _ in calls] == ["https://example.com/start"]
-    assert calls[0][1]["allow_redirects"] is False
+    assert [url for url, _ in calls] == ["https://example.com/start"]  # nosec B101
+    assert calls[0][1]["allow_redirects"] is False  # nosec B101
 
 
 def test_curl_fetch_preserves_redirect_established_cookie(monkeypatch):
@@ -450,10 +589,10 @@ def test_curl_fetch_preserves_redirect_established_cookie(monkeypatch):
         follow_redirects=True,
     )
 
-    assert [url for url, _ in calls] == [
+    assert [url for url, _ in calls] == [  # nosec B101
         "https://example.com/start",
         "https://example.com/final",
     ]
-    assert calls[1][1].get("challenge") == "passed"
-    assert resp["status"] == 200
-    assert resp["url"] == "https://example.com/final"
+    assert calls[1][1].get("challenge") == "passed"  # nosec B101
+    assert resp["status"] == 200  # nosec B101
+    assert resp["url"] == "https://example.com/final"  # nosec B101

--- a/tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py
+++ b/tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py
@@ -7,10 +7,17 @@ import tldw_Server_API.app.core.http_client as hc
 
 
 class DummyResp:
-    def __init__(self, url: str, headers: dict):
-        self.status_code = 200
+    def __init__(
+        self,
+        url: str,
+        headers: dict,
+        *,
+        status_code: int = 200,
+        text: str = "<html><body>ok</body></html>",
+    ):
+        self.status_code = status_code
         self.headers = headers
-        self.text = "<html><body>ok</body></html>"
+        self.text = text
         self.url = url
 
 
@@ -131,3 +138,322 @@ def test_curl_fetch_uses_curl_session_and_preserves_encodings(monkeypatch):
     assert resp["backend"] == "curl"
     assert calls["impersonate"] == "chrome120"
     assert "zstd" in resp["headers"].get("Accept-Encoding", "").lower()
+
+
+def test_curl_fetch_follows_same_host_redirects_under_policy(monkeypatch):
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+
+    calls = []
+
+    class DummyCurlSession:
+        def __init__(self, impersonate=None):
+            self.impersonate = impersonate
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            if url == "https://example.com/start":
+                return DummyResp(
+                    url,
+                    {"Location": "/final"},
+                    status_code=302,
+                    text="",
+                )
+            return DummyResp("https://example.com/final", {}, status_code=200, text="<html>final</html>")
+
+    monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
+
+    resp = hc.fetch(
+        "https://example.com/start",
+        headers={"Accept-Encoding": "gzip, br, zstd"},
+        backend="curl",
+        follow_redirects=True,
+    )
+
+    assert [url for url, _ in calls] == [
+        "https://example.com/start",
+        "https://example.com/final",
+    ]
+    assert calls[0][1]["allow_redirects"] is False
+    assert calls[1][1]["allow_redirects"] is False
+    assert resp["status"] == 200
+    assert resp["url"] == "https://example.com/final"
+
+
+def test_curl_fetch_follows_same_host_redirects_without_httpx(monkeypatch):
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+    monkeypatch.setattr(hc, "httpx", None)
+
+    calls = []
+
+    class DummyCurlSession:
+        def __init__(self, impersonate=None):
+            self.impersonate = impersonate
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            if url == "https://example.com/start":
+                return DummyResp(
+                    url,
+                    {"Location": "/final"},
+                    status_code=302,
+                    text="",
+                )
+            return DummyResp("https://example.com/final", {}, status_code=200, text="<html>final</html>")
+
+    monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
+
+    resp = hc.fetch(
+        "https://example.com/start",
+        backend="curl",
+        follow_redirects=True,
+    )
+
+    assert [url for url, _ in calls] == [
+        "https://example.com/start",
+        "https://example.com/final",
+    ]
+    assert calls[0][1]["allow_redirects"] is False
+    assert calls[1][1]["allow_redirects"] is False
+    assert resp["status"] == 200
+    assert resp["url"] == "https://example.com/final"
+
+
+def test_curl_fetch_cross_host_redirect_strips_origin_bound_state(monkeypatch):
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+    monkeypatch.setenv("HTTP_ALLOW_CROSS_HOST_REDIRECTS", "true")
+
+    calls = []
+
+    class DummyCurlSession:
+        def __init__(self, impersonate=None):
+            self.impersonate = impersonate
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            calls.append(
+                {
+                    "url": url,
+                    "headers": dict(kwargs.get("headers") or {}),
+                    "cookies": dict(kwargs.get("cookies") or {}),
+                }
+            )
+            if url == "https://source.example/start":
+                return DummyResp(
+                    url,
+                    {"Location": "https://target.example/final"},
+                    status_code=302,
+                    text="",
+                )
+            return DummyResp(url, {}, status_code=200, text="<html>final</html>")
+
+    monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
+
+    resp = hc.fetch(
+        "https://source.example/start",
+        backend="curl",
+        follow_redirects=True,
+        headers={
+            "Authorization": "Bearer top-secret",
+            "Proxy-Authorization": "Basic proxy-secret",
+            "X-Custom-Trace": "origin-bound",
+            "User-Agent": "tldw-test-agent/1.0",
+            "Accept-Encoding": "gzip, br",
+        },
+        cookies={"session": "origin-cookie"},
+    )
+
+    assert [c["url"] for c in calls] == [
+        "https://source.example/start",
+        "https://target.example/final",
+    ]
+    second_hop_headers = {k.lower(): v for k, v in calls[1]["headers"].items()}
+    assert "authorization" not in second_hop_headers
+    assert "proxy-authorization" not in second_hop_headers
+    assert "x-custom-trace" not in second_hop_headers
+    assert calls[1]["cookies"] == {}
+    assert second_hop_headers.get("user-agent") == "tldw-test-agent/1.0"
+    assert second_hop_headers.get("accept-encoding") == "gzip, br"
+    assert resp["status"] == 200
+    assert resp["url"] == "https://target.example/final"
+
+
+def test_httpx_fetch_cross_host_redirect_strips_origin_bound_state(monkeypatch):
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+    monkeypatch.setenv("HTTP_ALLOW_CROSS_HOST_REDIRECTS", "true")
+
+    calls = []
+
+    class DummyRedirectClient:
+        def __init__(self, timeout=None, trust_env=None, proxies=None):
+            self.timeout = timeout
+            self.trust_env = trust_env
+            self.proxies = proxies
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def request(self, method, url, headers=None, cookies=None, follow_redirects=None):
+            calls.append(
+                {
+                    "url": url,
+                    "headers": dict(headers or {}),
+                    "cookies": dict(cookies or {}),
+                    "follow_redirects": follow_redirects,
+                }
+            )
+            if url == "https://source.example/start":
+                return DummyResp(
+                    url,
+                    {"Location": "https://target.example/final"},
+                    status_code=302,
+                    text="",
+                )
+            return DummyResp(url, {}, status_code=200, text="<html>final</html>")
+
+    monkeypatch.setattr(hc, "_resolve_httpx", lambda: types.SimpleNamespace(Client=DummyRedirectClient))
+
+    resp = hc.fetch(
+        "https://source.example/start",
+        backend="httpx",
+        follow_redirects=True,
+        headers={
+            "Authorization": "Bearer top-secret",
+            "Proxy-Authorization": "Basic proxy-secret",
+            "X-Custom-Trace": "origin-bound",
+            "User-Agent": "tldw-test-agent/1.0",
+            "Accept-Encoding": "gzip, br",
+        },
+        cookies={"session": "origin-cookie"},
+    )
+
+    assert [c["url"] for c in calls] == [
+        "https://source.example/start",
+        "https://target.example/final",
+    ]
+    second_hop_headers = {k.lower(): v for k, v in calls[1]["headers"].items()}
+    assert "authorization" not in second_hop_headers
+    assert "proxy-authorization" not in second_hop_headers
+    assert "x-custom-trace" not in second_hop_headers
+    assert calls[1]["cookies"] == {}
+    assert second_hop_headers.get("user-agent") == "tldw-test-agent/1.0"
+    assert second_hop_headers.get("accept-encoding") == "gzip, br"
+    assert calls[0]["follow_redirects"] is False
+    assert calls[1]["follow_redirects"] is False
+    assert resp["status"] == 200
+    assert resp["url"] == "https://target.example/final"
+
+
+def test_curl_fetch_denies_blocked_redirect_hop(monkeypatch):
+    allowed = {
+        "https://example.com/start": True,
+        "https://example.com/final": False,
+    }
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: allowed.get(url, True))
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+
+    calls = []
+
+    class DummyCurlSession:
+        def __init__(self, impersonate=None):
+            self.impersonate = impersonate
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs))
+            return DummyResp(
+                url,
+                {"Location": "/final"},
+                status_code=302,
+                text="",
+            )
+
+    monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
+
+    with pytest.raises(ValueError):
+        hc.fetch("https://example.com/start", backend="curl", follow_redirects=True)
+
+    assert [url for url, _ in calls] == ["https://example.com/start"]
+    assert calls[0][1]["allow_redirects"] is False
+
+
+def test_curl_fetch_preserves_redirect_established_cookie(monkeypatch):
+    monkeypatch.setattr(hc, "_is_url_allowed", lambda url: True)
+    monkeypatch.setattr(hc, "_validate_proxies_or_raise", lambda proxies: None)
+
+    calls = []
+
+    class DummyCurlSession:
+        def __init__(self, impersonate=None):
+            self.impersonate = impersonate
+            self.cookie_jar = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, **kwargs):
+            request_cookies = dict(kwargs.get("cookies") or {})
+            merged_cookies = {**request_cookies, **self.cookie_jar}
+            calls.append((url, merged_cookies))
+
+            if url == "https://example.com/start":
+                # Simulate session cookie set during redirect response.
+                self.cookie_jar["challenge"] = "passed"
+                return DummyResp(
+                    url,
+                    {"Location": "/final", "Set-Cookie": "challenge=passed; Path=/"},
+                    status_code=302,
+                    text="",
+                )
+
+            if url == "https://example.com/final" and merged_cookies.get("challenge") == "passed":
+                return DummyResp(url, {}, status_code=200, text="<html>ok</html>")
+
+            return DummyResp(url, {}, status_code=403, text="<html>missing-cookie</html>")
+
+    monkeypatch.setattr(hc, "_resolve_curl_session", lambda: DummyCurlSession)
+
+    resp = hc.fetch(
+        "https://example.com/start",
+        backend="curl",
+        follow_redirects=True,
+    )
+
+    assert [url for url, _ in calls] == [
+        "https://example.com/start",
+        "https://example.com/final",
+    ]
+    assert calls[1][1].get("challenge") == "passed"
+    assert resp["status"] == 200
+    assert resp["url"] == "https://example.com/final"


### PR DESCRIPTION
## Summary
- add the web scraping ingest review, remediation design, and execution artifacts
- stabilize the /process-web-scraping endpoint tests while preserving the exported media shim compatibility path
- harden centralized redirect handling and secret/cookie propagation, and route enhanced curl scraping through the shared http client with direct guard coverage

## Test Plan
- [x] python -m pytest -v tldw_Server_API/tests/Web_Scraping/test_crawl_config_precedence.py tldw_Server_API/tests/WebScraping/test_webscraping_usage_events.py tldw_Server_API/tests/WebScraping/test_custom_headers_support.py tldw_Server_API/tests/Web_Scraping/test_friendly_ingest_crawl_flags.py tldw_Server_API/tests/Web_Scraping/test_http_client_fetch.py tldw_Server_API/tests/Web_Scraping/test_enhanced_web_scraping_guards.py tldw_Server_API/tests/Web_Scraping/test_robots_enforcement.py tldw_Server_API/tests/Media_Ingestion_Modification/test_media_compat_patchpoints.py
- [x] 33 passed
- [x] python -m bandit -r tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py tldw_Server_API/app/core/http_client.py tldw_Server_API/app/core/Web_Scraping/enhanced_web_scraping.py -f json -o /tmp/bandit_web_scraping_remediation.json
- [x] Bandit results: 0 findings