### PR TITLE
Harden strict audit durability and fail-closed workflows

### DIFF
--- a/Docs/Code_Documentation/Guides/Audit_Module_Code_Guide.md
+++ b/Docs/Code_Documentation/Guides/Audit_Module_Code_Guide.md
@@ -47,6 +47,8 @@ This guide helps project developers understand the Audit module’s architecture
 - If metadata isn’t JSON-serializable, the service stores a redacted representation as `{ "redacted_text": "..." }`.
 - Heuristic risk scoring; high‑risk events trigger immediate flush.
 - Background tasks: periodic flush and daily cleanup (disabled in test mode).
+- Strict write support: callers can force durability with `flush(raise_on_failure=True)` and surface
+  `MandatoryAuditWriteError` for fail-closed security or state-changing paths.
 
 ### Key Types
 
@@ -92,6 +94,22 @@ Note: a legacy migration file exists for evaluation DB instrumentation (`tldw_Se
 - Storage rule: even when general audit storage mode is `per_user`, Sharing audit still uses the shared audit DB so `GET /api/v1/sharing/admin/audit` remains a practical cross-user query surface.
 - Compatibility surface: `GET /api/v1/sharing/admin/audit` is the required operator-facing endpoint for Sharing audit history. Generic `GET /api/v1/audit/*` surfaces may include Sharing naturally in shared mode, but they are not required to aggregate Sharing events in `per_user` mode.
 - Historical backfill: `tldw_Server_API/app/core/Sharing/share_audit_unified_migration.py` migrates legacy `share_audit_log` rows idempotently, preserves historical timestamps, and reserves legacy integer ids as the compatibility ids returned by the Sharing admin audit API.
+
+## AuthNZ API-Key Audit
+
+- Mandatory unified audit now applies to API-key management actions in `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`:
+  create, rotate, revoke, and virtual-key creation.
+- Helper boundary: `tldw_Server_API/app/core/AuthNZ/api_key_audit.py` writes those events through an isolated
+  audit service instance, flushes with `raise_on_failure=True`, and stops that isolated service immediately after
+  the write. This avoids unrelated buffered events in a cached service causing false failures for strict AuthNZ flows.
+- Actor/target context: strict API-key audit metadata always includes `target_user_id`, and admin-triggered actions
+  also include actor metadata (`actor_user_id`, `actor_subject`, `actor_kind`, `actor_roles`) when available.
+- Failure contract: HTTP surfaces that depend on these mandatory writes should translate `MandatoryAuditWriteError`
+  to `503 Service Unavailable`. Auth state changes must not commit successfully if the mandatory audit write fails.
+- Compatibility boundary: legacy `api_key_audit_log` rows remain a best-effort mirror for compatibility during the
+  transition, but unified audit is now the required source of truth for those management events.
+- Best-effort exception: API-key usage/touch auditing remains best-effort so an audit outage does not become an
+  authentication outage.
 
 ## Configuration
 
@@ -154,7 +172,8 @@ async def handler(audit_service: UnifiedAuditService = Depends(get_audit_service
 
 Tips:
 - Always set `AuditContext.user_id`, and when in HTTP, set `endpoint` and `method`.
-- For streaming paths, schedule audit writes with `asyncio.create_task(...)` to avoid blocking.
+- For best-effort streaming paths, schedule audit writes with `asyncio.create_task(...)` to avoid blocking.
+- For mandatory audit paths, await the write and `flush(raise_on_failure=True)` before reporting success.
 - For timing an operation, prefer `audit_operation(...)` context manager (it logs success/failure and duration).
 
 ## Programmatic API (service methods)
@@ -201,7 +220,11 @@ async with audit_operation(service, AuditEventType.DATA_READ, ctx,
 
 - Background tasks: periodic flush (`flush_interval`) and daily cleanup. Disabled in test mode to avoid busy loops.
 - DI layer caches per‑user services (LRU). On app shutdown, call `shutdown_all_audit_services()` (see `Audit_DB_Deps.py`).
+- `shutdown_all_audit_services()` returns an `AuditShutdownSummary` and is best-effort by default; pass
+  `raise_on_error=True` for targeted callers or tests that need shutdown failures surfaced.
 - The service enforces owner‑loop shutdown; DI helpers schedule safe cross‑loop shutdown.
+- `UnifiedAuditService.stop()` attempts a final durable spill of buffered events to the fallback queue before raising
+  if the last flush still cannot be persisted cleanly.
 
 ## Performance & Scaling
 
@@ -231,6 +254,8 @@ async with audit_operation(service, AuditEventType.DATA_READ, ctx,
 
 - DB locked / flush failures: service retries with backoff; worst‑case, events spill to a fallback JSONL file adjacent to the audit DB (per‑user under the audit directory when using DI; `./Databases/` when using the default constructor). Check logs for `flush_failures` and the persisted queue file.
 - Missing events: ensure `await flush()` is called before shutdown; prefer DI and `await stop()` on app shutdown.
+- Mandatory write failures: check for `MandatoryAuditWriteError` and confirm the caller is using an isolated or
+  otherwise clean audit service boundary before the strict `flush(raise_on_failure=True)` call.
 - PII not redacting: verify patterns and `AUDIT_PII_*` settings; confirm fields are strings or in `metadata`.
 - Slow queries: verify indexes were created (service creates on init); filter narrowing with indexed fields (`timestamp`, `context_*`, `event_type`, `category`).
 - Admin requirement: export/count endpoints enforce admin via claim-first dependencies (`require_roles("admin")` / `require_permissions(...)`); override those deps in tests accordingly.

--- a/Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md
+++ b/Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md
@@ -1,0 +1,873 @@
+# AuthNZ Full Module Review Execution Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Execute the approved full AuthNZ review and deliver one findings-first, evidence-backed report plus staged review artifacts covering core AuthNZ, immediate API integration points, representative claim-first consumers, tests, and documentation contracts.
+
+**Architecture:** This is a read-first, boundary-aware audit plan. Execution starts by locking the current workspace baseline, creating staged review artifacts under `Docs/superpowers/reviews/authnz-full-module/`, and fixing the final report contract before deep reading begins. It then inspects runtime authentication and authorization behavior, persistence and configuration safety, and test or documentation alignment, using only the smallest targeted verification needed to confirm or weaken specific claims. Narrow proof-of-fix patches are not pre-authored in this plan; if a critical localized issue is confirmed, preserve the pre-fix evidence and write a dedicated remediation plan for that exact defect instead of improvising code changes from the review plan.
+
+**Tech Stack:** Python 3, FastAPI, pytest, git, ripgrep, sed, Markdown
+
+---
+
+## Scope Lock
+
+Keep these decisions fixed during execution:
+
+- review the current working tree by default, not only `HEAD`
+- label any finding that depends on uncommitted local changes
+- keep code scope centered on `tldw_Server_API/app/core/AuthNZ`, `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`, and `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- inspect representative admin or control-surface endpoints only when they directly use claim-first AuthNZ dependencies, are high-fan-out consumers of AuthNZ behavior, or emerge as regression hotspots from current evidence
+- use `tldw_Server_API/tests/AuthNZ`, `tldw_Server_API/tests/AuthNZ_SQLite`, `tldw_Server_API/tests/AuthNZ_Postgres`, `tldw_Server_API/tests/AuthNZ_Unit`, and `tldw_Server_API/tests/AuthNZ_Federation` as the primary test evidence set
+- start documentation review from the bounded seed set in the approved spec and expand only when a seed document points to another behavior-defining contract
+- separate `Confirmed finding`, `Probable risk`, `Improvement`, and `Open question`
+- keep pre-fix evidence in the stage artifacts before any remediation branch is considered
+- do not modify repository source files during this review execution plan
+- do not run broad blanket suites; use the smallest targeted verification needed to answer a concrete claim
+- keep blind spots explicit instead of implying unreviewed enterprise, federation, or secret-backend paths are safe
+- if a dedicated review worktree is not already available, execute this plan in the current workspace and rely on the Stage 1 baseline to distinguish pre-existing local changes from reviewed behavior
+
+## Review File Map
+
+**Create during execution:**
+- `Docs/superpowers/reviews/authnz-full-module/README.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md`
+- `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage5-final-synthesis-roadmap-and-patch-decisions.md`
+
+**Spec and plan inputs:**
+- `Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md`
+- `Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md`
+
+**Primary documentation and contract references:**
+- `tldw_Server_API/app/core/AuthNZ/README.md`
+- `Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md`
+- `Docs/API-related/User_Registration_API_Documentation.md`
+- `Docs/Operations/Env_Vars.md`
+- `Docs/Getting_Started/QUICKSTART.md`
+- `Docs/Getting_Started/TROUBLESHOOTING.md`
+
+**Primary source files to inspect first:**
+- `tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py`
+- `tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py`
+- `tldw_Server_API/app/core/AuthNZ/jwt_service.py`
+- `tldw_Server_API/app/core/AuthNZ/session_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/token_blacklist.py`
+- `tldw_Server_API/app/core/AuthNZ/password_service.py`
+- `tldw_Server_API/app/core/AuthNZ/mfa_service.py`
+- `tldw_Server_API/app/core/AuthNZ/lockout_tracker.py`
+- `tldw_Server_API/app/core/AuthNZ/auth_governor.py`
+- `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/virtual_keys.py`
+- `tldw_Server_API/app/core/AuthNZ/permissions.py`
+- `tldw_Server_API/app/core/AuthNZ/rbac.py`
+- `tldw_Server_API/app/core/AuthNZ/org_rbac.py`
+- `tldw_Server_API/app/core/AuthNZ/orgs_teams.py`
+- `tldw_Server_API/app/core/AuthNZ/settings.py`
+- `tldw_Server_API/app/core/AuthNZ/database.py`
+- `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- `tldw_Server_API/app/core/AuthNZ/initialize.py`
+- `tldw_Server_API/app/core/AuthNZ/migrate_to_multiuser.py`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/auth.py`
+
+**Representative integration consumers to inspect only if selected by Stage 1 criteria:**
+- `tldw_Server_API/app/api/v1/endpoints/users.py`
+- `tldw_Server_API/app/api/v1/endpoints/privileges.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_sessions_mfa.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_orgs.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_registration.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_system.py`
+- `tldw_Server_API/app/api/v1/endpoints/admin/admin_settings.py`
+
+**Representative repository files to inspect during persistence review:**
+- `tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/sessions_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/token_blacklist_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/users_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/mfa_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/rbac_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/orgs_teams_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/quotas_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/rate_limits_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/user_provider_secrets_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/org_provider_secrets_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/byok_oauth_state_repo.py`
+- `tldw_Server_API/app/core/AuthNZ/repos/identity_provider_repo.py`
+
+**High-value existing tests to reuse during the review:**
+- `tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_jwt_service_rs256.py`
+- `tldw_Server_API/tests/AuthNZ/property/test_jwt_service_property.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_session_manager_configured_key.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_session_revocation_blacklist.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_session_manager_token_metadata.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_session_refresh_cache.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_lockout_tracker.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_api_keys.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_jwt_membership.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_auth_deps_precedence.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_jwt_happy_path.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_api_key_happy_path.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_state_consistency.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_real_rate_limiter.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_jwt_refresh_rotation_blacklist.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_single_user_claims_permissions.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_rbac_effective_permissions.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_mfa_service.py`
+- `tldw_Server_API/tests/AuthNZ_Postgres/test_auth_enhanced_mfa.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_deps.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_route_level.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_permissions_claim_first.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_claim_first_single_user_mode_guardrail.py`
+- `tldw_Server_API/tests/AuthNZ_Unit/test_admin_roles_single_user_claims.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_api_keys.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_lockout_scope.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_usage_truthiness.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_migrate_to_multiuser_review_fixes.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_api_keys_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_sessions_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_token_blacklist_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_quotas_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_rate_limits_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ/unit/test_authnz_orgs_teams_repo_backend_selection.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_sessions_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_token_blacklist_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_quotas_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_rate_limits_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_orgs_teams_repo_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_virtual_keys_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_byok_runtime_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ_SQLite/test_byok_rotation_sqlite.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_api_keys_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_token_blacklist_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_quotas_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_rate_limits_repo_postgres.py`
+- `tldw_Server_API/tests/AuthNZ/integration/test_authnz_orgs_teams_repo_postgres.py`
+
+**Scratch artifacts allowed during execution:**
+- `/tmp/authnz_full_review_inventory.txt`
+- `/tmp/authnz_full_runtime_pytest.log`
+- `/tmp/authnz_full_persistence_pytest.log`
+- `/tmp/authnz_full_contract_pytest.log`
+- `/tmp/authnz_full_verification_notes.md`
+
+## Stage Overview
+
+## Stage 1: Baseline and Boundary Inventory
+**Goal:** Lock the current workspace baseline, create stable review artifacts, inventory the exact scoped files, and fix the final findings contract before deep reading begins.
+**Success Criteria:** Review artifacts exist under `Docs/superpowers/reviews/authnz-full-module/`, the baseline and inventory are recorded, the representative endpoint selection rule is operationalized, and the final response contract is frozen.
+**Tests:** No pytest execution in this stage.
+**Status:** Not Started
+
+## Stage 2: Runtime Authentication and Authorization Analysis
+**Goal:** Inspect credential resolution, JWT and session behavior, endpoint dependency chains, claim-first authorization, and stateful login security controls first.
+**Success Criteria:** Runtime and authz candidate findings are tied to exact files, tests, and verification commands, with confirmed findings separated cleanly from probable risks.
+**Tests:** Run only the smallest runtime and authz test slices listed below that materially confirm or weaken candidate findings.
+**Status:** Not Started
+
+## Stage 3: Persistence, Migrations, and Configuration Safety
+**Goal:** Review settings precedence, database routing, migration safety, initialization paths, and backend-specific repository behavior.
+**Success Criteria:** SQLite or PostgreSQL divergence, schema or migration hazards, and fail-open or fail-closed configuration issues are documented with direct code evidence and representative test coverage.
+**Tests:** Run only the smallest persistence, repo, migration, or backend-selection test slices needed to settle specific claims.
+**Status:** Not Started
+
+## Stage 4: Tests, Docs Drift, and Verification Gaps
+**Goal:** Compare the reviewed runtime behavior against documentation claims and the actual AuthNZ test surface, then identify missing, weak, or misleading coverage.
+**Success Criteria:** Documentation drift and test gaps are ranked by operational or regression risk, and unverified enterprise or federation paths are explicitly downgraded when direct validation is not available.
+**Tests:** Run only the narrow contract tests needed to reconcile code, docs, and existing test claims.
+**Status:** Not Started
+
+## Stage 5: Final Synthesis, Roadmap, and Patch Decisions
+**Goal:** Deduplicate findings across stages, produce the final findings-first report and roadmap, and decide whether any issue warrants a separate remediation branch.
+**Success Criteria:** The final review output follows the approved structure, every major claim is backed by code inspection, test inspection, verification, or an explicit confidence downgrade, and any patch candidate is either rejected or spun into a separate remediation plan with pre-fix evidence preserved.
+**Tests:** No new blanket suites. Reuse earlier verification output and run only one last narrow slice if a single claim remains unresolved.
+**Status:** Not Started
+
+### Task 1: Prepare Review Artifacts and Capture the Baseline
+
+**Files:**
+- Create: `Docs/superpowers/reviews/authnz-full-module/README.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md`
+- Create: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage5-final-synthesis-roadmap-and-patch-decisions.md`
+- Inspect: `Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md`
+- Inspect: `Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md`
+- Test: none
+
+- [ ] **Step 1: Create the review output directory**
+
+Run:
+```bash
+mkdir -p Docs/superpowers/reviews/authnz-full-module
+```
+
+Expected: the `Docs/superpowers/reviews/authnz-full-module` directory exists and no application source files change.
+
+- [ ] **Step 2: Create one markdown file per stage with a fixed evidence template**
+
+Use these exact title lines and section headings:
+```markdown
+# Stage 1: Baseline and Boundary Inventory
+# Stage 2: Runtime Authentication and Authorization Analysis
+# Stage 3: Persistence, Migrations, and Configuration Safety
+# Stage 4: Tests, Docs Drift, and Verification Gaps
+# Stage 5: Final Synthesis, Roadmap, and Patch Decisions
+
+## Scope
+## Files Reviewed
+## Tests Reviewed
+## Docs Reviewed
+## Validation Commands
+## Confirmed Findings
+## Probable Risks
+## Improvements
+## Open Questions
+## Exit Note
+```
+
+- [ ] **Step 3: Write `Docs/superpowers/reviews/authnz-full-module/README.md`**
+
+Document:
+- the stage order `1 -> 2 -> 3 -> 4 -> 5`
+- the path to each stage report
+- the rule that confirmed findings come before probable risks and improvements
+- the rule that issues fixed later in a separate remediation branch must still remain visible in the review record
+- the rule that enterprise, federation, and secret-backend paths need explicit confidence downgrades when direct verification is unavailable
+- the canonical final response structure from Step 7
+
+- [ ] **Step 4: Capture the workspace baseline**
+
+Run:
+```bash
+git status --short
+git rev-parse --short HEAD
+git log --oneline -n 20 -- tldw_Server_API/app/core/AuthNZ tldw_Server_API/app/api/v1/API_Deps/auth_deps.py tldw_Server_API/app/api/v1/endpoints/auth.py
+```
+
+Expected: a clear baseline showing the current dirty-worktree state, the short `HEAD` hash, and the recent churn window for the scoped AuthNZ surface.
+
+- [ ] **Step 5: Capture the exact scoped inventory**
+
+Run:
+```bash
+{
+  rg --files tldw_Server_API/app/core/AuthNZ
+  printf '%s\n' \
+    tldw_Server_API/app/api/v1/API_Deps/auth_deps.py \
+    tldw_Server_API/app/api/v1/endpoints/auth.py \
+    tldw_Server_API/app/core/AuthNZ/README.md \
+    Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md \
+    Docs/API-related/User_Registration_API_Documentation.md \
+    Docs/Operations/Env_Vars.md \
+    Docs/Getting_Started/QUICKSTART.md \
+    Docs/Getting_Started/TROUBLESHOOTING.md
+  rg --files tldw_Server_API/tests/AuthNZ tldw_Server_API/tests/AuthNZ_SQLite tldw_Server_API/tests/AuthNZ_Postgres tldw_Server_API/tests/AuthNZ_Unit tldw_Server_API/tests/AuthNZ_Federation
+} | sort | tee /tmp/authnz_full_review_inventory.txt
+```
+
+Expected: one stable inventory file containing the scoped implementation, seed docs, and AuthNZ-focused test surface.
+
+- [ ] **Step 6: Select the representative integration consumers before deep reading**
+
+Run:
+```bash
+rg -n "get_auth_principal|require_permissions\\(|require_roles\\(" \
+  tldw_Server_API/app/api/v1/endpoints/users.py \
+  tldw_Server_API/app/api/v1/endpoints/privileges.py \
+  tldw_Server_API/app/api/v1/endpoints/admin \
+  | head -n 200
+```
+
+Expected: a bounded candidate list of claim-first consumers to sample later, without expanding into a general endpoint audit.
+
+- [ ] **Step 7: Freeze the final user-facing review output contract**
+
+Use this exact final response structure:
+```markdown
+## Findings
+### Confirmed findings
+- severity, confidence, file references, impact, and fix direction when clear
+
+### Probable risks
+- material issues not fully proven, with explicit confidence limits
+
+### Improvements
+- lower-priority hardening or maintainability suggestions
+
+## Open Questions
+- only unresolved ambiguities that materially affect confidence
+
+## Verification
+- files and docs inspected, tests run, and what remains unverified
+
+## Remediation Roadmap
+- immediate fixes
+- near-term hardening
+- structural refactors worth scheduling
+```
+
+- [ ] **Step 8: Write the Stage 1 baseline note**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md` must record:
+- the dirty-worktree baseline from Step 4
+- the short `HEAD` hash from Step 4
+- the inventory from Step 5
+- the candidate integration-consumer list from Step 6
+- the fixed final response structure from Step 7
+- the explicit statement that this review plan does not authorize source patches
+
+- [ ] **Step 9: Commit the review scaffold**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module Docs/superpowers/plans/2026-04-08-authnz-full-module-review-execution-plan.md
+git commit -m "docs: scaffold AuthNZ full-module review artifacts"
+```
+
+Expected: one docs-only commit captures the review workspace before stage findings are added.
+
+### Task 2: Execute Stage 2 Runtime Authentication and Authorization Analysis
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/jwt_service.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/session_manager.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/token_blacklist.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/password_service.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/mfa_service.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/lockout_tracker.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/auth_governor.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/virtual_keys.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/permissions.py`
+- Inspect: `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_jwt_service_rs256.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_session_manager_configured_key.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_session_revocation_blacklist.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_lockout_tracker.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_api_keys.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_jwt_membership.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_auth_deps_precedence.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_deps.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_route_level.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_permissions_claim_first.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_jwt_happy_path.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_api_key_happy_path.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_state_consistency.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_real_rate_limiter.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_jwt_refresh_rotation_blacklist.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_mfa_service.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Postgres/test_auth_enhanced_mfa.py`
+
+- [ ] **Step 1: Read the runtime auth source files in one bounded pass**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
+sed -n '1,260p' tldw_Server_API/app/api/v1/endpoints/auth.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/permissions.py
+```
+
+Expected: the credential-resolution order, endpoint dependency chain, and claim-first enforcement entry points are visible before deeper subsystem reading begins.
+
+- [ ] **Step 2: Read the stateful identity and token files**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/jwt_service.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/session_manager.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/token_blacklist.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/password_service.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/mfa_service.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/lockout_tracker.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/auth_governor.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/api_key_manager.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/virtual_keys.py
+```
+
+Expected: JWT handling, session lifecycle, lockout state, API-key validation, and MFA flow assumptions are visible enough to record candidate findings.
+
+- [ ] **Step 3: Read the highest-value runtime and authz tests before running anything**
+
+Run:
+```bash
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_session_revocation_blacklist.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_permissions_claim_first.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_state_consistency.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_jwt_refresh_rotation_blacklist.py
+```
+
+Expected: the strongest existing runtime contracts are visible before verification commands are chosen.
+
+- [ ] **Step 4: Write the Stage 2 artifact before executing tests**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md` must record:
+- the exact files reviewed
+- the tests reviewed from Steps 1 through 3
+- candidate findings grouped as confirmed only when code evidence is already conclusive
+- any likely runtime risks that still need verification
+- the exact verification commands selected in Steps 5 and 6
+
+- [ ] **Step 5: Run the smallest unit-level runtime verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_jwt_service_rs256.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_session_manager_configured_key.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_session_revocation_blacklist.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_lockout_tracker.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_api_keys.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_user_db_handling_jwt_membership.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_deps_precedence.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_deps.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_claim_route_level.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_permissions_claim_first.py \
+  | tee /tmp/authnz_full_runtime_pytest.log
+```
+
+Expected: primarily `PASSED`; any `FAILED` or `SKIPPED` result must be treated as evidence to investigate, not as a pass by implication.
+
+- [ ] **Step 6: Run the smallest integration-level runtime verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_jwt_happy_path.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_api_key_happy_path.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_principal_state_consistency.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_real_rate_limiter.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_login_lockout_via_auth_governor.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_jwt_refresh_rotation_blacklist.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_mfa_service.py \
+  tldw_Server_API/tests/AuthNZ_Postgres/test_auth_enhanced_mfa.py \
+  | tee -a /tmp/authnz_full_runtime_pytest.log
+```
+
+Expected: passing or explicitly skipped backend-sensitive results; any skip reason must be copied into the stage artifact as a confidence limit.
+
+- [ ] **Step 7: Update and commit the Stage 2 artifact**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md` must be updated with:
+- the executed commands from Steps 5 and 6
+- the observed pass, fail, or skip outcomes
+- confidence upgrades or downgrades based on those results
+- the exact line-level file references supporting each finding
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md
+git commit -m "docs: record AuthNZ runtime and authz review stage"
+```
+
+Expected: one docs-only commit preserves the runtime-auth stage findings before later stages reinterpret them.
+
+### Task 3: Execute Stage 3 Persistence, Migrations, and Configuration Safety
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/settings.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/database.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/initialize.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/migrate_to_multiuser.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/sessions_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/token_blacklist_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/users_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/mfa_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/rbac_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/orgs_teams_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/quotas_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/rate_limits_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/user_provider_secrets_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/org_provider_secrets_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/byok_oauth_state_repo.py`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/repos/identity_provider_repo.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_api_keys.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_lockout_scope.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_usage_truthiness.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_migrate_to_multiuser_review_fixes.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_api_keys_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_sessions_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_token_blacklist_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_quotas_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_rate_limits_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_authnz_orgs_teams_repo_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_initialize_single_user_invariant_repo_routing.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_sessions_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_token_blacklist_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_quotas_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_rate_limits_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_orgs_teams_repo_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_virtual_keys_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_byok_runtime_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ_SQLite/test_byok_rotation_sqlite.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_api_keys_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_token_blacklist_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_quotas_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_rate_limits_repo_postgres.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_authnz_orgs_teams_repo_postgres.py`
+
+- [ ] **Step 1: Read the configuration and bootstrap files**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/settings.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/database.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/initialize.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/migrate_to_multiuser.py
+```
+
+Expected: settings precedence, mode handling, DB initialization, and migration-entry assumptions are visible before repo or schema details are judged.
+
+- [ ] **Step 2: Read the migration and representative repository files**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/migrations.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/sessions_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/token_blacklist_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/rate_limits_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/quotas_repo.py
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/repos/orgs_teams_repo.py
+```
+
+Expected: representative persistence routing, schema evolution, and backend-selection patterns are visible enough to classify candidate risks.
+
+- [ ] **Step 3: Read the highest-value persistence and backend-selection tests before running them**
+
+Run:
+```bash
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_api_keys.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_migrate_to_multiuser_review_fixes.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_authnz_api_keys_repo_backend_selection.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_authnz_api_keys_repo_postgres.py
+```
+
+Expected: the strongest schema and repo-routing expectations are visible before verification commands are chosen.
+
+- [ ] **Step 4: Write the Stage 3 artifact before executing tests**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md` must record:
+- the exact files and docs reviewed
+- any suspected fail-open or fail-closed branches
+- any backend divergence questions that require verification
+- the exact verification commands selected in Steps 5 and 6
+
+- [ ] **Step 5: Run the smallest unit-level persistence verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_api_keys.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_pg_migrations_api_keys.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_lockout_scope.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_migrations_usage_truthiness.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_migrate_to_multiuser_review_fixes.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_api_keys_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_sessions_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_token_blacklist_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_quotas_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_rate_limits_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_authnz_orgs_teams_repo_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ/unit/test_initialize_single_user_invariant_repo_routing.py \
+  | tee /tmp/authnz_full_persistence_pytest.log
+```
+
+Expected: primarily `PASSED`; any backend-selection or migration failure becomes direct evidence to investigate, not a reason to skip the area.
+
+- [ ] **Step 6: Run the smallest backend-sensitive persistence verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_api_keys_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_sessions_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_token_blacklist_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_quotas_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_rate_limits_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_authnz_orgs_teams_repo_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_virtual_keys_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_byok_runtime_sqlite.py \
+  tldw_Server_API/tests/AuthNZ_SQLite/test_byok_rotation_sqlite.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_api_keys_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_sessions_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_token_blacklist_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_quotas_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_rate_limits_repo_postgres.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_authnz_orgs_teams_repo_postgres.py \
+  | tee -a /tmp/authnz_full_persistence_pytest.log
+```
+
+Expected: passing or explicitly skipped backend-sensitive results; any skip or environment limitation must be copied into the stage artifact as a confidence downgrade.
+
+- [ ] **Step 7: Update and commit the Stage 3 artifact**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md` must be updated with:
+- the executed commands from Steps 5 and 6
+- the observed pass, fail, or skip outcomes
+- any backend-specific confidence limits
+- exact line-level file references supporting each persistence finding
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md
+git commit -m "docs: record AuthNZ persistence and configuration review stage"
+```
+
+Expected: one docs-only commit preserves the persistence stage before test-gap synthesis begins.
+
+### Task 4: Execute Stage 4 Tests, Docs Drift, and Verification Gaps
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md`
+- Inspect: `tldw_Server_API/app/core/AuthNZ/README.md`
+- Inspect: `Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md`
+- Inspect: `Docs/API-related/User_Registration_API_Documentation.md`
+- Inspect: `Docs/Operations/Env_Vars.md`
+- Inspect: `Docs/Getting_Started/QUICKSTART.md`
+- Inspect: `Docs/Getting_Started/TROUBLESHOOTING.md`
+- Inspect: `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- Test: `tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py`
+- Test: `tldw_Server_API/tests/AuthNZ/property/test_auth_endpoints_property.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration.py`
+- Test: `tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_legacy_admin_shim_removed.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_optional_current_user_shim_removed.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_db_adapter_backend_selection.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver_mode_shim_removed.py`
+- Test: `tldw_Server_API/tests/Resource_Governance/test_auth_route_map_coverage.py`
+
+- [ ] **Step 1: Read the documentation seed set in one bounded pass**
+
+Run:
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/AuthNZ/README.md
+sed -n '1,260p' Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md
+sed -n '1,260p' Docs/API-related/User_Registration_API_Documentation.md
+sed -n '1,260p' Docs/Operations/Env_Vars.md
+sed -n '1,260p' Docs/Getting_Started/QUICKSTART.md
+sed -n '1,260p' Docs/Getting_Started/TROUBLESHOOTING.md
+```
+
+Expected: the currently documented auth contracts are visible before code-vs-doc drift is classified.
+
+- [ ] **Step 2: Map the doc claims back to code and test anchors**
+
+Run:
+```bash
+rg -n "AUTH_MODE|single-user|single_user|multi-user|multi_user|JWT|X-API-KEY|virtual key|virtual keys|claim-first|get_auth_principal|require_permissions|require_roles" \
+  tldw_Server_API/app/core/AuthNZ/README.md \
+  Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md \
+  Docs/API-related/User_Registration_API_Documentation.md \
+  Docs/Operations/Env_Vars.md \
+  Docs/Getting_Started/QUICKSTART.md \
+  Docs/Getting_Started/TROUBLESHOOTING.md \
+  tldw_Server_API/app/api/v1/API_Deps/auth_deps.py \
+  tldw_Server_API/app/api/v1/endpoints/auth.py
+```
+
+Expected: a concrete claim map that makes documentation drift and contract mismatches actionable instead of impressionistic.
+
+- [ ] **Step 3: Read the strongest contract and hardening tests before running them**
+
+Run:
+```bash
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/property/test_auth_endpoints_property.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_legacy_admin_shim_removed.py
+sed -n '1,240p' tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_optional_current_user_shim_removed.py
+sed -n '1,240p' tldw_Server_API/tests/Resource_Governance/test_auth_route_map_coverage.py
+```
+
+Expected: documented endpoint and dependency behavior is cross-checked against the tests that claim to enforce it before verification commands are chosen.
+
+- [ ] **Step 4: Write the Stage 4 artifact before executing tests**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md` must record:
+- the exact docs reviewed
+- candidate documentation drifts and test-gap hypotheses
+- which claims are already proven by code alone
+- which claims need the verification commands from Steps 5 and 6
+
+- [ ] **Step 5: Run the smallest contract-level verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py \
+  tldw_Server_API/tests/AuthNZ/property/test_auth_endpoints_property.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration.py \
+  tldw_Server_API/tests/AuthNZ/integration/test_auth_endpoints_integration_fixed.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_legacy_admin_shim_removed.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_optional_current_user_shim_removed.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_db_adapter_backend_selection.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_auth_principal_resolver_mode_shim_removed.py \
+  | tee /tmp/authnz_full_contract_pytest.log
+```
+
+Expected: passing or explicitly skipped contract checks; any failures or skips become direct evidence for drift, not noise to ignore.
+
+- [ ] **Step 6: Run the route-coverage verification slice**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/Resource_Governance/test_auth_route_map_coverage.py | tee -a /tmp/authnz_full_contract_pytest.log
+```
+
+Expected: one targeted confirmation of route-map coverage for auth surfaces, or a clear failure that must be recorded as a contract gap.
+
+- [ ] **Step 7: Update and commit the Stage 4 artifact**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md` must be updated with:
+- the executed commands from Steps 5 and 6
+- the observed pass, fail, or skip outcomes
+- ranked documentation drifts
+- ranked missing or weak test invariants
+- explicit blind spots for enterprise, federation, or secret-backend paths that were not strongly validated
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md
+git commit -m "docs: record AuthNZ docs and test-gap review stage"
+```
+
+Expected: one docs-only commit preserves the docs and coverage assessment before final synthesis begins.
+
+### Task 5: Execute Stage 5 Final Synthesis, Roadmap, and Patch Decisions
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage5-final-synthesis-roadmap-and-patch-decisions.md`
+- Inspect: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md`
+- Inspect: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md`
+- Inspect: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md`
+- Inspect: `Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md`
+- Test: none by default
+
+- [ ] **Step 1: Read and deduplicate the stage findings**
+
+Run:
+```bash
+sed -n '1,260p' Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage1-baseline-and-boundary-inventory.md
+sed -n '1,260p' Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage2-runtime-authentication-and-authorization-analysis.md
+sed -n '1,260p' Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage3-persistence-migrations-and-configuration-safety.md
+sed -n '1,260p' Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage4-tests-docs-drift-and-verification-gaps.md
+```
+
+Expected: one consolidated set of findings without duplicate issues or conflicting severity labels.
+
+- [ ] **Step 2: Write the Stage 5 synthesis artifact**
+
+`Docs/superpowers/reviews/authnz-full-module/2026-04-08-stage5-final-synthesis-roadmap-and-patch-decisions.md` must contain:
+```markdown
+# Stage 5 Final Synthesis
+
+## Highest-Confidence Findings
+## Probable Risks
+## Improvements
+## Open Questions
+## Verification Summary
+## Remediation Roadmap
+## Patch-Gate Decisions
+## Blind Spots / Not Reviewed
+```
+
+- [ ] **Step 3: Bucket the remediation roadmap**
+
+Use these exact roadmap buckets:
+- `Immediate fixes`
+- `Near-term hardening`
+- `Structural refactors worth scheduling`
+
+Every roadmap item must name the exact file or file group affected and state why the item belongs in that bucket.
+
+- [ ] **Step 4: Make the patch-gate decision explicitly**
+
+Use this exact decision matrix:
+```markdown
+- Not confirmed: no remediation branch
+- Confirmed but broad or product-dependent: roadmap only
+- Confirmed, critical, localized, and verifiable: preserve pre-fix evidence and write a separate remediation plan before any code change
+```
+
+Expected: the review does not silently drift into patching. Any code-fix branch is either rejected or broken into a fresh remediation plan with pre-fix evidence preserved.
+
+- [ ] **Step 5: Run one last verification command only if a single claim remains unresolved**
+
+Reuse exactly one already-defined command from Task 2 Step 5, Task 2 Step 6, Task 3 Step 5, Task 3 Step 6, Task 4 Step 5, or Task 4 Step 6. If no unresolved claim remains, record `No additional verification required` in the Stage 5 artifact instead of running more tests.
+
+Expected: no blanket reruns. Either one unresolved claim is settled, or the decision to stop is explicit.
+
+- [ ] **Step 6: Commit the final review artifacts**
+
+Run:
+```bash
+git add Docs/superpowers/reviews/authnz-full-module
+git commit -m "docs: finalize AuthNZ full-module review artifacts"
+```
+
+Expected: one docs-only commit preserves the final staged review record.
+
+## Self-Review Checklist
+
+- Verify that every stage from the approved spec maps to a task in this plan.
+- Verify that the stage artifact path and filenames match the approved review workspace contract.
+- Verify that the plan never authorizes ad hoc source patches during the review.
+- Verify that the final response structure in Task 1 matches the approved design.
+- Verify that every verification command is targeted and uses the project virtual environment.
+- Verify that enterprise, federation, and secret-backend blind spots are explicitly preserved if direct validation is weak.

--- a/Docs/superpowers/plans/2026-04-08-chat-module-audit-execution-plan.md
+++ b/Docs/superpowers/plans/2026-04-08-chat-module-audit-execution-plan.md
@@ -1,0 +1,538 @@
+# Chat Module Audit Execution Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Execute the approved Chat audit, gather targeted test evidence, and deliver a severity-ranked review covering the scoped Chat routes and shared `core/Chat` code.
+
+**Architecture:** The audit proceeds in fixed route groups. Each group freezes its route and test inventory first, performs static inspection second, runs targeted tests only where they validate ambiguous or risky behavior third, and records findings immediately in one review artifact so evidence and conclusions stay linked. No production code changes are planned during this execution unless the user explicitly pivots from review to remediation.
+
+**Tech Stack:** Python/FastAPI source inspection, `rg`, `sed`, `pytest`, repo-local markdown docs under `Docs/superpowers/*`
+
+---
+
+## File Map
+
+- Create: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md` - canonical audit artifact with scope, evidence log, route inventory, findings, open questions, and coverage gaps.
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_documents.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_service.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_orchestrator.py`
+- Inspect: `tldw_Server_API/app/core/Chat/streaming_utils.py`
+- Inspect: `tldw_Server_API/app/core/Chat/request_queue.py`
+- Inspect: `tldw_Server_API/app/core/Chat/rate_limiter.py`
+- Inspect: `tldw_Server_API/app/core/Chat/document_generator.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_store.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_approval.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_engine.py`
+- Inspect: `tldw_Server_API/app/core/Chat/validate_dictionary.py`
+- Inspect: `tldw_Server_API/app/core/Chat/README.md`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/provider_resolution.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/request_validation.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/stream_execution.py`
+- Test: `tldw_Server_API/tests/Chat`
+- Test: `tldw_Server_API/tests/Chat_NEW`
+- Test: `tldw_Server_API/tests/Chat_Workflows`
+- Test: `tldw_Server_API/tests/Streaming`
+- Test: `tldw_Server_API/tests/e2e/test_workspace_chat_scope.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_deps.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_permissions.py`
+
+### Task 1: Freeze Inventory And Create The Audit Artifact
+
+**Files:**
+- Create: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_documents.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- Test: `tldw_Server_API/tests/Chat`
+- Test: `tldw_Server_API/tests/Chat_NEW`
+- Test: `tldw_Server_API/tests/Chat_Workflows`
+- Test: `tldw_Server_API/tests/Streaming`
+
+- [ ] **Step 1: Create the review scaffold**
+
+```markdown
+# Chat Module Audit Findings
+
+## Scope
+- Spec: `Docs/superpowers/specs/2026-04-08-chat-module-review-design.md`
+- In scope: `chat.py`, `chat_documents.py`, `chat_loop.py`, `chat_grammars.py`, `chat_dictionaries.py`, `chat_workflows.py`, shared `core/Chat/*`
+- Out of scope: Character Chat, Chatbooks, unrelated provider internals
+
+## Evidence Log
+| Group | Routes | Static review | Targeted tests | Result | Notes |
+| --- | --- | --- | --- | --- | --- |
+
+## Route Inventory
+
+## Critical
+_None._
+
+## High
+_None._
+
+## Medium
+_None._
+
+## Low
+_None._
+
+## Open Questions
+
+## Coverage Gaps
+```
+
+- [ ] **Step 2: Freeze the route inventory**
+
+Run:
+
+```bash
+rg -n "@router\\.(get|post|patch|delete)\\(" \
+  tldw_Server_API/app/api/v1/endpoints/chat.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_documents.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_loop.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_grammars.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py \
+  tldw_Server_API/app/api/v1/endpoints/chat_workflows.py
+```
+
+Expected: a concrete decorator list for every scoped endpoint file. Copy the route groupings into the `Route Inventory` section before reading implementation details.
+
+- [ ] **Step 3: Freeze the test inventory**
+
+Run:
+
+```bash
+rg --files tldw_Server_API/tests | rg '(^|/)(Chat|Chat_NEW|Chat_Workflows|Streaming)/|workspace_chat_scope|chat_workflows_(deps|permissions)'
+```
+
+Expected: a bounded evidence list for the scoped review. Map each relevant file into the `Evidence Log`, and write `no direct route test found` for scoped routes that have no direct evidence file.
+
+- [ ] **Step 4: Verify the low-traffic routes are not skipped**
+
+Run:
+
+```bash
+rg -n "async def list_chat_commands|async def validate_chat_dictionary|async def create_chat_completion|async def get_chat_queue_status|async def get_chat_queue_activity|async def list_chat_conversations|async def get_chat_conversation|async def update_chat_conversation|async def get_conversation_tree|async def create_conversation_share_link|async def resolve_conversation_share_token|async def save_chat_knowledge|async def get_chat_analytics|async def persist_rag_context|async def get_rag_context|async def get_messages_with_rag_context|async def get_conversation_citations" \
+  tldw_Server_API/app/api/v1/endpoints/chat.py
+```
+
+Expected: every major `chat.py` route family appears in `Route Inventory` and has either a mapped test file or an explicit `coverage gap candidate` note.
+
+- [ ] **Step 5: Save the artifact before deeper review**
+
+Run:
+
+```bash
+git diff -- Docs/superpowers/reviews/2026-04-08-chat-module-review.md
+```
+
+Expected: the diff shows only the scaffold, route inventory, and evidence-log seed entries.
+
+### Task 2: Audit Main Chat Completion, Queue, And Streaming Behavior
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_service.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_orchestrator.py`
+- Inspect: `tldw_Server_API/app/core/Chat/streaming_utils.py`
+- Inspect: `tldw_Server_API/app/core/Chat/request_queue.py`
+- Inspect: `tldw_Server_API/app/core/Chat/rate_limiter.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/provider_resolution.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/request_validation.py`
+- Inspect: `tldw_Server_API/app/core/Chat/orchestrator/stream_execution.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_endpoint_helpers.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_service_call_params.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_service_normalization.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_request_queue.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_streaming_utils.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_service_queue_future.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_service_queue_estimate.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_queue_status_endpoint.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_queue_activity_endpoint.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_chat_endpoint_streaming_normalization.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py`
+
+- [ ] **Step 1: Read the command, validation, completion, and queue entry points**
+
+Run:
+
+```bash
+rg -n "async def list_chat_commands|async def validate_chat_dictionary|async def create_chat_completion|async def get_chat_queue_status|async def get_chat_queue_activity" \
+  tldw_Server_API/app/api/v1/endpoints/chat.py
+```
+
+Expected: exact entry-point line numbers for the scoped route group. Read each function body plus the helper calls it delegates to before writing any findings.
+
+- [ ] **Step 2: Read the shared core files behind those routes**
+
+Run:
+
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/Chat/chat_service.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/chat_orchestrator.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/streaming_utils.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/request_queue.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/rate_limiter.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/orchestrator/provider_resolution.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/orchestrator/request_validation.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/orchestrator/stream_execution.py
+```
+
+Expected: enough implementation context to judge auth flow, provider resolution, queue backpressure, streaming lifecycle, and error mapping. If a finding depends on code below these ranges, extend the read around the exact symbol before recording it.
+
+- [ ] **Step 3: Read the matching tests before running them**
+
+Run:
+
+```bash
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_endpoint_helpers.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_service_call_params.py
+sed -n '1,240p' tldw_Server_API/tests/Chat/unit/test_request_queue.py
+sed -n '1,240p' tldw_Server_API/tests/Chat/unit/test_streaming_utils.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/integration/test_chat_endpoint_streaming_normalization.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/unit/test_queue_status_endpoint.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/unit/test_queue_activity_endpoint.py
+```
+
+Expected: a clear view of what the current tests actually assert, not just their filenames.
+
+- [ ] **Step 4: Run the targeted unit tests for this route group**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat/unit/test_chat_endpoint_helpers.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_call_params.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_normalization.py \
+  tldw_Server_API/tests/Chat/unit/test_request_queue.py \
+  tldw_Server_API/tests/Chat/unit/test_streaming_utils.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_queue_future.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_service_queue_estimate.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_queue_status_endpoint.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_queue_activity_endpoint.py \
+  -v
+```
+
+Expected: tests collect and run. Record pass, fail, flaky, or blocked status in `Evidence Log`, and classify any failures as product defect, coverage gap, or environment issue.
+
+- [ ] **Step 5: Run the targeted integration tests for this route group**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat/integration/test_chat_endpoint.py \
+  tldw_Server_API/tests/Chat/integration/test_chat_endpoint_streaming_normalization.py \
+  tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py \
+  -v
+```
+
+Expected: integration coverage for request normalization, routing, and streaming behavior. Record the outcome exactly; do not treat a pass as proof that the code path is safe if static review still shows a defect.
+
+- [ ] **Step 6: Record route-group findings immediately**
+
+Add findings to `Docs/superpowers/reviews/2026-04-08-chat-module-review.md` using this template:
+
+```markdown
+### High: Streaming branch can leave queue state inconsistent on early disconnect
+- Files: `tldw_Server_API/app/api/v1/endpoints/chat.py:4471`, `tldw_Server_API/app/core/Chat/request_queue.py:1`
+- Why it matters: A primary chat path can leak state or mis-report active work under disconnect pressure.
+- Evidence: Static review of queue commit callback and disconnect path; targeted tests in `tldw_Server_API/tests/Chat/integration/test_chat_endpoint_streaming_normalization.py`
+- Recommendation: Tighten queue cleanup invariants and add an assertion around disconnect-driven cleanup.
+```
+
+- [ ] **Step 7: Promote missing evidence to explicit coverage gaps**
+
+Run:
+
+```bash
+rg -n "queue|stream|routing|disconnect" \
+  tldw_Server_API/tests/Chat \
+  tldw_Server_API/tests/Chat_NEW \
+  tldw_Server_API/tests/Streaming
+```
+
+Expected: enough evidence to say either `covered` or `coverage gap`. Do not leave risky behavior implied but unclassified.
+
+### Task 3: Audit Conversations, Share Links, Knowledge Save, Analytics, And RAG Context Routes
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_history.py`
+- Inspect: `tldw_Server_API/app/core/Chat/conversation_enrichment.py`
+- Inspect: `tldw_Server_API/app/core/Chat/message_utils.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_conversations_api.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_conversations_scope.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_share_links_api.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_knowledge_save.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_conversations_tree_analytics.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_knowledge_save.py`
+- Test: `tldw_Server_API/tests/e2e/test_workspace_chat_scope.py`
+
+- [ ] **Step 1: Read the conversation, sharing, knowledge, and RAG-context entry points**
+
+Run:
+
+```bash
+rg -n "async def save_chat_knowledge|async def list_chat_conversations|async def get_chat_conversation|async def update_chat_conversation|async def get_conversation_tree|async def create_conversation_share_link|async def list_conversation_share_links|async def revoke_conversation_share_link|async def resolve_conversation_share_token|async def get_chat_analytics|async def persist_rag_context|async def get_rag_context|async def get_messages_with_rag_context|async def get_conversation_citations" \
+  tldw_Server_API/app/api/v1/endpoints/chat.py
+```
+
+Expected: exact line numbers for every scoped route in this group. Read each implementation before reviewing the supporting helpers.
+
+- [ ] **Step 2: Read the shared helpers behind conversation and knowledge routes**
+
+Run:
+
+```bash
+sed -n '1,240p' tldw_Server_API/app/core/Chat/chat_history.py
+sed -n '1,240p' tldw_Server_API/app/core/Chat/conversation_enrichment.py
+sed -n '1,240p' tldw_Server_API/app/core/Chat/message_utils.py
+```
+
+Expected: enough context to evaluate ownership checks, persisted metadata shape, share-token handling, and enrichment side effects.
+
+- [ ] **Step 3: Read the direct tests and note missing route coverage**
+
+Run:
+
+```bash
+sed -n '1,240p' tldw_Server_API/tests/Chat/unit/test_chat_conversations_api.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_conversations_scope.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_share_links_api.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_knowledge_save.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_conversations_tree_analytics.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_knowledge_save.py
+sed -n '1,220p' tldw_Server_API/tests/e2e/test_workspace_chat_scope.py
+rg -n "persist_rag_context|get_rag_context|get_messages_with_rag_context|get_conversation_citations" \
+  tldw_Server_API/tests/Chat \
+  tldw_Server_API/tests/Chat_NEW \
+  tldw_Server_API/tests/e2e
+```
+
+Expected: either direct tests for the route or a concrete `no direct route test found` note in `Coverage Gaps`, especially for RAG-context and citations endpoints.
+
+- [ ] **Step 4: Run the targeted tests for this route group**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat/unit/test_chat_conversations_api.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_conversations_scope.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_share_links_api.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_knowledge_save.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_conversations_tree_analytics.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_knowledge_save.py \
+  tldw_Server_API/tests/e2e/test_workspace_chat_scope.py \
+  -v
+```
+
+Expected: direct evidence for conversation ownership, share-link handling, knowledge-save rollback behavior, analytics/tree routes, and workspace scoping. Record exact outcomes in the `Evidence Log`.
+
+- [ ] **Step 5: Record findings and explicit no-test gaps**
+
+Add new findings to `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`, and add a `Coverage Gaps` item for any scoped route that still lacks a direct assertion file after the `rg` check in Step 3.
+
+### Task 4: Audit Documents, Loop, Grammars, Dictionaries, And Workflows
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_documents.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- Inspect: `tldw_Server_API/app/core/Chat/document_generator.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_store.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_approval.py`
+- Inspect: `tldw_Server_API/app/core/Chat/chat_loop_engine.py`
+- Inspect: `tldw_Server_API/app/core/Chat/validate_dictionary.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_document_generation_endpoints.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_document_generator.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_workflows.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_dictionary_validate_endpoint.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_endpoints.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_dual_emit_compat.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_store.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_store_compaction.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_engine.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_approval.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py`
+- Test: `tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_api.py`
+- Test: `tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_service.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_deps.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_permissions.py`
+
+- [ ] **Step 1: Read the five adjacent endpoint modules**
+
+Run:
+
+```bash
+sed -n '1,260p' tldw_Server_API/app/api/v1/endpoints/chat_documents.py
+sed -n '1,220p' tldw_Server_API/app/api/v1/endpoints/chat_loop.py
+sed -n '1,220p' tldw_Server_API/app/api/v1/endpoints/chat_grammars.py
+sed -n '1,260p' tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py
+sed -n '1,260p' tldw_Server_API/app/api/v1/endpoints/chat_workflows.py
+```
+
+Expected: a route-level view of auth, ownership, exception handling, streaming, and persistence behavior for each adjacent surface.
+
+- [ ] **Step 2: Read the supporting core modules**
+
+Run:
+
+```bash
+sed -n '1,260p' tldw_Server_API/app/core/Chat/document_generator.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/chat_loop_store.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/chat_loop_approval.py
+sed -n '1,260p' tldw_Server_API/app/core/Chat/chat_loop_engine.py
+sed -n '1,220p' tldw_Server_API/app/core/Chat/validate_dictionary.py
+```
+
+Expected: enough context to judge state lifetime, approval flow, document-generation contract handling, and dictionary validation logic.
+
+- [ ] **Step 3: Read the direct tests before running them**
+
+Run:
+
+```bash
+sed -n '1,220p' tldw_Server_API/tests/Chat/integration/test_document_generation_endpoints.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py
+sed -n '1,220p' tldw_Server_API/tests/Chat/unit/test_chat_workflows.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_endpoints.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_dual_emit_compat.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_NEW/integration/test_chat_dictionary_validate_endpoint.py
+sed -n '1,220p' tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_api.py
+sed -n '1,220p' tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_permissions.py
+```
+
+Expected: a concrete understanding of what the current tests cover for each adjacent surface, including auth wiring and compatibility expectations.
+
+- [ ] **Step 4: Run the targeted tests for documents, grammars, and dictionaries**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat/integration/test_document_generation_endpoints.py \
+  tldw_Server_API/tests/Chat/unit/test_document_generator.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_dictionary_validate_endpoint.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_dictionary_validator.py \
+  -v
+```
+
+Expected: route-level evidence for document-generation contracts, saved grammar behavior, dictionary CRUD/validation, and llama.cpp grammar bridging.
+
+- [ ] **Step 5: Run the targeted tests for loop and workflows**
+
+Run:
+
+```bash
+source .venv/bin/activate
+TEST_MODE=1 python -m pytest \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_endpoints.py \
+  tldw_Server_API/tests/Chat_NEW/integration/test_chat_loop_dual_emit_compat.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_store.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_store_compaction.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_engine.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_loop_approval.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_workflows.py \
+  tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_api.py \
+  tldw_Server_API/tests/Chat_Workflows/test_chat_workflows_service.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_deps.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_chat_workflows_permissions.py \
+  -v
+```
+
+Expected: evidence for in-memory loop state behavior, approval flow, workflow route correctness, and permission wiring.
+
+- [ ] **Step 6: Record findings for each adjacent surface separately**
+
+Expected: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md` contains distinct findings or `no issue found in this pass` notes for documents, loop, grammars, dictionaries, and workflows. Do not collapse these into one generic section.
+
+### Task 5: Synthesize Cross-Cutting Risks And Prepare Delivery
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`
+- Inspect: `Docs/superpowers/specs/2026-04-08-chat-module-review-design.md`
+- Inspect: `Docs/superpowers/plans/2026-04-08-chat-module-audit-execution-plan.md`
+
+- [ ] **Step 1: Deduplicate and normalize the findings**
+
+Review `Docs/superpowers/reviews/2026-04-08-chat-module-review.md` and merge duplicate findings that point to the same root cause. Keep the strongest file/line references and preserve route-specific evidence in the bullet text.
+
+- [ ] **Step 2: Re-apply the severity rubric from the spec**
+
+Run:
+
+```bash
+sed -n '94,126p' Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
+```
+
+Expected: every finding in the review doc still matches the agreed `Critical` / `High` / `Medium` / `Low` rules.
+
+- [ ] **Step 3: Verify evidence completeness**
+
+Run:
+
+```bash
+rg -n "^## Evidence Log|^## Route Inventory|^## Critical|^## High|^## Medium|^## Low|^## Open Questions|^## Coverage Gaps" \
+  Docs/superpowers/reviews/2026-04-08-chat-module-review.md
+```
+
+Expected: the review artifact contains all required sections. Every route group from Task 1 should have an `Evidence Log` row and either a finding, a `no issue found in this pass` note, or a `coverage gap` note.
+
+- [ ] **Step 4: Prepare the user-facing review summary**
+
+Copy the final findings into this structure for the terminal response:
+
+```markdown
+## Findings
+### High: ...
+- Files: `path:line`
+- Risk: ...
+- Evidence: ...
+
+## Open Questions
+- ...
+
+## Coverage Gaps
+- ...
+```
+
+Expected: the final terminal response can be written directly from the review doc without re-reading the whole codebase.
+
+- [ ] **Step 5: Leave remediation as a separate follow-on**
+
+Add this line to the bottom of `Docs/superpowers/reviews/2026-04-08-chat-module-review.md`:
+
+```markdown
+Remediation is intentionally out of scope for this audit. If the user wants fixes, create a separate remediation plan from the finalized findings set.
+```
+
+Expected: the review remains an audit artifact, not an implicit refactor plan.

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md
@@ -1,0 +1,21 @@
+# Characters Backend Delta Review
+
+## Scope
+
+## Baseline Artifacts Checked
+
+## Code Paths Reviewed
+
+## Tests Reviewed
+
+## Validation Commands
+
+## Findings
+
+## Residual Risks / Open Questions
+
+## Coverage Gaps
+
+## Improvements
+
+## Exit Note

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md
@@ -2,20 +2,95 @@
 
 ## Scope
 
+- backend Character lifecycle and persistence
+- backend import/export and retrieval
+- backend chat-coupled behavior
+
 ## Baseline Artifacts Checked
+
+- Docs/superpowers/specs/2026-03-23-characters-backend-review-design.md
+- Docs/superpowers/reviews/characters-backend/2026-03-23-stage2-api-crud-versioning.md
+- Docs/superpowers/reviews/characters-backend/2026-03-23-stage3-import-validation-export.md
+- Docs/superpowers/reviews/characters-backend/2026-03-23-stage4-exemplars-worldbooks-search.md
+- Docs/superpowers/reviews/characters-backend/2026-03-23-stage5-chat-rate-limit-synthesis.md
+- Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md
 
 ## Code Paths Reviewed
 
+- tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py: lifecycle, import/export, versions, exemplars, and world-book routes
+- tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py: Character chat session creation, completion prep, greeting injection, memory injection, and routing
+- tldw_Server_API/app/api/v1/endpoints/character_messages.py: Character message persistence and message retrieval paths
+- tldw_Server_API/app/core/Character_Chat/modules/character_db.py: persistence normalization and lifecycle helpers
+- tldw_Server_API/app/core/Character_Chat/modules/character_io.py: import, export, and file-format handling
+- tldw_Server_API/app/core/Character_Chat/modules/character_chat.py: chat-coupled Character behavior
+- tldw_Server_API/app/core/Character_Chat/character_rate_limiter.py and character_limits.py: quota and throttle behavior
+- tldw_Server_API/app/core/Character_Chat/world_book_manager.py and app/core/Chat/chat_characters.py: retrieval and cross-module Character coupling
+- tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py: Character DB invariants, restore, revert, and version history
+- tldw_Server_API/app/api/v1/schemas/character_schemas.py and character_memory_schemas.py: request and response contracts
+
 ## Tests Reviewed
+
+- tldw_Server_API/tests/Characters/test_characters_endpoint.py
+- tldw_Server_API/tests/Characters/test_character_functionality_db.py
+- tldw_Server_API/tests/Characters/test_character_chat_lib.py
+- tldw_Server_API/tests/Characters/test_character_chat_greetings_api.py
+- tldw_Server_API/tests/Characters/test_ccv3_parser.py
+- tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_api.py
+- tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_auto_routing.py
+- tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py
+- tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_exemplars_api.py
+- tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py
+- tldw_Server_API/tests/Character_Chat_NEW/unit/test_world_book_manager.py
+- tldw_Server_API/tests/unit/test_character_rate_limiter.py
 
 ## Validation Commands
 
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Characters/test_characters_endpoint.py tldw_Server_API/tests/Characters/test_character_functionality_db.py tldw_Server_API/tests/Characters/test_character_chat_lib.py tldw_Server_API/tests/Characters/test_ccv3_parser.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_api.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_png_export.py -q` — fail
+- Failing test: `tldw_Server_API/tests/Characters/test_character_functionality_db.py::TestCharacterCardUpdate::test_empty_update_payload_remains_a_noop` (`TypeError: CharactersRAGDB.get_character_card_by_id() got an unexpected keyword argument 'include_deleted'`). The rest of the lifecycle/import-export slice completed cleanly enough to show no adjacent breakage around the current review findings.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_exemplars_api.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_world_book_manager.py tldw_Server_API/tests/ChaChaNotesDB/test_character_exemplars_db.py tldw_Server_API/tests/RAG/test_dual_backend_characters_retriever.py -q` — pass
+- Confidence gained: the targeted retrieval and world-book slice passed (`67 passed, 2 skipped`), so no new retrieval-sensitive Character regression was reproduced in this Stage 3 sample.
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Characters/test_character_chat_greetings_api.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_auto_routing.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py tldw_Server_API/tests/Character_Chat/unit/test_chat_session_character_scope_api.py tldw_Server_API/tests/unit/test_character_rate_limiter.py tldw_Server_API/tests/Streaming/test_character_chat_sse_unified_flag.py -q` — fail
+- Failing tests: `tldw_Server_API/tests/Streaming/test_character_chat_sse_unified_flag.py::test_character_chat_streaming_unified_sse`, `::test_character_chat_streaming_unified_sse_slow_async_heartbeat`, `::test_character_chat_streaming_unified_sse_provider_duplicate_done`, `::test_character_chat_streaming_unified_sse_chunk_limit`, `::test_character_chat_streaming_unified_sse_byte_limit`, and `::test_character_chat_streaming_unified_sse_provider_error_emits_done`, each bootstrapping into `GET /api/v1/characters/` returning `503`. The adjacent persist and rate-limit tests in that slice otherwise passed.
+
 ## Findings
+
+### Confirmed finding: manual character-memory extraction checks a conversation owner field that the conversations table does not store
+
+- Severity: Medium
+- Type: correctness
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/reviews/characters-backend/2026-03-23-stage5-chat-rate-limit-synthesis.md; Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md
+- Why it matters: The newer manual memory-extraction path can reject valid, owned chats before any extraction work starts, which leaves the character-memory feature unusable from its API surface even though the underlying storage and extraction helpers exist.
+- Current evidence: Direct-edge inspection included `tldw_Server_API/app/api/v1/endpoints/character_memory.py:231-235`, where manual extraction authorizes against `conversation.get("user_id")`, and the adjacent unit coverage in `tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_memory.py`, which does not exercise the endpoint ownership check. That read was compared against the conversations schema and conversation write/read paths, which store and expose conversation ownership through `client_id` rather than `user_id` (`tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py:744-756`, `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py:19310-19399`). None of the reviewed Character backend tests exercise `/characters/{character_id}/memories/extract`, so this mismatch is currently unguarded.
+- Targeted validation note: None of the executed Stage 3 pytest slices covered `/api/v1/characters/{character_id}/memories/extract` or the endpoint ownership branch in `character_memory.py`, so runtime confirmation was not feasible within this task's prescribed test set.
+- Validation status: environment-limited, confidence unchanged
+
+### Probable risk: streamed assistant persistence skips message-cap enforcement when quota checks fail internally
+
+- Severity: Medium
+- Type: correctness
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/reviews/characters-backend/2026-03-23-stage5-chat-rate-limit-synthesis.md; Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md
+- Why it matters: This candidate is narrower than the March Stage 5 quota issue. The historical finding was about non-atomic count-then-check enforcement under concurrency; this delta item is about a distinct fail-open exception path in the newer streamed-persist write flow, where internal quota-check failures do not stop persistence.
+- Current evidence: `persist_streamed_assistant_message()` catches non-HTTP exceptions around `count_messages_for_conversation()` and `check_message_limit()` and only logs before continuing at `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py:6098-6105`. That is a separate failure mode from the March Stage 5 non-atomic enforcement review and it differs from the direct message-send path, which converts the same counting failure into `503` at `tldw_Server_API/app/api/v1/endpoints/character_messages.py:263-281`. The reviewed streaming persistence tests only cover happy-path persistence and speaker metadata, not quota-failure behavior (`tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py`).
+- Targeted validation note: The executed chat slice did hit `/api/v1/chats/{chat_id}/completions/persist` happy-path coverage and nearby limiter coverage, but it did not inject a `count_messages_for_conversation()` or `check_message_limit()` exception through the persist endpoint. The same slice also produced unrelated SSE bootstrap failures from `test_character_chat_sse_unified_flag.py`, where `GET /api/v1/characters/` returned `503` before the streaming assertions ran.
+- Validation status: not reproduced by targeted pytest slice, downgraded to probable risk
 
 ## Residual Risks / Open Questions
 
+- The March review set did not cover the newer character-memory API surface directly, so any broader claims about memory CRUD beyond the ownership mismatch above still need targeted runtime validation.
+- `character_chat_sessions.py` now carries process-local memory-extraction counters, and the static pass cannot tell whether their lifecycle is acceptable under multi-worker or long-running workloads without Stage 3 runtime checks.
+
 ## Coverage Gaps
+
+- No reviewed test exercises `/api/v1/characters/{character_id}/memories/extract`, so the conversation-ownership contract for manual character-memory extraction is currently untested.
+- No reviewed test forces `count_messages_for_conversation()` or rate-limiter failures through `/api/v1/chats/{chat_id}/completions/persist`, so the persist endpoint's fail-open branch is unguarded.
 
 ## Improvements
 
+- Add an endpoint regression test for manual character-memory extraction that uses a real chat session and asserts ownership is checked against the conversation field actually stored by `ChaChaNotes_DB`.
+- Add a persist-endpoint regression test that injects a message-count or limiter failure and asserts the API returns `503` instead of persisting the assistant reply.
+
 ## Exit Note
+
+Backend validation complete. All surviving confirmed findings now have either executed support or a clearly stated reason why runtime confirmation was not feasible in this environment.

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md
@@ -1,0 +1,21 @@
+# Characters Frontend Delta Review
+
+## Scope
+
+## Baseline Artifacts Checked
+
+## Code Paths Reviewed
+
+## Tests Reviewed
+
+## Validation Commands
+
+## Findings
+
+## Residual Risks / Open Questions
+
+## Coverage Gaps
+
+## Improvements
+
+## Exit Note

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md
@@ -2,20 +2,86 @@
 
 ## Scope
 
+- frontend Character workspace
+- frontend Character chat integration
+- frontend Character API client and shared utilities
+
 ## Baseline Artifacts Checked
+
+- Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md
+- Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md
+- Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md
 
 ## Code Paths Reviewed
 
+- apps/tldw-frontend/pages/characters.tsx and pages/settings/characters.tsx: route entry points and dynamic loading
+- apps/packages/ui/src/routes/option-characters.tsx: route-level Character workspace composition
+- apps/packages/ui/src/components/Option/Characters/Manager.tsx, CharactersWorkspace.tsx, CharacterEditorForm.tsx, CharacterDialogs.tsx, CharacterListContent.tsx, and CharacterGalleryCard.tsx: workspace state, editing, list rendering, dialogs, and gallery behavior
+- apps/packages/ui/src/components/Option/Characters/import-state-model.ts, search-utils.ts, and tag-manager-utils.ts: Character workspace state helpers and pure logic
+- apps/packages/ui/src/components/Option/Characters/hooks/useCharacterData.tsx, useCharacterCrud.tsx, useCharacterImportQueue.tsx, useCharacterVersionHistory.tsx, and useCharacterQuickChat.tsx: async data flow and workspace actions
+- apps/packages/ui/src/components/Common/CharacterSelect.tsx and components/Sidepanel/Chat/CharacterSelect.tsx: shared Character selection behavior
+- apps/packages/ui/src/hooks/useSelectedCharacter.ts, useCharacterGreeting.ts, hooks/chat/useCharacterChatMode.ts, hooks/chat/useServerChatLoader.ts, and hooks/chat/useSelectServerChat.ts: Character selection and chat-state synchronization
+- apps/packages/ui/src/services/tldw/domains/characters.ts: frontend API client normalization, fallbacks, and cache behavior
+- apps/packages/ui/src/utils/characters-route.ts, character-greetings.ts, character-mood.ts, default-character-preference.ts, selected-character-storage.ts, and character-export.ts: routing, greeting resolution, persistence helpers, and export shaping
+
 ## Tests Reviewed
+
+- apps/packages/ui/src/components/Option/Characters/__tests__/Manager.first-use.test.tsx
+- apps/packages/ui/src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx
+- apps/packages/ui/src/components/Option/Characters/__tests__/CharacterGalleryCard.test.tsx
+- apps/packages/ui/src/components/Option/Characters/__tests__/import-state-model.test.ts
+- apps/packages/ui/src/components/Option/Characters/__tests__/search-utils.test.ts
+- apps/packages/ui/src/components/Option/Characters/__tests__/tag-manager-utils.test.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.characters-list-all.test.ts
+- apps/packages/ui/src/services/__tests__/tldw-api-client.characters-delete.test.ts
+- apps/packages/ui/src/hooks/__tests__/useCharacterGreeting.test.tsx
+- apps/packages/ui/src/hooks/__tests__/useServerChatLoader.test.ts
+- apps/packages/ui/src/utils/__tests__/character-greetings.test.ts
+- apps/packages/ui/src/utils/__tests__/character-mood.test.ts
+- apps/packages/ui/src/utils/__tests__/default-character-preference.test.ts
+- apps/packages/ui/src/utils/__tests__/characters-route.test.ts
+- apps/tldw-frontend/e2e/workflows/tier-2-features/characters.spec.ts
+- apps/tldw-frontend/e2e/workflows/journeys/character-chat.spec.ts
 
 ## Validation Commands
 
+- `cd apps/packages/ui && bun run test -- src/components/Option/Characters/__tests__/Manager.first-use.test.tsx src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx src/components/Option/Characters/__tests__/CharacterGalleryCard.test.tsx src/components/Option/Characters/__tests__/import-state-model.test.ts src/components/Option/Characters/__tests__/search-utils.test.ts src/services/__tests__/tldw-api-client.characters-list-all.test.ts src/services/__tests__/tldw-api-client.characters-delete.test.ts src/hooks/__tests__/useCharacterGreeting.test.tsx src/hooks/__tests__/useServerChatLoader.test.ts src/utils/__tests__/character-greetings.test.ts src/utils/__tests__/character-mood.test.ts src/utils/__tests__/default-character-preference.test.ts src/utils/__tests__/characters-route.test.ts --maxWorkers=1` — environment-limited
+- No targeted UI tests executed. This checkout lacks a usable local frontend workspace install for the prescribed `apps/packages/ui` command path, so `bun run test` resolved to `vitest run` but could not execute it cleanly in this workspace and exited with `/bin/bash: vitest: command not found`.
+- `cd apps/tldw-frontend && bun run e2e:pw -- e2e/workflows/tier-2-features/characters.spec.ts e2e/workflows/journeys/character-chat.spec.ts --reporter=line` — environment-limited
+- No Character browser assertions executed. This workspace lacks a usable local frontend tool install for the prescribed `apps/tldw-frontend` command path, so `bun run e2e:pw` fell through to the non-repo binary `/Users/appledev/Documents/GitHub/tldw_server/3.13/bin/playwright`, which reported `unknown command 'test'`.
+
 ## Findings
 
-## Residual Risks / Open Questions
+### Probable risk: Character workspace handoffs store a truncated character selection payload
 
-## Coverage Gaps
+- Severity: Medium
+- Type: correctness
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md; Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md; Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md
+- Why it matters: Before the selected character is replaced with a hydrated server record, cross-surface consumers only see the reduced handoff payload. In that pre-hydration window, alternate greetings and `extensions`-backed mood portraits are unavailable even though downstream chat UI reads those fields from the selected character state.
+- Current evidence: `apps/packages/ui/src/components/Option/Characters/utils.ts:764-782` builds the workspace handoff payload with only `id`, `name`, `system_prompt`, `greeting`, and `avatar_url`; `apps/packages/ui/src/components/Option/Characters/hooks/useCharacterCrud.tsx:483-497` uses that payload for chat entry and `apps/packages/ui/src/components/Option/Characters/hooks/useCharacterQuickChat.tsx:37-54` duplicates it for quick-chat promotion. Downstream, `apps/packages/ui/src/hooks/useCharacterGreeting.ts:331-388` reads greeting variants from `selectedCharacter` first and only later fetches and merges the full record, while `apps/packages/ui/src/components/Common/CharacterSelect.tsx:306-308` and `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx:353-358` derive mood images from `selectedCharacter?.extensions`. The audited baseline artifacts define Character UX goals, but none describe or constrain this selection-payload handoff, so the novelty claim is anchored to current code paths rather than implied recent churn.
+- Validation status: environment-limited, confidence unchanged
 
-## Improvements
+### Probable risk: Quick-chat promotion does not seed server-chat assistant metadata before navigation
+
+- Severity: Medium
+- Type: correctness
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md; Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md; Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md
+- Why it matters: Promoting a quick-chat thread into the main chat route appears to leave a transient pre-hydration window where the server chat id is set but the assistant metadata has not yet been seeded. Any UI that gates character-specific behavior on `serverChatCharacterId` or assistant kind can therefore briefly evaluate against incomplete server-chat metadata before eager metadata loading fills it in.
+- Current evidence: `apps/packages/ui/src/components/Option/Characters/hooks/useCharacterQuickChat.tsx:265-305` sets `serverChatId`, state, topic, cluster/source/externalRef, history, and messages, but does not set `serverChatCharacterId`, `serverChatAssistantKind`, or `serverChatAssistantId`. `apps/packages/ui/src/components/Sidepanel/Chat/body.tsx:237-244` disables character identity whenever `serverChatId` exists and `serverChatCharacterId` is null. The recovery path is also visible statically: `apps/packages/ui/src/hooks/useMessage.tsx:281-305` eagerly reloads chat metadata when `serverChatId` exists and `serverChatMetaLoaded` is false, and `apps/packages/ui/src/hooks/chat/useServerChatLoader.ts:728-737` applies the metadata backfill setters after resolving `getChat(...)` data. The audited baseline artifacts do not contain comparable guidance for quick-chat promotion metadata seeding, so the novelty label is anchored to this currently reviewed frontend path.
+- Validation status: environment-limited, confidence unchanged
+
+### Confirmed finding: The character chat E2E journey does not validate character selection or prompt propagation
+
+- Severity: Medium
+- Type: test gap
+- Novelty: net-new
+- Baseline artifacts checked: Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md; Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md; Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md
+- Why it matters: The named journey test currently appears to cover the main create-character to chat flow, but it does not prove that the created character is selected in chat or that its system prompt reaches the completion request. That leaves the primary cross-feature integration path effectively unguarded despite a reassuring spec name.
+- Current evidence: `apps/tldw-frontend/e2e/workflows/journeys/character-chat.spec.ts:1-79` states that it selects the character and verifies system prompt inclusion, yet the body only creates a character, navigates to `/chat`, sends a generic message, and checks request status. No step selects the created character and no assertion inspects the request payload. The adjacent E2E coverage in `apps/tldw-frontend/e2e/workflows/tier-2-features/characters.spec.ts:1-133` covers page load, create, and delete only, so there is no directly relevant browser-level test in the reviewed suite that closes this create-character-to-chat selection and prompt-propagation gap. The audited baseline artifacts describe Character/chat UX goals, but none provide a comparable frontend baseline for this specific journey assertion.
+- Validation status: environment-limited, confidence unchanged
 
 ## Exit Note
+
+Frontend validation complete. All surviving confirmed findings now have either targeted test support or a clearly stated reason why browser-level confirmation was not feasible in this environment.

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md
@@ -1,0 +1,17 @@
+# Characters Full-Stack Delta Synthesis
+
+## Backend Findings
+
+## Frontend Findings
+
+## Cross-Layer Contract Drift
+
+## Open Questions / Residual Risks
+
+## Coverage Gaps
+
+## Improvement Opportunities
+
+## Verification Summary
+
+## Prioritized Next Steps

--- a/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md
@@ -2,16 +2,59 @@
 
 ## Backend Findings
 
+- Confirmed finding: manual character-memory extraction authorizes against `conversation.get("user_id")`, while Character conversations are stored and verified against `client_id`. That makes `/api/v1/characters/{character_id}/memories/extract` vulnerable to rejecting valid owned chats until the ownership field is aligned.
+- Probable risk: streamed assistant persistence in [character_chat_sessions.py](/Users/appledev/Documents/GitHub/tldw_server/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py) catches internal quota-check exceptions and continues persisting the assistant reply instead of failing closed. Adjacent targeted pytest slices did not reproduce the branch directly, so it remains a probable backend-only risk.
+
 ## Frontend Findings
+
+- Probable risk: Character workspace handoffs store a truncated selected-character payload with only `id`, `name`, `system_prompt`, `greeting`, and `avatar_url`. Consumers such as greeting resolution and mood portrait rendering also read `selectedCharacter.extensions` and alternate greeting fields, so the pre-hydration window can degrade Character-specific UI state.
+- Probable risk: quick-chat promotion sets `serverChatId` and navigates before seeding `serverChatCharacterId`, `serverChatAssistantKind`, or `serverChatAssistantId`. Frontend recovery depends on a later `getChat()` metadata load, so Character identity can be briefly disabled during the handoff.
+- Confirmed finding: the named Character journey spec still does not select the created character in chat or assert that the Character system prompt reaches `/chat/completions`. The reviewed browser suite therefore leaves the primary Character-to-chat path unguarded even though the spec name implies coverage.
+- Stage 5 frontend validation did not add runtime evidence. This checkout lacks a usable local frontend workspace install for the prescribed `apps/packages/ui` command path, so `bun run test` resolved to `vitest run` but could not execute it cleanly in this workspace. This workspace also lacks a usable local frontend tool install for the prescribed `apps/tldw-frontend` command path, so `bun run e2e:pw` fell through to `/Users/appledev/Documents/GitHub/tldw_server/3.13/bin/playwright`, which reported `unknown command 'test'`.
 
 ## Cross-Layer Contract Drift
 
+- Assistant identity metadata is the highest-risk contract seam. The backend persists and returns `character_id`, `assistant_kind`, and `assistant_id` for chat sessions in [character_chat_sessions.py](/Users/appledev/Documents/GitHub/tldw_server/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py), and the frontend loader in [useServerChatLoader.ts](/Users/appledev/Documents/GitHub/tldw_server/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts) reconstructs Character identity from exactly those fields. Quick-chat promotion bypasses that contract temporarily by only setting `serverChatId`, so the UI falls into a local pre-hydration state that the backend never explicitly models.
+- Selected-character payload shape is another drift seam. The backend `GET /api/v1/characters/{character_id}` contract returns the full character document, while frontend handoff helpers can seed a reduced local object first and rely on later hydration. Any UI path that reads the selected-character cache before hydration is therefore operating on a weaker contract than the backend actually serves.
+- The Character list/query surface is intentionally defensive on the frontend. [characters.ts](/Users/appledev/Documents/GitHub/tldw_server/apps/packages/ui/src/services/tldw/domains/characters.ts) falls back between `/api/v1/characters`, `/api/v1/characters/`, and `/api/v1/characters/query` when it sees 404/405/422 or `path.character_id` parsing errors, while the backend currently exposes both `/` and `/query` plus `versions`, `revert`, `restore`, and `world-books` routes. That fallback reduces breakage but is also evidence that this contract has already been route-order-sensitive enough to require client-side recovery logic.
+- Message speaker metadata looks aligned today but remains drift-sensitive. The backend persists `speaker_character_id` and `speaker_character_name` in streamed/persisted message metadata, and the frontend loader maps those fields back into chat messages for identity and mood rendering. The current review did not find a mismatch there, but there is also no targeted full-stack test covering it.
+
 ## Open Questions / Residual Risks
+
+- It is still unverified whether the truncated selected-character handoff produces a visible user-facing regression in the main chat route before the full character fetch completes, or whether the hydration window is usually too short to notice.
+- It is still unverified whether quick-chat promotion can race badly enough in production for Character identity gating in the sidepanel body to suppress Character-specific rendering during navigation.
+- The manual memory-extraction ownership mismatch remains runtime-unconfirmed because the approved backend slices did not include `/api/v1/characters/{character_id}/memories/extract`.
+- The streamed assistant persistence risk remains branch-unconfirmed because no targeted test injected a `count_messages_for_conversation()` or limiter failure into `/api/v1/chats/{chat_id}/completions/persist`.
 
 ## Coverage Gaps
 
+- The prescribed frontend Vitest slice could not run in `apps/packages/ui` because this checkout lacks a usable local frontend workspace install for that command path, so none of the targeted Character unit/integration tests produced fresh Stage 5 evidence.
+- The prescribed frontend Playwright slice could not run in `apps/tldw-frontend` because this workspace lacks a usable local frontend tool install for that command path and `bun run e2e:pw` fell through to `/Users/appledev/Documents/GitHub/tldw_server/3.13/bin/playwright`, so no browser-level evidence was added for the Character workspace or Character chat flows.
+- The existing Character journey E2E still does not assert Character selection or system-prompt propagation into `/chat/completions`.
+- No reviewed frontend or full-stack test proves that quick-chat promotion seeds assistant metadata before navigation.
+- No reviewed frontend or full-stack test proves that selected-character handoffs preserve alternate greetings, `extensions`, or mood assets before hydration.
+- No reviewed backend test covers the manual memory-extraction ownership branch or the streamed persist fail-open quota path.
+
 ## Improvement Opportunities
+
+- Restore a usable local frontend workspace/tool install for the prescribed `bun run test` and `bun run e2e:pw` command paths in this checkout so the targeted Character validation commands execute against repo-local tooling.
+- Add a narrow frontend regression test around Character handoff payload shape, either by preserving the richer selected-character object up front or by codifying that downstream consumers must tolerate pre-hydration truncation.
+- Add a quick-chat promotion regression that asserts `serverChatCharacterId`, `serverChatAssistantKind`, and `serverChatAssistantId` are seeded before navigation when a server chat id is promoted into the main chat experience.
+- Strengthen the Character journey E2E so it explicitly selects the created character and inspects the `/chat/completions` payload for Character prompt propagation.
+- Add backend endpoint tests for `/api/v1/characters/{character_id}/memories/extract` ownership and `/api/v1/chats/{chat_id}/completions/persist` quota-check failures.
 
 ## Verification Summary
 
+- Frontend targeted validation attempted:
+- `cd apps/packages/ui && bun run test -- src/components/Option/Characters/__tests__/Manager.first-use.test.tsx src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx src/components/Option/Characters/__tests__/CharacterGalleryCard.test.tsx src/components/Option/Characters/__tests__/import-state-model.test.ts src/components/Option/Characters/__tests__/search-utils.test.ts src/services/__tests__/tldw-api-client.characters-list-all.test.ts src/services/__tests__/tldw-api-client.characters-delete.test.ts src/hooks/__tests__/useCharacterGreeting.test.tsx src/hooks/__tests__/useServerChatLoader.test.ts src/utils/__tests__/character-greetings.test.ts src/utils/__tests__/character-mood.test.ts src/utils/__tests__/default-character-preference.test.ts src/utils/__tests__/characters-route.test.ts --maxWorkers=1` failed before discovery because this checkout lacks a usable local frontend workspace install for that command path, so `bun run test` resolved to `vitest run` but could not execute it cleanly in this workspace.
+- `cd apps/tldw-frontend && bun run e2e:pw -- e2e/workflows/tier-2-features/characters.spec.ts e2e/workflows/journeys/character-chat.spec.ts --reporter=line` failed at bootstrap because this workspace lacks a usable local frontend tool install for that command path, so `bun run e2e:pw` fell through to `/Users/appledev/Documents/GitHub/tldw_server/3.13/bin/playwright`, which reported `unknown command 'test'`.
+- Contract comparison executed with `rg -n "/api/v1/characters|/characters/query|character_id|versions|revert|restore|world-books|speaker_character|assistant_kind" ...` across the prescribed backend and frontend files. That comparison confirmed that frontend assistant identity and route fallbacks are explicitly keyed to backend Character/chat response fields.
+- Backend evidence was carried forward from the completed review in [2026-04-08-backend-review.md](/Users/appledev/Documents/GitHub/tldw_server/Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md), including one confirmed backend correctness issue and one surviving probable backend risk.
+
 ## Prioritized Next Steps
+
+1. Restore a usable local frontend workspace/tool install for the exact prescribed Vitest and Playwright Character command paths so those slices can run and either confirm or downgrade the two runtime-sensitive frontend risks.
+2. Expand the Character journey E2E to assert actual Character selection and prompt propagation into `/chat/completions`; that closes the largest current full-stack coverage gap.
+3. Add a focused regression for quick-chat promotion metadata seeding, because that is the clearest frontend/backend contract seam around `assistant_kind`, `assistant_id`, and `character_id`.
+4. Add a focused regression for selected-character handoff fidelity or explicitly narrow the supported pre-hydration contract so greeting and mood consumers are not reading fields the handoff does not preserve.
+5. Add backend endpoint tests for manual memory extraction ownership and streamed persistence quota failure so the surviving backend items move from static risk to directly exercised behavior.

--- a/Docs/superpowers/reviews/characters-fullstack-delta/README.md
+++ b/Docs/superpowers/reviews/characters-fullstack-delta/README.md
@@ -1,0 +1,24 @@
+# Characters Full-Stack Delta Review
+
+## Stage Order
+
+1. Baseline and artifact setup
+2. Backend delta static pass
+3. Backend targeted validation
+4. Frontend delta static pass
+5. Frontend targeted validation and cross-layer synthesis
+6. Final synthesis and handoff
+
+## Review Artifacts
+
+- `Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-backend-review.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-frontend-review.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/2026-04-08-synthesis.md`
+
+## Rules
+
+- Findings are written before remediation ideas.
+- Historical findings are not re-reported as current unless they still appear live.
+- Every reported finding includes a baseline artifact note.
+- Uncertain items are labeled as `Probable risk` or `Open question`, not overstated as confirmed defects.
+- Backend, frontend, and cross-layer findings stay separate until the final synthesis.

--- a/Docs/superpowers/specs/2026-04-08-audit-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-audit-module-review-design.md
@@ -1,0 +1,217 @@
+# Audit Module Review Design
+
+Date: 2026-04-08
+Status: Approved for planning
+Owner: Codex brainstorming session
+
+## Summary
+
+Run a deep, reliability-first review of the Audit subsystem in `tldw_server`.
+
+The review covers:
+
+- the core Audit service
+- dependency injection and lifecycle management
+- export and count endpoints
+- storage mode and tenant scoping behavior
+- migration and fallback durability paths
+- representative cross-module audit emitters and adapters
+- dedicated Audit tests plus selected integration tests that exercise audit behavior
+
+The output must prioritize actionable findings over commentary, with bugs and risks clearly separated from hardening suggestions.
+
+## Problem
+
+The Audit subsystem is a compliance and operational reliability surface. If it is wrong, the likely failures are not cosmetic. They are event loss, incomplete shutdown flushes, fallback queue corruption, tenant-boundary mistakes in shared mode, or export behavior that becomes unsafe under load.
+
+The module is also spread across several layers:
+
+- core logic in `tldw_Server_API/app/core/Audit/`
+- DI and lifecycle code in `tldw_Server_API/app/api/v1/API_Deps/`
+- REST endpoints in `tldw_Server_API/app/api/v1/endpoints/`
+- emitters and adapters across AuthNZ, Chat, Embeddings, Evaluations, Jobs, Sharing, MCP, and related backend surfaces
+
+Because the behavior is distributed, a useful review needs explicit slices, an evidence bar, and a narrow definition of what counts as a finding.
+
+## Goals
+
+- Produce a severity-ordered Audit review with actionable findings.
+- Optimize for reliability and operational risk rather than style.
+- Inspect both the Audit core and representative integrations.
+- Use static inspection and targeted test execution as evidence.
+- Separate `Confirmed issue`, `Likely risk`, and `Improvement suggestion`.
+- Identify important testing gaps where reliability-sensitive behavior is weakly protected.
+
+## Non-Goals
+
+- Refactor the Audit module during the review.
+- Expand the pass into a general backend style review.
+- Treat passing tests as proof that a code path is safe.
+- Propose broad architecture rewrites unless needed to explain a concrete issue.
+
+## Scope Confirmed With User
+
+The user approved the broader review scope rather than narrowing to only the Audit core package.
+
+The confirmed scope includes:
+
+- deep review depth
+- reliability and operational risk as the main optimization target
+- findings-first output with separate improvements
+
+## Review Baseline
+
+The review will inspect the current working tree by default.
+
+If a finding depends on uncommitted local changes, the review must say so explicitly instead of presenting the behavior as if it were clean `HEAD`.
+
+## Recommended Approach
+
+Use a risk-led layered review.
+
+Three candidate approaches were considered:
+
+1. Risk-led layered review
+2. Test-led review
+3. Integration-led review
+
+The recommended choice is the risk-led layered review because it is the most reliable way to surface silent-loss, shutdown, tenant-boundary, and export-scaling failures before test coverage biases the outcome.
+
+## Inspection Slices
+
+### 1. Core Service and Migration Reliability
+
+Inspect:
+
+- buffering and flush semantics
+- high-risk immediate flush logic
+- background-task behavior
+- shutdown guarantees
+- schema creation and initialization
+- retention cleanup
+- fallback queue append behavior
+- shared/per-user storage handling
+- migration resumability and partial-failure behavior
+
+Primary files:
+
+- `tldw_Server_API/app/core/Audit/unified_audit_service.py`
+- `tldw_Server_API/app/core/Audit/audit_shared_migration.py`
+
+### 2. DI, Lifecycle, and Tenancy
+
+Inspect:
+
+- per-user instance caching
+- eviction and reuse semantics
+- owner-loop and cross-loop shutdown behavior
+- request user binding
+- shared storage enablement and rollback precedence
+- DB path resolution
+- tenant scoping assumptions
+
+Primary files:
+
+- `tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py`
+- `tldw_Server_API/app/core/DB_Management/db_path_utils.py`
+- `tldw_Server_API/app/core/config.py`
+
+### 3. Export, Filtering, and Admin Access
+
+Inspect:
+
+- timestamp parsing
+- enum and filter mapping
+- stream versus non-stream behavior
+- row-limit and truncation logic
+- filename sanitization
+- access-control assumptions
+- tenant visibility rules in shared mode
+
+Primary file:
+
+- `tldw_Server_API/app/api/v1/endpoints/audit.py`
+
+### 4. Cross-Module Emitters and Adapter Consistency
+
+Sample high-value producers and adapters to find:
+
+- missing or inconsistent `AuditContext`
+- missing or incorrect user scoping
+- unsafe fire-and-forget audit writes
+- swallowed audit failures
+- inconsistent event naming or category mapping
+- brittle behavior in shutdown or error paths
+
+Priority integration areas:
+
+- AuthNZ
+- Chat
+- Embeddings
+- Evaluations
+- Jobs
+- Sharing
+- MCP
+- RAG-adjacent or governance surfaces when they materially rely on unified audit behavior
+
+### 5. Coverage and Drift
+
+Use dedicated Audit tests and selected integration tests to establish what behavior is actually protected, then identify where reliability-sensitive paths appear weakly covered or untested.
+
+Priority gap areas:
+
+- shutdown races
+- fallback durability and locking
+- shared-storage tenant edges
+- large export behavior
+- migration recovery and resumability
+- cross-module contract drift
+
+## Evidence Model
+
+Every review item must be labeled as one of:
+
+- `Confirmed issue`
+- `Likely risk`
+- `Improvement suggestion`
+
+Classification rules:
+
+- `Confirmed issue`: concrete failure mode in code, contract mismatch, or reproducible behavior from tests
+- `Likely risk`: credible concern with weak coverage or configuration-dependent behavior, but not fully proven
+- `Improvement suggestion`: non-bug hardening work that reduces fragility or operator pain
+
+Each finding must include:
+
+- exact file references
+- whether evidence came from static inspection, targeted test execution, or both
+- whether the behavior depends on the dirty worktree rather than only committed code
+
+## Deliverable Shape
+
+The final review should be concise and findings-first, using this structure:
+
+## Findings
+
+- severity-ordered issues and likely risks with file references and evidence notes
+
+## Open Questions / Assumptions
+
+- only unresolved items that materially affect confidence
+
+## Improvements
+
+- non-bug hardening suggestions kept separate from bug findings
+
+## Verification
+
+- baseline reviewed
+- tests run
+- important files inspected
+- anything left unverified
+
+## Verification Strategy
+
+Run the dedicated Audit tests plus selected integration tests that directly exercise audit behavior. Test execution is evidence of covered behavior, not proof of global correctness.
+
+The review should prefer representative test slices over blanket unrelated suite execution.

--- a/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
@@ -55,6 +55,13 @@ Representative endpoint and test entry points should include at least:
 - `tldw_Server_API/tests/AuthNZ/unit/`
 - `tldw_Server_API/tests/AuthNZ/property/`
 
+Representative admin/authz endpoint selection should favor:
+
+- endpoints that issue, refresh, revoke, or invalidate credentials
+- endpoints that mutate RBAC, roles, permissions, or admin-only state
+- endpoints whose protection depends on shared AuthNZ dependencies rather than local ad hoc checks
+- an adjacent non-auth endpoint only when it is needed to confirm that AuthNZ enforcement is actually applied at a real caller boundary
+
 Expansion beyond the initial hotspot set should be justified by one or more of:
 
 - high fan-out into other AuthNZ flows
@@ -168,6 +175,10 @@ The resulting review should be a concise, prioritized audit report with:
 2. Probable risks or open questions that materially affect confidence
 3. Improvements that would reduce future AuthNZ regression risk
 4. Brief residual-risk notes where coverage or runtime verification remains incomplete
+5. A coverage note listing:
+   - hotspot files reviewed directly
+   - files or tests only spot-checked
+   - notable scoped surfaces not reviewed deeply and why
 
 ## Success Criteria
 

--- a/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
@@ -1,5 +1,9 @@
 # AuthNZ Bug And Test-Gap Audit Design
 
+Date: 2026-04-08
+Topic: Bug-and-test-gap audit of AuthNZ runtime behavior
+Status: Revised after spec self-review
+
 ## Overview
 
 This review will audit the AuthNZ subsystem in `tldw_server` for bugs, unsafe edge cases, and missing or weak tests. The goal is not a broad style review. The goal is a prioritized findings report that identifies concrete correctness and security risks, then maps those risks to the test coverage that should exist.
@@ -16,6 +20,7 @@ This review will audit the AuthNZ subsystem in `tldw_server` for bugs, unsafe ed
 - No broad refactor proposal unless it directly addresses a bug pattern or persistent test gap.
 - No style-only review.
 - No review of unrelated modules outside AuthNZ and its directly related auth/admin entry points.
+- No remediation or code changes during the audit unless explicitly requested in a later step.
 
 ## Audit Scope
 
@@ -25,6 +30,38 @@ The audit covers:
 - `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
 - Related auth and admin API endpoints that depend on AuthNZ enforcement paths
 - AuthNZ integration, unit, and property tests that exercise those paths
+
+Initial hotspot files should include at least:
+
+- `tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py`
+- `tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py`
+- `tldw_Server_API/app/core/AuthNZ/jwt_service.py`
+- `tldw_Server_API/app/core/AuthNZ/session_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/permissions.py`
+- `tldw_Server_API/app/core/AuthNZ/rbac.py`
+- `tldw_Server_API/app/core/AuthNZ/settings.py`
+- `tldw_Server_API/app/core/AuthNZ/database.py`
+- `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/auth.py`
+
+Representative endpoint and test entry points should include at least:
+
+- auth endpoints under `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- representative admin/authz endpoints that materially depend on claim-first enforcement
+- `tldw_Server_API/tests/AuthNZ/integration/`
+- `tldw_Server_API/tests/AuthNZ/unit/`
+- `tldw_Server_API/tests/AuthNZ/property/`
+
+Expansion beyond the initial hotspot set should be justified by one or more of:
+
+- high fan-out into other AuthNZ flows
+- recent churn or repeated regressions
+- backend divergence between SQLite and PostgreSQL
+- privileged or externally reachable behavior
+- unusually large or multi-responsibility implementations
 
 The audit will treat the following areas as highest-risk surfaces:
 
@@ -71,6 +108,13 @@ Compare the high-risk behaviors from the first three passes against current Auth
 - tests that mock away the exact logic that should be verified
 - coverage that exists at unit level but not at integration boundaries
 
+### Pass 5: Evidence Cross-Check
+
+Use recent git history, the most relevant docs, and targeted verification only where they materially change confidence in a suspected issue. This pass exists to prevent two failure modes:
+
+- reporting stale-doc mismatches as defects when the runtime contract already changed intentionally
+- reporting probable risks as confirmed bugs when the critical branch or backend divergence has not been validated
+
 ## Prioritization Model
 
 Findings will be ranked by operational impact:
@@ -85,26 +129,45 @@ Each finding should include:
 
 - title
 - severity
+- confidence
+- classification
 - affected file and exact line reference
 - concrete failure mode
 - reason the behavior is risky or incorrect
 - current test coverage status
 - specific test that should be added or strengthened
 
+Classification should be one of:
+
+- Confirmed finding
+- Probable risk
+- Improvement
+
 ## Evidence Standards
 
 - Prefer direct code-path evidence over inference.
 - Use tests to confirm intended behavior when the implementation alone is ambiguous.
 - Treat inconsistencies between endpoint wiring, dependency logic, and test assumptions as findings when they could hide real regressions.
+- Perform targeted runtime verification when a high-risk claim depends on stateful behavior, backend divergence, or ambiguous guard execution and the answer is feasible to verify locally.
+- Be explicit when a conclusion is limited by unavailable runtime verification or fixture constraints.
 - Keep the final output focused on findings first. Any summary should be secondary.
+
+Targeted runtime verification is especially appropriate for:
+
+- refresh rotation and revocation behavior
+- lockout and rate-limit state transitions
+- SQLite versus PostgreSQL divergence on the same reviewed path
+- test-mode or environment-guard branches
+- endpoint-level enforcement where the dependency chain is unclear from static inspection alone
 
 ## Deliverable
 
 The resulting review should be a concise, prioritized audit report with:
 
-1. Findings ordered by severity
-2. Open questions or assumptions that affected confidence
-3. Brief residual-risk notes where coverage or runtime verification remains incomplete
+1. Confirmed findings ordered by severity
+2. Probable risks or open questions that materially affect confidence
+3. Improvements that would reduce future AuthNZ regression risk
+4. Brief residual-risk notes where coverage or runtime verification remains incomplete
 
 ## Success Criteria
 

--- a/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-bug-test-gap-audit-design.md
@@ -1,0 +1,116 @@
+# AuthNZ Bug And Test-Gap Audit Design
+
+## Overview
+
+This review will audit the AuthNZ subsystem in `tldw_server` for bugs, unsafe edge cases, and missing or weak tests. The goal is not a broad style review. The goal is a prioritized findings report that identifies concrete correctness and security risks, then maps those risks to the test coverage that should exist.
+
+## Goals
+
+- Produce a prioritized set of findings focused on real bugs, regressions, and unsafe behavior.
+- Include missing-test and weak-test findings when they materially increase regression risk.
+- Cover the runtime path from request authentication through authorization and stateful session/key handling.
+- Keep findings grounded in exact code references and current project behavior.
+
+## Non-Goals
+
+- No broad refactor proposal unless it directly addresses a bug pattern or persistent test gap.
+- No style-only review.
+- No review of unrelated modules outside AuthNZ and its directly related auth/admin entry points.
+
+## Audit Scope
+
+The audit covers:
+
+- `tldw_Server_API/app/core/AuthNZ/`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- Related auth and admin API endpoints that depend on AuthNZ enforcement paths
+- AuthNZ integration, unit, and property tests that exercise those paths
+
+The audit will treat the following areas as highest-risk surfaces:
+
+- Single-user vs multi-user auth branching
+- JWT parsing, validation, refresh, and revocation
+- Session lifecycle and blacklist behavior
+- API key validation, rotation, and scope enforcement
+- Admin and privileged endpoint protection
+- RBAC and permission resolution
+- Lockout, rate limit, quota, and governor interactions
+- Test mode and environment guardrails
+
+## Review Method
+
+The review will use a risk-driven method with a test-gap overlay.
+
+### Pass 1: Trust Boundary Review
+
+Inspect the request entry points where principals are resolved and privileged routes are gated. Focus on authentication precedence, token/key parsing, mode-specific behavior, and any branches that could bypass intended checks.
+
+### Pass 2: Stateful Flow Review
+
+Trace flows that depend on mutable state:
+
+- login
+- refresh rotation
+- session validation and revocation
+- token blacklist usage
+- API key lifecycle
+- lockout and rate-limit state transitions
+
+The purpose of this pass is to catch correctness bugs that emerge only when state changes across requests.
+
+### Pass 3: Authorization Review
+
+Inspect how permissions are derived, propagated, and enforced across auth/admin endpoints. Focus on privilege escalation risks, incorrect default behavior, inconsistent permission checks, and org/team/admin edge cases.
+
+### Pass 4: Test-Gap Review
+
+Compare the high-risk behaviors from the first three passes against current AuthNZ tests. Flag:
+
+- behavior with no direct test coverage
+- tests that assert happy paths but not failure paths
+- tests that mock away the exact logic that should be verified
+- coverage that exists at unit level but not at integration boundaries
+
+## Prioritization Model
+
+Findings will be ranked by operational impact:
+
+- High: auth bypass, privilege escalation, revocation failure, broken admin enforcement, unsafe test-mode or environment behavior
+- Medium: correctness bugs that deny valid access, break refresh or lockout flows, or create inconsistent authorization outcomes
+- Low: missing tests, brittle abstractions, duplicate enforcement paths, or maintainability issues likely to cause future regressions
+
+## Finding Format
+
+Each finding should include:
+
+- title
+- severity
+- affected file and exact line reference
+- concrete failure mode
+- reason the behavior is risky or incorrect
+- current test coverage status
+- specific test that should be added or strengthened
+
+## Evidence Standards
+
+- Prefer direct code-path evidence over inference.
+- Use tests to confirm intended behavior when the implementation alone is ambiguous.
+- Treat inconsistencies between endpoint wiring, dependency logic, and test assumptions as findings when they could hide real regressions.
+- Keep the final output focused on findings first. Any summary should be secondary.
+
+## Deliverable
+
+The resulting review should be a concise, prioritized audit report with:
+
+1. Findings ordered by severity
+2. Open questions or assumptions that affected confidence
+3. Brief residual-risk notes where coverage or runtime verification remains incomplete
+
+## Success Criteria
+
+This audit is successful if it:
+
+- identifies real, code-backed AuthNZ risks instead of generic advice
+- distinguishes bugs from lower-signal cleanup suggestions
+- maps important gaps in tests to the behaviors they fail to protect
+- gives the maintainer a clear order of operations for follow-up fixes

--- a/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
@@ -1,0 +1,326 @@
+# AuthNZ Full Module Review Design
+
+Date: 2026-04-08
+Topic: Full AuthNZ module deep review with remediation roadmap
+Status: Approved design
+
+## Objective
+
+Review the AuthNZ surface in `tldw_server` for concrete bugs, security issues,
+correctness problems, documentation drift, test gaps, and maintainability risks
+with a deep, evidence-first audit.
+
+The review should produce a ranked findings report and a prioritized remediation
+roadmap. Unlike narrower prior AuthNZ reviews, this run explicitly includes the
+core AuthNZ module, its immediate API integration points, and the tests and docs
+that define or describe current behavior.
+
+This review is allowed to include small proof-of-fix patches, but only for
+confirmed critical issues where the remediation is localized and can be verified
+without forcing a risky redesign during the audit.
+
+## Scope
+
+This review is centered on:
+
+- `tldw_Server_API/app/core/AuthNZ`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/auth.py`
+- representative admin or control-surface endpoints that materially depend on
+  AuthNZ claim-first enforcement
+- AuthNZ-focused tests and adjacent tests that validate AuthNZ runtime behavior
+- documentation that claims current AuthNZ behavior
+
+This includes:
+
+- authentication entry points and credential resolution
+- authorization and claim-first dependency enforcement
+- JWT issuance, validation, scoping, rotation, and revocation assumptions
+- session lifecycle and blacklist behavior
+- password, reset, email verification, MFA, API key, and virtual key flows
+- rate limit, quota, lockout, and budget guardrails where they are part of the
+  AuthNZ runtime contract
+- settings precedence, mode and profile handling, startup and initialization
+  behavior, and backend-specific persistence paths
+- migration and schema safety across SQLite and PostgreSQL
+- test coverage quality and documentation accuracy for the reviewed behavior
+
+This review excludes:
+
+- a full platform-wide endpoint audit outside AuthNZ-driven behavior
+- broad product UX critique
+- speculative rewrites that are not supported by concrete evidence
+- large remediation refactors during the review itself
+
+## Approaches Considered
+
+### Recommended: Layered risk audit
+
+Map trust boundaries first, then inspect the highest-risk AuthNZ internals and
+their integration points, and finally compare implementation behavior against
+tests and docs before writing findings.
+
+Why this is preferred:
+
+- it matches the user’s request for a deep audit plus roadmap
+- it surfaces security and authz failures before lower-value cleanup
+- it reduces the chance of missing issues hidden between core services and API
+  dependencies
+- it supports selective proof-of-fix patches without turning the review into a
+  rewrite
+
+### Alternative: Surface-first audit
+
+Inspect architecture, the largest files, and representative endpoints, then
+spot-check tests and docs.
+
+Trade-offs:
+
+- faster
+- useful for a quick health scan
+- weaker for edge-case runtime failures and persistence or migration hazards
+
+### Alternative: Endpoint-first behavior audit
+
+Start from `/api/v1/auth*`, `auth_deps.py`, and the current tests, then trace
+back into core AuthNZ services.
+
+Trade-offs:
+
+- strong for externally visible regressions
+- strong for auth and authz contract mismatches
+- weaker for dormant but dangerous internals such as migrations, settings
+  precedence, and backend divergence
+
+## Chosen Method
+
+Use the recommended layered risk audit with five ordered passes:
+
+1. `Boundary map`
+   Identify authentication entry points, authorization gates, trust boundaries,
+   secret and key handling, and mode or profile switches.
+2. `Runtime correctness`
+   Inspect credential resolution, session lifecycle, JWT or API-key behavior,
+   RBAC and claim enforcement, and stateful security controls.
+3. `Persistence and configuration safety`
+   Review settings precedence, startup and initialization behavior, DB
+   abstractions, migrations, and SQLite or PostgreSQL divergence.
+4. `Evidence cross-check`
+   Compare suspicious or high-risk behavior against tests, recent commits, and
+   current docs to distinguish confirmed defects from assumptions, stale docs,
+   or already-covered invariants.
+5. `Findings and remediation synthesis`
+   Produce a ranked review report and roadmap, and apply only narrowly scoped
+   proof-of-fix patches for confirmed critical issues that satisfy the patch
+   gate below.
+
+## Evidence Model
+
+The review will rely on:
+
+- direct source inspection of the scoped AuthNZ code and immediate integration
+  points
+- direct inspection of AuthNZ-focused tests across:
+  - `tldw_Server_API/tests/AuthNZ`
+  - `tldw_Server_API/tests/AuthNZ_SQLite`
+  - `tldw_Server_API/tests/AuthNZ_Postgres`
+  - `tldw_Server_API/tests/AuthNZ_Unit`
+  - `tldw_Server_API/tests/AuthNZ_Federation`
+- targeted caller inspection when an AuthNZ behavior is only meaningful in its
+  API dependency or endpoint context
+- targeted documentation inspection where docs claim current runtime behavior
+- recent git history when it helps explain regression-prone areas or newly
+  changed contracts
+
+The review is evidence-first, not style-first. A concern becomes a reported
+finding only when there is concrete support from code, tests, docs drift that
+creates real risk, or targeted verification.
+
+Runtime verification may be used selectively when it materially strengthens or
+weakens a specific claim. It should answer narrow questions such as:
+
+- whether a suspicious branch is actually exercised
+- whether a contract claimed by docs or tests no longer matches code
+- whether a critical invariant fails under current fixtures
+- whether SQLite and PostgreSQL behavior diverge on a reviewed path
+
+If verification cannot be run, the limitation should be stated explicitly and
+the issue should remain a probable risk unless source evidence is already
+conclusive.
+
+## Review Focus Areas
+
+The review order inside the scoped surface should bias toward:
+
+- credential resolution order and ambiguity between single-user key auth,
+  multi-user JWT auth, API keys, and virtual keys
+- claim-first authorization and the risk of mode-based bypasses
+- token creation, validation, revocation, refresh rotation, and blacklist usage
+- session lifecycle, encrypted token storage, key management, and revocation
+  consistency
+- password, reset, verification, MFA, and lockout behavior
+- API key and virtual key issuance, validation, scoping, quotas, and budgets
+- settings precedence, fail-open or fail-closed behavior, and deployment-mode
+  coordination
+- backend-specific persistence, migration safety, and schema harmonization
+- docs drift and test gaps on high-risk auth and authz contracts
+- maintainability problems in very large files where blurred boundaries are
+  likely to create future defects
+
+Initial hotspot files should include at least:
+
+- `tldw_Server_API/app/core/AuthNZ/User_DB_Handling.py`
+- `tldw_Server_API/app/core/AuthNZ/auth_principal_resolver.py`
+- `tldw_Server_API/app/core/AuthNZ/jwt_service.py`
+- `tldw_Server_API/app/core/AuthNZ/session_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- `tldw_Server_API/app/core/AuthNZ/permissions.py`
+- `tldw_Server_API/app/core/AuthNZ/settings.py`
+- `tldw_Server_API/app/core/AuthNZ/database.py`
+- `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`
+- `tldw_Server_API/app/api/v1/endpoints/auth.py`
+
+Representative expansion beyond the hotspot set should be driven by one or more
+of these signals:
+
+- high fan-out
+- recent churn or repeated regressions
+- security sensitivity
+- backend divergence
+- unusually large or multi-responsibility implementations
+
+## Findings Model
+
+The final report should present findings first, ordered by severity.
+
+Each observation should be classified as one of:
+
+### Confirmed finding
+
+A concrete bug, vulnerability, contract mismatch, persistence hazard, or design
+problem supported directly by code, tests, docs drift with operational risk, or
+targeted verification.
+
+### Probable risk
+
+Something that appears unsafe, brittle, or likely wrong but depends on
+assumptions that are not fully proven within the reviewed evidence.
+
+### Improvement
+
+A maintainability, hardening, or architectural simplification opportunity that
+would reduce future risk but is not itself strong evidence of a current defect.
+
+Each reported item should include:
+
+- severity
+- confidence
+- concise description of the failure mode or risk
+- why it matters
+- concrete file references
+
+## Severity Model
+
+Severity should be weighted primarily by:
+
+- security and privilege-escalation risk
+- authentication or authorization correctness risk
+- data integrity or session/token safety risk
+- blast radius across modes, backends, or high-fan-out callers
+- probability of recurring regressions caused by maintainability debt
+
+Documentation drift and test gaps are in scope, but they must not outrank a
+real runtime or security defect unless they create direct operational risk.
+
+## Deliverable Contract
+
+The review will produce three outputs:
+
+### 1. Findings report
+
+The final response should be in code-review style, ordered by severity, with
+runtime and security defects first, then correctness issues, then
+maintainability, docs drift, and test gaps.
+
+### 2. Remediation roadmap
+
+The roadmap should group work into:
+
+- immediate fixes
+- near-term hardening
+- structural refactors worth scheduling
+
+The roadmap should be concrete and minimal. It should recommend the smallest
+defensible change that addresses the real issue rather than broad rewrites.
+
+### 3. Proof-of-fix patches for confirmed critical issues only
+
+Patches are allowed only when all of these are true:
+
+- the issue is confirmed, not speculative
+- severity is critical or otherwise urgent enough to justify interrupting the
+  review flow
+- the fix is localized and low-risk
+- the change can be verified with targeted tests or other concrete checks
+
+If a safe fix requires a broader redesign, the review should stop at the
+finding plus roadmap item and not force a risky patch during the audit.
+
+## Patch Gate
+
+A proof-of-fix patch is permitted only if it satisfies this decision rule:
+
+1. The bug is real and supported by direct evidence.
+2. The touched area can be changed without broad coordination or endpoint-wide
+   redesign.
+3. The likely fix does not depend on unresolved product choices.
+4. Verification can be run against the changed behavior.
+
+If any of these are false, the issue stays in the report and roadmap only.
+
+## Testing And Verification Strategy
+
+Testing effort during the review should remain targeted, not exhaustive.
+
+Verification should prefer the smallest useful command set that can answer a
+specific question. When code changes are made, the review must verify them with
+focused tests or equivalent concrete checks before claiming success.
+
+Because touched code may include security-sensitive paths, completion for any
+proof-of-fix patch should also include Bandit on the touched scope using the
+project virtual environment.
+
+## Execution Boundaries
+
+- Stay focused on AuthNZ and its immediate integration surface.
+- Do not silently expand into a full application review.
+- Do not present speculation as a confirmed bug.
+- Do not let large-file maintainability commentary crowd out higher-signal auth
+  and authz failures.
+- Do not turn the deep audit into a large remediation project during the same
+  pass.
+
+## Success Criteria
+
+The review is successful when:
+
+- the full approved AuthNZ surface is covered with risk-weighted depth
+- findings are evidence-based and ordered by severity
+- code and security defects are clearly separated from softer risks and
+  maintainability issues
+- docs drift and test gaps are treated as first-class findings when they create
+  meaningful operational or regression risk
+- the final report is immediately usable for triage
+- any proof-of-fix patches are narrow, justified, and verified
+- unresolved blind spots are made explicit instead of being mistaken for clean
+  health
+
+## Expected Outcome
+
+This design yields a deep, boundary-aware AuthNZ audit that is broad enough to
+cover core services, API integration points, tests, and documentation contracts
+without losing prioritization. The result should be a high-signal findings
+report, a practical remediation roadmap, and only those small critical patches
+that can be made safely and verified during the review.

--- a/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
@@ -52,6 +52,18 @@ This review excludes:
 - speculative rewrites that are not supported by concrete evidence
 - large remediation refactors during the review itself
 
+Representative admin or control-surface endpoints are in scope only when at
+least one of these is true:
+
+- they directly use `get_auth_principal`, `require_permissions(...)`,
+  `require_roles(...)`, or related AuthNZ claim-first dependencies
+- they are a high-fan-out or high-risk consumer of AuthNZ authentication or
+  authorization behavior
+- recent churn or prior findings suggest they are a likely regression surface
+
+This keeps the integration review focused on AuthNZ contract boundaries rather
+than drifting into a general endpoint audit.
+
 ## Approaches Considered
 
 ### Recommended: Layered risk audit
@@ -132,6 +144,16 @@ The review will rely on:
 - recent git history when it helps explain regression-prone areas or newly
   changed contracts
 
+Documentation review should start from a bounded seed set and expand only when
+those docs point to another behavior-defining source. The seed set is:
+
+- `tldw_Server_API/app/core/AuthNZ/README.md`
+- `Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md`
+- `Docs/API-related/User_Registration_API_Documentation.md`
+- `Docs/Operations/Env_Vars.md`
+- relevant quickstart or troubleshooting docs only when they claim current auth
+  behavior that may affect runtime expectations
+
 The review is evidence-first, not style-first. A concern becomes a reported
 finding only when there is concrete support from code, tests, docs drift that
 creates real risk, or targeted verification.
@@ -147,6 +169,11 @@ weakens a specific claim. It should answer narrow questions such as:
 If verification cannot be run, the limitation should be stated explicitly and
 the issue should remain a probable risk unless source evidence is already
 conclusive.
+
+Feature-flagged, enterprise, federation, or secret-backend paths remain in
+scope, but any path that cannot be exercised or strongly validated from local
+evidence must be reported as a probable risk unless the source alone proves a
+confirmed defect.
 
 ## Review Focus Areas
 
@@ -190,6 +217,25 @@ of these signals:
 - security sensitivity
 - backend divergence
 - unusually large or multi-responsibility implementations
+
+## Review Artifact Contract
+
+The audit should leave a traceable review workspace under:
+
+- `Docs/superpowers/reviews/authnz-full-module/`
+
+That workspace should contain:
+
+- a `README.md` that fixes the stage order and links the stage reports
+- stage artifacts that separate inventory, runtime and authz analysis,
+  persistence/config review, and test/docs synthesis
+- a final synthesis artifact that captures the highest-confidence findings,
+  open questions, and verification limits before the final user-facing report is
+  written
+
+The user-facing final response should be based on those staged artifacts rather
+than on ad hoc notes. This keeps the audit resumable and preserves pre-fix
+evidence when narrow proof-of-fix patches are applied later in the review.
 
 ## Findings Model
 
@@ -280,6 +326,15 @@ A proof-of-fix patch is permitted only if it satisfies this decision rule:
 
 If any of these are false, the issue stays in the report and roadmap only.
 
+Before any proof-of-fix patch is applied, the review must first preserve the
+pre-fix evidence in the stage artifacts or review notes so the final report can
+describe the original defect and not just the repaired state.
+
+Proof-of-fix patches should generally be applied after the relevant stage has
+gathered enough surrounding context to avoid masking a broader pattern. If a
+patch would interfere with continued evidence gathering, defer it and keep the
+issue in the roadmap.
+
 ## Testing And Verification Strategy
 
 Testing effort during the review should remain targeted, not exhaustive.
@@ -291,6 +346,12 @@ focused tests or equivalent concrete checks before claiming success.
 Because touched code may include security-sensitive paths, completion for any
 proof-of-fix patch should also include Bandit on the touched scope using the
 project virtual environment.
+
+The final report should include a short verification section summarizing:
+
+- files and docs inspected
+- tests or checks run
+- what remains unverified
 
 ## Execution Boundaries
 

--- a/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-authnz-full-module-review-design.md
@@ -237,6 +237,17 @@ The user-facing final response should be based on those staged artifacts rather
 than on ad hoc notes. This keeps the audit resumable and preserves pre-fix
 evidence when narrow proof-of-fix patches are applied later in the review.
 
+The default stage order should be:
+
+1. `Stage 1: Baseline and boundary inventory`
+2. `Stage 2: Runtime authentication and authorization analysis`
+3. `Stage 3: Persistence, migrations, and configuration safety`
+4. `Stage 4: Tests, docs drift, and verification gaps`
+5. `Stage 5: Final synthesis, roadmap, and patch decisions`
+
+If the review needs to branch, it should still preserve this canonical sequence
+in the workspace so the evidence trail is easy to follow.
+
 ## Findings Model
 
 The final report should present findings first, ordered by severity.
@@ -289,6 +300,21 @@ The review will produce three outputs:
 The final response should be in code-review style, ordered by severity, with
 runtime and security defects first, then correctness issues, then
 maintainability, docs drift, and test gaps.
+
+The canonical final response structure should be:
+
+1. `Findings`
+2. `Open Questions` only when unresolved ambiguity materially affects confidence
+3. `Verification`
+4. `Remediation Roadmap`
+
+Inside `Findings`:
+
+- confirmed findings come before probable risks
+- probable risks come before improvements
+- any issue fixed during the review must still be listed, clearly marked as
+  `fixed during review`, with the original failure mode and the verification
+  evidence preserved
 
 ### 2. Remediation roadmap
 

--- a/Docs/superpowers/specs/2026-04-08-characters-fullstack-delta-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-characters-fullstack-delta-review-design.md
@@ -29,18 +29,29 @@ synthesis.
 - `tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py`
 - `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
 - `tldw_Server_API/app/api/v1/endpoints/character_messages.py`
+- `tldw_Server_API/app/api/v1/schemas/character_schemas.py`
+- `tldw_Server_API/app/api/v1/schemas/character_memory_schemas.py`
 - `tldw_Server_API/app/core/Character_Chat/Character_Chat_Lib_facade.py`
 - `tldw_Server_API/app/core/Character_Chat/character_limits.py`
 - `tldw_Server_API/app/core/Character_Chat/character_rate_limiter.py`
 - `tldw_Server_API/app/core/Character_Chat/modules/character_db.py`
 - `tldw_Server_API/app/core/Character_Chat/modules/character_io.py`
 - `tldw_Server_API/app/core/Character_Chat/modules/character_chat.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_validation.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_memory_extraction.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_templates.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_prompt_presets.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_generation_presets.py`
+- `tldw_Server_API/app/core/Character_Chat/world_book_manager.py`
+- `tldw_Server_API/app/core/Chat/chat_characters.py`
 - related Character retrieval, exemplar, and world-book logic touched by the
   current Character API and chat flows
 - backend Character tests under `tldw_Server_API/tests/Characters/`,
   `tldw_Server_API/tests/Character_Chat*`, `tldw_Server_API/tests/ChaChaNotesDB/`,
   and nearby integration/property/e2e suites where Character behavior is
   exercised
+- any additional backend module directly imported by the in-scope Character
+  entry points when that dependency materially affects Character behavior
 
 ### Frontend in scope
 
@@ -52,11 +63,22 @@ synthesis.
 - `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx`
 - `apps/packages/ui/src/hooks/useSelectedCharacter.ts`
 - `apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts`
+- `apps/packages/ui/src/hooks/chat/useServerChatLoader.ts`
+- `apps/packages/ui/src/hooks/chat/useSelectServerChat.ts`
+- `apps/packages/ui/src/utils/selected-character-storage.ts`
+- `apps/packages/ui/src/utils/characters-route.ts`
+- `apps/packages/ui/src/utils/character-greetings.ts`
+- `apps/packages/ui/src/utils/character-mood.ts`
+- `apps/packages/ui/src/utils/default-character-preference.ts`
+- `apps/packages/ui/src/utils/character-export.ts`
 - nearby Character-related selection, storage, server-chat loader, greeting, and
   workspace hooks/utilities
 - `apps/packages/ui/src/services/tldw/domains/characters.ts`
 - Character-focused frontend tests, including unit, integration, and e2e
   coverage where current Character behavior is exercised
+- any additional frontend hook, utility, or adapter directly imported by the
+  in-scope Character entry points when that dependency materially affects
+  Character behavior
 
 ## Non-Goals
 
@@ -81,6 +103,9 @@ Primary baseline artifacts:
 - `Docs/superpowers/specs/2026-03-23-characters-backend-review-design.md`
 - `Docs/superpowers/plans/2026-03-23-characters-backend-sequential-review.md`
 - `Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md`
+- `Docs/superpowers/specs/2026-03-27-chat-character-menu-and-system-prompt-editor-design.md`
+- `Docs/superpowers/plans/2026-03-27-chat-character-menu-and-system-prompt-editor-implementation-plan.md`
+- `Docs/Product/WebUI/PRD-Characters Playground UX Improvements.md`
 - related Character review and remediation docs created from that work
 
 Rule:
@@ -91,6 +116,14 @@ Rule:
   appears affected or has drifted back into the same failure mode
 - `historical only`: already known and apparently remediated; do not report as a
   current finding except as brief context
+
+Novelty rule:
+
+- each reported finding must note which historical artifacts were checked before
+  it was classified as net-new or a regression
+- if no comparable frontend baseline artifact exists for a frontend finding,
+  state that explicitly instead of implying stronger novelty confidence than the
+  evidence supports
 
 ## Approaches Considered
 
@@ -320,7 +353,10 @@ For each suspected issue:
 
 Permitted validation:
 
-- focused `pytest` invocations for the exact Character behavior under review
+- focused `pytest` invocations for backend Character behavior under review
+- focused frontend test commands for the exact Character behavior under review,
+  including package-scoped unit or integration tests and narrow Playwright or
+  e2e runs when that is the smallest reliable validation path
 - small read-oriented commands that clarify code paths, references, or coverage
 - minimal execution to confirm a suspected branch mismatch or regression
 
@@ -347,9 +383,14 @@ inspect, validation commands, and review artifacts to write.
 
 Write separate review artifacts for:
 
-- backend findings
-- frontend findings
-- final synthesis and cross-layer drift
+- `Docs/superpowers/reviews/characters-fullstack-delta/README.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/YYYY-MM-DD-backend-review.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/YYYY-MM-DD-frontend-review.md`
+- `Docs/superpowers/reviews/characters-fullstack-delta/YYYY-MM-DD-synthesis.md`
+
+If an existing directory or filename would create ambiguity with older Character
+reviews, prefer the dated `characters-fullstack-delta` path over reusing the
+older `characters-backend` location.
 
 ### 4. Final Findings Format
 
@@ -361,12 +402,15 @@ Findings first, ordered by severity. Each finding should include:
 - impact
 - concrete reasoning
 - file reference(s)
+- baseline artifact note
 - validation note when a command or targeted test was used
 
 Then include:
 
 - open questions or residual risks
 - coverage gaps
+- improvement opportunities that are worth addressing even when they are not
+  confirmed bugs
 - short cross-layer contract drift section
 
 ## Severity Model
@@ -401,3 +445,5 @@ This design is successful if the eventual audit:
   into unrelated chat or UI subsystems.
 - If a suspected issue cannot be validated confidently, it must be labeled as an
   open question or residual risk instead of a confirmed defect.
+- The execution plan must assume a dirty workspace is possible and should avoid
+  staging or committing unrelated files when writing review artifacts.

--- a/Docs/superpowers/specs/2026-04-08-characters-fullstack-delta-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-characters-fullstack-delta-review-design.md
@@ -1,0 +1,403 @@
+# Characters Full-Stack Delta Review Design
+
+Date: 2026-04-08
+Topic: Staged full-stack Characters review for `tldw_server`
+
+## Goal
+
+Produce an evidence-based staged review of the Characters module across backend
+and frontend surfaces that identifies:
+
+- net-new bugs and edge-case failures
+- still-open regressions previously thought to be remediated
+- backend or frontend contract drift
+- maintainability and performance risks
+- missing or misleading automated tests
+
+The review is intentionally delta-oriented. It should not re-report historical
+findings that were already documented and remediated unless the current code
+still appears affected.
+
+## Scope
+
+This review covers the Character surface across both backend and frontend,
+organized into separate backend and frontend stages plus a cross-layer
+synthesis.
+
+### Backend in scope
+
+- `tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py`
+- `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+- `tldw_Server_API/app/api/v1/endpoints/character_messages.py`
+- `tldw_Server_API/app/core/Character_Chat/Character_Chat_Lib_facade.py`
+- `tldw_Server_API/app/core/Character_Chat/character_limits.py`
+- `tldw_Server_API/app/core/Character_Chat/character_rate_limiter.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_db.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_io.py`
+- `tldw_Server_API/app/core/Character_Chat/modules/character_chat.py`
+- related Character retrieval, exemplar, and world-book logic touched by the
+  current Character API and chat flows
+- backend Character tests under `tldw_Server_API/tests/Characters/`,
+  `tldw_Server_API/tests/Character_Chat*`, `tldw_Server_API/tests/ChaChaNotesDB/`,
+  and nearby integration/property/e2e suites where Character behavior is
+  exercised
+
+### Frontend in scope
+
+- `apps/tldw-frontend/pages/characters.tsx`
+- `apps/tldw-frontend/pages/settings/characters.tsx`
+- `apps/packages/ui/src/routes/option-characters.tsx`
+- `apps/packages/ui/src/components/Option/Characters/`
+- `apps/packages/ui/src/components/Common/CharacterSelect.tsx`
+- `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx`
+- `apps/packages/ui/src/hooks/useSelectedCharacter.ts`
+- `apps/packages/ui/src/hooks/chat/useCharacterChatMode.ts`
+- nearby Character-related selection, storage, server-chat loader, greeting, and
+  workspace hooks/utilities
+- `apps/packages/ui/src/services/tldw/domains/characters.ts`
+- Character-focused frontend tests, including unit, integration, and e2e
+  coverage where current Character behavior is exercised
+
+## Non-Goals
+
+This review does not cover:
+
+- implementing fixes during the audit
+- broad unrelated chat or UI subsystems that do not materially depend on
+  Character behavior
+- re-documenting historical Character findings that are already covered and no
+  longer appear live
+- purely visual or stylistic frontend commentary unless it indicates a state,
+  correctness, or contract problem
+
+## Baseline Artifacts
+
+Earlier Character review and remediation artifacts are the baseline for deciding
+whether a finding is net-new or a regression. The audit should consult them
+before claiming novelty.
+
+Primary baseline artifacts:
+
+- `Docs/superpowers/specs/2026-03-23-characters-backend-review-design.md`
+- `Docs/superpowers/plans/2026-03-23-characters-backend-sequential-review.md`
+- `Docs/superpowers/specs/2026-04-07-characters-backend-remediation-design.md`
+- related Character review and remediation docs created from that work
+
+Rule:
+
+- `net-new finding`: not already covered by the historical review or
+  remediation docs
+- `possible regression`: historically covered, but the current code still
+  appears affected or has drifted back into the same failure mode
+- `historical only`: already known and apparently remediated; do not report as a
+  current finding except as brief context
+
+## Approaches Considered
+
+### 1. Recommended: Staged Delta Audit With Targeted Validation
+
+Review backend first, frontend second, using the earlier Character review and
+remediation artifacts as the baseline. Run a small set of focused validation
+commands only when code inspection alone is not strong enough to support a
+claim.
+
+Strengths:
+
+- strongest fit for the user's request for net-new findings
+- keeps findings attributable to either backend, frontend, or contract drift
+- avoids repeating already-resolved review material
+- allows stronger evidence without broad noisy suite runs
+
+Weaknesses:
+
+- depends on accurate interpretation of the earlier artifacts
+- requires discipline to avoid drifting into a fresh full audit
+
+### 2. Fresh Full Audit Then Dedupe
+
+Review the entire Character surface from scratch, then subtract anything already
+covered historically.
+
+Strengths:
+
+- highest independent confidence
+- less risk of missing a resurfaced issue because of documentation bias
+
+Weaknesses:
+
+- slower
+- likely to repeat large amounts of already-known material
+
+### 3. Fast Hot-Path Audit
+
+Inspect only the highest-risk flows: import/export, CRUD/versioning, chat
+session coupling, frontend state sync, and API client adapters.
+
+Strengths:
+
+- fastest route to high-severity findings
+- good if time is tightly constrained
+
+Weaknesses:
+
+- likely to miss lower-frequency correctness issues and test gaps
+- weaker final coverage story
+
+## Recommended Approach
+
+Use the staged delta audit with targeted validation.
+
+Execution order:
+
+1. establish the prior-review baseline
+2. run a backend delta pass
+3. run a frontend delta pass
+4. perform a cross-layer synthesis for contract drift
+5. support ambiguous findings with small focused validation only when it
+   materially improves confidence
+
+## Review Architecture
+
+The audit proceeds in three passes.
+
+### Pass 1: Backend Delta Review
+
+Review the current backend Character surfaces against the historical review and
+remediation artifacts.
+
+Focus:
+
+- CRUD, restore, revert, versioning, and persistence integrity
+- import/export and image handling contracts
+- rate limiting, chat/session coupling, greeting or memory injection, and
+  completion persistence
+- exemplar, world-book, search, and related retrieval behavior
+- test coverage around risky backend branches
+
+Output:
+
+- backend-only findings, residual risks, and coverage gaps
+
+### Pass 2: Frontend Delta Review
+
+Review the current frontend Character surfaces against the current backend
+contracts and the historical Character artifacts.
+
+Focus:
+
+- Character workspace state ownership and edit flows
+- selection, storage, and identity synchronization
+- chat integration and server-chat restoration behavior
+- API client normalization, fallback logic, caching, and invalidation
+- test coverage around risky frontend branches
+
+Output:
+
+- frontend-only findings, residual risks, and coverage gaps
+
+### Pass 3: Cross-Layer Synthesis
+
+Compare backend and frontend assumptions to identify Character-specific contract
+drift or boundary mismatches.
+
+Focus:
+
+- path or schema mismatches
+- stale fallback assumptions
+- inconsistent identity or version semantics
+- backend responses that the frontend currently tolerates but should not rely on
+
+Output:
+
+- short cross-layer findings section plus a combined synthesis
+
+## Review Slices
+
+To keep the audit bounded and attributable, use these six slices.
+
+### 1. Backend Lifecycle and Persistence
+
+Primary files:
+
+- `characters_endpoint.py`
+- `character_db.py`
+- `Character_Chat_Lib_facade.py`
+- `ChaChaNotes_DB.py`
+- related schemas and helpers
+
+Primary questions:
+
+- do CRUD, delete, restore, revert, and version flows preserve Character
+  invariants
+- are normalization and concurrency checks consistent
+- do current tests still cover the highest-risk persistence branches
+
+### 2. Backend Chat-Coupled Behavior
+
+Primary files:
+
+- `character_chat_sessions.py`
+- `character_messages.py`
+- `character_chat.py`
+- `character_rate_limiter.py`
+- `character_limits.py`
+
+Primary questions:
+
+- does Character-specific chat behavior still align with backend contracts
+- are quotas, greeting injection, memory injection, and completion persistence
+  coherent under current code
+- are there state-coupled regressions not covered by prior remediation
+
+### 3. Backend Retrieval Surfaces
+
+Primary areas:
+
+- exemplars
+- world books
+- Character search and retrieval fallbacks
+
+Primary questions:
+
+- do returned contracts still match current behavior
+- are fallback paths semantically correct
+- are there net-new correctness, performance, or permission risks
+
+### 4. Frontend Character Workspace
+
+Primary areas:
+
+- `CharactersWorkspace`
+- editor, list, dialog, inline-edit, bulk-ops, import, and version-history hooks
+
+Primary questions:
+
+- is state ownership clear and robust
+- can edits, import, bulk actions, or version flows desynchronize UI state
+- are there avoidable performance traps or missing tests
+
+### 5. Frontend Chat Integration
+
+Primary areas:
+
+- `useCharacterChatMode`
+- Character selection and storage hooks
+- shared Character selection components
+- server chat loader and synchronization helpers
+
+Primary questions:
+
+- can Character identity or session state drift between local UI and server
+- are greeting and chat-start flows robust
+- do frontend assumptions still match backend chat/session behavior
+
+### 6. Frontend API Client and Domain Layer
+
+Primary areas:
+
+- `apps/packages/ui/src/services/tldw/domains/characters.ts`
+- nearby Character routing and normalization utilities
+
+Primary questions:
+
+- are path fallbacks still necessary and correct
+- is cache invalidation coherent for create, update, revert, import, and delete
+- are payload normalization and error mapping defensible under current API
+
+## Evidence and Validation Rules
+
+The audit should be evidence-driven and conservative about claims.
+
+For each suspected issue:
+
+1. trace the current code path end to end
+2. inspect nearby tests and relevant historical Character artifacts
+3. classify the issue as `net-new`, `possible regression`, or `historical only`
+4. run targeted validation only when it materially increases confidence
+5. report uncertainty explicitly when a claim cannot be proven locally
+
+### Targeted Validation Rules
+
+Permitted validation:
+
+- focused `pytest` invocations for the exact Character behavior under review
+- small read-oriented commands that clarify code paths, references, or coverage
+- minimal execution to confirm a suspected branch mismatch or regression
+
+Avoid:
+
+- broad suite runs that add noise without improving confidence
+- speculative findings based only on style or code shape
+- presenting ambiguous concerns as confirmed bugs
+
+## Deliverables
+
+The audit should produce a compact review package.
+
+### 1. Design Spec
+
+This document defines scope, evidence rules, and deliverables before execution.
+
+### 2. Execution Plan
+
+A follow-on implementation plan should enumerate the stage order, files to
+inspect, validation commands, and review artifacts to write.
+
+### 3. Stage Review Docs
+
+Write separate review artifacts for:
+
+- backend findings
+- frontend findings
+- final synthesis and cross-layer drift
+
+### 4. Final Findings Format
+
+Findings first, ordered by severity. Each finding should include:
+
+- severity
+- type
+- whether it is net-new or a regression
+- impact
+- concrete reasoning
+- file reference(s)
+- validation note when a command or targeted test was used
+
+Then include:
+
+- open questions or residual risks
+- coverage gaps
+- short cross-layer contract drift section
+
+## Severity Model
+
+- `High`: likely bug, data loss/corruption risk, security issue, or major
+  behavioral regression risk
+- `Medium`: correctness edge case, contract inconsistency, meaningful
+  maintainability/performance issue, or important state-synchronization risk
+- `Low`: localized cleanup, smaller code smell, or minor missing-test issue
+
+## Success Criteria
+
+This design is successful if the eventual audit:
+
+- covers the full Character surface requested by the user while reporting only
+  net-new findings and still-open regressions
+- keeps backend findings separate from frontend findings
+- includes a short but concrete cross-layer synthesis
+- uses targeted validation only where it materially improves confidence
+- clearly separates confirmed defects, likely risks, open questions, and test
+  gaps
+- leaves review artifacts specific enough for later remediation work to pick up
+  individual findings without redoing the investigation
+
+## Boundaries
+
+- This phase remains review-only; no Character fixes are implemented during the
+  audit.
+- Previously resolved historical findings are not re-reported just for
+  completeness.
+- The audit stays focused on Character-dependent behavior and does not expand
+  into unrelated chat or UI subsystems.
+- If a suspected issue cannot be validated confidently, it must be labeled as an
+  open question or residual risk instead of a confirmed defect.

--- a/Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
@@ -28,9 +28,13 @@ Included:
   - `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
   - `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
   - `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
-  - `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
 - Primary test evidence under `tldw_Server_API/tests/Chat`
-- Directly relevant newer chat tests when they cover the same scoped routes or shared helpers
+- Additional evidence suites when they directly exercise the scoped routes or shared helpers:
+  - `tldw_Server_API/tests/Chat_NEW`
+  - `tldw_Server_API/tests/Chat_Workflows`
+  - `tldw_Server_API/tests/Streaming`
+  - targeted auth or adapter suites when the risk being checked is permission wiring or scoped SSE behavior rather than generic provider internals
 
 Excluded unless a shared defect crosses the boundary:
 
@@ -41,6 +45,8 @@ Excluded unless a shared defect crosses the boundary:
 ## Review Method
 
 The review will use an endpoint-by-endpoint sweep rather than a shared-subsystem-first audit.
+
+Before reviewing each group, freeze the concrete route and matching-test inventory so low-traffic endpoints such as queue, analytics, share-link, and loop routes are not skipped by accident.
 
 Planned review order:
 
@@ -82,6 +88,8 @@ Evidence rules:
 - Passing tests do not overrule a concrete code-level defect.
 - Failing or flaky tests count as findings when they imply product risk or weak coverage.
 - The review will not claim safety for untouched paths just because adjacent tests pass.
+- Environment or fixture failures will be reported separately from product defects unless the scoped code is responsible for the fragility.
+- For each targeted test run, record whether it passed, failed, was flaky, or could not be run, plus the reason.
 
 ## Success Criteria
 
@@ -91,6 +99,15 @@ The review is successful when it produces:
 - clear distinction between implementation bugs, test gaps, and lower-severity maintenance risks
 - targeted test evidence for ambiguous or high-risk paths
 - a short synthesis of recurring structural risks across the scoped Chat surfaces
+
+## Severity Rubric
+
+Use a consistent severity model in the final review:
+
+- Critical: cross-user data exposure, authz bypass, destructive persistence corruption, or similarly severe security failures
+- High: primary-path correctness failures, streaming contract breaks, serious resource or concurrency hazards, or information leakage with meaningful user impact
+- Medium: narrower endpoint bugs, incomplete validation, non-fatal persistence inconsistencies, or important missing coverage around risky behavior
+- Low: maintainability, observability, or cleanup issues that have limited immediate user impact but raise future defect risk
 
 ## Deliverable
 

--- a/Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-chat-module-review-design.md
@@ -1,0 +1,109 @@
+# Chat Module Review Design
+
+Date: 2026-04-08
+Topic: Core Chat module review with adjacent chat endpoints and tests
+Status: Approved for review planning
+
+## Goal
+
+Run an endpoint-by-endpoint engineering review of the Chat module in `tldw_server` to identify:
+
+- correctness bugs
+- security and authorization issues
+- async/concurrency hazards
+- persistence and state consistency problems
+- error-handling and information-leakage risks
+- test coverage gaps and maintainability issues that materially increase future defect risk
+
+This is a review spec, not an implementation spec. The output of the review will be findings, not code changes.
+
+## Scope
+
+Included:
+
+- `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Shared dependencies used by the main chat routes under `tldw_Server_API/app/core/Chat/`
+- Adjacent chat endpoints:
+  - `tldw_Server_API/app/api/v1/endpoints/chat_documents.py`
+  - `tldw_Server_API/app/api/v1/endpoints/chat_loop.py`
+  - `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+  - `tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py`
+  - `tldw_Server_API/app/api/v1/endpoints/chat_workflows.py`
+- Primary test evidence under `tldw_Server_API/tests/Chat`
+- Directly relevant newer chat tests when they cover the same scoped routes or shared helpers
+
+Excluded unless a shared defect crosses the boundary:
+
+- Character Chat
+- Chatbooks
+- Unrelated provider-adapter internals beyond what is necessary to validate Chat route behavior
+
+## Review Method
+
+The review will use an endpoint-by-endpoint sweep rather than a shared-subsystem-first audit.
+
+Planned review order:
+
+1. `chat.py` command discovery and dictionary-validation routes
+2. `chat.py` main completion path
+3. `chat.py` conversation, message, analytics, and share-link routes
+4. `chat.py` knowledge and RAG-context routes
+5. `chat_documents.py`
+6. `chat_loop.py`
+7. `chat_grammars.py`
+8. `chat_dictionaries.py`
+9. `chat_workflows.py`
+10. Shared-risk synthesis across `core/Chat/*` and the matching tests
+
+Each route group will be reviewed for:
+
+- behavior and contract correctness
+- authn, authz, and ownership enforcement
+- async boundaries, task lifecycle, and concurrency safety
+- queueing, rate limiting, and streaming behavior
+- persistence consistency and failure handling
+- error mapping, client-visible leakage, and operational observability
+- test quality, missing coverage, and brittle assertions
+
+## Evidence Model
+
+Static code review is the primary evidence source for all included route groups.
+
+Targeted tests are supporting evidence for high-risk or ambiguous behavior, especially:
+
+- streaming
+- auth and ownership checks
+- persistence semantics
+- queue and rate-limiter interactions
+- endpoint response contracts
+
+Evidence rules:
+
+- Passing tests do not overrule a concrete code-level defect.
+- Failing or flaky tests count as findings when they imply product risk or weak coverage.
+- The review will not claim safety for untouched paths just because adjacent tests pass.
+
+## Success Criteria
+
+The review is successful when it produces:
+
+- a severity-ordered findings list tied to concrete files and lines
+- clear distinction between implementation bugs, test gaps, and lower-severity maintenance risks
+- targeted test evidence for ambiguous or high-risk paths
+- a short synthesis of recurring structural risks across the scoped Chat surfaces
+
+## Deliverable
+
+The final review output will be structured as:
+
+1. findings first, ordered by severity, with file references
+2. open questions or assumptions
+3. short summary of coverage gaps and maintainability risks
+
+The review should stay focused on concrete, defensible issues. Broad refactor ideas are only included when they are justified by repeated risk patterns discovered during the sweep.
+
+## Assumptions
+
+- The user wants a broad audit, not only high-severity bugs.
+- Targeted test execution is allowed and should be used as supporting evidence.
+- The scoped review should remain centered on the chat-facing API family and shared `core/Chat` behavior, not expand into neighboring subsystems without a concrete cross-boundary issue.

--- a/Docs/superpowers/specs/2026-04-08-mcp-unified-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-mcp-unified-module-review-design.md
@@ -44,6 +44,7 @@ This review excludes:
 - broad product or UX critique
 - speculative architecture rewrites that are not justified by concrete defects
 - remediation work during the review unless explicitly requested later
+- generated artifacts such as `__pycache__` bytecode files
 
 ## Approaches Considered
 
@@ -120,11 +121,29 @@ traceable. The review will use these slices:
   `external_servers/*`, `command_runtime/*`, and related runtime configuration
   or adapter boundaries
 - governance and operations:
-  `governance_packs/*`, `monitoring/*`, `config.py`, `README.md`, and package
-  boundary files where they shape runtime expectations
+  `governance_packs/*`, `monitoring/*`, `config.py`, `README.md`,
+  `docker/Dockerfile`, and package boundary files where they shape runtime
+  expectations
 
-Every source file in `tldw_Server_API/app/core/MCP_unified` must be inspected,
-even if a given file ends up contributing no reportable issue.
+Every tracked, non-generated implementation or runtime artifact in
+`tldw_Server_API/app/core/MCP_unified` must be inspected, even if a given file
+ends up contributing no reportable issue. Tests remain supporting evidence
+rather than primary source files for the file-by-file audit.
+
+## Coverage Ledger
+
+To keep the file-by-file promise auditable, the review should maintain a
+working coverage ledger during execution.
+
+The ledger should list:
+
+- every inspected implementation or runtime file in scope
+- the review slice that owned it
+- whether it produced a finding, a probable risk, or no reportable issue
+- any tests or docs consulted for that file when relevant
+
+The final user-facing report may stay compact, but the review process should
+not rely on memory or an informal checklist.
 
 ## Evidence Model
 
@@ -144,6 +163,11 @@ The review will rely on:
 
 The review is source-first, not test-first. Tests and docs are supporting
 evidence, not substitutes for direct code inspection.
+
+Targeted runtime verification may be used selectively when static inspection
+alone leaves an important claim unresolved, especially for concurrency,
+transport divergence, or safety-guard behavior. It should stay narrow and
+evidence-driven rather than turning the audit into broad execution work.
 
 ## Findings Model
 
@@ -165,6 +189,15 @@ finding instead of repeated per file.
 
 If a file or slice does not contribute any meaningful issue, it should not be
 given filler commentary. The review should stay high-signal.
+
+Observations should be labeled as one of:
+
+- `Confirmed finding`: supported directly by source, tests, or tightly bounded
+  verification
+- `Probable risk`: a likely issue where the impact or trigger cannot be fully
+  proven from available local evidence
+- `Improvement`: a concrete change that is not strong evidence of a current
+  defect but would reduce future risk or maintenance friction
 
 ## Review Focus Areas
 
@@ -215,5 +248,7 @@ The canonical output will be one findings report in code-review style with:
 - explicit test-gap notes tied to those findings
 - a compact appendix listing the reviewed slices and files so the review is
   visibly file-by-file rather than sampled
+- a note on any selective runtime verification used to confirm or narrow a
+  claim
 
 The final response should prioritize bugs, risks, and weak spots over summary.

--- a/Docs/superpowers/specs/2026-04-08-mcp-unified-module-review-design.md
+++ b/Docs/superpowers/specs/2026-04-08-mcp-unified-module-review-design.md
@@ -1,0 +1,219 @@
+# MCP Unified Module Review Design
+
+Date: 2026-04-08
+Topic: MCP Unified module full file-by-file review with findings and fixes
+Status: Approved design
+
+## Objective
+
+Review the MCP Unified subsystem in `tldw_server` for concrete bugs,
+correctness issues, security weaknesses, operational hazards, test gaps, and
+maintainability problems using a full file-by-file audit.
+
+The review should produce a code-review-style findings report with concrete fix
+guidance for each issue. The emphasis is on actionable, evidence-backed
+problems rather than broad redesign advice or generic style commentary.
+
+## Scope
+
+This review is centered on:
+
+- `tldw_Server_API/app/core/MCP_unified`
+- `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py`
+- MCP Unified tests used to confirm intended behavior or expose coverage gaps
+
+This includes:
+
+- transport and request lifecycle behavior across HTTP and WebSocket entry
+  points
+- protocol parsing, request validation, response shaping, batching, and
+  idempotency behavior
+- auth, RBAC, rate limiting, request guards, persona and scope handling
+- module framework behavior including registry, base interfaces, and module
+  implementations
+- external server integration including manager, transports, config schema, and
+  runtime credential handling
+- governance packs, monitoring, config defaults, and operational safety
+- tests and documentation only when they materially define or claim current MCP
+  Unified behavior
+
+This review excludes:
+
+- the broader MCP Hub management surface under `/api/v1/mcp/hub`
+- unrelated platform endpoints that only mention MCP incidentally
+- broad product or UX critique
+- speculative architecture rewrites that are not justified by concrete defects
+- remediation work during the review unless explicitly requested later
+
+## Approaches Considered
+
+### Chosen: Full file-by-file audit
+
+Read every source file in the scoped MCP Unified tree, then synthesize findings
+across the subsystem with concrete fix guidance.
+
+Why this is preferred:
+
+- it matches the user’s explicit request for a full file-by-file review
+- it reduces the chance that low-visibility helpers or safety checks are missed
+- it supports subsystem-wide findings without depending on sampling assumptions
+- it produces a stronger basis for calling out test gaps and cross-file risks
+
+### Alternative: Entry-point-first audit
+
+Start from endpoint, server, protocol, and config files, then trace only into
+high-risk dependencies and hotspot modules.
+
+Trade-offs:
+
+- faster
+- better early signal for integration problems
+- weaker assurance that every module file actually received direct inspection
+
+### Alternative: Test-led audit
+
+Use the current MCP tests as the map of intended behavior, then inspect the
+code paths behind important or weakly covered behaviors.
+
+Trade-offs:
+
+- efficient for regressions and contract drift
+- good at exposing missing tests
+- risks normalizing existing blind spots in the test suite
+
+## Chosen Method
+
+Use the full file-by-file audit with five ordered passes:
+
+1. `Inventory and boundary map`
+   Enumerate the scoped files, identify trust boundaries, major runtime seams,
+   and hotspot areas likely to carry cross-file risk.
+2. `Direct file inspection`
+   Read every scoped source file, recording concrete concerns and cross-file
+   dependencies as they appear.
+3. `Behavior cross-check`
+   Use MCP-focused tests and targeted docs to confirm intended behavior,
+   distinguish confirmed defects from probable risks, and identify missing
+   coverage.
+4. `Finding synthesis`
+   Consolidate duplicate symptoms into single findings when they reflect one
+   underlying problem spanning multiple files.
+5. `Fix guidance`
+   Attach concrete remediation guidance and likely test additions to each
+   finding without turning the review into a speculative redesign roadmap.
+
+## Review Slices
+
+The file-by-file pass should still be organized so the findings remain
+traceable. The review will use these slices:
+
+- transport and request lifecycle:
+  `mcp_unified_endpoint.py`, `server.py`, `protocol.py`,
+  `security/request_guards.py`, `security/ip_filter.py`
+- auth and policy:
+  `auth/*`, `persona_scope.py`, and any scope-enforcement logic on the MCP
+  request path
+- module framework:
+  `modules/base.py`, `modules/registry.py`, `modules/disk_space.py`, and all
+  files under `modules/implementations/`
+- external integration:
+  `external_servers/*`, `command_runtime/*`, and related runtime configuration
+  or adapter boundaries
+- governance and operations:
+  `governance_packs/*`, `monitoring/*`, `config.py`, `README.md`, and package
+  boundary files where they shape runtime expectations
+
+Every source file in `tldw_Server_API/app/core/MCP_unified` must be inspected,
+even if a given file ends up contributing no reportable issue.
+
+## Evidence Model
+
+The review will rely on:
+
+- direct source inspection of every scoped MCP Unified source file
+- direct inspection of the main MCP endpoint surface in
+  `mcp_unified_endpoint.py`
+- targeted test inspection across:
+  - `tldw_Server_API/app/core/MCP_unified/tests`
+  - `tldw_Server_API/tests/MCP_unified` when those tests clarify intended
+    runtime behavior for the scoped subsystem
+- targeted documentation inspection where docs claim current MCP Unified
+  behavior and materially affect review conclusions
+- recent git history only when a suspicious area appears churn-heavy or
+  regression-prone
+
+The review is source-first, not test-first. Tests and docs are supporting
+evidence, not substitutes for direct code inspection.
+
+## Findings Model
+
+The review output should be organized as a code review with findings first,
+ordered by severity.
+
+Each finding should include:
+
+- severity
+- confidence
+- affected files with line references
+- the concrete bug, risk, or design weakness
+- why it matters in practice
+- the specific fix that is recommended
+- the tests that should be added, tightened, or updated
+
+When one issue spans multiple files, it should be reported once as a single
+finding instead of repeated per file.
+
+If a file or slice does not contribute any meaningful issue, it should not be
+given filler commentary. The review should stay high-signal.
+
+## Review Focus Areas
+
+The audit should bias toward:
+
+- authentication and authorization boundary mistakes
+- unsafe config defaults or confusing configuration precedence
+- request validation gaps and malformed input handling
+- state, concurrency, cache, or idempotency errors
+- transport inconsistencies between HTTP and WebSocket paths
+- credential leakage or redaction failures
+- fragile fallbacks and fail-open behavior
+- module registry and tool execution trust boundaries
+- external process or transport safety
+- operational hazards in metrics, health, or breaker behavior
+- maintainability risks in large or multi-responsibility files when they create
+  plausible defect pressure
+
+## Success Criteria
+
+Success for this review means:
+
+- every source file under `tldw_Server_API/app/core/MCP_unified` is inspected
+- `tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py` is included
+- findings are actionable enough to become implementation tasks without
+  rediscovering the issue
+- fix guidance is concrete and paired with likely test actions
+- obvious gaps in tests, validation, auth boundaries, state handling, or config
+  safety are called out explicitly
+
+## Execution Boundaries
+
+- The review remains non-invasive and should not silently turn into
+  remediation work.
+- Improvements should be proposed only when they address a concrete defect,
+  risk, or repeated maintenance hazard.
+- Runtime safety should not be claimed unless justified by source and available
+  tests.
+- Residual-risk notes are allowed at the end for complex areas that appear
+  acceptable by inspection but remain hard to fully validate statically.
+
+## Final Deliverable
+
+The canonical output will be one findings report in code-review style with:
+
+- findings first, ordered by severity
+- concrete remediation guidance for each finding
+- explicit test-gap notes tied to those findings
+- a compact appendix listing the reviewed slices and files so the review is
+  visibly file-by-file rather than sampled
+
+The final response should prioritize bugs, risks, and weak spots over summary.

--- a/Docs/superpowers/specs/2026-04-09-audit-strict-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-09-audit-strict-remediation-design.md
@@ -1,0 +1,358 @@
+# Audit Strict Remediation Design
+
+Date: 2026-04-09
+Status: Approved for planning
+Scope: Confirmed Audit defects, strict durability for selected security/state-changing flows, bounded compatibility cleanup
+Related: 2026-04-08 Audit module review, GitHub issue `rmusser01/tldw_server#1053`
+
+## Summary
+
+This tranche fixes the confirmed Audit and Sharing defects from the Audit module review and hardens a narrow set of high-value call sites so they do not report success unless their audit contract is satisfied.
+
+It is intentionally not the broad repo-wide audit unification effort. That larger refactor remains tracked separately in `rmusser01/tldw_server#1053`.
+
+The design decision for this tranche is:
+
+- fix confirmed Audit durability and migration defects first
+- make selected security and state-changing paths fail closed on audit persistence failure
+- keep compatibility layers only where they avoid immediate breakage
+- avoid expanding into a repo-wide audit architecture rewrite
+
+## Why This Exists
+
+The review surfaced a mix of confirmed bugs and risky behavior:
+
+- Sharing legacy backfill is broken because the migration calls a missing writer method
+- `UnifiedAuditService.stop()` can silently lose buffered events during final flush failure
+- shared audit migration can over-report inserted rows on commit failure
+- DI shutdown helpers can miss shared-mode services or hide real stop failures
+- Evaluations run creation persists and announces a run before the mandatory audit write succeeds
+- Chat moderation enforcement paths still treat audit as background best-effort work
+- Jobs audit currently relies on side-channel best-effort bridge behavior in places where operators would reasonably expect durable audit intent
+- AuthNZ API-key management history still bypasses unified audit as the source of truth
+
+These are reliability problems first, not taxonomy or UX problems. The safest response is a narrow remediation tranche with explicit boundaries.
+
+## Goals
+
+- Fix the Sharing legacy backfill regression.
+- Make final Audit shutdown flushes durable-or-loud instead of silently lossy.
+- Make shared audit migration counts and checkpoints commit-bound.
+- Make DI shutdown behavior correct in shared mode and explicit about stop failures.
+- Make Evaluation run creation fail closed if the mandatory audit write cannot persist.
+- Make Chat moderation enforcement stop reporting successful completion when its mandatory audit write fails.
+- Require durable audit intent for a narrow Jobs subset that has clean source-side transaction boundaries in this tranche.
+- Make API-key create, virtual-create, rotate, and revoke use unified audit as the mandatory source of truth.
+- Keep the remediation bounded enough to implement and verify with targeted tests.
+
+## Non-Goals
+
+- Repo-wide audit unification across every remaining domain-local or logger-only audit path.
+- Full Jobs lifecycle audit redesign across every worker/internal path.
+- A full streaming abstraction rewrite to support async-per-chunk moderation transforms.
+- Removal of every legacy compatibility table in the same tranche.
+- Broad audit taxonomy normalization beyond the touched paths.
+
+## Review-Driven Corrections
+
+This design incorporates the following corrections from the design self-review:
+
+- Jobs strictness is narrowed to source-side durable audit intent for `job.created` in this tranche. Full worker-lifecycle unification stays with issue `#1053`.
+- Streaming Chat moderation does not attempt to await audit persistence inside the synchronous text transform. Instead, mandatory moderation audit tasks are tracked and must succeed before the stream is allowed to complete successfully.
+- `shutdown_all_audit_services()` does not become raising-by-default, because app shutdown and cleanup-heavy tests currently rely on best-effort teardown. It will instead report aggregated failures and support an explicit raising mode for targeted callers/tests.
+- Evaluations “run started” webhook emission moves behind the new audit-plus-run-persistence success boundary so external systems are not notified about runs that never committed.
+- AuthNZ compatibility is one-way: unified audit is mandatory, while the legacy `api_key_audit_log` mirror remains best-effort during the transition.
+
+## Architectural Decisions
+
+### 1. Strict Audit Means Surface-Specific Success Boundaries
+
+“Strict audit” does not mean the same mechanism everywhere. It means the parent operation must not report success until the audit contract for that surface is satisfied.
+
+For this tranche:
+
+- Audit core shutdown: buffered events must either commit or be durably spilled to fallback before shutdown is considered clean.
+- Evaluations: the unified audit event must flush successfully before the run is persisted and before the start webhook is emitted.
+- Chat moderation:
+  - input enforcement and non-stream output enforcement must await mandatory audit persistence before returning their moderated result or error
+  - streaming output enforcement must not allow successful stream completion if the tracked mandatory moderation audit task failed
+- Jobs: strictness means durable audit intent at the source transaction boundary for `job.created`, not immediate direct unified-audit success for every internal lifecycle edge
+- AuthNZ API-key management: unified audit must persist before the action is considered successful; the legacy table mirror is secondary
+
+### 2. Typed Audit Failure Signaling
+
+Introduce explicit typed failures for mandatory audit behavior instead of leaking raw runtime or DB exceptions.
+
+Planned exception shape:
+
+- `MandatoryAuditWriteError`
+- `AuditShutdownError`
+
+These let call sites choose between:
+
+- surfacing a clean API error
+- aborting an internal operation
+- aggregating shutdown/reporting state without losing the underlying cause
+
+### 3. Compatibility Is Transitional, Not Co-Primary
+
+When a touched path moves to unified audit, unified audit becomes the only mandatory store.
+
+Legacy tables may remain temporarily for:
+
+- read compatibility
+- transition queries
+- low-risk best-effort mirroring
+
+But they do not become second mandatory durability dependencies.
+
+## Scope Of Changes
+
+### A. Sharing Backfill And Unified Writer Repair
+
+Touched areas:
+
+- `tldw_Server_API/app/core/Sharing/unified_share_audit.py`
+- `tldw_Server_API/app/core/Sharing/share_audit_unified_migration.py`
+- related Sharing tests
+
+Changes:
+
+- Add an explicit `import_legacy_event(...)` API on `UnifiedShareAuditWriter`.
+- Preserve:
+  - `compatibility_id == legacy_share_audit_id`
+  - stable legacy-derived `event_id`
+  - original `created_at` timestamp
+  - idempotent replay behavior
+- Keep compatibility-floor handling aligned with imported legacy ids.
+
+Constraints:
+
+- rerunning the migration must not duplicate imported rows
+- imported history must remain queryable through existing Sharing compatibility reads
+- no silent fallback to synthetic timestamps or ids when legacy values are present
+
+### B. Audit Core Shutdown Durability
+
+Touched areas:
+
+- `tldw_Server_API/app/core/Audit/unified_audit_service.py`
+- related Audit tests
+
+Changes:
+
+- Final `stop()` flush failures are no longer silently swallowed.
+- If the final flush fails, remaining buffered events are durably appended to the fallback queue before shutdown fails.
+- `stop()` raises `AuditShutdownError` when it cannot complete a clean durable shutdown.
+
+Constraints:
+
+- cancellation behavior still preserves buffered events
+- fallback queue append must remain bounded and deterministic
+- `stop()` failure must include enough context for lifecycle callers and tests
+
+### C. Shared Migration Commit-Bound Accounting
+
+Touched areas:
+
+- `tldw_Server_API/app/core/Audit/audit_shared_migration.py`
+- related Audit migration tests
+
+Changes:
+
+- per-chunk inserted/skipped/stat counters remain provisional until checkpoint save and commit succeed
+- report totals update only after successful commit
+- commit failure leaves returned counters consistent with durable state
+
+Constraints:
+
+- duplicate detection logging remains intact
+- checkpoint semantics stay monotonic
+- no inflated success counts on failed chunks
+
+### D. DI And Lifecycle Hardening
+
+Touched areas:
+
+- `tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py`
+- shutdown-related tests
+- app shutdown integration
+
+Changes:
+
+- `shutdown_user_audit_service()` resolves the correct cache key semantics in shared mode instead of only looking up the raw user id
+- targeted shutdown helpers collect and report real stop failures instead of only logging a narrow allowlist
+- `shutdown_all_audit_services()` returns clean aggregated reporting by default and accepts an explicit raising mode for targeted callers/tests
+
+Constraints:
+
+- app shutdown remains best-effort by default
+- cleanup-heavy tests can continue to tear down without widespread breakage
+- targeted tests can still assert that real stop failures surfaced
+
+### E. Evaluations Strict Run-Creation Ordering
+
+Touched areas:
+
+- `tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py`
+- `tldw_Server_API/app/core/DB_Management/Evaluations_DB.py`
+- Evaluations audit adapter/tests
+- Evaluations API tests
+
+Changes:
+
+- pre-generate `run_id`
+- write and flush the mandatory unified audit event using that `run_id`
+- persist the run row only after the audit succeeds
+- schedule async execution only after the run row exists
+- emit the “run started” webhook only after the audit-plus-run-persistence boundary succeeds
+
+Result:
+
+- no persisted run row when mandatory audit persistence fails
+- no external start webhook for a run that never committed
+
+Constraints:
+
+- no change to public response schema
+- no new id generation contract beyond optional `run_id` support already present in the DB layer
+
+### F. Chat Moderation Strictness
+
+Touched areas:
+
+- `tldw_Server_API/app/core/Chat/chat_service.py`
+- Chat moderation tests
+
+Changes:
+
+- Introduce a shared helper for mandatory moderation audit writes that performs `log_event(...)` plus `flush(raise_on_failure=True)`.
+- Input moderation and non-stream output moderation await that helper before returning a moderated result or raising a moderation error.
+- Streaming moderation uses tracked mandatory audit tasks:
+  - first block/redact schedules a mandatory audit task
+  - the stream may not finish successfully if any tracked mandatory moderation audit task failed
+  - block paths remain failing responses; audit failure is observed before successful completion is possible
+
+Important bound:
+
+- This tranche does not redesign streaming transforms to await per-chunk audit writes before every emitted moderated chunk.
+- For streaming redaction, the strict guarantee is “no successful completion without mandatory audit success,” not “no moderated bytes emitted before audit completion.”
+
+### G. Jobs Durable Source Boundary
+
+Touched areas:
+
+- `tldw_Server_API/app/core/Jobs/manager.py`
+- `tldw_Server_API/app/core/Jobs/event_stream.py`
+- `tldw_Server_API/app/core/Jobs/audit_bridge.py`
+- Jobs tests
+
+Changes:
+
+- Narrow this tranche to the `job.created` path, which already has a source-side transactional seam.
+- For `job.created`, require durable audit intent at the source transaction boundary rather than relying only on the side-channel audit bridge.
+- Keep the bridge/outbox replay path as the transport into unified audit where that remains the least-invasive implementation seam.
+
+Result:
+
+- parent success for `job.created` depends on durable audit intent existing
+- the implementation does not attempt a repo-wide rewrite of every worker lifecycle emission path
+
+Deferred:
+
+- broad direct unified-audit enforcement across all Jobs worker/internal lifecycle paths is tracked under issue `#1053`
+
+### H. AuthNZ API-Key Management Unification
+
+Touched areas:
+
+- `tldw_Server_API/app/core/AuthNZ/api_key_manager.py`
+- supporting AuthNZ repo/helpers as needed
+- AuthNZ integration tests
+
+Changes:
+
+- API-key create, virtual-create, rotate, and revoke write mandatory unified audit events
+- these actions fail closed if the mandatory unified audit write cannot persist
+- legacy `api_key_audit_log` writes become best-effort compatibility mirroring only
+- API-key usage-touch auditing remains best-effort and does not gate ordinary request authentication
+
+Reason:
+
+- management actions are security-significant and reviewable
+- usage heartbeat writes occur on normal request validation and should not turn audit trouble into broad auth outages
+
+## Failure Semantics
+
+### API/Service Calls
+
+For the touched strict surfaces:
+
+- mandatory audit persistence failure aborts the parent operation
+- call sites should raise `MandatoryAuditWriteError` (or a surface-specific wrapper) rather than raw DB/runtime errors
+- HTTP-facing paths in this tranche should map that failure to `503 Service Unavailable` with a stable audit-persistence failure detail
+
+### Shutdown
+
+- individual service `stop()` may raise `AuditShutdownError`
+- global shutdown helpers return an aggregated shutdown summary by default and log its failures
+- targeted callers/tests may opt into a raising mode when they need hard assertions
+
+## Testing Strategy
+
+All implementation work in this tranche follows TDD for each defect or behavior change.
+
+Required regression coverage:
+
+- Sharing legacy import remains idempotent and preserves ids/timestamps
+- final `stop()` flush failure spills to fallback and raises `AuditShutdownError`
+- shared migration counters are not inflated on commit failure
+- shared-mode `shutdown_user_audit_service()` actually stops the shared singleton
+- shutdown helpers can report non-allowlisted stop failures in targeted tests
+- Evaluations run creation leaves no run row and no run-start webhook when mandatory audit fails
+- Chat input moderation fails closed on mandatory audit failure
+- Chat streaming moderation does not end successfully if tracked mandatory moderation audit tasks fail
+- Jobs `job.created` requires durable audit intent, and no worker/internal lifecycle path is required to become direct unified-audit-strict in this tranche
+- AuthNZ API-key management actions write unified audit and fail closed when that write fails
+- legacy API-key audit compatibility mirror, if retained, remains best-effort and non-blocking
+
+## Risks And Mitigations
+
+### Risk: Over-broad Jobs remediation
+
+Mitigation:
+
+- explicitly narrow the Jobs scope to source-side transactional boundaries in this tranche
+- require `job.created` as the only mandatory Jobs write in the minimum acceptable implementation for this tranche
+- track broader lifecycle unification separately under `#1053`
+
+### Risk: Streaming moderation strictness is overstated
+
+Mitigation:
+
+- define the exact guarantee as completion-bound strictness for streaming redaction
+- avoid promising async-per-chunk audit enforcement without a broader stream refactor
+
+### Risk: Shutdown raising breaks existing cleanup flows
+
+Mitigation:
+
+- raise at service-stop granularity
+- keep global shutdown aggregated/best-effort by default
+- add explicit raising mode for targeted tests and narrow callers
+
+### Risk: Dual-write compatibility increases failure surface
+
+Mitigation:
+
+- make unified audit the only mandatory store
+- keep legacy mirrors best-effort only
+
+## Acceptance Criteria
+
+- The Sharing backfill regression is fixed and covered by tests.
+- `UnifiedAuditService.stop()` no longer silently loses buffered events during final flush failure.
+- shared migration reports match durable commit state.
+- shared-mode audit shutdown works correctly and targeted shutdown tests can detect real stop failures.
+- Evaluations run creation, selected Chat moderation paths, Jobs `job.created`, and AuthNZ API-key management actions all enforce their revised audit contract.
+- The remediation remains bounded and does not absorb the broader unification work tracked in `#1053`.

--- a/Docs/superpowers/specs/2026-04-09-characters-fullstack-findings-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-09-characters-fullstack-findings-remediation-design.md
@@ -1,0 +1,269 @@
+# Characters Full-Stack Findings Remediation Design
+
+**Date:** 2026-04-09
+
+**Goal:** Fix the approved Character audit findings and improvements across backend correctness, frontend behavior, frontend workspace tooling, and regression coverage, then verify the fixes with the same targeted validation slices that informed the review.
+
+## Problem Statement
+
+The completed Character full-stack delta review identified five live implementation issues plus one enabling infrastructure gap:
+
+- backend manual memory extraction authorizes against `user_id` even though conversations are stored with `client_id`
+- backend streamed assistant persistence can skip hard validation when internal quota/count checks fail
+- frontend Character handoff payloads are narrower than the fields downstream consumers already read before hydration
+- frontend quick-chat promotion seeds `serverChatId` before assistant identity metadata
+- the Character journey E2E does not actually validate Character selection or prompt propagation
+- the prescribed frontend Vitest and Playwright command paths do not currently resolve through usable repo-local tooling in this checkout
+
+These findings should be remediated as one coordinated effort because the frontend behavior fixes and their regression coverage depend on making the workspace toolchain runnable first.
+
+## Scope
+
+### In Scope
+
+- normalize frontend workspace tooling so the prescribed Character Vitest and Playwright commands execute against repo-local tooling
+- fix manual Character memory-extraction ownership validation
+- change streamed Character assistant persistence to save once, then return `503` on internal quota/count-check failure without duplicating the assistant reply on retry
+- widen Character handoff payloads so existing pre-hydration consumers receive the fields they already read
+- seed assistant identity metadata during quick-chat promotion before navigation when the data is already available
+- add backend, frontend, and browser regressions for the reviewed findings
+- rerun the targeted review validation slices after implementation
+
+### Out of Scope
+
+- unrelated Character UI redesign or workflow changes
+- broad chat-storage architecture changes outside the streamed Character persist path
+- generic cross-module deduplication frameworks
+- refactoring unrelated dirty-worktree files
+
+## Approved Decisions
+
+### Delivery Order
+
+Use a staged verification-first sequence:
+
+1. repair frontend workspace/tool resolution
+2. fix backend correctness
+3. fix frontend handoff behavior
+4. add and run regression coverage
+
+This order reduces risk because the frontend fixes should be verified with the same commands that previously failed for environment reasons.
+
+### Frontend Behavior Strategy
+
+Preserve fast navigation. Do not delay route changes just to wait for full Character hydration.
+
+Instead:
+
+- seed richer selected-character state immediately
+- seed quick-chat assistant metadata before navigation when already available
+- keep later hydration as the fallback path, not the primary source of truth
+
+### Streamed Persist Failure Strategy
+
+For internal quota/count-check failures in the streamed assistant persist path:
+
+- save the assistant reply
+- return `503` to signal degraded validation
+- prevent duplicate assistant persistence on retry of the same streamed reply
+
+This is intentionally different from the direct-send path, which still fails closed before persistence.
+
+## Architecture
+
+The remediation is split into four workstreams.
+
+### Workstream 1: Frontend Workspace Tooling
+
+Repair the shared `apps/` frontend workspace so the existing commands already named in the review execute against repo-local tools:
+
+- `cd apps/packages/ui && bun run test -- ...`
+- `cd apps/tldw-frontend && bun run e2e:pw -- ...`
+
+The fix should address command resolution, workspace dependency visibility, and runner invocation so the checkout does not fall back to broken or non-repo binaries.
+
+The target is broader than the Character module alone: the shared frontend workspace install should be normalized so sibling frontend test commands resolve through repo-local tooling too, even if the implementation validates only the Character slices immediately.
+
+### Workstream 2: Backend Correctness
+
+#### Manual Memory Extraction Ownership
+
+Align the memory-extraction endpoint with the ownership field actually stored and surfaced by conversation persistence. The endpoint should:
+
+- accept chats owned by the current user via stored conversation ownership
+- reject foreign chats
+- preserve the rest of the extraction flow unchanged
+
+#### Streamed Persist Save-Then-503
+
+Keep assistant persistence in the Character streamed persist path, but treat internal quota/count-check failures as degraded validation rather than as permission to silently continue.
+
+Required behavior:
+
+- assistant reply persists once
+- response returns `503`
+- retry of the same streamed reply does not write a duplicate assistant message
+
+### Workstream 3: Frontend Handoff Correctness
+
+#### Selected-Character Payload Fidelity
+
+The shared Character handoff payload should preserve the fields current pre-hydration consumers already read, including:
+
+- greeting variants
+- `extensions`
+- image-related fields
+- other existing Character identity fields already present on the source record
+
+The purpose is not to create a new canonical frontend Character shape. It is to stop handing downstream consumers a knowingly weaker temporary object than the data already available at the handoff point.
+
+#### Quick-Chat Assistant Metadata Seeding
+
+Quick-chat promotion should set:
+
+- `serverChatCharacterId`
+- `serverChatAssistantKind`
+- `serverChatAssistantId`
+
+before navigation whenever the promoted state already has enough information to do so.
+
+Later `getChat()`-based hydration remains the fallback for incomplete or stale state.
+
+### Workstream 4: Regression Coverage
+
+Add the minimal targeted regressions that directly encode the reviewed findings:
+
+- backend endpoint regression for memory-extraction ownership
+- backend persist regression for save-once, `503`, and no duplicate on retry
+- frontend regression for Character handoff payload richness
+- frontend regression for quick-chat metadata seeding before navigation
+- browser journey regression for Character selection and prompt propagation into `/chat/completions`
+
+## Data and Idempotency Strategy
+
+Duplicate suppression for streamed persist should remain narrow and local to the Character persist endpoint.
+
+Recommended contract:
+
+- derive or reuse a stable per-reply persist identity
+- scope that identity to the same conversation and same assistant reply
+- store the identity in persisted assistant-message metadata
+- on retry, detect an existing assistant message for the same persist identity and return the existing logical outcome instead of writing a second assistant reply
+
+Identity source preference:
+
+1. reuse an existing stable per-turn or per-message reference if the request already carries one across retries
+2. otherwise derive a deterministic fingerprint from conversation id, parent/user message id, and assistant reply payload
+
+This should be narrow enough to avoid blocking legitimate repeated assistant turns while still preventing duplicates when the initial save succeeded but the endpoint responded with `503`.
+
+## Testing Strategy
+
+### Frontend Tooling Verification
+
+First, make these exact commands runnable in this checkout:
+
+```bash
+cd apps/packages/ui && bun run test -- \
+  src/components/Option/Characters/__tests__/Manager.first-use.test.tsx \
+  src/components/Option/Characters/__tests__/Manager.crossFeatureStage1.test.tsx \
+  src/components/Option/Characters/__tests__/CharacterGalleryCard.test.tsx \
+  src/components/Option/Characters/__tests__/import-state-model.test.ts \
+  src/components/Option/Characters/__tests__/search-utils.test.ts \
+  src/services/__tests__/tldw-api-client.characters-list-all.test.ts \
+  src/services/__tests__/tldw-api-client.characters-delete.test.ts \
+  src/hooks/__tests__/useCharacterGreeting.test.tsx \
+  src/hooks/__tests__/useServerChatLoader.test.ts \
+  src/utils/__tests__/character-greetings.test.ts \
+  src/utils/__tests__/character-mood.test.ts \
+  src/utils/__tests__/default-character-preference.test.ts \
+  src/utils/__tests__/characters-route.test.ts \
+  --maxWorkers=1
+```
+
+```bash
+cd apps/tldw-frontend && bun run e2e:pw -- \
+  e2e/workflows/tier-2-features/characters.spec.ts \
+  e2e/workflows/journeys/character-chat.spec.ts \
+  --reporter=line
+```
+
+### Backend Regression Verification
+
+After backend fixes:
+
+- run focused backend tests for the new endpoint and streamed-persist behaviors
+- rerun the previously reviewed backend slices to confirm no local regression
+
+### Frontend Regression Verification
+
+After frontend fixes:
+
+- add targeted unit/integration tests for payload fidelity and quick-chat metadata seeding
+- rerun the prescribed Character frontend Vitest slice
+
+### Browser Verification
+
+After E2E changes:
+
+- rerun the Character Playwright slice
+- verify the journey test now asserts actual Character selection and `/chat/completions` prompt propagation
+
+### Security and Completion Verification
+
+Before completion:
+
+- run Bandit on touched Python paths from the project virtual environment
+- rerun the affected validation commands and capture exact outcomes
+
+## Risks and Mitigations
+
+### Risk: Toolchain repair bleeds into unrelated frontend setup
+
+Mitigation:
+
+- keep the goal narrowly tied to repo-local command resolution for the shared `apps/` workspace
+- prefer the smallest install/config change that restores workspace-local Vitest and Playwright resolution
+
+### Risk: Persist duplicate suppression blocks legitimate repeated turns
+
+Mitigation:
+
+- scope dedupe by conversation and stable reply identity
+- apply it only to the streamed Character persist path
+- cover retry and non-retry cases in tests
+
+### Risk: Richer handoff payloads drift from canonical Character normalization
+
+Mitigation:
+
+- keep the handoff change additive and field-preserving
+- avoid inventing new semantics
+- rely on later hydration to remain canonical
+
+### Risk: Fast-navigation quick-chat fix still misses edge timing
+
+Mitigation:
+
+- seed metadata before navigation when the data is already present
+- keep existing hydration paths intact
+- verify with targeted tests and the Character journey E2E
+
+## Success Criteria
+
+The remediation is complete when all of the following are true:
+
+- the shared frontend workspace resolves the prescribed Character Vitest and Playwright commands through repo-local tooling
+- manual memory extraction authorizes owned chats correctly
+- streamed Character persist saves once, returns `503` on internal quota/count-check failure, and does not duplicate on retry
+- Character handoff payloads include the fields already consumed before hydration
+- quick-chat promotion seeds assistant metadata before navigation when possible
+- backend, frontend, and browser regressions exist for the reviewed findings
+- the previously prescribed backend/frontend validation slices run successfully or fail only for clearly unrelated reasons
+
+## Implementation Notes
+
+- keep commits scoped by logical workstream where practical
+- do not touch unrelated dirty-worktree files
+- if dependency installation or lockfile changes are required, isolate them and verify they are intentional
+- preserve existing user-facing navigation speed while improving first-paint correctness

--- a/Docs/superpowers/specs/2026-04-09-characters-fullstack-findings-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-09-characters-fullstack-findings-remediation-design.md
@@ -24,6 +24,7 @@ These findings should be remediated as one coordinated effort because the fronte
 - normalize frontend workspace tooling so the prescribed Character Vitest and Playwright commands execute against repo-local tooling
 - fix manual Character memory-extraction ownership validation
 - change streamed Character assistant persistence to save once, then return `503` on internal quota/count-check failure without duplicating the assistant reply on retry
+- update Character streamed-persist callers so a saved-but-degraded `503` does not trigger duplicate fallback persistence
 - widen Character handoff payloads so existing pre-hydration consumers receive the fields they already read
 - seed assistant identity metadata during quick-chat promotion before navigation when the data is already available
 - add backend, frontend, and browser regressions for the reviewed findings
@@ -103,6 +104,8 @@ Required behavior:
 - assistant reply persists once
 - response returns `503`
 - retry of the same streamed reply does not write a duplicate assistant message
+- the degraded `503` exposes a machine-detectable saved outcome in error details so Character clients can distinguish "saved but validation degraded" from "not saved"
+- Character callers that currently fall back to `addChatMessage()` treat that saved-degraded outcome as terminal and do not perform duplicate fallback persistence
 
 ### Workstream 3: Frontend Handoff Correctness
 
@@ -117,6 +120,8 @@ The shared Character handoff payload should preserve the fields current pre-hydr
 
 The purpose is not to create a new canonical frontend Character shape. It is to stop handing downstream consumers a knowingly weaker temporary object than the data already available at the handoff point.
 
+Implement this through one shared field-preserving builder/helper used by both normal Character selection and quick-chat promotion, so the handoff contract cannot drift immediately across duplicate mappers.
+
 #### Quick-Chat Assistant Metadata Seeding
 
 Quick-chat promotion should set:
@@ -129,12 +134,15 @@ before navigation whenever the promoted state already has enough information to 
 
 Later `getChat()`-based hydration remains the fallback for incomplete or stale state.
 
+Pre-seeding must not mark server-chat metadata as fully loaded by itself. Keep `serverChatMetaLoaded` false unless the promoted state is already equivalent to authoritative server-chat metadata, so the later `getChat()` hydration path can still correct stale or incomplete assistant identity.
+
 ### Workstream 4: Regression Coverage
 
 Add the minimal targeted regressions that directly encode the reviewed findings:
 
 - backend endpoint regression for memory-extraction ownership
 - backend persist regression for save-once, `503`, and no duplicate on retry
+- frontend streamed-persist regression for saved-degraded `503` handling without `addChatMessage()` duplication
 - frontend regression for Character handoff payload richness
 - frontend regression for quick-chat metadata seeding before navigation
 - browser journey regression for Character selection and prompt propagation into `/chat/completions`
@@ -150,10 +158,19 @@ Recommended contract:
 - store the identity in persisted assistant-message metadata
 - on retry, detect an existing assistant message for the same persist identity and return the existing logical outcome instead of writing a second assistant reply
 
+Because the current streamed-persist request schema does not carry a dedicated idempotency key, server-side deterministic fingerprinting should be the default identity source.
+
+Fingerprint inputs should include the smallest stable fields that identify the same streamed reply:
+
+- conversation id
+- parent/user message id when present
+- speaker Character identity when present
+- normalized assistant reply payload
+
 Identity source preference:
 
-1. reuse an existing stable per-turn or per-message reference if the request already carries one across retries
-2. otherwise derive a deterministic fingerprint from conversation id, parent/user message id, and assistant reply payload
+1. derive the deterministic server-side fingerprint above
+2. reuse an existing stable per-turn or per-message reference only if the implementation confirms the request already carries one consistently across retries
 
 This should be narrow enough to avoid blocking legitimate repeated assistant turns while still preventing duplicates when the initial save succeeded but the endpoint responded with `503`.
 
@@ -199,7 +216,7 @@ After backend fixes:
 
 After frontend fixes:
 
-- add targeted unit/integration tests for payload fidelity and quick-chat metadata seeding
+- add targeted unit/integration tests for payload fidelity, quick-chat metadata seeding, and saved-degraded streamed-persist handling
 - rerun the prescribed Character frontend Vitest slice
 
 ### Browser Verification
@@ -256,6 +273,7 @@ The remediation is complete when all of the following are true:
 - the shared frontend workspace resolves the prescribed Character Vitest and Playwright commands through repo-local tooling
 - manual memory extraction authorizes owned chats correctly
 - streamed Character persist saves once, returns `503` on internal quota/count-check failure, and does not duplicate on retry
+- Character streamed-persist callers recognize the saved-degraded `503` outcome and do not fall back to duplicate `addChatMessage()` persistence
 - Character handoff payloads include the fields already consumed before hydration
 - quick-chat promotion seeds assistant metadata before navigation when possible
 - backend, frontend, and browser regressions exist for the reviewed findings

--- a/Docs/superpowers/specs/2026-04-09-writing-fullstack-review-design.md
+++ b/Docs/superpowers/specs/2026-04-09-writing-fullstack-review-design.md
@@ -41,6 +41,13 @@ This review covers the current full Writing module in the workspace, centered on
 
 The review includes route parity, API shape compatibility, capability handshake behavior, stateful session/template/theme flows, manuscript CRUD and reorder behavior, analysis and wordcloud behavior, editor integration, import/export paths, and the test coverage that defends those behaviors.
 
+Because the full Writing surface is large, execution should prioritize the highest-risk paths first rather than attempting a file-by-file sweep of every Writing utility. The highest-priority surfaces are:
+
+- shared Writing entrypoints, shell, store, and service layers
+- backend stateful Writing and manuscript routes plus their direct persistence boundaries
+- cross-surface parity guards and contract-heavy tests
+- auxiliary utility modules only when they participate in a concrete workflow, a failing guard, or a candidate finding
+
 ## Non-Goals
 
 This review does not cover:
@@ -117,6 +124,7 @@ Inspect:
 - shared UI component boundaries and state ownership
 - Writing store and service layers
 - backend endpoint and schema contracts
+- auth, dependency, and rate-limit boundaries on the Writing backend routes
 - parity guards and route-level tests
 
 Primary questions:
@@ -124,6 +132,7 @@ Primary questions:
 - do the web and extension surfaces rely on the shared Writing module consistently?
 - do service and store assumptions match backend request and response shapes?
 - are capability, mode, and route assumptions consistent across surfaces?
+- are auth, dependency, and rate-limit protections consistent with the exposed Writing behavior?
 
 ### Pass 2: Stateful workflow pass
 
@@ -164,7 +173,8 @@ Inspect and run only the highest-value tests needed to answer concrete questions
 - backend pytest slices under `tldw_Server_API/tests/Writing/`
 - Writing-specific shared UI tests under `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/`
 - route/store/service tests in the shared UI package
-- Writing parity and the smallest meaningful Writing e2e tests
+- Writing parity guards and route-level tests before any heavier end-to-end execution
+- the smallest meaningful Writing e2e tests only when a candidate finding cannot be settled by local code reading plus narrower tests, and only when the relevant harness is already runnable
 - Bandit on the Writing backend scope if code changes are later made as follow-up remediation
 
 Primary questions:
@@ -172,6 +182,7 @@ Primary questions:
 - which risky paths are already covered versus weakly defended?
 - do executed tests confirm the suspected behavior or reveal blind spots?
 - which remaining unknowns need to stay labeled as open questions?
+- if a heavier verification path is unavailable or too expensive for this review, is that blind spot stated explicitly instead of silently skipped?
 
 ## Review Criteria
 
@@ -208,6 +219,7 @@ The final review output should be organized as:
 Each finding should include:
 
 - severity (`High`, `Medium`, or `Low`)
+- confidence (`Confirmed` or `Probable`)
 - type (`correctness`, `security`, `performance`, `maintainability`, `parity`, or `test gap`)
 - impact
 - concrete reasoning
@@ -226,6 +238,7 @@ Each finding should include:
 - Large Writing files and duplicated logic are not findings by themselves unless they create drift, defects, or material maintenance risk.
 - Tests and code both matter, but passing tests do not override contradictory code evidence.
 - Targeted verification is required, but broad blanket suites are out of scope.
+- The review should not devolve into a blanket sweep of every Writing helper or test file. Lower-level utilities and heavier e2e suites are only pulled in when they support a concrete workflow, guard contract, or candidate finding.
 
 ## Success Criteria
 

--- a/Docs/superpowers/specs/2026-04-09-writing-fullstack-review-design.md
+++ b/Docs/superpowers/specs/2026-04-09-writing-fullstack-review-design.md
@@ -1,0 +1,237 @@
+# Writing Full-Stack Review Design
+
+Date: 2026-04-09
+Topic: Full-stack review of the Writing module in `tldw_server`
+
+## Goal
+
+Produce an evidence-based full-stack review of the Writing module that identifies:
+
+- correctness bugs and edge-case failures
+- cross-surface parity issues between shared UI, web route, extension route, and backend contracts
+- data integrity and optimistic-locking/versioning risks
+- security and unsafe-input handling issues
+- maintainability and drift risks in the large Writing code surface
+- performance concerns that can plausibly create user-facing defects
+- missing or misleading automated tests
+
+The review is intended to prioritize concrete, user-relevant findings over stylistic commentary.
+
+## Scope
+
+This review covers the current full Writing module in the workspace, centered on:
+
+- backend Writing endpoints and schemas:
+  - `tldw_Server_API/app/api/v1/endpoints/writing.py`
+  - `tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py`
+  - `tldw_Server_API/app/api/v1/schemas/writing_schemas.py`
+  - `tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py`
+  - `tldw_Server_API/app/core/Writing/manuscript_analysis.py`
+  - direct persistence and helper boundaries used by those routes, especially `ChaChaNotes_DB.py` and `ManuscriptDB.py`
+- backend Writing tests under `tldw_Server_API/tests/Writing/`
+- shared Writing Playground UI under `apps/packages/ui/src/components/Option/WritingPlayground/`
+- Writing route, store, and service layers:
+  - `apps/packages/ui/src/routes/option-writing-playground.tsx`
+  - `apps/packages/ui/src/store/writing-playground.tsx`
+  - `apps/packages/ui/src/services/writing-playground.ts`
+- web and extension route wrappers:
+  - `apps/tldw-frontend/pages/writing-playground.tsx`
+  - `apps/tldw-frontend/extension/routes/option-writing-playground.tsx`
+- Writing-specific frontend unit, integration, parity, and targeted e2e coverage
+
+The review includes route parity, API shape compatibility, capability handshake behavior, stateful session/template/theme flows, manuscript CRUD and reorder behavior, analysis and wordcloud behavior, editor integration, import/export paths, and the test coverage that defends those behaviors.
+
+## Non-Goals
+
+This review does not cover:
+
+- unrelated Notes, Chat, or broader app surfaces unless a Writing path directly depends on them
+- broad visual or styling feedback that does not affect correctness, parity, or maintainability
+- implementing fixes during the review phase
+- unrelated refactoring outside the Writing module
+- blanket repo-wide test or security sweeps outside Writing-related paths
+
+## Approaches Considered
+
+### 1. Full-stack boundary-first audit
+
+Start with user-visible Writing flows, then trace each flow through route, shared UI, store, service, backend, and persistence boundaries.
+
+Strengths:
+
+- strongest fit for a full-stack module with shared UI and multiple route shells
+- good at catching parity drift and contract mismatches
+- keeps findings tied to real workflows instead of isolated files
+
+Weaknesses:
+
+- slower than a backend-only or pure coverage-first review
+
+### 2. UI-first workflow audit
+
+Drive from end-user workflows first, then inspect code only where the workflow appears fragile or inconsistent.
+
+Strengths:
+
+- good at surfacing defects users will actually feel
+- efficient for navigation, editing, and interaction regressions
+
+Weaknesses:
+
+- easier to miss backend integrity issues that are not obvious from the UI
+
+### 3. Coverage-first audit
+
+Map the existing tests first, then inspect under-tested or untested branches and use targeted execution to validate risky paths.
+
+Strengths:
+
+- efficient for identifying false confidence and high-value test gaps
+- useful in a module with many guard tests and parity checks
+
+Weaknesses:
+
+- weaker when current tests already encode flawed assumptions
+- can underweight design-level contract problems
+
+## Recommended Approach
+
+Use a full-stack boundary-first audit with risk-first ordering.
+
+Execution order:
+
+1. inspect the shared UI surface, route wrappers, service/store contracts, and backend contracts together
+2. trace state-changing workflows end to end
+3. inspect editor, auxiliary tooling, and security-relevant client behavior
+4. compare findings against current tests and run only narrow verification needed to confirm or weaken specific claims
+
+This gives the best balance between bug-finding speed, parity checking, and practical full-stack scope control.
+
+## Review Method
+
+### Pass 1: Surface and parity pass
+
+Inspect:
+
+- web route wrapper, extension route wrapper, and shared Writing Playground entrypoints
+- shared UI component boundaries and state ownership
+- Writing store and service layers
+- backend endpoint and schema contracts
+- parity guards and route-level tests
+
+Primary questions:
+
+- do the web and extension surfaces rely on the shared Writing module consistently?
+- do service and store assumptions match backend request and response shapes?
+- are capability, mode, and route assumptions consistent across surfaces?
+
+### Pass 2: Stateful workflow pass
+
+Inspect:
+
+- sessions, templates, themes, and defaults
+- snapshot import/export and clone flows
+- manuscript CRUD, reorder, soft-delete, and search flows
+- analysis persistence and stale-marking behavior
+- versioning and optimistic-locking assumptions across client and server
+
+Primary questions:
+
+- can data be lost, duplicated, corrupted, or silently reshaped?
+- can stale state or ordering drift produce user-visible defects?
+- do state transitions preserve invariants across client and server boundaries?
+
+### Pass 3: Editor and auxiliary tools pass
+
+Inspect:
+
+- TipTap/editor integration and plain-text bridges
+- workspace mode logic and inspector panels
+- analysis modals and feedback-related helpers
+- tokenizer, logprob, response-inspector, and wordcloud utilities
+- import/export helpers and any unsafe rendering or CSS-handling assumptions
+
+Primary questions:
+
+- can editor-state or helper-state drift break workflows or mislead users?
+- are failure modes explicit and bounded?
+- are there client-side security or sanitization assumptions that are too weak?
+
+### Pass 4: Targeted verification pass
+
+Inspect and run only the highest-value tests needed to answer concrete questions:
+
+- backend pytest slices under `tldw_Server_API/tests/Writing/`
+- Writing-specific shared UI tests under `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/`
+- route/store/service tests in the shared UI package
+- Writing parity and the smallest meaningful Writing e2e tests
+- Bandit on the Writing backend scope if code changes are later made as follow-up remediation
+
+Primary questions:
+
+- which risky paths are already covered versus weakly defended?
+- do executed tests confirm the suspected behavior or reveal blind spots?
+- which remaining unknowns need to stay labeled as open questions?
+
+## Review Criteria
+
+Each potential issue is evaluated against these categories:
+
+- correctness and edge-case safety
+- cross-surface parity and contract consistency
+- data integrity and version/concurrency behavior
+- security and unsafe-input handling rigor
+- maintainability and drift risk
+- performance and unnecessary work on hot paths
+- test coverage and test quality
+
+## Evidence Standard
+
+The review should avoid speculative claims. A finding should be backed by at least one of:
+
+- a concrete code path that produces incorrect or risky behavior
+- an invariant mismatch between client, service, backend, or persistence layers
+- an unguarded failure mode
+- a meaningful missing or weak test around a critical branch or user-visible contract
+
+Ambiguous items should be labeled as open questions or assumptions rather than overstated as defects.
+
+## Deliverable Format
+
+The final review output should be organized as:
+
+1. findings first, ordered by severity
+2. open questions or assumptions
+3. lower-priority improvements
+4. verification performed and remaining blind spots
+
+Each finding should include:
+
+- severity (`High`, `Medium`, or `Low`)
+- type (`correctness`, `security`, `performance`, `maintainability`, `parity`, or `test gap`)
+- impact
+- concrete reasoning
+- file reference(s)
+
+## Severity Model
+
+- `High`: likely bug, data loss/corruption risk, security issue, or major cross-surface regression risk
+- `Medium`: correctness edge case, contract inconsistency, meaningful maintainability problem, or performance issue with user-visible impact
+- `Low`: smaller cleanup, localized code smell, or lower-priority missing-test issue
+
+## Constraints and Assumptions
+
+- This phase is analysis-first; fixes are out of scope unless explicitly requested afterward.
+- The review targets the current workspace state and should call out if any finding depends on uncommitted Writing changes. At the time of scoping, there were no uncommitted Writing-module changes.
+- Large Writing files and duplicated logic are not findings by themselves unless they create drift, defects, or material maintenance risk.
+- Tests and code both matter, but passing tests do not override contradictory code evidence.
+- Targeted verification is required, but broad blanket suites are out of scope.
+
+## Success Criteria
+
+This design is successful if it produces a full-stack Writing review that:
+
+- stays focused on the actual Writing module surface
+- finds issues across UI, API, and persistence boundaries rather than treating layers in isolation
+- ranks findings in a defensible, evidence-backed way
+- identifies where the module is solid, where it is risky, and where coverage is misleading or insufficient

--- a/tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py
@@ -4,6 +4,7 @@ Manages user-specific audit service instances for dependency injection.
 
 import asyncio
 import concurrent.futures
+import contextlib
 import os
 import threading
 import time
@@ -47,6 +48,8 @@ _VALID_STORAGE_MODES = {"per_user", "shared"}
 
 @dataclass(frozen=True)
 class AuditShutdownSummary:
+    """Summarize how many audit services shutdown attempted, stopped, or failed."""
+
     requested: int = 0
     stopped: int = 0
     timeout_count: int = 0
@@ -161,6 +164,7 @@ async def _stop_audit_service_instance(
     timeout_s: Optional[float] = None,
 ) -> tuple[bool, bool, Optional[str], Optional[BaseException]]:
     owner_loop = getattr(service, "owner_loop", None)
+    future: concurrent.futures.Future[Any] | None = None
     if owner_loop:
         try:
             if owner_loop.is_closed():
@@ -191,6 +195,9 @@ async def _stop_audit_service_instance(
             await awaitable
         return True, False, None, None
     except asyncio.TimeoutError as exc:
+        if future is not None:
+            with contextlib.suppress(Exception):
+                future.cancel()
         timeout_label = (
             f"Audit service shutdown timed out after {timeout_s:.2f}s ({label})"
             if timeout_s is not None
@@ -543,6 +550,7 @@ class _LoopState:
     init_lock: threading.Lock = field(default_factory=threading.Lock)
     initializing_users: set[Optional[Union[int, str]]] = field(default_factory=set)
     initializing_events: dict[Optional[Union[int, str]], asyncio.Event] = field(default_factory=dict)
+    shutting_down_keys: set[Optional[Union[int, str]]] = field(default_factory=set)
 
 
 _STATE_LOCK = threading.Lock()
@@ -657,6 +665,10 @@ async def _get_or_create_audit_service_for_key(user_id: Optional[Union[int, str]
 
     while True:
         with state.init_lock:
+            if cache_key in state.shutting_down_keys:
+                msg = f"Audit service initialization aborted during shutdown for user {user_id}"
+                logger.warning(msg)
+                raise ServiceInitializationError(msg)
             if cache_key in state.initializing_users:
                 if cache_key not in state.initializing_events:
                     state.initializing_events[cache_key] = asyncio.Event()
@@ -711,6 +723,11 @@ async def _get_or_create_audit_service_for_key(user_id: Optional[Union[int, str]
                 service_instance = await _create_audit_service_for_user(user_id)
 
             # Store in cache
+            with state.init_lock:
+                if cache_key in state.shutting_down_keys:
+                    msg = f"Audit service initialization aborted during shutdown for user {user_id}"
+                    logger.warning(msg)
+                    raise ServiceInitializationError(msg)
             with state.cache_lock:
                 state.cache[cache_key] = service_instance
 
@@ -727,6 +744,17 @@ async def _get_or_create_audit_service_for_key(user_id: Optional[Union[int, str]
                 event = state.initializing_events.pop(cache_key, None)
                 if event:
                     event.set()
+                should_clear_shutdown_key = (
+                    cache_key in state.shutting_down_keys
+                    and cache_key not in state.initializing_users
+                )
+            if should_clear_shutdown_key:
+                with state.cache_lock:
+                    has_cached_service = cache_key in state.cache
+                if not has_cached_service:
+                    with state.init_lock:
+                        if cache_key not in state.initializing_users:
+                            state.shutting_down_keys.discard(cache_key)
 
     if service_instance is None:
         # Defensive: should not happen, but avoid returning None.
@@ -838,48 +866,60 @@ async def shutdown_user_audit_service(user_id: int) -> AuditShutdownSummary:
     stopped = 0
 
     cache_keys = _shutdown_cache_keys(user_id)
-    for state in _all_loop_states():
-        with state.cache_lock:
-            for cache_key in cache_keys:
-                existing = state.cache.get(cache_key)
-                if existing:
-                    pop_no_cb = getattr(state.cache, "pop_no_callback", None)
-                    service = pop_no_cb(cache_key, None) if callable(pop_no_cb) else state.cache.pop(cache_key, None)
-                    if service:
-                        services.append(service)
+    states = list(_all_loop_states())
+    try:
+        for state in states:
+            waiters: list[asyncio.Event] = []
+            with state.init_lock:
+                for cache_key in cache_keys:
+                    state.shutting_down_keys.add(cache_key)
+                    event = state.initializing_events.get(cache_key)
+                    if event is not None:
+                        waiters.append(event)
+            for event in waiters:
+                event.set()
 
-        with state.init_lock:
-            for cache_key in cache_keys:
-                state.initializing_users.discard(cache_key)
-                event = state.initializing_events.pop(cache_key, None)
-                if event:
-                    event.set()
+            with state.cache_lock:
+                for cache_key in cache_keys:
+                    existing = state.cache.get(cache_key)
+                    if existing:
+                        pop_no_cb = getattr(state.cache, "pop_no_callback", None)
+                        service = pop_no_cb(cache_key, None) if callable(pop_no_cb) else state.cache.pop(cache_key, None)
+                        if service:
+                            services.append(service)
 
-    if not services:
-        return AuditShutdownSummary()
+        if not services:
+            return AuditShutdownSummary()
 
-    requested = len(services)
-    for service in services:
-        stopped_ok, _, error_message, _exc = await _stop_audit_service_instance(
-            service,
-            label=f"user {user_id}",
+        requested = len(services)
+        for service in services:
+            stopped_ok, _, error_message, _exc = await _stop_audit_service_instance(
+                service,
+                label=f"user {user_id}",
+            )
+            if stopped_ok:
+                stopped += 1
+                logger.info(f"Shut down audit service for user {user_id}")
+            elif error_message:
+                errors.append(error_message)
+
+        return AuditShutdownSummary(
+            requested=requested,
+            stopped=stopped,
+            timeout_count=0,
+            error_count=len(errors),
+            errors=tuple(errors),
         )
-        if stopped_ok:
-            stopped += 1
-            logger.info(f"Shut down audit service for user {user_id}")
-        elif error_message:
-            errors.append(error_message)
-
-    return AuditShutdownSummary(
-        requested=requested,
-        stopped=stopped,
-        timeout_count=0,
-        error_count=len(errors),
-        errors=tuple(errors),
-    )
+    finally:
+        for state in states:
+            with state.init_lock:
+                for cache_key in cache_keys:
+                    if cache_key not in state.initializing_users:
+                        state.shutting_down_keys.discard(cache_key)
+                        state.initializing_events.pop(cache_key, None)
 
 
-async def shutdown_all_audit_services(*, raise_on_error: bool = False) -> AuditShutdownSummary:
+async def shutdown_all_audit_services(*, raise_on_error: bool = True) -> AuditShutdownSummary:
     """
     Shutdown all cached audit service instances.
     Useful for application shutdown.
@@ -900,88 +940,105 @@ async def shutdown_all_audit_services(*, raise_on_error: bool = False) -> AuditS
     errors: list[str] = []
     first_exception: BaseException | None = None
 
-    for state in _all_loop_states():
-        with state.cache_lock:
-            keys = list(state.cache.keys())
-            total_instances += len(keys)
-            for key in keys:
-                pop_no_cb = getattr(state.cache, "pop_no_callback", None)
-                service = pop_no_cb(key, None) if callable(pop_no_cb) else state.cache.pop(key, None)
-                if service:
-                    services.append(service)
-
-        with state.init_lock:
-            for event in state.initializing_events.values():
-                event.set()
-            state.initializing_events.clear()
-            state.initializing_users.clear()
-
-    logger.info(f"Shutting down audit services for {total_instances} instances...")
-
-    def _service_label(service: UnifiedAuditService) -> str:
-        db_path = getattr(service, "db_path", None)
-        storage_mode = getattr(service, "storage_mode", None)
-        return f"id={id(service)} db_path={db_path} storage_mode={storage_mode}"
-
-    if services:
-        stop_tasks = [
-            asyncio.create_task(
-                _stop_audit_service_instance(
-                    service,
-                    label=_service_label(service),
-                    timeout_s=shutdown_timeout_s if shutdown_timeout_s > 0 else None,
-                )
-            )
-            for service in services
-        ]
-        stop_results = await asyncio.gather(*stop_tasks)
-        for stopped_ok, timeout_hit, error_message, exc in stop_results:
-            if stopped_ok:
-                stopped_count += 1
-            elif timeout_hit:
-                timeout_count += 1
-                if error_message:
-                    errors.append(error_message)
-                if first_exception is None:
-                    first_exception = exc
-            else:
-                error_count += 1
-                if error_message:
-                    errors.append(error_message)
-                if first_exception is None:
-                    first_exception = exc
-
+    states = list(_all_loop_states())
+    per_state_shutdown_keys: list[tuple[_LoopState, set[Optional[Union[int, str]]]]] = []
     try:
-        await _drain_scheduled_audit_stops(timeout=shutdown_timeout_s if shutdown_timeout_s > 0 else None)
-    except asyncio.TimeoutError as exc:
-        timeout_count += 1
-        drain_message = f"TimeoutError: scheduled audit stop drain timed out after {shutdown_timeout_s:.2f}s"
-        errors.append(drain_message)
-        if first_exception is None:
-            first_exception = exc
-        logger.error(f"Scheduled audit stop drain timed out after {shutdown_timeout_s:.2f}s")
+        for state in states:
+            waiters: list[asyncio.Event] = []
+            with state.init_lock:
+                shutdown_keys = set(state.initializing_users) | set(state.initializing_events.keys())
+            with state.cache_lock:
+                cache_keys = list(state.cache.keys())
+                total_instances += len(cache_keys)
+                shutdown_keys.update(cache_keys)
+                for key in cache_keys:
+                    pop_no_cb = getattr(state.cache, "pop_no_callback", None)
+                    service = pop_no_cb(key, None) if callable(pop_no_cb) else state.cache.pop(key, None)
+                    if service:
+                        services.append(service)
+            with state.init_lock:
+                state.shutting_down_keys.update(shutdown_keys)
+                for key in shutdown_keys:
+                    event = state.initializing_events.get(key)
+                    if event is not None:
+                        waiters.append(event)
+            for event in waiters:
+                event.set()
+            per_state_shutdown_keys.append((state, shutdown_keys))
 
-    summary = AuditShutdownSummary(
-        requested=total_instances,
-        stopped=stopped_count,
-        timeout_count=timeout_count,
-        error_count=error_count,
-        errors=tuple(errors),
-    )
+        logger.info(f"Shutting down audit services for {total_instances} instances...")
 
-    if timeout_count or error_count:
-        logger.warning(
-            f"Audit services shutdown completed with issues (timeouts={timeout_count}, errors={error_count})."
+        def _service_label(service: UnifiedAuditService) -> str:
+            db_path = getattr(service, "db_path", None)
+            storage_mode = getattr(service, "storage_mode", None)
+            return f"id={id(service)} db_path={db_path} storage_mode={storage_mode}"
+
+        if services:
+            stop_tasks = [
+                asyncio.create_task(
+                    _stop_audit_service_instance(
+                        service,
+                        label=_service_label(service),
+                        timeout_s=shutdown_timeout_s if shutdown_timeout_s > 0 else None,
+                    )
+                )
+                for service in services
+            ]
+            stop_results = await asyncio.gather(*stop_tasks)
+            for stopped_ok, timeout_hit, error_message, exc in stop_results:
+                if stopped_ok:
+                    stopped_count += 1
+                elif timeout_hit:
+                    timeout_count += 1
+                    if error_message:
+                        errors.append(error_message)
+                    if first_exception is None:
+                        first_exception = exc
+                else:
+                    error_count += 1
+                    if error_message:
+                        errors.append(error_message)
+                    if first_exception is None:
+                        first_exception = exc
+
+        try:
+            await _drain_scheduled_audit_stops(timeout=shutdown_timeout_s if shutdown_timeout_s > 0 else None)
+        except asyncio.TimeoutError as exc:
+            timeout_count += 1
+            drain_message = f"TimeoutError: scheduled audit stop drain timed out after {shutdown_timeout_s:.2f}s"
+            errors.append(drain_message)
+            if first_exception is None:
+                first_exception = exc
+            logger.error(f"Scheduled audit stop drain timed out after {shutdown_timeout_s:.2f}s")
+
+        summary = AuditShutdownSummary(
+            requested=total_instances,
+            stopped=stopped_count,
+            timeout_count=timeout_count,
+            error_count=error_count,
+            errors=tuple(errors),
         )
-    else:
-        logger.info("All audit services shut down successfully.")
 
-    return _finalize_shutdown_summary(
-        summary=summary,
-        raise_on_error=raise_on_error,
-        message="Audit services shutdown completed with issues",
-        first_exception=first_exception,
-    )
+        if timeout_count or error_count:
+            logger.warning(
+                f"Audit services shutdown completed with issues (timeouts={timeout_count}, errors={error_count})."
+            )
+        else:
+            logger.info("All audit services shut down successfully.")
+
+        return _finalize_shutdown_summary(
+            summary=summary,
+            raise_on_error=raise_on_error,
+            message="Audit services shutdown completed with issues",
+            first_exception=first_exception,
+        )
+    finally:
+        for state, shutdown_keys in per_state_shutdown_keys:
+            with state.init_lock:
+                for key in shutdown_keys:
+                    if key not in state.initializing_users:
+                        state.shutting_down_keys.discard(key)
+                        state.initializing_events.pop(key, None)
 
 # Example of how to register for shutdown event in FastAPI:
 # from fastapi import FastAPI

--- a/tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/Audit_DB_Deps.py
@@ -26,7 +26,10 @@ except ImportError:
     )
 
 # Local Imports
-from tldw_Server_API.app.core.Audit.unified_audit_service import UnifiedAuditService
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditShutdownError,
+    UnifiedAuditService,
+)
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
@@ -40,6 +43,15 @@ from tldw_Server_API.app.core.testing import is_test_mode, is_truthy
 
 _FALSEY = {"0", "false", "no", "n", "off"}
 _VALID_STORAGE_MODES = {"per_user", "shared"}
+
+
+@dataclass(frozen=True)
+class AuditShutdownSummary:
+    requested: int = 0
+    stopped: int = 0
+    timeout_count: int = 0
+    error_count: int = 0
+    errors: tuple[str, ...] = ()
 
 
 def _settings_int(
@@ -122,6 +134,73 @@ def _resolve_audit_storage_mode() -> str:
 def _shared_audit_db_path() -> str:
     """Resolve shared audit DB path from settings."""
     return str(DatabasePaths.get_shared_audit_db_path())
+
+
+def _shutdown_cache_keys(user_id: Optional[Union[int, str]]) -> list[Optional[Union[int, str]]]:
+    if _resolve_audit_storage_mode() == "shared":
+        return [None]
+    return [user_id]
+
+
+def _finalize_shutdown_summary(
+    *,
+    summary: AuditShutdownSummary,
+    raise_on_error: bool,
+    message: str,
+    first_exception: BaseException | None,
+) -> AuditShutdownSummary:
+    if raise_on_error and (summary.timeout_count or summary.error_count):
+        raise AuditShutdownError(f"{message}: {summary}") from first_exception
+    return summary
+
+
+async def _stop_audit_service_instance(
+    service: UnifiedAuditService,
+    *,
+    label: str,
+    timeout_s: Optional[float] = None,
+) -> tuple[bool, bool, Optional[str], Optional[BaseException]]:
+    owner_loop = getattr(service, "owner_loop", None)
+    if owner_loop:
+        try:
+            if owner_loop.is_closed():
+                owner_loop = None
+            elif not owner_loop.is_running():
+                logger.warning(
+                    f"Audit service owner loop not running; forcing shutdown on current loop ({label})"
+                )
+                owner_loop = None
+        except (AttributeError, RuntimeError):
+            owner_loop = None
+
+    try:
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        if owner_loop and current_loop is not owner_loop:
+            future = asyncio.run_coroutine_threadsafe(service.stop(), owner_loop)
+            awaitable = asyncio.wrap_future(future)
+        else:
+            awaitable = service.stop()
+
+        if timeout_s is not None and timeout_s > 0:
+            await asyncio.wait_for(awaitable, timeout=timeout_s)
+        else:
+            await awaitable
+        return True, False, None, None
+    except asyncio.TimeoutError as exc:
+        timeout_label = (
+            f"Audit service shutdown timed out after {timeout_s:.2f}s ({label})"
+            if timeout_s is not None
+            else f"Audit service shutdown timed out ({label})"
+        )
+        logger.error(timeout_label)
+        return False, True, timeout_label, exc
+    except Exception as exc:
+        logger.error(f"Error shutting down audit service ({label}): {exc}", exc_info=True)
+        return False, False, f"{type(exc).__name__}: {exc}", exc
 
 
 def _is_test_context() -> bool:
@@ -746,7 +825,7 @@ async def get_audit_service_for_user(
 
 # --- Cleanup Functions ---
 
-async def shutdown_user_audit_service(user_id: int):
+async def shutdown_user_audit_service(user_id: int) -> AuditShutdownSummary:
     """
     Shutdown audit service for a specific user.
 
@@ -754,52 +833,53 @@ async def shutdown_user_audit_service(user_id: int):
         user_id: The user's ID
     """
     services: list[UnifiedAuditService] = []
+    errors: list[str] = []
+    requested = 0
+    stopped = 0
 
+    cache_keys = _shutdown_cache_keys(user_id)
     for state in _all_loop_states():
         with state.cache_lock:
-            existing = state.cache.get(user_id)
-            if existing:
-                pop_no_cb = getattr(state.cache, "pop_no_callback", None)
-                service = pop_no_cb(user_id, None) if callable(pop_no_cb) else state.cache.pop(user_id, None)
-                if service:
-                    services.append(service)
+            for cache_key in cache_keys:
+                existing = state.cache.get(cache_key)
+                if existing:
+                    pop_no_cb = getattr(state.cache, "pop_no_callback", None)
+                    service = pop_no_cb(cache_key, None) if callable(pop_no_cb) else state.cache.pop(cache_key, None)
+                    if service:
+                        services.append(service)
 
         with state.init_lock:
-            state.initializing_users.discard(user_id)
-            event = state.initializing_events.pop(user_id, None)
-            if event:
-                event.set()
+            for cache_key in cache_keys:
+                state.initializing_users.discard(cache_key)
+                event = state.initializing_events.pop(cache_key, None)
+                if event:
+                    event.set()
 
     if not services:
-        return
+        return AuditShutdownSummary()
 
-    async def _stop_service(service: UnifiedAuditService) -> None:
-        owner_loop = getattr(service, "owner_loop", None)
-        if owner_loop and owner_loop.is_closed():
-            owner_loop = None
-
-        try:
-            try:
-                current_loop = asyncio.get_running_loop()
-            except RuntimeError:
-                current_loop = None
-
-            if owner_loop and current_loop is not owner_loop:
-                future = asyncio.run_coroutine_threadsafe(service.stop(), owner_loop)
-                await asyncio.wrap_future(future)
-            else:
-                await service.stop()
+    requested = len(services)
+    for service in services:
+        stopped_ok, _, error_message, _exc = await _stop_audit_service_instance(
+            service,
+            label=f"user {user_id}",
+        )
+        if stopped_ok:
+            stopped += 1
             logger.info(f"Shut down audit service for user {user_id}")
-        except (OSError, RuntimeError, TypeError, ValueError) as e:
-            logger.error(
-                f"Error shutting down audit service for user {user_id}: {e}",
-                exc_info=True,
-            )
+        elif error_message:
+            errors.append(error_message)
 
-    await asyncio.gather(*[_stop_service(s) for s in services], return_exceptions=True)
+    return AuditShutdownSummary(
+        requested=requested,
+        stopped=stopped,
+        timeout_count=0,
+        error_count=len(errors),
+        errors=tuple(errors),
+    )
 
 
-async def shutdown_all_audit_services():
+async def shutdown_all_audit_services(*, raise_on_error: bool = False) -> AuditShutdownSummary:
     """
     Shutdown all cached audit service instances.
     Useful for application shutdown.
@@ -816,6 +896,9 @@ async def shutdown_all_audit_services():
         shutdown_timeout_s = 0.0
     timeout_count = 0
     error_count = 0
+    stopped_count = 0
+    errors: list[str] = []
+    first_exception: BaseException | None = None
 
     for state in _all_loop_states():
         with state.cache_lock:
@@ -840,59 +923,51 @@ async def shutdown_all_audit_services():
         storage_mode = getattr(service, "storage_mode", None)
         return f"id={id(service)} db_path={db_path} storage_mode={storage_mode}"
 
-    async def _await_with_timeout(awaitable, *, label: str) -> None:
-        nonlocal timeout_count
-        if shutdown_timeout_s <= 0:
-            await awaitable
-            return
-        try:
-            await asyncio.wait_for(awaitable, timeout=shutdown_timeout_s)
-        except asyncio.TimeoutError:
-            timeout_count += 1
-            logger.error(
-                f"Audit service shutdown timed out after {shutdown_timeout_s:.2f}s ({label})"
-            )
-
-    async def _stop_service(service: UnifiedAuditService) -> None:
-        nonlocal error_count
-        owner_loop = getattr(service, "owner_loop", None)
-        if owner_loop:
-            try:
-                if owner_loop.is_closed():
-                    owner_loop = None
-                elif not owner_loop.is_running():
-                    logger.warning(
-                        f"Audit service owner loop not running; forcing shutdown on current loop ({_service_label(service)})"
-                    )
-                    owner_loop = None
-            except (AttributeError, RuntimeError):
-                owner_loop = None
-
-        try:
-            try:
-                current_loop = asyncio.get_running_loop()
-            except RuntimeError:
-                current_loop = None
-
-            if owner_loop and current_loop is not owner_loop:
-                future = asyncio.run_coroutine_threadsafe(service.stop(), owner_loop)
-                await _await_with_timeout(asyncio.wrap_future(future), label=_service_label(service))
-            else:
-                await _await_with_timeout(service.stop(), label=_service_label(service))
-        except (OSError, RuntimeError, TypeError, ValueError) as e:
-            error_count += 1
-            logger.error(f"Error shutting down audit service: {e}", exc_info=True)
-
     if services:
-        await asyncio.gather(*[_stop_service(s) for s in services], return_exceptions=True)
+        stop_tasks = [
+            asyncio.create_task(
+                _stop_audit_service_instance(
+                    service,
+                    label=_service_label(service),
+                    timeout_s=shutdown_timeout_s if shutdown_timeout_s > 0 else None,
+                )
+            )
+            for service in services
+        ]
+        stop_results = await asyncio.gather(*stop_tasks)
+        for stopped_ok, timeout_hit, error_message, exc in stop_results:
+            if stopped_ok:
+                stopped_count += 1
+            elif timeout_hit:
+                timeout_count += 1
+                if error_message:
+                    errors.append(error_message)
+                if first_exception is None:
+                    first_exception = exc
+            else:
+                error_count += 1
+                if error_message:
+                    errors.append(error_message)
+                if first_exception is None:
+                    first_exception = exc
 
     try:
         await _drain_scheduled_audit_stops(timeout=shutdown_timeout_s if shutdown_timeout_s > 0 else None)
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         timeout_count += 1
-        logger.error(
-            f"Scheduled audit stop drain timed out after {shutdown_timeout_s:.2f}s"
-        )
+        drain_message = f"TimeoutError: scheduled audit stop drain timed out after {shutdown_timeout_s:.2f}s"
+        errors.append(drain_message)
+        if first_exception is None:
+            first_exception = exc
+        logger.error(f"Scheduled audit stop drain timed out after {shutdown_timeout_s:.2f}s")
+
+    summary = AuditShutdownSummary(
+        requested=total_instances,
+        stopped=stopped_count,
+        timeout_count=timeout_count,
+        error_count=error_count,
+        errors=tuple(errors),
+    )
 
     if timeout_count or error_count:
         logger.warning(
@@ -900,6 +975,13 @@ async def shutdown_all_audit_services():
         )
     else:
         logger.info("All audit services shut down successfully.")
+
+    return _finalize_shutdown_summary(
+        summary=summary,
+        raise_on_error=raise_on_error,
+        message="Audit services shutdown completed with issues",
+        first_exception=first_exception,
+    )
 
 # Example of how to register for shutdown event in FastAPI:
 # from fastapi import FastAPI

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -59,7 +59,11 @@ from tldw_Server_API.app.api.v1.schemas.auth_schemas import (
     SessionResponse,
     TokenResponse,
 )
-from tldw_Server_API.app.core.Audit.unified_audit_service import AuditContext, AuditEventType
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditContext,
+    AuditEventType,
+    MandatoryAuditWriteError,
+)
 from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
 from tldw_Server_API.app.core.AuthNZ.auth_governor import get_auth_governor
 from tldw_Server_API.app.core.AuthNZ.csrf_protection import (
@@ -3528,6 +3532,15 @@ async def register(
                     expires_in_days=365
                 )
                 api_key_value = key_result.get('key')
+        except MandatoryAuditWriteError as exc:
+            logger.error(
+                "Mandatory audit write failed while auto-generating default API key for new user {}",
+                user_info["user_id"],
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Mandatory audit persistence unavailable",
+            ) from exc
         except _AUTH_NONCRITICAL_EXCEPTIONS as _e:
             logger.warning(f"Failed to auto-generate API key for new user {user_info['user_id']}: {_e}")
 

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -3534,12 +3534,20 @@ async def register(
                 api_key_value = key_result.get('key')
         except MandatoryAuditWriteError as exc:
             logger.error(
-                "Mandatory audit write failed while auto-generating default API key for new user {}",
+                "Mandatory audit write failed while auto-generating default API key for new user {}: {}",
                 user_info["user_id"],
+                exc,
+                exc_info=exc,
             )
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Mandatory audit persistence unavailable",
+                detail={
+                    "error": {
+                        "message": "Mandatory audit persistence unavailable",
+                        "type": "audit_persistence_failure",
+                        "code": "audit_persistence_failure",
+                    }
+                },
             ) from exc
         except _AUTH_NONCRITICAL_EXCEPTIONS as _e:
             logger.warning(f"Failed to auto-generate API key for new user {user_info['user_id']}: {_e}")

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -117,6 +117,7 @@ from tldw_Server_API.app.api.v1.schemas.chat_validators import (
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditContext,
     AuditEventType,
+    MandatoryAuditWriteError,
 )
 from tldw_Server_API.app.core.Character_Chat.modules.character_utils import (
     map_sender_to_role,
@@ -162,6 +163,7 @@ from tldw_Server_API.app.core.Chat.chat_service import (
     resolve_provider_and_model,
     resolve_provider_api_key,
     is_model_known_for_provider,
+    write_mandatory_moderation_audit,
 )
 
 # Backward-compatible re-exports for legacy tests patching these symbols on the endpoint module.
@@ -2552,20 +2554,19 @@ async def create_chat_completion(
                             with contextlib.suppress(_CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS):
                                 metrics.track_moderation_input(str(req_user_id or client_id), inj_mod['action'], category=(inj_mod.get('category') or "default"))
                             # Audit moderation decision
-                            try:
-                                if audit_service and context:
-                                    _schedule_audit_background_task(
-                                        audit_service.log_event(
-                                            event_type=AuditEventType.SECURITY_VIOLATION,
-                                            context=context,
-                                            action="moderation.input",
-                                            result=("failure" if inj_mod['blocked'] else "success"),
-                                            metadata={"phase": "input", "action": inj_mod['action'], "pattern": inj_mod.get('pattern'), "category": inj_mod.get('category')},
-                                        ),
-                                        task_name="chat.command.moderation.input.audit",
-                                    )
-                            except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS:
-                                pass
+                            await write_mandatory_moderation_audit(
+                                audit_service=audit_service,
+                                audit_context=context,
+                                audit_event_type=AuditEventType.SECURITY_VIOLATION,
+                                action="moderation.input",
+                                result=("failure" if inj_mod['blocked'] else "success"),
+                                metadata={"phase": "input", "action": inj_mod['action'], "pattern": inj_mod.get('pattern'), "category": inj_mod.get('category')},
+                            )
+                        except MandatoryAuditWriteError as exc:
+                            raise HTTPException(
+                                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                                detail="Mandatory audit persistence unavailable",
+                            ) from exc
                         except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS as _mod_err:
                             logger.debug(f"Slash command moderation step skipped due to error: {_mod_err}")
 
@@ -3045,6 +3046,11 @@ async def create_chat_completion(
                 dependent_user_id=_dep_user_id,
                 chat_type=input_moderation_chat_type,
             )
+        except MandatoryAuditWriteError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Mandatory audit persistence unavailable",
+            ) from exc
         except HTTPException:
             raise
         except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS as e:
@@ -4228,6 +4234,11 @@ async def create_chat_completion(
                 detail=safe_detail
             ) from e_chat
 
+        except MandatoryAuditWriteError as e_chat:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Mandatory audit persistence unavailable",
+            ) from e_chat
         except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS as e_chat:
             # Do not leak raw HTTPException details from underlying call sites.
             # For unexpected HTTPException from lower layers (e.g., provider shims),

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -353,6 +353,14 @@ def _chat_connectors_enabled() -> bool:
     """Feature flag for chat connectors v2 (email/issue/wiki exports)."""
     return _shared_env_flag_enabled("CHAT_CONNECTORS_V2_ENABLED")
 
+
+def _mandatory_audit_unavailable_detail() -> dict[str, str]:
+    """Return the standardized chat-module payload for mandatory audit failures."""
+    return {
+        "error_code": "mandatory_audit_unavailable",
+        "message": "Mandatory audit persistence is currently unavailable",
+    }
+
 # Load configuration values from config
 import contextlib
 
@@ -2565,7 +2573,7 @@ async def create_chat_completion(
                         except MandatoryAuditWriteError as exc:
                             raise HTTPException(
                                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                                detail="Mandatory audit persistence unavailable",
+                                detail=_mandatory_audit_unavailable_detail(),
                             ) from exc
                         except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS as _mod_err:
                             logger.debug(f"Slash command moderation step skipped due to error: {_mod_err}")
@@ -2640,6 +2648,10 @@ async def create_chat_completion(
                                     request_data.messages.append(sys_msg)
                                 except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS as inj_err:
                                     logger.debug(f"Failed to append system injection message: {inj_err}")
+        except HTTPException as _cmd_err:
+            if _cmd_err.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
+                raise
+            logger.debug(f"Slash command handling skipped due to error: {_cmd_err}")
         except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS as _cmd_err:
             logger.debug(f"Slash command handling skipped due to error: {_cmd_err}")
 
@@ -3049,7 +3061,7 @@ async def create_chat_completion(
         except MandatoryAuditWriteError as exc:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Mandatory audit persistence unavailable",
+                detail=_mandatory_audit_unavailable_detail(),
             ) from exc
         except HTTPException:
             raise
@@ -4237,7 +4249,7 @@ async def create_chat_completion(
         except MandatoryAuditWriteError as e_chat:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Mandatory audit persistence unavailable",
+                detail=_mandatory_audit_unavailable_detail(),
             ) from e_chat
         except _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS as e_chat:
             # Do not leak raw HTTPException details from underlying call sites.
@@ -4249,6 +4261,7 @@ async def create_chat_completion(
                 if e_chat.status_code in (
                     status.HTTP_402_PAYMENT_REQUIRED,
                     status.HTTP_429_TOO_MANY_REQUESTS,
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
                 ):
                     raise
                 raise HTTPException(

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_crud.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_crud.py
@@ -32,6 +32,7 @@ from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import (
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import EVALS_MANAGE, EVALS_READ
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.core.Evaluations.audit_adapter import MandatoryAuditWriteError
 from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import (
     get_unified_evaluation_service_for_user,
 )
@@ -332,6 +333,13 @@ async def create_run(
         return RunResponse(**run)
     except HTTPException:
         raise
+    except MandatoryAuditWriteError as e:
+        raise create_error_response(
+            message="Mandatory audit persistence unavailable",
+            error_type="service_unavailable",
+            code="audit_persistence_failure",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        ) from e
     except _EVALS_CRUD_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Failed to create run: {e}")
         raise create_error_response(

--- a/tldw_Server_API/app/api/v1/endpoints/users.py
+++ b/tldw_Server_API/app/api/v1/endpoints/users.py
@@ -68,6 +68,7 @@ from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal, is_single_user_principal
 from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 from tldw_Server_API.app.core.AuthNZ.session_manager import SessionManager
+from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
 from tldw_Server_API.app.core.testing import is_truthy
 from tldw_Server_API.app.core.UserProfiles.service import UserProfileService
 from tldw_Server_API.app.core.UserProfiles.update_service import UserProfileUpdateService
@@ -809,13 +810,23 @@ async def create_api_key(
     user_context = await _require_principal_active_verified(principal)
     user_id = int(user_context["id"])
     api_mgr = await get_api_key_manager()
-    result = await api_mgr.create_api_key(
-        user_id=user_id,
-        name=payload.name,
-        description=payload.description,
-        scope=payload.scope,
-        expires_in_days=payload.expires_in_days,
-    )
+    try:
+        result = await api_mgr.create_api_key(
+            user_id=user_id,
+            name=payload.name,
+            description=payload.description,
+            scope=payload.scope,
+            expires_in_days=payload.expires_in_days,
+            actor_user_id=_principal_user_id(principal),
+            actor_subject=principal.subject,
+            actor_kind=principal.kind,
+            actor_roles=list(principal.roles or []),
+        )
+    except MandatoryAuditWriteError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Mandatory audit persistence unavailable",
+        ) from exc
     return APIKeyCreateResponse(**result)
 
 
@@ -851,21 +862,31 @@ async def create_virtual_api_key(
     user_context = await _require_principal_active_verified(principal)
     user_id = int(user_context["id"])
     api_mgr = await get_api_key_manager()
-    result = await api_mgr.create_virtual_key(
-        user_id=user_id,
-        name=payload.name,
-        description=payload.description,
-        expires_in_days=payload.expires_in_days,
-        allowed_endpoints=payload.allowed_endpoints,
-        budget_day_tokens=payload.budget_day_tokens,
-        budget_month_tokens=payload.budget_month_tokens,
-        budget_day_usd=payload.budget_day_usd,
-        budget_month_usd=payload.budget_month_usd,
-        allowed_methods=payload.allowed_methods,
-        allowed_paths=payload.allowed_paths,
-        max_calls=payload.max_calls,
-        max_runs=payload.max_runs,
-    )
+    try:
+        result = await api_mgr.create_virtual_key(
+            user_id=user_id,
+            name=payload.name,
+            description=payload.description,
+            expires_in_days=payload.expires_in_days,
+            allowed_endpoints=payload.allowed_endpoints,
+            budget_day_tokens=payload.budget_day_tokens,
+            budget_month_tokens=payload.budget_month_tokens,
+            budget_day_usd=payload.budget_day_usd,
+            budget_month_usd=payload.budget_month_usd,
+            allowed_methods=payload.allowed_methods,
+            allowed_paths=payload.allowed_paths,
+            max_calls=payload.max_calls,
+            max_runs=payload.max_runs,
+            actor_user_id=_principal_user_id(principal),
+            actor_subject=principal.subject,
+            actor_kind=principal.kind,
+            actor_roles=list(principal.roles or []),
+        )
+    except MandatoryAuditWriteError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Mandatory audit persistence unavailable",
+        ) from exc
     return APIKeyCreateResponse(**result)
 
 
@@ -884,11 +905,21 @@ async def rotate_api_key(
     user_context = await _require_principal_active_verified(principal)
     user_id = int(user_context["id"])
     api_mgr = await get_api_key_manager()
-    result = await api_mgr.rotate_api_key(
-        key_id=key_id,
-        user_id=user_id,
-        expires_in_days=payload.expires_in_days,
-    )
+    try:
+        result = await api_mgr.rotate_api_key(
+            key_id=key_id,
+            user_id=user_id,
+            expires_in_days=payload.expires_in_days,
+            actor_user_id=_principal_user_id(principal),
+            actor_subject=principal.subject,
+            actor_kind=principal.kind,
+            actor_roles=list(principal.roles or []),
+        )
+    except MandatoryAuditWriteError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Mandatory audit persistence unavailable",
+        ) from exc
     return APIKeyCreateResponse(**result)
 
 
@@ -906,7 +937,20 @@ async def revoke_api_key(
     user_context = await _require_principal_active_verified(principal)
     user_id = int(user_context["id"])
     api_mgr = await get_api_key_manager()
-    success = await api_mgr.revoke_api_key(key_id=key_id, user_id=user_id)
+    try:
+        success = await api_mgr.revoke_api_key(
+            key_id=key_id,
+            user_id=user_id,
+            actor_user_id=_principal_user_id(principal),
+            actor_subject=principal.subject,
+            actor_kind=principal.kind,
+            actor_roles=list(principal.roles or []),
+        )
+    except MandatoryAuditWriteError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Mandatory audit persistence unavailable",
+        ) from exc
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API key not found")
     return MessageResponse(message="API key revoked")

--- a/tldw_Server_API/app/core/Audit/audit_shared_migration.py
+++ b/tldw_Server_API/app/core/Audit/audit_shared_migration.py
@@ -788,8 +788,10 @@ async def _migrate_source(
                     duplicates_existing = [r["event_id"] for r in records if r.get("event_id") in existing]
                     duplicates_total = len(duplicates_in_chunk) + len(duplicates_existing)
 
-                    counts.events_inserted += len(filtered)
-                    counts.events_skipped += duplicates_total
+                    chunk_events_inserted = len(filtered)
+                    chunk_events_skipped = duplicates_total
+                    chunk_stats_inserted = 0
+                    chunk_stats_skipped = duplicates_total
 
                     if duplicates_in_chunk:
                         logger.warning(
@@ -808,7 +810,6 @@ async def _migrate_source(
                             duplicates_existing[:5],
                         )
 
-                    counts.stats_skipped += duplicates_total
                     if filtered:
                         await shared_db.executemany(insert_sql, filtered)
                         stats_result = await _update_shared_daily_stats_from_records(
@@ -816,8 +817,8 @@ async def _migrate_source(
                             filtered,
                             unidentified_tenant_id=unidentified_tenant_id,
                         )
-                        counts.stats_inserted += stats_result.events_contributed
-                        counts.stats_skipped += stats_result.events_skipped
+                        chunk_stats_inserted = stats_result.events_contributed
+                        chunk_stats_skipped += stats_result.events_skipped
 
                     last_row = rows[-1]
                     with contextlib.suppress(_AUDIT_COERCE_EXCEPTIONS):
@@ -834,7 +835,13 @@ async def _migrate_source(
                         last_timestamp = last_timestamp
                     await _save_checkpoint(shared_db, source_key, last_rowid, last_event_id, last_timestamp)
                     await shared_db.commit()
+                    counts.events_inserted += chunk_events_inserted
+                    counts.events_skipped += chunk_events_skipped
+                    counts.stats_inserted += chunk_stats_inserted
+                    counts.stats_skipped += chunk_stats_skipped
     except _AUDIT_DB_EXCEPTIONS as exc:
+        with contextlib.suppress(_AUDIT_NONCRITICAL_EXCEPTIONS):
+            await shared_db.rollback()
         counts.failed = True
         counts.error = f"{type(exc).__name__}: {exc}"
         logger.warning(

--- a/tldw_Server_API/app/core/Audit/unified_audit_service.py
+++ b/tldw_Server_API/app/core/Audit/unified_audit_service.py
@@ -2559,6 +2559,8 @@ class UnifiedAuditService:
         with fb_path.open("a", encoding="utf-8") as fb:
             for ev in events:
                 fb.write(json.dumps(ev.to_dict(), ensure_ascii=False) + "\n")
+            fb.flush()
+            os.fsync(fb.fileno())
 
     async def _spill_events_to_fallback(self, events: list[AuditEvent]) -> Path:
         fb_path = self.db_path.parent / "audit_fallback_queue.jsonl"

--- a/tldw_Server_API/app/core/Audit/unified_audit_service.py
+++ b/tldw_Server_API/app/core/Audit/unified_audit_service.py
@@ -79,6 +79,14 @@ class AuditReadError(RuntimeError):
     """Raised when audit read/export queries fail and cannot be served safely."""
 
 
+class MandatoryAuditWriteError(RuntimeError):
+    """Raised when a caller requires durable audit persistence before success."""
+
+
+class AuditShutdownError(RuntimeError):
+    """Raised when the audit service cannot complete a durable shutdown."""
+
+
 #
 # Local Imports
 try:
@@ -2090,20 +2098,43 @@ class UnifiedAuditService:
             finally:
                 self._db_pool = None
 
-        # Final flush of any remaining buffered events
         try:
-            await self.flush()
-        except _AUDIT_NONCRITICAL_EXCEPTIONS as _e:
-            # During teardown it's acceptable to skip the final flush if the event loop
-            pass
-            # or DB is no longer available.
-            logger.debug(f"Audit final flush skipped due to shutdown condition: {_e}")
+            # Final flush of any remaining buffered events
+            await self.flush(raise_on_failure=True)
+        except asyncio.CancelledError:
+            raise
+        except _AUDIT_NONCRITICAL_EXCEPTIONS as exc:
+            async with self.buffer_lock:
+                remaining = list(self.event_buffer)
+            fb_path: Optional[Path] = None
+            spill_exc: Optional[BaseException] = None
+            if remaining:
+                try:
+                    fb_path = await self._spill_events_to_fallback(remaining)
+                except _AUDIT_NONCRITICAL_EXCEPTIONS as spill_error:
+                    spill_exc = spill_error
+                else:
+                    async with self.buffer_lock:
+                        spilled_ids = {event.event_id for event in remaining if event.event_id}
+                        if spilled_ids:
+                            self.event_buffer = [
+                                event for event in self.event_buffer
+                                if event.event_id not in spilled_ids
+                            ]
 
-        # Close connection pool
-        if self._db_pool:
-            await self._db_pool.close()
-            self._db_pool = None
-        self._owner_loop = None
+            detail = "UnifiedAuditService.stop failed to complete a durable shutdown"
+            if fb_path is not None:
+                detail = f"{detail}; buffered events spilled to {fb_path}"
+            if spill_exc is not None:
+                detail = f"{detail}; fallback spill failed: {spill_exc}"
+            raise AuditShutdownError(detail) from exc
+        finally:
+            # Close connection pool deterministically even when shutdown fails.
+            if self._db_pool:
+                with suppress(_AUDIT_NONCRITICAL_EXCEPTIONS):
+                    await self._db_pool.close()
+                self._db_pool = None
+            self._owner_loop = None
 
     @property
     def owner_loop(self) -> Optional[asyncio.AbstractEventLoop]:
@@ -2528,6 +2559,12 @@ class UnifiedAuditService:
         with fb_path.open("a", encoding="utf-8") as fb:
             for ev in events:
                 fb.write(json.dumps(ev.to_dict(), ensure_ascii=False) + "\n")
+
+    async def _spill_events_to_fallback(self, events: list[AuditEvent]) -> Path:
+        fb_path = self.db_path.parent / "audit_fallback_queue.jsonl"
+        async with _fallback_queue_lock(fb_path):
+            await asyncio.to_thread(self._append_events_to_fallback, fb_path, events)
+        return fb_path
 
     async def _update_daily_stats(self, db: aiosqlite.Connection, events: list[AuditEvent]):
         """Update daily statistics"""

--- a/tldw_Server_API/app/core/AuthNZ/api_key_audit.py
+++ b/tldw_Server_API/app/core/AuthNZ/api_key_audit.py
@@ -1,3 +1,5 @@
+"""Strict unified-audit helpers for API key management operations."""
+
 from __future__ import annotations
 
 from contextlib import suppress
@@ -10,10 +12,12 @@ from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventCategory,
     AuditEventType,
     MandatoryAuditWriteError,
+    UnifiedAuditService,
 )
 
 
-async def _get_or_create_audit_service(user_id: int):
+async def _get_or_create_audit_service(user_id: int) -> UnifiedAuditService:
+    """Return the cached audit service for the target user."""
     from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
         get_or_create_audit_service_for_user_id,
     )
@@ -21,7 +25,8 @@ async def _get_or_create_audit_service(user_id: int):
     return await get_or_create_audit_service_for_user_id(user_id)
 
 
-async def _create_isolated_audit_service(user_id: int):
+async def _create_isolated_audit_service(user_id: int) -> UnifiedAuditService:
+    """Create an isolated audit service instance for fail-closed writes."""
     from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
         _create_audit_service_for_user,
     )
@@ -54,8 +59,9 @@ async def emit_mandatory_api_key_management_audit(
     if actor_roles:
         merged_metadata["actor_roles"] = [str(role) for role in actor_roles if str(role).strip()]
 
-    audit_service = await _create_isolated_audit_service(int(user_id))
+    audit_service: UnifiedAuditService | None = None
     try:
+        audit_service = await _create_isolated_audit_service(int(user_id))
         await audit_service.log_event(
             event_type=event_type,
             category=category,
@@ -78,5 +84,6 @@ async def emit_mandatory_api_key_management_audit(
         )
         raise MandatoryAuditWriteError("Mandatory audit persistence unavailable") from exc
     finally:
-        with suppress(Exception):
-            await audit_service.stop()
+        if audit_service is not None:
+            with suppress(Exception):
+                await audit_service.stop()

--- a/tldw_Server_API/app/core/AuthNZ/api_key_audit.py
+++ b/tldw_Server_API/app/core/AuthNZ/api_key_audit.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditContext,
+    AuditEventCategory,
+    AuditEventType,
+    MandatoryAuditWriteError,
+)
+
+
+async def _get_or_create_audit_service(user_id: int):
+    from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
+        get_or_create_audit_service_for_user_id,
+    )
+
+    return await get_or_create_audit_service_for_user_id(user_id)
+
+
+async def _create_isolated_audit_service(user_id: int):
+    from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
+        _create_audit_service_for_user,
+    )
+
+    return await _create_audit_service_for_user(user_id)
+
+
+async def emit_mandatory_api_key_management_audit(
+    *,
+    user_id: int,
+    event_type: AuditEventType | str,
+    category: AuditEventCategory | str,
+    action: str,
+    resource_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    actor_user_id: int | None = None,
+    actor_subject: str | None = None,
+    actor_kind: str | None = None,
+    actor_roles: list[str] | None = None,
+) -> None:
+    """Emit a mandatory unified audit event for API-key management operations."""
+    merged_metadata = dict(metadata or {})
+    merged_metadata["target_user_id"] = int(user_id)
+    if actor_user_id is not None:
+        merged_metadata["actor_user_id"] = int(actor_user_id)
+    if actor_subject:
+        merged_metadata["actor_subject"] = str(actor_subject)
+    if actor_kind:
+        merged_metadata["actor_kind"] = str(actor_kind)
+    if actor_roles:
+        merged_metadata["actor_roles"] = [str(role) for role in actor_roles if str(role).strip()]
+
+    audit_service = await _create_isolated_audit_service(int(user_id))
+    try:
+        await audit_service.log_event(
+            event_type=event_type,
+            category=category,
+            context=AuditContext(user_id=str(user_id)),
+            resource_type="api_key",
+            resource_id=resource_id,
+            action=action,
+            metadata=merged_metadata,
+        )
+        await audit_service.flush(raise_on_failure=True)
+    except MandatoryAuditWriteError:
+        raise
+    except Exception as exc:
+        logger.opt(exception=True).error(
+            "Mandatory API key management audit write failed (action={}, user_id={}, resource_id={}): {}",
+            action,
+            user_id,
+            resource_id,
+            type(exc).__name__,
+        )
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable") from exc
+    finally:
+        with suppress(Exception):
+            await audit_service.stop()

--- a/tldw_Server_API/app/core/AuthNZ/api_key_manager.py
+++ b/tldw_Server_API/app/core/AuthNZ/api_key_manager.py
@@ -36,8 +36,16 @@ from tldw_Server_API.app.core.AuthNZ.crypto_utils import (
 #
 # Local imports
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
-from tldw_Server_API.app.core.AuthNZ.exceptions import DatabaseError, InvalidTokenError
+from tldw_Server_API.app.core.AuthNZ.exceptions import DatabaseError, InvalidTokenError, TransactionError
+from tldw_Server_API.app.core.AuthNZ.api_key_audit import (
+    emit_mandatory_api_key_management_audit,
+)
 from tldw_Server_API.app.core.AuthNZ.settings import Settings, get_settings
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditEventCategory,
+    AuditEventType,
+    MandatoryAuditWriteError,
+)
 
 if TYPE_CHECKING:
     from tldw_Server_API.app.core.AuthNZ.repos.api_keys_repo import AuthnzApiKeysRepo
@@ -551,7 +559,11 @@ class APIKeyManager:
         expires_in_days: Optional[int] = 90,
         rate_limit: Optional[int] = None,
         allowed_ips: Optional[list[str]] = None,
-        metadata: Optional[dict[str, Any]] = None
+        metadata: Optional[dict[str, Any]] = None,
+        actor_user_id: Optional[int] = None,
+        actor_subject: Optional[str] = None,
+        actor_kind: Optional[str] = None,
+        actor_roles: Optional[list[str]] = None,
     ) -> dict[str, Any]:
         """
         Create a new API key for a user
@@ -586,23 +598,42 @@ class APIKeyManager:
         if expires_in_days is not None:
             expires_at = datetime.now(timezone.utc) + timedelta(days=expires_in_days)
 
+        repo = self._get_repo()
         try:
-            repo = self._get_repo()
-            key_id = await repo.create_api_key_row(
-                user_id=user_id,
-                key_hash=key_hash,
-                key_identifier=key_identifier,
-                key_prefix=key_prefix,
-                name=name,
-                description=description,
-                scope=stored_scope,
-                expires_at=expires_at,
-                rate_limit=rate_limit,
-                allowed_ips=allowed_ips,
-                metadata=metadata,
-            )
+            async with self.db_pool.transaction() as conn:
+                key_id = await repo.create_api_key_row(
+                    user_id=user_id,
+                    key_hash=key_hash,
+                    key_identifier=key_identifier,
+                    key_prefix=key_prefix,
+                    name=name,
+                    description=description,
+                    scope=stored_scope,
+                    expires_at=expires_at,
+                    rate_limit=rate_limit,
+                    allowed_ips=allowed_ips,
+                    metadata=metadata,
+                    conn=conn,
+                )
 
-            # Log the creation (audit rows are still written here)
+                await emit_mandatory_api_key_management_audit(
+                    user_id=user_id,
+                    event_type=AuditEventType.DATA_WRITE,
+                    category=AuditEventCategory.DATA_MODIFICATION,
+                    action="api_key.create",
+                    resource_id=str(key_id),
+                    metadata={
+                        "scope": scope,
+                        "name": name,
+                        "expires_in_days": expires_in_days,
+                    },
+                    actor_user_id=actor_user_id,
+                    actor_subject=actor_subject,
+                    actor_kind=actor_kind,
+                    actor_roles=actor_roles,
+                )
+
+            # Keep legacy API-key audit mirror as best-effort compatibility.
             await self._log_action(key_id, "created", user_id)
 
             if self.settings.PII_REDACT_LOGS:
@@ -620,6 +651,8 @@ class APIKeyManager:
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "message": "Store this key securely - it will not be shown again"
             }
+        except MandatoryAuditWriteError:
+            raise
         except Exception as e:
             logger.exception("Failed to create API key")
             raise DatabaseError(
@@ -649,6 +682,10 @@ class APIKeyManager:
         allowed_paths: Optional[list[str]] = None,
         max_calls: Optional[int] = None,
         max_runs: Optional[int] = None,
+        actor_user_id: Optional[int] = None,
+        actor_subject: Optional[str] = None,
+        actor_kind: Optional[str] = None,
+        actor_roles: Optional[list[str]] = None,
     ) -> dict[str, Any]:
         """Create a Virtual API Key with LLM endpoint scope and budgets."""
         if not self._initialized:
@@ -666,33 +703,54 @@ class APIKeyManager:
             allowed_endpoints=allowed_endpoints,
         )
 
+        repo = self._get_repo()
         try:
-            repo = self._get_repo()
-            key_id = await repo.create_virtual_key_row(
-                user_id=user_id,
-                key_hash=key_hash,
-                key_identifier=key_identifier,
-                key_prefix=key_prefix,
-                name=name,
-                description=description,
-                expires_at=expires_at,
-                org_id=org_id,
-                team_id=team_id,
-                scope=effective_scope,
-                allowed_endpoints=allowed_endpoints,
-                allowed_providers=allowed_providers,
-                allowed_models=allowed_models,
-                budget_day_tokens=budget_day_tokens,
-                budget_month_tokens=budget_month_tokens,
-                budget_day_usd=budget_day_usd,
-                budget_month_usd=budget_month_usd,
-                parent_key_id=parent_key_id,
-                allowed_methods=allowed_methods,
-                allowed_paths=allowed_paths,
-                max_calls=max_calls,
-                max_runs=max_runs,
-            )
+            async with self.db_pool.transaction() as conn:
+                key_id = await repo.create_virtual_key_row(
+                    user_id=user_id,
+                    key_hash=key_hash,
+                    key_identifier=key_identifier,
+                    key_prefix=key_prefix,
+                    name=name,
+                    description=description,
+                    expires_at=expires_at,
+                    org_id=org_id,
+                    team_id=team_id,
+                    scope=effective_scope,
+                    allowed_endpoints=allowed_endpoints,
+                    allowed_providers=allowed_providers,
+                    allowed_models=allowed_models,
+                    budget_day_tokens=budget_day_tokens,
+                    budget_month_tokens=budget_month_tokens,
+                    budget_day_usd=budget_day_usd,
+                    budget_month_usd=budget_month_usd,
+                    parent_key_id=parent_key_id,
+                    allowed_methods=allowed_methods,
+                    allowed_paths=allowed_paths,
+                    max_calls=max_calls,
+                    max_runs=max_runs,
+                    conn=conn,
+                )
 
+                await emit_mandatory_api_key_management_audit(
+                    user_id=user_id,
+                    event_type=AuditEventType.DATA_WRITE,
+                    category=AuditEventCategory.DATA_MODIFICATION,
+                    action="api_key.create_virtual",
+                    resource_id=str(key_id),
+                    metadata={
+                        "scope": effective_scope,
+                        "org_id": org_id,
+                        "team_id": team_id,
+                        "allowed_endpoints": allowed_endpoints or [],
+                    },
+                    actor_user_id=actor_user_id,
+                    actor_subject=actor_subject,
+                    actor_kind=actor_kind,
+                    actor_roles=actor_roles,
+                )
+
+            # Keep legacy API-key audit mirror as best-effort compatibility.
             await self._log_action(key_id, "created_virtual", user_id, {
                 "org_id": org_id, "team_id": team_id, "budgets": {
                     "day_tokens": budget_day_tokens,
@@ -715,6 +773,8 @@ class APIKeyManager:
                 "message": "Store this key securely - it will not be shown again"
             }
 
+        except MandatoryAuditWriteError:
+            raise
         except Exception as e:
             logger.exception("Failed to create virtual API key")
             raise DatabaseError(
@@ -904,7 +964,11 @@ class APIKeyManager:
         self,
         key_id: int,
         user_id: int,
-        expires_in_days: Optional[int] = 90
+        expires_in_days: Optional[int] = 90,
+        actor_user_id: Optional[int] = None,
+        actor_subject: Optional[str] = None,
+        actor_kind: Optional[str] = None,
+        actor_roles: Optional[list[str]] = None,
     ) -> dict[str, Any]:
         """
         Rotate an API key - atomically create new one and revoke old one.
@@ -924,57 +988,72 @@ class APIKeyManager:
         if not self._initialized:
             await self.initialize()
 
+        repo = self._get_repo()
         try:
-            repo = self._get_repo()
-            # Get existing key info (authorization check remains here)
-            old_key = await repo.fetch_key_for_user(key_id=key_id, user_id=user_id)
+            async with self.db_pool.transaction() as conn:
+                old_key = await repo.fetch_key_for_user(key_id=key_id, user_id=user_id, conn=conn)
 
-            if not old_key:
-                raise ValueError("API key not found or unauthorized")
+                if not old_key:
+                    raise ValueError("API key not found or unauthorized")
+                if str(old_key.get("status") or "").lower() != APIKeyStatus.ACTIVE.value:
+                    raise ValueError("API key not found or unauthorized")
 
-            # Decode stored JSON fields in a fail-closed way for security-
-            # sensitive allowlists like allowed_ips.
-            raw_allowed_ips = old_key.get("allowed_ips")
-            allowed_ips: Optional[list[str]] = None
-            if raw_allowed_ips:
-                decoded_allowed_ips = self._coerce_json_field(raw_allowed_ips)
-                if decoded_allowed_ips is None or not isinstance(decoded_allowed_ips, list):
-                    raise TypeError("API key allowlist must be stored as JSON array")
-                allowed_ips = decoded_allowed_ips  # type: ignore[assignment]
+                raw_allowed_ips = old_key.get("allowed_ips")
+                allowed_ips: Optional[list[str]] = None
+                if raw_allowed_ips:
+                    decoded_allowed_ips = self._coerce_json_field(raw_allowed_ips)
+                    if decoded_allowed_ips is None or not isinstance(decoded_allowed_ips, list):
+                        raise TypeError("API key allowlist must be stored as JSON array")
+                    allowed_ips = decoded_allowed_ips  # type: ignore[assignment]
 
-            # Generate new key credentials
-            full_key, key_hash, key_identifier = self.generate_api_key()
-            key_prefix = full_key[:10] + "..."
+                full_key, key_hash, key_identifier = self.generate_api_key()
+                key_prefix = full_key[:10] + "..."
 
-            # Calculate expiration for new key
-            expires_at = None
-            if expires_in_days is not None:
-                expires_at = datetime.now(timezone.utc) + timedelta(days=expires_in_days)
+                expires_at = None
+                if expires_in_days is not None:
+                    expires_at = datetime.now(timezone.utc) + timedelta(days=expires_in_days)
 
-            # Prepare new key metadata
-            new_name = f"{old_key['name']} (rotated)" if old_key['name'] else "Rotated key"
-            new_metadata = self._coerce_json_field(old_key.get('metadata'))
+                new_name = f"{old_key['name']} (rotated)" if old_key['name'] else "Rotated key"
+                new_metadata = self._coerce_json_field(old_key.get('metadata'))
 
-            # Atomically create new key and mark old key as rotated
-            new_key_id = await repo.rotate_key_atomic(
-                user_id=user_id,
-                old_key_id=key_id,
-                new_key_hash=key_hash,
-                new_key_identifier=key_identifier,
-                new_key_prefix=key_prefix,
-                new_name=new_name,
-                new_description=old_key['description'],
-                new_scope=old_key['scope'],
-                new_expires_at=expires_at,
-                new_rate_limit=old_key['rate_limit'],
-                new_allowed_ips=allowed_ips,
-                new_metadata=new_metadata,
-                rotated_status=APIKeyStatus.ROTATED.value,
-                reason="Key rotation",
-                revoked_at=datetime.now(timezone.utc),
-            )
+                new_key_id = await repo.rotate_key_atomic(
+                    user_id=user_id,
+                    old_key_id=key_id,
+                    new_key_hash=key_hash,
+                    new_key_identifier=key_identifier,
+                    new_key_prefix=key_prefix,
+                    new_name=new_name,
+                    new_description=old_key['description'],
+                    new_scope=old_key['scope'],
+                    new_expires_at=expires_at,
+                    new_rate_limit=old_key['rate_limit'],
+                    new_allowed_ips=allowed_ips,
+                    new_metadata=new_metadata,
+                    active_status=APIKeyStatus.ACTIVE.value,
+                    rotated_status=APIKeyStatus.ROTATED.value,
+                    reason="Key rotation",
+                    revoked_at=datetime.now(timezone.utc),
+                    conn=conn,
+                )
 
-            # Log the rotation (non-critical, outside transaction)
+                await emit_mandatory_api_key_management_audit(
+                    user_id=user_id,
+                    event_type=AuditEventType.DATA_UPDATE,
+                    category=AuditEventCategory.DATA_MODIFICATION,
+                    action="api_key.rotate",
+                    resource_id=str(new_key_id),
+                    metadata={
+                        "old_key_id": key_id,
+                        "new_key_id": new_key_id,
+                        "expires_in_days": expires_in_days,
+                    },
+                    actor_user_id=actor_user_id,
+                    actor_subject=actor_subject,
+                    actor_kind=actor_kind,
+                    actor_roles=actor_roles,
+                )
+
+            # Keep legacy API-key audit mirror as best-effort compatibility.
             await self._log_action(key_id, "rotated", user_id)
             await self._log_action(new_key_id, "created_from_rotation", user_id)
 
@@ -998,6 +1077,19 @@ class APIKeyManager:
         except (ValueError, InvalidTokenError):
             # Preserve auth/not-found semantics; callers map to appropriate 4xx.
             raise
+        except MandatoryAuditWriteError:
+            raise
+        except TransactionError as exc:
+            message = str(exc)
+            if (
+                "API key not found or inactive" in message
+                or "API key not found or unauthorized" in message
+            ):
+                raise ValueError("API key not found or unauthorized") from exc
+            logger.exception("Failed to rotate API key")
+            raise DatabaseError(
+                f"Failed to rotate API key {self._db_context_hint()}"
+            ) from exc
         except Exception as e:
             logger.exception("Failed to rotate API key")
             raise DatabaseError(
@@ -1008,7 +1100,11 @@ class APIKeyManager:
         self,
         key_id: int,
         user_id: int,
-        reason: Optional[str] = None
+        reason: Optional[str] = None,
+        actor_user_id: Optional[int] = None,
+        actor_subject: Optional[str] = None,
+        actor_kind: Optional[str] = None,
+        actor_roles: Optional[list[str]] = None,
     ) -> bool:
         """
         Revoke an API key
@@ -1024,23 +1120,43 @@ class APIKeyManager:
         if not self._initialized:
             await self.initialize()
 
+        repo = self._get_repo()
+        reason_text = reason or "Manual revocation"
         try:
-            repo = self._get_repo()
-            success = await repo.revoke_api_key_for_user(
-                key_id=key_id,
-                user_id=user_id,
-                revoked_status=APIKeyStatus.REVOKED.value,
-                active_status=APIKeyStatus.ACTIVE.value,
-                reason=reason or "Manual revocation",
-                revoked_at=datetime.now(timezone.utc),
-            )
+            async with self.db_pool.transaction() as conn:
+                success = await repo.revoke_api_key_for_user(
+                    key_id=key_id,
+                    user_id=user_id,
+                    revoked_status=APIKeyStatus.REVOKED.value,
+                    active_status=APIKeyStatus.ACTIVE.value,
+                    reason=reason_text,
+                    revoked_at=datetime.now(timezone.utc),
+                    conn=conn,
+                )
+
+                if success:
+                    await emit_mandatory_api_key_management_audit(
+                        user_id=user_id,
+                        event_type=AuditEventType.DATA_UPDATE,
+                        category=AuditEventCategory.DATA_MODIFICATION,
+                        action="api_key.revoke",
+                        resource_id=str(key_id),
+                        metadata={"reason": reason_text},
+                        actor_user_id=actor_user_id,
+                        actor_subject=actor_subject,
+                        actor_kind=actor_kind,
+                        actor_roles=actor_roles,
+                    )
 
             if success:
-                await self._log_action(key_id, "revoked", user_id, {"reason": reason})
+                # Keep legacy API-key audit mirror as best-effort compatibility.
+                await self._log_action(key_id, "revoked", user_id, {"reason": reason_text})
                 logger.info(f"Revoked API key {key_id}")
 
             return success
 
+        except MandatoryAuditWriteError:
+            raise
         except Exception as e:
             logger.exception("Failed to revoke API key")
             raise DatabaseError(

--- a/tldw_Server_API/app/core/AuthNZ/database.py
+++ b/tldw_Server_API/app/core/AuthNZ/database.py
@@ -19,6 +19,7 @@ import asyncpg
 from fastapi import HTTPException
 from loguru import logger
 
+from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
 from tldw_Server_API.app.core.AuthNZ.exceptions import (
     ConnectionPoolExhaustedError,
     DatabaseError,
@@ -568,6 +569,8 @@ class DatabasePool:
             except HTTPException:
                 # Re-raise HTTP exceptions unchanged
                 raise
+            except MandatoryAuditWriteError:
+                raise
             except (DuplicateUserError, WeakPasswordError, InvalidRegistrationCodeError, RegistrationError, DuplicateOrganizationError, DuplicateTeamError, DuplicateRoleError, DuplicatePermissionError):
                 # Re-raise registration exceptions unchanged
                 raise
@@ -612,6 +615,8 @@ class DatabasePool:
                 raise TransactionError("SQLite transaction", str(e)) from e
             except HTTPException:
                 # Re-raise HTTP exceptions unchanged
+                raise
+            except MandatoryAuditWriteError:
                 raise
             except (DuplicateUserError, WeakPasswordError, InvalidRegistrationCodeError, RegistrationError, DuplicateOrganizationError, DuplicateTeamError, DuplicateRoleError, DuplicatePermissionError):
                 # Re-raise registration exceptions unchanged

--- a/tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py
@@ -16,6 +16,18 @@ from tldw_Server_API.app.core.AuthNZ.database import (
 )
 
 
+def _affected_row_count(result: Any) -> int:
+    """Normalize SQLite cursor/asyncpg status values to an affected-row count."""
+    rowcount = getattr(result, "rowcount", None)
+    if isinstance(rowcount, int):
+        return rowcount
+    if isinstance(result, str):
+        parts = result.strip().split()
+        if parts and parts[-1].isdigit():
+            return int(parts[-1])
+    return 0
+
+
 @dataclass
 class AuthnzApiKeysRepo:
     """
@@ -199,10 +211,28 @@ class AuthnzApiKeysRepo:
             logger.error(f"AuthnzApiKeysRepo.fetch_active_by_key_id failed: {exc}")
             raise
 
-    async def fetch_key_for_user(self, key_id: int, user_id: int) -> dict[str, Any] | None:
+    async def fetch_key_for_user(
+        self,
+        key_id: int,
+        user_id: int,
+        *,
+        conn: Any | None = None,
+    ) -> dict[str, Any] | None:
         """Fetch a specific key row for a user (id + user_id match)."""
         try:
-            if getattr(self.db_pool, "pool", None) is not None:
+            if conn is not None and self._is_postgres_backend():
+                row = await conn.fetchrow(
+                    "SELECT * FROM api_keys WHERE id = $1 AND user_id = $2",
+                    key_id,
+                    user_id,
+                )
+            elif conn is not None:
+                cursor = await conn.execute(
+                    "SELECT * FROM api_keys WHERE id = ? AND user_id = ?",
+                    (key_id, user_id),
+                )
+                row = await cursor.fetchone()
+            elif getattr(self.db_pool, "pool", None) is not None:
                 row = await self.db_pool.fetchone(
                     "SELECT * FROM api_keys WHERE id = $1 AND user_id = $2",
                     key_id,
@@ -432,6 +462,7 @@ class AuthnzApiKeysRepo:
         rate_limit: int | None,
         allowed_ips: list[str] | None,
         metadata: dict[str, Any] | None,
+        conn: Any | None = None,
     ) -> int:
         """
         Insert a new API key row and return its id.
@@ -440,23 +471,61 @@ class AuthnzApiKeysRepo:
         while centralizing dialect-specific SQL in the repository layer.
         """
         try:
-            async with self.db_pool.transaction() as conn:
-                if self._is_postgres_backend():
-                    expires_at_param = expires_at
-                    if (
-                        isinstance(expires_at_param, datetime)
-                        and expires_at_param.tzinfo is not None
-                    ):
-                        expires_at_param = expires_at_param.astimezone(timezone.utc).replace(tzinfo=None)
-                    key_id = await conn.fetchval(
-                        """
-                        INSERT INTO api_keys (
-                            user_id, key_hash, key_id, key_prefix, name, description,
-                            scope, expires_at, rate_limit, allowed_ips, metadata
-                        )
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-                        RETURNING id
-                        """,
+            if conn is None:
+                async with self.db_pool.transaction() as txn:
+                    return await self.create_api_key_row(
+                        user_id=user_id,
+                        key_hash=key_hash,
+                        key_identifier=key_identifier,
+                        key_prefix=key_prefix,
+                        name=name,
+                        description=description,
+                        scope=scope,
+                        expires_at=expires_at,
+                        rate_limit=rate_limit,
+                        allowed_ips=allowed_ips,
+                        metadata=metadata,
+                        conn=txn,
+                    )
+
+            if self._is_postgres_backend():
+                expires_at_param = expires_at
+                if (
+                    isinstance(expires_at_param, datetime)
+                    and expires_at_param.tzinfo is not None
+                ):
+                    expires_at_param = expires_at_param.astimezone(timezone.utc).replace(tzinfo=None)
+                key_id = await conn.fetchval(
+                    """
+                    INSERT INTO api_keys (
+                        user_id, key_hash, key_id, key_prefix, name, description,
+                        scope, expires_at, rate_limit, allowed_ips, metadata
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                    RETURNING id
+                    """,
+                    user_id,
+                    key_hash,
+                    key_identifier,
+                    key_prefix,
+                    name,
+                    description,
+                    scope,
+                    expires_at_param,
+                    rate_limit,
+                    json.dumps(allowed_ips) if allowed_ips else None,
+                    json.dumps(metadata) if metadata else None,
+                )
+            else:
+                cursor = await conn.execute(
+                    """
+                    INSERT INTO api_keys (
+                        user_id, key_hash, key_id, key_prefix, name, description,
+                        scope, expires_at, rate_limit, allowed_ips, metadata
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
                         user_id,
                         key_hash,
                         key_identifier,
@@ -464,35 +533,13 @@ class AuthnzApiKeysRepo:
                         name,
                         description,
                         scope,
-                        expires_at_param,
+                        expires_at.isoformat() if expires_at else None,
                         rate_limit,
                         json.dumps(allowed_ips) if allowed_ips else None,
                         json.dumps(metadata) if metadata else None,
-                    )
-                else:
-                    cursor = await conn.execute(
-                        """
-                        INSERT INTO api_keys (
-                            user_id, key_hash, key_id, key_prefix, name, description,
-                            scope, expires_at, rate_limit, allowed_ips, metadata
-                        )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            user_id,
-                            key_hash,
-                            key_identifier,
-                            key_prefix,
-                            name,
-                            description,
-                            scope,
-                            expires_at.isoformat() if expires_at else None,
-                            rate_limit,
-                            json.dumps(allowed_ips) if allowed_ips else None,
-                            json.dumps(metadata) if metadata else None,
-                        ),
-                    )
-                    key_id = getattr(cursor, "lastrowid", None)
+                    ),
+                )
+                key_id = getattr(cursor, "lastrowid", None)
 
             return int(key_id)
         except Exception as exc:  # pragma: no cover - surfaced via higher layers
@@ -524,6 +571,7 @@ class AuthnzApiKeysRepo:
         allowed_paths: list[str] | None,
         max_calls: int | None,
         max_runs: int | None,
+        conn: Any | None = None,
     ) -> int:
         """
         Insert a new virtual API key row and return its id.
@@ -546,128 +594,77 @@ class AuthnzApiKeysRepo:
 
             scope_value = str(scope).strip().lower() if scope else "read"
 
-            async with self.db_pool.transaction() as conn:
-                if self._is_postgres_backend():
-                    _endpoints = (
-                        json.dumps(allowed_endpoints)
-                        if allowed_endpoints is not None
-                        else None
+            if conn is None:
+                async with self.db_pool.transaction() as txn:
+                    return await self.create_virtual_key_row(
+                        user_id=user_id,
+                        key_hash=key_hash,
+                        key_identifier=key_identifier,
+                        key_prefix=key_prefix,
+                        name=name,
+                        description=description,
+                        expires_at=expires_at,
+                        org_id=org_id,
+                        team_id=team_id,
+                        scope=scope,
+                        allowed_endpoints=allowed_endpoints,
+                        allowed_providers=allowed_providers,
+                        allowed_models=allowed_models,
+                        budget_day_tokens=budget_day_tokens,
+                        budget_month_tokens=budget_month_tokens,
+                        budget_day_usd=budget_day_usd,
+                        budget_month_usd=budget_month_usd,
+                        parent_key_id=parent_key_id,
+                        allowed_methods=allowed_methods,
+                        allowed_paths=allowed_paths,
+                        max_calls=max_calls,
+                        max_runs=max_runs,
+                        conn=txn,
                     )
-                    _providers = (
-                        json.dumps(allowed_providers)
-                        if allowed_providers is not None
-                        else None
+
+            if self._is_postgres_backend():
+                _endpoints = (
+                    json.dumps(allowed_endpoints)
+                    if allowed_endpoints is not None
+                    else None
+                )
+                _providers = (
+                    json.dumps(allowed_providers)
+                    if allowed_providers is not None
+                    else None
+                )
+                _models = (
+                    json.dumps(allowed_models)
+                    if allowed_models is not None
+                    else None
+                )
+                _metadata = json.dumps(meta_dict) if meta_dict else None
+                expires_at_param = expires_at
+                if (
+                    isinstance(expires_at_param, datetime)
+                    and expires_at_param.tzinfo is not None
+                ):
+                    expires_at_param = expires_at_param.astimezone(timezone.utc).replace(tzinfo=None)
+
+                try:
+                    col_type = await conn.fetchval(
+                        """
+                        SELECT data_type FROM information_schema.columns
+                        WHERE table_name = 'api_keys' AND column_name = 'llm_allowed_endpoints'
+                        """
                     )
-                    _models = (
-                        json.dumps(allowed_models)
-                        if allowed_models is not None
-                        else None
+                except (AttributeError, LookupError) as exc:
+                    logger.debug(
+                        "AuthnzApiKeysRepo.create_virtual_key_row: column type "
+                        "detection for api_keys.llm_allowed_endpoints failed; "
+                        "treating as non-JSONB: {}",
+                        exc,
                     )
-                    _metadata = json.dumps(meta_dict) if meta_dict else None
-                    expires_at_param = expires_at
-                    if (
-                        isinstance(expires_at_param, datetime)
-                        and expires_at_param.tzinfo is not None
-                    ):
-                        expires_at_param = expires_at_param.astimezone(timezone.utc).replace(tzinfo=None)
+                    col_type = None
+                is_jsonb = isinstance(col_type, str) and ("json" in col_type.lower())
 
-                    # Detect column types to choose JSONB cast or plain text insert.
-                    # Use narrow exception handling so unexpected driver errors surface.
-                    try:
-                        col_type = await conn.fetchval(
-                            """
-                            SELECT data_type FROM information_schema.columns
-                            WHERE table_name = 'api_keys' AND column_name = 'llm_allowed_endpoints'
-                            """
-                        )
-                    except (AttributeError, LookupError) as exc:
-                        logger.debug(
-                            "AuthnzApiKeysRepo.create_virtual_key_row: column type "
-                            "detection for api_keys.llm_allowed_endpoints failed; "
-                            "treating as non-JSONB: {}",
-                            exc,
-                        )
-                        col_type = None
-                    is_jsonb = isinstance(col_type, str) and ("json" in col_type.lower())
-
-                    if is_jsonb:
-                        key_id = await conn.fetchval(
-                            """
-                            INSERT INTO api_keys (
-                                user_id, key_hash, key_id, key_prefix, name, description, scope, status, expires_at,
-                                is_virtual, parent_key_id, org_id, team_id,
-                                llm_budget_day_tokens, llm_budget_month_tokens,
-                                llm_budget_day_usd, llm_budget_month_usd,
-                                llm_allowed_endpoints, llm_allowed_providers, llm_allowed_models,
-                                metadata
-                            ) VALUES (
-                                $1,$2,$3,$4,$5,$6,$7,'active',$8,
-                                TRUE,$9,$10,$11,
-                                $12,$13,$14,$15,$16::jsonb,$17::jsonb,$18::jsonb,
-                                ($19)::jsonb
-                            ) RETURNING id
-                            """,
-                            user_id,
-                            key_hash,
-                            key_identifier,
-                            key_prefix,
-                            name,
-                            description,
-                            scope_value,
-                            expires_at_param,
-                            parent_key_id,
-                            org_id,
-                            team_id,
-                            budget_day_tokens,
-                            budget_month_tokens,
-                            budget_day_usd,
-                            budget_month_usd,
-                            _endpoints,
-                            _providers,
-                            _models,
-                            _metadata,
-                        )
-                    else:
-                        key_id = await conn.fetchval(
-                            """
-                            INSERT INTO api_keys (
-                                user_id, key_hash, key_id, key_prefix, name, description, scope, status, expires_at,
-                                is_virtual, parent_key_id, org_id, team_id,
-                                llm_budget_day_tokens, llm_budget_month_tokens,
-                                llm_budget_day_usd, llm_budget_month_usd,
-                                llm_allowed_endpoints, llm_allowed_providers, llm_allowed_models,
-                                metadata
-                            ) VALUES (
-                                $1,$2,$3,$4,$5,$6,$7,'active',$8,
-                                TRUE,$9,$10,$11,
-                                $12,$13,$14,$15,$16,$17,$18,
-                                $19
-                            ) RETURNING id
-                            """,
-                            user_id,
-                            key_hash,
-                            key_identifier,
-                            key_prefix,
-                            name,
-                            description,
-                            scope_value,
-                            expires_at_param,
-                            parent_key_id,
-                            org_id,
-                            team_id,
-                            budget_day_tokens,
-                            budget_month_tokens,
-                            budget_day_usd,
-                            budget_month_usd,
-                            _endpoints,
-                            _providers,
-                            _models,
-                            _metadata,
-                        )
-                else:
-                    _metadata = json.dumps(meta_dict) if meta_dict else None
-
-                    cursor = await conn.execute(
+                if is_jsonb:
+                    key_id = await conn.fetchval(
                         """
                         INSERT INTO api_keys (
                             user_id, key_hash, key_id, key_prefix, name, description, scope, status, expires_at,
@@ -676,37 +673,259 @@ class AuthnzApiKeysRepo:
                             llm_budget_day_usd, llm_budget_month_usd,
                             llm_allowed_endpoints, llm_allowed_providers, llm_allowed_models,
                             metadata
-                        ) VALUES (?,?,?,?,?,?,?,'active',?,
-                            1,?,?,?,?,?,?,?,?,?,?,?
-                        )
+                        ) VALUES (
+                            $1,$2,$3,$4,$5,$6,$7,'active',$8,
+                            TRUE,$9,$10,$11,
+                            $12,$13,$14,$15,$16::jsonb,$17::jsonb,$18::jsonb,
+                            ($19)::jsonb
+                        ) RETURNING id
                         """,
-                        (
-                            user_id,
-                            key_hash,
-                            key_identifier,
-                            key_prefix,
-                            name,
-                            description,
-                            scope_value,
-                            expires_at.isoformat() if expires_at else None,
-                            parent_key_id,
-                            org_id,
-                            team_id,
-                            budget_day_tokens,
-                            budget_month_tokens,
-                            budget_day_usd,
-                            budget_month_usd,
-                            (json.dumps(allowed_endpoints) if allowed_endpoints else None),
-                            (json.dumps(allowed_providers) if allowed_providers else None),
-                            (json.dumps(allowed_models) if allowed_models else None),
-                            _metadata,
-                        ),
+                        user_id,
+                        key_hash,
+                        key_identifier,
+                        key_prefix,
+                        name,
+                        description,
+                        scope_value,
+                        expires_at_param,
+                        parent_key_id,
+                        org_id,
+                        team_id,
+                        budget_day_tokens,
+                        budget_month_tokens,
+                        budget_day_usd,
+                        budget_month_usd,
+                        _endpoints,
+                        _providers,
+                        _models,
+                        _metadata,
                     )
-                    key_id = getattr(cursor, "lastrowid", None)
+                else:
+                    key_id = await conn.fetchval(
+                        """
+                        INSERT INTO api_keys (
+                            user_id, key_hash, key_id, key_prefix, name, description, scope, status, expires_at,
+                            is_virtual, parent_key_id, org_id, team_id,
+                            llm_budget_day_tokens, llm_budget_month_tokens,
+                            llm_budget_day_usd, llm_budget_month_usd,
+                            llm_allowed_endpoints, llm_allowed_providers, llm_allowed_models,
+                            metadata
+                        ) VALUES (
+                            $1,$2,$3,$4,$5,$6,$7,'active',$8,
+                            TRUE,$9,$10,$11,
+                            $12,$13,$14,$15,$16,$17,$18,
+                            $19
+                        ) RETURNING id
+                        """,
+                        user_id,
+                        key_hash,
+                        key_identifier,
+                        key_prefix,
+                        name,
+                        description,
+                        scope_value,
+                        expires_at_param,
+                        parent_key_id,
+                        org_id,
+                        team_id,
+                        budget_day_tokens,
+                        budget_month_tokens,
+                        budget_day_usd,
+                        budget_month_usd,
+                        _endpoints,
+                        _providers,
+                        _models,
+                        _metadata,
+                    )
+            else:
+                _metadata = json.dumps(meta_dict) if meta_dict else None
+
+                cursor = await conn.execute(
+                    """
+                    INSERT INTO api_keys (
+                        user_id, key_hash, key_id, key_prefix, name, description, scope, status, expires_at,
+                        is_virtual, parent_key_id, org_id, team_id,
+                        llm_budget_day_tokens, llm_budget_month_tokens,
+                        llm_budget_day_usd, llm_budget_month_usd,
+                        llm_allowed_endpoints, llm_allowed_providers, llm_allowed_models,
+                        metadata
+                    ) VALUES (?,?,?,?,?,?,?,'active',?,
+                        1,?,?,?,?,?,?,?,?,?,?,?
+                    )
+                    """,
+                    (
+                        user_id,
+                        key_hash,
+                        key_identifier,
+                        key_prefix,
+                        name,
+                        description,
+                        scope_value,
+                        expires_at.isoformat() if expires_at else None,
+                        parent_key_id,
+                        org_id,
+                        team_id,
+                        budget_day_tokens,
+                        budget_month_tokens,
+                        budget_day_usd,
+                        budget_month_usd,
+                        (json.dumps(allowed_endpoints) if allowed_endpoints else None),
+                        (json.dumps(allowed_providers) if allowed_providers else None),
+                        (json.dumps(allowed_models) if allowed_models else None),
+                        _metadata,
+                    ),
+                )
+                key_id = getattr(cursor, "lastrowid", None)
 
             return int(key_id)
         except Exception as exc:  # pragma: no cover - surfaced via higher layers
             logger.error(f"AuthnzApiKeysRepo.create_virtual_key_row failed: {exc}")
+            raise
+
+    async def delete_api_key_for_user(
+        self,
+        *,
+        key_id: int,
+        user_id: int,
+    ) -> bool:
+        """Delete a user-owned API key row, used for compensating rollback."""
+        try:
+            async with self.db_pool.transaction() as conn:
+                if self._is_postgres_backend():
+                    result = await conn.execute(
+                        "DELETE FROM api_keys WHERE id = $1 AND user_id = $2",
+                        key_id,
+                        user_id,
+                    )
+                    return _affected_row_count(result) > 0
+
+                cursor = await conn.execute(
+                    "DELETE FROM api_keys WHERE id = ? AND user_id = ?",
+                    (key_id, user_id),
+                )
+                return _affected_row_count(cursor) > 0
+        except Exception as exc:  # pragma: no cover - surfaced via higher layers
+            logger.error(f"AuthnzApiKeysRepo.delete_api_key_for_user failed: {exc}")
+            raise
+
+    async def rollback_key_rotation(
+        self,
+        *,
+        user_id: int,
+        old_key_id: int,
+        new_key_id: int,
+        active_status: str,
+        rotated_status: str,
+    ) -> bool:
+        """Restore the old key to active state and delete the new rotated key."""
+        try:
+            async with self.db_pool.transaction() as conn:
+                if self._is_postgres_backend():
+                    restore_result = await conn.execute(
+                        """
+                        UPDATE api_keys
+                        SET status = $1,
+                            rotated_to = NULL,
+                            revoked_at = NULL,
+                            revoked_by = NULL,
+                            revoke_reason = NULL
+                        WHERE id = $2 AND user_id = $3 AND status = $4 AND rotated_to = $5
+                        """,
+                        active_status,
+                        old_key_id,
+                        user_id,
+                        rotated_status,
+                        new_key_id,
+                    )
+                    delete_result = await conn.execute(
+                        """
+                        DELETE FROM api_keys
+                        WHERE id = $1 AND user_id = $2 AND rotated_from = $3
+                        """,
+                        new_key_id,
+                        user_id,
+                        old_key_id,
+                    )
+                    return (
+                        _affected_row_count(restore_result) > 0
+                        and _affected_row_count(delete_result) > 0
+                    )
+
+                restore_cursor = await conn.execute(
+                    """
+                    UPDATE api_keys
+                    SET status = ?,
+                        rotated_to = NULL,
+                        revoked_at = NULL,
+                        revoked_by = NULL,
+                        revoke_reason = NULL
+                    WHERE id = ? AND user_id = ? AND status = ? AND rotated_to = ?
+                    """,
+                    (
+                        active_status,
+                        old_key_id,
+                        user_id,
+                        rotated_status,
+                        new_key_id,
+                    ),
+                )
+                delete_cursor = await conn.execute(
+                    """
+                    DELETE FROM api_keys
+                    WHERE id = ? AND user_id = ? AND rotated_from = ?
+                    """,
+                    (new_key_id, user_id, old_key_id),
+                )
+                return (
+                    _affected_row_count(restore_cursor) > 0
+                    and _affected_row_count(delete_cursor) > 0
+                )
+        except Exception as exc:  # pragma: no cover - surfaced via higher layers
+            logger.error(f"AuthnzApiKeysRepo.rollback_key_rotation failed: {exc}")
+            raise
+
+    async def restore_revoked_api_key(
+        self,
+        *,
+        key_id: int,
+        user_id: int,
+        active_status: str,
+        revoked_status: str,
+    ) -> bool:
+        """Restore a revoked key to active state for compensating rollback."""
+        try:
+            async with self.db_pool.transaction() as conn:
+                if self._is_postgres_backend():
+                    result = await conn.execute(
+                        """
+                        UPDATE api_keys
+                        SET status = $1,
+                            revoked_at = NULL,
+                            revoked_by = NULL,
+                            revoke_reason = NULL
+                        WHERE id = $2 AND user_id = $3 AND status = $4
+                        """,
+                        active_status,
+                        key_id,
+                        user_id,
+                        revoked_status,
+                    )
+                    return _affected_row_count(result) > 0
+
+                cursor = await conn.execute(
+                    """
+                    UPDATE api_keys
+                    SET status = ?,
+                        revoked_at = NULL,
+                        revoked_by = NULL,
+                        revoke_reason = NULL
+                    WHERE id = ? AND user_id = ? AND status = ?
+                    """,
+                    (active_status, key_id, user_id, revoked_status),
+                )
+                return _affected_row_count(cursor) > 0
+        except Exception as exc:  # pragma: no cover - surfaced via higher layers
+            logger.error(f"AuthnzApiKeysRepo.restore_revoked_api_key failed: {exc}")
             raise
 
     async def mark_rotated(
@@ -789,9 +1008,11 @@ class AuthnzApiKeysRepo:
         new_rate_limit: int | None,
         new_allowed_ips: list[str] | None,
         new_metadata: dict[str, Any] | None,
+        active_status: str,
         rotated_status: str,
         reason: str,
         revoked_at: datetime,
+        conn: Any | None = None,
     ) -> int:
         """
         Atomically create a new API key and mark the old one as rotated.
@@ -807,26 +1028,94 @@ class AuthnzApiKeysRepo:
             Exception: If any part of the rotation fails (entire transaction rolls back).
         """
         try:
-            async with self.db_pool.transaction() as conn:
-                if self._is_postgres_backend():
-                    # PostgreSQL path
-                    expires_at_param = new_expires_at
-                    if (
-                        isinstance(expires_at_param, datetime)
-                        and expires_at_param.tzinfo is not None
-                    ):
-                        expires_at_param = expires_at_param.astimezone(timezone.utc).replace(tzinfo=None)
+            if conn is None:
+                async with self.db_pool.transaction() as txn:
+                    return await self.rotate_key_atomic(
+                        user_id=user_id,
+                        old_key_id=old_key_id,
+                        new_key_hash=new_key_hash,
+                        new_key_identifier=new_key_identifier,
+                        new_key_prefix=new_key_prefix,
+                        new_name=new_name,
+                        new_description=new_description,
+                        new_scope=new_scope,
+                        new_expires_at=new_expires_at,
+                        new_rate_limit=new_rate_limit,
+                        new_allowed_ips=new_allowed_ips,
+                        new_metadata=new_metadata,
+                        active_status=active_status,
+                        rotated_status=rotated_status,
+                        reason=reason,
+                        revoked_at=revoked_at,
+                        conn=txn,
+                    )
 
-                    # Create new key
-                    new_key_id = await conn.fetchval(
-                        """
-                        INSERT INTO api_keys (
-                            user_id, key_hash, key_id, key_prefix, name, description,
-                            scope, expires_at, rate_limit, allowed_ips, metadata
-                        )
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-                        RETURNING id
-                        """,
+            if self._is_postgres_backend():
+                expires_at_param = new_expires_at
+                if (
+                    isinstance(expires_at_param, datetime)
+                    and expires_at_param.tzinfo is not None
+                ):
+                    expires_at_param = expires_at_param.astimezone(timezone.utc).replace(tzinfo=None)
+
+                new_key_id = await conn.fetchval(
+                    """
+                    INSERT INTO api_keys (
+                        user_id, key_hash, key_id, key_prefix, name, description,
+                        scope, expires_at, rate_limit, allowed_ips, metadata
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                    RETURNING id
+                    """,
+                    user_id,
+                    new_key_hash,
+                    new_key_identifier,
+                    new_key_prefix,
+                    new_name,
+                    new_description,
+                    new_scope,
+                    expires_at_param,
+                    new_rate_limit,
+                    json.dumps(new_allowed_ips) if new_allowed_ips else None,
+                    json.dumps(new_metadata) if new_metadata else None,
+                )
+
+                norm_revoked_at = revoked_at
+                if isinstance(norm_revoked_at, datetime) and norm_revoked_at.tzinfo is not None:
+                    norm_revoked_at = norm_revoked_at.astimezone(timezone.utc).replace(tzinfo=None)
+
+                old_update_result = await conn.execute(
+                    """
+                    UPDATE api_keys
+                    SET status = $1, rotated_to = $2, revoked_at = $3,
+                        revoke_reason = $4
+                    WHERE id = $5 AND user_id = $6 AND status = $7
+                    """,
+                    rotated_status,
+                    new_key_id,
+                    norm_revoked_at,
+                    reason,
+                    old_key_id,
+                    user_id,
+                    active_status,
+                )
+                if _affected_row_count(old_update_result) == 0:
+                    raise ValueError("API key not found or inactive")
+                await conn.execute(
+                    "UPDATE api_keys SET rotated_from = $1 WHERE id = $2",
+                    old_key_id,
+                    new_key_id,
+                )
+            else:
+                cursor = await conn.execute(
+                    """
+                    INSERT INTO api_keys (
+                        user_id, key_hash, key_id, key_prefix, name, description,
+                        scope, expires_at, rate_limit, allowed_ips, metadata
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
                         user_id,
                         new_key_hash,
                         new_key_identifier,
@@ -834,83 +1123,39 @@ class AuthnzApiKeysRepo:
                         new_name,
                         new_description,
                         new_scope,
-                        expires_at_param,
+                        new_expires_at.isoformat() if new_expires_at else None,
                         new_rate_limit,
                         json.dumps(new_allowed_ips) if new_allowed_ips else None,
                         json.dumps(new_metadata) if new_metadata else None,
-                    )
+                    ),
+                )
+                new_key_id = getattr(cursor, "lastrowid", None)
 
-                    # Mark old key as rotated
-                    norm_revoked_at = revoked_at
-                    if isinstance(norm_revoked_at, datetime) and norm_revoked_at.tzinfo is not None:
-                        norm_revoked_at = norm_revoked_at.astimezone(timezone.utc).replace(tzinfo=None)
-
-                    await conn.execute(
-                        """
-                        UPDATE api_keys
-                        SET status = $1, rotated_to = $2, revoked_at = $3,
-                            revoke_reason = $4
-                        WHERE id = $5
-                        """,
+                old_update_cursor = await conn.execute(
+                    """
+                    UPDATE api_keys
+                    SET status = ?, rotated_to = ?, revoked_at = ?,
+                        revoke_reason = ?
+                    WHERE id = ? AND user_id = ? AND status = ?
+                    """,
+                    (
                         rotated_status,
                         new_key_id,
-                        norm_revoked_at,
+                        revoked_at.isoformat(),
                         reason,
                         old_key_id,
-                    )
-                    await conn.execute(
-                        "UPDATE api_keys SET rotated_from = $1 WHERE id = $2",
-                        old_key_id,
-                        new_key_id,
-                    )
-                else:
-                    # SQLite path
-                    cursor = await conn.execute(
-                        """
-                        INSERT INTO api_keys (
-                            user_id, key_hash, key_id, key_prefix, name, description,
-                            scope, expires_at, rate_limit, allowed_ips, metadata
-                        )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (
-                            user_id,
-                            new_key_hash,
-                            new_key_identifier,
-                            new_key_prefix,
-                            new_name,
-                            new_description,
-                            new_scope,
-                            new_expires_at.isoformat() if new_expires_at else None,
-                            new_rate_limit,
-                            json.dumps(new_allowed_ips) if new_allowed_ips else None,
-                            json.dumps(new_metadata) if new_metadata else None,
-                        ),
-                    )
-                    new_key_id = getattr(cursor, "lastrowid", None)
+                        user_id,
+                        active_status,
+                    ),
+                )
+                if _affected_row_count(old_update_cursor) == 0:
+                    raise ValueError("API key not found or inactive")
+                await conn.execute(
+                    "UPDATE api_keys SET rotated_from = ? WHERE id = ?",
+                    (old_key_id, new_key_id),
+                )
 
-                    # Mark old key as rotated
-                    await conn.execute(
-                        """
-                        UPDATE api_keys
-                        SET status = ?, rotated_to = ?, revoked_at = ?,
-                            revoke_reason = ?
-                        WHERE id = ?
-                        """,
-                        (
-                            rotated_status,
-                            new_key_id,
-                            revoked_at.isoformat(),
-                            reason,
-                            old_key_id,
-                        ),
-                    )
-                    await conn.execute(
-                        "UPDATE api_keys SET rotated_from = ? WHERE id = ?",
-                        (old_key_id, new_key_id),
-                    )
-
-                return int(new_key_id)
+            return int(new_key_id)
         except Exception as exc:
             logger.error(f"AuthnzApiKeysRepo.rotate_key_atomic failed: {exc}")
             raise
@@ -924,6 +1169,7 @@ class AuthnzApiKeysRepo:
         active_status: str,
         reason: str,
         revoked_at: datetime,
+        conn: Any | None = None,
     ) -> bool:
         """
         Revoke an API key owned by the given user.
@@ -931,47 +1177,58 @@ class AuthnzApiKeysRepo:
         Returns True when a row was updated (key existed and was active), False otherwise.
         """
         try:
-            async with self.db_pool.transaction() as conn:
-                if self._is_postgres_backend():
-                    norm_revoked_at = revoked_at
-                    if isinstance(norm_revoked_at, datetime) and norm_revoked_at.tzinfo is not None:
-                        norm_revoked_at = norm_revoked_at.astimezone(timezone.utc).replace(tzinfo=None)
-                    result = await conn.execute(
-                        """
-                        UPDATE api_keys
-                        SET status = $1, revoked_at = $2, revoked_by = $3,
-                            revoke_reason = $4
-                        WHERE id = $5 AND user_id = $6 AND status = $7
-                        """,
-                        revoked_status,
-                        norm_revoked_at,
-                        user_id,
-                        reason,
-                        key_id,
-                        user_id,
-                        active_status,
+            if conn is None:
+                async with self.db_pool.transaction() as txn:
+                    return await self.revoke_api_key_for_user(
+                        key_id=key_id,
+                        user_id=user_id,
+                        revoked_status=revoked_status,
+                        active_status=active_status,
+                        reason=reason,
+                        revoked_at=revoked_at,
+                        conn=txn,
                     )
-                    # asyncpg returns a status string like "UPDATE <n>"
-                    normalized = str(result).strip().upper()
-                    return normalized != "UPDATE 0"
-                cursor = await conn.execute(
+
+            if self._is_postgres_backend():
+                norm_revoked_at = revoked_at
+                if isinstance(norm_revoked_at, datetime) and norm_revoked_at.tzinfo is not None:
+                    norm_revoked_at = norm_revoked_at.astimezone(timezone.utc).replace(tzinfo=None)
+                result = await conn.execute(
                     """
                     UPDATE api_keys
-                    SET status = ?, revoked_at = ?, revoked_by = ?,
-                        revoke_reason = ?
-                    WHERE id = ? AND user_id = ? AND status = ?
+                    SET status = $1, revoked_at = $2, revoked_by = $3,
+                        revoke_reason = $4
+                    WHERE id = $5 AND user_id = $6 AND status = $7
                     """,
-                    (
-                        revoked_status,
-                        revoked_at.isoformat(),
-                        user_id,
-                        reason,
-                        key_id,
-                        user_id,
-                        active_status,
-                    ),
+                    revoked_status,
+                    norm_revoked_at,
+                    user_id,
+                    reason,
+                    key_id,
+                    user_id,
+                    active_status,
                 )
-                return getattr(cursor, "rowcount", 0) > 0
+                normalized = str(result).strip().upper()
+                return normalized != "UPDATE 0"
+
+            cursor = await conn.execute(
+                """
+                UPDATE api_keys
+                SET status = ?, revoked_at = ?, revoked_by = ?,
+                    revoke_reason = ?
+                WHERE id = ? AND user_id = ? AND status = ?
+                """,
+                (
+                    revoked_status,
+                    revoked_at.isoformat(),
+                    user_id,
+                    reason,
+                    key_id,
+                    user_id,
+                    active_status,
+                ),
+            )
+            return getattr(cursor, "rowcount", 0) > 0
         except Exception as exc:  # pragma: no cover - surfaced via higher layers
             logger.error(f"AuthnzApiKeysRepo.revoke_api_key_for_user failed: {exc}")
             raise

--- a/tldw_Server_API/app/core/Chat/chat_service.py
+++ b/tldw_Server_API/app/core/Chat/chat_service.py
@@ -30,7 +30,10 @@ from loguru import logger
 from starlette.responses import StreamingResponse
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import DEFAULT_CHARACTER_NAME
-from tldw_Server_API.app.core.Audit.unified_audit_service import AuditEventType
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditEventType,
+    MandatoryAuditWriteError,
+)
 from tldw_Server_API.app.core.Character_Chat.Character_Chat_Lib_facade import replace_placeholders
 from tldw_Server_API.app.core.Character_Chat.modules.character_utils import (
     map_sender_to_role,
@@ -2423,6 +2426,41 @@ def _build_assistant_message_payload(
     return message_payload
 
 
+async def write_mandatory_moderation_audit(
+    *,
+    audit_service: Any | None,
+    audit_context: Any | None,
+    audit_event_type: Any | None,
+    action: str,
+    result: str,
+    metadata: dict[str, Any],
+) -> None:
+    """Write a moderation audit event and fail closed if persistence is unavailable."""
+    if audit_service is None or audit_context is None:
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    try:
+        await audit_service.log_event(
+            event_type=audit_event_type or AuditEventType.SECURITY_VIOLATION,
+            context=audit_context,
+            action=action,
+            result=result,
+            metadata=metadata,
+        )
+        await audit_service.flush(raise_on_failure=True)
+    except MandatoryAuditWriteError:
+        raise
+    except Exception as exc:
+        logger.error(
+            "Mandatory moderation audit write failed for {} ({}): {}",
+            action,
+            result,
+            exc,
+            exc_info=True,
+        )
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable") from exc
+
+
 async def moderate_input_messages(
     request_data: Any,
     request: Any,
@@ -2604,20 +2642,14 @@ async def moderate_input_messages(
 
         with contextlib.suppress(_CHAT_NONCRITICAL_EXCEPTIONS):
             metrics.track_moderation_input(str(req_user_id or client_id), resolved_action, category=(category or "default"))
-        try:
-            if audit_service and audit_context:
-                _schedule_background_task(
-                    audit_service.log_event(
-                        event_type=audit_event_type,
-                        context=audit_context,
-                        action="moderation.input",
-                        result=("failure" if resolved_action == "block" else "success"),
-                        metadata={"phase": "input", "action": resolved_action, "pattern": sample},
-                    ),
-                    task_name="chat.moderation.input.audit",
-                )
-        except _CHAT_NONCRITICAL_EXCEPTIONS:
-            pass
+        await write_mandatory_moderation_audit(
+            audit_service=audit_service,
+            audit_context=audit_context,
+            audit_event_type=audit_event_type,
+            action="moderation.input",
+            result=("failure" if resolved_action == "block" else "success"),
+            metadata={"phase": "input", "action": resolved_action, "pattern": sample},
+        )
 
         if resolved_action == "block":
             block_detail = "Input violates moderation policy"
@@ -2648,6 +2680,8 @@ async def moderate_input_messages(
                             if isinstance(current, str):
                                 part.text = await _moderate_text_in_place(current)
     except HTTPException:
+        raise
+    except MandatoryAuditWriteError:
         raise
     except _CHAT_NONCRITICAL_EXCEPTIONS as e:
         logger.warning(f"Moderation input processing error: {e}")
@@ -4210,7 +4244,7 @@ async def execute_streaming_call(
 
             from tldw_Server_API.app.core.Chat.streaming_utils import StopStreamWithError
 
-            pending_audit_tasks: list[asyncio.Task[Any]] = []
+            mandatory_moderation_audit_tasks: list[asyncio.Task[Any]] = []
             stream_id = _uuid.uuid4().hex
             chunk_seq = 0
 
@@ -4243,6 +4277,28 @@ async def execute_streaming_call(
                 out = stream_holdback
                 stream_holdback = ""
                 return out
+
+            async def _await_mandatory_moderation_audits() -> None:
+                if not mandatory_moderation_audit_tasks:
+                    return
+                results = await asyncio.gather(
+                    *mandatory_moderation_audit_tasks,
+                    return_exceptions=True,
+                )
+                failures = [result for result in results if isinstance(result, BaseException)]
+                if not failures:
+                    return
+                for failure in failures:
+                    logger.error(
+                        "Mandatory moderation audit task failed for {}: {}",
+                        final_conversation_id,
+                        failure,
+                        exc_info=True,
+                    )
+                raise StopStreamWithError(
+                    message="Mandatory audit persistence unavailable",
+                    error_type="audit_persistence_failure",
+                ) from failures[0]
 
             def _out_transform(s: str) -> str:
                 nonlocal chunk_seq
@@ -4331,52 +4387,46 @@ async def execute_streaming_call(
                     if not stream_mod_state["block_logged"]:
                         with contextlib.suppress(_CHAT_NONCRITICAL_EXCEPTIONS):
                             metrics.track_moderation_stream_block(str(req_user_id or client_id), category=(out_category or "default"))
-                        try:
-                            if audit_service and audit_context:
-                                _schedule_background_task(
-                                    audit_service.log_event(
-                                        event_type=AuditEventType.SECURITY_VIOLATION,
-                                        context=audit_context,
-                                        action="moderation.output",
-                                        result="failure",
-                                        metadata={
-                                            "phase": "output",
-                                            "streaming": True,
-                                            "action": "block",
-                                            "pattern": sample,
-                                        },
-                                    ),
-                                    task_name="chat.streaming.output.block.audit",
-                                    pending_tasks=pending_audit_tasks,
+                        mandatory_moderation_audit_tasks.append(
+                            asyncio.create_task(
+                                write_mandatory_moderation_audit(
+                                    audit_service=audit_service,
+                                    audit_context=audit_context,
+                                    audit_event_type=AuditEventType.SECURITY_VIOLATION,
+                                    action="moderation.output",
+                                    result="failure",
+                                    metadata={
+                                        "phase": "output",
+                                        "streaming": True,
+                                        "action": "block",
+                                        "pattern": sample,
+                                    },
                                 )
-                        except _CHAT_NONCRITICAL_EXCEPTIONS:
-                            pass
+                            )
+                        )
                         stream_mod_state["block_logged"] = True
                     raise StopStreamWithError(message="Output violates moderation policy", error_type="output_moderation_block")
                 if resolved_action == "redact":
                     if not stream_mod_state["redact_logged"]:
                         with contextlib.suppress(_CHAT_NONCRITICAL_EXCEPTIONS):
                             metrics.track_moderation_output(str(req_user_id or client_id), "redact", streaming=True, category=(out_category or "default"))
-                        try:
-                            if audit_service and audit_context:
-                                _schedule_background_task(
-                                    audit_service.log_event(
-                                        event_type=AuditEventType.SECURITY_VIOLATION,
-                                        context=audit_context,
-                                        action="moderation.output",
-                                        result="success",
-                                        metadata={
-                                            "phase": "output",
-                                            "streaming": True,
-                                            "action": "redact",
-                                            "pattern": sample,
-                                        },
-                                    ),
-                                    task_name="chat.streaming.output.redact.audit",
-                                    pending_tasks=pending_audit_tasks,
+                        mandatory_moderation_audit_tasks.append(
+                            asyncio.create_task(
+                                write_mandatory_moderation_audit(
+                                    audit_service=audit_service,
+                                    audit_context=audit_context,
+                                    audit_event_type=AuditEventType.SECURITY_VIOLATION,
+                                    action="moderation.output",
+                                    result="success",
+                                    metadata={
+                                        "phase": "output",
+                                        "streaming": True,
+                                        "action": "redact",
+                                        "pattern": sample,
+                                    },
                                 )
-                        except _CHAT_NONCRITICAL_EXCEPTIONS:
-                            pass
+                            )
+                        )
                         stream_mod_state["redact_logged"] = True
                     redacted_out = (
                         redacted_combined
@@ -4429,6 +4479,7 @@ async def execute_streaming_call(
                 idle_timeout=CHAT_IDLE_TIMEOUT,
                 heartbeat_interval=CHAT_HEARTBEAT_INTERVAL,
                 text_transform=_out_transform,
+                before_success_callback=_await_mandatory_moderation_audits,
                 system_message_id=system_message_id,
                 continuation_metadata=normalized_continuation_metadata,
             )
@@ -4440,8 +4491,8 @@ async def execute_streaming_call(
                         stream_tracker.add_chunk()
                     yield chunk
             finally:
-                if pending_audit_tasks:
-                    await asyncio.gather(*pending_audit_tasks, return_exceptions=True)
+                if mandatory_moderation_audit_tasks:
+                    await asyncio.gather(*mandatory_moderation_audit_tasks, return_exceptions=True)
 
     streaming_generator = tracked_streaming_generator()
 
@@ -5059,9 +5110,10 @@ async def execute_non_stream_call(
                         pass
                     try:
                         if audit_service and audit_context:
-                            await audit_service.log_event(
-                                event_type=AuditEventType.SECURITY_VIOLATION,
-                                context=audit_context,
+                            await write_mandatory_moderation_audit(
+                                audit_service=audit_service,
+                                audit_context=audit_context,
+                                audit_event_type=AuditEventType.SECURITY_VIOLATION,
                                 action="moderation.output",
                                 result="success",
                                 metadata={
@@ -5071,8 +5123,8 @@ async def execute_non_stream_call(
                                     "pattern": sample,
                                 },
                             )
-                    except _CHAT_NONCRITICAL_EXCEPTIONS:
-                        pass
+                    except MandatoryAuditWriteError:
+                        raise
                     if isinstance(content_to_save, str):
                         content_to_save = (
                             redacted_val
@@ -5091,6 +5143,8 @@ async def execute_non_stream_call(
                     except _CHAT_NONCRITICAL_EXCEPTIONS:
                         pass
     except HTTPException:
+        raise
+    except MandatoryAuditWriteError:
         raise
     except _CHAT_NONCRITICAL_EXCEPTIONS as e:
         logger.warning(f"Moderation output processing error: {e}")

--- a/tldw_Server_API/app/core/Chat/chat_service.py
+++ b/tldw_Server_API/app/core/Chat/chat_service.py
@@ -3825,6 +3825,8 @@ async def execute_streaming_call(
 
     if not (hasattr(raw_stream_iter, "__aiter__") or hasattr(raw_stream_iter, "__iter__")):
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Provider did not return a valid stream.")
+    if hasattr(raw_stream_iter, "__iter__") and not hasattr(raw_stream_iter, "__aiter__"):
+        raw_stream_iter = wrap_sync_stream(raw_stream_iter)
 
     stream_mod_state = {"block_logged": False, "redact_logged": False}
     loop_compat_enabled = False
@@ -4279,29 +4281,35 @@ async def execute_streaming_call(
                 return out
 
             async def _await_mandatory_moderation_audits() -> None:
-                if not mandatory_moderation_audit_tasks:
-                    return
-                results = await asyncio.gather(
-                    *mandatory_moderation_audit_tasks,
-                    return_exceptions=True,
-                )
-                failures = [result for result in results if isinstance(result, BaseException)]
-                if not failures:
-                    return
-                for failure in failures:
-                    logger.error(
-                        "Mandatory moderation audit task failed for {}: {}",
-                        final_conversation_id,
-                        failure,
-                        exc_info=True,
+                pending_tasks = list(mandatory_moderation_audit_tasks)
+                mandatory_moderation_audit_tasks.clear()
+                failures: list[BaseException] = []
+                if pending_tasks:
+                    results = await asyncio.gather(
+                        *pending_tasks,
+                        return_exceptions=True,
                     )
-                raise StopStreamWithError(
-                    message="Mandatory audit persistence unavailable",
-                    error_type="audit_persistence_failure",
-                ) from failures[0]
+                    failures = [result for result in results if isinstance(result, BaseException)]
+                if failures:
+                    for failure in failures:
+                        logger.error(
+                            "Mandatory moderation audit task failed for {}: {}",
+                            final_conversation_id,
+                            failure,
+                            exc_info=True,
+                        )
+                    raise StopStreamWithError(
+                        message="Mandatory audit persistence unavailable",
+                        error_type="audit_persistence_failure",
+                    ) from failures[0]
+                pending_stopper = stream_mod_state.pop("pending_stop_error", None)
+                if pending_stopper is not None:
+                    raise pending_stopper
 
             def _out_transform(s: str) -> str:
-                nonlocal chunk_seq
+                nonlocal chunk_seq, stream_holdback
+                if stream_mod_state.get("pending_stop_error") is not None:
+                    return ""
                 try:
                     mon = None
                     try:
@@ -4405,7 +4413,12 @@ async def execute_streaming_call(
                             )
                         )
                         stream_mod_state["block_logged"] = True
-                    raise StopStreamWithError(message="Output violates moderation policy", error_type="output_moderation_block")
+                    stream_holdback = ""
+                    stream_mod_state["pending_stop_error"] = StopStreamWithError(
+                        message="Output violates moderation policy",
+                        error_type="output_moderation_block",
+                    )
+                    return ""
                 if resolved_action == "redact":
                     if not stream_mod_state["redact_logged"]:
                         with contextlib.suppress(_CHAT_NONCRITICAL_EXCEPTIONS):
@@ -5096,6 +5109,20 @@ async def execute_non_stream_call(
                     logger.debug(f"Topic monitoring (non-stream final) skipped: {_ex}")
 
                 if resolved_action == "block":
+                    if audit_service and audit_context:
+                        await write_mandatory_moderation_audit(
+                            audit_service=audit_service,
+                            audit_context=audit_context,
+                            audit_event_type=AuditEventType.SECURITY_VIOLATION,
+                            action="moderation.output",
+                            result="failure",
+                            metadata={
+                                "phase": "output",
+                                "streaming": False,
+                                "action": "block",
+                                "pattern": sample,
+                            },
+                        )
                     _emit_chat_run_first_completion_metric(
                         metrics,
                         context=run_first_metric_context,

--- a/tldw_Server_API/app/core/Chat/streaming_utils.py
+++ b/tldw_Server_API/app/core/Chat/streaming_utils.py
@@ -14,9 +14,9 @@ import json
 import os
 import threading
 import time
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from datetime import datetime, timezone
-from typing import Any, Callable, Optional, Union
+from typing import Any, Optional, Union
 
 from loguru import logger
 
@@ -928,7 +928,6 @@ class StreamingResponseHandler:
                 if (
                     not self.is_cancelled
                     and not self.error_occurred
-                    and has_output
                 ):
                     if before_success_callback and not self.is_cancelled:
                         try:

--- a/tldw_Server_API/app/core/Chat/streaming_utils.py
+++ b/tldw_Server_API/app/core/Chat/streaming_utils.py
@@ -16,7 +16,7 @@ import threading
 import time
 from collections.abc import AsyncIterator, Iterator
 from datetime import datetime, timezone
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from loguru import logger
 
@@ -576,6 +576,7 @@ class StreamingResponseHandler:
         stream: Union[Iterator, AsyncIterator],
         save_callback: Optional[callable] = None,
         finalize_callback: Optional[callable] = None,
+        before_success_callback: Optional[Callable[[], Any]] = None,
     ) -> AsyncIterator[str]:
         """
         Safely generate streaming responses with error handling and cleanup.
@@ -681,10 +682,7 @@ class StreamingResponseHandler:
                                             }
                                         }
                                         self._attach_stream_metadata(err_payload)
-                                        # Combine error and DONE into a single chunk to ensure clients see DONE
-                                        combined = f"data: {json.dumps(err_payload)}\n\n" + "data: [DONE]\n\n"
-                                        outputs.append(combined)
-                                        self.done_sent = True
+                                        outputs.append(f"data: {json.dumps(err_payload)}\n\n")
                                         self.error_occurred = True
                                         return outputs, True
                                     except StopIteration:
@@ -722,9 +720,7 @@ class StreamingResponseHandler:
                         }
                     }
                     self._attach_stream_metadata(err_payload)
-                    combined = f"data: {json.dumps(err_payload)}\n\n" + "data: [DONE]\n\n"
-                    outputs.append(combined)
-                    self.done_sent = True
+                    outputs.append(f"data: {json.dumps(err_payload)}\n\n")
                     self.error_occurred = True
                     return outputs, True
                 except StopIteration:
@@ -931,6 +927,40 @@ class StreamingResponseHandler:
                 has_output = self.has_accumulated_output()
                 if (
                     not self.is_cancelled
+                    and not self.error_occurred
+                    and has_output
+                ):
+                    if before_success_callback and not self.is_cancelled:
+                        try:
+                            maybe_before_success = before_success_callback()
+                            if hasattr(maybe_before_success, "__await__"):
+                                await maybe_before_success
+                        except StopStreamWithError as stopper:
+                            err_payload = {
+                                "error": {
+                                    "message": str(stopper) or "Stream blocked by policy",
+                                    "type": stopper.error_type,
+                                }
+                            }
+                            self._attach_stream_metadata(err_payload)
+                            self.error_occurred = True
+                            yield f"data: {json.dumps(err_payload)}\n\n"
+                        except _STREAMING_NONCRITICAL_EXCEPTIONS as before_success_err:
+                            logger.error(
+                                f"Before-success callback error for {self.conversation_id}: {before_success_err}"
+                            )
+                            self.error_occurred = True
+                            err_payload = {
+                                "error": {
+                                    "message": f"Stream error: {str(before_success_err)}",
+                                    "type": "stream_error",
+                                }
+                            }
+                            self._attach_stream_metadata(err_payload)
+                            yield f"data: {json.dumps(err_payload)}\n\n"
+
+                if (
+                    not self.is_cancelled
                     and save_callback
                     and not self.error_occurred
                     and has_output
@@ -1041,6 +1071,7 @@ async def create_streaming_response_with_timeout(
     model_name: str,
     save_callback: Optional[callable] = None,
     finalize_callback: Optional[callable] = None,
+    before_success_callback: Optional[Callable[[], Any]] = None,
     idle_timeout: int = STREAMING_IDLE_TIMEOUT,
     heartbeat_interval: int = HEARTBEAT_INTERVAL,
     text_transform: Optional[callable] = None,
@@ -1077,7 +1108,12 @@ async def create_streaming_response_with_timeout(
 
     # Create tasks for streaming and optional heartbeat using persistent generator instances
     async def stream_with_heartbeat():
-        stream_gen = handler.safe_stream_generator(stream, save_callback, finalize_callback)
+        stream_gen = handler.safe_stream_generator(
+            stream,
+            save_callback,
+            finalize_callback,
+            before_success_callback,
+        )
         heartbeats_enabled = isinstance(heartbeat_interval, (int, float)) and heartbeat_interval > 0
         heartbeat_gen = handler.heartbeat_generator() if heartbeats_enabled else None
 
@@ -1087,8 +1123,14 @@ async def create_streaming_response_with_timeout(
         )
 
         try:
-            while not handler.is_cancelled and not handler.error_occurred:
+            while not handler.is_cancelled and (stream_task is not None or heartbeat_task is not None):
+                if handler.error_occurred and heartbeat_task is not None:
+                    if not heartbeat_task.done():
+                        heartbeat_task.cancel()
+                    heartbeat_task = None
                 wait_set = {t for t in (stream_task, heartbeat_task) if t is not None}
+                if not wait_set:
+                    break
                 done, pending = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED)
 
                 should_exit = False

--- a/tldw_Server_API/app/core/Evaluations/audit_adapter.py
+++ b/tldw_Server_API/app/core/Evaluations/audit_adapter.py
@@ -23,6 +23,7 @@ from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
 )
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditContext,
+    MandatoryAuditWriteError,
     UnifiedAuditService,
 )
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
@@ -154,19 +155,29 @@ async def _emit(
     result: str = "success",
     metadata: dict[str, Any] | None = None,
 ) -> None:
-    svc = await _get_svc(user_id)
-    ctx = AuditContext(user_id=user_id)
-    await svc.log_event(
-        event_type=event_type,
-        context=ctx,
-        action=action,
-        resource_type=resource_type,
-        resource_id=resource_id,
-        result=result,
-        metadata=metadata,
-    )
-    # Mandatory audit: flush immediately and surface failures.
-    await svc.flush(raise_on_failure=True)
+    try:
+        svc = await _get_svc(user_id)
+        ctx = AuditContext(user_id=user_id)
+        await svc.log_event(
+            event_type=event_type,
+            context=ctx,
+            action=action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            result=result,
+            metadata=metadata,
+        )
+        # Mandatory audit: flush immediately and surface failures.
+        await svc.flush(raise_on_failure=True)
+    except Exception as exc:
+        logger.error(
+            "Mandatory evaluations audit write failed for {}:{} ({})",
+            action,
+            resource_id,
+            type(exc).__name__,
+            exc_info=True,
+        )
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable") from exc
 
 
 # Convenience wrappers

--- a/tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py
+++ b/tldw_Server_API/app/core/Evaluations/unified_evaluation_service.py
@@ -457,15 +457,26 @@ class UnifiedEvaluationService:
             if not evaluation:
                 raise ValueError(f"Evaluation {eval_id} not found")
 
-            # Create run record
+            run_id = f"run_{uuid.uuid4().hex[:12]}"
+
+            # Unified audit (mandatory)
+            await log_run_started_async(
+                user_id=created_by,
+                run_id=run_id,
+                eval_id=eval_id,
+                target_model=target_model,
+            )
+
+            # Create run record after mandatory audit persistence succeeds
             run_id = self.db.create_run(
                 eval_id=eval_id,
                 target_model=target_model,
                 config=config or {},
-                webhook_url=webhook_url
+                webhook_url=webhook_url,
+                run_id=run_id,
             )
 
-            # Send webhook for run started
+            # Send webhook for run started after the durable run row exists
             if webhook_url and self.enable_webhooks and self.webhook_manager:
                 effective_webhook_user = webhook_user_id_from_value(webhook_user_id) or webhook_user_id_from_value(created_by) or created_by
                 await self.webhook_manager.send_webhook(
@@ -490,7 +501,7 @@ class UnifiedEvaluationService:
                 "created_by": created_by,
             }
 
-            # Start async evaluation
+            # Start async evaluation only after the mandatory audit and row persistence succeed
             asyncio.create_task(
                 self._run_evaluation_async(
                     run_id=run_id,
@@ -500,9 +511,6 @@ class UnifiedEvaluationService:
                     webhook_user_id=webhook_user_id,
                 )
             )
-
-            # Unified audit (mandatory)
-            await log_run_started_async(user_id=created_by, run_id=run_id, eval_id=eval_id, target_model=target_model)
 
             # Return run info
             run = self.db.get_run(run_id)

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -1316,11 +1316,6 @@ class JobManager:
                                     "job_type": job_type,
                                 }
                             )
-                            try:
-                                if was_insert:
-                                    increment_created({"domain": domain, "queue": queue, "job_type": job_type})
-                            except _JOB_NONCRITICAL_EXCEPTIONS:
-                                pass
                             # Counters bump (PG, idempotent insert occurred)
                             try:
                                 if was_insert and JobManager._is_truthy(os.getenv("JOBS_COUNTERS_ENABLED", "")):
@@ -1334,36 +1329,35 @@ class JobManager:
                                     )
                             except _JOB_NONCRITICAL_EXCEPTIONS:
                                 pass
-                            try:
-                                # Write to outbox within the same transaction (Postgres path)
-                                attrs_json = json.dumps(
-                                    {
-                                        "idempotent": (not was_insert),
-                                        "owner_user_id": d.get("owner_user_id"),
-                                        "retry_count": int(d.get("retry_count") or 0),
-                                    }
-                                )
-                                cur.execute(
-                                    (
-                                        "INSERT INTO job_events("
-                                        "job_id, domain, queue, job_type, event_type, attrs_json, owner_user_id, request_id, trace_id, created_at"
-                                        ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())"
-                                    ),
-                                    (
-                                        int(d.get("id")),
-                                        d.get("domain"),
-                                        d.get("queue"),
-                                        d.get("job_type"),
-                                        "job.created",
-                                        attrs_json,
-                                        d.get("owner_user_id"),
-                                        d.get("request_id"),
-                                        d.get("trace_id"),
-                                    ),
-                                )
-                            except _JOB_NONCRITICAL_EXCEPTIONS:
-                                # Best-effort; do not fail job create on outbox errors
-                                pass
+                            # Write to outbox within the same transaction (Postgres path).
+                            attrs_json = json.dumps(
+                                {
+                                    "idempotent": (not was_insert),
+                                    "owner_user_id": d.get("owner_user_id"),
+                                    "retry_count": int(d.get("retry_count") or 0),
+                                }
+                            )
+                            cur.execute(
+                                (
+                                    "INSERT INTO job_events("
+                                    "job_id, domain, queue, job_type, event_type, attrs_json, owner_user_id, request_id, trace_id, created_at"
+                                    ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())"
+                                ),
+                                (
+                                    int(d.get("id")),
+                                    d.get("domain"),
+                                    d.get("queue"),
+                                    d.get("job_type"),
+                                    "job.created",
+                                    attrs_json,
+                                    d.get("owner_user_id"),
+                                    d.get("request_id"),
+                                    d.get("trace_id"),
+                                ),
+                            )
+                            with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
+                                if was_insert:
+                                    increment_created({"domain": domain, "queue": queue, "job_type": job_type})
                             # Emit event for in-process listeners when outbox is disabled
                             try:
                                 if not JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", "")):
@@ -1438,8 +1432,6 @@ class JobManager:
                             pass
                         with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
                             self._assert_invariants(d)
-                        with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                            increment_created({"domain": domain, "queue": queue, "job_type": job_type})
                         # Counters bump (PG, non-idempotent path)
                         try:
                             if JobManager._is_truthy(os.getenv("JOBS_COUNTERS_ENABLED", "")):
@@ -1453,34 +1445,33 @@ class JobManager:
                                 )
                         except _JOB_NONCRITICAL_EXCEPTIONS:
                             pass
-                        try:
-                            attrs_json = json.dumps(
-                                {
-                                    "idempotent": False,
-                                    "owner_user_id": d.get("owner_user_id"),
-                                    "retry_count": int(d.get("retry_count") or 0),
-                                }
-                            )
-                            cur.execute(
-                                (
-                                    "INSERT INTO job_events("
-                                    "job_id, domain, queue, job_type, event_type, attrs_json, owner_user_id, request_id, trace_id, created_at"
-                                    ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())"
-                                ),
-                                (
-                                    int(d.get("id")),
-                                    d.get("domain"),
-                                    d.get("queue"),
-                                    d.get("job_type"),
-                                    "job.created",
-                                    attrs_json,
-                                    d.get("owner_user_id"),
-                                    d.get("request_id"),
-                                    d.get("trace_id"),
-                                ),
-                            )
-                        except _JOB_NONCRITICAL_EXCEPTIONS:
-                            pass
+                        attrs_json = json.dumps(
+                            {
+                                "idempotent": False,
+                                "owner_user_id": d.get("owner_user_id"),
+                                "retry_count": int(d.get("retry_count") or 0),
+                            }
+                        )
+                        cur.execute(
+                            (
+                                "INSERT INTO job_events("
+                                "job_id, domain, queue, job_type, event_type, attrs_json, owner_user_id, request_id, trace_id, created_at"
+                                ") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())"
+                            ),
+                            (
+                                int(d.get("id")),
+                                d.get("domain"),
+                                d.get("queue"),
+                                d.get("job_type"),
+                                "job.created",
+                                attrs_json,
+                                d.get("owner_user_id"),
+                                d.get("request_id"),
+                                d.get("trace_id"),
+                            ),
+                        )
+                        with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
+                            increment_created({"domain": domain, "queue": queue, "job_type": job_type})
                         # Emit event for in-process listeners when outbox is disabled
                         try:
                             if not JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", "")):
@@ -1571,20 +1562,47 @@ class JobManager:
                                     d = dict(row)
                                     try:
                                         self._update_gauges(domain=domain, queue=queue, job_type=job_type)
-                                        if inserted:
-                                            increment_created({"domain": domain, "queue": queue, "job_type": job_type})
                                     except _JOB_NONCRITICAL_EXCEPTIONS:
                                         pass
-                                    with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                                        emit_job_event(
+                                    attrs = {
+                                        "idempotent": (not inserted),
+                                        "owner_user_id": d.get("owner_user_id"),
+                                        "retry_count": int(d.get("retry_count") or 0),
+                                    }
+                                    attrs_json = json.dumps(attrs)
+                                    conn.execute(
+                                        (
+                                            "INSERT INTO job_events(job_id, domain, queue, job_type, event_type, attrs_json, owner_user_id, request_id, trace_id, created_at) "
+                                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'))"
+                                        ),
+                                        (
+                                            int(d.get("id")),
+                                            d.get("domain"),
+                                            d.get("queue"),
+                                            d.get("job_type"),
                                             "job.created",
-                                            job=d,
-                                            attrs={
-                                                "idempotent": (not inserted),
-                                                "owner_user_id": d.get("owner_user_id"),
-                                                "retry_count": int(d.get("retry_count") or 0),
-                                            },
-                                        )
+                                            attrs_json,
+                                            d.get("owner_user_id"),
+                                            request_id,
+                                            trace_id,
+                                        ),
+                                    )
+                                    with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
+                                        if inserted:
+                                            increment_created({"domain": domain, "queue": queue, "job_type": job_type})
+                                    outbox_enabled = JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", ""))
+                                    if outbox_enabled:
+                                        with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
+                                            submit_job_audit_event(
+                                                "job.created",
+                                                job={**d, "request_id": request_id, "trace_id": trace_id},
+                                                attrs=attrs,
+                                            )
+                                    else:
+                                        try:
+                                            emit_job_event("job.created", job=d, attrs=attrs)
+                                        except _JOB_NONCRITICAL_EXCEPTIONS:
+                                            pass
                                     return d
                             # Non-idempotent (or no existing row on IGNORE path): normal insert
                             conn.execute(
@@ -1634,7 +1652,6 @@ class JobManager:
                             )
                             try:
                                 self._update_gauges(domain=domain, queue=queue, job_type=job_type)
-                                increment_created({"domain": domain, "queue": queue, "job_type": job_type})
                             except _JOB_NONCRITICAL_EXCEPTIONS:
                                 pass
                             try:
@@ -1658,33 +1675,32 @@ class JobManager:
                                     )
                             except _JOB_NONCRITICAL_EXCEPTIONS:
                                 pass
-                            try:
-                                attrs_json = json.dumps(
-                                    {
-                                        "idempotent": False,
-                                        "owner_user_id": d.get("owner_user_id"),
-                                        "retry_count": int(d.get("retry_count") or 0),
-                                    }
-                                )
-                                conn.execute(
-                                    (
-                                        "INSERT INTO job_events(job_id, domain, queue, job_type, event_type, attrs_json, owner_user_id, request_id, trace_id, created_at) "
-                                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'))"
-                                    ),
-                                    (
-                                        int(d.get("id")),
-                                        d.get("domain"),
-                                        d.get("queue"),
-                                        d.get("job_type"),
-                                        "job.created",
-                                        attrs_json,
-                                        d.get("owner_user_id"),
-                                        request_id,
-                                        trace_id,
-                                    ),
-                                )
-                            except _JOB_NONCRITICAL_EXCEPTIONS:
-                                pass
+                            attrs_json = json.dumps(
+                                {
+                                    "idempotent": False,
+                                    "owner_user_id": d.get("owner_user_id"),
+                                    "retry_count": int(d.get("retry_count") or 0),
+                                }
+                            )
+                            conn.execute(
+                                (
+                                    "INSERT INTO job_events(job_id, domain, queue, job_type, event_type, attrs_json, owner_user_id, request_id, trace_id, created_at) "
+                                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'))"
+                                ),
+                                (
+                                    int(d.get("id")),
+                                    d.get("domain"),
+                                    d.get("queue"),
+                                    d.get("job_type"),
+                                    "job.created",
+                                    attrs_json,
+                                    d.get("owner_user_id"),
+                                    request_id,
+                                    trace_id,
+                                ),
+                            )
+                            with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
+                                increment_created({"domain": domain, "queue": queue, "job_type": job_type})
                             # Emit event for in-process listeners when outbox is disabled
                             try:
                                 if not JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", "")):

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -84,6 +84,20 @@ _fair_share: FairShareScheduler | None = None
 _fair_share_limits: tuple[int, int] | None = None
 
 
+def _safe_increment_created_metric(*, domain: str, queue: str, job_type: str) -> None:
+    """Keep job creation non-fatal while surfacing metric update failures."""
+    try:
+        increment_created({"domain": domain, "queue": queue, "job_type": job_type})
+    except _JOB_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(
+            "Non-critical jobs created metric update failed for {}:{}:{}: {}",
+            domain,
+            queue,
+            job_type,
+            exc,
+        )
+
+
 def _fair_share_enabled() -> bool:
     """Return whether fair-share admission/priority logic is explicitly enabled."""
     return any(
@@ -1356,9 +1370,12 @@ class JobManager:
                                     trace_id,
                                 ),
                             )
-                            with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                                if was_insert:
-                                    increment_created({"domain": domain, "queue": queue, "job_type": job_type})
+                            if was_insert:
+                                _safe_increment_created_metric(
+                                    domain=domain,
+                                    queue=queue,
+                                    job_type=job_type,
+                                )
                             # Emit event for in-process listeners when outbox is disabled
                             try:
                                 if not JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", "")):
@@ -1471,8 +1488,11 @@ class JobManager:
                                 d.get("trace_id"),
                             ),
                         )
-                        with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                            increment_created({"domain": domain, "queue": queue, "job_type": job_type})
+                        _safe_increment_created_metric(
+                            domain=domain,
+                            queue=queue,
+                            job_type=job_type,
+                        )
                         # Emit event for in-process listeners when outbox is disabled
                         try:
                             if not JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", "")):
@@ -1588,9 +1608,12 @@ class JobManager:
                                             trace_id,
                                         ),
                                     )
-                                    with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                                        if inserted:
-                                            increment_created({"domain": domain, "queue": queue, "job_type": job_type})
+                                    if inserted:
+                                        _safe_increment_created_metric(
+                                            domain=domain,
+                                            queue=queue,
+                                            job_type=job_type,
+                                        )
                                     outbox_enabled = JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", ""))
                                     if outbox_enabled:
                                         with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
@@ -1700,8 +1723,11 @@ class JobManager:
                                     trace_id,
                                 ),
                             )
-                            with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
-                                increment_created({"domain": domain, "queue": queue, "job_type": job_type})
+                            _safe_increment_created_metric(
+                                domain=domain,
+                                queue=queue,
+                                job_type=job_type,
+                            )
                             # Emit event for in-process listeners when outbox is disabled
                             try:
                                 if not JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", "")):

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -1316,6 +1316,7 @@ class JobManager:
                                     "job_type": job_type,
                                 }
                             )
+                            emitted_job = {**d, "request_id": request_id, "trace_id": trace_id}
                             # Counters bump (PG, idempotent insert occurred)
                             try:
                                 if was_insert and JobManager._is_truthy(os.getenv("JOBS_COUNTERS_ENABLED", "")):
@@ -1351,8 +1352,8 @@ class JobManager:
                                     "job.created",
                                     attrs_json,
                                     d.get("owner_user_id"),
-                                    d.get("request_id"),
-                                    d.get("trace_id"),
+                                    request_id,
+                                    trace_id,
                                 ),
                             )
                             with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
@@ -1363,7 +1364,7 @@ class JobManager:
                                 if not JobManager._is_truthy(os.getenv("JOBS_EVENTS_OUTBOX", "")):
                                     emit_job_event(
                                         "job.created",
-                                        job=d,
+                                        job=emitted_job,
                                         attrs={
                                             "idempotent": (not was_insert),
                                             "owner_user_id": d.get("owner_user_id"),
@@ -1376,7 +1377,7 @@ class JobManager:
                             with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
                                 submit_job_audit_event(
                                     "job.created",
-                                    job=d,
+                                    job=emitted_job,
                                     attrs={
                                         "idempotent": (not was_insert),
                                         "owner_user_id": d.get("owner_user_id"),

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/governance_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/governance_module.py
@@ -105,32 +105,26 @@ class GovernanceModule(BaseModule):
             return self._to_jsonable(result)
 
         if tool_name == "governance.validate_change":
+            scope = self._verified_scope(args, metadata)
             result = await service.validate_change(
                 surface=str(args.get("surface") or ""),
                 summary=str(args.get("summary") or ""),
                 category=self._optional_str(args.get("category")),
-                metadata=metadata,
+                metadata={**metadata, **scope},
                 fallback_mode=self._optional_str(args.get("fallback_mode")),
             )
             return self._to_jsonable(result)
 
         if tool_name == "governance.resolve_gap":
+            scope = self._verified_scope(args, metadata)
             result = await service.resolve_gap(
                 question=str(args.get("question") or ""),
                 category=self._optional_str(args.get("category")),
                 metadata=metadata,
-                org_id=self._optional_int(
-                    self._first_non_none(args.get("org_id"), metadata.get("org_id"))
-                ),
-                team_id=self._optional_int(
-                    self._first_non_none(args.get("team_id"), metadata.get("team_id"))
-                ),
-                persona_id=self._optional_str(
-                    self._first_non_none(args.get("persona_id"), metadata.get("persona_id"))
-                ),
-                workspace_id=self._optional_str(
-                    self._first_non_none(args.get("workspace_id"), metadata.get("workspace_id"))
-                ),
+                org_id=scope["org_id"],
+                team_id=scope["team_id"],
+                persona_id=scope["persona_id"],
+                workspace_id=scope["workspace_id"],
                 resolution_mode=self._optional_str(args.get("resolution_mode")),
             )
             return self._to_jsonable(result)
@@ -159,10 +153,6 @@ class GovernanceModule(BaseModule):
             return self._governance_service
 
     @staticmethod
-    def _first_non_none(primary: Any, secondary: Any) -> Any:
-        return primary if primary is not None else secondary
-
-    @staticmethod
     def _optional_int(value: Any) -> int | None:
         if value is None:
             return None
@@ -179,6 +169,26 @@ class GovernanceModule(BaseModule):
             return None
         rendered = str(value).strip()
         return rendered or None
+
+    def _verified_scope(self, args: dict[str, Any], metadata: dict[str, Any]) -> dict[str, Any]:
+        verified = {
+            "org_id": self._optional_int(metadata.get("org_id")),
+            "team_id": self._optional_int(metadata.get("team_id")),
+            "persona_id": self._optional_str(metadata.get("persona_id")),
+            "workspace_id": self._optional_str(metadata.get("workspace_id")),
+        }
+        for field, expected in verified.items():
+            provided = args.get(field)
+            if provided is None or expected is None:
+                continue
+            if str(provided) != str(expected):
+                raise PermissionError(f"{field} must match authenticated context")
+        return {
+            "org_id": verified["org_id"] if verified["org_id"] is not None else self._optional_int(args.get("org_id")),
+            "team_id": verified["team_id"] if verified["team_id"] is not None else self._optional_int(args.get("team_id")),
+            "persona_id": verified["persona_id"] if verified["persona_id"] is not None else self._optional_str(args.get("persona_id")),
+            "workspace_id": verified["workspace_id"] if verified["workspace_id"] is not None else self._optional_str(args.get("workspace_id")),
+        }
 
     @staticmethod
     def _merged_metadata(arguments: dict[str, Any], context: Any | None) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/governance_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/governance_module.py
@@ -105,26 +105,32 @@ class GovernanceModule(BaseModule):
             return self._to_jsonable(result)
 
         if tool_name == "governance.validate_change":
-            scope = self._verified_scope(args, metadata)
             result = await service.validate_change(
                 surface=str(args.get("surface") or ""),
                 summary=str(args.get("summary") or ""),
                 category=self._optional_str(args.get("category")),
-                metadata={**metadata, **scope},
+                metadata=metadata,
                 fallback_mode=self._optional_str(args.get("fallback_mode")),
             )
             return self._to_jsonable(result)
 
         if tool_name == "governance.resolve_gap":
-            scope = self._verified_scope(args, metadata)
             result = await service.resolve_gap(
                 question=str(args.get("question") or ""),
                 category=self._optional_str(args.get("category")),
                 metadata=metadata,
-                org_id=scope["org_id"],
-                team_id=scope["team_id"],
-                persona_id=scope["persona_id"],
-                workspace_id=scope["workspace_id"],
+                org_id=self._optional_int(
+                    self._first_non_none(args.get("org_id"), metadata.get("org_id"))
+                ),
+                team_id=self._optional_int(
+                    self._first_non_none(args.get("team_id"), metadata.get("team_id"))
+                ),
+                persona_id=self._optional_str(
+                    self._first_non_none(args.get("persona_id"), metadata.get("persona_id"))
+                ),
+                workspace_id=self._optional_str(
+                    self._first_non_none(args.get("workspace_id"), metadata.get("workspace_id"))
+                ),
                 resolution_mode=self._optional_str(args.get("resolution_mode")),
             )
             return self._to_jsonable(result)
@@ -153,6 +159,10 @@ class GovernanceModule(BaseModule):
             return self._governance_service
 
     @staticmethod
+    def _first_non_none(primary: Any, secondary: Any) -> Any:
+        return primary if primary is not None else secondary
+
+    @staticmethod
     def _optional_int(value: Any) -> int | None:
         if value is None:
             return None
@@ -169,26 +179,6 @@ class GovernanceModule(BaseModule):
             return None
         rendered = str(value).strip()
         return rendered or None
-
-    def _verified_scope(self, args: dict[str, Any], metadata: dict[str, Any]) -> dict[str, Any]:
-        verified = {
-            "org_id": self._optional_int(metadata.get("org_id")),
-            "team_id": self._optional_int(metadata.get("team_id")),
-            "persona_id": self._optional_str(metadata.get("persona_id")),
-            "workspace_id": self._optional_str(metadata.get("workspace_id")),
-        }
-        for field, expected in verified.items():
-            provided = args.get(field)
-            if provided is None or expected is None:
-                continue
-            if str(provided) != str(expected):
-                raise PermissionError(f"{field} must match authenticated context")
-        return {
-            "org_id": verified["org_id"] if verified["org_id"] is not None else self._optional_int(args.get("org_id")),
-            "team_id": verified["team_id"] if verified["team_id"] is not None else self._optional_int(args.get("team_id")),
-            "persona_id": verified["persona_id"] if verified["persona_id"] is not None else self._optional_str(args.get("persona_id")),
-            "workspace_id": verified["workspace_id"] if verified["workspace_id"] is not None else self._optional_str(args.get("workspace_id")),
-        }
 
     @staticmethod
     def _merged_metadata(arguments: dict[str, Any], context: Any | None) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_governance_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_governance_module.py
@@ -129,21 +129,3 @@ async def test_resolve_gap_uses_context_scope_when_args_missing():
     assert fake_service.last_gap["org_id"] == 55
     assert fake_service.last_gap["team_id"] == 66
     assert fake_service.last_gap["workspace_id"] == "ws-gap"
-
-
-@pytest.mark.asyncio
-async def test_resolve_gap_rejects_conflicting_workspace_scope():
-    fake_service = _FakeGovernanceService()
-    mod = GovernanceModule(ModuleConfig(name="governance"), governance_service=fake_service)
-    ctx = RequestContext(
-        request_id="gov-scope-conflict",
-        user_id="1",
-        metadata={"org_id": 55, "team_id": 66, "persona_id": "persona-1", "workspace_id": "ws-ctx"},
-    )
-
-    with pytest.raises(PermissionError, match="workspace_id must match authenticated context"):
-        await mod.execute_tool(
-            "governance.resolve_gap",
-            {"question": "gap?", "workspace_id": "ws-arg"},
-            context=ctx,
-        )

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_governance_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_governance_module.py
@@ -129,3 +129,21 @@ async def test_resolve_gap_uses_context_scope_when_args_missing():
     assert fake_service.last_gap["org_id"] == 55
     assert fake_service.last_gap["team_id"] == 66
     assert fake_service.last_gap["workspace_id"] == "ws-gap"
+
+
+@pytest.mark.asyncio
+async def test_resolve_gap_rejects_conflicting_workspace_scope():
+    fake_service = _FakeGovernanceService()
+    mod = GovernanceModule(ModuleConfig(name="governance"), governance_service=fake_service)
+    ctx = RequestContext(
+        request_id="gov-scope-conflict",
+        user_id="1",
+        metadata={"org_id": 55, "team_id": 66, "persona_id": "persona-1", "workspace_id": "ws-ctx"},
+    )
+
+    with pytest.raises(PermissionError, match="workspace_id must match authenticated context"):
+        await mod.execute_tool(
+            "governance.resolve_gap",
+            {"question": "gap?", "workspace_id": "ws-arg"},
+            context=ctx,
+        )

--- a/tldw_Server_API/app/core/Sharing/unified_share_audit.py
+++ b/tldw_Server_API/app/core/Sharing/unified_share_audit.py
@@ -30,7 +30,6 @@ _SHARE_AUDIT_STATE_TABLE = "share_audit_state"
 _SHARE_AUDIT_SEQUENCE_KEY = "compatibility_id_seq"
 _RESERVED_METADATA_KEYS = {
     "compatibility_id",
-    "legacy_share_audit_id",
     "owner_user_id",
     "actor_user_id",
     "share_id",
@@ -355,6 +354,53 @@ class UnifiedShareAuditWriter:
             metadata=payload,
         )
 
+    async def import_legacy_event(
+        self,
+        *,
+        legacy_share_audit_id: int | None = None,
+        legacy_audit_id: int | None = None,
+        event_type: str,
+        resource_type: str,
+        resource_id: str,
+        owner_user_id: int,
+        actor_user_id: int | None = None,
+        share_id: int | None = None,
+        token_id: int | None = None,
+        metadata: dict[str, Any] | None = None,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+        result: str = "success",
+        created_at: Any = None,
+    ) -> int | None:
+        legacy_id = legacy_share_audit_id
+        if legacy_id is None:
+            legacy_id = legacy_audit_id
+        elif legacy_audit_id is not None and legacy_audit_id != legacy_id:
+            raise ValueError(
+                "legacy_share_audit_id and legacy_audit_id must match when both are provided"
+            )
+        if legacy_id is None:
+            raise TypeError("legacy_share_audit_id is required")
+
+        compatibility_id = await self._write_event_transaction(
+            event_type=event_type,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            owner_user_id=owner_user_id,
+            actor_user_id=actor_user_id,
+            share_id=share_id,
+            token_id=token_id,
+            metadata=metadata,
+            ip_address=ip_address,
+            user_agent=user_agent,
+            result=result,
+            compatibility_id=legacy_id,
+            legacy_share_audit_id=legacy_id,
+            timestamp=created_at,
+            event_id=_legacy_event_id(legacy_id),
+        )
+        return compatibility_id
+
     async def _write_event_transaction(
         self,
         *,
@@ -487,6 +533,7 @@ class UnifiedShareAuditWriter:
 
         query = f"""
             SELECT
+                event_id,
                 timestamp,
                 event_type,
                 tenant_user_id,
@@ -549,6 +596,7 @@ class UnifiedShareAuditWriter:
 
         return {
             "id": compatibility_id,
+            "event_id": row.get("event_id"),
             "event_type": str(row.get("event_type") or ""),
             "actor_user_id": actor_user_id,
             "resource_type": row.get("resource_type"),

--- a/tldw_Server_API/app/core/Sharing/unified_share_audit.py
+++ b/tldw_Server_API/app/core/Sharing/unified_share_audit.py
@@ -21,6 +21,7 @@ from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection_async,
 )
+from tldw_Server_API.app.core.exceptions import ValidationError
 
 _SHARE_EVENT_FILTER_SQL = (
     "(event_type LIKE 'share.%'"
@@ -372,15 +373,16 @@ class UnifiedShareAuditWriter:
         result: str = "success",
         created_at: Any = None,
     ) -> int | None:
+        """Import a legacy share-audit row while preserving its compatibility id."""
         legacy_id = legacy_share_audit_id
         if legacy_id is None:
             legacy_id = legacy_audit_id
         elif legacy_audit_id is not None and legacy_audit_id != legacy_id:
-            raise ValueError(
+            raise ValidationError(
                 "legacy_share_audit_id and legacy_audit_id must match when both are provided"
             )
         if legacy_id is None:
-            raise TypeError("legacy_share_audit_id is required")
+            raise ValidationError("legacy_share_audit_id is required")
 
         compatibility_id = await self._write_event_transaction(
             event_type=event_type,

--- a/tldw_Server_API/app/services/admin_api_keys_service.py
+++ b/tldw_Server_API/app/services/admin_api_keys_service.py
@@ -17,6 +17,7 @@ from tldw_Server_API.app.api.v1.schemas.api_key_schemas import (
     APIKeyUpdateRequest,
 )
 from tldw_Server_API.app.api.v1.schemas.org_team_schemas import VirtualKeyCreateRequest
+from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
 from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.services import admin_scope_service
@@ -31,6 +32,34 @@ _ADMIN_API_KEYS_NONCRITICAL_EXCEPTIONS = (
     TypeError,
     ValueError,
 )
+
+
+def _principal_actor_user_id(principal: Any) -> int | None:
+    raw_user_id = getattr(principal, "user_id", None)
+    if raw_user_id is None:
+        return None
+    try:
+        return int(raw_user_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _principal_actor_roles(principal: Any) -> list[str]:
+    raw_roles = getattr(principal, "roles", None)
+    if not raw_roles:
+        return []
+    if isinstance(raw_roles, (list, tuple, set)):
+        return [str(role) for role in raw_roles]
+    return [str(raw_roles)]
+
+
+def _principal_actor_kwargs(principal: Any) -> dict[str, Any]:
+    return {
+        "actor_user_id": _principal_actor_user_id(principal),
+        "actor_subject": getattr(principal, "subject", None),
+        "actor_kind": getattr(principal, "kind", None),
+        "actor_roles": _principal_actor_roles(principal),
+    }
 
 
 async def list_user_api_keys(
@@ -65,10 +94,14 @@ async def create_user_api_key(
             description=request.description,
             scope=request.scope,
             expires_in_days=request.expires_in_days,
+            **_principal_actor_kwargs(principal),
         )
         return APIKeyCreateResponse(**result)
     except HTTPException:
         raise
+    except MandatoryAuditWriteError as e:
+        logger.error(f"Admin mandatory audit write failed while creating API key for user {user_id}: {e}")
+        raise HTTPException(status_code=503, detail="Mandatory audit persistence unavailable") from e
     except _ADMIN_API_KEYS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Admin failed to create API key for user {user_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to create API key") from e
@@ -87,10 +120,14 @@ async def rotate_user_api_key(
             key_id=key_id,
             user_id=user_id,
             expires_in_days=request.expires_in_days,
+            **_principal_actor_kwargs(principal),
         )
         return APIKeyCreateResponse(**result)
     except HTTPException:
         raise
+    except MandatoryAuditWriteError as e:
+        logger.error(f"Admin mandatory audit write failed while rotating API key {key_id} for user {user_id}: {e}")
+        raise HTTPException(status_code=503, detail="Mandatory audit persistence unavailable") from e
     except _ADMIN_API_KEYS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Admin failed to rotate API key {key_id} for user {user_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to rotate API key") from e
@@ -104,12 +141,19 @@ async def revoke_user_api_key(
     try:
         await admin_scope_service.enforce_admin_user_scope(principal, user_id, require_hierarchy=True)
         api_mgr = await get_api_key_manager()
-        success = await api_mgr.revoke_api_key(key_id=key_id, user_id=user_id)
+        success = await api_mgr.revoke_api_key(
+            key_id=key_id,
+            user_id=user_id,
+            **_principal_actor_kwargs(principal),
+        )
         if not success:
             raise HTTPException(status_code=404, detail="API key not found")
         return {"message": "API key revoked", "user_id": user_id, "key_id": key_id}
     except HTTPException:
         raise
+    except MandatoryAuditWriteError as e:
+        logger.error(f"Admin mandatory audit write failed while revoking API key {key_id} for user {user_id}: {e}")
+        raise HTTPException(status_code=503, detail="Mandatory audit persistence unavailable") from e
     except _ADMIN_API_KEYS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Admin failed to revoke API key {key_id} for user {user_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to revoke API key") from e
@@ -180,10 +224,14 @@ async def create_virtual_key(
             allowed_paths=payload.allowed_paths,
             max_calls=payload.max_calls,
             max_runs=payload.max_runs,
+            **_principal_actor_kwargs(principal),
         )
         return result
     except HTTPException:
         raise
+    except MandatoryAuditWriteError as e:
+        logger.error(f"Admin mandatory audit write failed while creating virtual key for user {user_id}: {e}")
+        raise HTTPException(status_code=503, detail="Mandatory audit persistence unavailable") from e
     except _ADMIN_API_KEYS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Admin failed to create virtual key for user {user_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to create virtual key") from e

--- a/tldw_Server_API/tests/Audit/test_audit_db_deps.py
+++ b/tldw_Server_API/tests/Audit/test_audit_db_deps.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import time
 
 import pytest
@@ -58,6 +59,14 @@ class _BlockingStopService:
         self.stopped = True
         self._started_event.set()
         await self._release_event.wait()
+
+
+class _OwnerLoopStub:
+    def is_closed(self) -> bool:
+        return False
+
+    def is_running(self) -> bool:
+        return True
 
 
 @pytest.mark.asyncio
@@ -166,7 +175,13 @@ async def test_shutdown_all_audit_services_returns_summary_and_can_raise(monkeyp
     state = _make_state()
     monkeypatch.setattr(deps, "_all_loop_states", lambda: [state])
 
-    summary = await deps.shutdown_all_audit_services()
+    with pytest.raises(deps.AuditShutdownError):
+        await deps.shutdown_all_audit_services()
+
+    state = _make_state()
+    monkeypatch.setattr(deps, "_all_loop_states", lambda: [state])
+
+    summary = await deps.shutdown_all_audit_services(raise_on_error=False)
 
     assert isinstance(summary, deps.AuditShutdownSummary)
     assert summary.requested == 2
@@ -176,13 +191,6 @@ async def test_shutdown_all_audit_services_returns_summary_and_can_raise(monkeyp
     assert summary.errors
     assert "stop failed" in summary.errors[0]
     assert state.cache == {}
-
-    state = _make_state()
-    monkeypatch.setattr(deps, "_all_loop_states", lambda: [state])
-
-    with pytest.raises(deps.AuditShutdownError):
-        await deps.shutdown_all_audit_services(raise_on_error=True)
-
 
 @pytest.mark.asyncio
 async def test_shutdown_all_audit_services_runs_stop_fan_out_concurrently(monkeypatch):
@@ -211,6 +219,73 @@ async def test_shutdown_all_audit_services_runs_stop_fan_out_concurrently(monkey
     assert summary.error_count == 0
     assert summary.timeout_count == 0
     assert state.cache == {}
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_does_not_recache_service_after_shutdown(monkeypatch):
+    state = deps._LoopState(cache={})
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _fake_create(_user_id):
+        started.set()
+        await release.wait()
+        return _StoppingService(asyncio.get_running_loop())
+
+    monkeypatch.setattr(deps, "_resolve_audit_storage_mode", lambda: "per_user")
+    monkeypatch.setattr(deps, "_state_for_loop", lambda: state)
+    monkeypatch.setattr(deps, "_all_loop_states", lambda: [state])
+    monkeypatch.setattr(deps, "_create_audit_service_for_user", _fake_create)
+
+    init_task = asyncio.create_task(deps._get_or_create_audit_service_for_key(123))
+    await asyncio.wait_for(started.wait(), timeout=5)
+
+    summary = await deps.shutdown_user_audit_service(123)
+    assert summary.requested == 0
+    assert state.cache == {}
+
+    release.set()
+
+    with pytest.raises(ServiceInitializationError, match="shutdown"):
+        await asyncio.wait_for(init_task, timeout=5)
+
+    assert state.cache == {}
+
+
+@pytest.mark.asyncio
+async def test_stop_audit_service_instance_cancels_cross_loop_future_on_timeout(monkeypatch):
+    cancel_called = {"value": False}
+
+    class _CancelableFuture(concurrent.futures.Future):
+        def cancel(self) -> bool:
+            cancel_called["value"] = True
+            return super().cancel()
+
+    class _CrossLoopService:
+        owner_loop = _OwnerLoopStub()
+
+        async def stop(self) -> None:
+            await asyncio.sleep(60)
+
+    future = _CancelableFuture()
+
+    def _fake_run_coroutine_threadsafe(coro, _loop):
+        coro.close()
+        return future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", _fake_run_coroutine_threadsafe)
+
+    stopped_ok, timeout_hit, error_message, exc = await deps._stop_audit_service_instance(
+        _CrossLoopService(),
+        label="cross-loop",
+        timeout_s=0.01,
+    )
+
+    assert stopped_ok is False
+    assert timeout_hit is True
+    assert error_message is not None and "timed out" in error_message
+    assert isinstance(exc, asyncio.TimeoutError)
+    assert cancel_called["value"] is True
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Audit/test_audit_db_deps.py
+++ b/tldw_Server_API/tests/Audit/test_audit_db_deps.py
@@ -14,13 +14,50 @@ class _DummyService:
         self._tldw_stop_scheduled = False
         self._last_used_ts = time.monotonic() - 10.0
         self._tldw_evicted_at = None
+        self.stopped = False
 
     @property
     def owner_loop(self):
         return self._loop
 
     async def stop(self) -> None:
-        raise RuntimeError("stop failed")
+        self.stopped = True
+        raise LookupError("stop failed")
+
+
+class _StoppingService:
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        self.stopped = False
+
+    @property
+    def owner_loop(self):
+        return self._loop
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _BlockingStopService:
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        started_event: asyncio.Event,
+        release_event: asyncio.Event,
+    ) -> None:
+        self._loop = loop
+        self._started_event = started_event
+        self._release_event = release_event
+        self.stopped = False
+
+    @property
+    def owner_loop(self):
+        return self._loop
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self._started_event.set()
+        await self._release_event.wait()
 
 
 @pytest.mark.asyncio
@@ -94,6 +131,86 @@ async def test_schedule_service_stop_clears_flag_on_failure(monkeypatch):
 
     assert svc._tldw_stop_scheduled is False
     assert id(svc) not in deps._services_stopping
+
+
+@pytest.mark.asyncio
+async def test_shutdown_user_audit_service_uses_shared_cache_key(monkeypatch):
+    state = deps._LoopState(cache={})
+    svc = _StoppingService(asyncio.get_running_loop())
+    state.cache[None] = svc
+
+    monkeypatch.setattr(deps, "_resolve_audit_storage_mode", lambda: "shared")
+    monkeypatch.setattr(deps, "_all_loop_states", lambda: [state])
+
+    summary = await deps.shutdown_user_audit_service(123)
+
+    assert isinstance(summary, deps.AuditShutdownSummary)
+    assert summary.requested == 1
+    assert summary.stopped == 1
+    assert summary.error_count == 0
+    assert summary.timeout_count == 0
+    assert svc.stopped is True
+    assert None not in state.cache
+
+
+@pytest.mark.asyncio
+async def test_shutdown_all_audit_services_returns_summary_and_can_raise(monkeypatch):
+    loop = asyncio.get_running_loop()
+
+    def _make_state() -> deps._LoopState:
+        return deps._LoopState(cache={
+            1: _StoppingService(loop),
+            2: _DummyService(loop),
+        })
+
+    state = _make_state()
+    monkeypatch.setattr(deps, "_all_loop_states", lambda: [state])
+
+    summary = await deps.shutdown_all_audit_services()
+
+    assert isinstance(summary, deps.AuditShutdownSummary)
+    assert summary.requested == 2
+    assert summary.stopped == 1
+    assert summary.error_count == 1
+    assert summary.timeout_count == 0
+    assert summary.errors
+    assert "stop failed" in summary.errors[0]
+    assert state.cache == {}
+
+    state = _make_state()
+    monkeypatch.setattr(deps, "_all_loop_states", lambda: [state])
+
+    with pytest.raises(deps.AuditShutdownError):
+        await deps.shutdown_all_audit_services(raise_on_error=True)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_all_audit_services_runs_stop_fan_out_concurrently(monkeypatch):
+    loop = asyncio.get_running_loop()
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    release = asyncio.Event()
+    state = deps._LoopState(cache={
+        1: _BlockingStopService(loop, first_started, release),
+        2: _BlockingStopService(loop, second_started, release),
+    })
+
+    monkeypatch.setattr(deps, "_all_loop_states", lambda: [state])
+
+    shutdown_task = asyncio.create_task(deps.shutdown_all_audit_services())
+
+    await asyncio.wait_for(first_started.wait(), timeout=5)
+    await asyncio.wait_for(second_started.wait(), timeout=5)
+    release.set()
+
+    summary = await asyncio.wait_for(shutdown_task, timeout=5)
+
+    assert isinstance(summary, deps.AuditShutdownSummary)
+    assert summary.requested == 2
+    assert summary.stopped == 2
+    assert summary.error_count == 0
+    assert summary.timeout_count == 0
+    assert state.cache == {}
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Audit/test_audit_shared_migration.py
+++ b/tldw_Server_API/tests/Audit/test_audit_shared_migration.py
@@ -316,7 +316,7 @@ async def test_migration_checkpoint_handles_empty_timestamp_resume(tmp_path, mon
 
         async def commit_with_interrupt():
             call_count["count"] += 1
-            if call_count["count"] == 1:
+            if call_count["count"] == 2:
                 raise RuntimeError("interrupt")
             await orig_commit()
 
@@ -331,14 +331,14 @@ async def test_migration_checkpoint_handles_empty_timestamp_resume(tmp_path, mon
             chunk_size=1,
         )
         assert counts.failed is True
-        assert counts.events_inserted == 0
+        assert counts.events_inserted == 1
         assert counts.events_skipped == 0
-        assert counts.stats_inserted == 0
+        assert counts.stats_inserted == 1
         assert counts.stats_skipped == 0
 
         async with shared_db.execute("SELECT COUNT(*) AS n FROM audit_events") as cur:
             row = await cur.fetchone()
-        assert row["n"] == 0
+        assert row["n"] == 1
 
         monkeypatch.setattr(shared_db, "commit", orig_commit)
         counts2 = await audit_migration._migrate_source(
@@ -350,7 +350,7 @@ async def test_migration_checkpoint_handles_empty_timestamp_resume(tmp_path, mon
             unidentified_tenant_id="unidentified_user",
             chunk_size=1,
         )
-        assert counts2.events_inserted == 2
+        assert counts2.events_inserted == 1
 
         async with shared_db.execute("SELECT event_id FROM audit_events") as cur:
             rows = await cur.fetchall()

--- a/tldw_Server_API/tests/Audit/test_audit_shared_migration.py
+++ b/tldw_Server_API/tests/Audit/test_audit_shared_migration.py
@@ -315,10 +315,10 @@ async def test_migration_checkpoint_handles_empty_timestamp_resume(tmp_path, mon
         call_count = {"count": 0}
 
         async def commit_with_interrupt():
-            await orig_commit()
             call_count["count"] += 1
             if call_count["count"] == 1:
                 raise RuntimeError("interrupt")
+            await orig_commit()
 
         monkeypatch.setattr(shared_db, "commit", commit_with_interrupt)
         counts = await audit_migration._migrate_source(
@@ -331,6 +331,14 @@ async def test_migration_checkpoint_handles_empty_timestamp_resume(tmp_path, mon
             chunk_size=1,
         )
         assert counts.failed is True
+        assert counts.events_inserted == 0
+        assert counts.events_skipped == 0
+        assert counts.stats_inserted == 0
+        assert counts.stats_skipped == 0
+
+        async with shared_db.execute("SELECT COUNT(*) AS n FROM audit_events") as cur:
+            row = await cur.fetchone()
+        assert row["n"] == 0
 
         monkeypatch.setattr(shared_db, "commit", orig_commit)
         counts2 = await audit_migration._migrate_source(
@@ -342,7 +350,7 @@ async def test_migration_checkpoint_handles_empty_timestamp_resume(tmp_path, mon
             unidentified_tenant_id="unidentified_user",
             chunk_size=1,
         )
-        assert counts2.events_inserted == 1
+        assert counts2.events_inserted == 2
 
         async with shared_db.execute("SELECT event_id FROM audit_events") as cur:
             rows = await cur.fetchall()

--- a/tldw_Server_API/tests/Audit/test_unified_audit_service.py
+++ b/tldw_Server_API/tests/Audit/test_unified_audit_service.py
@@ -22,6 +22,7 @@ from tldw_Server_API.app.core.AuthNZ.audit_integrity import verify_audit_chain
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     UnifiedAuditService,
     AuditReadError,
+    AuditShutdownError,
     AuditEvent,
     AuditContext,
     AuditEventType,
@@ -800,6 +801,174 @@ class TestUnifiedAuditService:
         assert any(row.get("event_id") == ev.event_id for row in events)
         # Fallback file cleaned up
         assert not fallback_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_stop_spills_remaining_events_to_fallback_before_raising(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "audit_stop.db"
+        service = UnifiedAuditService(
+            db_path=str(db_path),
+            enable_pii_detection=False,
+            enable_risk_scoring=False,
+            buffer_size=10,
+            flush_interval=60.0,
+        )
+        await service.initialize(start_background_tasks=False)
+        await service._ensure_db_pool()
+        await service.log_event(
+            AuditEventType.DATA_WRITE,
+            context=AuditContext(user_id="stop-user"),
+            resource_type="doc",
+            resource_id="doc-1",
+        )
+
+        original_update_daily_stats = service._update_daily_stats
+
+        async def _boom_update_daily_stats(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(service, "_update_daily_stats", _boom_update_daily_stats)
+
+        with pytest.raises(AuditShutdownError) as exc_info:
+            await service.stop()
+
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        fb_path = db_path.parent / "audit_fallback_queue.jsonl"
+        assert fb_path.exists()
+        assert len(fb_path.read_text(encoding="utf-8").splitlines()) == 1
+        assert service._db_pool is None
+        assert service.owner_loop is None
+        monkeypatch.setattr(service, "_update_daily_stats", original_update_daily_stats)
+
+    @pytest.mark.asyncio
+    async def test_stop_wraps_original_flush_failure_in_shutdown_error(self, tmp_path, monkeypatch):
+        service = UnifiedAuditService(
+            db_path=str(tmp_path / "audit_stop_cause.db"),
+            enable_pii_detection=False,
+            enable_risk_scoring=False,
+            buffer_size=10,
+            flush_interval=60.0,
+        )
+        await service.initialize(start_background_tasks=False)
+        await service._ensure_db_pool()
+
+        async def _boom_update_daily_stats(*_args, **_kwargs):
+            raise RuntimeError("flush exploded")
+
+        monkeypatch.setattr(service, "_update_daily_stats", _boom_update_daily_stats)
+
+        await service.log_event(
+            AuditEventType.DATA_WRITE,
+            context=AuditContext(user_id="stop-user-cause"),
+            resource_type="doc",
+            resource_id="doc-2",
+        )
+
+        with pytest.raises(AuditShutdownError) as exc_info:
+            await service.stop()
+
+        assert "durable shutdown" in str(exc_info.value).lower()
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert service._db_pool is None
+        assert service.owner_loop is None
+
+    @pytest.mark.asyncio
+    async def test_stop_keeps_buffer_when_fallback_spill_fails(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "audit_stop_spill_fail.db"
+        service = UnifiedAuditService(
+            db_path=str(db_path),
+            enable_pii_detection=False,
+            enable_risk_scoring=False,
+            buffer_size=10,
+            flush_interval=60.0,
+        )
+        await service.initialize(start_background_tasks=False)
+        await service._ensure_db_pool()
+        await service.log_event(
+            AuditEventType.DATA_WRITE,
+            context=AuditContext(user_id="stop-spill-user"),
+            resource_type="doc",
+            resource_id="doc-3",
+        )
+
+        async def _boom_update_daily_stats(*_args, **_kwargs):
+            raise RuntimeError("flush exploded")
+
+        async def _boom_spill(_events):
+            raise OSError("spill failed")
+
+        monkeypatch.setattr(service, "_update_daily_stats", _boom_update_daily_stats)
+        monkeypatch.setattr(service, "_spill_events_to_fallback", _boom_spill)
+
+        with pytest.raises(AuditShutdownError) as exc_info:
+            await service.stop()
+
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert "spill failed" in str(exc_info.value).lower()
+        assert len(service.event_buffer) == 1
+        assert service._db_pool is None
+        assert service.owner_loop is None
+
+    @pytest.mark.asyncio
+    async def test_stop_preserves_late_arrivals_during_fallback_spill(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "audit_stop_race.db"
+        service = UnifiedAuditService(
+            db_path=str(db_path),
+            enable_pii_detection=False,
+            enable_risk_scoring=False,
+            buffer_size=10,
+            flush_interval=60.0,
+        )
+        await service.initialize(start_background_tasks=False)
+        await service._ensure_db_pool()
+
+        first_event_id = await service.log_event(
+            AuditEventType.DATA_WRITE,
+            context=AuditContext(user_id="race-user"),
+            resource_type="doc",
+            resource_id="doc-4",
+        )
+
+        async def _boom_update_daily_stats(*_args, **_kwargs):
+            raise RuntimeError("flush exploded")
+
+        spill_started = asyncio.Event()
+        release_spill = asyncio.Event()
+        captured_event_ids: list[str] = []
+        original_spill = service._spill_events_to_fallback
+
+        async def _blocked_spill(events):
+            captured_event_ids.extend(event.event_id for event in events)
+            spill_started.set()
+            await release_spill.wait()
+            return await original_spill(events)
+
+        monkeypatch.setattr(service, "_update_daily_stats", _boom_update_daily_stats)
+        monkeypatch.setattr(service, "_spill_events_to_fallback", _blocked_spill)
+
+        stop_task = asyncio.create_task(service.stop())
+        await asyncio.wait_for(spill_started.wait(), timeout=5)
+
+        second_event_id = await service.log_event(
+            AuditEventType.DATA_WRITE,
+            context=AuditContext(user_id="race-user"),
+            resource_type="doc",
+            resource_id="doc-5",
+        )
+
+        release_spill.set()
+
+        with pytest.raises(AuditShutdownError) as exc_info:
+            await stop_task
+
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert captured_event_ids == [first_event_id]
+        fb_path = db_path.parent / "audit_fallback_queue.jsonl"
+        assert fb_path.exists()
+        assert first_event_id in fb_path.read_text(encoding="utf-8")
+        assert len(service.event_buffer) == 1
+        assert service.event_buffer[0].event_id == second_event_id
+        assert service._db_pool is None
+        assert service.owner_loop is None
 
     @pytest.mark.asyncio
     async def test_export_events_json_and_csv(self, audit_service):
@@ -2110,6 +2279,7 @@ async def test_flush_propagates_cancellation_and_preserves_buffer(audit_service,
         await audit_service.flush()
 
     assert len(audit_service.event_buffer) == 1
+    monkeypatch.undo()
 
 
 @pytest.mark.asyncio
@@ -2586,4 +2756,3 @@ async def test_export_events_flushes_buffered_events(tmp_path):
         assert service.event_buffer == []
     finally:
         await service.stop()
-

--- a/tldw_Server_API/tests/Audit/test_unified_audit_service.py
+++ b/tldw_Server_API/tests/Audit/test_unified_audit_service.py
@@ -835,6 +835,7 @@ class TestUnifiedAuditService:
         fb_path = db_path.parent / "audit_fallback_queue.jsonl"
         assert fb_path.exists()
         assert len(fb_path.read_text(encoding="utf-8").splitlines()) == 1
+        assert service.event_buffer == []
         assert service._db_pool is None
         assert service.owner_loop is None
         monkeypatch.setattr(service, "_update_daily_stats", original_update_daily_stats)
@@ -964,7 +965,9 @@ class TestUnifiedAuditService:
         assert captured_event_ids == [first_event_id]
         fb_path = db_path.parent / "audit_fallback_queue.jsonl"
         assert fb_path.exists()
-        assert first_event_id in fb_path.read_text(encoding="utf-8")
+        fallback_contents = fb_path.read_text(encoding="utf-8")
+        assert first_event_id in fallback_contents
+        assert second_event_id not in fallback_contents
         assert len(service.event_buffer) == 1
         assert service.event_buffer[0].event_id == second_event_id
         assert service._db_pool is None

--- a/tldw_Server_API/tests/AuthNZ/integration/test_api_key_rotation_audit.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_api_key_rotation_audit.py
@@ -1,41 +1,23 @@
-import pytest
+import json
+import sqlite3
 import uuid
+
+import pytest
 import pytest_asyncio
 
-from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager
+from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import shutdown_all_audit_services
+import tldw_Server_API.app.core.AuthNZ.api_key_manager as api_key_manager_module
+from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
+from tldw_Server_API.app.core.AuthNZ.api_key_manager import APIKeyManager, APIKeyStatus
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 
 pytestmark = pytest.mark.integration
 
 
-@pytest_asyncio.fixture
-async def sqlite_authnz_pool(tmp_path, monkeypatch):
-    from tldw_Server_API.app.core.AuthNZ.api_key_manager import reset_api_key_manager
-
-    db_path = tmp_path / f"api_key_rotation_{uuid.uuid4().hex}.sqlite"
-    monkeypatch.setenv("AUTH_MODE", "single_user")
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
-
-    await reset_api_key_manager()
-    await reset_db_pool()
-    pool = await get_db_pool()
-    try:
-        yield pool
-    finally:
-        await reset_api_key_manager()
-        await reset_db_pool()
-
-
-@pytest.mark.asyncio
-async def test_api_key_rotation_and_audit_sqlite(sqlite_authnz_pool):
-    pool = sqlite_authnz_pool
-
-    # Ensure a user exists (minimal row)
-    # Use a unique username/email per test run to avoid collisions with
-    # prior executions against the shared sqlite users.db
-    uname = f"akuser_{uuid.uuid4().hex[:8]}"
+async def _create_auth_user(pool, *, prefix: str) -> int:
+    uname = f"{prefix}_{uuid.uuid4().hex[:8]}"
     email = f"{uname}@example.com"
-
     await pool.execute(
         """
         INSERT INTO users (username, email, password_hash, is_active)
@@ -44,7 +26,47 @@ async def test_api_key_rotation_and_audit_sqlite(sqlite_authnz_pool):
         (uname, email, "x"),
     )
     user_row = await pool.fetchone("SELECT id FROM users WHERE username = ?", uname)
-    user_id = user_row["id"] if isinstance(user_row, dict) else user_row[0]
+    return user_row["id"] if isinstance(user_row, dict) else user_row[0]
+
+
+def _install_failing_mandatory_audit(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fail_audit(**_kwargs):
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    monkeypatch.setattr(
+        api_key_manager_module,
+        "emit_mandatory_api_key_management_audit",
+        _fail_audit,
+    )
+
+
+@pytest_asyncio.fixture
+async def sqlite_authnz_pool(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.AuthNZ.api_key_manager import reset_api_key_manager
+
+    db_path = tmp_path / f"api_key_rotation_{uuid.uuid4().hex}.sqlite"
+    user_db_base = (tmp_path / "user_databases").resolve()
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(user_db_base))
+
+    await reset_api_key_manager()
+    await reset_db_pool()
+    await shutdown_all_audit_services()
+    pool = await get_db_pool()
+    try:
+        yield pool
+    finally:
+        await shutdown_all_audit_services()
+        await reset_api_key_manager()
+        await reset_db_pool()
+
+
+@pytest.mark.asyncio
+async def test_api_key_rotation_and_audit_sqlite(sqlite_authnz_pool):
+    pool = sqlite_authnz_pool
+
+    user_id = await _create_auth_user(pool, prefix="akuser")
 
     mgr = APIKeyManager(db_pool=pool)
     await mgr.initialize()
@@ -61,28 +83,38 @@ async def test_api_key_rotation_and_audit_sqlite(sqlite_authnz_pool):
     ok = await mgr.revoke_api_key(rotated["id"], user_id=user_id, reason="cleanup")
     assert ok is True
 
-    # Audit log should have entries
+    # Legacy compatibility audit mirror should still have entries.
     rows = await pool.fetchall("SELECT COUNT(*) AS c FROM api_key_audit_log")
-    count = rows[0]["c"] if isinstance(rows[0], dict) else rows[0][0]
-    assert count >= 2
+    legacy_count = rows[0]["c"] if isinstance(rows[0], dict) else rows[0][0]
+    assert legacy_count >= 3
+
+    # Mandatory unified audit should persist in the real per-user audit DB.
+    audit_db_path = DatabasePaths.get_audit_db_path(user_id)
+    assert audit_db_path.exists(), f"Expected audit DB at {audit_db_path}"
+
+    with sqlite3.connect(audit_db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        unified_rows = conn.execute(
+            "SELECT action, resource_id, metadata FROM audit_events ORDER BY timestamp ASC"
+        ).fetchall()
+
+    assert len(unified_rows) >= 3
+    actions = [str(row["action"]) for row in unified_rows]
+    assert "api_key.create" in actions
+    assert "api_key.rotate" in actions
+    assert "api_key.revoke" in actions
+
+    rotate_row = next(row for row in unified_rows if row["action"] == "api_key.rotate")
+    rotate_metadata = json.loads(rotate_row["metadata"] or "{}")
+    assert int(rotate_metadata["old_key_id"]) == int(key_id)
+    assert int(rotate_metadata["new_key_id"]) == int(rotated["id"])
 
 
 @pytest.mark.asyncio
 async def test_api_key_rotation_preserves_allowlists_and_metadata(sqlite_authnz_pool):
     pool = sqlite_authnz_pool
 
-    uname = f"akuser_meta_{uuid.uuid4().hex[:8]}"
-    email = f"{uname}@example.com"
-
-    await pool.execute(
-        """
-        INSERT INTO users (username, email, password_hash, is_active)
-        VALUES (?, ?, ?, 1)
-        """,
-        (uname, email, "x"),
-    )
-    user_row = await pool.fetchone("SELECT id FROM users WHERE username = ?", uname)
-    user_id = user_row["id"] if isinstance(user_row, dict) else user_row[0]
+    user_id = await _create_auth_user(pool, prefix="akuser_meta")
 
     mgr = APIKeyManager(db_pool=pool)
     await mgr.initialize()
@@ -121,3 +153,231 @@ async def test_api_key_rotation_preserves_allowlists_and_metadata(sqlite_authnz_
 
     await pool.execute("DELETE FROM api_keys WHERE user_id = ?", (user_id,))
     await pool.execute("DELETE FROM users WHERE id = ?", (user_id,))
+
+
+@pytest.mark.asyncio
+async def test_create_api_key_rolls_back_when_mandatory_audit_fails(
+    sqlite_authnz_pool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pool = sqlite_authnz_pool
+    user_id = await _create_auth_user(pool, prefix="akuser_create_fail")
+    mgr = APIKeyManager(db_pool=pool)
+    await mgr.initialize()
+    _install_failing_mandatory_audit(monkeypatch)
+
+    with pytest.raises(MandatoryAuditWriteError, match="Mandatory audit persistence unavailable"):
+        await mgr.create_api_key(user_id=user_id, name="k-fail", description="d1", scope="read")
+
+    rows = await pool.fetchall("SELECT id FROM api_keys WHERE user_id = ?", user_id)
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_create_api_key_does_not_commit_authnz_state_before_mandatory_audit(
+    sqlite_authnz_pool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pool = sqlite_authnz_pool
+    user_id = await _create_auth_user(pool, prefix="akuser_uncommitted")
+    mgr = APIKeyManager(db_pool=pool)
+    await mgr.initialize()
+    observed: dict[str, int] = {}
+
+    async def _fail_audit(*, resource_id: str | None = None, **_kwargs):
+        assert resource_id is not None
+        row = await pool.fetchone("SELECT COUNT(*) AS c FROM api_keys WHERE id = ?", int(resource_id))
+        observed["visible_count"] = row["c"] if isinstance(row, dict) else row[0]
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    monkeypatch.setattr(
+        api_key_manager_module,
+        "emit_mandatory_api_key_management_audit",
+        _fail_audit,
+    )
+
+    with pytest.raises(MandatoryAuditWriteError, match="Mandatory audit persistence unavailable"):
+        await mgr.create_api_key(user_id=user_id, name="k-uncommitted", description="d1", scope="read")
+
+    assert observed["visible_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_virtual_key_rolls_back_when_mandatory_audit_fails(
+    sqlite_authnz_pool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pool = sqlite_authnz_pool
+    user_id = await _create_auth_user(pool, prefix="akuser_virtual_fail")
+    mgr = APIKeyManager(db_pool=pool)
+    await mgr.initialize()
+    _install_failing_mandatory_audit(monkeypatch)
+
+    with pytest.raises(MandatoryAuditWriteError, match="Mandatory audit persistence unavailable"):
+        await mgr.create_virtual_key(user_id=user_id, name="vk-fail", allowed_endpoints=["chat.completions"])
+
+    rows = await pool.fetchall(
+        "SELECT id FROM api_keys WHERE user_id = ? AND COALESCE(is_virtual, 0) = 1",
+        user_id,
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_create_virtual_key_writes_unified_audit_sqlite(sqlite_authnz_pool):
+    pool = sqlite_authnz_pool
+    user_id = await _create_auth_user(pool, prefix="akuser_virtual_audit")
+    mgr = APIKeyManager(db_pool=pool)
+    await mgr.initialize()
+
+    created = await mgr.create_virtual_key(
+        user_id=user_id,
+        name="vk-success",
+        allowed_endpoints=["chat.completions"],
+    )
+
+    audit_db_path = DatabasePaths.get_audit_db_path(user_id)
+    assert audit_db_path.exists(), f"Expected audit DB at {audit_db_path}"
+
+    with sqlite3.connect(audit_db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """
+            SELECT action, resource_id
+            FROM audit_events
+            WHERE action = 'api_key.create_virtual'
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """
+        ).fetchone()
+
+    assert row is not None
+    assert row["action"] == "api_key.create_virtual"
+    assert int(row["resource_id"]) == int(created["id"])
+
+
+@pytest.mark.asyncio
+async def test_legacy_api_key_audit_mirror_failure_is_non_blocking(
+    sqlite_authnz_pool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pool = sqlite_authnz_pool
+    user_id = await _create_auth_user(pool, prefix="akuser_legacy_fail")
+    mgr = APIKeyManager(db_pool=pool)
+    await mgr.initialize()
+    repo = mgr._get_repo()
+
+    async def _failing_insert_audit_log(**_kwargs):
+        raise RuntimeError("legacy mirror unavailable")
+
+    monkeypatch.setattr(repo, "insert_audit_log", _failing_insert_audit_log)
+
+    created = await mgr.create_api_key(user_id=user_id, name="k-legacy", description="d1", scope="read")
+    assert int(created["id"]) > 0
+
+    audit_db_path = DatabasePaths.get_audit_db_path(user_id)
+    with sqlite3.connect(audit_db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """
+            SELECT action, resource_id
+            FROM audit_events
+            WHERE action = 'api_key.create'
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """
+        ).fetchone()
+
+    assert row is not None
+    assert row["action"] == "api_key.create"
+    assert int(row["resource_id"]) == int(created["id"])
+
+
+@pytest.mark.asyncio
+async def test_rotate_api_key_rolls_back_when_mandatory_audit_fails(
+    sqlite_authnz_pool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pool = sqlite_authnz_pool
+    user_id = await _create_auth_user(pool, prefix="akuser_rotate_fail")
+    mgr = APIKeyManager(db_pool=pool)
+    await mgr.initialize()
+
+    created = await mgr.create_api_key(user_id=user_id, name="k1", description="d1", scope="read")
+    original_key_id = int(created["id"])
+    _install_failing_mandatory_audit(monkeypatch)
+
+    with pytest.raises(MandatoryAuditWriteError, match="Mandatory audit persistence unavailable"):
+        await mgr.rotate_api_key(key_id=original_key_id, user_id=user_id)
+
+    rows = await pool.fetchall(
+        """
+        SELECT id, status, rotated_to, rotated_from, revoked_at
+        FROM api_keys
+        WHERE user_id = ?
+        ORDER BY id ASC
+        """,
+        user_id,
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert int(row["id"] if isinstance(row, dict) else row[0]) == original_key_id
+    status_value = row["status"] if isinstance(row, dict) else row[1]
+    rotated_to = row["rotated_to"] if isinstance(row, dict) else row[2]
+    rotated_from = row["rotated_from"] if isinstance(row, dict) else row[3]
+    revoked_at = row["revoked_at"] if isinstance(row, dict) else row[4]
+    assert status_value == APIKeyStatus.ACTIVE.value
+    assert rotated_to is None
+    assert rotated_from is None
+    assert revoked_at is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_api_key_rolls_back_when_mandatory_audit_fails(
+    sqlite_authnz_pool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pool = sqlite_authnz_pool
+    user_id = await _create_auth_user(pool, prefix="akuser_revoke_fail")
+    mgr = APIKeyManager(db_pool=pool)
+    await mgr.initialize()
+
+    created = await mgr.create_api_key(user_id=user_id, name="k1", description="d1", scope="read")
+    key_id = int(created["id"])
+    _install_failing_mandatory_audit(monkeypatch)
+
+    with pytest.raises(MandatoryAuditWriteError, match="Mandatory audit persistence unavailable"):
+        await mgr.revoke_api_key(key_id, user_id=user_id, reason="cleanup")
+
+    row = await pool.fetchone(
+        "SELECT status, revoked_at, revoked_by, revoke_reason FROM api_keys WHERE id = ?",
+        key_id,
+    )
+    if isinstance(row, dict):
+        status_value = row["status"]
+        revoked_at = row["revoked_at"]
+        revoked_by = row["revoked_by"]
+        revoke_reason = row["revoke_reason"]
+    else:
+        status_value, revoked_at, revoked_by, revoke_reason = row
+
+    assert status_value == APIKeyStatus.ACTIVE.value
+    assert revoked_at is None
+    assert revoked_by is None
+    assert revoke_reason is None
+
+
+@pytest.mark.asyncio
+async def test_rotate_api_key_rejects_revoked_source_key(sqlite_authnz_pool):
+    pool = sqlite_authnz_pool
+    user_id = await _create_auth_user(pool, prefix="akuser_rotate_revoked")
+    mgr = APIKeyManager(db_pool=pool)
+    await mgr.initialize()
+
+    created = await mgr.create_api_key(user_id=user_id, name="k1", description="d1", scope="read")
+    key_id = int(created["id"])
+    revoked = await mgr.revoke_api_key(key_id, user_id=user_id, reason="cleanup")
+    assert revoked is True
+
+    with pytest.raises(ValueError, match="not found or unauthorized"):
+        await mgr.rotate_api_key(key_id=key_id, user_id=user_id)

--- a/tldw_Server_API/tests/AuthNZ/unit/test_api_key_audit.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_api_key_audit.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import tldw_Server_API.app.core.AuthNZ.api_key_audit as api_key_audit
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditEventCategory,
+    AuditEventType,
+    MandatoryAuditWriteError,
+)
+
+
+class _StubAuditService:
+    def __init__(self) -> None:
+        self.log_calls: list[dict[str, Any]] = []
+        self.flush_calls: list[dict[str, Any]] = []
+
+    async def log_event(self, **kwargs: Any) -> None:
+        self.log_calls.append(kwargs)
+
+    async def flush(self, **kwargs: Any) -> None:
+        self.flush_calls.append(kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_emit_mandatory_api_key_audit_writes_unified_event_and_flushes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    stub = _StubAuditService()
+
+    async def _fake_get_or_create(user_id: int):
+        captured["user_id"] = user_id
+        return stub
+
+    monkeypatch.setattr(api_key_audit, "_create_isolated_audit_service", _fake_get_or_create)
+
+    await api_key_audit.emit_mandatory_api_key_management_audit(
+        user_id=42,
+        event_type=AuditEventType.DATA_UPDATE,
+        category=AuditEventCategory.DATA_MODIFICATION,
+        action="api_key.rotate",
+        resource_id="101",
+        metadata={"old_key_id": 10, "new_key_id": 101},
+    )
+
+    assert captured["user_id"] == 42
+    assert len(stub.log_calls) == 1
+    assert stub.log_calls[0]["event_type"] == AuditEventType.DATA_UPDATE
+    assert stub.log_calls[0]["category"] == AuditEventCategory.DATA_MODIFICATION
+    assert stub.log_calls[0]["action"] == "api_key.rotate"
+    assert stub.log_calls[0]["resource_type"] == "api_key"
+    assert stub.log_calls[0]["resource_id"] == "101"
+    assert stub.log_calls[0]["metadata"] == {
+        "old_key_id": 10,
+        "new_key_id": 101,
+        "target_user_id": 42,
+    }
+    assert stub.log_calls[0]["context"].user_id == "42"
+    assert stub.flush_calls == [{"raise_on_failure": True}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_emit_mandatory_api_key_audit_wraps_log_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingAuditService:
+        async def log_event(self, **_kwargs: Any) -> None:
+            raise RuntimeError("boom")
+
+        async def flush(self, **_kwargs: Any) -> None:
+            raise AssertionError("flush should not run when log_event fails")
+
+    async def _fake_get_or_create(_user_id: int):
+        return _FailingAuditService()
+
+    monkeypatch.setattr(api_key_audit, "_create_isolated_audit_service", _fake_get_or_create)
+
+    with pytest.raises(MandatoryAuditWriteError, match="Mandatory audit persistence unavailable"):
+        await api_key_audit.emit_mandatory_api_key_management_audit(
+            user_id=7,
+            event_type=AuditEventType.DATA_WRITE,
+            category=AuditEventCategory.DATA_MODIFICATION,
+            action="api_key.create",
+            resource_id="7",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_emit_mandatory_api_key_audit_wraps_flush_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingFlushAuditService:
+        async def log_event(self, **_kwargs: Any) -> None:
+            return None
+
+        async def flush(self, **_kwargs: Any) -> None:
+            raise RuntimeError("flush boom")
+
+    async def _fake_get_or_create(_user_id: int):
+        return _FailingFlushAuditService()
+
+    monkeypatch.setattr(api_key_audit, "_create_isolated_audit_service", _fake_get_or_create)
+
+    with pytest.raises(MandatoryAuditWriteError, match="Mandatory audit persistence unavailable"):
+        await api_key_audit.emit_mandatory_api_key_management_audit(
+            user_id=8,
+            event_type=AuditEventType.DATA_UPDATE,
+            category=AuditEventCategory.SECURITY,
+            action="api_key.revoke",
+            resource_id="18",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_emit_mandatory_api_key_audit_uses_isolated_service_and_preserves_actor_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cached = _StubAuditService()
+    isolated = _StubAuditService()
+
+    async def _fake_get_or_create(_user_id: int):
+        return cached
+
+    async def _fake_create_isolated(_user_id: int):
+        return isolated
+
+    async def _fail_cached_flush(**_kwargs: Any) -> None:
+        raise AssertionError("cached service should not be flushed for strict API key writes")
+
+    cached.flush = _fail_cached_flush  # type: ignore[method-assign]
+    monkeypatch.setattr(api_key_audit, "_get_or_create_audit_service", _fake_get_or_create)
+    monkeypatch.setattr(
+        api_key_audit,
+        "_create_isolated_audit_service",
+        _fake_create_isolated,
+        raising=False,
+    )
+
+    await api_key_audit.emit_mandatory_api_key_management_audit(
+        user_id=42,
+        event_type=AuditEventType.DATA_WRITE,
+        category=AuditEventCategory.DATA_MODIFICATION,
+        action="api_key.create",
+        resource_id="101",
+        metadata={"scope": "read"},
+        actor_user_id=7,
+        actor_subject="admin-user",
+        actor_kind="user",
+        actor_roles=["admin"],
+    )
+
+    assert cached.log_calls == []
+    assert len(isolated.log_calls) == 1
+    assert isolated.log_calls[0]["metadata"]["scope"] == "read"
+    assert isolated.log_calls[0]["metadata"]["actor_user_id"] == 7
+    assert isolated.log_calls[0]["metadata"]["actor_subject"] == "admin-user"
+    assert isolated.log_calls[0]["metadata"]["actor_kind"] == "user"
+    assert isolated.log_calls[0]["metadata"]["actor_roles"] == ["admin"]
+    assert isolated.log_calls[0]["metadata"]["target_user_id"] == 42

--- a/tldw_Server_API/tests/AuthNZ/unit/test_api_key_audit.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_api_key_audit.py
@@ -65,6 +65,28 @@ async def test_emit_mandatory_api_key_audit_writes_unified_event_and_flushes(
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_emit_mandatory_api_key_audit_wraps_service_creation_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fail_create(_user_id: int) -> None:
+        raise RuntimeError("bootstrap boom")
+
+    monkeypatch.setattr(api_key_audit, "_create_isolated_audit_service", _fail_create)
+
+    with pytest.raises(MandatoryAuditWriteError) as exc_info:
+        await api_key_audit.emit_mandatory_api_key_management_audit(
+            user_id=9,
+            event_type=AuditEventType.DATA_WRITE,
+            category=AuditEventCategory.DATA_MODIFICATION,
+            action="api_key.create",
+        )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "bootstrap boom" in str(exc_info.value.__cause__)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_emit_mandatory_api_key_audit_wraps_log_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_register_strict_audit.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_register_strict_audit.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, Response
+
+from tldw_Server_API.app.api.v1.endpoints import auth as auth_endpoints
+from tldw_Server_API.app.api.v1.schemas.auth_schemas import RegisterRequest
+from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
+
+
+class _FakeRegistrationService:
+    async def register_user(self, **kwargs):
+        return {
+            "user_id": 77,
+            "username": kwargs["username"],
+            "email": kwargs["email"],
+            "is_verified": True,
+        }
+
+
+class _FailingAPIKeyManager:
+    async def create_api_key(self, **_kwargs):
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_register_returns_503_when_default_api_key_audit_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_get_api_key_manager():
+        return _FailingAPIKeyManager()
+
+    monkeypatch.setattr(
+        auth_endpoints,
+        "get_settings",
+        lambda: SimpleNamespace(DATABASE_URL="sqlite:///tmp/authnz-test.db", PII_REDACT_LOGS=False),
+    )
+    monkeypatch.setattr(auth_endpoints, "get_profile", lambda: "multi_user")
+    monkeypatch.setattr(auth_endpoints, "get_api_key_manager", _fake_get_api_key_manager)
+    monkeypatch.setattr(auth_endpoints, "_finalize_register_diag", lambda *_args, **_kwargs: None)
+
+    request = SimpleNamespace(
+        headers={},
+        state=SimpleNamespace(),
+        url=SimpleNamespace(path="/api/v1/auth/register"),
+        method="POST",
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_endpoints.register(
+            payload=RegisterRequest(
+                username="strictregister",
+                email="strictregister@example.com",
+                password="SecurePass123!",
+            ),
+            http_request=request,
+            response=Response(),
+            _diag=None,
+            registration_service=_FakeRegistrationService(),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_register_strict_audit.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_register_strict_audit.py
@@ -64,4 +64,10 @@ async def test_register_returns_503_when_default_api_key_audit_fails(
         )
 
     assert exc_info.value.status_code == 503
-    assert exc_info.value.detail == "Mandatory audit persistence unavailable"
+    assert exc_info.value.detail == {
+        "error": {
+            "message": "Mandatory audit persistence unavailable",
+            "type": "audit_persistence_failure",
+            "code": "audit_persistence_failure",
+        }
+    }

--- a/tldw_Server_API/tests/AuthNZ/unit/test_user_api_key_endpoints.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_user_api_key_endpoints.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from tldw_Server_API.app.api.v1.endpoints import users as users_endpoints
+from tldw_Server_API.app.api.v1.schemas.api_key_schemas import (
+    APIKeyCreateRequest,
+    APIKeyRotateRequest,
+)
+from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+
+
+class _FailingAPIKeyManager:
+    async def create_api_key(self, **_kwargs: Any) -> dict[str, Any]:
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    async def create_virtual_key(self, **_kwargs: Any) -> dict[str, Any]:
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    async def rotate_api_key(self, **_kwargs: Any) -> dict[str, Any]:
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    async def revoke_api_key(self, **_kwargs: Any) -> bool:
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+
+def _principal() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        api_key_id=None,
+        subject="unit-user",
+        token_type="access",
+        jti=None,
+        roles=["user"],
+        permissions=[],
+        is_admin=False,
+        org_ids=[],
+        team_ids=[],
+    )
+
+
+@pytest.fixture
+def _patched_user_api_keys_deps(monkeypatch: pytest.MonkeyPatch):
+    async def _fake_require_principal_active_verified(*_args, **_kwargs):
+        return {
+            "id": 1,
+            "username": "api-key-user",
+            "email": "api-key-user@example.com",
+            "role": "user",
+            "is_active": True,
+            "is_verified": True,
+            "storage_quota_mb": 5120,
+            "storage_used_mb": 0.0,
+            "created_at": datetime.utcnow(),
+            "last_login": None,
+        }
+
+    async def _fake_get_api_key_manager():
+        return _FailingAPIKeyManager()
+
+    monkeypatch.setattr(
+        users_endpoints,
+        "_require_principal_active_verified",
+        _fake_require_principal_active_verified,
+    )
+    monkeypatch.setattr(users_endpoints, "get_api_key_manager", _fake_get_api_key_manager)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_users_create_api_key_returns_503_on_mandatory_audit_failure(
+    _patched_user_api_keys_deps,
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoints.create_api_key(
+            payload=APIKeyCreateRequest(name="strict-audit-key", scope="read"),
+            request=object(),
+            principal=_principal(),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_users_create_virtual_api_key_returns_503_on_mandatory_audit_failure(
+    _patched_user_api_keys_deps,
+) -> None:
+    payload = users_endpoints.SelfVirtualAPIKeyRequest(name="strict-audit-virtual")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoints.create_virtual_api_key(
+            payload=payload,
+            request=object(),
+            principal=_principal(),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_users_rotate_api_key_returns_503_on_mandatory_audit_failure(
+    _patched_user_api_keys_deps,
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoints.rotate_api_key(
+            key_id=123,
+            payload=APIKeyRotateRequest(expires_in_days=90),
+            request=object(),
+            principal=_principal(),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_users_revoke_api_key_returns_503_on_mandatory_audit_failure(
+    _patched_user_api_keys_deps,
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoints.revoke_api_key(
+            key_id=321,
+            request=object(),
+            principal=_principal(),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"

--- a/tldw_Server_API/tests/Chat_NEW/integration/test_moderation.py
+++ b/tldw_Server_API/tests/Chat_NEW/integration/test_moderation.py
@@ -11,8 +11,10 @@ from unittest.mock import patch
 from fastapi import FastAPI
 from tldw_Server_API.app.api.v1.endpoints.chat import router as chat_router
 from tldw_Server_API.app.api.v1.endpoints.health import router as health_router
+from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user, DEFAULT_CHARACTER_NAME
+from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
 
 
 # Minimal app with only health and chat routers to avoid unrelated imports
@@ -161,6 +163,25 @@ class _CharacterScopedGuardianEngine:
         )
 
 
+class _FailingMandatoryAuditService:
+    def __init__(self):
+        self.logged_events: list[dict[str, Any]] = []
+
+    async def log_event(self, **kwargs):
+        self.logged_events.append(kwargs)
+
+    async def flush(self, raise_on_failure: bool = False):
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+
+async def _failing_audit_service_override():
+    return _FailingMandatoryAuditService()
+
+
+async def _missing_audit_service_override():
+    return None
+
+
 @pytest.mark.unit
 def test_input_block_returns_400(monkeypatch):
     db, db_path = _make_test_db()
@@ -190,6 +211,74 @@ def test_input_block_returns_400(monkeypatch):
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
+
+
+@pytest.mark.unit
+def test_input_block_fails_closed_when_mandatory_audit_fails():
+    db, db_path = _make_test_db()
+    try:
+        app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+        app.dependency_overrides[get_audit_service_for_user] = _failing_audit_service_override
+        policy = _StubPolicy(enabled=True, input_action='block', output_action='redact')
+
+        with patch("tldw_Server_API.app.api.v1.endpoints.chat.get_moderation_service", return_value=_StubModerationService(policy)), \
+             patch("tldw_Server_API.app.api.v1.endpoints.chat.perform_chat_api_call") as mock_provider:
+            with TestClient(app) as client:
+                resp = client.get("/api/v1/health")
+                client.csrf_token = resp.cookies.get("csrf_token", "")
+                body = {
+                    "api_provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "please say secret"}],
+                    "stream": False,
+                }
+                r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
+                assert r.status_code == 503
+                assert "mandatory audit persistence unavailable" in r.json().get("detail", "").lower()
+                assert not mock_provider.called
+    finally:
+        try:
+            os.unlink(db_path)
+            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
+            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+        except Exception:
+            _ = None
+        app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        app.dependency_overrides.pop(get_audit_service_for_user, None)
+
+
+@pytest.mark.unit
+def test_input_block_fails_closed_when_audit_service_missing():
+    db, db_path = _make_test_db()
+    try:
+        app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+        app.dependency_overrides[get_audit_service_for_user] = _missing_audit_service_override
+        policy = _StubPolicy(enabled=True, input_action='block', output_action='redact')
+
+        with patch("tldw_Server_API.app.api.v1.endpoints.chat.get_moderation_service", return_value=_StubModerationService(policy)), \
+             patch("tldw_Server_API.app.api.v1.endpoints.chat.perform_chat_api_call") as mock_provider:
+            with TestClient(app) as client:
+                resp = client.get("/api/v1/health")
+                client.csrf_token = resp.cookies.get("csrf_token", "")
+                body = {
+                    "api_provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "please say secret"}],
+                    "stream": False,
+                }
+                r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
+                assert r.status_code == 503
+                assert "mandatory audit persistence unavailable" in r.json().get("detail", "").lower()
+                assert not mock_provider.called
+    finally:
+        try:
+            os.unlink(db_path)
+            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
+            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+        except Exception:
+            _ = None
+        app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        app.dependency_overrides.pop(get_audit_service_for_user, None)
 
 
 @pytest.mark.unit
@@ -234,6 +323,49 @@ def test_output_redaction_non_streaming(monkeypatch):
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
+
+
+@pytest.mark.unit
+def test_output_redaction_non_streaming_fails_closed_when_mandatory_audit_fails():
+    db, db_path = _make_test_db()
+    try:
+        app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+        app.dependency_overrides[get_audit_service_for_user] = _failing_audit_service_override
+        policy = _StubPolicy(enabled=True, input_action='warn', output_action='redact', redact='[REDACTED]')
+
+        reply = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-4o-mini",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "this has secret token"}, "finish_reason": "stop"}
+            ]
+        }
+
+        with patch("tldw_Server_API.app.api.v1.endpoints.chat.get_moderation_service", return_value=_StubModerationService(policy)), \
+             patch("tldw_Server_API.app.api.v1.endpoints.chat.perform_chat_api_call", return_value=reply):
+            with TestClient(app) as client:
+                resp = client.get("/api/v1/health")
+                client.csrf_token = resp.cookies.get("csrf_token", "")
+                body = {
+                    "api_provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "stream": False,
+                }
+                r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
+                assert r.status_code == 503
+                assert "mandatory audit persistence unavailable" in r.json().get("detail", "").lower()
+    finally:
+        try:
+            os.unlink(db_path)
+            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
+            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+        except Exception:
+            _ = None
+        app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        app.dependency_overrides.pop(get_audit_service_for_user, None)
 
 
 @pytest.mark.unit
@@ -409,6 +541,64 @@ def test_streaming_block_emits_sse_error_and_finishes():
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
+
+
+@pytest.mark.unit
+def test_streaming_redaction_emits_audit_failure_and_fails_closed(monkeypatch):
+    db, db_path = _make_test_db()
+    try:
+        monkeypatch.setenv("STREAMS_UNIFIED", "0")
+        app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+        app.dependency_overrides[get_audit_service_for_user] = _failing_audit_service_override
+        policy = _StubPolicy(enabled=True, input_action='warn', output_action='redact', redact='[REDACTED]')
+
+        def upstream_stream():
+            chunk1 = {"choices": [{"delta": {"content": "leak: secret"}}]}
+            chunk2 = {"choices": [{"delta": {"content": " appears"}}]}
+            yield f"data: {json.dumps(chunk1)}\n\n"
+            yield f"data: {json.dumps(chunk2)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        with (
+            patch("tldw_Server_API.app.api.v1.endpoints.chat.get_moderation_service",
+                  return_value=_StubModerationService(policy)),
+            patch("tldw_Server_API.app.api.v1.endpoints.chat.perform_chat_api_call",
+                  return_value=upstream_stream()),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/api/v1/health")
+                client.csrf_token = resp.cookies.get("csrf_token", "")
+                body = {
+                    "api_provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                }
+                r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
+                assert r.status_code == 200
+                text = r.text
+                assert "[REDACTED]" in text
+                assert "audit_persistence_failure" in text
+                assert "[DONE]" in text
+                stream_end_payload = None
+                for block in text.split("\n\n"):
+                    if not block.startswith("event: stream_end"):
+                        continue
+                    data_line = next((line for line in block.splitlines() if line.startswith("data: ")), None)
+                    assert data_line is not None
+                    stream_end_payload = json.loads(data_line[6:])
+                    break
+                assert stream_end_payload is not None, text
+                assert stream_end_payload["success"] is False
+    finally:
+        try:
+            os.unlink(db_path)
+            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
+            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+        except Exception:
+            _ = None
+        app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        app.dependency_overrides.pop(get_audit_service_for_user, None)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Chat_NEW/integration/test_moderation.py
+++ b/tldw_Server_API/tests/Chat_NEW/integration/test_moderation.py
@@ -22,6 +22,21 @@ app = FastAPI()
 app.include_router(health_router, prefix="/api/v1")
 app.include_router(chat_router, prefix="/api/v1/chat")
 
+
+def _assert_mandatory_audit_detail(detail: dict[str, Any]) -> None:
+    assert detail == {
+        "error_code": "mandatory_audit_unavailable",
+        "message": "Mandatory audit persistence is currently unavailable",
+    }
+
+
+def _cleanup_db_artifacts(db_path: str) -> None:
+    os.unlink(db_path)
+    if os.path.exists(db_path + "-wal"):
+        os.unlink(db_path + "-wal")
+    if os.path.exists(db_path + "-shm"):
+        os.unlink(db_path + "-shm")
+
 def _make_test_db():
 
     with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as tmp:
@@ -205,9 +220,7 @@ def test_input_block_returns_400(monkeypatch):
                 assert "violates" in r.json().get("detail", "").lower()
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
@@ -234,13 +247,11 @@ def test_input_block_fails_closed_when_mandatory_audit_fails():
                 }
                 r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
                 assert r.status_code == 503
-                assert "mandatory audit persistence unavailable" in r.json().get("detail", "").lower()
+                _assert_mandatory_audit_detail(r.json().get("detail", {}))
                 assert not mock_provider.called
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
@@ -268,13 +279,11 @@ def test_input_block_fails_closed_when_audit_service_missing():
                 }
                 r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
                 assert r.status_code == 503
-                assert "mandatory audit persistence unavailable" in r.json().get("detail", "").lower()
+                _assert_mandatory_audit_detail(r.json().get("detail", {}))
                 assert not mock_provider.called
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
@@ -317,9 +326,7 @@ def test_output_redaction_non_streaming(monkeypatch):
                 assert got == "this has [REDACTED] token"
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
@@ -356,12 +363,51 @@ def test_output_redaction_non_streaming_fails_closed_when_mandatory_audit_fails(
                 }
                 r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
                 assert r.status_code == 503
-                assert "mandatory audit persistence unavailable" in r.json().get("detail", "").lower()
+                _assert_mandatory_audit_detail(r.json().get("detail", {}))
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
+        except Exception:
+            _ = None
+        app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        app.dependency_overrides.pop(get_audit_service_for_user, None)
+
+
+@pytest.mark.unit
+def test_output_block_non_streaming_fails_closed_when_mandatory_audit_fails():
+    db, db_path = _make_test_db()
+    try:
+        app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+        app.dependency_overrides[get_audit_service_for_user] = _failing_audit_service_override
+        policy = _StubPolicy(enabled=True, input_action='warn', output_action='block')
+
+        reply = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-4o-mini",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "this has secret token"}, "finish_reason": "stop"}
+            ]
+        }
+
+        with patch("tldw_Server_API.app.api.v1.endpoints.chat.get_moderation_service", return_value=_StubModerationService(policy)), \
+             patch("tldw_Server_API.app.api.v1.endpoints.chat.perform_chat_api_call", return_value=reply):
+            with TestClient(app) as client:
+                resp = client.get("/api/v1/health")
+                client.csrf_token = resp.cookies.get("csrf_token", "")
+                body = {
+                    "api_provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "stream": False,
+                }
+                r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
+                assert r.status_code == 503
+                _assert_mandatory_audit_detail(r.json().get("detail", {}))
+    finally:
+        try:
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
@@ -422,9 +468,7 @@ def test_streaming_redaction_applied():
                 assert "[REDACTED]" in full
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
@@ -491,9 +535,7 @@ def test_streaming_cross_chunk_redaction_output(monkeypatch):
                 assert "[REDACTED]" in full
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
@@ -535,12 +577,50 @@ def test_streaming_block_emits_sse_error_and_finishes():
                 assert saw_done, "Expected [DONE] marker for graceful finish"
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)
+
+
+@pytest.mark.unit
+def test_streaming_block_emits_audit_failure_when_mandatory_audit_fails(monkeypatch):
+    db, db_path = _make_test_db()
+    try:
+        monkeypatch.setenv("STREAMS_UNIFIED", "0")
+        app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+        app.dependency_overrides[get_audit_service_for_user] = _failing_audit_service_override
+        policy = _StubPolicy(enabled=True, input_action='warn', output_action='block', redact='[REDACTED]')
+
+        def upstream_stream():
+            chunk1 = {"choices": [{"delta": {"content": "this contains secret"}}]}
+            chunk2 = {"choices": [{"delta": {"content": " should be blocked"}}]}
+            yield f"data: {json.dumps(chunk1)}\n\n"
+            yield f"data: {json.dumps(chunk2)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        with patch("tldw_Server_API.app.api.v1.endpoints.chat.get_moderation_service", return_value=_StubModerationService(policy)), \
+             patch("tldw_Server_API.app.api.v1.endpoints.chat.perform_chat_api_call", return_value=upstream_stream()):
+            with TestClient(app) as client:
+                resp = client.get("/api/v1/health")
+                client.csrf_token = resp.cookies.get("csrf_token", "")
+                body = {
+                    "api_provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                }
+                r = _post_with_csrf(client, "/api/v1/chat/completions", json=body, headers=_auth_headers(client))
+                assert r.status_code == 200
+                assert "audit_persistence_failure" in r.text
+                assert "[DONE]" in r.text
+    finally:
+        try:
+            _cleanup_db_artifacts(db_path)
+        except Exception:
+            _ = None
+        app.dependency_overrides.pop(get_chacha_db_for_user, None)
+        app.dependency_overrides.pop(get_audit_service_for_user, None)
 
 
 @pytest.mark.unit
@@ -592,9 +672,7 @@ def test_streaming_redaction_emits_audit_failure_and_fails_closed(monkeypatch):
                 assert stream_end_payload["success"] is False
     finally:
         try:
-            os.unlink(db_path)
-            if os.path.exists(db_path + "-wal"): os.unlink(db_path + "-wal")
-            if os.path.exists(db_path + "-shm"): os.unlink(db_path + "-shm")
+            _cleanup_db_artifacts(db_path)
         except Exception:
             _ = None
         app.dependency_overrides.pop(get_chacha_db_for_user, None)

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_audit_adapter.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_audit_adapter.py
@@ -6,8 +6,9 @@ from tldw_Server_API.app.core.Audit.unified_audit_service import AuditEventType,
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 import tldw_Server_API.app.core.Evaluations.audit_adapter as eval_adapter
 from tldw_Server_API.app.core.Evaluations.audit_adapter import (
+    MandatoryAuditWriteError,
     log_evaluation_created,
-    log_evaluation_created_async,
+    log_run_started_async,
     _in_test_mode,
     _parse_cache_size,
     shutdown_evaluations_audit_services,
@@ -51,19 +52,22 @@ async def test_evaluation_created_threadpool_fallback(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_evaluation_adapter_propagates_failures(monkeypatch):
+async def test_evaluation_adapter_wraps_mandatory_failures(monkeypatch):
     async def _boom(_user_id):
         raise RuntimeError("audit boom")
 
     monkeypatch.setattr(eval_adapter, "get_or_create_audit_service_for_user_id_optional", _boom)
 
-    with pytest.raises(RuntimeError):
-        await log_evaluation_created_async(
+    with pytest.raises(MandatoryAuditWriteError) as exc_info:
+        await log_run_started_async(
             user_id="user-x",
             eval_id="eval-fail",
-            name="Failing Eval",
-            eval_type="unit",
+            run_id="run-fail",
+            target_model="unit",
         )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "audit boom" in str(exc_info.value.__cause__)
 
 
 def test_evaluations_local_shutdown_helper_stops_loop(monkeypatch):

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_crud_create_run_api.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_crud_create_run_api.py
@@ -4,6 +4,8 @@ from typing import Tuple
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.core.Evaluations.audit_adapter import MandatoryAuditWriteError
+
 
 @pytest.fixture()
 def evals_crud_client() -> Tuple[TestClient, dict]:
@@ -77,3 +79,28 @@ def test_create_run_forbids_extra_keys(evals_crud_client, monkeypatch):
     r = client.post("/api/v1/evaluations/e1/runs", json=payload, headers=headers)
     # Pydantic extra='forbid' should 422 on extra keys
     assert r.status_code == 422
+
+
+@pytest.mark.integration
+def test_create_run_returns_503_on_mandatory_audit_failure(evals_crud_client, monkeypatch):
+    client, headers = evals_crud_client
+
+    class _SvcStub:
+        async def create_run(self, *args, **kwargs):
+            raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    import tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_crud as crud
+
+    monkeypatch.setattr(crud, "get_unified_evaluation_service_for_user", lambda uid: _SvcStub())
+
+    response = client.post(
+        "/api/v1/evaluations/eval_abc/runs",
+        json={"target_model": "gpt-4o-mini"},
+        headers=headers,
+    )
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["detail"]["error"]["message"] == "Mandatory audit persistence unavailable"
+    assert body["detail"]["error"]["type"] == "service_unavailable"
+    assert body["detail"]["error"]["code"] == "audit_persistence_failure"

--- a/tldw_Server_API/tests/Evaluations/test_unified_evaluation_service_strict_audit.py
+++ b/tldw_Server_API/tests/Evaluations/test_unified_evaluation_service_strict_audit.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tldw_Server_API.app.core.Evaluations import unified_evaluation_service as eval_service
+from tldw_Server_API.app.core.Evaluations.audit_adapter import MandatoryAuditWriteError
+from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import UnifiedEvaluationService
+
+
+@pytest.mark.asyncio
+async def test_create_run_leaves_no_row_webhook_or_async_task_when_mandatory_audit_fails(tmp_path, monkeypatch):
+    service = UnifiedEvaluationService(
+        db_path=str(tmp_path / "evaluations.db"),
+        enable_webhooks=True,
+    )
+    await service.initialize()
+    try:
+        service.db.create_evaluation(
+            name="Strict Eval",
+            eval_type="exact_match",
+            eval_spec={"metrics": ["exact_match"]},
+            created_by="17",
+            eval_id="eval_1",
+        )
+
+        service.webhook_manager = SimpleNamespace(send_webhook=AsyncMock())
+
+        def _unexpected_create_run(*_args, **_kwargs):
+            raise AssertionError("db.create_run should not be called when mandatory audit fails")
+
+        monkeypatch.setattr(service.db, "create_run", _unexpected_create_run)
+
+        def _unexpected_create_task(*_args, **_kwargs):
+            raise AssertionError("asyncio.create_task should not be called when mandatory audit fails")
+
+        monkeypatch.setattr(eval_service.asyncio, "create_task", _unexpected_create_task)
+
+        async def _boom(*_args, **_kwargs):
+            raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+        monkeypatch.setattr(eval_service, "log_run_started_async", _boom)
+
+        with pytest.raises(MandatoryAuditWriteError) as exc_info:
+            await service.create_run(
+                eval_id="eval_1",
+                target_model="gpt-4o-mini",
+                config={"temperature": 0.0},
+                webhook_url="https://example.com/hook",
+                created_by="17",
+                webhook_user_id="29",
+            )
+
+        assert "Mandatory audit persistence unavailable" in str(exc_info.value)
+        assert service.db.list_runs(eval_id="eval_1", created_by="17") == []
+        service.webhook_manager.send_webhook.assert_not_awaited()
+    finally:
+        await service.shutdown()

--- a/tldw_Server_API/tests/Jobs/test_jobs_fault_injection_sqlite.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_fault_injection_sqlite.py
@@ -15,6 +15,47 @@ def _parse_sqlite_ts(s: str) -> datetime:
         return datetime.fromisoformat(s)
 
 
+class _FailJobEventsInsertConnection:
+    def __init__(self, inner: sqlite3.Connection):
+        self._inner = inner
+
+    def __enter__(self):
+        self._inner.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return self._inner.__exit__(exc_type, exc, tb)
+
+    def execute(self, sql: str, params=()):
+        if "INSERT INTO job_events" in str(sql):
+            raise sqlite3.OperationalError("forced job_events insert failure")
+        return self._inner.execute(sql, params)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def _count_jobs(db_path, domain: str, queue: str, job_type: str) -> int:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM jobs WHERE domain = ? AND queue = ? AND job_type = ?",
+            (domain, queue, job_type),
+        ).fetchone()
+    return int(row[0] if row else 0)
+
+
+def _count_job_created_events(db_path, domain: str, queue: str, job_type: str) -> int:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            (
+                "SELECT COUNT(*) FROM job_events "
+                "WHERE domain = ? AND queue = ? AND job_type = ? AND event_type = 'job.created'"
+            ),
+            (domain, queue, job_type),
+        ).fetchone()
+    return int(row[0] if row else 0)
+
+
 def test_acquire_with_transient_db_timeout_then_retry_sqlite(monkeypatch, tmp_path):
 
 
@@ -99,3 +140,147 @@ def test_renew_with_clock_skew_does_not_shrink_lease_sqlite(monkeypatch, tmp_pat
     row2 = jm.get_job(int(acq["id"]))
     after = _parse_sqlite_ts(row2["leased_until"]) if isinstance(row2["leased_until"], str) else row2["leased_until"]
     assert after >= before
+
+
+@pytest.mark.parametrize("idempotency_key", [None, "idem-k"])
+def test_create_rolls_back_when_job_created_event_insert_fails_sqlite(tmp_path, idempotency_key):
+    db_path = tmp_path / "jobs_create_fail.db"
+    ensure_jobs_tables(db_path)
+    jm = JobManager(db_path)
+
+    orig_connect = jm._connect
+    jm._connect = lambda: _FailJobEventsInsertConnection(orig_connect())  # type: ignore[method-assign]
+
+    with pytest.raises(sqlite3.OperationalError, match="job_events insert failure"):
+        jm.create_job(
+            domain="ps",
+            queue="default",
+            job_type="event-fail",
+            payload={"x": 1},
+            owner_user_id="u",
+            idempotency_key=idempotency_key,
+        )
+
+    if _count_jobs(db_path, "ps", "default", "event-fail") != 0:
+        raise AssertionError("create_job should not commit a new row when job.created event insert fails")
+
+
+def test_idempotent_existing_create_fails_when_job_created_event_insert_fails_sqlite(tmp_path):
+    db_path = tmp_path / "jobs_create_fail_existing.db"
+    ensure_jobs_tables(db_path)
+    jm = JobManager(db_path)
+
+    first = jm.create_job(
+        domain="ps",
+        queue="default",
+        job_type="event-fail-existing",
+        payload={"x": 1},
+        owner_user_id="u",
+        idempotency_key="stable-key",
+    )
+    if not first.get("id"):
+        raise AssertionError("expected first idempotent create call to return a persisted job id")
+    if _count_jobs(db_path, "ps", "default", "event-fail-existing") != 1:
+        raise AssertionError("expected exactly one persisted row after initial idempotent create")
+
+    orig_connect = jm._connect
+    jm._connect = lambda: _FailJobEventsInsertConnection(orig_connect())  # type: ignore[method-assign]
+
+    with pytest.raises(sqlite3.OperationalError, match="job_events insert failure"):
+        jm.create_job(
+            domain="ps",
+            queue="default",
+            job_type="event-fail-existing",
+            payload={"x": 2},
+            owner_user_id="u",
+            idempotency_key="stable-key",
+        )
+
+    if _count_jobs(db_path, "ps", "default", "event-fail-existing") != 1:
+        raise AssertionError("failing idempotent create-existing call must not add a new job row")
+
+
+def test_create_failure_does_not_increment_created_metric_sqlite(monkeypatch, tmp_path):
+    import tldw_Server_API.app.core.Jobs.manager as mgr
+
+    calls = {"n": 0}
+
+    def _inc(_labels):
+        calls["n"] += 1
+
+    monkeypatch.setattr(mgr, "increment_created", _inc)
+
+    db_path = tmp_path / "jobs_create_fail_metrics.db"
+    ensure_jobs_tables(db_path)
+    jm = JobManager(db_path)
+
+    orig_connect = jm._connect
+    jm._connect = lambda: _FailJobEventsInsertConnection(orig_connect())  # type: ignore[method-assign]
+
+    with pytest.raises(sqlite3.OperationalError, match="job_events insert failure"):
+        jm.create_job(
+            domain="ps",
+            queue="default",
+            job_type="event-fail-metrics",
+            payload={"x": 1},
+            owner_user_id="u",
+        )
+
+    if calls["n"] != 0:
+        raise AssertionError("increment_created must not be called when create rolls back due to job_events failure")
+
+
+@pytest.mark.parametrize(
+    ("outbox_enabled", "expected_emit_calls", "expected_direct_audit_calls"),
+    [
+        (False, 1, 0),
+        (True, 0, 1),
+    ],
+)
+def test_idempotent_create_uses_exactly_one_audit_bridge_path_sqlite(
+    monkeypatch,
+    tmp_path,
+    outbox_enabled,
+    expected_emit_calls,
+    expected_direct_audit_calls,
+):
+    import tldw_Server_API.app.core.Jobs.manager as mgr
+
+    monkeypatch.setenv("JOBS_EVENTS_OUTBOX", "true" if outbox_enabled else "false")
+    calls = {"emit_n": 0, "audit_n": 0}
+
+    def _emit(_event_type, **_kwargs):
+        calls["emit_n"] += 1
+
+    def _audit(_event_type, **_kwargs):
+        calls["audit_n"] += 1
+
+    monkeypatch.setattr(mgr, "emit_job_event", _emit)
+    monkeypatch.setattr(mgr, "submit_job_audit_event", _audit)
+
+    mode = "outbox" if outbox_enabled else "non_outbox"
+    db_path = tmp_path / f"jobs_create_idem_{mode}.db"
+    ensure_jobs_tables(db_path)
+    jm = JobManager(db_path)
+
+    created = jm.create_job(
+        domain="ps",
+        queue="default",
+        job_type=f"event-idem-{mode}",
+        payload={"x": 1},
+        owner_user_id="u",
+        idempotency_key=f"stable-idem-{mode}",
+    )
+
+    if not created.get("id"):
+        raise AssertionError("expected idempotent create to return a job row")
+    if calls["emit_n"] != expected_emit_calls:
+        raise AssertionError(
+            f"expected emit_job_event calls={expected_emit_calls}, got {calls['emit_n']} for mode={mode}"
+        )
+    if calls["audit_n"] != expected_direct_audit_calls:
+        raise AssertionError(
+            f"expected direct submit_job_audit_event calls={expected_direct_audit_calls}, got {calls['audit_n']} for mode={mode}"
+        )
+    if _count_job_created_events(db_path, "ps", "default", f"event-idem-{mode}") != 1:
+        raise AssertionError("expected exactly one transactional job.created record for idempotent create")

--- a/tldw_Server_API/tests/Jobs/test_jobs_manager_pg_fakes_extended.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_manager_pg_fakes_extended.py
@@ -12,6 +12,7 @@ class FakePGCursor:
         self._last = None
         self.rowcount = 0
         self._fetch_buffer = None
+        self.job_event_inserts = []
 
     def __enter__(self):
 
@@ -65,6 +66,9 @@ class FakePGCursor:
                     self._fetch_buffer = j
                     return
             self._fetch_buffer = None
+            return
+        if "INSERT INTO job_events(" in s:
+            self.job_event_inserts.append(tuple(params or ()))
             return
         # Count(*) aliases c
         if s.startswith("SELECT COUNT(*) AS c FROM jobs"):
@@ -178,6 +182,50 @@ def test_pg_create_job_idempotent_gates_created_metric(monkeypatch, tmp_path):
     d2 = jm.create_job(domain="pg", queue="default", job_type="x", payload={}, owner_user_id=None, idempotency_key="K")
     assert d2 and d2.get("status") == "queued"
     assert calls["n"] == 1
+
+
+@pytest.mark.unit
+def test_pg_idempotent_create_uses_current_request_context_for_job_created_event(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOBS_DB_URL", "postgresql://fake")
+    jm = JobManager(db_path=tmp_path / "dummy.db")
+    jm.backend = "postgres"
+
+    jobs = {
+        1: {
+            "id": 1,
+            "domain": "pg",
+            "queue": "default",
+            "job_type": "x",
+            "idempotency_key": "K",
+            "status": "queued",
+            "priority": 5,
+            "available_at": None,
+            "owner_user_id": "owner-1",
+            "request_id": "old-request",
+            "trace_id": "old-trace",
+            "retry_count": 0,
+        }
+    }
+    cursor = FakePGCursor(jobs)
+    monkeypatch.setattr(jm, "_connect", lambda: FakePGConn())
+    monkeypatch.setattr(jm, "_pg_cursor", lambda conn: cursor)
+
+    row = jm.create_job(
+        domain="pg",
+        queue="default",
+        job_type="x",
+        payload={},
+        owner_user_id=None,
+        idempotency_key="K",
+        request_id="new-request",
+        trace_id="new-trace",
+    )
+
+    assert row["id"] == 1
+    assert cursor.job_event_inserts
+    event_params = cursor.job_event_inserts[-1]
+    assert event_params[7] == "new-request"
+    assert event_params[8] == "new-trace"
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Jobs/test_jobs_manager_pg_fakes_extended.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_manager_pg_fakes_extended.py
@@ -185,6 +185,55 @@ def test_pg_create_job_idempotent_gates_created_metric(monkeypatch, tmp_path):
 
 
 @pytest.mark.unit
+def test_pg_create_job_logs_created_metric_failure_without_aborting(monkeypatch, tmp_path):
+    warnings: list[tuple] = []
+
+    class _LoggerStub:
+        def warning(self, *args, **kwargs):
+            warnings.append((args, kwargs))
+
+        def info(self, *args, **kwargs):
+            return None
+
+        def debug(self, *args, **kwargs):
+            return None
+
+        def error(self, *args, **kwargs):
+            return None
+
+    def _inc(_labels):
+        raise RuntimeError("metric backend offline")
+
+    monkeypatch.setenv("JOBS_DB_URL", "postgresql://fake")
+    jm = JobManager(db_path=tmp_path / "dummy.db")
+    jm.backend = "postgres"
+
+    import tldw_Server_API.app.core.Jobs.manager as mgr
+
+    monkeypatch.setattr(mgr, "increment_created", _inc)
+    monkeypatch.setattr(mgr, "logger", _LoggerStub())
+
+    jobs = {}
+    monkeypatch.setattr(jm, "_connect", lambda: FakePGConn())
+    monkeypatch.setattr(jm, "_pg_cursor", lambda conn: FakePGCursor(jobs))
+
+    row = jm.create_job(
+        domain="pg",
+        queue="default",
+        job_type="x",
+        payload={},
+        owner_user_id=None,
+        idempotency_key="K",
+    )
+
+    assert row and row.get("status") == "queued"
+    assert len(warnings) == 1
+    assert warnings[0][0][0] == "Non-critical jobs created metric update failed for {}:{}:{}: {}"
+    assert warnings[0][0][1:4] == ("pg", "default", "x")
+    assert str(warnings[0][0][4]) == "metric backend offline"
+
+
+@pytest.mark.unit
 def test_pg_idempotent_create_uses_current_request_context_for_job_created_event(monkeypatch, tmp_path):
     monkeypatch.setenv("JOBS_DB_URL", "postgresql://fake")
     jm = JobManager(db_path=tmp_path / "dummy.db")

--- a/tldw_Server_API/tests/Jobs/test_jobs_manager_pg_fakes_extended.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_manager_pg_fakes_extended.py
@@ -114,6 +114,14 @@ class FakePGCursor:
         return []
 
 
+class FailingJobEventsPGCursor(FakePGCursor):
+    def execute(self, sql, params=None):
+        s = str(sql)
+        if "INSERT INTO job_events(" in s:
+            raise RuntimeError("forced job_events insert failure")
+        return super().execute(sql, params)
+
+
 class FakePGConn:
     def __init__(self):
         pass
@@ -201,3 +209,37 @@ def test_pg_batch_complete_encrypts_results(monkeypatch, tmp_path):
     r2 = jobs[2].get("result_json")
     assert isinstance(r1, dict) and "_encrypted" in r1
     assert isinstance(r2, dict) and "_encrypted" in r2
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("idempotency_key", [None, "K"])
+def test_pg_create_failure_on_job_events_insert_does_not_increment_created(monkeypatch, tmp_path, idempotency_key):
+    calls = {"n": 0}
+
+    def _inc(_labels):
+        calls["n"] += 1
+
+    monkeypatch.setenv("JOBS_DB_URL", "postgresql://fake")
+    jm = JobManager(db_path=tmp_path / "dummy.db")
+    jm.backend = "postgres"
+
+    import tldw_Server_API.app.core.Jobs.manager as mgr
+
+    monkeypatch.setattr(mgr, "increment_created", _inc)
+
+    jobs = {}
+    monkeypatch.setattr(jm, "_connect", lambda: FakePGConn())
+    monkeypatch.setattr(jm, "_pg_cursor", lambda conn: FailingJobEventsPGCursor(jobs))
+
+    with pytest.raises(RuntimeError, match="job_events insert failure"):
+        jm.create_job(
+            domain="pg",
+            queue="default",
+            job_type="x",
+            payload={},
+            owner_user_id=None,
+            idempotency_key=idempotency_key,
+        )
+
+    if calls["n"] != 0:
+        raise AssertionError("increment_created must not be called when create fails at job_events insert")

--- a/tldw_Server_API/tests/Services/test_admin_api_keys_service_backend_selection.py
+++ b/tldw_Server_API/tests/Services/test_admin_api_keys_service_backend_selection.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 import pytest
+from fastapi import HTTPException
 
-from tldw_Server_API.app.api.v1.schemas.api_key_schemas import APIKeyUpdateRequest
+from tldw_Server_API.app.api.v1.schemas.api_key_schemas import (
+    APIKeyCreateRequest,
+    APIKeyRotateRequest,
+    APIKeyUpdateRequest,
+)
+from tldw_Server_API.app.api.v1.schemas.org_team_schemas import VirtualKeyCreateRequest
+from tldw_Server_API.app.core.Audit.unified_audit_service import MandatoryAuditWriteError
 from tldw_Server_API.app.services import admin_api_keys_service as svc
 
 
@@ -60,3 +67,175 @@ async def test_update_user_api_key_passes_backend_mode_to_admin_service(
         "rate_limit": 55,
         "allowed_ips": ["10.1.1.1"],
     }
+
+
+class _FailingAdminAPIKeyManager:
+    async def create_api_key(self, **_kwargs):
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    async def rotate_api_key(self, **_kwargs):
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    async def revoke_api_key(self, **_kwargs):
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+    async def create_virtual_key(self, **_kwargs):
+        raise MandatoryAuditWriteError("Mandatory audit persistence unavailable")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_create_user_api_key_returns_503_on_mandatory_audit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_enforce_admin_user_scope(*_args, **_kwargs):
+        return None
+
+    async def _fake_get_mgr():
+        return _FailingAdminAPIKeyManager()
+
+    monkeypatch.setattr(svc.admin_scope_service, "enforce_admin_user_scope", _fake_enforce_admin_user_scope)
+    monkeypatch.setattr(svc, "get_api_key_manager", _fake_get_mgr)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.create_user_api_key(
+            principal=object(),
+            user_id=22,
+            request=APIKeyCreateRequest(name="admin-key", scope="read"),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_rotate_user_api_key_returns_503_on_mandatory_audit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_enforce_admin_user_scope(*_args, **_kwargs):
+        return None
+
+    async def _fake_get_mgr():
+        return _FailingAdminAPIKeyManager()
+
+    monkeypatch.setattr(svc.admin_scope_service, "enforce_admin_user_scope", _fake_enforce_admin_user_scope)
+    monkeypatch.setattr(svc, "get_api_key_manager", _fake_get_mgr)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.rotate_user_api_key(
+            principal=object(),
+            user_id=22,
+            key_id=345,
+            request=APIKeyRotateRequest(expires_in_days=90),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_create_user_api_key_passes_actor_metadata_to_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _CapturingAdminAPIKeyManager:
+        async def create_api_key(self, **kwargs):
+            captured.update(kwargs)
+            return {
+                "id": 44,
+                "key": "tldw_test_key",
+                "key_prefix": "tldw_test...",
+                "name": "actor-key",
+                "scope": "read",
+                "expires_at": None,
+                "created_at": "2026-04-09T00:00:00+00:00",
+                "message": "ok",
+            }
+
+    async def _fake_enforce_admin_user_scope(*_args, **_kwargs):
+        return None
+
+    async def _fake_get_mgr():
+        return _CapturingAdminAPIKeyManager()
+
+    principal = svc.AuthPrincipal(
+        kind="user",
+        user_id=999,
+        api_key_id=None,
+        subject="admin-subject",
+        token_type="access",
+        jti=None,
+        roles=["admin"],
+        permissions=[],
+        is_admin=True,
+        org_ids=[],
+        team_ids=[],
+    )
+
+    monkeypatch.setattr(svc.admin_scope_service, "enforce_admin_user_scope", _fake_enforce_admin_user_scope)
+    monkeypatch.setattr(svc, "get_api_key_manager", _fake_get_mgr)
+
+    await svc.create_user_api_key(
+        principal=principal,
+        user_id=22,
+        request=APIKeyCreateRequest(name="actor-key", scope="read"),
+    )
+
+    assert captured["user_id"] == 22
+    assert captured["actor_user_id"] == 999
+    assert captured["actor_subject"] == "admin-subject"
+    assert captured["actor_kind"] == "user"
+    assert captured["actor_roles"] == ["admin"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_revoke_user_api_key_returns_503_on_mandatory_audit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_enforce_admin_user_scope(*_args, **_kwargs):
+        return None
+
+    async def _fake_get_mgr():
+        return _FailingAdminAPIKeyManager()
+
+    monkeypatch.setattr(svc.admin_scope_service, "enforce_admin_user_scope", _fake_enforce_admin_user_scope)
+    monkeypatch.setattr(svc, "get_api_key_manager", _fake_get_mgr)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.revoke_user_api_key(
+            principal=object(),
+            user_id=22,
+            key_id=345,
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_create_virtual_key_returns_503_on_mandatory_audit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_enforce_admin_user_scope(*_args, **_kwargs):
+        return None
+
+    async def _fake_get_mgr():
+        return _FailingAdminAPIKeyManager()
+
+    monkeypatch.setattr(svc.admin_scope_service, "enforce_admin_user_scope", _fake_enforce_admin_user_scope)
+    monkeypatch.setattr(svc, "get_api_key_manager", _fake_get_mgr)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await svc.create_virtual_key(
+            principal=object(),
+            user_id=22,
+            payload=VirtualKeyCreateRequest(name="vkey"),
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Mandatory audit persistence unavailable"

--- a/tldw_Server_API/tests/Sharing/test_share_audit_unified_migration.py
+++ b/tldw_Server_API/tests/Sharing/test_share_audit_unified_migration.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import pytest
 
+from tldw_Server_API.app.core.exceptions import ValidationError
+
 pytestmark = pytest.mark.unit
 
 
@@ -66,7 +68,7 @@ async def test_share_audit_backfill_is_idempotent(repo, sharing_db, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_share_audit_legacy_import_replay_is_skipped(repo, tmp_path):
+async def test_share_audit_legacy_import_replay_is_skipped(tmp_path):
     from tldw_Server_API.app.core.Sharing.unified_share_audit import UnifiedShareAuditWriter
 
     shared_audit_path = tmp_path / "audit_shared.db"
@@ -102,6 +104,35 @@ async def test_share_audit_legacy_import_replay_is_skipped(repo, tmp_path):
     assert inserted_id == 7
     assert replay_id is None
     assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_share_audit_legacy_import_uses_validation_errors(tmp_path):
+    from tldw_Server_API.app.core.Sharing.unified_share_audit import UnifiedShareAuditWriter
+
+    shared_audit_path = tmp_path / "audit_shared.db"
+    writer = UnifiedShareAuditWriter(db_path=str(shared_audit_path))
+    await writer.initialize()
+    try:
+        with pytest.raises(ValidationError, match="must match"):
+            await writer.import_legacy_event(
+                legacy_share_audit_id=7,
+                legacy_audit_id=8,
+                event_type="share.created",
+                resource_type="workspace",
+                resource_id="ws-1",
+                owner_user_id=1,
+            )
+
+        with pytest.raises(ValidationError, match="required"):
+            await writer.import_legacy_event(
+                event_type="share.created",
+                resource_type="workspace",
+                resource_id="ws-1",
+                owner_user_id=1,
+            )
+    finally:
+        await writer.stop()
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Sharing/test_share_audit_unified_migration.py
+++ b/tldw_Server_API/tests/Sharing/test_share_audit_unified_migration.py
@@ -59,8 +59,49 @@ async def test_share_audit_backfill_is_idempotent(repo, sharing_db, tmp_path):
     assert report1.max_legacy_id == legacy_id
     assert report2.inserted == 0
     assert compatibility_ids == [legacy_id]
+    assert rows[0]["event_id"] == f"share-audit-legacy-{legacy_id}"
     assert rows[0]["created_at"] == legacy_created_at
+    assert rows[0]["metadata"]["legacy_share_audit_id"] == legacy_id
     assert sorted(row["id"] for row in after_rows) == [legacy_id, legacy_id + 1]
+
+
+@pytest.mark.asyncio
+async def test_share_audit_legacy_import_replay_is_skipped(repo, tmp_path):
+    from tldw_Server_API.app.core.Sharing.unified_share_audit import UnifiedShareAuditWriter
+
+    shared_audit_path = tmp_path / "audit_shared.db"
+    writer = UnifiedShareAuditWriter(db_path=str(shared_audit_path))
+    await writer.initialize()
+    try:
+        inserted_id = await writer.import_legacy_event(
+            legacy_share_audit_id=7,
+            event_type="share.created",
+            resource_type="workspace",
+            resource_id="ws-1",
+            owner_user_id=1,
+            actor_user_id=2,
+            share_id=5,
+            metadata={"scope_type": "team"},
+            created_at="2026-04-09T19:00:00+00:00",
+        )
+        replay_id = await writer.import_legacy_event(
+            legacy_share_audit_id=7,
+            event_type="share.created",
+            resource_type="workspace",
+            resource_id="ws-1",
+            owner_user_id=1,
+            actor_user_id=2,
+            share_id=5,
+            metadata={"scope_type": "team"},
+            created_at="2026-04-09T19:00:00+00:00",
+        )
+        rows = await writer.query_events(owner_user_id=1)
+    finally:
+        await writer.stop()
+
+    assert inserted_id == 7
+    assert replay_id is None
+    assert len(rows) == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/conftest.py
+++ b/tldw_Server_API/tests/conftest.py
@@ -605,7 +605,7 @@ def pytest_sessionfinish(session, exitstatus):  # pragma: no cover - diagnostics
 
         try:
             from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import shutdown_all_audit_services
-            _run_coro_sync_best_effort(shutdown_all_audit_services())
+            _run_coro_sync_best_effort(shutdown_all_audit_services(raise_on_error=False))
         except Exception:
             _ = None
         try:


### PR DESCRIPTION
## Summary
- harden unified audit shutdown durability, fallback replay, shared migration accounting, and sharing legacy import handling
- enforce fail-closed audit behavior for evaluations, chat moderation, jobs create intent, and AuthNZ API-key management flows
- document the stricter audit contract and add regression coverage across Audit, AuthNZ, Chat, Evaluations, Jobs, and Sharing

## Test Plan
- [x] source ../../.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Audit tldw_Server_API/tests/Services/test_admin_api_keys_service_backend_selection.py tldw_Server_API/tests/AuthNZ/unit/test_api_key_audit.py tldw_Server_API/tests/AuthNZ/integration/test_api_key_rotation_audit.py tldw_Server_API/tests/AuthNZ/unit/test_user_api_key_endpoints.py tldw_Server_API/tests/AuthNZ/unit/test_auth_register_strict_audit.py
- [x] source ../../.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat_NEW/integration/test_moderation.py
- [x] source ../../.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Evaluations/test_evaluations_audit_adapter.py tldw_Server_API/tests/Evaluations/test_evaluations_crud_create_run_api.py tldw_Server_API/tests/Evaluations/test_unified_evaluation_service_strict_audit.py
- [x] source ../../.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Jobs/test_jobs_fault_injection_sqlite.py tldw_Server_API/tests/Jobs/test_jobs_manager_pg_fakes_extended.py tldw_Server_API/tests/Sharing/test_share_audit_unified_migration.py
- [x] source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/users.py tldw_Server_API/app/core/AuthNZ/api_key_audit.py tldw_Server_API/app/core/AuthNZ/api_key_manager.py tldw_Server_API/app/core/AuthNZ/repos/api_keys_repo.py tldw_Server_API/app/services/admin_api_keys_service.py -f json -o /tmp/bandit_audit_strict_authnz.json

## Notes
- Residual risk left intentionally out of scope: /auth/register can still create the user before a default API-key mandatory-audit failure turns into a 503; fixing that cleanly needs a broader registration transaction redesign.
