### PR TITLE
fix(persona): harden archetype loader against malformed YAML

### DIFF
--- a/tldw_Server_API/app/core/Persona/archetype_loader.py
+++ b/tldw_Server_API/app/core/Persona/archetype_loader.py
@@ -6,6 +6,7 @@ Pydantic, and caches them in memory for fast access by API endpoints.
 """
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from threading import RLock
 
@@ -66,7 +67,14 @@ def load_archetypes_from_directory(
                     "Skipping {}: missing top-level 'archetype' key", yaml_file.name
                 )
                 continue
-            template = ArchetypeTemplate(**data["archetype"])
+            archetype_data = data["archetype"]
+            if not isinstance(archetype_data, Mapping):
+                logger.warning(
+                    "Skipping {}: top-level 'archetype' value must be a mapping",
+                    yaml_file.name,
+                )
+                continue
+            template = ArchetypeTemplate(**archetype_data)
             new_cache[template.key] = template
             logger.debug("Loaded archetype '{}' from {}", template.key, yaml_file.name)
         except (OSError, ValidationError, yaml.YAMLError):

--- a/tldw_Server_API/app/core/Persona/archetype_loader.py
+++ b/tldw_Server_API/app/core/Persona/archetype_loader.py
@@ -74,7 +74,7 @@ def load_archetypes_from_directory(
                     yaml_file.name,
                 )
                 continue
-            template = ArchetypeTemplate(**archetype_data)
+            template = ArchetypeTemplate.model_validate(archetype_data)
             new_cache[template.key] = template
             logger.debug("Loaded archetype '{}' from {}", template.key, yaml_file.name)
         except (OSError, ValidationError, yaml.YAMLError):

--- a/tldw_Server_API/tests/unit/test_archetype_loader.py
+++ b/tldw_Server_API/tests/unit/test_archetype_loader.py
@@ -105,6 +105,15 @@ class TestLoadArchetypesFromDirectory:
 
         assert len(result) == 0
 
+    def test_yaml_with_non_mapping_archetype_value_skipped(self, tmp_path: Path):
+        (tmp_path / "good.yaml").write_text(_VALID_YAML, encoding="utf-8")
+        (tmp_path / "bad.yaml").write_text("archetype:\n  - not-a-mapping\n", encoding="utf-8")
+
+        result = archetype_loader.load_archetypes_from_directory(tmp_path)
+
+        assert len(result) == 1
+        assert "researcher" in result
+
     def test_empty_directory(self, tmp_path: Path):
         result = archetype_loader.load_archetypes_from_directory(tmp_path)
 

--- a/tldw_Server_API/tests/unit/test_archetype_loader.py
+++ b/tldw_Server_API/tests/unit/test_archetype_loader.py
@@ -114,6 +114,15 @@ class TestLoadArchetypesFromDirectory:
         assert len(result) == 1
         assert "researcher" in result
 
+    def test_yaml_with_non_string_archetype_keys_skipped(self, tmp_path: Path):
+        (tmp_path / "good.yaml").write_text(_VALID_YAML, encoding="utf-8")
+        (tmp_path / "bad.yaml").write_text("archetype:\n  1: bad\n", encoding="utf-8")
+
+        result = archetype_loader.load_archetypes_from_directory(tmp_path)
+
+        assert len(result) == 1
+        assert "researcher" in result
+
     def test_empty_directory(self, tmp_path: Path):
         result = archetype_loader.load_archetypes_from_directory(tmp_path)
 


### PR DESCRIPTION
## Summary
- carry the post-merge archetype loader fixes from `fix/knowledge-workspace-ux-audit-fixes` back to `dev`
- skip malformed top-level `archetype` values instead of raising during load
- validate archetype mappings via `model_validate` so non-string keys are handled through the existing validation-error path
- add regression coverage for malformed YAML cases

## Context
PR #1052 was already merged into `dev`.
PR #1062 was merged into `fix/knowledge-workspace-ux-audit-fixes` after that merge, so this PR brings those follow-up fixes back to `dev` from the original branch.

## Verification
- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/unit/test_archetype_loader.py -q`
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Persona/archetype_loader.py -f json -o /tmp/bandit_pr1062_qodo_followup.json`