### PR TITLE
feat: add study suggestion grounding normalization v2

### DIFF
--- a/Docs/superpowers/plans/2026-04-09-study-suggestions-grounding-normalization-v2-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-09-study-suggestions-grounding-normalization-v2-implementation-plan.md
@@ -1,0 +1,531 @@
+# Study Suggestions Grounding And Normalization V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement deterministic `StudySuggestions` grounding/normalization v2: namespaced `topic_key`s, safe persisted V2 snapshots, richer flashcard provenance/performance inputs, and stable dedupe/reopen behavior for quiz and flashcard follow-ups.
+
+**Architecture:** Keep the existing shared `StudySuggestions` backend domain, but split responsibilities more cleanly: adapters emit structured evidence, `topic_pipeline.py` owns canonicalization and ranking, `snapshot_service.py` orchestrates payload creation, and `actions.py` owns semantic duplicate identity plus refreshed-lineage reopen behavior. Extend `flashcard_review_sessions` with lightweight aggregates while treating `flashcard_reviews.review_session_id` rows as canonical, and preserve backward compatibility by layering V2 fields onto the current topic payload contract instead of replacing it.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite/PostgreSQL via `ChaChaNotes_DB`, pytest, Bandit, React, TanStack Query, Ant Design, Vitest
+
+---
+
+## Scope Lock
+
+Keep these decisions fixed during implementation:
+
+- deterministic only:
+  - no LLM enrichment
+  - no embeddings-based similarity
+- no global topic catalog table in this phase
+- `flashcard_reviews.review_session_id` is canonical when aggregates and reconstructed rollups disagree
+- persisted snapshot payloads stay deny-by-default and permission-safe
+- at most one active direct generation link exists per:
+  - `snapshot_id`
+  - `target_service`
+  - `target_type`
+  - `selection_fingerprint`
+- refreshed-lineage reuse stays read-only in phase 1:
+  - no persisted child alias rows in `suggestion_generation_links`
+- old snapshots and old label-based fingerprints must continue to work
+- UI changes stay minimal:
+  - compatibility mapping
+  - badge/copy improvements
+  - no new workflow
+
+## File Structure
+
+- `tldw_Server_API/app/core/StudySuggestions/types.py`
+  Purpose: add V2 topic dataclasses and internal action-resolution structures such as semantic-topic selection and richer evidence metadata.
+- `tldw_Server_API/app/core/StudySuggestions/topic_aliases.py`
+  Purpose: hold the deterministic alias dictionary, namespace rules, and `NORMALIZATION_VERSION` constant for V2 canonicalization.
+- `tldw_Server_API/app/core/StudySuggestions/topic_pipeline.py`
+  Purpose: refactor normalization into explicit V2 stages, emit namespaced `topic_key`s, and rank topics with stable evidence metadata.
+- `tldw_Server_API/app/core/StudySuggestions/quiz_adapter.py`
+  Purpose: emit structured quiz evidence inputs from citations, tags, and incorrect/correct question outcomes.
+- `tldw_Server_API/app/core/StudySuggestions/flashcard_adapter.py`
+  Purpose: emit flashcard evidence from persisted session aggregates, reconstructed review rollups, deck lineage, and citation/source metadata.
+- `tldw_Server_API/app/core/StudySuggestions/snapshot_service.py`
+  Purpose: orchestrate anchor reads, call adapters + pipeline, serialize V2 payloads, and keep legacy snapshot behavior intact.
+- `tldw_Server_API/app/core/StudySuggestions/actions.py`
+  Purpose: separate semantic identity from edited prompt text, enforce direct-link uniqueness, validate reopen targets, and walk refreshed snapshot ancestry.
+- `tldw_Server_API/app/api/v1/endpoints/study_suggestions.py`
+  Purpose: wire the updated action-preparation path and preserve the external request/response contract.
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+  Purpose: extend `flashcard_review_sessions`, update suggestion payload sanitization, tighten generation-link uniqueness, and add rollup/lineage helpers.
+- `tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py`
+  Purpose: lock persisted V2 payload round-trip, sanitizer behavior, generation-link uniqueness, and refreshed-lineage reopen storage behavior.
+- `tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py`
+  Purpose: verify aggregate writes, reconstruction fallback, and drift reconciliation for flashcard sessions.
+- `tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py`
+  Purpose: verify namespaced `topic_key` generation, normalization versioning, alias collapse, and namespace-collision protection.
+- `tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py`
+  Purpose: verify quiz and flashcard evidence extraction, provenance downgrade rules, and grounded/manual session classification.
+- `tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py`
+  Purpose: verify action dedupe, `force_regenerate`, stale-target rejection, and legacy snapshot compatibility.
+- `tldw_Server_API/tests/StudySuggestions/fixtures/flashcard_grounding_audit_cases.json`
+  Purpose: fixture-based audit cases for grounded vs exploratory flashcard sessions.
+- `apps/packages/ui/src/services/studySuggestions.ts`
+  Purpose: extend frontend topic types with optional V2 fields while preserving the current request contract.
+- `apps/packages/ui/src/components/StudySuggestions/hooks/useStudySuggestions.ts`
+  Purpose: keep action payload construction stable while accepting richer snapshot payloads.
+- `apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx`
+  Purpose: map V2 topic rows into the existing editor state, preserve snapshot-local IDs, and show minimal evidence-copy improvements.
+- `apps/packages/ui/src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx`
+  Purpose: verify the unchanged action request shape and response handling with richer snapshots.
+- `apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx`
+  Purpose: verify mixed legacy/V2 snapshots, topic-key-aware rendering, and no regression in manual-topic handling.
+
+## Task 1: Persist V2 Snapshot Fields Safely
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/app/core/StudySuggestions/types.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_study_suggestion_schemas.py`
+
+- [ ] **Step 1: Write the failing storage tests**
+
+Add assertions like:
+
+```python
+payload = {
+    "topics": [
+        {
+            "id": "topic-1",
+            "topic_key": "renal:renal-physiology",
+            "normalization_version": "norm-v2",
+            "display_label": "Renal Physiology",
+            "canonical_label": "renal physiology",
+            "evidence_reasons": ["missed_question"],
+        }
+    ]
+}
+```
+
+Verify that `create_suggestion_snapshot(...)` + `get_suggestion_snapshot(...)` preserves `topic_key`, `normalization_version`, and `evidence_reasons`, while still dropping unsafe text keys.
+
+- [ ] **Step 2: Run the targeted backend tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_schemas.py -v
+```
+
+- [ ] **Step 3: Implement the minimal persistence contract**
+
+Make these changes:
+
+- extend the safe suggestion-payload allowlist in `ChaChaNotes_DB.py`
+- keep the sanitizer deny-by-default for unknown keys
+- extend internal StudySuggestions types so V2 topic rows have explicit fields for:
+  - `topic_key`
+  - `normalization_version`
+  - `source_count`
+  - `evidence_reasons`
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_schemas.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/app/core/StudySuggestions/types.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_schemas.py
+git commit -m "feat: persist study suggestion v2 payload fields"
+```
+
+## Task 2: Add Flashcard Session Aggregates And Reconciliation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py`
+
+- [ ] **Step 1: Write the failing session-rollup tests**
+
+Cover:
+
+- `review_flashcard(...)` updates `cards_reviewed` and compatibility `correct_count`
+- legacy sessions without aggregate fields still reconstruct from `flashcard_reviews.review_session_id`
+- impossible aggregates such as `correct_count > cards_reviewed` fall back to reconstruction
+- reconciliation prefers reconstructed values and may repair the aggregate row
+
+Example assertion:
+
+```python
+rollup = db.get_flashcard_review_session_rollup(session_id)
+assert rollup["cards_reviewed"] == 3
+assert rollup["aggregate_source"] in {"session", "reconstructed"}
+```
+
+- [ ] **Step 2: Run the targeted backend tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py -v
+```
+
+- [ ] **Step 3: Implement aggregate writes and reconciliation helpers**
+
+Make these changes:
+
+- add `flashcard_review_sessions` columns for:
+  - `cards_reviewed`
+  - compatibility `correct_count`
+  - `source_bundle_json`
+  - optional `study_pack_id`
+- update `review_flashcard(...)` to write review rows and aggregate counters in the same transaction
+- add one DB helper that returns the merged rollup used by suggestions and encapsulates:
+  - primary aggregate read
+  - fallback reconstruction from `flashcard_reviews`
+  - aggregate repair when cached values drift
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py
+git commit -m "feat: add flashcard session rollups for study suggestions"
+```
+
+## Task 3: Build The V2 Topic Pipeline
+
+**Files:**
+- Create: `tldw_Server_API/app/core/StudySuggestions/topic_aliases.py`
+- Modify: `tldw_Server_API/app/core/StudySuggestions/types.py`
+- Modify: `tldw_Server_API/app/core/StudySuggestions/topic_pipeline.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py`
+
+- [ ] **Step 1: Write the failing normalization tests**
+
+Cover:
+
+- semantically equivalent labels collapse to one namespaced `topic_key`
+- different namespaces can reuse the same slug without collision
+- `normalization_version` is attached to every ranked topic
+- `display_label` drift does not alter semantic identity
+
+Example assertion:
+
+```python
+assert ranked[0].topic_key == "renal:renal-physiology"
+assert ranked[0].normalization_version == "norm-v2"
+```
+
+- [ ] **Step 2: Run the targeted backend tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py -v
+```
+
+- [ ] **Step 3: Implement the deterministic V2 pipeline**
+
+Make these changes:
+
+- move alias and namespace rules into `topic_aliases.py`
+- split `topic_pipeline.py` into explicit stages:
+  - clean label
+  - phrase/token normalization
+  - alias resolution
+  - canonical label selection
+  - namespace + `topic_key` generation
+  - evidence merge
+  - ranking
+- extend `RankedTopic`/`TopicCandidate` dataclasses with:
+  - `topic_key`
+  - `normalization_version`
+  - `source_count`
+  - `evidence_reasons`
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/StudySuggestions/topic_aliases.py \
+  tldw_Server_API/app/core/StudySuggestions/types.py \
+  tldw_Server_API/app/core/StudySuggestions/topic_pipeline.py \
+  tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py
+git commit -m "feat: add study suggestion topic normalization v2"
+```
+
+## Task 4: Refactor Adapters And Snapshot Serialization
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/StudySuggestions/quiz_adapter.py`
+- Modify: `tldw_Server_API/app/core/StudySuggestions/flashcard_adapter.py`
+- Modify: `tldw_Server_API/app/core/StudySuggestions/snapshot_service.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py`
+- Create: `tldw_Server_API/tests/StudySuggestions/fixtures/flashcard_grounding_audit_cases.json`
+
+- [ ] **Step 1: Write the failing adapter/snapshot tests**
+
+Cover:
+
+- quiz snapshots serialize `topic_key`, `normalization_version`, `canonical_label`, and `evidence_reasons`
+- flashcard snapshots consume merged session rollups rather than hardcoded zeros
+- grounded flashcard fixtures produce grounded or weakly grounded topics in the top 3
+- exploratory/manual fixtures do not produce falsely grounded topics
+
+- [ ] **Step 2: Run the targeted backend tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py -v
+```
+
+- [ ] **Step 3: Implement adapter-owned evidence extraction**
+
+Make these changes:
+
+- move quiz extraction details out of `snapshot_service.py` and into `quiz_adapter.py`
+- have `flashcard_adapter.py` consume the new merged session rollup and card/deck/study-pack provenance
+- update `snapshot_service.py` to serialize V2 topic rows while keeping legacy-safe snapshot shapes readable
+- keep frozen payloads lightweight:
+  - no excerpts
+  - no question text
+  - only allowlisted labels and light refs
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/StudySuggestions/quiz_adapter.py \
+  tldw_Server_API/app/core/StudySuggestions/flashcard_adapter.py \
+  tldw_Server_API/app/core/StudySuggestions/snapshot_service.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py \
+  tldw_Server_API/tests/StudySuggestions/fixtures/flashcard_grounding_audit_cases.json
+git commit -m "feat: serialize study suggestion snapshots with v2 grounding"
+```
+
+## Task 5: Rework Action Semantics And Refreshed-Lineage Reopen
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/StudySuggestions/actions.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/study_suggestions.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py`
+- Modify: `tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py`
+
+- [ ] **Step 1: Write the failing action/dedupe tests**
+
+Cover:
+
+- semantic identity is derived from selected snapshot rows and not from edited display labels
+- `force_regenerate` replaces the active direct link for a snapshot/fingerprint instead of leaving multiple active rows
+- refreshed child snapshots reopen validated ancestor artifacts
+- stale/deleted ancestor targets are ignored instead of reopening broken links
+
+Example assertion:
+
+```python
+assert response["disposition"] == "opened_existing"
+assert response["target_id"] == str(existing_quiz_id)
+```
+
+- [ ] **Step 2: Run the targeted backend tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py -v
+```
+
+- [ ] **Step 3: Implement the action-resolution changes**
+
+Make these changes:
+
+- split internal action resolution into:
+  - semantic keys used for fingerprints/dedupe
+  - prompt labels used for generation instructions
+- tighten DB uniqueness for active direct generation links so `target_id` is not part of the canonical duplicate identity
+- walk only the `refreshed_from_snapshot_id` ancestor chain for reopen lookup
+- validate target liveness before returning `opened_existing`
+- keep refreshed-lineage reuse read-only:
+  - do not write child alias rows in phase 1
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/StudySuggestions/actions.py \
+  tldw_Server_API/app/api/v1/endpoints/study_suggestions.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
+git commit -m "feat: stabilize study suggestion action dedupe semantics"
+```
+
+## Task 6: Update Frontend Compatibility For V2 Topics
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/studySuggestions.ts`
+- Modify: `apps/packages/ui/src/components/StudySuggestions/hooks/useStudySuggestions.ts`
+- Modify: `apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx`
+- Modify: `apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing frontend tests**
+
+Cover:
+
+- V2 snapshot topics with `topic_key`, `canonical_label`, and `evidence_reasons` still render through the current panel
+- legacy snapshot topics still work unchanged
+- action requests still submit `selected_topic_ids`, `selected_topic_edits`, and `manual_topic_labels`
+- edited labels remain user-visible without changing selection IDs
+
+- [ ] **Step 2: Run the targeted frontend tests to verify they fail**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui && bunx vitest run \
+  src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx \
+  src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+```
+
+- [ ] **Step 3: Implement the minimal compatibility pass**
+
+Make these changes:
+
+- extend `StudySuggestionSnapshotTopic` with optional V2 fields
+- keep request payload shape unchanged
+- map V2 topic rows into the existing `TopicBuilderTopic` model by preserving:
+  - snapshot-local `id`
+  - editable `display_label`
+  - optional provenance/evidence copy
+- do not add new UI workflow elements in this task
+
+- [ ] **Step 4: Re-run the targeted frontend tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui && bunx vitest run \
+  src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx \
+  src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  apps/packages/ui/src/services/studySuggestions.ts \
+  apps/packages/ui/src/components/StudySuggestions/hooks/useStudySuggestions.ts \
+  apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx \
+  apps/packages/ui/src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx \
+  apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+git commit -m "feat: add study suggestion v2 frontend compatibility"
+```
+
+## Task 7: Final Verification
+
+**Files:**
+- Modify: `Docs/superpowers/specs/2026-04-08-study-suggestions-grounding-normalization-v2-design.md` only if implementation requires an approved spec correction
+
+- [ ] **Step 1: Run the full touched backend suite**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py \
+  tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestion_schemas.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py \
+  tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py -v
+```
+
+- [ ] **Step 2: Run the touched frontend tests**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui && bunx vitest run \
+  src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx \
+  src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+```
+
+- [ ] **Step 3: Run security and diff hygiene checks**
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/StudySuggestions \
+  tldw_Server_API/app/api/v1/endpoints/study_suggestions.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  -f json -o /tmp/bandit_study_suggestions_grounding_v2.json
+git diff --check
+```
+
+- [ ] **Step 4: Commit the final integration pass if needed**
+
+```bash
+git add <touched files>
+git commit -m "fix: finalize study suggestion grounding normalization v2"
+```
+

--- a/apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx
+++ b/apps/packages/ui/src/components/StudySuggestions/StudySuggestionsPanel.tsx
@@ -58,6 +58,31 @@ const mapRankReason = (value: unknown): TopicBuilderRankReason => {
   return "candidate"
 }
 
+const readTopicLabel = (raw: Record<string, unknown>): string => {
+  const label = raw.display_label ?? raw.canonical_label
+  return normalizeLabel(String(label || ""))
+}
+
+const readTopicId = (raw: Record<string, unknown>, index: number): string => {
+  const id = raw.id
+  const normalizedId = normalizeLabel(String(id || ""))
+  return normalizedId || `topic-${index + 1}`
+}
+
+const readEvidenceClass = (raw: Record<string, unknown>): string | null => {
+  const evidenceReasons = raw.evidence_reasons
+  if (Array.isArray(evidenceReasons)) {
+    const normalizedReasons = evidenceReasons
+      .map((reason) => normalizeLabel(String(reason || "")))
+      .filter(Boolean)
+    if (normalizedReasons.length > 0) {
+      return normalizedReasons.join(", ")
+    }
+  }
+
+  return normalizeLabel(String(raw.type || raw.source_type || "")) || null
+}
+
 const hasSourceAwareEvidence = (
   snapshot: StudySuggestionSnapshotResponse | null
 ): boolean => {
@@ -96,7 +121,7 @@ const buildTopicsFromSnapshot = (
         return null
       }
       const raw = topic as Record<string, unknown>
-      const label = normalizeLabel(String(raw.display_label || ""))
+      const label = readTopicLabel(raw)
       if (!label) {
         return null
       }
@@ -106,14 +131,13 @@ const buildTopicsFromSnapshot = (
           ? "exploratory"
           : normalizedRankReason
       return {
-        id: String(raw.id || `topic-${index + 1}`),
+        id: readTopicId(raw, index),
         label,
         rankReason,
         selected: raw.selected !== false,
-        evidenceClass:
-          options?.suppressSourceAwareAdjacency
-            ? "exploratory"
-            : normalizeLabel(String(raw.type || "")) || null,
+        evidenceClass: options?.suppressSourceAwareAdjacency
+          ? "exploratory"
+          : readEvidenceClass(raw),
         isManual: false
       }
     })

--- a/apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx
@@ -57,6 +57,50 @@ const initialSnapshot = {
   }
 }
 
+const v2Snapshot = {
+  snapshot: {
+    id: 91,
+    service: "quiz",
+    activity_type: "quiz_attempt",
+    anchor_type: "quiz_attempt",
+    anchor_id: 404,
+    suggestion_type: "study_suggestions",
+    status: "active",
+    payload: {
+      summary: {
+        score: 8,
+        correct_count: 3,
+        total_count: 4
+      },
+      topics: [
+        {
+          id: "topic-local-1",
+          display_label: "Cardiovascular review",
+          topic_key: "cardio-001",
+          canonical_label: "Cardiovascular review",
+          evidence_reasons: ["topic_gap", "incorrect_answer"],
+          type: "grounded",
+          status: "weakness",
+          selected: true
+        }
+      ]
+    },
+    user_selection: {
+      selected_topic_ids: ["cardio-001"]
+    },
+    refreshed_from_snapshot_id: null,
+    created_at: "2026-04-05T18:00:00Z",
+    last_modified: "2026-04-05T18:00:00Z"
+  },
+  live_evidence: {
+    "cardio-001": {
+      source_available: true,
+      source_type: "note",
+      source_id: "note-9"
+    }
+  }
+}
+
 describe("StudySuggestionsPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -97,30 +141,36 @@ describe("StudySuggestionsPanel", () => {
     })
   })
 
-  it("sends current selected labels for renamed and manual topics, and selection toggles change the payload", async () => {
+  it("renders V2 snapshot topics through the current panel and keeps edited labels tied to the snapshot-local id", async () => {
     mocks.performAction.mockResolvedValue({
       disposition: "generated",
-      snapshot_id: 88,
-      selection_fingerprint: "snapshot_id=88|target_service=flashcards|target_type=deck|topics=acid base,renal physiology|action_kind=follow_up_flashcards|generator_version=v1",
+      snapshot_id: 91,
+      selection_fingerprint: "snapshot_id=91|target_service=flashcards|target_type=deck|topics=acid base,cardiovascular review|action_kind=follow_up_flashcards|generator_version=v1",
       target_service: "flashcards",
       target_type: "deck",
       target_id: "deck-12"
     })
 
-    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={101} />)
+    vi.mocked(useStudySuggestions).mockReturnValue({
+      status: "ready",
+      snapshot: v2Snapshot,
+      isLoading: false,
+      isRefreshing: false,
+      refresh: mocks.refresh,
+      performAction: mocks.performAction
+    } as never)
 
-    expect(screen.getByText("Weakness")).toBeInTheDocument()
-    expect(screen.getByText("Evidence: Grounded")).toBeInTheDocument()
+    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={404} />)
+
+    expect(screen.getByDisplayValue("Cardiovascular review")).toBeInTheDocument()
+    expect(screen.getByText("Evidence: Topic Gap, Incorrect Answer")).toBeInTheDocument()
 
     const firstTopicInput = screen.getByLabelText("Topic 1")
-    fireEvent.change(firstTopicInput, { target: { value: "  Renal physiology  " } })
+    fireEvent.change(firstTopicInput, { target: { value: "  Cardio review  " } })
+    expect(screen.getByDisplayValue("Cardio review")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: /Add topic/i }))
     fireEvent.change(screen.getByLabelText("Topic 2"), { target: { value: "  Acid base  " } })
-
-    const firstToggle = screen.getByRole("button", { name: "Toggle selection for topic 1" })
-    expect(firstToggle).toHaveAttribute("aria-pressed", "true")
-    expect(firstToggle).toHaveTextContent("Selected")
 
     fireEvent.click(screen.getByRole("button", { name: "Create flashcards" }))
 
@@ -130,17 +180,17 @@ describe("StudySuggestionsPanel", () => {
           targetService: "flashcards",
           targetType: "deck",
           actionKind: "follow_up_flashcards",
-          selectedTopicIds: ["topic-1"],
-          selectedTopicEdits: [{ id: "topic-1", label: "Renal physiology" }],
+          selectedTopicIds: ["topic-local-1"],
+          selectedTopicEdits: [{ id: "topic-local-1", label: "Cardio review" }],
           manualTopicLabels: ["Acid base"],
           hasExplicitSelection: true
         })
       )
     })
 
+    const firstToggle = screen.getByRole("button", { name: "Toggle selection for topic 1" })
     fireEvent.click(firstToggle)
     expect(firstToggle).toHaveAttribute("aria-pressed", "false")
-    expect(firstToggle).toHaveTextContent("Excluded")
 
     fireEvent.click(screen.getByRole("button", { name: "Create flashcards" }))
 
@@ -156,13 +206,10 @@ describe("StudySuggestionsPanel", () => {
     })
 
     fireEvent.click(screen.getByRole("button", { name: "Toggle selection for topic 2" }))
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Toggle selection for topic 2" })).toHaveAttribute(
-        "aria-pressed",
-        "false"
-      )
-    })
+    expect(screen.getByRole("button", { name: "Toggle selection for topic 2" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    )
 
     fireEvent.click(screen.getByRole("button", { name: "Create flashcards" }))
 
@@ -176,6 +223,14 @@ describe("StudySuggestionsPanel", () => {
         })
       )
     })
+  })
+
+  it("keeps legacy snapshot topics rendering unchanged", async () => {
+    render(<StudySuggestionsPanel anchorType="quiz_attempt" anchorId={101} />)
+
+    expect(screen.getByDisplayValue("Renal basics")).toBeInTheDocument()
+    expect(screen.getByText("Weakness")).toBeInTheDocument()
+    expect(screen.getByText("Evidence: Grounded")).toBeInTheDocument()
   })
 
   it("shows Open existing when the follow-up action reuses an existing result", async () => {

--- a/apps/packages/ui/src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx
+++ b/apps/packages/ui/src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx
@@ -69,6 +69,50 @@ const buildSnapshot = (id: number, label: string) => ({
   }
 })
 
+const buildSnapshotV2 = (id: number) => ({
+  snapshot: {
+    id,
+    service: "quiz",
+    activity_type: "quiz_attempt",
+    anchor_type: "quiz_attempt",
+    anchor_id: 101,
+    suggestion_type: "study_suggestions",
+    status: "active",
+    payload: {
+      summary: {
+        score: 8,
+        correct_count: 3,
+        total_count: 4
+      },
+      topics: [
+        {
+          id: "topic-local-1",
+          display_label: "Cardiovascular review",
+          topic_key: "cardio-001",
+          canonical_label: "Cardiovascular review",
+          evidence_reasons: ["topic_gap", "incorrect_answer"],
+          type: "grounded",
+          status: "weakness",
+          selected: true
+        }
+      ]
+    },
+    user_selection: {
+      selected_topic_ids: ["cardio-001"]
+    },
+    refreshed_from_snapshot_id: null,
+    created_at: "2026-04-05T18:00:00Z",
+    last_modified: "2026-04-05T18:00:00Z"
+  },
+  live_evidence: {
+    "cardio-001": {
+      source_available: true,
+      source_type: "note",
+      source_id: "note-9"
+    }
+  }
+})
+
 describe("useStudySuggestions", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -253,5 +297,46 @@ describe("useStudySuggestions", () => {
 
     expect(getStudySuggestionAnchorStatus).toHaveBeenCalledTimes(1)
     expect(getStudySuggestionSnapshot).not.toHaveBeenCalled()
+  })
+
+  it("preserves V2 snapshot topic fields in the hook response", async () => {
+    vi.mocked(getStudySuggestionAnchorStatus).mockResolvedValue({
+      anchor_type: "quiz_attempt",
+      anchor_id: 404,
+      status: "ready",
+      job_id: null,
+      snapshot_id: 91
+    })
+    vi.mocked(getStudySuggestionSnapshot).mockResolvedValue(buildSnapshotV2(91))
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false }
+      }
+    })
+
+    const { result } = renderHook(() => useStudySuggestions("quiz_attempt", 404), {
+      wrapper: buildWrapper(queryClient)
+    })
+
+    await waitFor(() => {
+      expect(result.current.snapshot?.snapshot.id).toBe(91)
+    })
+
+    const snapshot = result.current.snapshot
+    const topic =
+      snapshot &&
+      snapshot.snapshot.payload &&
+      typeof snapshot.snapshot.payload === "object" &&
+      !Array.isArray(snapshot.snapshot.payload)
+        ? (snapshot.snapshot.payload as { topics?: Array<Record<string, unknown>> }).topics?.[0]
+        : null
+
+    expect(topic).toMatchObject({
+      id: "topic-local-1",
+      topic_key: "cardio-001",
+      canonical_label: "Cardiovascular review",
+      evidence_reasons: ["topic_gap", "incorrect_answer"]
+    })
   })
 })

--- a/apps/packages/ui/src/services/studySuggestions.ts
+++ b/apps/packages/ui/src/services/studySuggestions.ts
@@ -16,7 +16,10 @@ export type StudySuggestionStatusResponse = {
 
 export type StudySuggestionSnapshotTopic = {
   id: string
-  display_label: string
+  display_label?: string | null
+  topic_key?: string | null
+  canonical_label?: string | null
+  evidence_reasons?: string[] | null
   type?: string | null
   status?: string | null
   selected?: boolean | null

--- a/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import threading
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -93,6 +93,8 @@ def _serialize_job(job: dict[str, object]) -> dict[str, object]:
 
 
 def _is_generation_link_target_live(note_db: CharactersRAGDB, generation_link: dict[str, Any]) -> bool:
+    """Return whether a persisted generation link still points at a launchable target."""
+
     target_service = str(generation_link.get("target_service") or "").strip().lower()
     target_type = str(generation_link.get("target_type") or "").strip().lower()
     target_id = str(generation_link.get("target_id") or "").strip()
@@ -117,7 +119,9 @@ def _is_generation_link_target_live(note_db: CharactersRAGDB, generation_link: d
 def _iter_refreshed_ancestor_snapshots(
     note_db: CharactersRAGDB,
     snapshot_row: dict[str, Any],
-):
+) -> Iterator[dict[str, Any]]:
+    """Yield refreshed ancestor snapshots from newest parent to oldest reachable ancestor."""
+
     seen_ids: set[int] = set()
     parent_id = snapshot_row.get("refreshed_from_snapshot_id")
     while parent_id is not None:
@@ -145,6 +149,8 @@ def _find_live_generation_link_in_refreshed_lineage(
     action_kind: str,
     generator_version: str | None,
 ) -> dict[str, Any] | None:
+    """Find a reusable live generation link in refreshed ancestor snapshots."""
+
     if not requested_identity_groups:
         return None
 
@@ -189,6 +195,8 @@ def _build_selection_fingerprint_variants(
     generator_version: str | None,
     normalization_version: str,
 ) -> tuple[str, str | None]:
+    """Build current and legacy-compatible selection fingerprints for one action."""
+
     selection_fingerprint = build_selection_fingerprint(
         snapshot_id=snapshot_id,
         target_service=target_service,
@@ -222,6 +230,8 @@ def _list_generation_link_candidates(
     selection_fingerprint: str,
     legacy_selection_fingerprint: str | None,
 ) -> list[tuple[dict[str, Any], str]]:
+    """Return matching generation links for current and legacy fingerprints."""
+
     candidates: list[tuple[dict[str, Any], str]] = []
     seen_fingerprints: set[str] = set()
     for fingerprint in (selection_fingerprint, legacy_selection_fingerprint):
@@ -495,20 +505,23 @@ def refresh_suggestion_snapshot(
     if not snapshot_row:
         raise HTTPException(status_code=404, detail="Suggestion snapshot not found")
 
-    job = jm.create_job(
-        domain=STUDY_SUGGESTIONS_DOMAIN,
-        queue=study_suggestions_jobs_queue(),
-        job_type=STUDY_SUGGESTIONS_REFRESH_JOB_TYPE,
-        payload=build_study_suggestions_job_payload(
+    try:
+        job = jm.create_job(
+            domain=STUDY_SUGGESTIONS_DOMAIN,
+            queue=study_suggestions_jobs_queue(),
             job_type=STUDY_SUGGESTIONS_REFRESH_JOB_TYPE,
-            anchor_type=str(snapshot_row["anchor_type"]),
-            anchor_id=int(snapshot_row["anchor_id"]),
-            snapshot_id=int(snapshot_row["id"]),
-        ),
-        owner_user_id=str(current_user.id),
-        priority=5,
-        max_retries=1,
-    )
+            payload=build_study_suggestions_job_payload(
+                job_type=STUDY_SUGGESTIONS_REFRESH_JOB_TYPE,
+                anchor_type=str(snapshot_row["anchor_type"]),
+                anchor_id=int(snapshot_row["anchor_id"]),
+                snapshot_id=int(snapshot_row["id"]),
+            ),
+            owner_user_id=str(current_user.id),
+            priority=5,
+            max_retries=1,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return SuggestionJobAcceptedResponse.model_validate({"job": _serialize_job(job)})
 
 
@@ -635,16 +648,23 @@ def _prepare_action(
                     "target_id": str(ancestor_link["target_id"]),
                 }
             )
-        )
+    )
 
     if not payload.force_regenerate:
         for _existing_link, matched_existing_fingerprint in stale_existing:
-            with contextlib.suppress(Exception):
+            try:
                 db.soft_delete_suggestion_generation_link(
                     snapshot_id=snapshot_id,
                     target_service=action_contract["target_service"],
                     target_type=action_contract["target_type"],
                     selection_fingerprint=matched_existing_fingerprint,
+                )
+            except Exception as exc:  # pragma: no cover - defensive cleanup path
+                logger.warning(
+                    "Failed to retire stale study suggestion generation link for snapshot_id={} fingerprint={}: {}",
+                    snapshot_id,
+                    matched_existing_fingerprint,
+                    exc,
                 )
         try:
             reserve_generation_link(

--- a/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
@@ -35,9 +35,14 @@ from tldw_Server_API.app.core.StudySuggestions.actions import (
     finalize_generation_link,
     find_generation_link_by_fingerprint,
     is_pending_generation_target_id,
+    normalize_selected_topics,
     release_generation_link_reservation,
     reserve_generation_link,
+    resolve_lineage_equivalent_topic_selection,
+    resolve_selected_topic_identity_groups,
     resolve_selected_topic_labels,
+    resolve_selected_topic_normalization_version,
+    resolve_selected_topic_semantic_keys,
     soft_delete_deck,
 )
 from tldw_Server_API.app.core.StudySuggestions import snapshot_service
@@ -85,6 +90,154 @@ def _serialize_job(job: dict[str, object]) -> dict[str, object]:
         "id": int(job["id"]),
         "status": str(job.get("status") or "queued"),
     }
+
+
+def _is_generation_link_target_live(note_db: CharactersRAGDB, generation_link: dict[str, Any]) -> bool:
+    target_service = str(generation_link.get("target_service") or "").strip().lower()
+    target_type = str(generation_link.get("target_type") or "").strip().lower()
+    target_id = str(generation_link.get("target_id") or "").strip()
+    if not target_id or is_pending_generation_target_id(target_id):
+        return False
+    if target_service == "quiz" and target_type == "quiz":
+        try:
+            quiz_id = int(target_id)
+        except (TypeError, ValueError):
+            return False
+        return note_db.get_quiz(quiz_id) is not None
+    if target_service == "flashcards" and target_type == "deck":
+        try:
+            deck_id = int(target_id)
+        except (TypeError, ValueError):
+            return False
+        deck = note_db.get_deck(deck_id)
+        return bool(deck) and not bool(deck.get("deleted"))
+    return False
+
+
+def _iter_refreshed_ancestor_snapshots(
+    note_db: CharactersRAGDB,
+    snapshot_row: dict[str, Any],
+):
+    seen_ids: set[int] = set()
+    parent_id = snapshot_row.get("refreshed_from_snapshot_id")
+    while parent_id is not None:
+        try:
+            ancestor_snapshot = note_db.get_suggestion_snapshot(int(parent_id))
+        except (TypeError, ValueError):
+            break
+        if not ancestor_snapshot:
+            break
+        ancestor_id = int(ancestor_snapshot["id"])
+        if ancestor_id in seen_ids:
+            break
+        seen_ids.add(ancestor_id)
+        yield ancestor_snapshot
+        parent_id = ancestor_snapshot.get("refreshed_from_snapshot_id")
+
+
+def _find_live_generation_link_in_refreshed_lineage(
+    note_db: CharactersRAGDB,
+    snapshot_row: dict[str, Any],
+    *,
+    target_service: str,
+    target_type: str,
+    requested_identity_groups: list[frozenset[str]],
+    action_kind: str,
+    generator_version: str | None,
+) -> dict[str, Any] | None:
+    if not requested_identity_groups:
+        return None
+
+    for ancestor_snapshot in _iter_refreshed_ancestor_snapshots(note_db, snapshot_row):
+        lineage_selection = resolve_lineage_equivalent_topic_selection(
+            ancestor_snapshot,
+            requested_identity_groups=requested_identity_groups,
+        )
+        if lineage_selection is None:
+            continue
+        selected_topics, normalization_version = lineage_selection
+        current_fingerprint, legacy_fingerprint = _build_selection_fingerprint_variants(
+            snapshot_id=int(ancestor_snapshot["id"]),
+            target_service=target_service,
+            target_type=target_type,
+            selected_topics=selected_topics,
+            action_kind=action_kind,
+            generator_version=generator_version,
+            normalization_version=normalization_version,
+        )
+        candidates = _list_generation_link_candidates(
+            note_db,
+            snapshot_id=int(ancestor_snapshot["id"]),
+            target_service=target_service,
+            target_type=target_type,
+            selection_fingerprint=current_fingerprint,
+            legacy_selection_fingerprint=legacy_fingerprint,
+        )
+        for existing_link, _matched_fingerprint in candidates:
+            if _is_generation_link_target_live(note_db, existing_link):
+                return existing_link
+    return None
+
+
+def _build_selection_fingerprint_variants(
+    *,
+    snapshot_id: int,
+    target_service: str,
+    target_type: str,
+    selected_topics: list[str],
+    action_kind: str,
+    generator_version: str | None,
+    normalization_version: str,
+) -> tuple[str, str | None]:
+    selection_fingerprint = build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service=target_service,
+        target_type=target_type,
+        selected_topics=selected_topics,
+        action_kind=action_kind,
+        generator_version=generator_version,
+        normalization_version=normalization_version,
+    )
+    legacy_selection_fingerprint = build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service=target_service,
+        target_type=target_type,
+        selected_topics=selected_topics,
+        action_kind=action_kind,
+        generator_version=generator_version,
+        normalization_version=normalization_version,
+        include_normalization_version=False,
+    )
+    return selection_fingerprint, (
+        legacy_selection_fingerprint if legacy_selection_fingerprint != selection_fingerprint else None
+    )
+
+
+def _list_generation_link_candidates(
+    note_db: CharactersRAGDB,
+    *,
+    snapshot_id: int,
+    target_service: str,
+    target_type: str,
+    selection_fingerprint: str,
+    legacy_selection_fingerprint: str | None,
+) -> list[tuple[dict[str, Any], str]]:
+    candidates: list[tuple[dict[str, Any], str]] = []
+    seen_fingerprints: set[str] = set()
+    for fingerprint in (selection_fingerprint, legacy_selection_fingerprint):
+        if not fingerprint or fingerprint in seen_fingerprints:
+            continue
+        seen_fingerprints.add(fingerprint)
+        existing_link = find_generation_link_by_fingerprint(
+            note_db,
+            snapshot_id=snapshot_id,
+            target_service=target_service,
+            target_type=target_type,
+            selection_fingerprint=fingerprint,
+        )
+        if existing_link:
+            candidates.append((existing_link, fingerprint))
+    return candidates
 
 
 def _resolve_quiz_sources(
@@ -363,7 +516,7 @@ def _prepare_action(
     db: CharactersRAGDB,
     snapshot_id: int,
     payload: SuggestionActionRequest,
-) -> tuple[dict[str, Any], dict[str, str], list[str], str, bool]:
+) -> tuple[dict[str, Any], dict[str, str], list[str], str, bool, str | None]:
     """Synchronous pre-dispatch phase: validate, deduplicate, and reserve."""
 
     snapshot_row = db.get_suggestion_snapshot(snapshot_id)
@@ -385,26 +538,69 @@ def _prepare_action(
         manual_topic_labels=payload.manual_topic_labels,
         has_explicit_selection=payload.has_explicit_selection,
     )
-    selection_fingerprint = build_selection_fingerprint(
+    semantic_selected_topics = resolve_selected_topic_semantic_keys(
+        snapshot_row,
+        selected_topic_ids=payload.selected_topic_ids,
+        manual_topic_labels=payload.manual_topic_labels,
+        has_explicit_selection=payload.has_explicit_selection,
+    )
+    normalized_manual_topic_labels = normalize_selected_topics(payload.manual_topic_labels or [])
+    normalization_version = resolve_selected_topic_normalization_version(
+        snapshot_row,
+        selected_topic_ids=payload.selected_topic_ids,
+        has_explicit_selection=payload.has_explicit_selection,
+    )
+    requested_identity_groups = resolve_selected_topic_identity_groups(
+        snapshot_row,
+        selected_topic_ids=payload.selected_topic_ids,
+        has_explicit_selection=payload.has_explicit_selection,
+    )
+    selection_fingerprint, legacy_selection_fingerprint = _build_selection_fingerprint_variants(
         snapshot_id=snapshot_id,
         target_service=action_contract["target_service"],
         target_type=action_contract["target_type"],
-        selected_topics=selected_topics,
+        selected_topics=semantic_selected_topics,
         action_kind=action_contract["action_kind"],
         generator_version=payload.generator_version,
+        normalization_version=normalization_version,
     )
     pending_reservation_created = False
 
-    existing_link = find_generation_link_by_fingerprint(
+    existing_candidates = _list_generation_link_candidates(
         db,
         snapshot_id=snapshot_id,
         target_service=action_contract["target_service"],
         target_type=action_contract["target_type"],
         selection_fingerprint=selection_fingerprint,
+        legacy_selection_fingerprint=legacy_selection_fingerprint,
     )
-    if existing_link and is_pending_generation_target_id(existing_link.get("target_id")) and not payload.force_regenerate:
+    pending_existing = next(
+        (
+            (existing_link, matched_fingerprint)
+            for existing_link, matched_fingerprint in existing_candidates
+            if is_pending_generation_target_id(existing_link.get("target_id"))
+        ),
+        None,
+    )
+    live_existing = next(
+        (
+            (existing_link, matched_fingerprint)
+            for existing_link, matched_fingerprint in existing_candidates
+            if not is_pending_generation_target_id(existing_link.get("target_id"))
+            and _is_generation_link_target_live(db, existing_link)
+        ),
+        None,
+    )
+    stale_existing = [
+        (existing_link, matched_fingerprint)
+        for existing_link, matched_fingerprint in existing_candidates
+        if not is_pending_generation_target_id(existing_link.get("target_id"))
+        and not _is_generation_link_target_live(db, existing_link)
+    ]
+    if pending_existing and not payload.force_regenerate:
         raise HTTPException(status_code=409, detail="Study suggestion action already in progress")
-    if existing_link and not payload.force_regenerate:
+    if live_existing and not payload.force_regenerate:
+        existing_link, _matched_existing_fingerprint = live_existing
         raise _EarlyReturn(
             SuggestionActionResponse.model_validate(
                 {
@@ -417,7 +613,39 @@ def _prepare_action(
                 }
             )
         )
+
+    ancestor_link = _find_live_generation_link_in_refreshed_lineage(
+        db,
+        snapshot_row,
+        target_service=action_contract["target_service"],
+        target_type=action_contract["target_type"],
+        requested_identity_groups=[] if normalized_manual_topic_labels else requested_identity_groups,
+        action_kind=action_contract["action_kind"],
+        generator_version=payload.generator_version,
+    )
+    if ancestor_link and not payload.force_regenerate:
+        raise _EarlyReturn(
+            SuggestionActionResponse.model_validate(
+                {
+                    "disposition": "opened_existing",
+                    "snapshot_id": snapshot_id,
+                    "selection_fingerprint": selection_fingerprint,
+                    "target_service": action_contract["target_service"],
+                    "target_type": action_contract["target_type"],
+                    "target_id": str(ancestor_link["target_id"]),
+                }
+            )
+        )
+
     if not payload.force_regenerate:
+        for _existing_link, matched_existing_fingerprint in stale_existing:
+            with contextlib.suppress(Exception):
+                db.soft_delete_suggestion_generation_link(
+                    snapshot_id=snapshot_id,
+                    target_service=action_contract["target_service"],
+                    target_type=action_contract["target_type"],
+                    selection_fingerprint=matched_existing_fingerprint,
+                )
         try:
             reserve_generation_link(
                 db,
@@ -428,16 +656,35 @@ def _prepare_action(
             )
             pending_reservation_created = True
         except Exception:
-            existing_link = find_generation_link_by_fingerprint(
+            existing_candidates = _list_generation_link_candidates(
                 db,
                 snapshot_id=snapshot_id,
                 target_service=action_contract["target_service"],
                 target_type=action_contract["target_type"],
                 selection_fingerprint=selection_fingerprint,
+                legacy_selection_fingerprint=legacy_selection_fingerprint,
             )
-            if existing_link and is_pending_generation_target_id(existing_link.get("target_id")):
+            pending_existing = next(
+                (
+                    (existing_link, matched_fingerprint)
+                    for existing_link, matched_fingerprint in existing_candidates
+                    if is_pending_generation_target_id(existing_link.get("target_id"))
+                ),
+                None,
+            )
+            live_existing = next(
+                (
+                    (existing_link, matched_fingerprint)
+                    for existing_link, matched_fingerprint in existing_candidates
+                    if not is_pending_generation_target_id(existing_link.get("target_id"))
+                    and _is_generation_link_target_live(db, existing_link)
+                ),
+                None,
+            )
+            if pending_existing:
                 raise HTTPException(status_code=409, detail="Study suggestion action already in progress")
-            if existing_link and not payload.force_regenerate:
+            if live_existing and not payload.force_regenerate:
+                existing_link, _matched_existing_fingerprint = live_existing
                 raise _EarlyReturn(
                     SuggestionActionResponse.model_validate(
                         {
@@ -452,7 +699,26 @@ def _prepare_action(
                 )
             raise
 
-    return snapshot_row, action_contract, selected_topics, selection_fingerprint, pending_reservation_created
+    retired_selection_fingerprint = (
+        next(
+            (
+                matched_fingerprint
+                for _existing_link, matched_fingerprint in existing_candidates
+                if matched_fingerprint != selection_fingerprint
+            ),
+            None,
+        )
+        if existing_candidates
+        else None
+    )
+    return (
+        snapshot_row,
+        action_contract,
+        selected_topics,
+        selection_fingerprint,
+        pending_reservation_created,
+        retired_selection_fingerprint,
+    )
 
 
 def _finalize_action(
@@ -462,9 +728,18 @@ def _finalize_action(
     generated: dict[str, str],
     selection_fingerprint: str,
     pending_reservation_created: bool,
+    force_regenerate: bool,
+    retired_selection_fingerprint: str | None,
 ) -> None:
     """Synchronous post-dispatch phase: persist the generation link."""
 
+    if retired_selection_fingerprint:
+        db.soft_delete_suggestion_generation_link(
+            snapshot_id=snapshot_id,
+            target_service=str(generated["target_service"]),
+            target_type=str(generated["target_type"]),
+            selection_fingerprint=retired_selection_fingerprint,
+        )
     if pending_reservation_created:
         finalize_generation_link(
             db,
@@ -473,6 +748,14 @@ def _finalize_action(
             target_type=str(generated["target_type"]),
             selection_fingerprint=selection_fingerprint,
             final_target_id=str(generated["target_id"]),
+        )
+    elif force_regenerate:
+        db.replace_suggestion_generation_link(
+            snapshot_id=snapshot_id,
+            target_service=str(generated["target_service"]),
+            target_type=str(generated["target_type"]),
+            target_id=str(generated["target_id"]),
+            selection_fingerprint=selection_fingerprint,
         )
     else:
         db.create_suggestion_generation_link(
@@ -499,7 +782,14 @@ async def trigger_suggestion_action(
     media_db: Any = Depends(get_media_db_for_user),
 ) -> SuggestionActionResponse:
     try:
-        snapshot_row, action_contract, selected_topics, selection_fingerprint, pending_reservation_created = (
+        (
+            snapshot_row,
+            action_contract,
+            selected_topics,
+            selection_fingerprint,
+            pending_reservation_created,
+            retired_selection_fingerprint,
+        ) = (
             await asyncio.to_thread(_prepare_action, db, snapshot_id, payload)
         )
     except _EarlyReturn as early:
@@ -522,6 +812,8 @@ async def trigger_suggestion_action(
             generated=generated,
             selection_fingerprint=selection_fingerprint,
             pending_reservation_created=pending_reservation_created,
+            force_regenerate=payload.force_regenerate,
+            retired_selection_fingerprint=retired_selection_fingerprint,
         )
     except HTTPException:
         if pending_reservation_created:

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -121,6 +121,7 @@ _SUPPORTED_NOTE_STUDIO_HANDWRITING_MODES = {"off", "accented"}
 _FLASHCARD_REVIEW_SESSION_STATUSES = frozenset({"active", "completed", "abandoned"})
 _FLASHCARD_REVIEW_MODES = frozenset({"due", "cram"})
 _FLASHCARD_REVIEW_SESSION_TIMEOUT = timedelta(minutes=30)
+_FLASHCARD_REVIEW_SESSION_JSON_FIELDS = ["source_bundle_json"]
 _SUPPORTED_WEB_CLIPPER_DESTINATIONS = {"note", "workspace", "both"}
 _SUPPORTED_WEB_CLIPPER_OUTCOME_STATES = {"saved", "saved_with_warnings", "partially_saved", "failed"}
 _SUPPORTED_WEB_CLIPPER_ENRICHMENT_TYPES = {"ocr", "vlm"}
@@ -1538,6 +1539,10 @@ CREATE TABLE IF NOT EXISTS flashcard_review_sessions(
   started_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   last_activity_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   completed_at     DATETIME,
+  cards_reviewed   INTEGER DEFAULT 0,
+  correct_count    INTEGER DEFAULT 0,
+  source_bundle_json TEXT,
+  study_pack_id    INTEGER,
   client_id        TEXT NOT NULL DEFAULT 'unknown'
 );
 CREATE INDEX IF NOT EXISTS idx_flashcard_review_sessions_scope ON flashcard_review_sessions(scope_key);
@@ -9463,10 +9468,25 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   started_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   last_activity_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   completed_at     DATETIME,
+                  cards_reviewed   INTEGER DEFAULT 0,
+                  correct_count    INTEGER DEFAULT 0,
+                  source_bundle_json TEXT,
+                  study_pack_id    INTEGER,
                   client_id        TEXT NOT NULL DEFAULT 'unknown'
                 )
                 """
             )
+            session_cols = {
+                str(row[1]): row for row in conn.execute("PRAGMA table_info('flashcard_review_sessions')").fetchall()
+            }
+            if "cards_reviewed" not in session_cols:
+                conn.execute("ALTER TABLE flashcard_review_sessions ADD COLUMN cards_reviewed INTEGER DEFAULT 0")
+            if "correct_count" not in session_cols:
+                conn.execute("ALTER TABLE flashcard_review_sessions ADD COLUMN correct_count INTEGER DEFAULT 0")
+            if "source_bundle_json" not in session_cols:
+                conn.execute("ALTER TABLE flashcard_review_sessions ADD COLUMN source_bundle_json TEXT")
+            if "study_pack_id" not in session_cols:
+                conn.execute("ALTER TABLE flashcard_review_sessions ADD COLUMN study_pack_id INTEGER")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_flashcard_review_sessions_scope ON flashcard_review_sessions(scope_key)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_flashcard_review_sessions_status ON flashcard_review_sessions(status)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_flashcard_review_sessions_deck ON flashcard_review_sessions(deck_id)")
@@ -9686,9 +9706,29 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   started_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   last_activity_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   completed_at TIMESTAMPTZ,
+                  cards_reviewed INTEGER DEFAULT 0,
+                  correct_count INTEGER DEFAULT 0,
+                  source_bundle_json TEXT,
+                  study_pack_id BIGINT,
                   client_id TEXT NOT NULL DEFAULT 'unknown'
                 )
                 """,
+                connection=conn,
+            )
+            self.backend.execute(
+                "ALTER TABLE flashcard_review_sessions ADD COLUMN IF NOT EXISTS cards_reviewed INTEGER DEFAULT 0",
+                connection=conn,
+            )
+            self.backend.execute(
+                "ALTER TABLE flashcard_review_sessions ADD COLUMN IF NOT EXISTS correct_count INTEGER DEFAULT 0",
+                connection=conn,
+            )
+            self.backend.execute(
+                "ALTER TABLE flashcard_review_sessions ADD COLUMN IF NOT EXISTS source_bundle_json TEXT",
+                connection=conn,
+            )
+            self.backend.execute(
+                "ALTER TABLE flashcard_review_sessions ADD COLUMN IF NOT EXISTS study_pack_id BIGINT",
                 connection=conn,
             )
             self.backend.execute(
@@ -10184,6 +10224,53 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except sqlite3.Error as exc:
             raise SchemaError(f"Failed ensuring SQLite study pack sync triggers: {exc}") from exc  # noqa: TRY003
 
+    def _dedupe_suggestion_generation_links_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Collapse legacy duplicate active generation links before enforcing the v2 unique index."""
+        conn.execute(
+            """
+            WITH ranked AS (
+                SELECT id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY snapshot_id, target_service, target_type, selection_fingerprint
+                           ORDER BY CASE WHEN target_id LIKE 'pending:%' THEN 1 ELSE 0 END ASC, id DESC
+                       ) AS row_rank
+                  FROM suggestion_generation_links
+                 WHERE deleted = 0
+            )
+            UPDATE suggestion_generation_links
+               SET deleted = 1,
+                   last_modified = CURRENT_TIMESTAMP,
+                   client_id = COALESCE(NULLIF(TRIM(client_id), ''), 'migration'),
+                   version = version + 1
+             WHERE id IN (SELECT id FROM ranked WHERE row_rank > 1)
+            """
+        )
+
+    def _dedupe_suggestion_generation_links_postgres(self, conn) -> None:
+        """Collapse legacy duplicate active generation links before enforcing the v2 unique index."""
+        self.backend.execute(
+            """
+            WITH ranked AS (
+                SELECT id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY snapshot_id, target_service, target_type, selection_fingerprint
+                           ORDER BY CASE WHEN target_id LIKE 'pending:%' THEN 1 ELSE 0 END ASC, id DESC
+                       ) AS row_rank
+                  FROM suggestion_generation_links
+                 WHERE deleted = FALSE
+            )
+            UPDATE suggestion_generation_links AS links
+               SET deleted = TRUE,
+                   last_modified = CURRENT_TIMESTAMP,
+                   client_id = COALESCE(NULLIF(BTRIM(client_id), ''), 'migration'),
+                   version = version + 1
+              FROM ranked
+             WHERE links.id = ranked.id
+               AND ranked.row_rank > 1
+            """,
+            connection=conn,
+        )
+
     def _ensure_study_pack_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Ensure study pack tables exist for SQLite."""
         try:
@@ -10301,16 +10388,12 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_suggestion_generation_links_snapshot_id ON suggestion_generation_links(snapshot_id)"
             )
+            self._dedupe_suggestion_generation_links_sqlite(conn)
+            conn.execute("DROP INDEX IF EXISTS idx_suggestion_generation_links_unique_active")
             conn.execute(
                 """
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_suggestion_generation_links_unique_active
-                    ON suggestion_generation_links(
-                        snapshot_id,
-                        target_service,
-                        target_type,
-                        target_id,
-                        selection_fingerprint
-                    )
+                    ON suggestion_generation_links(snapshot_id, target_service, target_type, selection_fingerprint)
                  WHERE deleted = 0
                 """
             )
@@ -10423,16 +10506,24 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "CREATE INDEX IF NOT EXISTS idx_suggestion_snapshots_status ON suggestion_snapshots(status)",
             "CREATE INDEX IF NOT EXISTS idx_suggestion_snapshots_deleted ON suggestion_snapshots(deleted)",
             "CREATE INDEX IF NOT EXISTS idx_suggestion_generation_links_snapshot_id ON suggestion_generation_links(snapshot_id)",
-            """
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_suggestion_generation_links_unique_active
-                ON suggestion_generation_links(snapshot_id, target_service, target_type, target_id, selection_fingerprint)
-             WHERE deleted = FALSE
-            """,
             "CREATE INDEX IF NOT EXISTS idx_suggestion_generation_links_deleted ON suggestion_generation_links(deleted)",
         ]
         try:
             for statement in statements:
                 self.backend.execute(statement, connection=conn)
+            self._dedupe_suggestion_generation_links_postgres(conn)
+            self.backend.execute(
+                "DROP INDEX IF EXISTS idx_suggestion_generation_links_unique_active",
+                connection=conn,
+            )
+            self.backend.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_suggestion_generation_links_unique_active
+                    ON suggestion_generation_links(snapshot_id, target_service, target_type, selection_fingerprint)
+                 WHERE deleted = FALSE
+                """,
+                connection=conn,
+            )
         except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:
             raise SchemaError(f"Failed ensuring PostgreSQL study pack schema: {exc}") from exc  # noqa: TRY003
 
@@ -26165,6 +26256,92 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             raise InputError("status must be one of: active, completed, abandoned")  # noqa: TRY003
         return normalized
 
+    @staticmethod
+    def _normalize_flashcard_review_session_source_bundle(source_bundle_value: Any) -> list[dict[str, Any]]:
+        if isinstance(source_bundle_value, dict) and isinstance(source_bundle_value.get("items"), list):
+            source_bundle_value = source_bundle_value.get("items")
+
+        if isinstance(source_bundle_value, list):
+            return [dict(entry) for entry in source_bundle_value if isinstance(entry, dict)]
+        if isinstance(source_bundle_value, dict):
+            return [dict(source_bundle_value)]
+        return []
+
+    def _deserialize_flashcard_review_session_row(self, row: Any) -> dict[str, Any] | None:
+        item = self._deserialize_row_fields(row, _FLASHCARD_REVIEW_SESSION_JSON_FIELDS)
+        if not item:
+            return None
+
+        if item.get("cards_reviewed") is not None:
+            item["cards_reviewed"] = int(item["cards_reviewed"])
+        if item.get("correct_count") is not None:
+            item["correct_count"] = int(item["correct_count"])
+        if item.get("study_pack_id") is not None:
+            item["study_pack_id"] = int(item["study_pack_id"])
+
+        normalized_bundle = self._normalize_flashcard_review_session_source_bundle(item.get("source_bundle_json"))
+        item["source_bundle_json"] = normalized_bundle or None
+        item["source_bundle"] = normalized_bundle
+        return item
+
+    def _get_flashcard_review_session_row_for_conn(self, conn: Any, session_id: int) -> dict[str, Any] | None:
+        row = conn.execute(
+            """
+            SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
+                   started_at, last_activity_at, completed_at, client_id,
+                   cards_reviewed, correct_count, source_bundle_json, study_pack_id
+              FROM flashcard_review_sessions
+             WHERE id = ?
+            """,
+            (int(session_id),),
+        ).fetchone()
+        return self._deserialize_flashcard_review_session_row(row) if row else None
+
+    def _get_flashcard_review_session_reconstructed_aggregates(self, conn: Any, session_id: int) -> tuple[int, int]:
+        row = conn.execute(
+            """
+            SELECT COUNT(*) AS cards_reviewed,
+                   COALESCE(SUM(CASE WHEN rating >= 3 THEN 1 ELSE 0 END), 0) AS correct_count
+              FROM flashcard_reviews
+             WHERE review_session_id = ?
+            """,
+            (int(session_id),),
+        ).fetchone()
+        if not row:
+            return 0, 0
+        return int(row["cards_reviewed"] or 0), int(row["correct_count"] or 0)
+
+    def _repair_flashcard_review_session_aggregates_if_unchanged(
+        self,
+        conn: Any,
+        session_id: int,
+        *,
+        expected_cards_reviewed: int | None,
+        expected_correct_count: int | None,
+        repaired_cards_reviewed: int,
+        repaired_correct_count: int,
+    ) -> bool:
+        cursor = conn.execute(
+            """
+            UPDATE flashcard_review_sessions
+               SET cards_reviewed = ?,
+                   correct_count = ?
+             WHERE id = ?
+               AND ((cards_reviewed IS NULL AND ? IS NULL) OR cards_reviewed = ?)
+               AND ((correct_count IS NULL AND ? IS NULL) OR correct_count = ?)
+            """,
+            (
+                repaired_cards_reviewed,
+                repaired_correct_count,
+                int(session_id),
+                expected_cards_reviewed,
+                expected_cards_reviewed,
+                expected_correct_count,
+                expected_correct_count,
+            ),
+        )
+        return max(0, int(getattr(cursor, "rowcount", 0) or 0)) > 0
+
     def abandon_stale_flashcard_review_sessions(self, *, scope_key: str | None = None) -> int:
         """Mark active review sessions as abandoned when inactive for over 30 minutes."""
         cutoff = to_iso_z(datetime.now(timezone.utc) - _FLASHCARD_REVIEW_SESSION_TIMEOUT) or self._get_current_utc_timestamp_iso()
@@ -26196,7 +26373,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         query_parts = [
             """
             SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
-                   started_at, last_activity_at, completed_at, client_id
+                   started_at, last_activity_at, completed_at, client_id,
+                   cards_reviewed, correct_count, source_bundle_json, study_pack_id
               FROM flashcard_review_sessions
              WHERE 1 = 1
             """
@@ -26214,7 +26392,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         query_parts.append("ORDER BY last_activity_at DESC, started_at DESC, id DESC LIMIT ?")
         params.append(max(1, int(limit)))
         cursor = self.execute_query(" ".join(query_parts), tuple(params))
-        return [dict(row) for row in cursor.fetchall()]
+        return [
+            session
+            for row in cursor.fetchall()
+            if (session := self._deserialize_flashcard_review_session_row(row)) is not None
+        ]
 
     def get_or_create_flashcard_review_session(
         self,
@@ -26238,7 +26420,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 rows = conn.execute(
                     """
                     SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
-                           started_at, last_activity_at, completed_at, client_id
+                           started_at, last_activity_at, completed_at, client_id,
+                           cards_reviewed, correct_count, source_bundle_json, study_pack_id
                       FROM flashcard_review_sessions
                      WHERE scope_key = ? AND status = 'active'
                      ORDER BY last_activity_at DESC, started_at DESC, id DESC
@@ -26246,7 +26429,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     (normalized_scope_key,),
                 ).fetchall()
                 if rows:
-                    authoritative = dict(rows[0])
+                    authoritative = self._deserialize_flashcard_review_session_row(rows[0]) or {}
                     if len(rows) > 1:
                         duplicate_ids = [int(row["id"]) for row in rows[1:]]
                         placeholders = ", ".join("?" for _ in duplicate_ids)
@@ -26270,9 +26453,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         """
                         INSERT INTO flashcard_review_sessions(
                             deck_id, review_mode, tag_filter, scope_key, status,
-                            started_at, last_activity_at, completed_at, client_id
+                            started_at, last_activity_at, completed_at, cards_reviewed,
+                            correct_count, source_bundle_json, study_pack_id, client_id
                         )
-                        VALUES(?, ?, ?, ?, 'active', ?, ?, NULL, ?)
+                        VALUES(?, ?, ?, ?, 'active', ?, ?, NULL, 0, 0, NULL, NULL, ?)
                         RETURNING id
                         """,
                         (
@@ -26292,9 +26476,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         """
                         INSERT INTO flashcard_review_sessions(
                             deck_id, review_mode, tag_filter, scope_key, status,
-                            started_at, last_activity_at, completed_at, client_id
+                            started_at, last_activity_at, completed_at, cards_reviewed,
+                            correct_count, source_bundle_json, study_pack_id, client_id
                         )
-                        VALUES(?, ?, ?, ?, 'active', ?, ?, NULL, ?)
+                        VALUES(?, ?, ?, ?, 'active', ?, ?, NULL, 0, 0, NULL, NULL, ?)
                         """,
                         (
                             int(deck_id) if deck_id is not None else None,
@@ -26312,13 +26497,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 row = conn.execute(
                     """
                     SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
-                           started_at, last_activity_at, completed_at, client_id
+                           started_at, last_activity_at, completed_at, client_id,
+                           cards_reviewed, correct_count, source_bundle_json, study_pack_id
                       FROM flashcard_review_sessions
                      WHERE id = ?
                     """,
                     (session_id,),
                 ).fetchone()
-                return dict(row)
+                return self._deserialize_flashcard_review_session_row(row) or {}
         except sqlite3.Error as exc:
             raise CharactersRAGDBError(f"Failed to get or create flashcard review session: {exc}") from exc  # noqa: TRY003
         except BackendDatabaseError as exc:
@@ -26329,14 +26515,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         cursor = self.execute_query(
             """
             SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
-                   started_at, last_activity_at, completed_at, client_id
+                   started_at, last_activity_at, completed_at, client_id,
+                   cards_reviewed, correct_count, source_bundle_json, study_pack_id
               FROM flashcard_review_sessions
              WHERE id = ?
             """,
             (int(session_id),),
         )
         row = cursor.fetchone()
-        return dict(row) if row else None
+        return self._deserialize_flashcard_review_session_row(row) if row else None
 
     def mark_flashcard_review_session_completed(self, session_id: int) -> dict[str, Any]:
         """Mark a persisted review session as completed."""
@@ -26358,17 +26545,95 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             row = self.execute_query(
                 """
                 SELECT id, deck_id, review_mode, tag_filter, scope_key, status,
-                       started_at, last_activity_at, completed_at, client_id
+                       started_at, last_activity_at, completed_at, client_id,
+                       cards_reviewed, correct_count, source_bundle_json, study_pack_id
                   FROM flashcard_review_sessions
                  WHERE id = ?
                 """,
                 (int(session_id),),
             ).fetchone()
-            return dict(row)
+            return self._deserialize_flashcard_review_session_row(row) or {}
         except CharactersRAGDBError:
             raise
         except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:
             raise CharactersRAGDBError(f"Failed to mark flashcard review session completed: {exc}") from exc  # noqa: TRY003
+
+    def get_flashcard_review_session_rollup(
+        self,
+        session_id: int,
+        *,
+        repair_session_aggregates: bool = True,
+    ) -> dict[str, Any] | None:
+        """Return a merged session view that trusts review rows when cached aggregates drift."""
+        try:
+            with self.transaction() as conn:
+                session = self._get_flashcard_review_session_row_for_conn(conn, int(session_id))
+                if not session:
+                    return None
+
+                reconstructed_cards_reviewed, reconstructed_correct_count = (
+                    self._get_flashcard_review_session_reconstructed_aggregates(conn, int(session_id))
+                )
+                session_cards_reviewed = session.get("cards_reviewed")
+                session_correct_count = session.get("correct_count")
+                session_aggregates_match = (
+                    session_cards_reviewed is not None
+                    and session_correct_count is not None
+                    and session_cards_reviewed >= 0
+                    and session_correct_count >= 0
+                    and session_correct_count <= session_cards_reviewed
+                    and session_cards_reviewed == reconstructed_cards_reviewed
+                    and session_correct_count == reconstructed_correct_count
+                )
+
+                if session_aggregates_match:
+                    session["aggregate_source"] = "session"
+                    return session
+
+                if repair_session_aggregates:
+                    repaired = self._repair_flashcard_review_session_aggregates_if_unchanged(
+                        conn,
+                        int(session_id),
+                        expected_cards_reviewed=session_cards_reviewed,
+                        expected_correct_count=session_correct_count,
+                        repaired_cards_reviewed=reconstructed_cards_reviewed,
+                        repaired_correct_count=reconstructed_correct_count,
+                    )
+                    if repaired:
+                        session["cards_reviewed"] = reconstructed_cards_reviewed
+                        session["correct_count"] = reconstructed_correct_count
+                        session["aggregate_source"] = "reconstructed"
+                        return session
+
+                    session = self._get_flashcard_review_session_row_for_conn(conn, int(session_id))
+                    if not session:
+                        return None
+                    reconstructed_cards_reviewed, reconstructed_correct_count = (
+                        self._get_flashcard_review_session_reconstructed_aggregates(conn, int(session_id))
+                    )
+                    session_cards_reviewed = session.get("cards_reviewed")
+                    session_correct_count = session.get("correct_count")
+                    session_aggregates_match = (
+                        session_cards_reviewed is not None
+                        and session_correct_count is not None
+                        and session_cards_reviewed >= 0
+                        and session_correct_count >= 0
+                        and session_correct_count <= session_cards_reviewed
+                        and session_cards_reviewed == reconstructed_cards_reviewed
+                        and session_correct_count == reconstructed_correct_count
+                    )
+                    if session_aggregates_match:
+                        session["aggregate_source"] = "session"
+                        return session
+
+                session["cards_reviewed"] = reconstructed_cards_reviewed
+                session["correct_count"] = reconstructed_correct_count
+                session["aggregate_source"] = "reconstructed"
+                return session
+        except CharactersRAGDBError:
+            raise
+        except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:
+            raise CharactersRAGDBError(f"Failed to fetch flashcard review session rollup: {exc}") from exc  # noqa: TRY003
 
     def get_latest_flashcard_review(self, card_uuid: str) -> dict[str, Any] | None:
         """Return the most recent review row for a flashcard, including nullable session linkage."""
@@ -26515,13 +26780,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     )
                 )
                 if resolved_review_session_id is not None:
+                    correct_increment = 1 if int(rating) >= 3 else 0
                     conn.execute(
                         """
                         UPDATE flashcard_review_sessions
-                           SET last_activity_at = ?
+                           SET last_activity_at = ?,
+                               cards_reviewed = COALESCE(cards_reviewed, 0) + 1,
+                               correct_count = COALESCE(correct_count, 0) + ?
                          WHERE id = ?
                         """,
-                        (now, resolved_review_session_id),
+                        (now, correct_increment, resolved_review_session_id),
                     )
                 updated = conn.execute(
                     """
@@ -27231,6 +27499,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "selected",
             "display_label",
             "label",
+            "topic_key",
+            "normalization_version",
+            "evidence_reasons",
             "source_id",
             "source_type",
             "source_ref",
@@ -27240,6 +27511,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "available",
             "enabled",
             "count",
+            "source_count",
             "total",
             "id",
             "ids",
@@ -27266,6 +27538,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         "_status",
     )
     _SAFE_SUGGESTION_PAYLOAD_MAX_TEXT_LENGTH = 256
+    _SAFE_SUGGESTION_EVIDENCE_REASONS = frozenset(
+        {
+            "missed_question",
+            "source_citation",
+            "tag_match",
+            "derived_label",
+        }
+    )
 
     @classmethod
     def _is_safe_suggestion_payload_key(cls, key: str) -> bool:
@@ -27273,6 +27553,28 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         return normalized in cls._SAFE_SUGGESTION_PAYLOAD_EXACT_KEYS or normalized.endswith(
             cls._SAFE_SUGGESTION_PAYLOAD_SUFFIXES
         )
+
+    @classmethod
+    def _sanitize_suggestion_evidence_reasons(cls, value: Any) -> list[str] | None:
+        """Persist only structured evidence reason codes from the approved set."""
+        if value is None:
+            return None
+
+        if isinstance(value, str):
+            raw_items: list[Any] = [value]
+        elif isinstance(value, list | tuple | set):
+            raw_items = list(value)
+        else:
+            return None
+
+        sanitized: list[str] = []
+        for item in raw_items:
+            reason = str(item or "").strip().lower()
+            if not reason or reason not in cls._SAFE_SUGGESTION_EVIDENCE_REASONS:
+                continue
+            if reason not in sanitized:
+                sanitized.append(reason)
+        return sanitized or None
 
     @classmethod
     def _sanitize_suggestion_payload(cls, payload: Any, *, parent_key: str | None = None) -> Any:
@@ -27283,7 +27585,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 key_text = str(raw_key)
                 if not cls._is_safe_suggestion_payload_key(key_text):
                     continue
-                cleaned_value = cls._sanitize_suggestion_payload(value, parent_key=key_text)
+                if key_text.strip().lower() == "evidence_reasons":
+                    cleaned_value = cls._sanitize_suggestion_evidence_reasons(value)
+                else:
+                    cleaned_value = cls._sanitize_suggestion_payload(value, parent_key=key_text)
                 if cleaned_value in (None, {}, []):
                     continue
                 sanitized[key_text] = cleaned_value
@@ -27494,7 +27799,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 raise ConflictError(
                     "Suggestion generation link already exists",
                     entity="suggestion_generation_links",
-                    identifier=f"{snapshot_id}:{target_service}:{target_type}:{target_id}:{selection_fingerprint}",
+                    identifier=f"{snapshot_id}:{target_service}:{target_type}:{selection_fingerprint}",
                 ) from exc
             raise CharactersRAGDBError(f"Failed to create suggestion generation link: {exc}") from exc  # noqa: TRY003
         except BackendDatabaseError as exc:
@@ -27502,7 +27807,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 raise ConflictError(
                     "Suggestion generation link already exists",
                     entity="suggestion_generation_links",
-                    identifier=f"{snapshot_id}:{target_service}:{target_type}:{target_id}:{selection_fingerprint}",
+                    identifier=f"{snapshot_id}:{target_service}:{target_type}:{selection_fingerprint}",
                 ) from exc
             raise CharactersRAGDBError(f"Failed to create suggestion generation link: {exc}") from exc  # noqa: TRY003
         except sqlite3.Error as exc:
@@ -27537,6 +27842,111 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         )
         row = cursor.fetchone()
         return dict(row) if row else None
+
+    def replace_suggestion_generation_link(
+        self,
+        *,
+        snapshot_id: int,
+        target_service: str,
+        target_type: str,
+        target_id: str,
+        selection_fingerprint: str,
+    ) -> int:
+        """Upsert a direct generation link without accumulating multiple active rows."""
+        now = self._get_current_utc_timestamp_iso()
+        try:
+            with self.transaction() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT id
+                      FROM suggestion_generation_links
+                     WHERE snapshot_id = ?
+                       AND target_service = ?
+                       AND target_type = ?
+                       AND selection_fingerprint = ?
+                       AND deleted = 0
+                     ORDER BY id DESC
+                    """,
+                    (
+                        int(snapshot_id),
+                        target_service,
+                        target_type,
+                        selection_fingerprint,
+                    ),
+                ).fetchall()
+                if rows:
+                    keeper_id = int(rows[0]["id"])
+                    updated = conn.execute(
+                        """
+                        UPDATE suggestion_generation_links
+                           SET target_id = ?, last_modified = ?, version = version + 1, client_id = ?
+                         WHERE id = ? AND deleted = 0
+                        """,
+                        (
+                            str(target_id),
+                            now,
+                            self.client_id,
+                            keeper_id,
+                        ),
+                    ).rowcount
+                    stale_ids = [int(row["id"]) for row in rows[1:]]
+                    for stale_id in stale_ids:
+                        conn.execute(
+                            """
+                            UPDATE suggestion_generation_links
+                               SET deleted = ?, last_modified = ?, version = version + 1, client_id = ?
+                             WHERE id = ? AND deleted = 0
+                            """,
+                            (True, now, self.client_id, stale_id),
+                        )
+                    return int(updated)
+
+                insert_sql = (
+                    "INSERT INTO suggestion_generation_links("
+                    "snapshot_id, target_service, target_type, target_id, selection_fingerprint, "
+                    "created_at, last_modified, deleted, client_id, version"
+                    ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                )
+                params = (
+                    int(snapshot_id),
+                    target_service,
+                    target_type,
+                    str(target_id),
+                    selection_fingerprint,
+                    now,
+                    now,
+                    False,
+                    self.client_id,
+                    1,
+                )
+                if self.backend_type == BackendType.POSTGRESQL:
+                    cursor = conn.execute(insert_sql + " RETURNING id", params)
+                    row = cursor.fetchone()
+                    link_id = int(row["id"]) if row else None
+                else:
+                    cursor = conn.execute(insert_sql, params)
+                    link_id = int(cursor.lastrowid) if cursor.lastrowid is not None else None
+                if link_id is None:
+                    raise CharactersRAGDBError("Failed to determine suggestion generation link ID after insert")  # noqa: TRY003
+                return link_id
+        except sqlite3.IntegrityError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(
+                    "Suggestion generation link already exists",
+                    entity="suggestion_generation_links",
+                    identifier=f"{snapshot_id}:{target_service}:{target_type}:{selection_fingerprint}",
+                ) from exc
+            raise CharactersRAGDBError(f"Failed to replace suggestion generation link: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(
+                    "Suggestion generation link already exists",
+                    entity="suggestion_generation_links",
+                    identifier=f"{snapshot_id}:{target_service}:{target_type}:{selection_fingerprint}",
+                ) from exc
+            raise CharactersRAGDBError(f"Failed to replace suggestion generation link: {exc}") from exc  # noqa: TRY003
+        except sqlite3.Error as exc:
+            raise CharactersRAGDBError(f"Failed to replace suggestion generation link: {exc}") from exc  # noqa: TRY003
 
     def find_suggestion_generation_link_by_fingerprint(
         self,
@@ -27610,6 +28020,44 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             raise CharactersRAGDBError(f"Failed to finalize suggestion generation link: {exc}") from exc  # noqa: TRY003
         except BackendDatabaseError as exc:
             raise CharactersRAGDBError(f"Failed to finalize suggestion generation link: {exc}") from exc  # noqa: TRY003
+
+    def soft_delete_suggestion_generation_link(
+        self,
+        *,
+        snapshot_id: int,
+        target_service: str,
+        target_type: str,
+        selection_fingerprint: str,
+    ) -> int:
+        """Soft-delete active generation links matching a snapshot fingerprint."""
+        now = self._get_current_utc_timestamp_iso()
+        try:
+            with self.transaction() as conn:
+                updated = conn.execute(
+                    """
+                    UPDATE suggestion_generation_links
+                       SET deleted = ?, last_modified = ?, version = version + 1, client_id = ?
+                     WHERE snapshot_id = ?
+                       AND target_service = ?
+                       AND target_type = ?
+                       AND selection_fingerprint = ?
+                       AND deleted = 0
+                    """,
+                    (
+                        True,
+                        now,
+                        self.client_id,
+                        int(snapshot_id),
+                        target_service,
+                        target_type,
+                        selection_fingerprint,
+                    ),
+                ).rowcount
+            return int(updated)
+        except sqlite3.Error as exc:
+            raise CharactersRAGDBError(f"Failed to soft-delete suggestion generation link: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            raise CharactersRAGDBError(f"Failed to soft-delete suggestion generation link: {exc}") from exc  # noqa: TRY003
 
     def release_suggestion_generation_link_reservation(
         self,

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -26635,6 +26635,26 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:
             raise CharactersRAGDBError(f"Failed to fetch flashcard review session rollup: {exc}") from exc  # noqa: TRY003
 
+    def get_flashcard_reviewed_cards(self, session_id: int) -> list[dict[str, Any]]:
+        """Return reviewed flashcard metadata for a session in review order."""
+        cursor = self.execute_query(
+            """
+            SELECT f.uuid,
+                   MAX(f.tags_json) AS tags_json,
+                   MAX(f.source_ref_type) AS source_ref_type,
+                   MAX(f.source_ref_id) AS source_ref_id,
+                   MAX(d.name) AS deck_name
+              FROM flashcard_reviews fr
+              JOIN flashcards f ON f.id = fr.card_id
+              LEFT JOIN decks d ON d.id = f.deck_id
+             WHERE fr.review_session_id = ?
+             GROUP BY f.uuid
+             ORDER BY MIN(fr.id)
+            """,
+            (int(session_id),),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
     def get_latest_flashcard_review(self, card_uuid: str) -> dict[str, Any] | None:
         """Return the most recent review row for a flashcard, including nullable session linkage."""
         cursor = self.execute_query(
@@ -27899,7 +27919,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                             """,
                             (True, now, self.client_id, stale_id),
                         )
-                    return int(updated)
+                    if updated <= 0:
+                        raise CharactersRAGDBError("Failed to update existing suggestion generation link")  # noqa: TRY003
+                    return keeper_id
 
                 insert_sql = (
                     "INSERT INTO suggestion_generation_links("

--- a/tldw_Server_API/app/core/StudySuggestions/actions.py
+++ b/tldw_Server_API/app/core/StudySuggestions/actions.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 
 
 DEFAULT_GENERATOR_VERSION = "v1"
+LEGACY_NORMALIZATION_VERSION = "legacy"
 PENDING_GENERATION_TARGET_PREFIX = "pending:"
 FOLLOW_UP_ACTION_CONTRACTS = {
     "follow_up_quiz": {
@@ -38,6 +39,65 @@ def normalize_selected_topics(selected_topics: Iterable[object]) -> list[str]:
     return sorted(normalized)
 
 
+def _iter_snapshot_topics(snapshot_row: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    payload = snapshot_row.get("payload_json") or {}
+    topics = payload.get("topics") if isinstance(payload, Mapping) else []
+    return [topic for topic in topics if isinstance(topic, Mapping)] if isinstance(topics, list) else []
+
+
+def _iter_selected_snapshot_topics(
+    snapshot_row: Mapping[str, Any],
+    *,
+    selected_topic_ids: Iterable[object],
+    has_explicit_selection: bool = False,
+) -> list[Mapping[str, Any]]:
+    topics = _iter_snapshot_topics(snapshot_row)
+    selected_ids = {str(topic_id).strip() for topic_id in selected_topic_ids if str(topic_id).strip()}
+    use_default_selected = not has_explicit_selection and not selected_ids
+
+    selected_topics: list[Mapping[str, Any]] = []
+    for topic in topics:
+        topic_id = str(topic.get("id") or "").strip()
+        if use_default_selected:
+            if not bool(topic.get("selected")):
+                continue
+        elif topic_id not in selected_ids:
+            continue
+        selected_topics.append(topic)
+    return selected_topics
+
+
+def _resolve_topic_semantic_key(topic: Mapping[str, Any]) -> str:
+    for field_name in ("topic_key", "canonical_label", "display_label"):
+        value = str(topic.get(field_name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _topic_identity_tokens(topic: Mapping[str, Any]) -> frozenset[str]:
+    identities = {
+        normalized
+        for field_name in ("topic_key", "canonical_label", "display_label")
+        if (normalized := _normalize_text(topic.get(field_name)))
+    }
+    return frozenset(identities)
+
+
+def _resolve_normalization_version_values(values: Iterable[object]) -> str:
+    normalized = normalize_selected_topics(values)
+    return ",".join(normalized) if normalized else LEGACY_NORMALIZATION_VERSION
+
+
+def _resolve_snapshot_normalization_version(snapshot_row: Mapping[str, Any]) -> str:
+    versions = [
+        str(topic.get("normalization_version") or "").strip()
+        for topic in _iter_snapshot_topics(snapshot_row)
+        if str(topic.get("normalization_version") or "").strip()
+    ]
+    return _resolve_normalization_version_values(versions)
+
+
 def build_selection_fingerprint(
     *,
     snapshot_id: int,
@@ -46,21 +106,27 @@ def build_selection_fingerprint(
     selected_topics: Iterable[object],
     action_kind: str,
     generator_version: str | None = None,
+    normalization_version: str | None = None,
+    include_normalization_version: bool = True,
 ) -> str:
     """Build a stable, human-readable fingerprint for one follow-up action selection."""
 
     normalized_topics = normalize_selected_topics(selected_topics)
     resolved_generator_version = _normalize_text(generator_version or DEFAULT_GENERATOR_VERSION) or DEFAULT_GENERATOR_VERSION
-    return "|".join(
-        (
-            f"snapshot_id={int(snapshot_id)}",
-            f"target_service={_normalize_text(target_service)}",
-            f"target_type={_normalize_text(target_type)}",
-            f"topics={','.join(normalized_topics)}",
-            f"action_kind={_normalize_text(action_kind)}",
-            f"generator_version={resolved_generator_version}",
-        )
+    resolved_normalization_version = _resolve_normalization_version_values(
+        [normalization_version] if normalization_version is not None else []
     )
+    components = [
+        f"snapshot_id={int(snapshot_id)}",
+        f"target_service={_normalize_text(target_service)}",
+        f"target_type={_normalize_text(target_type)}",
+        f"topics={','.join(normalized_topics)}",
+        f"action_kind={_normalize_text(action_kind)}",
+        f"generator_version={resolved_generator_version}",
+    ]
+    if include_normalization_version:
+        components.append(f"normalization_version={resolved_normalization_version}")
+    return "|".join(components)
 
 
 def canonicalize_follow_up_action(
@@ -103,9 +169,6 @@ def resolve_selected_topic_labels(
 ) -> list[str]:
     """Resolve requested topic ids into display labels from the frozen snapshot payload."""
 
-    payload = snapshot_row.get("payload_json") or {}
-    topics = payload.get("topics") if isinstance(payload, Mapping) else []
-    selected_ids = {str(topic_id).strip() for topic_id in selected_topic_ids if str(topic_id).strip()}
     edit_labels: dict[str, str] = {}
     for item in selected_topic_edits or []:
         if not isinstance(item, Mapping):
@@ -115,22 +178,134 @@ def resolve_selected_topic_labels(
         if topic_id and topic_label:
             edit_labels[topic_id] = topic_label
     manual_labels = normalize_selected_topics(manual_topic_labels or [])
-    use_default_selected = not has_explicit_selection and not selected_ids
     labels: list[str] = []
-    for topic in topics if isinstance(topics, list) else []:
-        if not isinstance(topic, Mapping):
-            continue
+    for topic in _iter_selected_snapshot_topics(
+        snapshot_row,
+        selected_topic_ids=selected_topic_ids,
+        has_explicit_selection=has_explicit_selection,
+    ):
         topic_id = str(topic.get("id") or "").strip()
-        if use_default_selected:
-            if not bool(topic.get("selected")):
-                continue
-        elif topic_id and topic_id not in selected_ids:
-            continue
         label = edit_labels.get(topic_id) or str(topic.get("display_label") or "").strip()
         if label:
             labels.append(label)
     labels.extend(manual_labels)
     return normalize_selected_topics(labels)
+
+
+def resolve_selected_topic_semantic_keys(
+    snapshot_row: Mapping[str, Any],
+    *,
+    selected_topic_ids: Iterable[object],
+    manual_topic_labels: Iterable[object] | None = None,
+    has_explicit_selection: bool = False,
+) -> list[str]:
+    """Resolve selected snapshot rows into semantic keys for fingerprinting."""
+
+    manual_labels = normalize_selected_topics(manual_topic_labels or [])
+    semantic_keys: list[str] = []
+    for topic in _iter_selected_snapshot_topics(
+        snapshot_row,
+        selected_topic_ids=selected_topic_ids,
+        has_explicit_selection=has_explicit_selection,
+    ):
+        semantic_key = _resolve_topic_semantic_key(topic)
+        if semantic_key:
+            semantic_keys.append(semantic_key)
+    semantic_keys.extend(manual_labels)
+    return normalize_selected_topics(semantic_keys)
+
+
+def resolve_selected_topic_normalization_version(
+    snapshot_row: Mapping[str, Any],
+    *,
+    selected_topic_ids: Iterable[object],
+    has_explicit_selection: bool = False,
+) -> str:
+    """Resolve the deterministic normalization-version contract for one selection."""
+
+    selected_versions = [
+        str(topic.get("normalization_version") or "").strip()
+        for topic in _iter_selected_snapshot_topics(
+            snapshot_row,
+            selected_topic_ids=selected_topic_ids,
+            has_explicit_selection=has_explicit_selection,
+        )
+        if str(topic.get("normalization_version") or "").strip()
+    ]
+    if selected_versions:
+        return _resolve_normalization_version_values(selected_versions)
+    return _resolve_snapshot_normalization_version(snapshot_row)
+
+
+def resolve_selected_topic_identity_groups(
+    snapshot_row: Mapping[str, Any],
+    *,
+    selected_topic_ids: Iterable[object],
+    has_explicit_selection: bool = False,
+) -> list[frozenset[str]]:
+    """Return comparable per-topic identity groups for refreshed-lineage matching."""
+
+    identity_groups: list[frozenset[str]] = []
+    for topic in _iter_selected_snapshot_topics(
+        snapshot_row,
+        selected_topic_ids=selected_topic_ids,
+        has_explicit_selection=has_explicit_selection,
+    ):
+        identities = _topic_identity_tokens(topic)
+        if identities:
+            identity_groups.append(identities)
+    return identity_groups
+
+
+def resolve_lineage_equivalent_topic_selection(
+    snapshot_row: Mapping[str, Any],
+    *,
+    requested_identity_groups: Iterable[Iterable[object]],
+) -> tuple[list[str], str] | None:
+    """Map the current semantic selection onto one ancestor snapshot's native topic identity."""
+
+    normalized_groups: list[frozenset[str]] = []
+    for group in requested_identity_groups:
+        normalized_group = normalize_selected_topics(group)
+        if normalized_group:
+            normalized_groups.append(frozenset(normalized_group))
+    if not normalized_groups:
+        return None
+
+    topics = _iter_snapshot_topics(snapshot_row)
+    matched_semantic_keys: list[str] = []
+    matched_versions: list[str] = []
+    used_topic_indexes: set[int] = set()
+
+    for identity_group in normalized_groups:
+        matched_index: int | None = None
+        for index, topic in enumerate(topics):
+            if index in used_topic_indexes:
+                continue
+            if _topic_identity_tokens(topic) & identity_group:
+                matched_index = index
+                break
+        if matched_index is None:
+            return None
+
+        matched_topic = topics[matched_index]
+        used_topic_indexes.add(matched_index)
+        semantic_key = _resolve_topic_semantic_key(matched_topic)
+        if semantic_key:
+            matched_semantic_keys.append(semantic_key)
+        normalization_version = str(matched_topic.get("normalization_version") or "").strip()
+        if normalization_version:
+            matched_versions.append(normalization_version)
+
+    if len(matched_semantic_keys) != len(normalized_groups):
+        return None
+
+    return (
+        normalize_selected_topics(matched_semantic_keys),
+        _resolve_normalization_version_values(matched_versions)
+        if matched_versions
+        else _resolve_snapshot_normalization_version(snapshot_row),
+    )
 
 
 def _titleize_label(value: object) -> str:
@@ -393,6 +568,7 @@ def soft_delete_deck(note_db: CharactersRAGDB, *, deck_id: int) -> None:
 __all__ = [
     "DEFAULT_GENERATOR_VERSION",
     "FOLLOW_UP_ACTION_CONTRACTS",
+    "LEGACY_NORMALIZATION_VERSION",
     "PENDING_GENERATION_TARGET_PREFIX",
     "build_flashcard_generation_payload",
     "build_follow_up_flashcard_deck_name",
@@ -406,6 +582,10 @@ __all__ = [
     "normalize_selected_topics",
     "release_generation_link_reservation",
     "reserve_generation_link",
+    "resolve_lineage_equivalent_topic_selection",
     "resolve_selected_topic_labels",
+    "resolve_selected_topic_identity_groups",
+    "resolve_selected_topic_normalization_version",
+    "resolve_selected_topic_semantic_keys",
     "soft_delete_deck",
 ]

--- a/tldw_Server_API/app/core/StudySuggestions/flashcard_adapter.py
+++ b/tldw_Server_API/app/core/StudySuggestions/flashcard_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+import json
 from typing import Any
 
 from .types import SuggestionContext
@@ -10,6 +11,172 @@ from .types import SuggestionContext
 
 def _copy_source_bundle(source_bundle: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]]:
     return [dict(item) for item in (source_bundle or [])]
+
+
+def _safe_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _unique_preserve(values: Sequence[object]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        text = _safe_text(value)
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(text)
+    return ordered
+
+
+def _unique_sources(values: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
+    seen: set[tuple[str, str, str | None]] = set()
+    ordered: list[dict[str, str]] = []
+    for value in values:
+        source_type = _safe_text(value.get("source_type"))
+        source_id = _safe_text(value.get("source_id"))
+        label = _safe_text(value.get("label"))
+        if not source_type or not source_id:
+            continue
+        key = (source_type.casefold(), source_id.casefold(), label.casefold() if label else None)
+        if key in seen:
+            continue
+        seen.add(key)
+        item = {
+            "source_type": source_type,
+            "source_id": source_id,
+        }
+        if label:
+            item["label"] = label
+        ordered.append(item)
+    return ordered
+
+
+def _parse_tags(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return _unique_preserve(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        try:
+            decoded = json.loads(stripped)
+        except json.JSONDecodeError:
+            return _unique_preserve([stripped])
+        if isinstance(decoded, list):
+            return _unique_preserve(decoded)
+    return []
+
+
+def _normalize_source_items(value: Any) -> list[Mapping[str, Any]]:
+    if isinstance(value, Mapping):
+        nested_items = value.get("items")
+        if isinstance(nested_items, list):
+            return [item for item in nested_items if isinstance(item, Mapping)]
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        return [item for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _merge_flashcard_provenance(
+    session: Mapping[str, Any],
+    provenance: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    merged = dict(session)
+    if not provenance:
+        return merged
+
+    for key in ("source_bundle", "study_pack_id", "deck_name", "tag_filter", "workspace_id"):
+        if merged.get(key) is None and provenance.get(key) is not None:
+            merged[key] = provenance.get(key)
+    return merged
+
+
+def extract_flashcard_suggestion_evidence(
+    session: Mapping[str, Any],
+    *,
+    provenance: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Extract flashcard labels and light refs from a merged review-session view."""
+
+    merged_session = _merge_flashcard_provenance(session, provenance)
+    source_labels: list[str] = []
+    tag_labels: list[str] = []
+    derived_labels: list[str] = []
+    adjacent_labels: list[str] = []
+    source_bundle: list[dict[str, str]] = []
+
+    def add_source_items(items: Any) -> None:
+        for item in _normalize_source_items(items):
+            source_type = _safe_text(item.get("source_type"))
+            source_id = _safe_text(item.get("source_id"))
+            label = _safe_text(item.get("label"))
+            if not source_type or not source_id:
+                continue
+            if label:
+                source_labels.append(label)
+            source_item = {
+                "source_type": source_type,
+                "source_id": source_id,
+            }
+            if label:
+                source_item["label"] = label
+            source_bundle.append(source_item)
+
+    add_source_items(merged_session.get("source_bundle"))
+
+    study_pack = provenance.get("study_pack") if provenance else None
+    if isinstance(study_pack, Mapping):
+        add_source_items(study_pack.get("source_bundle_json"))
+        if _safe_text(study_pack.get("title")):
+            derived_labels.append(str(study_pack["title"]))
+
+    tag_filter = _safe_text(merged_session.get("tag_filter"))
+    if tag_filter:
+        tag_labels.append(tag_filter)
+        adjacent_labels.append(tag_filter)
+
+    deck_name = _safe_text(merged_session.get("deck_name"))
+    if deck_name:
+        derived_labels.append(deck_name)
+
+    reviewed_cards = provenance.get("reviewed_cards") if provenance else None
+    if isinstance(reviewed_cards, Sequence):
+        for card in reviewed_cards:
+            if not isinstance(card, Mapping):
+                continue
+            tag_labels.extend(_parse_tags(card.get("tags_json")))
+            source_type = _safe_text(card.get("source_ref_type"))
+            source_id = _safe_text(card.get("source_ref_id"))
+            if source_type and source_id and source_type != "manual":
+                source_bundle.append(
+                    {
+                        "source_type": source_type,
+                        "source_id": source_id,
+                    }
+                )
+
+    if tag_labels:
+        adjacent_labels.extend(tag_labels)
+    elif derived_labels:
+        adjacent_labels.extend(derived_labels)
+    else:
+        derived_labels.append("spaced repetition")
+        adjacent_labels.append("spaced repetition")
+
+    return {
+        "source_labels": _unique_preserve(source_labels),
+        "tag_labels": _unique_preserve(tag_labels),
+        "derived_labels": _unique_preserve(derived_labels),
+        "weakness_labels": [],
+        "adjacent_labels": _unique_preserve(adjacent_labels),
+        "source_bundle": _unique_sources(source_bundle),
+    }
 
 
 def is_source_grounded_session(session: Mapping[str, Any]) -> bool:
@@ -25,29 +192,42 @@ def is_source_grounded_session(session: Mapping[str, Any]) -> bool:
     return False
 
 
-def build_flashcard_suggestion_context(session: Mapping[str, Any]) -> SuggestionContext:
-    cards_reviewed = int(session.get("cards_reviewed") or 0)
-    correct_count = int(session.get("correct_count") or 0)
-    deck_id = int(session["deck_id"]) if session.get("deck_id") is not None else None
-    grounded = is_source_grounded_session(session)
-    review_mode = str(session.get("review_mode") or "")
+def build_flashcard_suggestion_context(
+    session: Mapping[str, Any],
+    *,
+    provenance: Mapping[str, Any] | None = None,
+) -> SuggestionContext:
+    merged_session = _merge_flashcard_provenance(session, provenance)
+    cards_reviewed = int(merged_session.get("cards_reviewed") or 0)
+    correct_count = int(merged_session.get("correct_count") or 0)
+    deck_id = int(merged_session["deck_id"]) if merged_session.get("deck_id") is not None else None
+    grounded = is_source_grounded_session(merged_session)
+    review_mode = str(merged_session.get("review_mode") or "")
     supports_source_aware_adjacency = grounded and review_mode != "manual"
 
     return SuggestionContext(
         service="flashcards",
         activity_type="flashcard_review_session",
         anchor_type="flashcard_review_session",
-        anchor_id=int(session["id"]),
-        workspace_id=session.get("workspace_id"),
+        anchor_id=int(merged_session["id"]),
+        workspace_id=merged_session.get("workspace_id"),
         summary_metrics={
             "deck_id": deck_id,
             "cards_reviewed": cards_reviewed,
             "correct_count": correct_count,
+            "study_pack_id": merged_session.get("study_pack_id"),
         },
         performance_signals={
             "accuracy": (correct_count / cards_reviewed) if cards_reviewed else 0.0,
             "is_source_grounded_session": grounded,
             "supports_source_aware_adjacency": supports_source_aware_adjacency,
         },
-        source_bundle=_copy_source_bundle(session.get("source_bundle")),
+        source_bundle=_copy_source_bundle(merged_session.get("source_bundle")),
     )
+
+
+__all__ = [
+    "build_flashcard_suggestion_context",
+    "extract_flashcard_suggestion_evidence",
+    "is_source_grounded_session",
+]

--- a/tldw_Server_API/app/core/StudySuggestions/flashcard_adapter.py
+++ b/tldw_Server_API/app/core/StudySuggestions/flashcard_adapter.py
@@ -69,6 +69,8 @@ def _parse_tags(value: Any) -> list[str]:
             return _unique_preserve([stripped])
         if isinstance(decoded, list):
             return _unique_preserve(decoded)
+        if isinstance(decoded, str):
+            return _unique_preserve([decoded])
     return []
 
 
@@ -78,7 +80,7 @@ def _normalize_source_items(value: Any) -> list[Mapping[str, Any]]:
         if isinstance(nested_items, list):
             return [item for item in nested_items if isinstance(item, Mapping)]
         return [value]
-    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
         return [item for item in value if isinstance(item, Mapping)]
     return []
 

--- a/tldw_Server_API/app/core/StudySuggestions/quiz_adapter.py
+++ b/tldw_Server_API/app/core/StudySuggestions/quiz_adapter.py
@@ -12,6 +12,118 @@ def _copy_source_bundle(source_bundle: Sequence[Mapping[str, Any]] | None) -> li
     return [dict(item) for item in (source_bundle or [])]
 
 
+def _safe_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _unique_preserve(values: Sequence[object]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        text = _safe_text(value)
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(text)
+    return ordered
+
+
+def _unique_sources(values: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
+    seen: set[tuple[str, str, str | None]] = set()
+    ordered: list[dict[str, str]] = []
+    for value in values:
+        source_type = _safe_text(value.get("source_type"))
+        source_id = _safe_text(value.get("source_id"))
+        label = _safe_text(value.get("label"))
+        if not source_type or not source_id:
+            continue
+        key = (source_type.casefold(), source_id.casefold(), label.casefold() if label else None)
+        if key in seen:
+            continue
+        seen.add(key)
+        item = {
+            "source_type": source_type,
+            "source_id": source_id,
+        }
+        if label:
+            item["label"] = label
+        ordered.append(item)
+    return ordered
+
+
+def _normalize_citation_source(citation: Mapping[str, Any]) -> dict[str, str] | None:
+    source_type = _safe_text(citation.get("source_type"))
+    source_id = _safe_text(citation.get("source_id"))
+    label = _safe_text(citation.get("label"))
+    if not source_type or not source_id:
+        return None
+    source: dict[str, str] = {
+        "source_type": source_type,
+        "source_id": source_id,
+    }
+    if label:
+        source["label"] = label
+    return source
+
+
+def extract_quiz_suggestion_evidence(attempt: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract quiz labels and light refs from an attempt row."""
+
+    questions = attempt.get("questions") or []
+    answers = attempt.get("answers") or []
+    answers_by_question_id = {
+        int(answer["question_id"]): answer
+        for answer in answers
+        if isinstance(answer, Mapping) and answer.get("question_id") is not None
+    }
+
+    source_labels: list[str] = []
+    tag_labels: list[str] = []
+    weakness_labels: list[str] = []
+    adjacent_labels: list[str] = []
+    source_bundle: list[dict[str, str]] = []
+
+    for question in questions:
+        if not isinstance(question, Mapping):
+            continue
+        question_id = question.get("id")
+        answer = answers_by_question_id.get(int(question_id)) if question_id is not None else None
+        question_tags = [tag for tag in (question.get("tags") or []) if _safe_text(tag)]
+        citations = [item for item in (question.get("source_citations") or []) if isinstance(item, Mapping)]
+        citation_labels = [_safe_text(citation.get("label")) for citation in citations]
+        citation_labels = [label for label in citation_labels if label]
+
+        tag_labels.extend(question_tags)
+        source_labels.extend(citation_labels)
+        for citation in citations:
+            source = _normalize_citation_source(citation)
+            if source:
+                source_bundle.append(source)
+
+        is_incorrect = bool(answer) and answer.get("is_correct") is False
+        target = weakness_labels if is_incorrect else adjacent_labels
+        target.extend(question_tags)
+        target.extend(citation_labels)
+
+    derived_labels: list[str] = []
+    if not source_labels and not tag_labels:
+        incorrect_count = sum(1 for answer in answers if isinstance(answer, Mapping) and answer.get("is_correct") is False)
+        derived_labels.append("missed questions" if incorrect_count else "review")
+
+    return {
+        "source_labels": _unique_preserve(source_labels),
+        "tag_labels": _unique_preserve(tag_labels),
+        "derived_labels": _unique_preserve(derived_labels),
+        "weakness_labels": _unique_preserve(weakness_labels),
+        "adjacent_labels": _unique_preserve(adjacent_labels),
+        "source_bundle": _unique_sources(source_bundle),
+    }
+
+
 def build_quiz_suggestion_context(
     *,
     quiz_attempt: Mapping[str, Any],
@@ -41,3 +153,9 @@ def build_quiz_suggestion_context(
         },
         source_bundle=_copy_source_bundle(source_bundle),
     )
+
+
+__all__ = [
+    "build_quiz_suggestion_context",
+    "extract_quiz_suggestion_evidence",
+]

--- a/tldw_Server_API/app/core/StudySuggestions/snapshot_service.py
+++ b/tldw_Server_API/app/core/StudySuggestions/snapshot_service.py
@@ -11,13 +11,14 @@ from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 
-from .flashcard_adapter import build_flashcard_suggestion_context
+from .flashcard_adapter import build_flashcard_suggestion_context, extract_flashcard_suggestion_evidence
 from .jobs import (
     STUDY_SUGGESTIONS_DOMAIN,
     STUDY_SUGGESTIONS_REFRESH_JOB_TYPE,
     study_suggestions_jobs_queue,
 )
-from .quiz_adapter import build_quiz_suggestion_context
+from .quiz_adapter import build_quiz_suggestion_context, extract_quiz_suggestion_evidence
+from .topic_aliases import DEFAULT_NAMESPACE, NORMALIZATION_VERSION, topic_key_for
 from .topic_pipeline import rank_suggestion_topics, resolve_topic_candidates
 
 
@@ -33,122 +34,41 @@ def _titleize_label(label: str) -> str:
     return " ".join(word.capitalize() for word in words)
 
 
-def _unique_preserve(values: Iterable[object]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for value in values:
-        text = _safe_text(value)
-        if not text:
-            continue
-        key = text.casefold()
-        if key in seen:
-            continue
-        seen.add(key)
-        ordered.append(text)
-    return ordered
-
-
-def _unique_sources(values: Iterable[Mapping[str, Any]]) -> list[dict[str, str]]:
-    seen: set[tuple[str, str, str | None]] = set()
-    ordered: list[dict[str, str]] = []
-    for value in values:
-        source_type = _safe_text(value.get("source_type"))
-        source_id = _safe_text(value.get("source_id"))
-        label = _safe_text(value.get("label"))
-        if not source_type or not source_id:
-            continue
-        key = (source_type.casefold(), source_id.casefold(), label.casefold() if label else None)
-        if key in seen:
-            continue
-        seen.add(key)
-        item = {
-            "source_type": source_type,
-            "source_id": source_id,
-        }
-        if label:
-            item["label"] = label
-        ordered.append(item)
-    return ordered
-
-
-def _normalize_citation_source(citation: Mapping[str, Any]) -> dict[str, str] | None:
-    source_type = _safe_text(citation.get("source_type"))
-    source_id = _safe_text(citation.get("source_id"))
-    label = _safe_text(citation.get("label"))
-    if not source_type or not source_id:
-        return None
-    source: dict[str, str] = {
-        "source_type": source_type,
-        "source_id": source_id,
+def _fallback_topic_item(
+    *,
+    index: int,
+    display_label: str,
+    status: str = "candidate",
+    selected: bool = False,
+) -> dict[str, Any]:
+    canonical_label = str(display_label or "review").strip().lower() or "review"
+    return {
+        "id": f"topic-{index}",
+        "display_label": _titleize_label(display_label),
+        "type": "derived",
+        "status": status,
+        "selected": selected,
+        "topic_key": topic_key_for(DEFAULT_NAMESPACE, canonical_label),
+        "normalization_version": NORMALIZATION_VERSION,
+        "canonical_label": canonical_label,
+        "evidence_reasons": ["derived_label"],
+        "source_count": 0,
     }
-    if label:
-        source["label"] = label
-    return source
-
-
-def _extract_quiz_labels(
-    attempt: Mapping[str, Any],
-) -> tuple[list[str], list[str], list[str], list[str], list[str], list[dict[str, str]]]:
-    questions = attempt.get("questions") or []
-    answers = attempt.get("answers") or []
-    answers_by_question_id = {
-        int(answer["question_id"]): answer
-        for answer in answers
-        if isinstance(answer, Mapping) and answer.get("question_id") is not None
-    }
-
-    source_labels: list[str] = []
-    tag_labels: list[str] = []
-    weakness_labels: list[str] = []
-    adjacent_labels: list[str] = []
-    source_bundle: list[dict[str, str]] = []
-
-    for question in questions:
-        if not isinstance(question, Mapping):
-            continue
-        question_id = question.get("id")
-        answer = answers_by_question_id.get(int(question_id)) if question_id is not None else None
-        question_tags = [tag for tag in (question.get("tags") or []) if _safe_text(tag)]
-        citations = [item for item in (question.get("source_citations") or []) if isinstance(item, Mapping)]
-        citation_labels = [_safe_text(citation.get("label")) for citation in citations]
-        citation_labels = [label for label in citation_labels if label]
-
-        tag_labels.extend(question_tags)
-        source_labels.extend(citation_labels)
-        for citation in citations:
-            source = _normalize_citation_source(citation)
-            if source:
-                source_bundle.append(source)
-
-        is_incorrect = bool(answer) and answer.get("is_correct") is False
-        target = weakness_labels if is_incorrect else adjacent_labels
-        target.extend(question_tags)
-        target.extend(citation_labels)
-
-    derived_labels = []
-    if not source_labels and not tag_labels:
-        incorrect_count = sum(1 for answer in answers if isinstance(answer, Mapping) and answer.get("is_correct") is False)
-        derived_labels.append("missed questions" if incorrect_count else "review")
-
-    return (
-        _unique_preserve(source_labels),
-        _unique_preserve(tag_labels),
-        _unique_preserve(derived_labels),
-        _unique_preserve(weakness_labels),
-        _unique_preserve(adjacent_labels),
-        _unique_sources(source_bundle),
-    )
 
 
 def _find_quiz_topic_source(
     canonical_label: str,
     source_bundle: list[dict[str, str]],
+    *,
+    allow_fallback: bool = True,
 ) -> dict[str, str] | None:
     for source in source_bundle:
         source_label = _safe_text(source.get("label"))
         if source_label and source_label.casefold() == canonical_label.casefold():
             return source
-    return source_bundle[0] if source_bundle else None
+    if allow_fallback and source_bundle:
+        return source_bundle[0]
+    return None
 
 
 def _build_quiz_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tuple[str, str, dict[str, Any]]:
@@ -166,7 +86,7 @@ def _build_quiz_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tu
         }
         for answer in answers
     ]
-    source_labels, tag_labels, derived_labels, weakness_labels, adjacent_labels, source_bundle = _extract_quiz_labels(attempt)
+    evidence = extract_quiz_suggestion_evidence(attempt)
     context = build_quiz_suggestion_context(
         quiz_attempt={
             "id": int(attempt["id"]),
@@ -177,22 +97,26 @@ def _build_quiz_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tu
             "total_questions": len(questions),
             "question_results": question_results,
         },
-        source_bundle=source_bundle,
+        source_bundle=evidence["source_bundle"],
     )
     candidates = resolve_topic_candidates(
-        source_labels=source_labels,
-        tag_labels=tag_labels,
-        derived_labels=derived_labels,
+        source_labels=evidence["source_labels"],
+        tag_labels=evidence["tag_labels"],
+        derived_labels=evidence["derived_labels"],
     )
     ranked_topics = rank_suggestion_topics(
         candidates,
-        weakness_labels=weakness_labels,
-        adjacent_labels=adjacent_labels,
-        exploratory_labels=derived_labels,
+        weakness_labels=evidence["weakness_labels"],
+        adjacent_labels=evidence["adjacent_labels"],
+        exploratory_labels=evidence["derived_labels"],
     )
     topics: list[dict[str, Any]] = []
     for index, topic in enumerate(ranked_topics[:6], start=1):
-        source = _find_quiz_topic_source(topic.canonical_label, context.source_bundle)
+        source = _find_quiz_topic_source(
+            topic.canonical_label,
+            context.source_bundle,
+            allow_fallback=False,
+        )
         raw_label = topic.raw_labels[0] if topic.raw_labels else topic.canonical_label
         item: dict[str, Any] = {
             "id": f"topic-{index}",
@@ -200,6 +124,11 @@ def _build_quiz_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tu
             "type": topic.evidence_class,
             "status": topic.rank_reason,
             "selected": topic.rank_reason == "weakness",
+            "topic_key": topic.topic_key,
+            "normalization_version": topic.normalization_version,
+            "canonical_label": topic.canonical_label,
+            "evidence_reasons": list(topic.evidence_reasons),
+            "source_count": topic.source_count,
         }
         if source:
             item["source_type"] = source["source_type"]
@@ -207,15 +136,7 @@ def _build_quiz_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tu
         topics.append(item)
 
     if not topics:
-        topics.append(
-            {
-                "id": "topic-1",
-                "display_label": "Review",
-                "type": "derived",
-                "status": "candidate",
-                "selected": False,
-            }
-        )
+        topics.append(_fallback_topic_item(index=1, display_label="Review"))
 
     payload = {
         "summary": {
@@ -231,55 +152,97 @@ def _build_quiz_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tu
     return context.service, context.activity_type, payload
 
 
+def _load_flashcard_reviewed_cards(note_db: CharactersRAGDB, session_id: int) -> list[dict[str, Any]]:
+    cursor = note_db.execute_query(
+        """
+        SELECT f.uuid,
+               MAX(f.tags_json) AS tags_json,
+               MAX(f.source_ref_type) AS source_ref_type,
+               MAX(f.source_ref_id) AS source_ref_id,
+               MAX(d.name) AS deck_name
+          FROM flashcard_reviews fr
+          JOIN flashcards f ON f.id = fr.card_id
+          LEFT JOIN decks d ON d.id = f.deck_id
+         WHERE fr.review_session_id = ?
+         GROUP BY f.uuid
+         ORDER BY MIN(fr.id)
+        """,
+        (int(session_id),),
+    )
+    return [dict(row) for row in cursor.fetchall()]
+
+
 def _build_flashcard_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tuple[str, str, dict[str, Any]]:
-    session = note_db.get_flashcard_review_session(int(anchor_id))
-    if not session:
+    session_rollup = note_db.get_flashcard_review_session_rollup(int(anchor_id))
+    if not session_rollup:
         raise ConflictError("Flashcard review session not found", entity="flashcard_review_sessions", identifier=anchor_id)  # noqa: TRY003
 
-    context = build_flashcard_suggestion_context(
-        {
-            **session,
-            "cards_reviewed": 0,
-            "correct_count": 0,
-            "source_bundle": [],
-        }
-    )
-    derived_labels = []
-    if session.get("tag_filter"):
-        derived_labels.append(str(session["tag_filter"]))
-    if session.get("deck_id"):
-        deck = note_db.get_deck(int(session["deck_id"]))
+    provenance: dict[str, Any] = {
+        "source_bundle": session_rollup.get("source_bundle") or [],
+    }
+    if session_rollup.get("study_pack_id") is not None:
+        provenance["study_pack_id"] = session_rollup.get("study_pack_id")
+        study_pack = note_db.get_study_pack(int(session_rollup["study_pack_id"]))
+        if study_pack:
+            provenance["study_pack"] = study_pack
+    if session_rollup.get("deck_id") is not None:
+        deck = note_db.get_deck(int(session_rollup["deck_id"]))
         if deck and deck.get("name"):
-            derived_labels.append(str(deck["name"]))
-    if not derived_labels:
-        derived_labels.append("spaced repetition")
+            provenance["deck_name"] = str(deck["name"])
+    reviewed_cards = _load_flashcard_reviewed_cards(note_db, int(anchor_id))
+    if reviewed_cards:
+        provenance["reviewed_cards"] = reviewed_cards
+
+    context = build_flashcard_suggestion_context(
+        session_rollup,
+        provenance=provenance,
+    )
+    evidence = extract_flashcard_suggestion_evidence(
+        session_rollup,
+        provenance=provenance,
+    )
 
     candidates = resolve_topic_candidates(
-        source_labels=[],
-        tag_labels=[session["tag_filter"]] if session.get("tag_filter") else [],
-        derived_labels=derived_labels,
+        source_labels=evidence["source_labels"],
+        tag_labels=evidence["tag_labels"],
+        derived_labels=evidence["derived_labels"],
     )
     ranked_topics = rank_suggestion_topics(
         candidates,
-        weakness_labels=[],
-        adjacent_labels=[session["tag_filter"]] if session.get("tag_filter") else [],
-        exploratory_labels=derived_labels,
+        weakness_labels=evidence["weakness_labels"],
+        adjacent_labels=evidence["adjacent_labels"],
+        exploratory_labels=evidence["derived_labels"],
     )
-    topics = [
-        {
+    topics: list[dict[str, Any]] = []
+    for index, topic in enumerate(ranked_topics[:4], start=1):
+        source = _find_quiz_topic_source(
+            topic.canonical_label,
+            evidence["source_bundle"],
+            allow_fallback=False,
+        )
+        item: dict[str, Any] = {
             "id": f"topic-{index}",
             "display_label": _titleize_label(topic.raw_labels[0] if topic.raw_labels else topic.canonical_label),
             "type": topic.evidence_class,
             "status": topic.rank_reason,
             "selected": topic.rank_reason == "adjacent",
+            "topic_key": topic.topic_key,
+            "normalization_version": topic.normalization_version,
+            "canonical_label": topic.canonical_label,
+            "evidence_reasons": list(topic.evidence_reasons),
+            "source_count": topic.source_count,
         }
-        for index, topic in enumerate(ranked_topics[:4], start=1)
-    ]
+        if source:
+            item["source_type"] = source["source_type"]
+            item["source_id"] = source["source_id"]
+        topics.append(item)
+    if not topics:
+        topics.append(_fallback_topic_item(index=1, display_label="Spaced repetition", status="exploratory"))
     payload = {
         "summary": {
             "deck_id": context.summary_metrics.get("deck_id"),
-            "correct_count": 0,
-            "total_count": 0,
+            "correct_count": int(context.summary_metrics.get("correct_count") or 0),
+            "total_count": int(context.summary_metrics.get("cards_reviewed") or 0),
         },
         "counts": {
             "topic_count": len(topics),

--- a/tldw_Server_API/app/core/StudySuggestions/snapshot_service.py
+++ b/tldw_Server_API/app/core/StudySuggestions/snapshot_service.py
@@ -57,14 +57,21 @@ def _fallback_topic_item(
 
 
 def _find_quiz_topic_source(
-    canonical_label: str,
+    topic_labels: Iterable[str],
     source_bundle: list[dict[str, str]],
     *,
     allow_fallback: bool = True,
 ) -> dict[str, str] | None:
+    """Return the source bundle item whose label matches any known topic label."""
+
+    matchable_labels = {
+        label.casefold()
+        for label in topic_labels
+        if isinstance(label, str) and label.strip()
+    }
     for source in source_bundle:
         source_label = _safe_text(source.get("label"))
-        if source_label and source_label.casefold() == canonical_label.casefold():
+        if source_label and source_label.casefold() in matchable_labels:
             return source
     if allow_fallback and source_bundle:
         return source_bundle[0]
@@ -113,7 +120,7 @@ def _build_quiz_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tu
     topics: list[dict[str, Any]] = []
     for index, topic in enumerate(ranked_topics[:6], start=1):
         source = _find_quiz_topic_source(
-            topic.canonical_label,
+            [*topic.raw_labels, topic.canonical_label, topic.semantic_label],
             context.source_bundle,
             allow_fallback=False,
         )
@@ -152,26 +159,6 @@ def _build_quiz_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tu
     return context.service, context.activity_type, payload
 
 
-def _load_flashcard_reviewed_cards(note_db: CharactersRAGDB, session_id: int) -> list[dict[str, Any]]:
-    cursor = note_db.execute_query(
-        """
-        SELECT f.uuid,
-               MAX(f.tags_json) AS tags_json,
-               MAX(f.source_ref_type) AS source_ref_type,
-               MAX(f.source_ref_id) AS source_ref_id,
-               MAX(d.name) AS deck_name
-          FROM flashcard_reviews fr
-          JOIN flashcards f ON f.id = fr.card_id
-          LEFT JOIN decks d ON d.id = f.deck_id
-         WHERE fr.review_session_id = ?
-         GROUP BY f.uuid
-         ORDER BY MIN(fr.id)
-        """,
-        (int(session_id),),
-    )
-    return [dict(row) for row in cursor.fetchall()]
-
-
 def _build_flashcard_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) -> tuple[str, str, dict[str, Any]]:
     session_rollup = note_db.get_flashcard_review_session_rollup(int(anchor_id))
     if not session_rollup:
@@ -189,7 +176,7 @@ def _build_flashcard_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) 
         deck = note_db.get_deck(int(session_rollup["deck_id"]))
         if deck and deck.get("name"):
             provenance["deck_name"] = str(deck["name"])
-    reviewed_cards = _load_flashcard_reviewed_cards(note_db, int(anchor_id))
+    reviewed_cards = note_db.get_flashcard_reviewed_cards(int(anchor_id))
     if reviewed_cards:
         provenance["reviewed_cards"] = reviewed_cards
 
@@ -216,7 +203,7 @@ def _build_flashcard_snapshot_payload(note_db: CharactersRAGDB, anchor_id: int) 
     topics: list[dict[str, Any]] = []
     for index, topic in enumerate(ranked_topics[:4], start=1):
         source = _find_quiz_topic_source(
-            topic.canonical_label,
+            [*topic.raw_labels, topic.canonical_label, topic.semantic_label],
             evidence["source_bundle"],
             allow_fallback=False,
         )

--- a/tldw_Server_API/app/core/StudySuggestions/topic_aliases.py
+++ b/tldw_Server_API/app/core/StudySuggestions/topic_aliases.py
@@ -46,7 +46,7 @@ def clean_label_text(label: object) -> str | None:
     text = str(label or "").strip().lower()
     if not text:
         return None
-    text = text.replace("/", " ").replace("_", " ").replace("-", " ")
+    text = re.sub(r"[-/_]", " ", text)
     text = _WHITESPACE_RE.sub(" ", text)
     return text.strip() or None
 
@@ -75,10 +75,14 @@ def lookup_topic_alias(label: str) -> tuple[str, str] | None:
 
 
 def resolve_topic_alias(label: str) -> tuple[str, str]:
-    alias = lookup_topic_alias(label)
+    cleaned = clean_label_text(label)
+    if cleaned is None:
+        return DEFAULT_NAMESPACE, ""
+    semantic = normalize_semantic_label(cleaned) or cleaned
+    alias = lookup_topic_alias(cleaned) or lookup_topic_alias(semantic)
     if alias is not None:
         return alias
-    return resolve_namespace(label), label
+    return resolve_namespace(semantic), semantic
 
 
 def canonical_slug(label: str) -> str:

--- a/tldw_Server_API/app/core/StudySuggestions/topic_aliases.py
+++ b/tldw_Server_API/app/core/StudySuggestions/topic_aliases.py
@@ -1,0 +1,99 @@
+"""Deterministic alias and namespace rules for study suggestion topics."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import re
+
+NORMALIZATION_VERSION = "norm-v2"
+DEFAULT_NAMESPACE = "general"
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+_TOKEN_ALIASES: dict[str, str] = {
+    "kidney": "renal",
+    "kidneys": "renal",
+    "nephrology": "renal",
+    "heart": "cardiac",
+    "hearts": "cardiac",
+    "cardiology": "cardiac",
+    "brain": "neuro",
+    "brains": "neuro",
+    "neural": "neuro",
+    "neuronal": "neuro",
+}
+
+NAMESPACE_RULES: dict[str, tuple[str, ...]] = {
+    "renal": ("renal", "kidney", "kidneys", "nephrology"),
+    "cardiac": ("cardiac", "heart", "hearts", "cardiology"),
+    "neuro": ("neuro", "brain", "brains", "neural", "neuronal"),
+}
+
+EXACT_TOPIC_ALIASES: dict[str, tuple[str, str]] = {
+    "kidney physiology": ("renal", "renal physiology"),
+    "renal physiology": ("renal", "renal physiology"),
+    "renal-physiology": ("renal", "renal physiology"),
+    "kidney basics": ("renal", "renal basics"),
+    "renal basics": ("renal", "renal basics"),
+    "renal overview": ("renal", "overview"),
+    "cardiac overview": ("cardiac", "overview"),
+    "cardiac physiology": ("cardiac", "cardiac physiology"),
+    "heart physiology": ("cardiac", "cardiac physiology"),
+}
+
+
+def clean_label_text(label: object) -> str | None:
+    text = str(label or "").strip().lower()
+    if not text:
+        return None
+    text = text.replace("/", " ").replace("_", " ").replace("-", " ")
+    text = _WHITESPACE_RE.sub(" ", text)
+    return text.strip() or None
+
+
+def normalize_semantic_label(label: object) -> str | None:
+    cleaned = clean_label_text(label)
+    if cleaned is None:
+        return None
+    tokens = [_TOKEN_ALIASES.get(token, token) for token in cleaned.split()]
+    return " ".join(tokens).strip() or None
+
+
+def resolve_namespace(label: str) -> str:
+    tokens = label.split()
+    for namespace, aliases in NAMESPACE_RULES.items():
+        if any(alias in tokens for alias in aliases):
+            return namespace
+    return DEFAULT_NAMESPACE
+
+
+def lookup_topic_alias(label: str) -> tuple[str, str] | None:
+    alias = EXACT_TOPIC_ALIASES.get(label)
+    if alias is not None:
+        return alias
+    return None
+
+
+def resolve_topic_alias(label: str) -> tuple[str, str]:
+    alias = lookup_topic_alias(label)
+    if alias is not None:
+        return alias
+    return resolve_namespace(label), label
+
+
+def canonical_slug(label: str) -> str:
+    slug = _NON_ALNUM_RE.sub("-", label.lower()).strip("-")
+    slug = _WHITESPACE_RE.sub("-", slug)
+    return slug or DEFAULT_NAMESPACE
+
+
+def topic_key_for(namespace: str, canonical_label: str) -> str:
+    return f"{namespace}:{canonical_slug(canonical_label)}"
+
+
+def dedupe_reasons(reasons: Iterable[str]) -> list[str]:
+    unique: list[str] = []
+    for reason in reasons:
+        if reason and reason not in unique:
+            unique.append(reason)
+    return unique

--- a/tldw_Server_API/app/core/StudySuggestions/topic_pipeline.py
+++ b/tldw_Server_API/app/core/StudySuggestions/topic_pipeline.py
@@ -1,65 +1,173 @@
-"""Minimal deterministic topic normalization and ranking helpers."""
+"""Deterministic topic normalization, alias resolution, and ranking."""
 
 from __future__ import annotations
 
-import re
 from collections import OrderedDict
 from collections.abc import Iterable
 
-from .types import NormalizedTopicLabel, RankedTopic, TopicCandidate
+from .topic_aliases import (
+    DEFAULT_NAMESPACE,
+    NORMALIZATION_VERSION,
+    clean_label_text,
+    dedupe_reasons,
+    lookup_topic_alias,
+    normalize_semantic_label,
+    resolve_namespace,
+    topic_key_for,
+)
+from .types import NormalizedTopicLabel, RankedTopic, ResolvedTopicLabel, TopicCandidate
 
 
-_WHITESPACE_RE = re.compile(r"\s+")
-_SEPARATOR_RE = re.compile(r"[-_/]+")
-_GROUPING_SYNONYMS = {
-    "kidney": "renal",
-    "kidneys": "renal",
-}
 _EVIDENCE_PRIORITY = {
     "grounded": 0,
     "weakly_grounded": 1,
     "derived": 2,
 }
+_EVIDENCE_REASON_BY_CLASS = {
+    "grounded": "source_citation",
+    "weakly_grounded": "tag_match",
+    "derived": "derived_label",
+}
 
 
-def _clean_label(label: object) -> str | None:
-    text = str(label or "").strip().lower()
-    if not text:
+def _normalize_label_text(label: object) -> str | None:
+    return clean_label_text(label)
+
+
+def _resolve_label(raw_label: object, evidence_class: str) -> ResolvedTopicLabel | None:
+    cleaned = _normalize_label_text(raw_label)
+    if cleaned is None:
         return None
-    text = _SEPARATOR_RE.sub(" ", text)
-    text = _WHITESPACE_RE.sub(" ", text)
-    return text.strip() or None
 
+    semantic_label = normalize_semantic_label(cleaned)
+    if semantic_label is None:
+        return None
 
-def _fingerprint(label: str) -> str:
-    tokens = [_GROUPING_SYNONYMS.get(token, token) for token in label.split()]
-    return " ".join(tokens)
+    alias = lookup_topic_alias(cleaned) or lookup_topic_alias(semantic_label)
+    if alias is not None:
+        namespace, semantic_basis = alias
+    else:
+        namespace = resolve_namespace(semantic_label)
+        semantic_basis = semantic_label
 
+    canonical_slug = topic_key_for(namespace, semantic_basis).split(":", 1)[1]
+    topic_key = f"{namespace}:{canonical_slug}"
+    evidence_reason = _EVIDENCE_REASON_BY_CLASS.get(evidence_class, "derived_label")
+    source_count = 1 if evidence_class == "grounded" else 0
 
-def _canonical_preference(label: str) -> tuple[int, int, str]:
-    lacks_renal = "renal" not in label.split()
-    return (lacks_renal, len(label), label)
+    return ResolvedTopicLabel(
+        namespace=namespace,
+        canonical_slug=canonical_slug,
+        canonical_label=semantic_basis,
+        semantic_label=semantic_basis,
+        topic_key=topic_key,
+        normalization_version=NORMALIZATION_VERSION,
+        raw_labels=[str(raw_label)],
+        evidence_reasons=[evidence_reason],
+        source_count=source_count,
+    )
 
 
 def normalize_topic_labels(labels: Iterable[object]) -> list[NormalizedTopicLabel]:
-    grouped: "OrderedDict[str, list[tuple[str, str]]]" = OrderedDict()
-    for raw_label in labels:
-        cleaned = _clean_label(raw_label)
-        if cleaned is None:
+    resolved_topics = (_resolve_label(raw_label, "grounded") for raw_label in labels)
+    grouped: "OrderedDict[str, list[ResolvedTopicLabel]]" = OrderedDict()
+    for resolved in resolved_topics:
+        if resolved is None:
             continue
-        fingerprint = _fingerprint(cleaned)
-        grouped.setdefault(fingerprint, []).append((cleaned, str(raw_label)))
+        grouped.setdefault(resolved.topic_key, []).append(resolved)
 
-    normalized: list[NormalizedTopicLabel] = []
-    for entries in grouped.values():
-        canonical = min((cleaned for cleaned, _ in entries), key=_canonical_preference)
-        normalized.append(
+    normalized_group_rows: list[tuple[str, str, str, list[str]]] = []
+    for grouped_topics in grouped.values():
+        semantic_labels = [resolved.semantic_label for resolved in grouped_topics]
+        semantic_canonical = min(semantic_labels, key=_canonical_label_preference)
+        namespace = grouped_topics[0].namespace
+        raw_labels: list[str] = []
+        for resolved in grouped_topics:
+            for raw_label in resolved.raw_labels:
+                if raw_label not in raw_labels:
+                    raw_labels.append(raw_label)
+
+        normalized_group_rows.append((namespace, semantic_canonical, semantic_canonical, raw_labels))
+
+    semantic_label_counts: dict[str, int] = {}
+    for _, semantic_canonical, _, _ in normalized_group_rows:
+        semantic_label_counts[semantic_canonical] = semantic_label_counts.get(semantic_canonical, 0) + 1
+
+    normalized_topics: list[NormalizedTopicLabel] = []
+    for namespace, semantic_canonical, representative_canonical, raw_labels in normalized_group_rows:
+        canonical_label = semantic_canonical
+        if semantic_label_counts.get(semantic_canonical, 0) > 1:
+            canonical_label = semantic_canonical
+            if namespace != DEFAULT_NAMESPACE and not semantic_canonical.startswith(f"{namespace} "):
+                canonical_label = f"{namespace} {semantic_canonical}".strip()
+        normalized_topics.append(
             NormalizedTopicLabel(
-                canonical_label=canonical,
-                raw_labels=[raw for _, raw in entries],
+                canonical_label=canonical_label,
+                raw_labels=raw_labels,
             )
         )
-    return normalized
+
+    return normalized_topics
+
+
+def _canonical_label_preference(label: str) -> tuple[int, str]:
+    return (len(label), label)
+
+
+def _resolved_evidence_class(resolved: ResolvedTopicLabel) -> str:
+    if "source_citation" in resolved.evidence_reasons:
+        return "grounded"
+    if "tag_match" in resolved.evidence_reasons:
+        return "weakly_grounded"
+    return "derived"
+
+
+def _resolved_canonical_selection_key(
+    resolved: ResolvedTopicLabel,
+) -> tuple[int, tuple[int, str], str]:
+    evidence_class = _resolved_evidence_class(resolved)
+    return (
+        _EVIDENCE_PRIORITY[evidence_class],
+        _canonical_label_preference(resolved.canonical_label),
+        resolved.canonical_label,
+    )
+
+
+def _merge_resolved_group(grouped_topics: list[ResolvedTopicLabel]) -> ResolvedTopicLabel:
+    representative = min(grouped_topics, key=_resolved_canonical_selection_key)
+    raw_labels: list[str] = []
+    evidence_reasons: list[str] = []
+    source_count = 0
+    for resolved in grouped_topics:
+        for raw_label in resolved.raw_labels:
+            if raw_label not in raw_labels:
+                raw_labels.append(raw_label)
+        evidence_reasons = dedupe_reasons([*evidence_reasons, *resolved.evidence_reasons])
+        source_count += resolved.source_count
+    if not raw_labels:
+        raw_labels.append(representative.canonical_label)
+
+    return ResolvedTopicLabel(
+        namespace=representative.namespace,
+        canonical_slug=representative.canonical_slug,
+        canonical_label=representative.canonical_label,
+        semantic_label=representative.semantic_label,
+        topic_key=representative.topic_key,
+        normalization_version=representative.normalization_version,
+        raw_labels=raw_labels,
+        evidence_reasons=evidence_reasons,
+        source_count=source_count,
+    )
+
+
+def _merge_resolved_topics(
+    resolved_topics: Iterable[ResolvedTopicLabel],
+) -> list[ResolvedTopicLabel]:
+    grouped: "OrderedDict[str, list[ResolvedTopicLabel]]" = OrderedDict()
+    for resolved in resolved_topics:
+        grouped.setdefault(resolved.topic_key, []).append(resolved)
+
+    return [_merge_resolved_group(grouped_topics) for grouped_topics in grouped.values()]
 
 
 def resolve_topic_candidates(
@@ -68,40 +176,62 @@ def resolve_topic_candidates(
     tag_labels: Iterable[object],
     derived_labels: Iterable[object],
 ) -> list[TopicCandidate]:
-    combined: dict[str, TopicCandidate] = {}
-
-    for evidence_class, labels in (
+    resolved_topics: list[ResolvedTopicLabel] = []
+    evidence_classes = (
         ("grounded", source_labels),
         ("weakly_grounded", tag_labels),
         ("derived", derived_labels),
-    ):
-        for normalized in normalize_topic_labels(labels):
-            existing = combined.get(normalized.canonical_label)
-            if existing is None:
-                combined[normalized.canonical_label] = TopicCandidate(
-                    canonical_label=normalized.canonical_label,
-                    raw_labels=list(normalized.raw_labels),
-                    evidence_class=evidence_class,
-                )
-                continue
+    )
 
-            existing.raw_labels.extend(
-                raw for raw in normalized.raw_labels if raw not in existing.raw_labels
+    for evidence_class, labels in evidence_classes:
+        for raw_label in labels:
+            resolved = _resolve_label(raw_label, evidence_class)
+            if resolved is not None:
+                resolved_topics.append(resolved)
+
+    grouped = _merge_resolved_topics(resolved_topics)
+    semantic_label_counts: dict[str, int] = {}
+    for resolved in grouped:
+        semantic_label_counts[resolved.semantic_label] = semantic_label_counts.get(resolved.semantic_label, 0) + 1
+
+    candidates: list[TopicCandidate] = []
+    for resolved in grouped:
+        evidence_class = _resolved_evidence_class(resolved)
+        canonical_label = resolved.semantic_label
+        if semantic_label_counts.get(resolved.semantic_label, 0) > 1:
+            if resolved.namespace != DEFAULT_NAMESPACE and not canonical_label.startswith(f"{resolved.namespace} "):
+                canonical_label = f"{resolved.namespace} {canonical_label}".strip()
+
+        candidates.append(
+            TopicCandidate(
+                canonical_label=canonical_label,
+                semantic_label=resolved.semantic_label,
+                raw_labels=list(resolved.raw_labels),
+                evidence_class=evidence_class,  # type: ignore[arg-type]
+                topic_key=resolved.topic_key,
+                normalization_version=resolved.normalization_version,
+                source_count=resolved.source_count,
+                evidence_reasons=list(resolved.evidence_reasons),
             )
-            if _EVIDENCE_PRIORITY[evidence_class] < _EVIDENCE_PRIORITY[existing.evidence_class]:
-                existing.evidence_class = evidence_class
+        )
 
     return sorted(
-        combined.values(),
+        candidates,
         key=lambda candidate: (
             _EVIDENCE_PRIORITY[candidate.evidence_class],
-            candidate.canonical_label,
+            candidate.topic_key or "",
+            _canonical_label_preference(candidate.canonical_label),
         ),
     )
 
 
-def _canonical_set(labels: Iterable[object]) -> set[str]:
-    return {item.canonical_label for item in normalize_topic_labels(labels)}
+def _topic_key_set(labels: Iterable[object]) -> set[str]:
+    topic_keys: set[str] = set()
+    for raw_label in labels:
+        resolved = _resolve_label(raw_label, "grounded")
+        if resolved is not None:
+            topic_keys.add(resolved.topic_key)
+    return topic_keys
 
 
 def rank_suggestion_topics(
@@ -111,22 +241,25 @@ def rank_suggestion_topics(
     adjacent_labels: Iterable[object],
     exploratory_labels: Iterable[object],
 ) -> list[RankedTopic]:
-    weakness = _canonical_set(weakness_labels)
-    adjacent = _canonical_set(adjacent_labels)
-    exploratory = _canonical_set(exploratory_labels)
+    weakness = _topic_key_set(weakness_labels)
+    adjacent = _topic_key_set(adjacent_labels)
+    exploratory = _topic_key_set(exploratory_labels)
 
     ranked: list[tuple[tuple[int, int, str], RankedTopic]] = []
     for candidate in candidates:
-        canonical = candidate.canonical_label
-        if canonical in weakness:
+        topic_key = candidate.topic_key or topic_key_for("general", candidate.canonical_label)
+        normalization_version = candidate.normalization_version or NORMALIZATION_VERSION
+        evidence_reasons = list(candidate.evidence_reasons)
+        if topic_key in weakness:
             rank_reason = "weakness"
             source_aware = candidate.evidence_class != "derived"
             priority = 0
-        elif canonical in exploratory:
+            evidence_reasons = dedupe_reasons([*evidence_reasons, "missed_question"])
+        elif topic_key in exploratory:
             rank_reason = "exploratory"
             source_aware = False
             priority = 2
-        elif canonical in adjacent and candidate.evidence_class != "derived":
+        elif topic_key in adjacent and candidate.evidence_class != "derived":
             rank_reason = "adjacent"
             source_aware = True
             priority = 1
@@ -137,13 +270,18 @@ def rank_suggestion_topics(
 
         ranked.append(
             (
-                (priority, _EVIDENCE_PRIORITY[candidate.evidence_class], canonical),
+                (priority, _EVIDENCE_PRIORITY[candidate.evidence_class], topic_key),
                 RankedTopic(
-                    canonical_label=canonical,
+                    canonical_label=candidate.canonical_label,
+                    semantic_label=candidate.semantic_label,
                     raw_labels=list(candidate.raw_labels),
                     evidence_class=candidate.evidence_class,
                     rank_reason=rank_reason,
                     adjacency_is_source_aware=source_aware,
+                    topic_key=topic_key,
+                    normalization_version=normalization_version,
+                    source_count=candidate.source_count,
+                    evidence_reasons=evidence_reasons,
                 ),
             )
         )

--- a/tldw_Server_API/app/core/StudySuggestions/topic_pipeline.py
+++ b/tldw_Server_API/app/core/StudySuggestions/topic_pipeline.py
@@ -10,9 +10,7 @@ from .topic_aliases import (
     NORMALIZATION_VERSION,
     clean_label_text,
     dedupe_reasons,
-    lookup_topic_alias,
-    normalize_semantic_label,
-    resolve_namespace,
+    resolve_topic_alias,
     topic_key_for,
 )
 from .types import NormalizedTopicLabel, RankedTopic, ResolvedTopicLabel, TopicCandidate
@@ -39,19 +37,12 @@ def _resolve_label(raw_label: object, evidence_class: str) -> ResolvedTopicLabel
     if cleaned is None:
         return None
 
-    semantic_label = normalize_semantic_label(cleaned)
-    if semantic_label is None:
+    namespace, semantic_basis = resolve_topic_alias(cleaned)
+    if not semantic_basis:
         return None
 
-    alias = lookup_topic_alias(cleaned) or lookup_topic_alias(semantic_label)
-    if alias is not None:
-        namespace, semantic_basis = alias
-    else:
-        namespace = resolve_namespace(semantic_label)
-        semantic_basis = semantic_label
-
-    canonical_slug = topic_key_for(namespace, semantic_basis).split(":", 1)[1]
-    topic_key = f"{namespace}:{canonical_slug}"
+    topic_key = topic_key_for(namespace, semantic_basis)
+    canonical_slug = topic_key.split(":", 1)[1]
     evidence_reason = _EVIDENCE_REASON_BY_CLASS.get(evidence_class, "derived_label")
     source_count = 1 if evidence_class == "grounded" else 0
 
@@ -76,7 +67,7 @@ def normalize_topic_labels(labels: Iterable[object]) -> list[NormalizedTopicLabe
             continue
         grouped.setdefault(resolved.topic_key, []).append(resolved)
 
-    normalized_group_rows: list[tuple[str, str, str, list[str]]] = []
+    normalized_group_rows: list[tuple[str, str, list[str]]] = []
     for grouped_topics in grouped.values():
         semantic_labels = [resolved.semantic_label for resolved in grouped_topics]
         semantic_canonical = min(semantic_labels, key=_canonical_label_preference)
@@ -87,14 +78,14 @@ def normalize_topic_labels(labels: Iterable[object]) -> list[NormalizedTopicLabe
                 if raw_label not in raw_labels:
                     raw_labels.append(raw_label)
 
-        normalized_group_rows.append((namespace, semantic_canonical, semantic_canonical, raw_labels))
+        normalized_group_rows.append((namespace, semantic_canonical, raw_labels))
 
     semantic_label_counts: dict[str, int] = {}
-    for _, semantic_canonical, _, _ in normalized_group_rows:
+    for _, semantic_canonical, _ in normalized_group_rows:
         semantic_label_counts[semantic_canonical] = semantic_label_counts.get(semantic_canonical, 0) + 1
 
     normalized_topics: list[NormalizedTopicLabel] = []
-    for namespace, semantic_canonical, representative_canonical, raw_labels in normalized_group_rows:
+    for namespace, semantic_canonical, raw_labels in normalized_group_rows:
         canonical_label = semantic_canonical
         if semantic_label_counts.get(semantic_canonical, 0) > 1:
             canonical_label = semantic_canonical

--- a/tldw_Server_API/app/core/StudySuggestions/types.py
+++ b/tldw_Server_API/app/core/StudySuggestions/types.py
@@ -29,16 +29,39 @@ class NormalizedTopicLabel:
 
 
 @dataclass(slots=True)
+class ResolvedTopicLabel:
+    namespace: str
+    canonical_slug: str
+    canonical_label: str
+    semantic_label: str
+    topic_key: str
+    normalization_version: str
+    raw_labels: list[str] = field(default_factory=list)
+    evidence_reasons: list[str] = field(default_factory=list)
+    source_count: int = 0
+
+
+@dataclass(slots=True)
 class TopicCandidate:
     canonical_label: str
+    semantic_label: str
     raw_labels: list[str]
     evidence_class: EvidenceClass
+    topic_key: str | None = None
+    normalization_version: str | None = None
+    source_count: int = 0
+    evidence_reasons: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)
 class RankedTopic:
     canonical_label: str
+    semantic_label: str
     raw_labels: list[str]
     evidence_class: EvidenceClass
     rank_reason: RankReason
     adjacency_is_source_aware: bool
+    topic_key: str | None = None
+    normalization_version: str | None = None
+    source_count: int = 0
+    evidence_reasons: list[str] = field(default_factory=list)

--- a/tldw_Server_API/tests/StudySuggestions/fixtures/flashcard_grounding_audit_cases.json
+++ b/tldw_Server_API/tests/StudySuggestions/fixtures/flashcard_grounding_audit_cases.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "grounded_session_from_source_bundle",
+    "deck_name": "Grounded Audit Deck",
+    "review_mode": "due",
+    "scope_prefix": "due:grounded-audit",
+    "tag_filter": null,
+    "source_bundle_json": [
+      {
+        "source_type": "note",
+        "source_id": "note-7",
+        "label": "Renal basics"
+      }
+    ],
+    "study_pack_id": 44,
+    "reviews": [
+      {"rating": 4, "answer_time_ms": 850},
+      {"rating": 2, "answer_time_ms": 600},
+      {"rating": 4, "answer_time_ms": 700}
+    ]
+  },
+  {
+    "name": "exploratory_session_without_provenance",
+    "deck_name": "Exploratory Audit Deck",
+    "review_mode": "cram",
+    "scope_prefix": "cram:exploratory-audit",
+    "tag_filter": null,
+    "source_bundle_json": [],
+    "study_pack_id": null,
+    "reviews": [
+      {"rating": 2, "answer_time_ms": 500},
+      {"rating": 1, "answer_time_ms": 550}
+    ]
+  }
+]

--- a/tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py
@@ -72,6 +72,26 @@ def _create_card(db: CharactersRAGDB, *, deck_name: str = "Session Deck") -> tup
     return deck_id, card_uuid
 
 
+def _create_cards(
+    db: CharactersRAGDB,
+    *,
+    count: int,
+    deck_name: str = "Session Deck",
+) -> tuple[int, list[str]]:
+    deck_id = db.add_deck(deck_name, "desc")
+    card_uuids: list[str] = []
+    for index in range(count):
+        card_uuid = db.add_flashcard(
+            {
+                "deck_id": deck_id,
+                "front": f"Front {index}",
+                "back": f"Back {index}",
+            }
+        )
+        card_uuids.append(card_uuid)
+    return deck_id, card_uuids
+
+
 def test_first_review_submission_in_scope_creates_active_session_and_links_review(db: CharactersRAGDB):
     deck_id, card_uuid = _create_card(db)
 
@@ -251,6 +271,198 @@ def test_review_flashcard_rejects_unknown_or_wrong_deck_review_session_id(db: Ch
 
     sessions = db.list_flashcard_review_sessions(deck_id=deck_id)
     assert sessions == []  # nosec B101
+
+
+def test_review_flashcard_updates_session_aggregates_and_rollup(db: CharactersRAGDB):
+    deck_id, card_uuids = _create_cards(db, count=3, deck_name="Aggregate Session Deck")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter=None,
+        scope_key=f"due:deck:{deck_id}",
+    )
+
+    db.review_flashcard(card_uuids[0], rating=4, answer_time_ms=600, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[1], rating=1, answer_time_ms=750, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[2], rating=3, answer_time_ms=900, review_session_id=session["id"])
+
+    session_row = db.get_flashcard_review_session(session["id"])
+    rollup = db.get_flashcard_review_session_rollup(session["id"])
+
+    assert session_row["cards_reviewed"] == 3  # nosec B101
+    assert session_row["correct_count"] == 2  # nosec B101
+    assert rollup["cards_reviewed"] == 3  # nosec B101
+    assert rollup["correct_count"] == 2  # nosec B101
+    assert rollup["aggregate_source"] in {"session", "reconstructed"}  # nosec B101
+
+
+def test_flashcard_review_session_rollup_reconstructs_missing_aggregates(db: CharactersRAGDB):
+    deck_id, card_uuids = _create_cards(db, count=3, deck_name="Legacy Aggregate Deck")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter=None,
+        scope_key=f"due:deck:{deck_id}",
+    )
+
+    db.review_flashcard(card_uuids[0], rating=4, answer_time_ms=600, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[1], rating=2, answer_time_ms=750, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[2], rating=3, answer_time_ms=900, review_session_id=session["id"])
+    db.execute_query(
+        """
+        UPDATE flashcard_review_sessions
+           SET cards_reviewed = NULL,
+               correct_count = NULL
+         WHERE id = ?
+        """,
+        (session["id"],),
+        commit=True,
+    )
+
+    rollup = db.get_flashcard_review_session_rollup(session["id"], repair_session_aggregates=False)
+
+    assert rollup["cards_reviewed"] == 3  # nosec B101
+    assert rollup["correct_count"] == 2  # nosec B101
+    assert rollup["aggregate_source"] == "reconstructed"  # nosec B101
+
+
+def test_flashcard_review_session_rollup_reconstructs_impossible_aggregates(db: CharactersRAGDB):
+    deck_id, card_uuids = _create_cards(db, count=3, deck_name="Impossible Aggregate Deck")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter=None,
+        scope_key=f"due:deck:{deck_id}",
+    )
+
+    db.review_flashcard(card_uuids[0], rating=4, answer_time_ms=600, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[1], rating=1, answer_time_ms=750, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[2], rating=3, answer_time_ms=900, review_session_id=session["id"])
+    db.execute_query(
+        """
+        UPDATE flashcard_review_sessions
+           SET cards_reviewed = 2,
+               correct_count = 3
+         WHERE id = ?
+        """,
+        (session["id"],),
+        commit=True,
+    )
+
+    rollup = db.get_flashcard_review_session_rollup(session["id"], repair_session_aggregates=False)
+
+    assert rollup["cards_reviewed"] == 3  # nosec B101
+    assert rollup["correct_count"] == 2  # nosec B101
+    assert rollup["aggregate_source"] == "reconstructed"  # nosec B101
+
+
+def test_flashcard_review_session_rollup_repairs_stale_aggregates_from_reviews(db: CharactersRAGDB):
+    deck_id, card_uuids = _create_cards(db, count=3, deck_name="Repair Aggregate Deck")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter=None,
+        scope_key=f"due:deck:{deck_id}",
+    )
+
+    db.review_flashcard(card_uuids[0], rating=4, answer_time_ms=600, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[1], rating=1, answer_time_ms=750, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[2], rating=3, answer_time_ms=900, review_session_id=session["id"])
+    db.execute_query(
+        """
+        UPDATE flashcard_review_sessions
+           SET cards_reviewed = 17,
+               correct_count = 1
+         WHERE id = ?
+        """,
+        (session["id"],),
+        commit=True,
+    )
+
+    rollup = db.get_flashcard_review_session_rollup(session["id"], repair_session_aggregates=True)
+    repaired = db.get_flashcard_review_session(session["id"])
+
+    assert rollup["cards_reviewed"] == 3  # nosec B101
+    assert rollup["correct_count"] == 2  # nosec B101
+    assert rollup["aggregate_source"] == "reconstructed"  # nosec B101
+    assert repaired["cards_reviewed"] == 3  # nosec B101
+    assert repaired["correct_count"] == 2  # nosec B101
+
+
+def test_flashcard_review_session_rollup_reload_after_conditional_repair_race(
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    deck_id, card_uuids = _create_cards(db, count=4, deck_name="Repair Race Deck")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter=None,
+        scope_key=f"due:deck:{deck_id}",
+    )
+
+    db.review_flashcard(card_uuids[0], rating=4, answer_time_ms=600, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[1], rating=1, answer_time_ms=750, review_session_id=session["id"])
+    db.review_flashcard(card_uuids[2], rating=3, answer_time_ms=900, review_session_id=session["id"])
+    db.execute_query(
+        """
+        UPDATE flashcard_review_sessions
+           SET cards_reviewed = 17,
+               correct_count = 1
+         WHERE id = ?
+        """,
+        (session["id"],),
+        commit=True,
+    )
+
+    def _lose_repair_race(conn, session_id, *, expected_cards_reviewed, expected_correct_count, repaired_cards_reviewed, repaired_correct_count):
+        conn.execute(
+            """
+            INSERT INTO flashcard_reviews(
+                card_id, reviewed_at, rating, answer_time_ms, scheduled_interval_days,
+                new_ef, new_repetitions, was_lapse, client_id, scheduler_type,
+                previous_queue_state, next_queue_state, previous_due_at, next_due_at, review_session_id
+            )
+            SELECT
+                id, ?, 4, 500, NULL,
+                2.6, 2, 0, ?, 'sm2_plus',
+                'learning', 'review', NULL, ?, ?
+              FROM flashcards
+             WHERE uuid = ?
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+                db.client_id,
+                datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+                session_id,
+                card_uuids[3],
+            ),
+        )
+        conn.execute(
+            """
+            UPDATE flashcard_review_sessions
+               SET cards_reviewed = 4,
+                   correct_count = 3
+             WHERE id = ?
+            """,
+            (session_id,),
+        )
+        return False
+
+    monkeypatch.setattr(
+        db,
+        "_repair_flashcard_review_session_aggregates_if_unchanged",
+        _lose_repair_race,
+    )
+
+    rollup = db.get_flashcard_review_session_rollup(session["id"], repair_session_aggregates=True)
+    repaired = db.get_flashcard_review_session(session["id"])
+
+    assert rollup["cards_reviewed"] == 4  # nosec B101
+    assert rollup["correct_count"] == 3  # nosec B101
+    assert rollup["aggregate_source"] == "session"  # nosec B101
+    assert repaired["cards_reviewed"] == 4  # nosec B101
+    assert repaired["correct_count"] == 3  # nosec B101
 
 
 def test_legacy_rows_with_null_review_session_id_remain_readable(db: CharactersRAGDB):

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py
@@ -1,8 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.StudySuggestions import snapshot_service
 from tldw_Server_API.app.core.StudySuggestions.flashcard_adapter import (
     build_flashcard_suggestion_context,
+    extract_flashcard_suggestion_evidence,
     is_source_grounded_session,
 )
 from tldw_Server_API.app.core.StudySuggestions.quiz_adapter import build_quiz_suggestion_context
+
+
+def _admin_principal() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        username="admin",
+        roles=["admin"],
+        permissions=["*"],
+        is_admin=True,
+    )
+
+
+def _load_flashcard_audit_cases() -> list[dict[str, object]]:
+    fixture_path = Path(__file__).with_name("fixtures") / "flashcard_grounding_audit_cases.json"
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def db(tmp_path):
+    chacha = CharactersRAGDB(str(tmp_path / "study-suggestion-adapters.db"), client_id="study-suggestion-adapter-tests")
+    try:
+        yield chacha
+    finally:
+        chacha.close_connection()
 
 
 def test_quiz_attempts_emit_stable_suggestion_context():
@@ -87,3 +123,180 @@ def test_flashcard_sessions_without_lineage_remain_exploratory_only():
     assert context.summary_metrics["deck_id"] is None  # nosec B101
     assert context.performance_signals["is_source_grounded_session"] is False  # nosec B101
     assert context.performance_signals["supports_source_aware_adjacency"] is False  # nosec B101
+
+
+def test_flashcard_evidence_extraction_uses_study_pack_and_reviewed_card_provenance():
+    session = {
+        "id": 18,
+        "deck_id": 5,
+        "workspace_id": "ws-3",
+        "review_mode": "due",
+        "cards_reviewed": 2,
+        "correct_count": 1,
+        "tag_filter": None,
+        "source_bundle": [],
+        "study_pack_id": 44,
+    }
+
+    evidence = extract_flashcard_suggestion_evidence(
+        session,
+        provenance={
+            "deck_name": "Renal Review Deck",
+            "study_pack": {
+                "id": 44,
+                "title": "Renal Pack",
+                "source_bundle_json": {
+                    "items": [
+                        {"source_type": "note", "source_id": "note-7", "label": "Renal basics"},
+                    ]
+                },
+            },
+            "reviewed_cards": [
+                {
+                    "uuid": "card-1",
+                    "tags_json": '["Electrolyte balance"]',
+                    "source_ref_type": "note",
+                    "source_ref_id": "note-7",
+                },
+            ],
+        },
+    )
+
+    assert evidence["source_labels"] == ["Renal basics"]  # nosec B101
+    assert evidence["tag_labels"] == ["Electrolyte balance"]  # nosec B101
+    assert "Renal Pack" in evidence["derived_labels"]  # nosec B101
+    assert "Renal Review Deck" in evidence["derived_labels"]  # nosec B101
+    assert evidence["source_bundle"][0] == {  # nosec B101
+        "source_type": "note",
+        "source_id": "note-7",
+        "label": "Renal basics",
+    }
+    assert any(  # nosec B101
+        item["source_type"] == "note" and item["source_id"] == "note-7"
+        for item in evidence["source_bundle"]
+    )
+
+
+def _create_flashcard_session_for_audit_case(
+    db: CharactersRAGDB,
+    case: dict[str, object],
+) -> tuple[int, int, int]:
+    deck_name = str(case["deck_name"])
+    deck_id = db.add_deck(deck_name, "desc")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode=str(case["review_mode"]),
+        tag_filter=case.get("tag_filter") if isinstance(case.get("tag_filter"), str) else None,
+        scope_key=f"{case['scope_prefix']}:{deck_id}",
+    )
+    db.execute_query(
+        """
+        UPDATE flashcard_review_sessions
+           SET source_bundle_json = ?,
+               study_pack_id = ?
+         WHERE id = ?
+        """,
+        (
+            json.dumps(case.get("source_bundle_json") or []),
+            case.get("study_pack_id"),
+            session["id"],
+        ),
+        commit=True,
+    )
+    review_specs = case.get("reviews") or []
+    for index, review_spec in enumerate(review_specs):
+        card_uuid = db.add_flashcard(
+            {
+                "deck_id": deck_id,
+                "front": f"Front {index}",
+                "back": f"Back {index}",
+            }
+        )
+        db.review_flashcard(
+            card_uuid,
+            rating=int(review_spec["rating"]),
+            answer_time_ms=review_spec.get("answer_time_ms"),
+            review_session_id=int(session["id"]),
+        )
+    return deck_id, int(session["id"]), len(review_specs)
+
+
+@pytest.mark.parametrize("case", _load_flashcard_audit_cases())
+def test_flashcard_snapshot_audit_cases_classify_grounding_from_rollups(
+    db: CharactersRAGDB,
+    case: dict[str, object],
+):
+    _, session_id, review_count = _create_flashcard_session_for_audit_case(db, case)
+
+    snapshot_id = snapshot_service.refresh_snapshot_for_anchor(
+        note_db=db,
+        anchor_type="flashcard_review_session",
+        anchor_id=session_id,
+        principal=_admin_principal(),
+    )
+    row = db.get_suggestion_snapshot(snapshot_id)
+    payload = row["payload_json"]
+    topics = payload["topics"][:3]
+    grounded_types = {topic["type"] for topic in topics if isinstance(topic, dict)}
+    expected_source_bundle = case.get("source_bundle_json") or []
+    correct_count = sum(1 for review_spec in (case.get("reviews") or []) if int(review_spec["rating"]) >= 3)
+
+    assert payload["summary"]["correct_count"] == correct_count  # nosec B101
+    assert payload["summary"]["total_count"] == review_count  # nosec B101
+    assert all("source_count" in topic for topic in topics)  # nosec B101
+
+    if expected_source_bundle:
+        assert grounded_types & {"grounded", "weakly_grounded"}  # nosec B101
+    else:
+        assert grounded_types.isdisjoint({"grounded", "weakly_grounded"})  # nosec B101
+
+
+def test_flashcard_snapshot_assigns_source_refs_only_to_matching_topics(db: CharactersRAGDB):
+    deck_id = db.add_deck("Grounded Audit Deck", "desc")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter=None,
+        scope_key=f"due:deck:{deck_id}",
+    )
+    db.execute_query(
+        """
+        UPDATE flashcard_review_sessions
+           SET source_bundle_json = ?
+         WHERE id = ?
+        """,
+        (
+            '[{"source_type":"note","source_id":"note-7","label":"Renal basics"}]',
+            session["id"],
+        ),
+        commit=True,
+    )
+    card_uuid = db.add_flashcard(
+        {
+            "deck_id": deck_id,
+            "front": "Front",
+            "back": "Back",
+        }
+    )
+    db.review_flashcard(
+        card_uuid,
+        rating=4,
+        answer_time_ms=700,
+        review_session_id=int(session["id"]),
+    )
+
+    snapshot_id = snapshot_service.refresh_snapshot_for_anchor(
+        note_db=db,
+        anchor_type="flashcard_review_session",
+        anchor_id=int(session["id"]),
+        principal=_admin_principal(),
+    )
+    payload = db.get_suggestion_snapshot(snapshot_id)["payload_json"]
+    topics_by_label = {
+        topic["display_label"]: topic
+        for topic in payload["topics"]
+        if isinstance(topic, dict) and isinstance(topic.get("display_label"), str)
+    }
+
+    assert topics_by_label["Renal Basics"]["source_id"] == "note-7"  # nosec B101
+    assert "source_id" not in topics_by_label["Grounded Audit Deck"]  # nosec B101

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py
@@ -177,6 +177,32 @@ def test_flashcard_evidence_extraction_uses_study_pack_and_reviewed_card_provena
     )
 
 
+def test_flashcard_evidence_extraction_accepts_json_encoded_string_tags():
+    evidence = extract_flashcard_suggestion_evidence(
+        {
+            "id": 19,
+            "deck_id": 5,
+            "review_mode": "due",
+            "cards_reviewed": 1,
+            "correct_count": 1,
+            "source_bundle": [],
+        },
+        provenance={
+            "reviewed_cards": [
+                {
+                    "uuid": "card-1",
+                    "tags_json": '"Renal focus"',
+                    "source_ref_type": "note",
+                    "source_ref_id": "note-9",
+                }
+            ],
+        },
+    )
+
+    assert evidence["tag_labels"] == ["Renal focus"]  # nosec B101
+    assert "Renal focus" in evidence["adjacent_labels"]  # nosec B101
+
+
 def _create_flashcard_session_for_audit_case(
     db: CharactersRAGDB,
     case: dict[str, object],

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_schemas.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_schemas.py
@@ -1,6 +1,9 @@
+from dataclasses import fields
+
 import pytest
 from pydantic import ValidationError
 
+from tldw_Server_API.app.core.StudySuggestions.types import RankedTopic, TopicCandidate
 from tldw_Server_API.app.api.v1.schemas.study_suggestions import (
     SuggestionActionResponse,
     SuggestionRefreshRequest,
@@ -77,3 +80,10 @@ def test_action_response_requires_known_disposition_and_target_service():
             target_type="quiz",
             target_id="quiz-9",
         )
+
+
+@pytest.mark.parametrize("topic_type", [TopicCandidate, RankedTopic])
+def test_topic_types_expose_v2_identity_fields(topic_type):
+    field_names = {field.name for field in fields(topic_type)}
+
+    assert {"topic_key", "normalization_version", "source_count", "evidence_reasons"} <= field_names  # nosec B101

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py
@@ -331,6 +331,46 @@ def test_flashcard_review_session_rollup_unwraps_study_pack_bundle_items_shape(d
     ]
 
 
+def test_get_flashcard_reviewed_cards_returns_ordered_card_metadata(db: CharactersRAGDB):
+    deck_id = db.add_deck("Reviewed Cards Deck", "desc")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter=None,
+        scope_key=f"due:deck:{deck_id}",
+    )
+    first_card = db.add_flashcard(
+        {
+            "deck_id": deck_id,
+            "front": "Front 1",
+            "back": "Back 1",
+            "tags": ["Renal basics"],
+            "source_ref_type": "note",
+            "source_ref_id": "note-7",
+        }
+    )
+    second_card = db.add_flashcard(
+        {
+            "deck_id": deck_id,
+            "front": "Front 2",
+            "back": "Back 2",
+            "tags": ["Electrolytes"],
+            "source_ref_type": "note",
+            "source_ref_id": "note-8",
+        }
+    )
+
+    db.review_flashcard(first_card, rating=4, answer_time_ms=500, review_session_id=int(session["id"]))
+    db.review_flashcard(second_card, rating=2, answer_time_ms=650, review_session_id=int(session["id"]))
+
+    reviewed_cards = db.get_flashcard_reviewed_cards(int(session["id"]))
+
+    assert [card["uuid"] for card in reviewed_cards] == [first_card, second_card]  # nosec B101
+    assert reviewed_cards[0]["deck_name"] == "Reviewed Cards Deck"  # nosec B101
+    assert reviewed_cards[0]["source_ref_id"] == "note-7"  # nosec B101
+    assert reviewed_cards[1]["source_ref_id"] == "note-8"  # nosec B101
+
+
 def test_refresh_snapshot_serializes_quiz_v2_topic_fields(db: CharactersRAGDB):
     quiz_id = db.create_quiz(
         name="Renal Quiz",
@@ -415,6 +455,7 @@ def test_refresh_snapshot_serializes_semantic_canonical_label_for_alias_source_t
     assert topic["topic_key"] == "renal:renal-physiology"  # nosec B101
     assert topic["canonical_label"] == "renal physiology"  # nosec B101
     assert topic["display_label"] == "Kidney Physiology"  # nosec B101
+    assert topic["source_id"] == "note-8"  # nosec B101
 
 
 def test_quiz_snapshot_assigns_source_refs_only_to_matching_topics(db: CharactersRAGDB):
@@ -528,6 +569,45 @@ def test_suggestion_generation_link_duplicate_identity_ignores_target_id_for_act
             target_id="quiz-99",
             selection_fingerprint="sel-1",
         )
+
+
+def test_replace_suggestion_generation_link_returns_retained_link_id_when_updating_existing_row(
+    db: CharactersRAGDB,
+):
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={"topics": [{"display_label": "Renal basics"}]},
+    )
+    original_link_id = db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id="quiz-55",
+        selection_fingerprint="sel-1",
+    )
+
+    updated_link_id = db.replace_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id="quiz-99",
+        selection_fingerprint="sel-1",
+    )
+    row = db.find_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id="quiz-99",
+        selection_fingerprint="sel-1",
+    )
+
+    assert updated_link_id == original_link_id  # nosec B101
+    assert row is not None  # nosec B101
+    assert int(row["id"]) == original_link_id  # nosec B101
 
 
 def test_suggestion_generation_link_schema_dedupes_legacy_active_duplicates_before_unique_index(

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.StudySuggestions import snapshot_service
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
@@ -16,6 +20,17 @@ def db(tmp_path):
         yield chacha
     finally:
         chacha.close_connection()
+
+
+def _admin_principal() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        username="admin",
+        roles=["admin"],
+        permissions=["*"],
+        is_admin=True,
+    )
 
 
 def test_create_suggestion_snapshot_defaults_to_active_status(db: CharactersRAGDB):
@@ -89,6 +104,58 @@ def test_suggestion_snapshot_payload_defaults_to_permission_safe_fields_only(db:
     assert "analysis_markdown" not in payload["topics"][0]  # nosec B101
     assert "narrative" not in payload  # nosec B101
     assert "quote_cache" not in payload  # nosec B101
+
+
+def test_suggestion_snapshot_payload_preserves_v2_topic_identity_fields(db: CharactersRAGDB):
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "summary": {"score": 7},
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:renal-physiology",
+                    "normalization_version": "norm-v2",
+                    "display_label": "Renal Physiology",
+                    "canonical_label": "renal physiology",
+                    "source_count": 2,
+                    "evidence_reasons": [
+                        "missed_question",
+                        "source_citation",
+                        "tag_match",
+                        "derived_label",
+                        "this should not persist",
+                    ],
+                    "source_type": "note",
+                    "source_id": "note-7",
+                    "selected": True,
+                    "excerpt_text": "This explanation should not be persisted.",
+                    "analysis_markdown": "## This explanation should not be persisted either",
+                }
+            ],
+        },
+    )
+
+    row = db.get_suggestion_snapshot(snapshot_id)
+    topic = row["payload_json"]["topics"][0]
+
+    assert topic["topic_key"] == "renal:renal-physiology"  # nosec B101
+    assert topic["normalization_version"] == "norm-v2"  # nosec B101
+    assert topic["source_count"] == 2  # nosec B101
+    assert topic["evidence_reasons"] == [  # nosec B101
+        "missed_question",
+        "source_citation",
+        "tag_match",
+        "derived_label",
+    ]
+    assert topic["canonical_label"] == "renal physiology"  # nosec B101
+    assert topic["source_id"] == "note-7"  # nosec B101
+    assert "excerpt_text" not in topic  # nosec B101
+    assert "analysis_markdown" not in topic  # nosec B101
 
 
 def test_suggestion_snapshot_user_selection_survives_refresh_lineage_without_resubmission(db: CharactersRAGDB):
@@ -205,6 +272,195 @@ def test_generation_links_persist_one_row_per_snapshot_action_result(db: Charact
     assert count_row["count"] == 2  # nosec B101
 
 
+def test_flashcard_review_session_rollup_preserves_provenance_fields(db: CharactersRAGDB):
+    deck_id = db.add_deck("Grounded Deck", "desc")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter="renal basics",
+        scope_key=f"due:deck:{deck_id}",
+    )
+    db.execute_query(
+        """
+        UPDATE flashcard_review_sessions
+           SET source_bundle_json = ?,
+               study_pack_id = ?
+         WHERE id = ?
+        """,
+        (
+            '[{"source_type":"note","source_id":"note-7","label":"Renal basics"}]',
+            44,
+            session["id"],
+        ),
+        commit=True,
+    )
+
+    rollup = db.get_flashcard_review_session_rollup(session["id"], repair_session_aggregates=False)
+
+    assert rollup["study_pack_id"] == 44  # nosec B101
+    assert rollup["source_bundle"] == [  # nosec B101
+        {"source_type": "note", "source_id": "note-7", "label": "Renal basics"},
+    ]
+
+
+def test_flashcard_review_session_rollup_unwraps_study_pack_bundle_items_shape(db: CharactersRAGDB):
+    deck_id = db.add_deck("Packed Grounded Deck", "desc")
+    session = db.get_or_create_flashcard_review_session(
+        deck_id=deck_id,
+        review_mode="due",
+        tag_filter="renal basics",
+        scope_key=f"due:deck:{deck_id}",
+    )
+    db.execute_query(
+        """
+        UPDATE flashcard_review_sessions
+           SET source_bundle_json = ?
+         WHERE id = ?
+        """,
+        (
+            '{"items":[{"source_type":"note","source_id":"note-7","label":"Renal basics"}]}',
+            session["id"],
+        ),
+        commit=True,
+    )
+
+    rollup = db.get_flashcard_review_session_rollup(session["id"], repair_session_aggregates=False)
+
+    assert rollup["source_bundle"] == [  # nosec B101
+        {"source_type": "note", "source_id": "note-7", "label": "Renal basics"},
+    ]
+
+
+def test_refresh_snapshot_serializes_quiz_v2_topic_fields(db: CharactersRAGDB):
+    quiz_id = db.create_quiz(
+        name="Renal Quiz",
+        source_bundle_json=[{"source_type": "note", "source_id": "note-7", "label": "Renal basics"}],
+    )
+    question_id = db.create_question(
+        quiz_id=quiz_id,
+        question_type="multiple_choice",
+        question_text="Which organ filters blood?",
+        options=["Heart", "Kidney", "Lung"],
+        correct_answer=1,
+        explanation="The kidney filters blood.",
+        tags=["Renal basics"],
+        source_citations=[{"source_type": "note", "source_id": "note-7", "label": "Renal basics"}],
+    )
+    attempt = db.start_attempt(quiz_id)
+    db.submit_attempt(
+        attempt["id"],
+        [
+            {
+                "question_id": question_id,
+                "user_answer": 0,
+                "time_spent_ms": 900,
+            }
+        ],
+    )
+
+    snapshot_id = snapshot_service.refresh_snapshot_for_anchor(
+        note_db=db,
+        anchor_type="quiz_attempt",
+        anchor_id=int(attempt["id"]),
+        principal=_admin_principal(),
+    )
+    row = db.get_suggestion_snapshot(snapshot_id)
+    topic = row["payload_json"]["topics"][0]
+
+    assert topic["topic_key"]  # nosec B101
+    assert topic["normalization_version"] == "norm-v2"  # nosec B101
+    assert topic["canonical_label"]  # nosec B101
+    assert isinstance(topic["evidence_reasons"], list)  # nosec B101
+    assert topic["evidence_reasons"]  # nosec B101
+    assert "missed_question" in topic["evidence_reasons"]  # nosec B101
+    assert "question_text" not in topic  # nosec B101
+    assert "excerpt_text" not in topic  # nosec B101
+
+
+def test_refresh_snapshot_serializes_semantic_canonical_label_for_alias_source_text(db: CharactersRAGDB):
+    quiz_id = db.create_quiz(
+        name="Alias Canonical Quiz",
+        source_bundle_json=[{"source_type": "note", "source_id": "note-8", "label": "Kidney physiology"}],
+    )
+    question_id = db.create_question(
+        quiz_id=quiz_id,
+        question_type="multiple_choice",
+        question_text="Which system handles filtration?",
+        options=["Respiratory", "Renal", "Digestive"],
+        correct_answer=1,
+        explanation="The renal system handles filtration.",
+        tags=[],
+        source_citations=[{"source_type": "note", "source_id": "note-8", "label": "Kidney physiology"}],
+    )
+    attempt = db.start_attempt(quiz_id)
+    db.submit_attempt(
+        attempt["id"],
+        [
+            {
+                "question_id": question_id,
+                "user_answer": 0,
+                "time_spent_ms": 700,
+            }
+        ],
+    )
+
+    snapshot_id = snapshot_service.refresh_snapshot_for_anchor(
+        note_db=db,
+        anchor_type="quiz_attempt",
+        anchor_id=int(attempt["id"]),
+        principal=_admin_principal(),
+    )
+    topic = db.get_suggestion_snapshot(snapshot_id)["payload_json"]["topics"][0]
+
+    assert topic["topic_key"] == "renal:renal-physiology"  # nosec B101
+    assert topic["canonical_label"] == "renal physiology"  # nosec B101
+    assert topic["display_label"] == "Kidney Physiology"  # nosec B101
+
+
+def test_quiz_snapshot_assigns_source_refs_only_to_matching_topics(db: CharactersRAGDB):
+    quiz_id = db.create_quiz(
+        name="Mixed Quiz",
+        source_bundle_json=[{"source_type": "note", "source_id": "note-7", "label": "Cited source"}],
+    )
+    question_id = db.create_question(
+        quiz_id=quiz_id,
+        question_type="multiple_choice",
+        question_text="Which label should stay tag-only?",
+        options=["Tagged only", "Cited source", "Both"],
+        correct_answer=1,
+        explanation="The citation and tag should remain separate topics.",
+        tags=["Tagged only"],
+        source_citations=[{"source_type": "note", "source_id": "note-7", "label": "Cited source"}],
+    )
+    attempt = db.start_attempt(quiz_id)
+    db.submit_attempt(
+        attempt["id"],
+        [
+            {
+                "question_id": question_id,
+                "user_answer": 0,
+                "time_spent_ms": 850,
+            }
+        ],
+    )
+
+    snapshot_id = snapshot_service.refresh_snapshot_for_anchor(
+        note_db=db,
+        anchor_type="quiz_attempt",
+        anchor_id=int(attempt["id"]),
+        principal=_admin_principal(),
+    )
+    payload = db.get_suggestion_snapshot(snapshot_id)["payload_json"]
+    topics_by_label = {
+        topic["display_label"]: topic
+        for topic in payload["topics"]
+        if isinstance(topic, dict) and isinstance(topic.get("display_label"), str)
+    }
+
+    assert topics_by_label["Cited Source"]["source_id"] == "note-7"  # nosec B101
+    assert "source_id" not in topics_by_label["Tagged Only"]  # nosec B101
+
+
 def test_suggestion_generation_link_duplicate_is_conflict_but_fk_failure_is_not(db: CharactersRAGDB):
     snapshot_id = db.create_suggestion_snapshot(
         service="quiz",
@@ -242,6 +498,155 @@ def test_suggestion_generation_link_duplicate_is_conflict_but_fk_failure_is_not(
         )
 
     assert not isinstance(exc_info.value, ConflictError)  # nosec B101
+
+
+def test_suggestion_generation_link_duplicate_identity_ignores_target_id_for_active_rows(
+    db: CharactersRAGDB,
+):
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={"topics": [{"display_label": "Renal basics"}]},
+    )
+
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id="quiz-55",
+        selection_fingerprint="sel-1",
+    )
+
+    with pytest.raises(ConflictError, match="already exists"):
+        db.create_suggestion_generation_link(
+            snapshot_id=snapshot_id,
+            target_service="quiz",
+            target_type="quiz",
+            target_id="quiz-99",
+            selection_fingerprint="sel-1",
+        )
+
+
+def test_suggestion_generation_link_schema_dedupes_legacy_active_duplicates_before_unique_index(
+    db: CharactersRAGDB,
+):
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={"topics": [{"display_label": "Renal basics"}]},
+    )
+
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id="quiz-55",
+        selection_fingerprint="sel-1",
+    )
+    db.execute_query("DROP INDEX IF EXISTS idx_suggestion_generation_links_unique_active", commit=True)
+
+    now = db._get_current_utc_timestamp_iso()
+    insert_sql = """
+        INSERT INTO suggestion_generation_links(
+            snapshot_id, target_service, target_type, target_id, selection_fingerprint,
+            created_at, last_modified, deleted, client_id, version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+    db.execute_query(
+        insert_sql,
+        (
+            snapshot_id,
+            "quiz",
+            "quiz",
+            "pending:sel-1",
+            "sel-1",
+            now,
+            now,
+            False,
+            "legacy-test",
+            1,
+        ),
+        commit=True,
+    )
+    db.execute_query(
+        insert_sql,
+        (
+            snapshot_id,
+            "quiz",
+            "quiz",
+            "quiz-99",
+            "sel-1",
+            now,
+            now,
+            False,
+            "legacy-test",
+            1,
+        ),
+        commit=True,
+    )
+
+    with db.transaction() as conn:
+        db._ensure_study_pack_schema_sqlite(conn)
+
+    rows = [
+        dict(row)
+        for row in db.execute_query(
+            """
+            SELECT target_id, deleted
+              FROM suggestion_generation_links
+             WHERE snapshot_id = ? AND target_service = ? AND target_type = ? AND selection_fingerprint = ?
+             ORDER BY id
+            """,
+            (snapshot_id, "quiz", "quiz", "sel-1"),
+        ).fetchall()
+    ]
+    active_rows = [row for row in rows if not row["deleted"]]
+
+    assert [row["target_id"] for row in active_rows] == ["quiz-99"]  # nosec B101
+
+    with pytest.raises(ConflictError, match="already exists"):
+        db.create_suggestion_generation_link(
+            snapshot_id=snapshot_id,
+            target_service="quiz",
+            target_type="quiz",
+            target_id="quiz-100",
+            selection_fingerprint="sel-1",
+        )
+
+
+def test_study_pack_postgres_schema_dedupes_before_unique_index_recreation() -> None:
+    executed_statements: list[str] = []
+
+    class RecordingBackend:
+        def execute(self, statement, connection=None):  # noqa: ANN001
+            executed_statements.append(" ".join(str(statement).split()))
+            return None
+
+    db = CharactersRAGDB.__new__(CharactersRAGDB)
+    db.backend = RecordingBackend()
+    db._dedupe_suggestion_generation_links_postgres = lambda conn: executed_statements.append("__DEDUPE__")  # type: ignore[method-assign]
+
+    db._ensure_study_pack_schema_postgres(conn=object())
+
+    dedupe_index = executed_statements.index("__DEDUPE__")
+    drop_index = next(
+        index
+        for index, statement in enumerate(executed_statements)
+        if "DROP INDEX IF EXISTS idx_suggestion_generation_links_unique_active" in statement
+    )
+    create_index = next(
+        index
+        for index, statement in enumerate(executed_statements)
+        if "CREATE UNIQUE INDEX IF NOT EXISTS idx_suggestion_generation_links_unique_active" in statement
+    )
+
+    assert dedupe_index < drop_index < create_index  # nosec B101
 
 
 def test_suggestion_storage_tables_include_sync_and_version_fields(db: CharactersRAGDB):

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
@@ -387,6 +387,8 @@ def test_snapshot_actions_open_existing_generation_link_when_fingerprint_matches
     db: CharactersRAGDB,
 ):
     _endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    ancestor_quiz_id = db.create_quiz(name="Ancestor Quiz", source_bundle_json=[])
+    unrelated_quiz_id = db.create_quiz(name="Unrelated Quiz", source_bundle_json=[])
     snapshot_id = db.create_suggestion_snapshot(
         service="quiz",
         activity_type="quiz_attempt",
@@ -395,8 +397,20 @@ def test_snapshot_actions_open_existing_generation_link_when_fingerprint_matches
         suggestion_type="study_suggestions",
         payload_json={
             "topics": [
-                {"id": "topic-1", "display_label": " Renal Basics ", "selected": True},
-                {"id": "topic-2", "display_label": "Acid Base", "selected": True},
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "canonical_label": "kidney functions",
+                    "display_label": " Renal Basics ",
+                    "selected": True,
+                },
+                {
+                    "id": "topic-2",
+                    "topic_key": "renal:acid-base",
+                    "canonical_label": "acid base",
+                    "display_label": "Acid Base",
+                    "selected": True,
+                },
             ]
         },
     )
@@ -404,7 +418,7 @@ def test_snapshot_actions_open_existing_generation_link_when_fingerprint_matches
         snapshot_id=snapshot_id,
         target_service="quiz",
         target_type="quiz",
-        selected_topics=["acid base", "renal basics"],
+        selected_topics=["renal:acid-base", "renal:kidney-functions"],
         action_kind="follow_up_quiz",
         generator_version="v1",
     )
@@ -412,7 +426,39 @@ def test_snapshot_actions_open_existing_generation_link_when_fingerprint_matches
         snapshot_id=snapshot_id,
         target_service="quiz",
         target_type="quiz",
-        target_id="quiz-55",
+        target_id=str(ancestor_quiz_id),
+        selection_fingerprint=fingerprint,
+    )
+    unrelated_snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "canonical_label": "kidney functions",
+                    "display_label": " Renal Basics ",
+                    "selected": True,
+                },
+                {
+                    "id": "topic-2",
+                    "topic_key": "renal:acid-base",
+                    "canonical_label": "acid base",
+                    "display_label": "Acid Base",
+                    "selected": True,
+                },
+            ]
+        },
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=unrelated_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id=str(unrelated_quiz_id),
         selection_fingerprint=fingerprint,
     )
 
@@ -430,7 +476,7 @@ def test_snapshot_actions_open_existing_generation_link_when_fingerprint_matches
 
     assert response.status_code == 200  # nosec B101
     assert response.json()["disposition"] == "opened_existing"  # nosec B101
-    assert response.json()["target_id"] == "quiz-55"  # nosec B101
+    assert response.json()["target_id"] == str(ancestor_quiz_id)  # nosec B101
     assert response.json()["selection_fingerprint"] == fingerprint  # nosec B101
 
 
@@ -448,8 +494,20 @@ def test_snapshot_actions_use_selected_topic_edits_and_manual_labels_for_generat
         suggestion_type="study_suggestions",
         payload_json={
             "topics": [
-                {"id": "topic-1", "display_label": "Renal Basics", "selected": True},
-                {"id": "topic-2", "display_label": "Acid Base", "selected": True},
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:basics",
+                    "canonical_label": "renal basics",
+                    "display_label": "Renal Basics",
+                    "selected": True,
+                },
+                {
+                    "id": "topic-2",
+                    "topic_key": "renal:acid-base",
+                    "canonical_label": "acid base",
+                    "display_label": "Acid Base",
+                    "selected": True,
+                },
             ]
         },
     )
@@ -459,7 +517,7 @@ def test_snapshot_actions_use_selected_topic_edits_and_manual_labels_for_generat
         snapshot_id=snapshot_id,
         target_service="quiz",
         target_type="quiz",
-        selected_topics=expected_topics,
+        selected_topics=["electrolyte ladder", "renal:acid-base"],
         action_kind="follow_up_quiz",
         generator_version="v2",
     )
@@ -820,3 +878,935 @@ def test_snapshot_actions_return_conflict_when_matching_generation_is_already_re
 
     assert response.status_code == 409  # nosec B101
     assert "already in progress" in response.json()["detail"].lower()  # nosec B101
+
+
+def test_snapshot_actions_use_snapshot_semantics_for_fingerprint_and_edit_labels_for_generation(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, _actions_mod = _load_modules()
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+
+    expected_fingerprint = "semantic-fingerprint"
+
+    def fake_build_selection_fingerprint(
+        *,
+        snapshot_id: int,
+        target_service: str,
+        target_type: str,
+        selected_topics,
+        action_kind: str,
+        generator_version: str | None = None,
+        normalization_version: str | None = None,
+        include_normalization_version: bool = True,
+    ) -> str:
+        assert snapshot_id == snapshot_id_value  # nosec B101
+        assert target_service == "quiz"  # nosec B101
+        assert target_type == "quiz"  # nosec B101
+        assert list(selected_topics) == ["renal:kidney-functions"]  # nosec B101
+        assert action_kind == "follow_up_quiz"  # nosec B101
+        assert generator_version == "v2"  # nosec B101
+        assert normalization_version == "norm-v2"  # nosec B101
+        assert include_normalization_version in {True, False}  # nosec B101
+        return expected_fingerprint
+
+    snapshot_id_value = snapshot_id
+    monkeypatch.setattr(endpoints_mod, "build_selection_fingerprint", fake_build_selection_fingerprint)
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == snapshot_id  # nosec B101
+        assert request_body["selected_topics"] == ["renal remix"]  # nosec B101
+        assert request_body["selected_topic_edits"] == [{"id": "topic-1", "label": "Renal Remix"}]  # nosec B101
+        return {
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "target_id": "quiz-77",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{snapshot_id}/actions",
+        json={
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "action_kind": "follow_up_quiz",
+            "selected_topic_ids": ["topic-1"],
+            "selected_topic_edits": [{"id": "topic-1", "label": "Renal Remix"}],
+            "manual_topic_labels": [],
+            "has_explicit_selection": True,
+            "generator_version": "v2",
+            "force_regenerate": True,
+        },
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "generated"  # nosec B101
+    assert response.json()["selection_fingerprint"] == expected_fingerprint  # nosec B101
+
+
+def test_snapshot_actions_reopen_existing_links_written_before_normalization_version_fingerprints(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    existing_quiz_id = db.create_quiz(name="Existing Quiz", source_bundle_json=[])
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    legacy_fingerprint = (
+        f"snapshot_id={snapshot_id}|target_service=quiz|target_type=quiz|"
+        "topics=renal:kidney-functions|action_kind=follow_up_quiz|generator_version=v1"
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id=str(existing_quiz_id),
+        selection_fingerprint=legacy_fingerprint,
+    )
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == snapshot_id  # nosec B101
+        return {
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "target_id": "quiz-generated",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{snapshot_id}/actions",
+        json={
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "action_kind": "follow_up_quiz",
+            "selected_topic_ids": ["topic-1"],
+            "generator_version": "v1",
+            "force_regenerate": False,
+        },
+    )
+
+    expected_fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_quiz",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "opened_existing"  # nosec B101
+    assert response.json()["target_id"] == str(existing_quiz_id)  # nosec B101
+    assert response.json()["selection_fingerprint"] == expected_fingerprint  # nosec B101
+
+
+def test_snapshot_actions_prefer_live_legacy_links_when_stale_current_fingerprint_rows_exist(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    live_deck_id = db.add_deck("Live Deck", "desc")
+    stale_deck_id = db.add_deck("Stale Deck", "desc")
+    db.soft_delete_deck_by_id(stale_deck_id)
+    snapshot_id = db.create_suggestion_snapshot(
+        service="flashcards",
+        activity_type="flashcard_review_session",
+        anchor_type="flashcard_review_session",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    current_fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_flashcards",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+    legacy_fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_flashcards",
+        generator_version="v1",
+        normalization_version="norm-v2",
+        include_normalization_version=False,
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        target_id=str(stale_deck_id),
+        selection_fingerprint=current_fingerprint,
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        target_id=str(live_deck_id),
+        selection_fingerprint=legacy_fingerprint,
+    )
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == snapshot_id  # nosec B101
+        return {
+            "target_service": "flashcards",
+            "target_type": "deck",
+            "target_id": "deck-generated",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{snapshot_id}/actions",
+        json={
+            "target_service": "flashcards",
+            "target_type": "deck",
+            "action_kind": "follow_up_flashcards",
+            "selected_topic_ids": ["topic-1"],
+            "generator_version": "v1",
+            "force_regenerate": False,
+        },
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "opened_existing"  # nosec B101
+    assert response.json()["target_id"] == str(live_deck_id)  # nosec B101
+    assert response.json()["selection_fingerprint"] == current_fingerprint  # nosec B101
+
+
+def test_snapshot_actions_reserve_conflict_rechecks_live_legacy_links_before_opening_existing(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    live_deck_id = db.add_deck("Live Deck", "desc")
+    stale_deck_id = db.add_deck("Stale Deck", "desc")
+    db.soft_delete_deck_by_id(stale_deck_id)
+    snapshot_id = db.create_suggestion_snapshot(
+        service="flashcards",
+        activity_type="flashcard_review_session",
+        anchor_type="flashcard_review_session",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    current_fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_flashcards",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+    legacy_fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_flashcards",
+        generator_version="v1",
+        normalization_version="norm-v2",
+        include_normalization_version=False,
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        target_id=str(stale_deck_id),
+        selection_fingerprint=current_fingerprint,
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        target_id=str(live_deck_id),
+        selection_fingerprint=legacy_fingerprint,
+    )
+
+    def fake_reserve_generation_link(*args, **kwargs):
+        raise RuntimeError("simulated reservation race")
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == snapshot_id  # nosec B101
+        return {
+            "target_service": "flashcards",
+            "target_type": "deck",
+            "target_id": "deck-generated",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "reserve_generation_link", fake_reserve_generation_link)
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{snapshot_id}/actions",
+        json={
+            "target_service": "flashcards",
+            "target_type": "deck",
+            "action_kind": "follow_up_flashcards",
+            "selected_topic_ids": ["topic-1"],
+            "generator_version": "v1",
+            "force_regenerate": False,
+        },
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "opened_existing"  # nosec B101
+    assert response.json()["target_id"] == str(live_deck_id)  # nosec B101
+    assert response.json()["selection_fingerprint"] == current_fingerprint  # nosec B101
+
+
+def test_snapshot_actions_reopen_refreshed_ancestor_link_without_writing_child_alias_rows(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    ancestor_quiz_id = db.create_quiz(name="Ancestor Quiz", source_bundle_json=[])
+    unrelated_quiz_id = db.create_quiz(name="Unrelated Quiz", source_bundle_json=[])
+    original_snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=original_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_quiz",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=original_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id=str(ancestor_quiz_id),
+        selection_fingerprint=fingerprint,
+    )
+    unrelated_snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=unrelated_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id=str(unrelated_quiz_id),
+        selection_fingerprint=fingerprint,
+    )
+    child_snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+        refreshed_from_snapshot_id=original_snapshot_id,
+    )
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == child_snapshot_id  # nosec B101
+        return {
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "target_id": "quiz-generated",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{child_snapshot_id}/actions",
+        json={
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "action_kind": "follow_up_quiz",
+            "selected_topic_ids": ["topic-1"],
+            "generator_version": "v1",
+            "force_regenerate": False,
+        },
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "opened_existing"  # nosec B101
+    assert response.json()["target_id"] == str(ancestor_quiz_id)  # nosec B101
+    expected_child_fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=child_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_quiz",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+    assert response.json()["selection_fingerprint"] == expected_child_fingerprint  # nosec B101
+
+    child_link = db.execute_query(
+        """
+        SELECT COUNT(*) AS count
+          FROM suggestion_generation_links
+         WHERE snapshot_id = ? AND deleted = 0
+        """,
+        (child_snapshot_id,),
+    ).fetchone()
+    assert int(child_link["count"]) == 0  # nosec B101
+
+
+def test_snapshot_actions_reopen_refreshed_ancestor_links_written_before_normalization_version_fingerprints(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    ancestor_quiz_id = db.create_quiz(name="Ancestor Quiz", source_bundle_json=[])
+    original_snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    legacy_fingerprint = (
+        f"snapshot_id={original_snapshot_id}|target_service=quiz|target_type=quiz|"
+        "topics=renal:kidney-functions|action_kind=follow_up_quiz|generator_version=v1"
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=original_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id=str(ancestor_quiz_id),
+        selection_fingerprint=legacy_fingerprint,
+    )
+    child_snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+        refreshed_from_snapshot_id=original_snapshot_id,
+    )
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == child_snapshot_id  # nosec B101
+        return {
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "target_id": "quiz-generated",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{child_snapshot_id}/actions",
+        json={
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "action_kind": "follow_up_quiz",
+            "selected_topic_ids": ["topic-1"],
+            "generator_version": "v1",
+            "force_regenerate": False,
+        },
+    )
+
+    expected_fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=child_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_quiz",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "opened_existing"  # nosec B101
+    assert response.json()["target_id"] == str(ancestor_quiz_id)  # nosec B101
+    assert response.json()["selection_fingerprint"] == expected_fingerprint  # nosec B101
+
+
+def test_snapshot_actions_ignore_deleted_targets_when_reopening_existing_links(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    deck_id = db.add_deck("Session Deck", "desc")
+    snapshot_id = db.create_suggestion_snapshot(
+        service="flashcards",
+        activity_type="flashcard_review_session",
+        anchor_type="flashcard_review_session",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_flashcards",
+        generator_version="v1",
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        target_id=str(deck_id),
+        selection_fingerprint=fingerprint,
+    )
+    db.soft_delete_deck_by_id(deck_id)
+
+    monkeypatch.setattr(endpoints_mod, "build_selection_fingerprint", lambda **_: fingerprint)
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == snapshot_id  # nosec B101
+        return {
+            "target_service": "flashcards",
+            "target_type": "deck",
+            "target_id": "deck-999",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{snapshot_id}/actions",
+        json={
+            "target_service": "flashcards",
+            "target_type": "deck",
+            "action_kind": "follow_up_flashcards",
+            "selected_topic_ids": ["topic-1"],
+            "generator_version": "v1",
+            "force_regenerate": False,
+        },
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "generated"  # nosec B101
+    assert response.json()["target_id"] == "deck-999"  # nosec B101
+    active_link = db.execute_query(
+        """
+        SELECT COUNT(*) AS count
+          FROM suggestion_generation_links
+         WHERE snapshot_id = ? AND deleted = 0
+        """,
+        (snapshot_id,),
+    ).fetchone()
+    assert int(active_link["count"]) == 1  # nosec B101
+
+
+def test_snapshot_actions_ignore_deleted_ancestor_targets_in_refreshed_lineage_lookup(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    deleted_deck_id = db.add_deck("Deleted Ancestor Deck", "desc")
+    original_snapshot_id = db.create_suggestion_snapshot(
+        service="flashcards",
+        activity_type="flashcard_review_session",
+        anchor_type="flashcard_review_session",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=original_snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_flashcards",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=original_snapshot_id,
+        target_service="flashcards",
+        target_type="deck",
+        target_id=str(deleted_deck_id),
+        selection_fingerprint=fingerprint,
+    )
+    db.soft_delete_deck_by_id(deleted_deck_id)
+    child_snapshot_id = db.create_suggestion_snapshot(
+        service="flashcards",
+        activity_type="flashcard_review_session",
+        anchor_type="flashcard_review_session",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+        refreshed_from_snapshot_id=original_snapshot_id,
+    )
+
+    monkeypatch.setattr(endpoints_mod, "build_selection_fingerprint", lambda **_: fingerprint)
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == child_snapshot_id  # nosec B101
+        return {
+            "target_service": "flashcards",
+            "target_type": "deck",
+            "target_id": "deck-1234",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{child_snapshot_id}/actions",
+        json={
+            "target_service": "flashcards",
+            "target_type": "deck",
+            "action_kind": "follow_up_flashcards",
+            "selected_topic_ids": ["topic-1"],
+            "generator_version": "v1",
+            "force_regenerate": False,
+        },
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "generated"  # nosec B101
+    assert response.json()["target_id"] == "deck-1234"  # nosec B101
+
+
+def test_snapshot_actions_generate_new_output_for_refreshed_ancestor_requests_with_manual_topic_labels(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    ancestor_quiz_id = db.create_quiz(name="Ancestor Quiz", source_bundle_json=[])
+    original_snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=original_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["electrolyte ladder", "renal:kidney-functions"],
+        action_kind="follow_up_quiz",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=original_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id=str(ancestor_quiz_id),
+        selection_fingerprint=fingerprint,
+    )
+    child_snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "normalization_version": "norm-v2",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+        refreshed_from_snapshot_id=original_snapshot_id,
+    )
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == child_snapshot_id  # nosec B101
+        return {
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "target_id": "quiz-generated",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{child_snapshot_id}/actions",
+        json={
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "action_kind": "follow_up_quiz",
+            "selected_topic_ids": ["topic-1"],
+            "manual_topic_labels": [" Electrolyte Ladder "],
+            "generator_version": "v1",
+            "force_regenerate": False,
+        },
+    )
+
+    expected_fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=child_snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["electrolyte ladder", "renal:kidney-functions"],
+        action_kind="follow_up_quiz",
+        generator_version="v1",
+        normalization_version="norm-v2",
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "generated"  # nosec B101
+    assert response.json()["target_id"] == "quiz-generated"  # nosec B101
+    assert response.json()["selection_fingerprint"] == expected_fingerprint  # nosec B101
+
+
+def test_snapshot_actions_force_regenerate_replaces_active_direct_link(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    endpoints_mod, _quizzes_mod, _flashcards_mod, _snapshot_service_mod, _jobs_mod, actions_mod = _load_modules()
+    existing_quiz_id = db.create_quiz(name="Existing Quiz", source_bundle_json=[])
+    snapshot_id = db.create_suggestion_snapshot(
+        service="quiz",
+        activity_type="quiz_attempt",
+        anchor_type="quiz_attempt",
+        anchor_id=101,
+        suggestion_type="study_suggestions",
+        payload_json={
+            "topics": [
+                {
+                    "id": "topic-1",
+                    "topic_key": "renal:kidney-functions",
+                    "canonical_label": "kidney functions",
+                    "display_label": "Kidney Functions",
+                    "selected": True,
+                }
+            ]
+        },
+    )
+    fingerprint = actions_mod.build_selection_fingerprint(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        selected_topics=["renal:kidney-functions"],
+        action_kind="follow_up_quiz",
+        generator_version="v1",
+    )
+    db.create_suggestion_generation_link(
+        snapshot_id=snapshot_id,
+        target_service="quiz",
+        target_type="quiz",
+        target_id=str(existing_quiz_id),
+        selection_fingerprint=fingerprint,
+    )
+
+    monkeypatch.setattr(endpoints_mod, "build_selection_fingerprint", lambda **_: fingerprint)
+
+    async def fake_dispatch_action(*, note_db, snapshot_row, request_body, media_db=None):
+        assert int(snapshot_row["id"]) == snapshot_id  # nosec B101
+        assert request_body["force_regenerate"] is True  # nosec B101
+        return {
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "target_id": "quiz-99",
+        }
+
+    monkeypatch.setattr(endpoints_mod, "_dispatch_follow_up_action", fake_dispatch_action)
+
+    response = client.post(
+        f"/api/v1/study-suggestions/snapshots/{snapshot_id}/actions",
+        json={
+            "target_service": "quiz",
+            "target_type": "quiz",
+            "action_kind": "follow_up_quiz",
+            "selected_topic_ids": ["topic-1"],
+            "generator_version": "v1",
+            "force_regenerate": True,
+        },
+    )
+
+    assert response.status_code == 200  # nosec B101
+    assert response.json()["disposition"] == "generated"  # nosec B101
+    assert response.json()["target_id"] == "quiz-99"  # nosec B101
+    active_links = db.execute_query(
+        """
+        SELECT COUNT(*) AS count
+          FROM suggestion_generation_links
+         WHERE snapshot_id = ? AND selection_fingerprint = ? AND deleted = 0
+        """,
+        (snapshot_id, fingerprint),
+    ).fetchone()
+    assert int(active_links["count"]) == 1  # nosec B101

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py
@@ -258,13 +258,30 @@ def test_refresh_enqueues_job_for_existing_snapshot(
 
     assert refresh.status_code == 202  # nosec B101
     assert refresh.json()["job"]["status"] == "queued"  # nosec B101
-
     job = _jobs_manager(jobs_db_path).get_job(int(refresh.json()["job"]["id"]))
     assert job is not None  # nosec B101
     assert job["domain"] == jobs_mod.STUDY_SUGGESTIONS_DOMAIN  # nosec B101
     assert job["job_type"] == jobs_mod.STUDY_SUGGESTIONS_REFRESH_JOB_TYPE  # nosec B101
     assert int(job["payload"]["snapshot_id"]) == snapshot_id  # nosec B101
     assert int(job["payload"]["anchor_id"]) == 101  # nosec B101
+
+
+def test_refresh_maps_job_manager_validation_errors_to_http_400(
+    client: TestClient,
+    db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    snapshot_id = _create_snapshot(db)
+
+    def fail_create_job(self, *args, **kwargs):  # noqa: ANN001, ARG001
+        raise ValueError("invalid refresh request")
+
+    monkeypatch.setattr(JobManager, "create_job", fail_create_job)
+
+    refresh = client.post(f"/api/v1/study-suggestions/snapshots/{snapshot_id}/refresh", json={})
+
+    assert refresh.status_code == 400  # nosec B101
+    assert refresh.json()["detail"] == "invalid refresh request"  # nosec B101
 
 
 def test_live_evidence_permission_failures_degrade_to_source_unavailable(

--- a/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py
@@ -321,7 +321,7 @@ async def test_worker_sdk_cancellation_marks_study_suggestions_job_cancelled_wit
     assert stored["status"] == "cancelled"  # nosec B101
 
 
-async def test_selection_fingerprint_includes_snapshot_target_topics_action_and_generator_version():
+async def test_selection_fingerprint_includes_snapshot_target_topics_action_generator_and_normalization_version():
     actions_mod, _snapshot_service_mod, _jobs_mod, _worker_mod = _load_modules()
 
     fingerprint = actions_mod.build_selection_fingerprint(
@@ -331,6 +331,7 @@ async def test_selection_fingerprint_includes_snapshot_target_topics_action_and_
         selected_topics=[" Renal Basics ", "acid base", "renal basics"],
         action_kind="follow_up_quiz",
         generator_version="v2",
+        normalization_version="norm-v2",
     )
 
     assert "snapshot_id=17" in fingerprint  # nosec B101
@@ -339,6 +340,7 @@ async def test_selection_fingerprint_includes_snapshot_target_topics_action_and_
     assert "topics=acid base,renal basics" in fingerprint  # nosec B101
     assert "action_kind=follow_up_quiz" in fingerprint  # nosec B101
     assert "generator_version=v2" in fingerprint  # nosec B101
+    assert "normalization_version=norm-v2" in fingerprint  # nosec B101
 
 
 async def test_resolve_selected_topic_labels_defaults_to_snapshot_selected_topics():

--- a/tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py
@@ -1,5 +1,6 @@
 from tldw_Server_API.app.core.StudySuggestions.topic_aliases import (
     NORMALIZATION_VERSION,
+    resolve_topic_alias,
 )
 from tldw_Server_API.app.core.StudySuggestions.topic_pipeline import (
     normalize_topic_labels,
@@ -81,6 +82,13 @@ def test_normalize_topic_labels_uses_semantic_canonical_label_for_explicit_alias
     assert len(normalized) == 1  # nosec B101
     assert normalized[0].canonical_label == "renal physiology"  # nosec B101
     assert normalized[0].raw_labels == ["Kidney physiology"]  # nosec B101
+
+
+def test_resolve_topic_alias_normalizes_raw_input_before_lookup():
+    assert resolve_topic_alias("Kidney_Physiology") == (  # nosec B101
+        "renal",
+        "renal physiology",
+    )
 
 
 def test_normalize_topic_labels_collapses_mixed_raw_forms_stably():

--- a/tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py
+++ b/tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py
@@ -1,8 +1,170 @@
+from tldw_Server_API.app.core.StudySuggestions.topic_aliases import (
+    NORMALIZATION_VERSION,
+)
 from tldw_Server_API.app.core.StudySuggestions.topic_pipeline import (
     normalize_topic_labels,
     rank_suggestion_topics,
     resolve_topic_candidates,
 )
+from tldw_Server_API.app.core.StudySuggestions.types import TopicCandidate
+
+
+def _candidate_by_topic_key(candidates, topic_key):
+    for candidate in candidates:
+        if candidate.topic_key == topic_key:
+            return candidate
+    raise AssertionError(f"missing candidate for {topic_key}")
+
+
+def test_grounded_labels_preserve_unaliased_source_text_and_collapse_explicit_synonyms():
+    candidates = resolve_topic_candidates(
+        source_labels=[
+            "Kidney function",
+            "Kidney physiology",
+            "renal physiology",
+        ],
+        tag_labels=[],
+        derived_labels=[],
+    )
+
+    assert len(candidates) == 2  # nosec B101
+    function_candidate = _candidate_by_topic_key(candidates, "renal:renal-function")
+    physiology_candidate = _candidate_by_topic_key(candidates, "renal:renal-physiology")
+
+    assert function_candidate.canonical_label == "renal function"  # nosec B101
+    assert function_candidate.raw_labels[0] == "Kidney function"  # nosec B101
+    assert function_candidate.semantic_label == "renal function"  # nosec B101
+    assert "Kidney function" in function_candidate.raw_labels  # nosec B101
+    assert physiology_candidate.canonical_label == "renal physiology"  # nosec B101
+    assert physiology_candidate.raw_labels[0] == "Kidney physiology"  # nosec B101
+    assert physiology_candidate.semantic_label == "renal physiology"  # nosec B101
+    assert "Kidney physiology" in physiology_candidate.raw_labels  # nosec B101
+    assert "renal physiology" in physiology_candidate.raw_labels  # nosec B101
+    assert function_candidate.normalization_version == NORMALIZATION_VERSION  # nosec B101
+    assert physiology_candidate.normalization_version == NORMALIZATION_VERSION  # nosec B101
+
+
+def test_source_and_tag_labels_collapse_by_semantic_topic_key_without_rewriting_source_label():
+    candidates = resolve_topic_candidates(
+        source_labels=["Kidney function"],
+        tag_labels=["renal function"],
+        derived_labels=[],
+    )
+
+    assert len(candidates) == 1  # nosec B101
+    candidate = candidates[0]
+    assert candidate.topic_key == "renal:renal-function"  # nosec B101
+    assert candidate.canonical_label == "renal function"  # nosec B101
+    assert candidate.raw_labels[0] == "Kidney function"  # nosec B101
+    assert candidate.semantic_label == "renal function"  # nosec B101
+    assert "Kidney function" in candidate.raw_labels  # nosec B101
+    assert "renal function" in candidate.raw_labels  # nosec B101
+    assert candidate.source_count == 1  # nosec B101
+
+
+def test_single_explicit_alias_source_label_uses_stable_semantic_canonical_label():
+    candidate = resolve_topic_candidates(
+        source_labels=["Kidney physiology"],
+        tag_labels=[],
+        derived_labels=[],
+    )[0]
+
+    assert candidate.topic_key == "renal:renal-physiology"  # nosec B101
+    assert candidate.canonical_label == "renal physiology"  # nosec B101
+    assert candidate.raw_labels == ["Kidney physiology"]  # nosec B101
+    assert candidate.semantic_label == "renal physiology"  # nosec B101
+
+
+def test_normalize_topic_labels_uses_semantic_canonical_label_for_explicit_aliases():
+    normalized = normalize_topic_labels(["Kidney physiology"])
+
+    assert len(normalized) == 1  # nosec B101
+    assert normalized[0].canonical_label == "renal physiology"  # nosec B101
+    assert normalized[0].raw_labels == ["Kidney physiology"]  # nosec B101
+
+
+def test_normalize_topic_labels_collapses_mixed_raw_forms_stably():
+    normalized = normalize_topic_labels(["Renal Basics", "renal-basics", "Kidney basics"])
+
+    assert len(normalized) == 1  # nosec B101
+    assert normalized[0].canonical_label == "renal basics"  # nosec B101
+    assert normalized[0].raw_labels == [  # nosec B101
+        "Renal Basics",
+        "renal-basics",
+        "Kidney basics",
+    ]
+
+
+def test_normalize_topic_labels_preserves_namespace_disambiguation_for_semantic_collisions():
+    normalized = normalize_topic_labels(["renal overview", "cardiac overview"])
+
+    assert [topic.canonical_label for topic in normalized] == [  # nosec B101
+        "renal overview",
+        "cardiac overview",
+    ]
+    assert [topic.raw_labels for topic in normalized] == [  # nosec B101
+        ["renal overview"],
+        ["cardiac overview"],
+    ]
+
+
+def test_normalize_topic_labels_uses_stable_namespace_labels_for_token_alias_collisions():
+    normalized = normalize_topic_labels(["renal overview", "heart overview"])
+
+    assert [topic.canonical_label for topic in normalized] == [  # nosec B101
+        "renal overview",
+        "cardiac overview",
+    ]
+    assert [topic.raw_labels for topic in normalized] == [  # nosec B101
+        ["renal overview"],
+        ["heart overview"],
+    ]
+
+
+def test_normalize_topic_labels_keeps_general_namespace_collision_unprefixed():
+    normalized = normalize_topic_labels(["overview", "heart overview"])
+
+    assert [topic.canonical_label for topic in normalized] == [  # nosec B101
+        "overview",
+        "cardiac overview",
+    ]
+    assert [topic.raw_labels for topic in normalized] == [  # nosec B101
+        ["overview"],
+        ["heart overview"],
+    ]
+
+
+def test_canonical_label_selection_is_order_independent_for_colliding_source_labels():
+    forward = resolve_topic_candidates(
+        source_labels=["Kidney function", "renal function"],
+        tag_labels=[],
+        derived_labels=[],
+    )
+    reverse = resolve_topic_candidates(
+        source_labels=["renal function", "Kidney function"],
+        tag_labels=[],
+        derived_labels=[],
+    )
+
+    assert len(forward) == 1  # nosec B101
+    assert len(reverse) == 1  # nosec B101
+    assert forward[0].topic_key == reverse[0].topic_key == "renal:renal-function"  # nosec B101
+    assert forward[0].canonical_label == reverse[0].canonical_label  # nosec B101
+    assert forward[0].raw_labels[0] in {"Kidney function", "renal function"}  # nosec B101
+    assert reverse[0].raw_labels[0] in {"Kidney function", "renal function"}  # nosec B101
+    assert forward[0].canonical_label == "renal function"  # nosec B101
+
+
+def test_source_count_only_tracks_grounded_source_labels():
+    candidates = resolve_topic_candidates(
+        source_labels=["Kidney physiology"],
+        tag_labels=["Cardiac overview"],
+        derived_labels=["Kidney function"],
+    )
+
+    assert _candidate_by_topic_key(candidates, "renal:renal-physiology").source_count == 1  # nosec B101
+    assert _candidate_by_topic_key(candidates, "cardiac:overview").source_count == 0  # nosec B101
+    assert _candidate_by_topic_key(candidates, "renal:renal-function").source_count == 0  # nosec B101
 
 
 def test_source_metadata_outranks_tags_and_tags_outrank_derived_labels():
@@ -17,14 +179,88 @@ def test_source_metadata_outranks_tags_and_tags_outrank_derived_labels():
         "weakly_grounded",
         "derived",
     ]
-    assert candidates[0].canonical_label == "kidney function"  # nosec B101
+    assert candidates[0].canonical_label == "renal function"  # nosec B101
 
 
-def test_obvious_near_duplicates_normalize_to_one_canonical_label():
-    normalized = normalize_topic_labels([" Renal Basics ", "renal-basics", "Kidney basics"])
+def test_different_namespaces_can_reuse_the_same_slug_without_collision():
+    candidates = resolve_topic_candidates(
+        source_labels=["Renal overview", "Cardiac overview"],
+        tag_labels=[],
+        derived_labels=[],
+    )
 
-    assert normalized[0].canonical_label == "renal basics"  # nosec B101
-    assert normalized[0].raw_labels == [" Renal Basics ", "renal-basics", "Kidney basics"]  # nosec B101
+    assert {candidate.topic_key for candidate in candidates} == {  # nosec B101
+        "renal:overview",
+        "cardiac:overview",
+    }
+    assert len({candidate.topic_key for candidate in candidates}) == 2  # nosec B101
+    assert {candidate.normalization_version for candidate in candidates} == {  # nosec B101
+        NORMALIZATION_VERSION
+    }
+
+
+def test_ranked_topics_default_normalization_version_when_missing():
+    ranked = rank_suggestion_topics(
+        [
+            TopicCandidate(
+                canonical_label="kidney function",
+                semantic_label="renal function",
+                raw_labels=["Kidney function"],
+                evidence_class="grounded",
+                topic_key="renal:renal-function",
+            )
+        ],
+        weakness_labels=[],
+        adjacent_labels=[],
+        exploratory_labels=[],
+    )
+
+    assert ranked[0].topic_key == "renal:renal-function"  # nosec B101
+    assert ranked[0].normalization_version == NORMALIZATION_VERSION  # nosec B101
+
+
+def test_ranked_topics_carry_normalization_version_and_topic_identity():
+    candidates = resolve_topic_candidates(
+        source_labels=["Renal physiology"],
+        tag_labels=["Cardiac overview"],
+        derived_labels=[],
+    )
+
+    ranked = rank_suggestion_topics(
+        candidates,
+        weakness_labels=[],
+        adjacent_labels=[],
+        exploratory_labels=[],
+    )
+
+    assert [topic.topic_key for topic in ranked] == [  # nosec B101
+        "renal:renal-physiology",
+        "cardiac:overview",
+    ]
+    assert all(  # nosec B101
+        topic.normalization_version == NORMALIZATION_VERSION for topic in ranked
+    )
+    assert all(topic.source_count >= 0 for topic in ranked)  # nosec B101
+
+
+def test_display_label_and_raw_label_drift_do_not_change_semantic_identity():
+    kidney_variant = resolve_topic_candidates(
+        source_labels=["Kidney function"],
+        tag_labels=[],
+        derived_labels=[],
+    )[0]
+    renal_variant = resolve_topic_candidates(
+        source_labels=["renal function"],
+        tag_labels=[],
+        derived_labels=[],
+    )[0]
+
+    assert kidney_variant.topic_key == renal_variant.topic_key  # nosec B101
+    assert kidney_variant.semantic_label == renal_variant.semantic_label == "renal function"  # nosec B101
+    assert kidney_variant.canonical_label == "renal function"  # nosec B101
+    assert kidney_variant.raw_labels[0] == "Kidney function"  # nosec B101
+    assert renal_variant.canonical_label == "renal function"  # nosec B101
+    assert renal_variant.raw_labels[0] == "renal function"  # nosec B101
 
 
 def test_weakness_first_ranking_preserves_weakness_before_adjacent_topics():
@@ -43,10 +279,28 @@ def test_weakness_first_ranking_preserves_weakness_before_adjacent_topics():
 
     assert [topic.canonical_label for topic in ranked[:2]] == [  # nosec B101
         "electrolyte balance",
-        "kidney function",
+        "renal function",
     ]
     assert ranked[0].rank_reason == "weakness"  # nosec B101
     assert ranked[1].rank_reason == "adjacent"  # nosec B101
+
+
+def test_weakness_ranking_adds_missed_question_provenance():
+    candidates = resolve_topic_candidates(
+        source_labels=["Kidney function"],
+        tag_labels=[],
+        derived_labels=[],
+    )
+
+    ranked = rank_suggestion_topics(
+        candidates,
+        weakness_labels=["Kidney function"],
+        adjacent_labels=[],
+        exploratory_labels=[],
+    )
+
+    assert ranked[0].rank_reason == "weakness"  # nosec B101
+    assert "missed_question" in ranked[0].evidence_reasons  # nosec B101
 
 
 def test_exploratory_topics_never_claim_source_aware_adjacency():


### PR DESCRIPTION
## Summary
- add deterministic topic grounding and normalization v2 for study suggestions, including stable topic keys, namespaced aliases, richer adapter evidence, and legacy-safe snapshot serialization
- improve flashcard and quiz suggestion quality, duplicate handling, lineage reuse, and Postgres/SQLite migration safety for generation links
- add frontend compatibility for v2 topic payloads plus regression coverage across backend adapters, storage, endpoints, jobs, and UI hooks/panels

## Test Plan
- [x] `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/StudySuggestions/test_topic_pipeline.py tldw_Server_API/tests/StudySuggestions/test_study_suggestion_adapters.py tldw_Server_API/tests/StudySuggestions/test_flashcard_review_sessions.py tldw_Server_API/tests/StudySuggestions/test_study_suggestion_storage.py tldw_Server_API/tests/StudySuggestions/test_study_suggestion_schemas.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_endpoints_api.py tldw_Server_API/tests/StudySuggestions/test_study_suggestions_jobs_worker.py -q``
- [x] `cd apps/packages/ui && bun install && bunx vitest run src/components/StudySuggestions/hooks/__tests__/useStudySuggestions.test.tsx src/components/StudySuggestions/components/__tests__/StudySuggestionsPanel.test.tsx`
- [x] `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/StudySuggestions tldw_Server_API/app/api/v1/endpoints/study_suggestions.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_study_suggestions_grounding_v2_followup.json`