### PR TITLE
fix(prompts): guard archetype loader malformed YAML values

### DIFF
--- a/tldw_Server_API/app/core/Persona/archetype_loader.py
+++ b/tldw_Server_API/app/core/Persona/archetype_loader.py
@@ -6,6 +6,7 @@ Pydantic, and caches them in memory for fast access by API endpoints.
 """
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from threading import RLock
 
@@ -66,7 +67,14 @@ def load_archetypes_from_directory(
                     "Skipping {}: missing top-level 'archetype' key", yaml_file.name
                 )
                 continue
-            template = ArchetypeTemplate(**data["archetype"])
+            archetype_data = data["archetype"]
+            if not isinstance(archetype_data, Mapping):
+                logger.warning(
+                    "Skipping {}: top-level 'archetype' value must be a mapping",
+                    yaml_file.name,
+                )
+                continue
+            template = ArchetypeTemplate(**archetype_data)
             new_cache[template.key] = template
             logger.debug("Loaded archetype '{}' from {}", template.key, yaml_file.name)
         except (OSError, ValidationError, yaml.YAMLError):

--- a/tldw_Server_API/app/core/Persona/archetype_loader.py
+++ b/tldw_Server_API/app/core/Persona/archetype_loader.py
@@ -74,7 +74,7 @@ def load_archetypes_from_directory(
                     yaml_file.name,
                 )
                 continue
-            template = ArchetypeTemplate(**archetype_data)
+            template = ArchetypeTemplate.model_validate(archetype_data)
             new_cache[template.key] = template
             logger.debug("Loaded archetype '{}' from {}", template.key, yaml_file.name)
         except (OSError, ValidationError, yaml.YAMLError):

--- a/tldw_Server_API/tests/unit/test_archetype_loader.py
+++ b/tldw_Server_API/tests/unit/test_archetype_loader.py
@@ -105,6 +105,15 @@ class TestLoadArchetypesFromDirectory:
 
         assert len(result) == 0
 
+    def test_yaml_with_non_mapping_archetype_value_skipped(self, tmp_path: Path):
+        (tmp_path / "good.yaml").write_text(_VALID_YAML, encoding="utf-8")
+        (tmp_path / "bad.yaml").write_text("archetype:\n  - not-a-mapping\n", encoding="utf-8")
+
+        result = archetype_loader.load_archetypes_from_directory(tmp_path)
+
+        assert len(result) == 1
+        assert "researcher" in result
+
     def test_empty_directory(self, tmp_path: Path):
         result = archetype_loader.load_archetypes_from_directory(tmp_path)
 

--- a/tldw_Server_API/tests/unit/test_archetype_loader.py
+++ b/tldw_Server_API/tests/unit/test_archetype_loader.py
@@ -114,6 +114,15 @@ class TestLoadArchetypesFromDirectory:
         assert len(result) == 1
         assert "researcher" in result
 
+    def test_yaml_with_non_string_archetype_keys_skipped(self, tmp_path: Path):
+        (tmp_path / "good.yaml").write_text(_VALID_YAML, encoding="utf-8")
+        (tmp_path / "bad.yaml").write_text("archetype:\n  1: bad\n", encoding="utf-8")
+
+        result = archetype_loader.load_archetypes_from_directory(tmp_path)
+
+        assert len(result) == 1
+        assert "researcher" in result
+
     def test_empty_directory(self, tmp_path: Path):
         result = archetype_loader.load_archetypes_from_directory(tmp_path)
 


### PR DESCRIPTION
## Summary
- guard the archetype loader when top-level `archetype` is present but not a mapping
- keep malformed files skippable instead of raising `TypeError`
- add a regression test covering `archetype: []`

## Verification
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/pr-1052-review-comments/tldw_Server_API/tests/unit/test_archetype_loader.py -q`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/pr-1052-review-comments/tldw_Server_API/app/core/Persona/archetype_loader.py -f json -o /tmp/bandit_pr1052_round2_prod.json`