### PR TITLE
fix(notes): NNG UX audit rounds 3-6 — terminology, disclosure, help, keyboard

### DIFF
--- a/apps/packages/ui/src/components/Notes/CollapsibleSection.tsx
+++ b/apps/packages/ui/src/components/Notes/CollapsibleSection.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 
 interface CollapsibleSectionProps {
-  title: string
+  title: React.ReactNode
+  titleAccessory?: React.ReactNode
   badge?: string | number | null
   defaultOpen?: boolean
   storageKey?: string
@@ -12,6 +13,7 @@ interface CollapsibleSectionProps {
 
 const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
   title,
+  titleAccessory,
   badge,
   defaultOpen = false,
   storageKey,
@@ -46,30 +48,33 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
 
   return (
     <div data-testid={testId}>
-      <button
-        type="button"
-        onClick={toggle}
-        className="flex w-full items-center justify-between py-1.5 text-[11px] uppercase tracking-[0.08em] text-text-muted hover:text-text transition-colors"
-        aria-expanded={open}
-        data-testid={testId ? `${testId}-toggle` : undefined}
-      >
-        <span className="flex items-center gap-1.5">
-          {title}
-          {badge != null && !open && (
-            <span
-              className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary"
-              data-testid={testId ? `${testId}-badge` : undefined}
-            >
-              {badge}
-            </span>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={toggle}
+          className="flex min-w-0 flex-1 items-center justify-between py-1.5 text-[11px] uppercase tracking-[0.08em] text-text-muted hover:text-text transition-colors"
+          aria-expanded={open}
+          data-testid={testId ? `${testId}-toggle` : undefined}
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate">{title}</span>
+            {badge != null && !open && (
+              <span
+                className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary"
+                data-testid={testId ? `${testId}-badge` : undefined}
+              >
+                {badge}
+              </span>
+            )}
+          </span>
+          {open ? (
+            <ChevronDown className="w-3.5 h-3.5" />
+          ) : (
+            <ChevronRight className="w-3.5 h-3.5" />
           )}
-        </span>
-        {open ? (
-          <ChevronDown className="w-3.5 h-3.5" />
-        ) : (
-          <ChevronRight className="w-3.5 h-3.5" />
-        )}
-      </button>
+        </button>
+        {titleAccessory ? <div className="flex items-center">{titleAccessory}</div> : null}
+      </div>
       {open && <div className="space-y-2 pb-2">{children}</div>}
     </div>
   )

--- a/apps/packages/ui/src/components/Notes/KeywordPickerModal.tsx
+++ b/apps/packages/ui/src/components/Notes/KeywordPickerModal.tsx
@@ -96,10 +96,10 @@ const KeywordPickerModal: React.FC<KeywordPickerModalProps> = ({
     <Modal
       open={open}
       title={t('option:notesSearch.keywordPickerTitle', {
-        defaultValue: 'Browse keywords'
+        defaultValue: 'Browse tags'
       })}
       aria-label={t('option:notesSearch.keywordPickerTitle', {
-        defaultValue: 'Browse keywords'
+        defaultValue: 'Browse tags'
       })}
       onCancel={onCancel}
       onOk={onApply}
@@ -114,7 +114,7 @@ const KeywordPickerModal: React.FC<KeywordPickerModalProps> = ({
       <Input
         allowClear
         placeholder={t('option:notesSearch.keywordPickerSearch', {
-          defaultValue: 'Search keywords'
+          defaultValue: 'Search tags'
         })}
         value={keywordPickerQuery}
         onChange={(e) => onQueryChange(e.target.value)}
@@ -122,7 +122,7 @@ const KeywordPickerModal: React.FC<KeywordPickerModalProps> = ({
       <div className="space-y-1">
         <Typography.Text type="secondary" className="text-xs text-text-muted">
           {t('option:notesSearch.keywordPickerSortLabel', {
-            defaultValue: 'Sort keywords'
+            defaultValue: 'Sort tags'
           })}
         </Typography.Text>
         <select
@@ -133,7 +133,7 @@ const KeywordPickerModal: React.FC<KeywordPickerModalProps> = ({
           className="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text"
           data-testid="notes-keyword-picker-sort-select"
           aria-label={t('option:notesSearch.keywordPickerSortAriaLabel', {
-            defaultValue: 'Sort keywords'
+            defaultValue: 'Sort tags'
           })}
         >
           <option value="frequency_desc">
@@ -156,7 +156,7 @@ const KeywordPickerModal: React.FC<KeywordPickerModalProps> = ({
       <div className="flex items-center justify-between gap-2">
         <Typography.Text type="secondary" className="text-xs text-text-muted">
           {t('option:notesSearch.keywordPickerCount', {
-            defaultValue: '{{count}} keywords',
+            defaultValue: '{{count}} tags',
             count: availableKeywords.length
           })}
         </Typography.Text>
@@ -187,7 +187,7 @@ const KeywordPickerModal: React.FC<KeywordPickerModalProps> = ({
               data-testid="notes-keyword-picker-open-manager"
             >
               {t('option:notesSearch.keywordPickerManageAction', {
-                defaultValue: 'Manage keywords'
+                defaultValue: 'Manage tags'
               })}
             </Button>
           ) : null}
@@ -228,7 +228,7 @@ const KeywordPickerModal: React.FC<KeywordPickerModalProps> = ({
             className="block text-xs text-text-muted text-center"
           >
             {t('option:notesSearch.keywordPickerEmpty', {
-              defaultValue: 'No keywords found'
+              defaultValue: 'No tags found'
             })}
           </Typography.Text>
         ) : (

--- a/apps/packages/ui/src/components/Notes/NotesEditorHeader.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesEditorHeader.tsx
@@ -432,7 +432,7 @@ const NotesEditorHeader: React.FC<NotesEditorHeaderProps> = ({
                   defaultValue: 'Add a title or content to save'
                 })
               : t('option:notesSearch.toolbarSaveTooltip', {
-                  defaultValue: 'Save note'
+                  defaultValue: 'Save note (auto-saves after 5 seconds)'
                 })
           }
         >

--- a/apps/packages/ui/src/components/Notes/NotesEditorHeader.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesEditorHeader.tsx
@@ -126,6 +126,34 @@ const NotesEditorHeader: React.FC<NotesEditorHeaderProps> = ({
   const overflowMenuItems: MenuProps['items'] = useMemo(() => {
     const items: MenuProps['items'] = []
 
+    // --- Editor mode group (mobile only) ---
+    if (isMobileViewport) {
+      items.push({
+        type: 'group' as const,
+        label: t('option:notesSearch.overflowGroupEditorMode', { defaultValue: 'View' }),
+        children: [
+          {
+            key: 'mode-edit',
+            icon: (<EditIcon className="w-4 h-4" />),
+            label: t('option:notesSearch.editModeLabel', { defaultValue: 'Edit' }),
+            disabled: editorMode === 'edit',
+          },
+          {
+            key: 'mode-split',
+            icon: (<SplitIcon className="w-4 h-4" />),
+            label: t('option:notesSearch.splitModeLabel', { defaultValue: 'Split' }),
+            disabled: editorMode === 'split',
+          },
+          {
+            key: 'mode-preview',
+            icon: (<EyeIcon className="w-4 h-4" />),
+            label: t('option:notesSearch.previewModeLabel', { defaultValue: 'Preview' }),
+            disabled: editorMode === 'preview',
+          },
+        ]
+      })
+    }
+
     // --- Create group ---
     if (!editorDisabled) {
       const createChildren: MenuProps['items'] = []
@@ -296,6 +324,8 @@ const NotesEditorHeader: React.FC<NotesEditorHeaderProps> = ({
     return items
   }, [
     editorDisabled,
+    editorMode,
+    isMobileViewport,
     canDuplicate,
     canPin,
     isPinned,
@@ -315,6 +345,15 @@ const NotesEditorHeader: React.FC<NotesEditorHeaderProps> = ({
 
   const handleOverflowMenuClick: MenuProps['onClick'] = ({ key }) => {
     switch (key) {
+      case 'mode-edit':
+        onChangeEditorMode('edit')
+        break
+      case 'mode-split':
+        onChangeEditorMode('split')
+        break
+      case 'mode-preview':
+        onChangeEditorMode('preview')
+        break
       case 'duplicate':
         onDuplicate?.()
         break

--- a/apps/packages/ui/src/components/Notes/NotesEditorPane.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesEditorPane.tsx
@@ -70,6 +70,7 @@ export interface NotesEditorPaneProps {
 
   // Selection / identity
   selectedId: string | number | null
+  showEmptyState: boolean
   title: string
   content: string
   editorDisabled: boolean
@@ -226,6 +227,7 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
   isMobileViewport,
   setMobileSidebarOpen,
   selectedId,
+  showEmptyState,
   title,
   content,
   editorDisabled,
@@ -337,6 +339,18 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
   applyWikilinkSuggestion,
 }) => {
   const { t } = useTranslation(['option', 'common'])
+  const renderHelpButton = React.useCallback(
+    (label: string) => (
+      <button
+        type="button"
+        className="inline-flex items-center rounded-sm text-text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        aria-label={label}
+      >
+        <QuestionCircleOutlined className="text-[11px]" />
+      </button>
+    ),
+    []
+  )
 
   const renderMarkdownPreviewSurface = (
     testId: string,
@@ -450,7 +464,7 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
         studioBadgeLabel={studioBadgeLabel}
       />
       <div className="flex-1 flex flex-col px-4 py-3 overflow-auto">
-        {selectedId == null && !loadingDetail && (
+        {showEmptyState && !loadingDetail && (
           <div className="flex flex-col items-center justify-center gap-4 px-8 py-12 text-center" data-testid="notes-editor-empty-state">
             <div className="text-lg font-medium text-text">
               {t('option:notesSearch.editorEmptyTitle', {
@@ -714,17 +728,21 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
         </div>
         {selectedId != null && (
           <CollapsibleSection
-            title={
-              <span className="inline-flex items-center gap-1">
-                {t('option:notesSearch.connectionsSectionTitle', {
-                  defaultValue: 'Connections'
-                })}
-                <Tooltip title={t('option:notesSearch.connectionsHelpTooltip', {
+            title={t('option:notesSearch.connectionsSectionTitle', {
+              defaultValue: 'Connections'
+            })}
+            titleAccessory={
+              <Tooltip
+                title={t('option:notesSearch.connectionsHelpTooltip', {
                   defaultValue: 'Links between this note and others — created by you, by [[ ]] note links, or automatically.'
-                })}>
-                  <QuestionCircleOutlined className="text-text-muted text-[11px]" />
-                </Tooltip>
-              </span>
+                })}
+              >
+                {renderHelpButton(
+                  t('option:notesSearch.connectionsHelpLabel', {
+                    defaultValue: 'Connections help'
+                  })
+                )}
+              </Tooltip>
             }
             defaultOpen
             storageKey="connections"

--- a/apps/packages/ui/src/components/Notes/NotesEditorPane.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesEditorPane.tsx
@@ -85,6 +85,7 @@ export interface NotesEditorPaneProps {
   noteRelations: NoteRelationsShape
   noteNeighborsLoading: boolean
   noteNeighborsError: boolean
+  onRetryNeighbors?: () => void
 
   // Pinning
   selectedNotePinned: boolean
@@ -234,6 +235,7 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
   noteRelations,
   noteNeighborsLoading,
   noteNeighborsError,
+  onRetryNeighbors,
   selectedNotePinned,
   editorMode,
   editorInputMode,
@@ -629,8 +631,7 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
               <span>
                 {t('option:notesSearch.staleVersionWarning', {
                   defaultValue:
-                    'A newer version is available on the server (v{{version}}).',
-                  version: remoteVersionInfo.version
+                    'This note was updated elsewhere. Reload to see the latest version.'
                 })}
               </span>
               <Button
@@ -789,15 +790,26 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
                   })}
                 </Typography.Text>
               ) : noteNeighborsError ? (
-                <Typography.Text
-                  type="danger"
-                  className="block mt-2 text-[12px]"
-                  data-testid="notes-related-error"
-                >
-                  {t('option:notesSearch.relatedNotesError', {
-                    defaultValue: 'Could not load related notes.'
-                  })}
-                </Typography.Text>
+                <div className="mt-2" data-testid="notes-related-error">
+                  <Typography.Text type="danger" className="text-[12px]">
+                    {t('option:notesSearch.relatedNotesError', {
+                      defaultValue: 'Could not load related notes.'
+                    })}
+                  </Typography.Text>
+                  {onRetryNeighbors && (
+                    <Button
+                      size="small"
+                      type="link"
+                      className="ml-1 !px-0 text-[12px]"
+                      onClick={onRetryNeighbors}
+                      data-testid="notes-related-retry"
+                    >
+                      {t('option:notesSearch.relatedNotesRetry', {
+                        defaultValue: 'Retry'
+                      })}
+                    </Button>
+                  )}
+                </div>
               ) : noteRelations.related.length === 0 ? (
                 <Typography.Text
                   type="secondary"

--- a/apps/packages/ui/src/components/Notes/NotesEditorPane.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesEditorPane.tsx
@@ -11,9 +11,11 @@ import {
   Code2 as CodeIcon,
   Paperclip as PaperclipIcon
 } from 'lucide-react'
+import { QuestionCircleOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import NotesEditorHeader from '@/components/Notes/NotesEditorHeader'
 import NotesStudioView from '@/components/Notes/NotesStudioView'
+import CollapsibleSection from '@/components/Notes/CollapsibleSection'
 import type { ActiveWikilinkQuery, WikilinkCandidate } from '@/components/Notes/wikilinks'
 import type {
   SaveIndicatorState,
@@ -130,6 +132,8 @@ export interface NotesEditorPaneProps {
 
   // Assist
   assistLoadingAction: NotesAssistAction | null
+  canUndoAssist: boolean
+  undoAssist: () => void
 
   // TOC
   shouldShowToc: boolean
@@ -268,6 +272,8 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
   manualLinkOptions,
   manualLinkDeletingEdgeId,
   assistLoadingAction,
+  canUndoAssist,
+  undoAssist,
   shouldShowToc,
   tocEntries,
   previewContent,
@@ -444,6 +450,36 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
         studioBadgeLabel={studioBadgeLabel}
       />
       <div className="flex-1 flex flex-col px-4 py-3 overflow-auto">
+        {selectedId == null && !loadingDetail && (
+          <div className="flex flex-col items-center justify-center gap-4 px-8 py-12 text-center" data-testid="notes-editor-empty-state">
+            <div className="text-lg font-medium text-text">
+              {t('option:notesSearch.editorEmptyTitle', {
+                defaultValue: 'Select or create a note'
+              })}
+            </div>
+            <div className="max-w-sm text-sm text-text-muted">
+              {t('option:notesSearch.editorEmptyDescription', {
+                defaultValue: 'Choose a note from the list to start editing, or create a new one.'
+              })}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="primary"
+                onClick={() => void handleNewNote()}
+                data-testid="notes-editor-empty-create"
+              >
+                {t('option:notesSearch.editorEmptyCreateAction', {
+                  defaultValue: 'Create note'
+                })}
+              </Button>
+            </div>
+            <div className="mt-2 text-xs text-text-muted">
+              {t('option:notesSearch.editorEmptyHint', {
+                defaultValue: 'Tip: Type [[ in a note to link to another note.'
+              })}
+            </div>
+          </div>
+        )}
         {showStudioMarkdownOnlyNotice ? (
           <div className="mb-3 flex items-center justify-between gap-3 rounded border border-warn/40 bg-warn/10 px-3 py-2 text-sm text-warn">
             <span>
@@ -579,7 +615,7 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
             mode="tags"
             allowClear
             placeholder={t('option:notesSearch.keywordsEditorPlaceholder', {
-              defaultValue: 'Keywords (tags)'
+              defaultValue: 'Tags'
             })}
             data-testid="notes-keywords-editor"
             className="w-full"
@@ -661,10 +697,41 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
               <div className="mt-1">{monitoringNotice.guidance}</div>
             </div>
           )}
+          {canUndoAssist && (
+            <div className="mt-2">
+              <Button
+                size="small"
+                onClick={undoAssist}
+                className="text-xs"
+                data-testid="notes-undo-assist"
+              >
+                {t('option:notesSearch.undoAssistAction', {
+                  defaultValue: 'Undo AI change'
+                })}
+              </Button>
+            </div>
+          )}
         </div>
         {selectedId != null && (
+          <CollapsibleSection
+            title={
+              <span className="inline-flex items-center gap-1">
+                {t('option:notesSearch.connectionsSectionTitle', {
+                  defaultValue: 'Connections'
+                })}
+                <Tooltip title={t('option:notesSearch.connectionsHelpTooltip', {
+                  defaultValue: 'Links between this note and others — created by you, by [[ ]] note links, or automatically.'
+                })}>
+                  <QuestionCircleOutlined className="text-text-muted text-[11px]" />
+                </Tooltip>
+              </span>
+            }
+            defaultOpen
+            storageKey="connections"
+            testId="notes-section-connections"
+          >
           <div
-            className="mt-3 grid grid-cols-1 gap-3 xl:grid-cols-2"
+            className="grid grid-cols-1 gap-3 xl:grid-cols-2"
             data-testid="notes-graph-relation-panels"
           >
             <div className="rounded-lg border border-border bg-surface2 p-3">
@@ -893,6 +960,7 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
               )}
             </div>
           </div>
+          </CollapsibleSection>
         )}
         {editorMode !== 'preview' && (
           <div className="mt-3 flex items-center flex-wrap gap-1 rounded-lg border border-border bg-surface2 p-2">
@@ -1065,7 +1133,7 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
             </Tooltip>
             <Tooltip
               title={t('option:notesSearch.assistSuggestKeywordsTooltip', {
-                defaultValue: 'Suggest keywords from note content'
+                defaultValue: 'Suggest tags from note content'
               })}
             >
               <Button
@@ -1080,7 +1148,7 @@ const NotesEditorPane: React.FC<NotesEditorPaneProps> = ({
                 data-testid="notes-assist-suggest-keywords"
               >
                 {t('option:notesSearch.assistSuggestKeywordsAction', {
-                  defaultValue: 'Suggest keywords'
+                  defaultValue: 'Suggest tags'
                 })}
               </Button>
             </Tooltip>

--- a/apps/packages/ui/src/components/Notes/NotesGraphModal.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesGraphModal.tsx
@@ -318,6 +318,33 @@ const NotesGraphModal: React.FC<NotesGraphModalProps> = ({
           data-testid="notes-graph-canvas"
         />
       )}
+
+      <div
+        className="mt-3 flex flex-wrap items-center gap-3 border-t border-border pt-3 text-[11px] text-text-muted"
+        data-testid="notes-graph-legend"
+      >
+        <span className="font-medium uppercase tracking-[0.08em]">
+          {t('option:notesSearch.graphLegendTitle', { defaultValue: 'Legend' })}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-[#2563eb]" />
+          {t('option:notesSearch.graphLegendNote', { defaultValue: 'Note' })}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded bg-[#0f766e]" />
+          {t('option:notesSearch.graphLegendTag', { defaultValue: 'Tag' })}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rotate-45 bg-[#7c3aed]" />
+          {t('option:notesSearch.graphLegendSource', { defaultValue: 'Source' })}
+        </span>
+        <span className="ml-2 border-l border-border pl-2 font-medium uppercase tracking-[0.08em]">
+          {t('option:notesSearch.graphLegendEdges', { defaultValue: 'Connections' })}
+        </span>
+        <span>{t('option:notesSearch.graphLegendManual', { defaultValue: 'Manual = linked by you' })}</span>
+        <span>{t('option:notesSearch.graphLegendWikilink', { defaultValue: 'Note link = [[ ]] syntax' })}</span>
+        <span>{t('option:notesSearch.graphLegendBacklink', { defaultValue: 'Backlink = linked from another note' })}</span>
+      </div>
     </Modal>
   )
 }

--- a/apps/packages/ui/src/components/Notes/NotesListPanel.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesListPanel.tsx
@@ -293,9 +293,12 @@ const NotesListPanel: React.FC<NotesListPanelProps> = ({
                 defaultValue: 'Exporting {{format}}'
               })
                 .replace('{{format}}', exportProgress.format.toUpperCase())}
-              {`: ${exportProgress.fetchedNotes} notes across ${exportProgress.fetchedPages} batch${
-                exportProgress.fetchedPages === 1 ? '' : 'es'
-              }`}
+              {' '}
+              {t('option:notesSearch.exportProgressCount', {
+                defaultValue: '{{count}} notes exported so far...',
+                count: exportProgress.fetchedNotes
+              })
+                .replace('{{count}}', String(exportProgress.fetchedNotes))}
             </span>
             {exportProgress.failedBatches > 0 && (
               <span>

--- a/apps/packages/ui/src/components/Notes/NotesListPanel.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesListPanel.tsx
@@ -429,7 +429,7 @@ const NotesListPanel: React.FC<NotesListPanelProps> = ({
                                   {hasKeywords && (
                                     <Tooltip
                                       title={t('option:notesSearch.badgeHasKeywords', {
-                                        defaultValue: 'Has keywords'
+                                        defaultValue: 'Has tags'
                                       })}
                                     >
                                       <TagIcon className="h-3.5 w-3.5" aria-hidden="true" />

--- a/apps/packages/ui/src/components/Notes/NotesListPanel.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesListPanel.tsx
@@ -325,7 +325,7 @@ const NotesListPanel: React.FC<NotesListPanelProps> = ({
         renderEmptyStateSurface('unsupported')
       ) : Array.isArray(notes) && notes.length > 0 ? (
         <>
-          <div className="divide-y divide-border">
+          <div className="divide-y divide-border" role="listbox">
             {notes.map((item) => (
               (() => {
                 const itemIdText = String(item.id)
@@ -394,9 +394,24 @@ const NotesListPanel: React.FC<NotesListPanelProps> = ({
                         onSelectNote(item.id)
                       }}
                       className="w-full text-left"
+                      role="option"
                       aria-selected={isSelectedNote}
                       aria-current={isSelectedNote ? "true" : undefined}
                       data-testid={`notes-open-button-${itemIdText.replace(/[^a-z0-9_-]/gi, '_')}`}
+                      data-notes-list-item
+                      onKeyDown={(e) => {
+                        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+                          e.preventDefault()
+                          const buttons = Array.from(
+                            e.currentTarget.closest('[data-testid="notes-list-region"]')
+                              ?.querySelectorAll<HTMLButtonElement>('[data-notes-list-item]') ?? []
+                          )
+                          const idx = buttons.indexOf(e.currentTarget as HTMLButtonElement)
+                          if (idx < 0) return
+                          const next = e.key === 'ArrowDown' ? buttons[idx + 1] : buttons[idx - 1]
+                          next?.focus()
+                        }
+                      }}
                     >
                       <div className="w-full">
                         {(() => {

--- a/apps/packages/ui/src/components/Notes/NotesManagerOverlays.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerOverlays.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Button, Checkbox, Input, Modal, Typography } from "antd"
+import { Button, Checkbox, Input, Modal, Select, Typography } from "antd"
 
 import KeywordPickerModal from "@/components/Notes/KeywordPickerModal"
 import NotesGraphModal from "@/components/Notes/NotesGraphModal"
@@ -392,6 +392,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
         })}
         cancelText={t("common:cancel", { defaultValue: "Cancel" })}
         confirmLoading={kw.keywordManagerActionLoading}
+        okButtonProps={{ danger: true }}
         destroyOnHidden
         title={t("option:notesSearch.keywordManagerMergeTitle", {
           defaultValue: "Merge keyword",
@@ -407,6 +408,16 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
                 "Move all links from the source keyword to the selected target keyword.",
             })}
           </Typography.Text>
+          <Typography.Text
+            type="danger"
+            className="block text-xs"
+            data-testid="notes-keyword-merge-warning"
+          >
+            {t("option:notesSearch.keywordManagerMergeWarning", {
+              defaultValue:
+                "This will permanently combine these keywords. The source keyword will be deleted. This cannot be undone.",
+            })}
+          </Typography.Text>
           <div className="text-xs text-text-muted">
             {t("option:notesSearch.keywordManagerMergeSourceLabel", {
               defaultValue: "Source",
@@ -416,34 +427,32 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
               {kw.keywordMergeDraft?.source.keyword ?? ""}
             </span>
           </div>
-          <select
-            className="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text"
-            value={kw.keywordMergeDraft?.targetKeywordId ?? ""}
-            onChange={(event) => {
-              const parsed = Number(event.target.value)
+          <Select
+            className="w-full"
+            showSearch
+            allowClear
+            optionFilterProp="label"
+            placeholder={t("option:notesSearch.keywordManagerMergeTargetPlaceholder", {
+              defaultValue: "Select target keyword",
+            })}
+            value={kw.keywordMergeDraft?.targetKeywordId ?? undefined}
+            onChange={(value: number | undefined) => {
               kw.setKeywordMergeDraft((current) =>
                 current
                   ? {
                       ...current,
                       targetKeywordId:
-                        Number.isFinite(parsed) && parsed > 0 ? parsed : null,
+                        value != null && Number.isFinite(value) && value > 0 ? value : null,
                     }
                   : current,
               )
             }}
+            options={kw.keywordMergeTargetOptions.map((item) => ({
+              value: item.id,
+              label: `${item.keyword} (${item.noteCount})`,
+            }))}
             data-testid="notes-keyword-manager-merge-target"
-          >
-            <option value="">
-              {t("option:notesSearch.keywordManagerMergeTargetPlaceholder", {
-                defaultValue: "Select target keyword",
-              })}
-            </option>
-            {kw.keywordMergeTargetOptions.map((item) => (
-              <option key={`keyword-merge-target-${item.id}`} value={item.id}>
-                {item.keyword} ({item.noteCount})
-              </option>
-            ))}
-          </select>
+          />
         </div>
       </Modal>
 
@@ -509,6 +518,17 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
                 })}
               </option>
             </select>
+            {imp.importDuplicateStrategy === 'overwrite' && (
+              <Typography.Text
+                type="danger"
+                className="block mt-1 text-xs"
+                data-testid="notes-import-overwrite-warning"
+              >
+                {t("option:notesSearch.importOverwriteWarning", {
+                  defaultValue: "Warning: Existing notes with matching IDs will be permanently replaced. This cannot be undone.",
+                })}
+              </Typography.Text>
+            )}
           </div>
           <div
             className="rounded border border-border bg-surface2 px-2 py-2 text-xs text-text-muted"
@@ -528,7 +548,14 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
                   {`${file.format.toUpperCase()} · ${file.detectedNotes} note${file.detectedNotes === 1 ? "" : "s"} detected`}
                 </div>
                 {file.parseError && (
-                  <div className="mt-1 text-[11px] text-warn">{file.parseError}</div>
+                  <div className="mt-1 text-[11px] text-warn">
+                    {file.parseError}
+                    <span className="block mt-0.5 text-text-muted">
+                      {t("option:notesSearch.importParseErrorHint", {
+                        defaultValue: "Check that JSON files match the tldw export format, or use plain Markdown (.md) files.",
+                      })}
+                    </span>
+                  </div>
                 )}
               </div>
             ))}
@@ -555,24 +582,35 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
         })}
         destroyOnHidden
       >
-        <div className="space-y-2 text-sm text-text" data-testid="notes-shortcuts-modal">
+        <div className="space-y-4 text-sm text-text" data-testid="notes-shortcuts-modal">
           <div>
-            <strong>Ctrl/Cmd + S</strong>:{" "}
-            {t("option:notesSearch.shortcutSaveDescription", {
-              defaultValue: "Save the current note.",
-            })}
+            <div className="text-[11px] uppercase tracking-[0.08em] text-text-muted mb-1">
+              {t("option:notesSearch.shortcutGroupGeneral", { defaultValue: "General" })}
+            </div>
+            <div className="space-y-1">
+              <div><strong>Ctrl/Cmd + S</strong>: {t("option:notesSearch.shortcutSaveDescription", { defaultValue: "Save the current note." })}</div>
+              <div><strong>?</strong>: {t("option:notesSearch.shortcutOpenHelpDescription", { defaultValue: "Open keyboard shortcut help." })}</div>
+              <div><strong>Esc</strong>: {t("option:notesSearch.shortcutCloseDialogDescription", { defaultValue: "Close the current dialog." })}</div>
+            </div>
           </div>
           <div>
-            <strong>?</strong>:{" "}
-            {t("option:notesSearch.shortcutOpenHelpDescription", {
-              defaultValue: "Open keyboard shortcut help.",
-            })}
+            <div className="text-[11px] uppercase tracking-[0.08em] text-text-muted mb-1">
+              {t("option:notesSearch.shortcutGroupEditing", { defaultValue: "Editing" })}
+            </div>
+            <div className="space-y-1">
+              <div><strong>[[</strong>: {t("option:notesSearch.shortcutWikilinkDescription", { defaultValue: "Start a note link — type a note title to search, then select." })}</div>
+              <div><strong>Ctrl/Cmd + B</strong>: {t("option:notesSearch.shortcutBoldDescription", { defaultValue: "Bold text (Markdown mode)." })}</div>
+              <div><strong>Ctrl/Cmd + I</strong>: {t("option:notesSearch.shortcutItalicDescription", { defaultValue: "Italic text (Markdown mode)." })}</div>
+            </div>
           </div>
           <div>
-            <strong>Esc</strong>:{" "}
-            {t("option:notesSearch.shortcutCloseDialogDescription", {
-              defaultValue: "Close the current dialog.",
-            })}
+            <div className="text-[11px] uppercase tracking-[0.08em] text-text-muted mb-1">
+              {t("option:notesSearch.shortcutGroupSearch", { defaultValue: "Search" })}
+            </div>
+            <div className="space-y-1">
+              <div><strong>Ctrl/Cmd + F</strong>: {t("option:notesSearch.shortcutBrowserFindDescription", { defaultValue: "Find text in the current note (browser find)." })}</div>
+              <div><strong>{'"exact phrase"'}</strong>: {t("option:notesSearch.shortcutExactMatchDescription", { defaultValue: "Search for an exact phrase in the notes search box." })}</div>
+            </div>
           </div>
         </div>
       </Modal>

--- a/apps/packages/ui/src/components/Notes/NotesManagerOverlays.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerOverlays.tsx
@@ -14,7 +14,11 @@ import type {
   KeywordRenameDraft,
   PendingImportFile,
 } from "./notes-manager-types"
-import { toKeywordTestIdSegment } from "./notes-manager-utils"
+import {
+  NOTES_TUTORIAL_SHOWN_STORAGE_KEY,
+  notesUiStorage,
+  toKeywordTestIdSegment
+} from "./notes-manager-utils"
 
 type TranslationFn = (
   key: string,
@@ -623,9 +627,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
               className="text-xs text-primary hover:underline"
               data-testid="notes-restart-tutorial"
               onClick={() => {
-                if (typeof window !== 'undefined') {
-                  localStorage.removeItem('notes-tutorial-shown')
-                }
+                void notesUiStorage.remove(NOTES_TUTORIAL_SHOWN_STORAGE_KEY).catch(() => undefined)
                 setShortcutHelpOpen(false)
                 useTutorialStore.getState().startTutorial('notes-basics')
               }}

--- a/apps/packages/ui/src/components/Notes/NotesManagerOverlays.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerOverlays.tsx
@@ -134,7 +134,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
         cancelText={t("common:cancel", { defaultValue: "Cancel" })}
         destroyOnHidden
         title={t("option:notesSearch.assistKeywordsReviewTitle", {
-          defaultValue: "Review suggested keywords",
+          defaultValue: "Review suggested tags",
         })}
       >
         <div
@@ -146,7 +146,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
             className="block text-xs text-text-muted"
           >
             {t("option:notesSearch.assistKeywordsReviewHelp", {
-              defaultValue: "Select which suggested keywords to add to this note.",
+              defaultValue: "Select which suggested tags to add to this note.",
             })}
           </Typography.Text>
           <div className="flex items-center gap-2">
@@ -224,7 +224,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
         open={kw.keywordManagerOpen}
         onCancel={kw.closeKeywordManager}
         title={t("option:notesSearch.keywordManagerTitle", {
-          defaultValue: "Manage keywords",
+          defaultValue: "Manage tags",
         })}
         destroyOnHidden
         footer={[
@@ -239,7 +239,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
             className="block text-xs text-text-muted"
           >
             {t("option:notesSearch.keywordManagerHelp", {
-              defaultValue: "Rename, merge, or delete keywords from one place.",
+              defaultValue: "Rename, merge, or delete tags from one place.",
             })}
           </Typography.Text>
           <Input
@@ -247,7 +247,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
             value={kw.keywordManagerQuery}
             onChange={(event) => kw.setKeywordManagerQuery(event.target.value)}
             placeholder={t("option:notesSearch.keywordManagerSearchPlaceholder", {
-              defaultValue: "Filter keywords",
+              defaultValue: "Filter tags",
             })}
             data-testid="notes-keyword-manager-search"
           />
@@ -255,13 +255,13 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
             {kw.keywordManagerLoading ? (
               <Typography.Text type="secondary" className="text-xs text-text-muted">
                 {t("option:notesSearch.keywordManagerLoading", {
-                  defaultValue: "Loading keywords...",
+                  defaultValue: "Loading tags...",
                 })}
               </Typography.Text>
             ) : kw.keywordManagerVisibleItems.length === 0 ? (
               <Typography.Text type="secondary" className="text-xs text-text-muted">
                 {t("option:notesSearch.keywordManagerEmpty", {
-                  defaultValue: "No keywords found.",
+                  defaultValue: "No tags found.",
                 })}
               </Typography.Text>
             ) : (
@@ -351,7 +351,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
         confirmLoading={kw.keywordManagerActionLoading}
         destroyOnHidden
         title={t("option:notesSearch.keywordManagerRenameTitle", {
-          defaultValue: "Rename keyword",
+          defaultValue: "Rename tag",
         })}
       >
         <div className="space-y-2">
@@ -360,7 +360,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
             className="block text-xs text-text-muted"
           >
             {t("option:notesSearch.keywordManagerRenameHelp", {
-              defaultValue: "Choose a new name for this keyword.",
+              defaultValue: "Choose a new name for this tag.",
             })}
           </Typography.Text>
           <Input
@@ -395,7 +395,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
         okButtonProps={{ danger: true }}
         destroyOnHidden
         title={t("option:notesSearch.keywordManagerMergeTitle", {
-          defaultValue: "Merge keyword",
+          defaultValue: "Merge tag",
         })}
       >
         <div className="space-y-2">
@@ -405,7 +405,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
           >
             {t("option:notesSearch.keywordManagerMergeHelp", {
               defaultValue:
-                "Move all links from the source keyword to the selected target keyword.",
+                "Move all links from the source tag to the selected target tag.",
             })}
           </Typography.Text>
           <Typography.Text
@@ -415,7 +415,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
           >
             {t("option:notesSearch.keywordManagerMergeWarning", {
               defaultValue:
-                "This will permanently combine these keywords. The source keyword will be deleted. This cannot be undone.",
+                "This will permanently combine these tags. The source tag will be deleted. This cannot be undone.",
             })}
           </Typography.Text>
           <div className="text-xs text-text-muted">
@@ -433,7 +433,7 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
             allowClear
             optionFilterProp="label"
             placeholder={t("option:notesSearch.keywordManagerMergeTargetPlaceholder", {
-              defaultValue: "Select target keyword",
+              defaultValue: "Select target tag",
             })}
             value={kw.keywordMergeDraft?.targetKeywordId ?? undefined}
             onChange={(value: number | undefined) => {
@@ -589,6 +589,9 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
             </div>
             <div className="space-y-1">
               <div><strong>Ctrl/Cmd + S</strong>: {t("option:notesSearch.shortcutSaveDescription", { defaultValue: "Save the current note." })}</div>
+              <div><strong>Alt + N</strong>: {t("option:notesSearch.shortcutNewNoteDescription", { defaultValue: "Create a new note." })}</div>
+              <div><strong>Ctrl/Cmd + K</strong>: {t("option:notesSearch.shortcutFocusSearchDescription", { defaultValue: "Focus the search input." })}</div>
+              <div><strong>Ctrl/Cmd + Shift + E/S/P</strong>: {t("option:notesSearch.shortcutEditorModesDescription", { defaultValue: "Switch editor mode (Edit / Split / Preview)." })}</div>
               <div><strong>?</strong>: {t("option:notesSearch.shortcutOpenHelpDescription", { defaultValue: "Open keyboard shortcut help." })}</div>
               <div><strong>Esc</strong>: {t("option:notesSearch.shortcutCloseDialogDescription", { defaultValue: "Close the current dialog." })}</div>
             </div>

--- a/apps/packages/ui/src/components/Notes/NotesManagerOverlays.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerOverlays.tsx
@@ -4,6 +4,8 @@ import { Button, Checkbox, Input, Modal, Select, Typography } from "antd"
 import KeywordPickerModal from "@/components/Notes/KeywordPickerModal"
 import NotesGraphModal from "@/components/Notes/NotesGraphModal"
 
+import { useTutorialStore } from "@/store/tutorials"
+
 import type {
   ImportDuplicateStrategy,
   KeywordManagementItem,
@@ -614,6 +616,24 @@ const NotesManagerOverlays: React.FC<NotesManagerOverlaysProps> = ({
               <div><strong>Ctrl/Cmd + F</strong>: {t("option:notesSearch.shortcutBrowserFindDescription", { defaultValue: "Find text in the current note (browser find)." })}</div>
               <div><strong>{'"exact phrase"'}</strong>: {t("option:notesSearch.shortcutExactMatchDescription", { defaultValue: "Search for an exact phrase in the notes search box." })}</div>
             </div>
+          </div>
+          <div className="border-t border-border pt-3">
+            <button
+              type="button"
+              className="text-xs text-primary hover:underline"
+              data-testid="notes-restart-tutorial"
+              onClick={() => {
+                if (typeof window !== 'undefined') {
+                  localStorage.removeItem('notes-tutorial-shown')
+                }
+                setShortcutHelpOpen(false)
+                useTutorialStore.getState().startTutorial('notes-basics')
+              }}
+            >
+              {t("option:notesSearch.restartTutorialAction", {
+                defaultValue: "Restart tutorial",
+              })}
+            </button>
           </div>
         </div>
       </Modal>

--- a/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
@@ -74,6 +74,7 @@ import {
   TRASH_LOOKUP_PAGE_SIZE,
   TRASH_LOOKUP_MAX_PAGES,
   sortNotesByPinnedIds,
+  promptModal,
 } from './notes-manager-utils'
 
 const LazyNotesManagerOverlays = React.lazy(() => import("./NotesManagerOverlays"))
@@ -1119,10 +1120,13 @@ const NotesManagerPage: React.FC = () => {
     const okToLeave = await ed.confirmDiscardIfDirty()
     if (!okToLeave) return
     const suggested = kw.keywordTokens.join(', ')
-    const rawInput = window.prompt(
-      'Assign keywords to selected notes (comma-separated):',
-      suggested
-    )
+    const rawInput = await promptModal({
+      title: 'Assign tags to selected notes',
+      label: 'Enter tag names separated by commas.',
+      defaultValue: suggested,
+      placeholder: 'tag1, tag2, tag3',
+      okText: 'Assign',
+    })
     if (rawInput == null) return
     const keywords = rawInput.split(',').map((entry) => entry.trim()).filter(Boolean)
     if (keywords.length === 0) {
@@ -1206,10 +1210,25 @@ const NotesManagerPage: React.FC = () => {
         else if (action === 'heading') execute('formatBlock', '<h2>')
         else if (action === 'list') execute('insertUnorderedList')
         else if (action === 'link') {
-          const href = typeof window !== 'undefined' ? window.prompt('Link URL', 'https://') : 'https://'
-          const normalizedHref = String(href || '').trim()
-          if (!normalizedHref) return
-          execute('createLink', normalizedHref)
+          ;(async () => {
+            const href = await promptModal({
+              title: 'Insert link',
+              defaultValue: 'https://',
+              placeholder: 'https://example.com',
+              okText: 'Insert',
+            })
+            const normalizedHref = String(href || '').trim()
+            if (!normalizedHref) return
+            richEditor.focus()
+            execute('createLink', normalizedHref)
+            const nextHtml = richEditor.innerHTML
+            ed.setWysiwygHtml(nextHtml)
+            ed.setWysiwygSessionDirty(true)
+            const nextMarkdown = wysiwygHtmlToMarkdown(nextHtml)
+            ed.setContentDirty(nextMarkdown)
+            ed.setEditorCursorIndex(nextMarkdown.length)
+          })()
+          return
         } else if (action === 'code') execute('insertText', '`code`')
 
         const nextHtml = richEditor.innerHTML

--- a/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Input, Typography, Button } from 'antd'
+import type { InputRef } from 'antd'
 import {
   ChevronLeft,
   ChevronRight,
@@ -76,6 +77,8 @@ import {
   TRASH_LOOKUP_MAX_PAGES,
   sortNotesByPinnedIds,
   promptModal,
+  NOTES_TUTORIAL_SHOWN_STORAGE_KEY,
+  notesUiStorage,
 } from './notes-manager-utils'
 
 const LazyNotesManagerOverlays = React.lazy(() => import("./NotesManagerOverlays"))
@@ -152,6 +155,7 @@ const NotesManagerPage: React.FC = () => {
   const conversationLabelRetryAttemptsRef = React.useRef<Record<string, number>>({})
   const conversationLabelRetryTimeoutRef = React.useRef<number | null>(null)
   const [conversationLabelRetryTick, setConversationLabelRetryTick] = React.useState(0)
+  const searchInputRef = React.useRef<InputRef | null>(null)
 
   // ---- Notebook keyword tokens (needed before list hook) ----
   // We compute this after list hook provides selectedNotebook
@@ -247,6 +251,24 @@ const NotesManagerPage: React.FC = () => {
     setKeywordSuggestionSelection: kw.setKeywordSuggestionSelection,
     editorDisabled,
   })
+  const [hasActiveDraft, setHasActiveDraft] = React.useState(false)
+  const resetEditorToEmptyState = React.useCallback(() => {
+    setHasActiveDraft(false)
+    ed.resetEditor()
+  }, [ed.resetEditor])
+  const startDraftSession = React.useCallback(() => {
+    setHasActiveDraft(true)
+    ed.resetEditor()
+  }, [ed.resetEditor])
+  const focusSearchInput = React.useCallback(() => {
+    searchInputRef.current?.focus()
+  }, [])
+
+  React.useEffect(() => {
+    if (ed.selectedId != null) {
+      setHasActiveDraft(false)
+    }
+  }, [ed.selectedId])
 
   const [notesStudioCreateOpen, setNotesStudioCreateOpen] = React.useState(false)
   const [notesStudioCreateLoading, setNotesStudioCreateLoading] = React.useState(false)
@@ -340,7 +362,8 @@ const NotesManagerPage: React.FC = () => {
   const {
     data: noteNeighborsData,
     isLoading: noteNeighborsLoading,
-    isError: noteNeighborsError
+    isError: noteNeighborsError,
+    refetch: refetchNoteNeighbors
   } = useQuery({
     queryKey: ['note-graph-neighbors', ed.selectedId, ed.graphMutationTick],
     enabled: isOnline && ed.selectedId != null,
@@ -698,7 +721,7 @@ const NotesManagerPage: React.FC = () => {
     if (!ok) return
     if (list.listMode !== 'active') list.setListMode('active')
     if (isMobileViewport) setMobileSidebarOpen(false)
-    ed.resetEditor()
+    startDraftSession()
     const template = NOTE_TEMPLATES.find((entry) => entry.id === templateId)
     if (template) {
       ed.setTitle(template.title)
@@ -710,7 +733,19 @@ const NotesManagerPage: React.FC = () => {
     setTimeout(() => {
       ed.titleInputRef.current?.focus()
     }, 0)
-  }, [ed, isMobileViewport, list, message])
+  }, [
+    ed.confirmDiscardIfDirty,
+    ed.setContent,
+    ed.setIsDirty,
+    ed.setSaveIndicator,
+    ed.setTitle,
+    ed.titleInputRef,
+    isMobileViewport,
+    list.listMode,
+    list.setListMode,
+    message,
+    startDraftSession
+  ])
 
   const handleCreateStudyPackFromNote = React.useCallback(() => {
     const selectedNoteId = ed.selectedId
@@ -771,7 +806,7 @@ const NotesManagerPage: React.FC = () => {
     const duplicateContent = ed.content
     const duplicateKeywords = [...kw.editorKeywords]
 
-    ed.resetEditor()
+    startDraftSession()
     ed.setTitle(duplicateTitle)
     ed.setContent(duplicateContent)
     kw.setEditorKeywords(duplicateKeywords)
@@ -782,12 +817,22 @@ const NotesManagerPage: React.FC = () => {
       ed.titleInputRef.current?.focus()
     }, 0)
   }, [
-    ed,
+    ed.content,
+    ed.selectedId,
+    ed.setContent,
+    ed.setIsDirty,
+    ed.setSaveIndicator,
+    ed.setTitle,
+    ed.title,
+    ed.titleInputRef,
     editorDisabled,
     isMobileViewport,
-    kw,
-    list,
+    kw.editorKeywords,
+    kw.setEditorKeywords,
+    list.listMode,
+    list.setListMode,
     message,
+    startDraftSession
   ])
 
   // Manual links
@@ -1018,7 +1063,7 @@ const NotesManagerPage: React.FC = () => {
         headers: { "expected-version": String(expectedVersion) }
       })
       showDeleteUndoToast(targetId)
-      if (ed.selectedId != null && String(ed.selectedId) === targetId) ed.resetEditor()
+      if (ed.selectedId != null && String(ed.selectedId) === targetId) resetEditorToEmptyState()
       await list.refetch()
     } catch (e: any) {
       if (ed.isVersionConflictError(e)) {
@@ -1103,7 +1148,7 @@ const NotesManagerPage: React.FC = () => {
     if (deleted > 0) {
       message.success(`Deleted ${deleted} selected note${deleted === 1 ? '' : 's'}`)
       if (ed.selectedId != null && deletedIds.has(String(ed.selectedId))) {
-        ed.resetEditor()
+        resetEditorToEmptyState()
       }
       list.setBulkSelectedIds((current) => current.filter((id) => !deletedIds.has(id)))
       await list.refetch()
@@ -1200,10 +1245,12 @@ const NotesManagerPage: React.FC = () => {
       if (ed.editorInputMode === 'wysiwyg') {
         const richEditor = ed.richEditorRef.current
         if (!richEditor) return
-        richEditor.focus()
-        const execute = (command: string, value?: string) => {
+        const execute = (command: string, value?: string, options?: { focus?: boolean }) => {
           if (typeof document === 'undefined') return
           if (typeof document.execCommand !== 'function') return
+          if (options?.focus !== false) {
+            richEditor.focus()
+          }
           document.execCommand(command, false, value)
         }
         if (action === 'bold') execute('bold')
@@ -1212,6 +1259,17 @@ const NotesManagerPage: React.FC = () => {
         else if (action === 'list') execute('insertUnorderedList')
         else if (action === 'link') {
           ;(async () => {
+            const savedSelection =
+              typeof window !== 'undefined'
+                ? (() => {
+                    const selection = window.getSelection()
+                    if (!selection || selection.rangeCount === 0) return null
+                    const currentRange = selection.getRangeAt(0)
+                    return richEditor.contains(currentRange.commonAncestorContainer)
+                      ? currentRange.cloneRange()
+                      : null
+                  })()
+                : null
             const href = await promptModal({
               title: 'Insert link',
               defaultValue: 'https://',
@@ -1221,7 +1279,12 @@ const NotesManagerPage: React.FC = () => {
             const normalizedHref = String(href || '').trim()
             if (!normalizedHref) return
             richEditor.focus()
-            execute('createLink', normalizedHref)
+            if (savedSelection) {
+              const selection = window.getSelection()
+              selection?.removeAllRanges()
+              selection?.addRange(savedSelection)
+            }
+            execute('createLink', normalizedHref, { focus: false })
             const nextHtml = richEditor.innerHTML
             ed.setWysiwygHtml(nextHtml)
             ed.setWysiwygSessionDirty(true)
@@ -1764,6 +1827,13 @@ const NotesManagerPage: React.FC = () => {
 
   const showLargeListPaginationHint =
     list.listMode === 'active' && list.listViewMode !== 'moodboard' && list.total >= LARGE_NOTES_PAGINATION_THRESHOLD
+  const showEditorEmptyState =
+    ed.selectedId == null &&
+    !hasActiveDraft &&
+    !ed.isDirty &&
+    ed.title.trim().length === 0 &&
+    ed.content.trim().length === 0 &&
+    kw.editorKeywords.length === 0
 
   // Timeline sections
   const timelineSections = React.useMemo(() => {
@@ -1887,6 +1957,7 @@ const NotesManagerPage: React.FC = () => {
 
       // Alt+N — create new note
       if (event.altKey && (event.key === 'n' || event.key === 'N') && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
+        if (shouldIgnoreGlobalShortcut(event.target)) return
         event.preventDefault()
         void handleNewNote()
         return
@@ -1894,9 +1965,9 @@ const NotesManagerPage: React.FC = () => {
 
       // Ctrl/Cmd+K — focus search
       if ((event.ctrlKey || event.metaKey) && event.key === 'k' && !event.shiftKey && !event.altKey) {
+        if (shouldIgnoreGlobalShortcut(event.target)) return
         event.preventDefault()
-        const searchInput = document.querySelector<HTMLInputElement>('[data-testid="notes-list-region"] input[type="search"], [data-testid="notes-list-region"] input')
-        searchInput?.focus()
+        focusSearchInput()
         return
       }
 
@@ -1904,8 +1975,7 @@ const NotesManagerPage: React.FC = () => {
       if (event.key === '/' && !event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
         if (shouldIgnoreGlobalShortcut(event.target)) return
         event.preventDefault()
-        const searchInput = document.querySelector<HTMLInputElement>('[data-testid="notes-list-region"] input[type="search"], [data-testid="notes-list-region"] input')
-        searchInput?.focus()
+        focusSearchInput()
         return
       }
 
@@ -1930,18 +2000,31 @@ const NotesManagerPage: React.FC = () => {
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [handleNewNote, ed])
+  }, [ed.setEditorMode, focusSearchInput, handleNewNote])
 
   // Auto-trigger notes tutorial on first visit
   React.useEffect(() => {
-    const key = 'notes-tutorial-shown'
     if (typeof window === 'undefined') return
-    if (localStorage.getItem(key)) return
-    const timer = window.setTimeout(() => {
-      localStorage.setItem(key, '1')
-      useTutorialStore.getState().startTutorial('notes-basics')
-    }, 1000)
-    return () => window.clearTimeout(timer)
+    let cancelled = false
+    let timer: number | null = null
+
+    void (async () => {
+      const alreadyShown = await notesUiStorage
+        .get<string | null>(NOTES_TUTORIAL_SHOWN_STORAGE_KEY)
+        .catch(() => null)
+      if (cancelled || alreadyShown) return
+      timer = window.setTimeout(() => {
+        void notesUiStorage
+          .set(NOTES_TUTORIAL_SHOWN_STORAGE_KEY, '1')
+          .catch(() => undefined)
+        useTutorialStore.getState().startTutorial('notes-basics')
+      }, 1000)
+    })()
+
+    return () => {
+      cancelled = true
+      if (timer != null) window.clearTimeout(timer)
+    }
   }, [])
 
   // Cleanup
@@ -2051,6 +2134,7 @@ const NotesManagerPage: React.FC = () => {
         setPageSize={list.setPageSize}
         setSortOption={list.setSortOption}
         setQueryInput={list.setQueryInput}
+        searchInputRef={searchInputRef}
         setSelectedMoodboardId={list.setSelectedMoodboardId}
         setSelectedNotebookId={list.setSelectedNotebookId}
         setSearchTipsQuery={list.setSearchTipsQuery}
@@ -2079,7 +2163,7 @@ const NotesManagerPage: React.FC = () => {
         exportAllCSV={exp.exportAllCSV}
         exportAllJSON={exp.exportAllJSON}
         openImportPicker={imp.openImportPicker}
-        resetEditor={ed.resetEditor}
+        resetEditor={resetEditorToEmptyState}
         renderKeywordLabelWithFrequency={kw.renderKeywordLabelWithFrequency}
         onOpenSettings={() => navigate('/settings/tldw')}
         onOpenHealth={() => navigate('/settings/health')}
@@ -2101,6 +2185,7 @@ const NotesManagerPage: React.FC = () => {
         isMobileViewport={isMobileViewport}
         setMobileSidebarOpen={setMobileSidebarOpen}
         selectedId={ed.selectedId}
+        showEmptyState={showEditorEmptyState}
         title={ed.title}
         content={ed.content}
         editorDisabled={editorDisabled}
@@ -2114,6 +2199,9 @@ const NotesManagerPage: React.FC = () => {
         noteRelations={noteRelations}
         noteNeighborsLoading={noteNeighborsLoading}
         noteNeighborsError={noteNeighborsError}
+        onRetryNeighbors={() => {
+          void refetchNoteNeighbors()
+        }}
         selectedNotePinned={ed.selectedNotePinned}
         editorMode={ed.editorMode}
         editorInputMode={ed.editorInputMode}

--- a/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
@@ -1130,13 +1130,13 @@ const NotesManagerPage: React.FC = () => {
     if (rawInput == null) return
     const keywords = rawInput.split(',').map((entry) => entry.trim()).filter(Boolean)
     if (keywords.length === 0) {
-      message.warning('Enter at least one keyword to assign')
+      message.warning('Enter at least one tag to assign')
       return
     }
     const confirmed = await confirmDanger({
-      title: 'Apply keywords to selected notes?',
+      title: 'Apply tags to selected notes?',
       content: `Apply ${keywords.join(', ')} to ${list.selectedBulkNotes.length} selected notes?`,
-      okText: 'Apply keywords',
+      okText: 'Apply tags',
       cancelText: 'Cancel'
     })
     if (!confirmed) return
@@ -1164,14 +1164,14 @@ const NotesManagerPage: React.FC = () => {
     }
 
     if (updated > 0) {
-      message.success(`Updated keywords on ${updated} selected note${updated === 1 ? '' : 's'}`)
+      message.success(`Updated tags on ${updated} selected note${updated === 1 ? '' : 's'}`)
       await list.refetch()
       if (ed.selectedId != null && list.selectedBulkNotes.some((note) => String(note.id) === String(ed.selectedId))) {
         await ed.loadDetail(ed.selectedId)
       }
     }
     if (failed > 0) {
-      message.warning(`${failed} selected note${failed === 1 ? '' : 's'} failed keyword update`)
+      message.warning(`${failed} selected note${failed === 1 ? '' : 's'} failed tag update`)
     }
   }, [confirmDanger, ed, kw.keywordTokens, list, message])
 
@@ -1755,8 +1755,8 @@ const NotesManagerPage: React.FC = () => {
     const effectiveQuery = list.query.trim() || list.queryInput.trim()
     const details: string[] = []
     if (effectiveQuery) details.push(`${t('option:notesSearch.summaryQueryLabel', { defaultValue: 'Query' })}: "${effectiveQuery}"`)
-    if (list.selectedNotebook != null) details.push(`${t('option:notesSearch.summaryNotebookLabel', { defaultValue: 'Smart collection' })}: ${list.selectedNotebook.name}`)
-    if (kw.keywordTokens.length > 0) details.push(`${t('option:notesSearch.summaryKeywordsLabel', { defaultValue: 'Keywords' })}: ${kw.keywordTokens.join(', ')}`)
+    if (list.selectedNotebook != null) details.push(`${t('option:notesSearch.summaryNotebookLabel', { defaultValue: 'Saved filter' })}: ${list.selectedNotebook.name}`)
+    if (kw.keywordTokens.length > 0) details.push(`${t('option:notesSearch.summaryKeywordsLabel', { defaultValue: 'Tags' })}: ${kw.keywordTokens.join(', ')}`)
     const countText = `${t('option:notesSearch.summaryShowing', { defaultValue: 'Showing' })} ${filteredCount} ${t('option:notesSearch.summaryOf', { defaultValue: 'of' })} ${list.total} ${t('option:notesSearch.summaryNotes', { defaultValue: 'notes' })}`
     return { countText, detailsText: details.join(' + ') }
   }, [kw.keywordTokens, list, t])
@@ -1802,7 +1802,7 @@ const NotesManagerPage: React.FC = () => {
   const searchableTips = React.useMemo(() => [
     { id: 'phrase', text: t('option:notesSearch.searchTipPhrase', { defaultValue: 'Use quotes for phrases, e.g. "project roadmap".' }) },
     { id: 'prefix', text: t('option:notesSearch.searchTipPrefix', { defaultValue: 'Use prefix terms (like analy*) for broader matches.' }) },
-    { id: 'and', text: t('option:notesSearch.searchTipAnd', { defaultValue: 'Text query + selected keywords are combined with AND.' }) },
+    { id: 'and', text: t('option:notesSearch.searchTipAnd', { defaultValue: 'Text query + selected tags are combined with AND.' }) },
     { id: 'in-note', text: t('option:notesSearch.searchTipInNote', { defaultValue: 'To find text inside the open note, use browser Ctrl/Cmd+F.' }) }
   ], [t])
 
@@ -1871,17 +1871,65 @@ const NotesManagerPage: React.FC = () => {
     setSidebarCollapsed(desktopSidebarCollapsedRef.current)
   }, [isMobileViewport])
 
-  // Shortcut help
+  // Global keyboard shortcuts
   React.useEffect(() => {
     const handler = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || event.key !== '?' || event.metaKey || event.ctrlKey || event.altKey) return
-      if (shouldIgnoreGlobalShortcut(event.target)) return
-      event.preventDefault()
-      setShortcutHelpOpen(true)
+      if (event.defaultPrevented) return
+
+      // ? — open shortcut help (only when not typing in an input)
+      if (event.key === '?' && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        if (shouldIgnoreGlobalShortcut(event.target)) return
+        event.preventDefault()
+        setShortcutHelpOpen(true)
+        return
+      }
+
+      // Alt+N — create new note
+      if (event.altKey && (event.key === 'n' || event.key === 'N') && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
+        event.preventDefault()
+        void handleNewNote()
+        return
+      }
+
+      // Ctrl/Cmd+K — focus search
+      if ((event.ctrlKey || event.metaKey) && event.key === 'k' && !event.shiftKey && !event.altKey) {
+        event.preventDefault()
+        const searchInput = document.querySelector<HTMLInputElement>('[data-testid="notes-list-region"] input[type="search"], [data-testid="notes-list-region"] input')
+        searchInput?.focus()
+        return
+      }
+
+      // / — focus search (only when not typing in an input)
+      if (event.key === '/' && !event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
+        if (shouldIgnoreGlobalShortcut(event.target)) return
+        event.preventDefault()
+        const searchInput = document.querySelector<HTMLInputElement>('[data-testid="notes-list-region"] input[type="search"], [data-testid="notes-list-region"] input')
+        searchInput?.focus()
+        return
+      }
+
+      // Ctrl/Cmd+Shift+E/S/P — switch editor mode
+      if ((event.ctrlKey || event.metaKey) && event.shiftKey && !event.altKey) {
+        if (event.key === 'E' || event.key === 'e') {
+          event.preventDefault()
+          ed.setEditorMode('edit')
+          return
+        }
+        if (event.key === 'S' || event.key === 's') {
+          event.preventDefault()
+          ed.setEditorMode('split')
+          return
+        }
+        if (event.key === 'P' || event.key === 'p') {
+          event.preventDefault()
+          ed.setEditorMode('preview')
+          return
+        }
+      }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [])
+  }, [handleNewNote, ed])
 
   // Cleanup
   React.useEffect(() => {
@@ -2089,6 +2137,8 @@ const NotesManagerPage: React.FC = () => {
         manualLinkOptions={manualLinkOptions}
         manualLinkDeletingEdgeId={ed.manualLinkDeletingEdgeId}
         assistLoadingAction={ed.assistLoadingAction}
+        canUndoAssist={ed.canUndoAssist}
+        undoAssist={ed.undoAssist}
         shouldShowToc={wl.shouldShowToc}
         tocEntries={wl.tocEntries}
         previewContent={wl.previewContent}

--- a/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesManagerPage.tsx
@@ -15,6 +15,7 @@ import { useServerCapabilities } from '@/hooks/useServerCapabilities'
 import { tldwClient } from '@/services/tldw/TldwApiClient'
 import { useAntdMessage } from '@/hooks/useAntdMessage'
 import { useStoreMessageOption } from "@/store/option"
+import { useTutorialStore } from "@/store/tutorials"
 import { shallow } from "zustand/shallow"
 import { updatePageTitle } from "@/utils/update-page-title"
 import { normalizeChatRole } from "@/utils/normalize-chat-role"
@@ -1930,6 +1931,18 @@ const NotesManagerPage: React.FC = () => {
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [handleNewNote, ed])
+
+  // Auto-trigger notes tutorial on first visit
+  React.useEffect(() => {
+    const key = 'notes-tutorial-shown'
+    if (typeof window === 'undefined') return
+    if (localStorage.getItem(key)) return
+    const timer = window.setTimeout(() => {
+      localStorage.setItem(key, '1')
+      useTutorialStore.getState().startTutorial('notes-basics')
+    }, 1000)
+    return () => window.clearTimeout(timer)
+  }, [])
 
   // Cleanup
   React.useEffect(() => {

--- a/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import type { InputRef } from 'antd'
 import { Input, Typography, Select, Button, Tooltip, Popover, Spin } from 'antd'
 import {
   Plus as PlusIcon,
@@ -118,6 +119,7 @@ export interface NotesSidebarProps {
   setPageSize: React.Dispatch<React.SetStateAction<number>>
   setSortOption: (option: NotesSortOption) => void
   setQueryInput: (value: string) => void
+  searchInputRef?: React.Ref<InputRef>
   setSelectedMoodboardId: (id: number | null) => void
   setSelectedNotebookId: (id: number | null) => void
   setSearchTipsQuery: (query: string) => void
@@ -245,6 +247,7 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
   setPageSize,
   setSortOption,
   setQueryInput,
+  searchInputRef,
   setSelectedMoodboardId,
   setSelectedNotebookId,
   setSearchTipsQuery,
@@ -283,6 +286,18 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
   onOpenHealth,
 }) => {
   const { t } = useTranslation(['option', 'common'])
+  const renderHelpButton = React.useCallback(
+    (label: string) => (
+      <button
+        type="button"
+        className="inline-flex items-center rounded-sm text-text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        aria-label={label}
+      >
+        <QuestionCircleOutlined className="text-[11px]" />
+      </button>
+    ),
+    []
+  )
 
   // Compute active filter count for badge
   const activeFilterCount =
@@ -443,17 +458,21 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                   </Button>
                 </div>
                 <CollapsibleSection
-                  title={
-                    <span className="inline-flex items-center gap-1">
-                      {t('option:notesSearch.organizeSectionTitle', {
-                        defaultValue: 'Organize'
-                      })}
-                      <Tooltip title={t('option:notesSearch.organizeHelpTooltip', {
+                  title={t('option:notesSearch.organizeSectionTitle', {
+                    defaultValue: 'Organize'
+                  })}
+                  titleAccessory={
+                    <Tooltip
+                      title={t('option:notesSearch.organizeHelpTooltip', {
                         defaultValue: 'Collections group notes manually. Saved filters auto-group notes by tags.'
-                      })}>
-                        <QuestionCircleOutlined className="text-text-muted text-[11px]" />
-                      </Tooltip>
-                    </span>
+                      })}
+                    >
+                      {renderHelpButton(
+                        t('option:notesSearch.organizeHelpLabel', {
+                          defaultValue: 'Organize help'
+                        })
+                      )}
+                    </Tooltip>
                   }
                   defaultOpen={false}
                   storageKey="organize"
@@ -650,6 +669,7 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                           setQuery(queryInput)
                           setPage(1)
                         }}
+                        ref={searchInputRef}
                       />
                     </div>
                     <Select
@@ -757,10 +777,16 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                             defaultValue: 'Browse tags'
                           })}
                         </Button>
-                        <Tooltip title={t('option:notesSearch.tagsHelpTooltip', {
-                          defaultValue: 'Tags help you organize and filter notes. Add tags in the editor, then filter here.'
-                        })}>
-                          <QuestionCircleOutlined className="text-text-muted text-[11px]" />
+                        <Tooltip
+                          title={t('option:notesSearch.tagsHelpTooltip', {
+                            defaultValue: 'Tags help you organize and filter notes. Add tags in the editor, then filter here.'
+                          })}
+                        >
+                          {renderHelpButton(
+                            t('option:notesSearch.tagsHelpLabel', {
+                              defaultValue: 'Tags help'
+                            })
+                          )}
                         </Tooltip>
                       </div>
                       {availableKeywords.length > 0 && (

--- a/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
@@ -357,10 +357,10 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
             </div>
 
             <div className="space-y-2">
-              {/* ---- Collapsible: View & Organize (always visible) ---- */}
+              {/* ---- Collapsible: Views (always visible) ---- */}
               <CollapsibleSection
                 title={t('option:notesSearch.viewOrganizeSectionTitle', {
-                  defaultValue: 'View & Organize'
+                  defaultValue: 'Views'
                 })}
                 defaultOpen
                 storageKey="view-organize"

--- a/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
@@ -4,6 +4,7 @@ import {
   Plus as PlusIcon,
   Search as SearchIcon,
 } from 'lucide-react'
+import { QuestionCircleOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import NotesListPanel from '@/components/Notes/NotesListPanel'
 import CollapsibleSection from '@/components/Notes/CollapsibleSection'
@@ -441,6 +442,23 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                     })}
                   </Button>
                 </div>
+                <CollapsibleSection
+                  title={
+                    <span className="inline-flex items-center gap-1">
+                      {t('option:notesSearch.organizeSectionTitle', {
+                        defaultValue: 'Organize'
+                      })}
+                      <Tooltip title={t('option:notesSearch.organizeHelpTooltip', {
+                        defaultValue: 'Collections group notes manually. Saved filters auto-group notes by tags.'
+                      })}>
+                        <QuestionCircleOutlined className="text-text-muted text-[11px]" />
+                      </Tooltip>
+                    </span>
+                  }
+                  defaultOpen={false}
+                  storageKey="organize"
+                  testId="notes-section-organize"
+                >
                 {listMode === 'active' && listViewMode === 'moodboard' && (
                   <div
                     className="space-y-2 rounded border border-border bg-surface2 p-2"
@@ -536,7 +554,7 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                       className="block text-[11px] text-text-muted"
                     >
                       {t('option:notesSearch.notebookLabel', {
-                        defaultValue: 'Smart collection'
+                        defaultValue: 'Saved filter'
                       })}
                     </Typography.Text>
                     <div className="flex items-center gap-2">
@@ -560,7 +578,7 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                         }}
                         allowClear
                         placeholder={t('option:notesSearch.notebookAllOption', {
-                          defaultValue: 'All smart collections'
+                          defaultValue: 'All saved filters'
                         })}
                         options={notebookOptions.map((notebook) => ({
                           value: notebook.id,
@@ -599,16 +617,17 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                     >
                       {selectedNotebook
                         ? t('option:notesSearch.notebookHelperSelected', {
-                            defaultValue: 'Smart collection applies {{count}} keyword filters.',
+                            defaultValue: 'Saved filter applies {{count}} tag filters.',
                             count: selectedNotebook.keywords.length
                           })
                         : t('option:notesSearch.notebookHelperDefault', {
                             defaultValue:
-                              'Save current keyword filters as smart collections.'
+                              'Save current tag filters as saved filters.'
                           })}
                     </Typography.Text>
                   </div>
                 )}
+                </CollapsibleSection>
               </CollapsibleSection>
 
               {listMode === 'active' ? (
@@ -712,7 +731,7 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                       mode="tags"
                       allowClear
                       placeholder={t('option:notesSearch.keywordsPlaceholder', {
-                        defaultValue: 'Filter by keyword'
+                        defaultValue: 'Filter by tag'
                       })}
                       className="w-full"
                       value={keywordTokens}
@@ -727,16 +746,23 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                       }))}
                     />
                     <div className="flex items-center justify-between gap-2">
-                      <Button
-                        size="small"
-                        onClick={openKeywordPicker}
-                        disabled={!isOnline}
-                        className="text-xs"
-                      >
-                        {t('option:notesSearch.keywordsBrowse', {
-                          defaultValue: 'Browse keywords'
-                        })}
-                      </Button>
+                      <div className="inline-flex items-center gap-1">
+                        <Button
+                          size="small"
+                          onClick={openKeywordPicker}
+                          disabled={!isOnline}
+                          className="text-xs"
+                        >
+                          {t('option:notesSearch.keywordsBrowse', {
+                            defaultValue: 'Browse tags'
+                          })}
+                        </Button>
+                        <Tooltip title={t('option:notesSearch.tagsHelpTooltip', {
+                          defaultValue: 'Tags help you organize and filter notes. Add tags in the editor, then filter here.'
+                        })}>
+                          <QuestionCircleOutlined className="text-text-muted text-[11px]" />
+                        </Tooltip>
+                      </div>
                       {availableKeywords.length > 0 && (
                         <Typography.Text
                           type="secondary"
@@ -1186,6 +1212,7 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
               <div className="mt-2 grid grid-cols-3 gap-2">
                 <Button
                   size="small"
+                  className={isMobileViewport ? 'min-h-[44px]' : undefined}
                   onClick={exportSelectedBulk}
                   data-testid="notes-bulk-export"
                 >
@@ -1195,17 +1222,19 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                 </Button>
                 <Button
                   size="small"
+                  className={isMobileViewport ? 'min-h-[44px]' : undefined}
                   onClick={() => {
                     void assignKeywordsToSelectedBulk()
                   }}
                   data-testid="notes-bulk-assign-keywords"
                 >
                   {t('option:notesSearch.bulkAssignKeywords', {
-                    defaultValue: 'Assign keywords'
+                    defaultValue: 'Assign tags'
                   })}
                 </Button>
                 <Button
                   size="small"
+                  className={isMobileViewport ? 'min-h-[44px]' : undefined}
                   danger
                   onClick={() => {
                     void deleteSelectedBulk()

--- a/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesSidebar.tsx
@@ -373,7 +373,7 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                   >
                     {t('option:notesSearch.largeListPaginationHint', {
                       defaultValue:
-                        'Large collection detected. Using paginated list mode; virtualization is deferred for now.'
+                        'Showing notes in pages for faster loading.'
                     })}
                   </Typography.Text>
                 )}
@@ -619,7 +619,7 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                       <Input
                         allowClear
                         placeholder={t('option:notesSearch.placeholder', {
-                          defaultValue: 'Search titles & content...'
+                          defaultValue: 'Search notes... (use quotes for exact match)'
                         })}
                         prefix={(<SearchIcon className="w-4 h-4 text-text-subtle" />)}
                         value={queryInput}
@@ -953,10 +953,10 @@ const NotesSidebar: React.FC<NotesSidebarProps> = ({
                         const membership = String(note.membership_source || 'manual')
                         const membershipLabel =
                           membership === 'both'
-                            ? t('option:notesSearch.moodboardMembershipBoth', { defaultValue: 'Manual + Smart' })
+                            ? t('option:notesSearch.moodboardMembershipBoth', { defaultValue: 'Pinned + Rule-matched' })
                             : membership === 'smart'
-                              ? t('option:notesSearch.moodboardMembershipSmart', { defaultValue: 'Smart' })
-                              : t('option:notesSearch.moodboardMembershipManual', { defaultValue: 'Manual' })
+                              ? t('option:notesSearch.moodboardMembershipSmart', { defaultValue: 'Rule-matched' })
+                              : t('option:notesSearch.moodboardMembershipManual', { defaultValue: 'Pinned' })
                         return (
                           <button
                             key={noteId}

--- a/apps/packages/ui/src/components/Notes/NotesToolbar.tsx
+++ b/apps/packages/ui/src/components/Notes/NotesToolbar.tsx
@@ -88,7 +88,7 @@ const NotesToolbar: React.FC<NotesToolbarProps> = ({
             mode="tags"
             allowClear
             placeholder={t('option:notesSearch.keywordsPlaceholder', {
-              defaultValue: 'Filter by keyword'
+              defaultValue: 'Filter by tag'
             })}
             className="min-w-[12rem] w-full pl-2"
             value={keywordTokens}

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
@@ -243,7 +243,7 @@ describe("NotesManagerPage stage 1 editor reliability", () => {
       }
     )
 
-    const searchInput = screen.getByPlaceholderText("Search titles & content...")
+    const searchInput = screen.getByPlaceholderText("Search notes... (use quotes for exact match)")
     fireEvent.focus(searchInput)
     fireEvent.keyDown(searchInput, { key: "s", ctrlKey: true })
     fireEvent.keyDown(searchInput, { key: "s", metaKey: true })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage1.editor-reliability.test.tsx
@@ -253,6 +253,18 @@ describe("NotesManagerPage stage 1 editor reliability", () => {
     })
   })
 
+  it("hides the welcome state after starting a new draft", async () => {
+    renderPage()
+
+    expect(screen.getByTestId("notes-editor-empty-state")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId("notes-editor-empty-create"))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("notes-editor-empty-state")).not.toBeInTheDocument()
+    })
+  })
+
   it("preserves the pending last-note setting when note hydration fails", async () => {
     mockGetSetting.mockResolvedValue("pending-note")
     mockBgRequest.mockImplementation(async (request: { path?: string; method?: string }) => {

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage10.ai-content-assist.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage10.ai-content-assist.test.tsx
@@ -130,7 +130,26 @@ vi.mock("@/components/Common/MarkdownPreview", () => ({
 }))
 
 vi.mock("@/components/Notes/NotesListPanel", () => ({
-  default: () => <div data-testid="notes-list-panel" />
+  default: ({
+    notes,
+    onSelectNote
+  }: {
+    notes?: Array<{ id: string | number; title?: string }>
+    onSelectNote?: (id: string | number) => void
+  }) => (
+    <div data-testid="notes-list-panel">
+      {(notes || []).map((note) => (
+        <button
+          key={String(note.id)}
+          type="button"
+          data-testid={`notes-open-button-${String(note.id)}`}
+          onClick={() => onSelectNote?.(note.id)}
+        >
+          {note.title || `Note ${String(note.id)}`}
+        </button>
+      ))}
+    </div>
+  )
 }))
 
 const renderPage = () => {
@@ -158,7 +177,43 @@ describe("NotesManagerPage stage 10 AI content assist actions", () => {
       const path = String(request.path || "")
       const method = String(request.method || "GET").toUpperCase()
       if (path.startsWith("/api/v1/notes/?")) {
-        return { items: [], pagination: { total_items: 0, total_pages: 1 } }
+        return {
+          items: [
+            { id: "note-a", title: "Alpha note", content: "Alpha source body", metadata: { keywords: [] }, version: 1 },
+            { id: "note-b", title: "Beta note", content: "Beta source body", metadata: { keywords: [] }, version: 1 }
+          ],
+          pagination: { total_items: 2, total_pages: 1 }
+        }
+      }
+      if (path === "/api/v1/notes/note-a" && method === "GET") {
+        return {
+          id: "note-a",
+          title: "Alpha note",
+          content: "Alpha source body",
+          metadata: { keywords: [] },
+          version: 1
+        }
+      }
+      if (path === "/api/v1/notes/note-b" && method === "GET") {
+        return {
+          id: "note-b",
+          title: "Beta note",
+          content: "Beta source body",
+          metadata: { keywords: [] },
+          version: 1
+        }
+      }
+      if (path.startsWith("/api/v1/notes/note-a/neighbors")) {
+        return {
+          nodes: [{ id: "note-a", type: "note", label: "Alpha note" }],
+          edges: []
+        }
+      }
+      if (path.startsWith("/api/v1/notes/note-b/neighbors")) {
+        return {
+          nodes: [{ id: "note-b", type: "note", label: "Beta note" }],
+          edges: []
+        }
       }
       if (path === "/api/v1/admin/notes/title-settings" && method === "GET") {
         return {
@@ -273,5 +328,25 @@ describe("NotesManagerPage stage 10 AI content assist actions", () => {
     })
     const editorKeywordsControl = screen.getByTestId("notes-keywords-editor")
     expect(within(editorKeywordsControl).queryByText("quantum")).not.toBeInTheDocument()
+  })
+
+  it("clears AI undo state when switching to a different note", async () => {
+    renderPage()
+
+    fireEvent.click(await screen.findByTestId("notes-open-button-note-a"))
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Alpha note")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId("notes-assist-summarize"))
+    expect(await screen.findByTestId("notes-undo-assist")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId("notes-open-button-note-b"))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Beta note")).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue("Beta source body")).toBeInTheDocument()
+    expect(screen.queryByTestId("notes-undo-assist")).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage10.ai-content-assist.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage10.ai-content-assist.test.tsx
@@ -194,14 +194,14 @@ describe("NotesManagerPage stage 10 AI content assist actions", () => {
       ).toContain("Summary:")
     })
     expect(screen.getByTestId("notes-editor-provenance")).toHaveTextContent(
-      "Edit source: Generated (Summarize"
+      "Origin: AI-generated (Summarize"
     )
 
     fireEvent.change(screen.getByPlaceholderText("Write your note here... (Markdown supported)"), {
       target: { value: "manual update after summary" }
     })
     await waitFor(() => {
-      expect(screen.getByTestId("notes-editor-provenance")).toHaveTextContent("Edit source: Manual")
+      expect(screen.getByTestId("notes-editor-provenance")).toHaveTextContent("Origin: Typed manually")
     })
   })
 
@@ -221,7 +221,7 @@ describe("NotesManagerPage stage 10 AI content assist actions", () => {
       expect(mockConfirmDanger).toHaveBeenCalled()
     })
     expect(textarea.value).toBe("Keep this draft exactly as typed.")
-    expect(screen.getByTestId("notes-editor-provenance")).toHaveTextContent("Edit source: Manual")
+    expect(screen.getByTestId("notes-editor-provenance")).toHaveTextContent("Origin: Typed manually")
   })
 
   it("suggests keywords with explicit selection and marks generated provenance after apply", async () => {
@@ -244,10 +244,10 @@ describe("NotesManagerPage stage 10 AI content assist actions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Apply selected" }))
 
     await waitFor(() => {
-      expect(mockMessageSuccess).toHaveBeenCalledWith("Applied suggested keywords.")
+      expect(mockMessageSuccess).toHaveBeenCalledWith("Applied suggested tags.")
     })
     expect(screen.getByTestId("notes-editor-provenance")).toHaveTextContent(
-      "Edit source: Generated (Suggest keywords"
+      "Origin: AI-generated (Suggest tags"
     )
     const editorKeywordsControl = screen.getByTestId("notes-keywords-editor")
     expect(within(editorKeywordsControl).getByText("quantum")).toBeInTheDocument()
@@ -269,7 +269,7 @@ describe("NotesManagerPage stage 10 AI content assist actions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
 
     await waitFor(() => {
-      expect(screen.getByTestId("notes-editor-provenance")).toHaveTextContent("Edit source: Manual")
+      expect(screen.getByTestId("notes-editor-provenance")).toHaveTextContent("Origin: Typed manually")
     })
     const editorKeywordsControl = screen.getByTestId("notes-keywords-editor")
     expect(within(editorKeywordsControl).queryByText("quantum")).not.toBeInTheDocument()

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage11.search-filtering.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage11.search-filtering.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import NotesManagerPage from "../NotesManagerPage"
 
 const {
@@ -146,8 +146,12 @@ const renderPage = () => {
     </QueryClientProvider>
   )
 }
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+const isNotesSearchPath = (request: { path?: string } | undefined) =>
+  /\/api\/v1\/notes\/search\/?\?/.test(String(request?.path || ""))
+const getSearchCalls = () =>
+  mockBgRequest.mock.calls.filter(([request]) =>
+    isNotesSearchPath(request as { path?: string })
+  )
 
 describe("NotesManagerPage stage 11 search filtering", () => {
   beforeEach(() => {
@@ -162,7 +166,7 @@ describe("NotesManagerPage stage 11 search filtering", () => {
       if (path.startsWith("/api/v1/notes/?")) {
         return { items: [], pagination: { total_items: 0, total_pages: 1 } }
       }
-      if (path.startsWith("/api/v1/notes/search/?")) {
+      if (isNotesSearchPath(request)) {
         return { items: [], pagination: { total_items: 0, total_pages: 1 } }
       }
       if (path === "/api/v1/admin/notes/title-settings" && method === "GET") {
@@ -175,6 +179,10 @@ describe("NotesManagerPage stage 11 search filtering", () => {
       }
       return {}
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("shows search input", () => {
@@ -214,64 +222,62 @@ describe("NotesManagerPage stage 11 search filtering", () => {
   })
 
   it("debounces rapid typing and issues only one final search request", async () => {
+    vi.useFakeTimers()
     renderPage()
     const input = screen.getByPlaceholderText("Search notes... (use quotes for exact match)")
 
-    fireEvent.change(input, { target: { value: "a" } })
-    fireEvent.change(input, { target: { value: "al" } })
-    fireEvent.change(input, { target: { value: "alpha" } })
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "a" } })
+      await Promise.resolve()
+    })
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "al" } })
+      await Promise.resolve()
+    })
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "alpha" } })
+      await Promise.resolve()
+    })
 
-    const searchCallsBefore = mockBgRequest.mock.calls.filter(([request]) =>
-      String(request?.path || "").startsWith("/api/v1/notes/search/?")
-    )
-    expect(searchCallsBefore.length).toBe(0)
+    expect(getSearchCalls()).toHaveLength(0)
 
-    await sleep(250)
-    const searchCallsNearDebounce = mockBgRequest.mock.calls.filter(([request]) =>
-      String(request?.path || "").startsWith("/api/v1/notes/search/?")
-    )
-    expect(searchCallsNearDebounce.length).toBe(0)
+    await act(async () => {
+      vi.advanceTimersByTime(349)
+      await Promise.resolve()
+    })
+    expect(getSearchCalls()).toHaveLength(0)
 
-    await waitFor(
-      () => {
-        const searchCalls = mockBgRequest.mock.calls.filter(([request]) =>
-          String(request?.path || "").startsWith("/api/v1/notes/search/?")
-        )
-        expect(searchCalls.length).toBe(1)
-      },
-      { timeout: 1500 }
-    )
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
 
-    const finalSearchCall = mockBgRequest.mock.calls.find(([request]) =>
-      String(request?.path || "").includes("/api/v1/notes/search/?")
-    )
+    expect(getSearchCalls()).toHaveLength(1)
+
+    const finalSearchCall = getSearchCalls()[0]
     expect(String(finalSearchCall?.[0]?.path || "")).toContain("query=alpha")
   })
 
   it("sends search requests for search queries", async () => {
+    vi.useFakeTimers()
     renderPage()
     const input = screen.getByPlaceholderText("Search notes... (use quotes for exact match)")
 
     fireEvent.change(input, { target: { value: "alpha" } })
-    await waitFor(
-      () => {
-        const searchCalls = mockBgRequest.mock.calls.filter(([request]) =>
-          String(request?.path || "").startsWith("/api/v1/notes/search/?")
-        )
-        expect(searchCalls.length).toBe(1)
-      },
-      { timeout: 1500 }
-    )
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(getSearchCalls()).toHaveLength(1)
 
     fireEvent.change(input, { target: { value: "alpha beta" } })
-    await waitFor(
-      () => {
-        const searchCalls = mockBgRequest.mock.calls.filter(([request]) =>
-          String(request?.path || "").startsWith("/api/v1/notes/search/?")
-        )
-        expect(searchCalls.length).toBe(2)
-      },
-      { timeout: 1500 }
-    )
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(getSearchCalls()).toHaveLength(2)
   })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage11.search-filtering.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage11.search-filtering.test.tsx
@@ -179,7 +179,7 @@ describe("NotesManagerPage stage 11 search filtering", () => {
 
   it("shows search input", () => {
     renderPage()
-    expect(screen.getByPlaceholderText("Search titles & content...")).toBeInTheDocument()
+    expect(screen.getByPlaceholderText("Search notes... (use quotes for exact match)")).toBeInTheDocument()
   })
 
   it("opens search tips popover with phrase and AND guidance", async () => {
@@ -192,7 +192,7 @@ describe("NotesManagerPage stage 11 search filtering", () => {
       ).toBeInTheDocument()
     })
     expect(
-      screen.getByText("Text query + selected keywords are combined with AND.")
+      screen.getByText("Text query + selected tags are combined with AND.")
     ).toBeInTheDocument()
   })
 
@@ -215,7 +215,7 @@ describe("NotesManagerPage stage 11 search filtering", () => {
 
   it("debounces rapid typing and issues only one final search request", async () => {
     renderPage()
-    const input = screen.getByPlaceholderText("Search titles & content...")
+    const input = screen.getByPlaceholderText("Search notes... (use quotes for exact match)")
 
     fireEvent.change(input, { target: { value: "a" } })
     fireEvent.change(input, { target: { value: "al" } })
@@ -250,7 +250,7 @@ describe("NotesManagerPage stage 11 search filtering", () => {
 
   it("sends search requests for search queries", async () => {
     renderPage()
-    const input = screen.getByPlaceholderText("Search titles & content...")
+    const input = screen.getByPlaceholderText("Search notes... (use quotes for exact match)")
 
     fireEvent.change(input, { target: { value: "alpha" } })
     await waitFor(

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage13.navigation-filter-summary.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage13.navigation-filter-summary.test.tsx
@@ -263,7 +263,7 @@ describe("NotesManagerPage stage 13 navigation filter summary", () => {
 
   it("renders keyword-only summary after applying keyword picker selection", async () => {
     renderPage()
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     await screen.findByText("Apply filters")
     fireEvent.click(screen.getByText(/^research\b/i))
     fireEvent.click(screen.getByRole("button", { name: "Apply filters" }))
@@ -274,7 +274,7 @@ describe("NotesManagerPage stage 13 navigation filter summary", () => {
       )
     })
     expect(screen.getByTestId("notes-active-filter-summary-details")).toHaveTextContent(
-      "Keywords: research"
+      "Tags: research"
     )
   })
 
@@ -289,7 +289,7 @@ describe("NotesManagerPage stage 13 navigation filter summary", () => {
       )
     })
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     await screen.findByText("Apply filters")
     fireEvent.click(screen.getByText(/^research\b/i))
     fireEvent.click(screen.getByRole("button", { name: "Apply filters" }))
@@ -300,7 +300,7 @@ describe("NotesManagerPage stage 13 navigation filter summary", () => {
       )
     })
     expect(screen.getByTestId("notes-active-filter-summary-details")).toHaveTextContent(
-      'Query: "ML" + Keywords: research'
+      'Query: "ML" + Tags: research'
     )
     expect(screen.getByLabelText("Clear active note filters")).toBeInTheDocument()
   }, 12000)

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage13.navigation-filter-summary.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage13.navigation-filter-summary.test.tsx
@@ -245,7 +245,7 @@ describe("NotesManagerPage stage 13 navigation filter summary", () => {
 
   it("renders query-only summary with accessible live-region metadata", async () => {
     renderPage()
-    fireEvent.change(screen.getByPlaceholderText("Search titles & content..."), {
+    fireEvent.change(screen.getByPlaceholderText("Search notes... (use quotes for exact match)"), {
       target: { value: "ML" }
     })
 
@@ -280,7 +280,7 @@ describe("NotesManagerPage stage 13 navigation filter summary", () => {
 
   it("renders combined query + keyword summary and preserves clear action labeling", async () => {
     renderPage()
-    fireEvent.change(screen.getByPlaceholderText("Search titles & content..."), {
+    fireEvent.change(screen.getByPlaceholderText("Search notes... (use quotes for exact match)"), {
       target: { value: "ML" }
     })
     await waitFor(() => {

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage15.keyword-counts.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage15.keyword-counts.test.tsx
@@ -187,13 +187,13 @@ describe("NotesManagerPage stage 15 keyword counts", () => {
       expect(mockGetAllNoteKeywordStats).toHaveBeenCalled()
     })
 
-    fireEvent.mouseDown(screen.getByText("Filter by keyword"))
+    fireEvent.mouseDown(screen.getByText("Filter by tag"))
     await waitFor(() => {
       expect(screen.getByText("research (12)")).toBeInTheDocument()
       expect(screen.getByText("ml (0)")).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     await waitFor(() => {
       expect(screen.getByText("Apply filters")).toBeInTheDocument()
     })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage16.bulk-actions.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage16.bulk-actions.test.tsx
@@ -14,7 +14,8 @@ const {
   mockConfirmDanger,
   mockGetSetting,
   mockSetSetting,
-  mockClearSetting
+  mockClearSetting,
+  mockPromptModal
 } = vi.hoisted(() => {
   return {
     mockBgRequest: vi.fn(),
@@ -26,8 +27,14 @@ const {
     mockConfirmDanger: vi.fn(),
     mockGetSetting: vi.fn(),
     mockSetSetting: vi.fn(),
-    mockClearSetting: vi.fn()
+    mockClearSetting: vi.fn(),
+    mockPromptModal: vi.fn()
   }
+})
+
+vi.mock("@/components/Notes/notes-manager-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/Notes/notes-manager-utils")>()
+  return { ...actual, promptModal: mockPromptModal }
 })
 
 vi.mock("react-i18next", () => ({
@@ -272,7 +279,7 @@ describe("NotesManagerPage stage 16 bulk actions", () => {
   })
 
   it("confirms and dispatches bulk keyword assignment patches", async () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("research, summary")
+    mockPromptModal.mockResolvedValue("research, summary")
     renderPage()
     fireEvent.click(await screen.findByTestId("mock-select-n1"))
 
@@ -297,6 +304,5 @@ describe("NotesManagerPage stage 16 bulk actions", () => {
     expect(mockConfirmDanger).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Apply keywords to selected notes?" })
     )
-    promptSpy.mockRestore()
   })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage16.bulk-actions.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage16.bulk-actions.test.tsx
@@ -302,7 +302,7 @@ describe("NotesManagerPage stage 16 bulk actions", () => {
     )
     expect(patchCall?.[0]?.body?.keywords).toEqual(["research", "summary"])
     expect(mockConfirmDanger).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Apply keywords to selected notes?" })
+      expect.objectContaining({ title: "Apply tags to selected notes?" })
     )
   })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage20.accessibility-shortcuts.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage20.accessibility-shortcuts.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { fireEvent, render, screen } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import NotesManagerPage from "../NotesManagerPage"
 
 const {
@@ -12,7 +12,11 @@ const {
   mockNavigate,
   mockConfirmDanger,
   mockGetSetting,
-  mockClearSetting
+  mockClearSetting,
+  mockStorageGet,
+  mockStorageSet,
+  mockStorageRemove,
+  mockStartTutorial
 } = vi.hoisted(() => {
   return {
     mockBgRequest: vi.fn(),
@@ -22,7 +26,11 @@ const {
     mockNavigate: vi.fn(),
     mockConfirmDanger: vi.fn(),
     mockGetSetting: vi.fn(),
-    mockClearSetting: vi.fn()
+    mockClearSetting: vi.fn(),
+    mockStorageGet: vi.fn(),
+    mockStorageSet: vi.fn(),
+    mockStorageRemove: vi.fn(),
+    mockStartTutorial: vi.fn()
   }
 })
 
@@ -118,6 +126,23 @@ vi.mock("@/services/tldw/TldwApiClient", () => ({
   }
 }))
 
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => ({
+    get: mockStorageGet,
+    set: mockStorageSet,
+    remove: mockStorageRemove
+  })
+}))
+
+vi.mock("@/store/tutorials", () => {
+  const store = Object.assign(() => ({}), {
+    getState: () => ({
+      startTutorial: mockStartTutorial
+    })
+  })
+  return { useTutorialStore: store }
+})
+
 vi.mock("@/components/Notes/NotesListPanel", () => ({
   default: () => <div data-testid="notes-list-panel" />
 }))
@@ -142,6 +167,9 @@ describe("NotesManagerPage stage 20 accessibility shortcut discovery", () => {
     mockConfirmDanger.mockResolvedValue(true)
     mockGetSetting.mockResolvedValue(null)
     mockClearSetting.mockResolvedValue(undefined)
+    mockStorageGet.mockResolvedValue(null)
+    mockStorageSet.mockResolvedValue(undefined)
+    mockStorageRemove.mockResolvedValue(undefined)
 
     mockBgRequest.mockImplementation(async (request: { path?: string }) => {
       const path = String(request.path || "")
@@ -153,6 +181,10 @@ describe("NotesManagerPage stage 20 accessibility shortcut discovery", () => {
       }
       return {}
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("adds shortcut summary semantics and opens shortcut help from the toolbar", async () => {
@@ -184,5 +216,59 @@ describe("NotesManagerPage stage 20 accessibility shortcut discovery", () => {
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument()
     expect(await screen.findByTestId("notes-shortcuts-modal")).toBeInTheDocument()
+  })
+
+  it("ignores Ctrl/Cmd+K and Alt+N while typing, but still focuses search globally", async () => {
+    vi.useFakeTimers()
+    renderPage()
+
+    const textarea = screen.getByLabelText("Note content")
+    const searchInput = screen.getByPlaceholderText(
+      "Search notes... (use quotes for exact match)"
+    )
+
+    textarea.focus()
+    fireEvent.keyDown(textarea, { key: "k", ctrlKey: true })
+    expect(textarea).toHaveFocus()
+
+    fireEvent.keyDown(textarea, { key: "N", altKey: true })
+    await act(async () => {
+      vi.runOnlyPendingTimers()
+    })
+    expect(textarea).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true })
+    expect(searchInput).toHaveFocus()
+  })
+
+  it("persists tutorial state through shared storage on first visit", async () => {
+    vi.useFakeTimers()
+    renderPage()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mockStorageGet).toHaveBeenCalledWith("notes-tutorial-shown")
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockStorageSet).toHaveBeenCalledWith("notes-tutorial-shown", "1")
+    expect(mockStartTutorial).toHaveBeenCalledWith("notes-basics")
+  })
+
+  it("removes tutorial state from shared storage when restarting the tutorial", async () => {
+    renderPage()
+
+    fireEvent.click(screen.getByTestId("notes-shortcuts-help-button"))
+    fireEvent.click(await screen.findByTestId("notes-restart-tutorial"))
+
+    await waitFor(() => {
+      expect(mockStorageRemove).toHaveBeenCalledWith("notes-tutorial-shown")
+    })
+    expect(mockStartTutorial).toHaveBeenCalledWith("notes-basics")
   })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage21.accessibility-modal-focus.test.tsx
@@ -241,10 +241,10 @@ describe("NotesManagerPage stage 21 accessibility modal focus handoff", () => {
     })
   })
 
-  it("closes keyword picker with Escape and restores focus to Browse keywords trigger", async () => {
+  it("closes keyword picker with Escape and restores focus to Browse tags trigger", async () => {
     renderPage()
 
-    const browseButton = screen.getByRole("button", { name: "Browse keywords" })
+    const browseButton = screen.getByRole("button", { name: "Browse tags" })
     browseButton.focus()
     fireEvent.click(browseButton)
 

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage22.accessibility-regression.test.tsx
@@ -301,12 +301,12 @@ describe("NotesManagerPage stage 22 accessibility regression", () => {
   it("has no core aria/name violations in the keyword picker modal state", async () => {
     renderPage()
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     const modalBody = await screen.findByTestId("notes-keyword-picker-modal")
     const modalRoot = modalBody.closest(".ant-modal-root") || document.body
 
     const modalTitle = modalRoot.querySelector(".ant-modal-title")
-    expect(modalTitle).toHaveTextContent("Browse keywords")
+    expect(modalTitle).toHaveTextContent("Browse tags")
     const results = await runA11yRules(modalRoot, CORE_RULES)
     expect(results.violations).toEqual([])
   })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage24.keyword-picker-prioritization.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage24.keyword-picker-prioritization.test.tsx
@@ -193,7 +193,7 @@ describe("NotesManagerPage stage 24 keyword picker prioritization", () => {
   it("defaults to frequency sorting and supports alphabetical sort toggles", async () => {
     renderPage()
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     await waitFor(() => {
       expect(screen.getByTestId("notes-keyword-picker-sort-select")).toBeInTheDocument()
     })
@@ -220,7 +220,7 @@ describe("NotesManagerPage stage 24 keyword picker prioritization", () => {
   it("surfaces recently used keywords at the top of the picker", async () => {
     renderPage()
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     await waitFor(() => {
       expect(screen.getByText("Apply filters")).toBeInTheDocument()
     })
@@ -229,7 +229,7 @@ describe("NotesManagerPage stage 24 keyword picker prioritization", () => {
     fireEvent.click(screen.getByText("alpha (2)"))
     fireEvent.click(screen.getByText("Apply filters"))
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     const recentSection = await screen.findByTestId("notes-keyword-picker-recent-section")
     const recentButtons = within(recentSection).getAllByRole("button")
 

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage25.keyword-management.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage25.keyword-management.test.tsx
@@ -301,8 +301,15 @@ describe("NotesManagerPage stage 25 keyword management", () => {
     })
 
     fireEvent.click(screen.getByTestId("notes-keyword-manager-merge-2"))
-    const mergeTargetSelect = await screen.findByTestId("notes-keyword-manager-merge-target")
-    fireEvent.change(mergeTargetSelect, { target: { value: "1" } })
+    const mergeTargetContainer = await screen.findByTestId("notes-keyword-manager-merge-target")
+    const mergeTargetContent = mergeTargetContainer.querySelector('.ant-select-content') || mergeTargetContainer
+    fireEvent.mouseDown(mergeTargetContent)
+    await waitFor(() => {
+      const options = document.querySelectorAll('.ant-select-item-option')
+      const match = Array.from(options).find(el => el.textContent?.includes('alpha-renamed'))
+      if (!match) throw new Error('Option for "alpha-renamed" not found')
+      fireEvent.click(match)
+    })
 
     const mergeButtons = screen.getAllByRole("button", { name: "Merge" })
     fireEvent.click(mergeButtons[mergeButtons.length - 1])

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage25.keyword-management.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage25.keyword-management.test.tsx
@@ -268,7 +268,7 @@ describe("NotesManagerPage stage 25 keyword management", () => {
   it("opens keyword manager from the browse-keywords modal", async () => {
     renderPage()
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     const managerButton = await screen.findByTestId("notes-keyword-picker-open-manager")
     fireEvent.click(managerButton)
 
@@ -282,7 +282,7 @@ describe("NotesManagerPage stage 25 keyword management", () => {
   it("supports rename, merge, and delete workflows from keyword manager", async () => {
     renderPage()
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     fireEvent.click(await screen.findByTestId("notes-keyword-picker-open-manager"))
 
     await waitFor(() => {
@@ -297,7 +297,7 @@ describe("NotesManagerPage stage 25 keyword management", () => {
     fireEvent.click(renameButtons[renameButtons.length - 1])
 
     await waitFor(() => {
-      expect(mockMessageSuccess).toHaveBeenCalledWith('Renamed keyword to "alpha-renamed"')
+      expect(mockMessageSuccess).toHaveBeenCalledWith('Renamed tag to "alpha-renamed"')
     })
 
     fireEvent.click(screen.getByTestId("notes-keyword-manager-merge-2"))
@@ -320,7 +320,7 @@ describe("NotesManagerPage stage 25 keyword management", () => {
 
     fireEvent.click(screen.getByTestId("notes-keyword-manager-delete-1"))
     await waitFor(() => {
-      expect(mockMessageSuccess).toHaveBeenCalledWith('Deleted keyword "alpha-renamed"')
+      expect(mockMessageSuccess).toHaveBeenCalledWith('Deleted tag "alpha-renamed"')
     })
 
     const requestCalls = mockBgRequest.mock.calls.map((call) => call[0])

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage34.keyword-partial-save-warning.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage34.keyword-partial-save-warning.test.tsx
@@ -225,7 +225,7 @@ describe("NotesManagerPage stage 34 keyword partial save warnings", () => {
     })
     expect(mockMessageSuccess).toHaveBeenCalledWith("Note created")
     expect(mockMessageWarning).toHaveBeenCalledWith(
-      expect.stringContaining("1 keyword failed to attach (beta)")
+      expect.stringContaining("1 tag failed to attach (beta)")
     )
 
     fireEvent.change(contentInput, {
@@ -240,7 +240,7 @@ describe("NotesManagerPage stage 34 keyword partial save warnings", () => {
     })
     expect(mockMessageSuccess).toHaveBeenCalledWith("Note updated")
     expect(mockMessageWarning).toHaveBeenCalledWith(
-      expect.stringContaining("2 keywords failed to attach (beta, gamma)")
+      expect.stringContaining("2 tags failed to attach (beta, gamma)")
     )
   })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage39.organization-model.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage39.organization-model.test.tsx
@@ -292,6 +292,12 @@ describe("NotesManagerPage stage 39 organization model", () => {
     seededServerNotebooks = [{ id: 11, name: "Research", keywords: ["research", "ml"] }]
     renderPage()
 
+    // Open the nested Organize section (collapsed by default)
+    await waitFor(() => {
+      expect(screen.getByTestId("notes-section-organize-toggle")).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId("notes-section-organize-toggle"))
+
     await waitFor(() => {
       expect(screen.getByTestId("notes-notebook-select")).toBeInTheDocument()
     })
@@ -319,7 +325,7 @@ describe("NotesManagerPage stage 39 organization model", () => {
     })
 
     expect(screen.getByTestId("notes-active-filter-summary-details")).toHaveTextContent(
-      "Smart collection: Research"
+      "Saved filter: Research"
     )
   })
 
@@ -327,7 +333,13 @@ describe("NotesManagerPage stage 39 organization model", () => {
     mockPromptModal.mockResolvedValue("Research Notebook")
     renderPage()
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
+    // Open the nested Organize section (collapsed by default)
+    await waitFor(() => {
+      expect(screen.getByTestId("notes-section-organize-toggle")).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId("notes-section-organize-toggle"))
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse tags" }))
     const modalBody = await screen.findByTestId("notes-keyword-picker-modal")
     const pickerDialog =
       (modalBody.closest(".ant-modal") as HTMLElement | null) ??
@@ -341,7 +353,7 @@ describe("NotesManagerPage stage 39 organization model", () => {
     fireEvent.click(screen.getByTestId("notes-save-notebook"))
 
     await waitFor(() => {
-      expect(mockMessageSuccess).toHaveBeenCalledWith('Saved smart collection "Research Notebook"')
+      expect(mockMessageSuccess).toHaveBeenCalledWith('Saved filter "Research Notebook"')
     })
 
     expect(mockBgRequest).toHaveBeenCalledWith(
@@ -360,7 +372,7 @@ describe("NotesManagerPage stage 39 organization model", () => {
     })
     expect(notebookPersistCall).toBeTruthy()
     expect(screen.getByTestId("notes-active-filter-summary-details")).toHaveTextContent(
-      "Smart collection: Research Notebook"
+      "Saved filter: Research Notebook"
     )
 
   }, 10000)

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage39.organization-model.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage39.organization-model.test.tsx
@@ -14,7 +14,8 @@ const {
   mockConfirmDanger,
   mockGetSetting,
   mockSetSetting,
-  mockClearSetting
+  mockClearSetting,
+  mockPromptModal
 } = vi.hoisted(() => ({
   mockBgRequest: vi.fn(),
   mockMessageSuccess: vi.fn(),
@@ -25,8 +26,14 @@ const {
   mockConfirmDanger: vi.fn(),
   mockGetSetting: vi.fn(),
   mockSetSetting: vi.fn(),
-  mockClearSetting: vi.fn()
+  mockClearSetting: vi.fn(),
+  mockPromptModal: vi.fn()
 }))
+
+vi.mock("@/components/Notes/notes-manager-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/Notes/notes-manager-utils")>()
+  return { ...actual, promptModal: mockPromptModal }
+})
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -317,7 +324,7 @@ describe("NotesManagerPage stage 39 organization model", () => {
   })
 
   it("saves current keyword filters as a notebook and persists it", async () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Research Notebook")
+    mockPromptModal.mockResolvedValue("Research Notebook")
     renderPage()
 
     fireEvent.click(screen.getByRole("button", { name: "Browse keywords" }))
@@ -356,7 +363,6 @@ describe("NotesManagerPage stage 39 organization model", () => {
       "Smart collection: Research Notebook"
     )
 
-    promptSpy.mockRestore()
   }, 10000)
 
   it("renders timeline view groups for date-based browsing", async () => {

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage39.organization-model.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage39.organization-model.test.tsx
@@ -399,4 +399,11 @@ describe("NotesManagerPage stage 39 organization model", () => {
       )
     })
   })
+
+  it("renders keyboard-focusable help buttons for organize and tags guidance", async () => {
+    renderPage()
+
+    expect(await screen.findByRole("button", { name: "Organize help" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Tags help" })).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage40.advanced-editing-navigation.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage40.advanced-editing-navigation.test.tsx
@@ -13,7 +13,8 @@ const {
   mockConfirmDanger,
   mockGetSetting,
   mockSetSetting,
-  mockClearSetting
+  mockClearSetting,
+  mockPromptModal
 } = vi.hoisted(() => ({
   mockBgRequest: vi.fn(),
   mockMessageSuccess: vi.fn(),
@@ -23,8 +24,14 @@ const {
   mockConfirmDanger: vi.fn(),
   mockGetSetting: vi.fn(),
   mockSetSetting: vi.fn(),
-  mockClearSetting: vi.fn()
+  mockClearSetting: vi.fn(),
+  mockPromptModal: vi.fn()
 }))
+
+vi.mock("@/components/Notes/notes-manager-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/Notes/notes-manager-utils")>()
+  return { ...actual, promptModal: mockPromptModal }
+})
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -245,5 +252,60 @@ describe("NotesManagerPage stage 40 advanced editing and navigation", () => {
       expect(markdownTextarea.value).toContain("## New Section")
       expect(markdownTextarea.value).toContain("Added **bold**")
     })
+  })
+
+  it("restores the WYSIWYG selection before creating a link after prompt focus steals it", async () => {
+    renderPage()
+
+    const textarea = screen.getByPlaceholderText(
+      "Write your note here... (Markdown supported)"
+    ) as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: "Link target here" } })
+
+    fireEvent.click(screen.getByTestId("notes-input-mode-wysiwyg"))
+    const richEditor = await screen.findByTestId("notes-wysiwyg-editor")
+    ;(richEditor as HTMLDivElement).innerHTML = "<p>Link target here</p>"
+
+    const textNode = richEditor.querySelector("p")?.firstChild
+    expect(textNode?.nodeType).toBe(Node.TEXT_NODE)
+
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.setStart(textNode as Text, 0)
+    range.setEnd(textNode as Text, "Link target".length)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    const selectionSnapshots: string[] = []
+    const docWithExec = document as Document & {
+      execCommand?: ReturnType<typeof vi.fn>
+    }
+    const originalExecCommand = docWithExec.execCommand
+    docWithExec.execCommand = vi.fn((command: string) => {
+      if (command === "createLink") {
+        selectionSnapshots.push(window.getSelection()?.toString() || "")
+      }
+      return true
+    })
+
+    mockPromptModal.mockImplementation(async () => {
+      window.getSelection()?.removeAllRanges()
+      return "https://example.com"
+    })
+
+    try {
+      fireEvent.click(screen.getByTestId("notes-toolbar-link"))
+
+      await waitFor(() => {
+        expect(docWithExec.execCommand).toHaveBeenCalledWith(
+          "createLink",
+          false,
+          "https://example.com"
+        )
+      })
+      expect(selectionSnapshots[0]).toBe("Link target")
+    } finally {
+      docWithExec.execCommand = originalExecCommand
+    }
   })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage42.moodboard-view.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage42.moodboard-view.test.tsx
@@ -231,7 +231,7 @@ describe("NotesManagerPage stage 42 moodboard view", () => {
         const nextId = seededMoodboards.reduce((max, item) => Math.max(max, item.id), 0) + 1
         const created = {
           id: nextId,
-          name: String(body.name || "").trim() || `Moodboard ${nextId}`,
+          name: String(body.name || "").trim() || `Collection ${nextId}`,
           description: null,
           version: 1
         }
@@ -330,6 +330,12 @@ describe("NotesManagerPage stage 42 moodboard view", () => {
 
     allowMoodboardFetch = true
     fireEvent.click(screen.getByTestId("notes-view-mode-moodboard"))
+
+    // Open the nested Organize section (collapsed by default)
+    await waitFor(() => {
+      expect(screen.getByTestId("notes-section-organize-toggle")).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId("notes-section-organize-toggle"))
 
     await waitFor(() => {
       expect(screen.getByTestId("notes-moodboard-controls")).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage42.moodboard-view.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage42.moodboard-view.test.tsx
@@ -14,7 +14,8 @@ const {
   mockConfirmDanger,
   mockGetSetting,
   mockSetSetting,
-  mockClearSetting
+  mockClearSetting,
+  mockPromptModal
 } = vi.hoisted(() => ({
   mockBgRequest: vi.fn(),
   mockMessageSuccess: vi.fn(),
@@ -25,8 +26,14 @@ const {
   mockConfirmDanger: vi.fn(),
   mockGetSetting: vi.fn(),
   mockSetSetting: vi.fn(),
-  mockClearSetting: vi.fn()
+  mockClearSetting: vi.fn(),
+  mockPromptModal: vi.fn()
 }))
+
+vi.mock("@/components/Notes/notes-manager-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/Notes/notes-manager-utils")>()
+  return { ...actual, promptModal: mockPromptModal }
+})
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -315,10 +322,9 @@ describe("NotesManagerPage stage 42 moodboard view", () => {
   })
 
   it("supports create, rename, and delete actions for moodboards", async () => {
-    const promptSpy = vi
-      .spyOn(window, "prompt")
-      .mockReturnValueOnce("Fresh Board")
-      .mockReturnValueOnce("Renamed Board")
+    mockPromptModal
+      .mockResolvedValueOnce("Fresh Board")
+      .mockResolvedValueOnce("Renamed Board")
 
     renderPage()
 
@@ -362,7 +368,6 @@ describe("NotesManagerPage stage 42 moodboard view", () => {
       )
     })
 
-    promptSpy.mockRestore()
   })
 
   it("supports moodboard pagination controls and page navigation", async () => {

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage5.graph-panels.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage5.graph-panels.test.tsx
@@ -396,4 +396,54 @@ describe('NotesManagerPage graph stage 1 related/backlinks panels', () => {
       'Could not load backlinks.'
     )
   })
+
+  it('retries neighbor loading after an error', async () => {
+    let neighborAttempts = 0
+    mockBgRequest.mockImplementation(async (request: { path?: string; method?: string }) => {
+      const path = String(request.path || '')
+      const method = String(request.method || 'GET').toUpperCase()
+
+      if (path.startsWith('/api/v1/notes/?')) {
+        return {
+          items: [],
+          pagination: { total_items: 0, total_pages: 1 }
+        }
+      }
+      if (path === '/api/v1/notes/' && method === 'POST') {
+        return { id: 'note-a', version: 1, last_modified: '2026-02-18T10:00:00.000Z' }
+      }
+      if (path === '/api/v1/notes/note-a' && method === 'GET') {
+        return {
+          id: 'note-a',
+          title: 'Graph seed note',
+          content: 'Seed content',
+          metadata: { keywords: [] },
+          version: 1,
+          last_modified: '2026-02-18T10:00:00.000Z'
+        }
+      }
+      if (path.startsWith('/api/v1/notes/note-a/neighbors')) {
+        neighborAttempts += 1
+        if (neighborAttempts === 1) throw new Error('graph unavailable')
+        return {
+          nodes: [{ id: 'note-a', type: 'note', label: 'Graph seed note' }],
+          edges: []
+        }
+      }
+      return {}
+    })
+
+    renderPage()
+    await seedAndSaveNote()
+
+    const retryButton = await screen.findByTestId('notes-related-retry')
+    fireEvent.click(retryButton)
+
+    await waitFor(() => {
+      expect(neighborAttempts).toBe(2)
+    })
+    expect(await screen.findByTestId('notes-related-empty')).toHaveTextContent(
+      'No related notes yet.'
+    )
+  })
 })

--- a/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage9.stale-version-warning.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/NotesManagerPage.stage9.stale-version-warning.test.tsx
@@ -220,7 +220,7 @@ describe("NotesManagerPage stage 9 stale-version warning", () => {
 
     expect(await screen.findByTestId("notes-editor-revision-meta")).toHaveTextContent("Version 1")
     expect(await screen.findByTestId("notes-stale-version-warning")).toHaveTextContent(
-      "A newer version is available on the server"
+      "This note was updated elsewhere. Reload to see the latest version."
     )
 
     fireEvent.change(screen.getByPlaceholderText("Write your note here... (Markdown supported)"), {

--- a/apps/packages/ui/src/components/Notes/__tests__/notes-manager-utils.prompt-modal.test.tsx
+++ b/apps/packages/ui/src/components/Notes/__tests__/notes-manager-utils.prompt-modal.test.tsx
@@ -1,0 +1,62 @@
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { promptModal } from "../notes-manager-utils"
+
+const { mockConfirm } = vi.hoisted(() => ({
+  mockConfirm: vi.fn()
+}))
+
+vi.mock("antd", () => ({
+  Modal: {
+    confirm: mockConfirm
+  },
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement("input", props)
+}))
+
+const getPromptParts = () => {
+  const config = mockConfirm.mock.calls[0]?.[0]
+  const content = config.content as React.ReactElement<{ children?: React.ReactNode }>
+  const children = React.Children.toArray(content.props.children)
+  const inputElement = children[children.length - 1] as React.ReactElement<
+    React.InputHTMLAttributes<HTMLInputElement>
+  >
+
+  return {
+    config,
+    inputProps: inputElement.props
+  }
+}
+
+describe("promptModal", () => {
+  beforeEach(() => {
+    mockConfirm.mockReset()
+  })
+
+  it("returns an empty string when submit is confirmed with blank input", async () => {
+    const destroy = vi.fn()
+    mockConfirm.mockImplementation(() => ({ destroy }))
+
+    const prompt = promptModal({ title: "Assign tags" })
+    const { inputProps } = getPromptParts()
+
+    inputProps.onChange?.({
+      target: { value: "   " }
+    } as React.ChangeEvent<HTMLInputElement>)
+    inputProps.onPressEnter?.({} as React.KeyboardEvent<HTMLInputElement>)
+
+    await expect(prompt).resolves.toBe("")
+    expect(destroy).toHaveBeenCalled()
+  })
+
+  it("returns null when the prompt is canceled", async () => {
+    mockConfirm.mockImplementation(() => ({ destroy: vi.fn() }))
+
+    const prompt = promptModal({ title: "Assign tags" })
+    const { config } = getPromptParts()
+
+    config.onCancel?.()
+
+    await expect(prompt).resolves.toBeNull()
+  })
+})

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
@@ -164,6 +164,11 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
   const markdownBeforeWysiwygRef = React.useRef<string | null>(null)
   const graphModalReturnFocusRef = React.useRef<HTMLElement | null>(null)
 
+  // ---- AI assist undo ----
+  const contentBeforeAssistRef = React.useRef<string | null>(null)
+  const assistUndoTimerRef = React.useRef<number | null>(null)
+  const [canUndoAssist, setCanUndoAssist] = React.useState(false)
+
   const pinnedNoteIdSet = React.useMemo(() => new Set(pinnedNoteIds), [pinnedNoteIds])
 
   const clearAutosaveTimeout = React.useCallback(() => {
@@ -642,7 +647,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
       const keywordSuffix =
         warning.failedKeywords.length > 0 ? ` (${warning.failedKeywords.join(', ')})` : ''
       message.warning(
-        `Note ${action}, but ${warning.failedCount} keyword${
+        `Note ${action}, but ${warning.failedCount} tag${
           warning.failedCount === 1 ? '' : 's'
         } failed to attach${keywordSuffix}.`
       )
@@ -1218,7 +1223,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
           if (suggestedKeywords.length === 0) {
             message.warning(
               t('option:notesSearch.assistKeywordsNoResult', {
-                defaultValue: 'No additional keyword suggestions were found.'
+                defaultValue: 'No additional tag suggestions were found.'
               })
             )
             return
@@ -1261,6 +1266,15 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
           })
         })
         if (!apply) return
+        // Store content before replacement so the user can undo the AI change
+        contentBeforeAssistRef.current = sourceContent
+        setCanUndoAssist(true)
+        if (assistUndoTimerRef.current != null) window.clearTimeout(assistUndoTimerRef.current)
+        assistUndoTimerRef.current = window.setTimeout(() => {
+          contentBeforeAssistRef.current = null
+          setCanUndoAssist(false)
+          assistUndoTimerRef.current = null
+        }, 30_000)
         setContentDirty(generatedContent, { provenance: action })
         message.success(
           action === 'summarize'
@@ -1291,6 +1305,29 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
       t
     ]
   )
+
+  const undoAssist = React.useCallback(() => {
+    if (contentBeforeAssistRef.current == null) return
+    setContentDirty(contentBeforeAssistRef.current, { provenance: undefined })
+    contentBeforeAssistRef.current = null
+    setCanUndoAssist(false)
+    if (assistUndoTimerRef.current != null) {
+      window.clearTimeout(assistUndoTimerRef.current)
+      assistUndoTimerRef.current = null
+    }
+    message.info(
+      t('option:notesSearch.undoAssistApplied', {
+        defaultValue: 'Reverted AI change.'
+      })
+    )
+  }, [setContentDirty, message, t])
+
+  // Clean up assist undo timer on unmount
+  React.useEffect(() => {
+    return () => {
+      if (assistUndoTimerRef.current != null) window.clearTimeout(assistUndoTimerRef.current)
+    }
+  }, [])
 
   // ---- pinned notes ----
   const selectedNotePinned =
@@ -1682,7 +1719,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
         ? t('option:notesSearch.assistSummarizeAction', { defaultValue: 'Summarize' })
         : editProvenance.action === 'expand_outline'
           ? t('option:notesSearch.assistExpandOutlineAction', { defaultValue: 'Expand outline' })
-          : t('option:notesSearch.assistSuggestKeywordsAction', { defaultValue: 'Suggest keywords' })
+          : t('option:notesSearch.assistSuggestKeywordsAction', { defaultValue: 'Suggest tags' })
     const generatedAt = new Date(editProvenance.at).toLocaleTimeString()
     const generatedPrefix = t('option:notesSearch.provenanceGeneratedPrefix', {
       defaultValue: 'Origin: AI-generated'
@@ -1724,6 +1761,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
     editorCursorIndex, setEditorCursorIndex,
     titleSuggestionLoading,
     assistLoadingAction,
+    canUndoAssist,
     editProvenance,
     monitoringNotice, setMonitoringNotice,
     recentNotes,
@@ -1774,6 +1812,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
     reloadNotes,
     suggestTitle,
     runAssistAction,
+    undoAssist,
     toggleNotePinned,
     isVersionConflictError,
     handleVersionConflict,

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { InputRef } from 'antd'
-import { Button } from 'antd'
+import { Button, Modal } from 'antd'
 import type { MessageInstance } from 'antd/es/message/interface'
 import type { QueryClient } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
@@ -426,15 +426,55 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
         await saveNoteRef.current({ showSuccessMessage: false })
         return true
       } catch {
-        // Save failed - fall through to confirmation dialog
+        // Save failed — show 3-button dialog: retry / discard / cancel
+        const retryResult = await new Promise<'saved' | 'discard' | 'cancel'>((resolve) => {
+          const modalRef = Modal.confirm({
+            title: t('option:notesSearch.unsavedChangesTitle', { defaultValue: 'Save changes?' }),
+            content: t('option:notesSearch.unsavedChangesContent', {
+              defaultValue: 'Auto-save could not reach the server. You can try saving again or discard your changes.'
+            }),
+            okText: t('option:notesSearch.retrySave', { defaultValue: 'Try saving again' }),
+            cancelText: t('common:cancel', { defaultValue: 'Cancel' }),
+            okButtonProps: { type: 'primary' },
+            onOk: async () => {
+              try {
+                if (saveNoteRef.current) {
+                  await saveNoteRef.current({ showSuccessMessage: true })
+                }
+                resolve('saved')
+              } catch {
+                // Save still failed — stay on current note
+                resolve('cancel')
+              }
+            },
+            onCancel: () => resolve('cancel'),
+            footer: (_, { OkBtn, CancelBtn }) => (
+              <>
+                <CancelBtn />
+                <Button
+                  danger
+                  onClick={() => {
+                    modalRef.destroy()
+                    resolve('discard')
+                  }}
+                >
+                  {t('option:notesSearch.discardChanges', { defaultValue: 'Discard changes' })}
+                </Button>
+                <OkBtn />
+              </>
+            ),
+          })
+        })
+        return retryResult === 'saved' || retryResult === 'discard'
       }
     }
+    // Fallback for edge cases (empty content or save in progress)
     const ok = await confirmDanger({
       title: t('option:notesSearch.unsavedChangesTitle', { defaultValue: 'Save changes?' }),
       content: t('option:notesSearch.unsavedChangesContent', {
         defaultValue: 'Your changes could not be saved automatically. What would you like to do?'
       }),
-      okText: t('option:notesSearch.discardChanges', { defaultValue: 'Discard' }),
+      okText: t('option:notesSearch.discardChanges', { defaultValue: 'Discard changes' }),
       cancelText: t('common:cancel', { defaultValue: 'Cancel' })
     })
     return ok
@@ -1072,7 +1112,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
         return {
           value: strategy,
           label: t('option:notesSearch.titleStrategyLlm', {
-            defaultValue: 'LLM (quality)'
+            defaultValue: 'AI-powered'
           })
         }
       }
@@ -1080,14 +1120,14 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
         return {
           value: strategy,
           label: t('option:notesSearch.titleStrategyLlmFallback', {
-            defaultValue: 'LLM fallback'
+            defaultValue: 'AI-powered with fallback'
           })
         }
       }
       return {
         value: strategy,
         label: t('option:notesSearch.titleStrategyHeuristic', {
-          defaultValue: 'Heuristic (fast)'
+          defaultValue: 'Quick (from content)'
         })
       }
     })
@@ -1587,7 +1627,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
     }
     if (saveIndicator === 'error') {
       return t('option:notesSearch.autosaveFailed', {
-        defaultValue: 'Autosave failed. Press Save to retry.'
+        defaultValue: 'Could not save — check your connection and try again.'
       })
     }
     if (saveIndicator === 'saved' && !isDirty) {
@@ -1634,7 +1674,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
   const provenanceSummaryText = React.useMemo(() => {
     if (editProvenance.mode === 'manual') {
       return t('option:notesSearch.provenanceManual', {
-        defaultValue: 'Edit source: Manual'
+        defaultValue: 'Origin: Typed manually'
       })
     }
     const actionLabel =
@@ -1645,7 +1685,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
           : t('option:notesSearch.assistSuggestKeywordsAction', { defaultValue: 'Suggest keywords' })
     const generatedAt = new Date(editProvenance.at).toLocaleTimeString()
     const generatedPrefix = t('option:notesSearch.provenanceGeneratedPrefix', {
-      defaultValue: 'Edit source: Generated'
+      defaultValue: 'Origin: AI-generated'
     })
     return `${generatedPrefix} (${actionLabel} at ${generatedAt})`
   }, [editProvenance, t])

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
@@ -1363,7 +1363,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
     const handler = (event: KeyboardEvent) => {
       const lowered = event.key.toLowerCase()
       const hasModifier = event.ctrlKey || event.metaKey
-      if (!hasModifier || lowered !== 's' || event.altKey) return
+      if (!hasModifier || lowered !== 's' || event.altKey || event.shiftKey) return
       if (!isEditorSaveShortcutContext(event.target)) return
       event.preventDefault()
       if (editorDisabled) return

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesEditorState.tsx
@@ -169,6 +169,15 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
   const assistUndoTimerRef = React.useRef<number | null>(null)
   const [canUndoAssist, setCanUndoAssist] = React.useState(false)
 
+  const clearAssistUndoState = React.useCallback(() => {
+    if (assistUndoTimerRef.current != null) {
+      window.clearTimeout(assistUndoTimerRef.current)
+      assistUndoTimerRef.current = null
+    }
+    contentBeforeAssistRef.current = null
+    setCanUndoAssist(false)
+  }, [])
+
   const pinnedNoteIdSet = React.useMemo(() => new Set(pinnedNoteIds), [pinnedNoteIds])
 
   const clearAutosaveTimeout = React.useCallback(() => {
@@ -358,6 +367,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
   }, [])
 
   const loadDetail = React.useCallback(async (id: string | number): Promise<boolean> => {
+    clearAssistUndoState()
     setLoadingDetail(true)
     try {
       const d = await bgRequest<any>({ path: `/api/v1/notes/${id}` as any, method: 'GET' as any })
@@ -400,9 +410,10 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
       message.error('Failed to load note')
       return false
     } finally { setLoadingDetail(false) }
-  }, [applyOfflineDraftToEditor, message, rememberRecentNote, setEditorKeywords])
+  }, [applyOfflineDraftToEditor, clearAssistUndoState, message, rememberRecentNote, setEditorKeywords])
 
   const resetEditor = React.useCallback(() => {
+    clearAssistUndoState()
     setSelectedId(null)
     setTitle('')
     setContent('')
@@ -422,7 +433,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
     setWysiwygHtml('<p><br/></p>')
     setWysiwygSessionDirty(false)
     markdownBeforeWysiwygRef.current = null
-  }, [setEditorKeywords])
+  }, [clearAssistUndoState, setEditorKeywords])
 
   const confirmDiscardIfDirty = React.useCallback(async () => {
     if (!isDirty) return true
@@ -1308,7 +1319,7 @@ export function useNotesEditorState(deps: UseNotesEditorStateDeps) {
 
   const undoAssist = React.useCallback(() => {
     if (contentBeforeAssistRef.current == null) return
-    setContentDirty(contentBeforeAssistRef.current, { provenance: undefined })
+    setContentDirty(contentBeforeAssistRef.current, { provenance: 'manual' })
     contentBeforeAssistRef.current = null
     setCanUndoAssist(false)
     if (assistUndoTimerRef.current != null) {

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesKeywords.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesKeywords.tsx
@@ -311,7 +311,7 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
       setKeywordNoteCountByKey(nextCounts)
       return nextItems
     } catch (error: any) {
-      message.error(String(error?.message || 'Could not load keyword management data'))
+      message.error(String(error?.message || 'Could not load tag management data'))
       return [] as KeywordManagementItem[]
     } finally {
       setKeywordManagerLoading(false)
@@ -367,8 +367,8 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
     async (item: KeywordManagementItem) => {
       if (keywordManagerActionLoading) return
       const ok = await confirmDanger({
-        title: 'Delete keyword?',
-        content: `Delete keyword "${item.keyword}"?`,
+        title: 'Delete tag?',
+        content: `Delete tag "${item.keyword}"?`,
         okText: 'Delete',
         cancelText: 'Cancel'
       })
@@ -383,16 +383,16 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
             'expected-version': String(item.version)
           }
         })
-        message.success(`Deleted keyword "${item.keyword}"`)
+        message.success(`Deleted tag "${item.keyword}"`)
         await refreshKeywordDataAfterManagement()
       } catch (error: any) {
         const statusCode = getRequestStatusCode(error)
         if (statusCode === 404 || statusCode === 409) {
-          message.warning('Keyword changed on the server. Reloaded keyword list.')
+          message.warning('Tag changed on the server. Reloaded tag list.')
           await loadKeywordManagementItems()
           return
         }
-        message.error(String(error?.message || 'Could not delete keyword'))
+        message.error(String(error?.message || 'Could not delete tag'))
       } finally {
         setKeywordManagerActionLoading(false)
       }
@@ -411,7 +411,7 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
     if (!keywordRenameDraft || keywordManagerActionLoading) return
     const nextKeyword = keywordRenameDraft.nextKeyword.trim()
     if (!nextKeyword) {
-      message.warning('Enter a keyword name')
+      message.warning('Enter a tag name')
       return
     }
     if (nextKeyword.toLowerCase() === keywordRenameDraft.currentKeyword.toLowerCase()) {
@@ -433,17 +433,17 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
         }
       })
       setKeywordRenameDraft(null)
-      message.success(`Renamed keyword to "${String(renamed?.keyword || nextKeyword)}"`)
+      message.success(`Renamed tag to "${String(renamed?.keyword || nextKeyword)}"`)
       await refreshKeywordDataAfterManagement()
     } catch (error: any) {
       const statusCode = getRequestStatusCode(error)
       if (statusCode === 404 || statusCode === 409) {
-        message.warning('Keyword rename conflict. Reloaded keyword list.')
+        message.warning('Tag rename conflict. Reloaded tag list.')
         setKeywordRenameDraft(null)
         await loadKeywordManagementItems()
         return
       }
-      message.error(String(error?.message || 'Could not rename keyword'))
+      message.error(String(error?.message || 'Could not rename tag'))
     } finally {
       setKeywordManagerActionLoading(false)
     }
@@ -459,7 +459,7 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
   const submitKeywordMerge = React.useCallback(async () => {
     if (!keywordMergeDraft || keywordManagerActionLoading) return
     if (keywordMergeDraft.targetKeywordId == null) {
-      message.warning('Select a target keyword')
+      message.warning('Select a target tag')
       return
     }
 
@@ -467,7 +467,7 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
       (item) => item.id === keywordMergeDraft.targetKeywordId
     )
     if (!target) {
-      message.warning('Target keyword no longer exists. Reloaded keyword list.')
+      message.warning('Target tag no longer exists. Reloaded tag list.')
       await loadKeywordManagementItems()
       return
     }
@@ -492,12 +492,12 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
     } catch (error: any) {
       const statusCode = getRequestStatusCode(error)
       if (statusCode === 404 || statusCode === 409) {
-        message.warning('Keyword merge conflict. Reloaded keyword list.')
+        message.warning('Tag merge conflict. Reloaded tag list.')
         setKeywordMergeDraft(null)
         await loadKeywordManagementItems()
         return
       }
-      message.error(String(error?.message || 'Could not merge keywords'))
+      message.error(String(error?.message || 'Could not merge tags'))
     } finally {
       setKeywordManagerActionLoading(false)
     }
@@ -533,7 +533,7 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
     if (selectedSuggestions.length === 0) {
       message.warning(
         t('option:notesSearch.assistKeywordsSelectAtLeastOne', {
-          defaultValue: 'Select at least one suggested keyword to apply.'
+          defaultValue: 'Select at least one suggested tag to apply.'
         })
       )
       return
@@ -561,7 +561,7 @@ export function useNotesKeywords(deps: UseNotesKeywordsDeps) {
     closeKeywordSuggestionModal()
     message.success(
       t('option:notesSearch.assistKeywordsApplied', {
-        defaultValue: 'Applied suggested keywords.'
+        defaultValue: 'Applied suggested tags.'
       })
     )
   }, [

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesListManagement.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesListManagement.tsx
@@ -371,7 +371,7 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
         if (!Number.isFinite(id)) return null
         return {
           id: Math.floor(id),
-          name: String(item?.name || "").trim() || `Moodboard ${id}`,
+          name: String(item?.name || "").trim() || `Collection ${id}`,
           description: item?.description ?? null,
           smart_rule: item?.smart_rule ?? null,
           version:
@@ -435,15 +435,15 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
       }
       setListViewMode("moodboard")
       setPage(1)
-      message.success(`Created moodboard "${name}"`)
+      message.success(`Created collection "${name}"`)
     } catch {
-      message.error("Could not create moodboard")
+      message.error("Could not create collection")
     }
   }, [message, refetchMoodboards])
 
   const renameMoodboard = React.useCallback(async () => {
     if (!selectedMoodboard) {
-      message.warning("Select a moodboard first")
+      message.warning("Select a collection first")
       return
     }
     const nextName = await promptModal({
@@ -462,19 +462,19 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
         body: { name: nextName }
       })
       await refetchMoodboards()
-      message.success(`Renamed moodboard to "${nextName}"`)
+      message.success(`Renamed collection to "${nextName}"`)
     } catch {
-      message.error("Could not rename moodboard")
+      message.error("Could not rename collection")
     }
   }, [message, refetchMoodboards, selectedMoodboard])
 
   const deleteMoodboard = React.useCallback(async () => {
     if (!selectedMoodboard) {
-      message.warning("Select a moodboard first")
+      message.warning("Select a collection first")
       return
     }
     const ok = await confirmDanger({
-      title: "Delete moodboard?",
+      title: "Delete collection?",
       content: `Delete "${selectedMoodboard.name}"?`,
       okText: "Delete",
       cancelText: "Cancel"
@@ -489,9 +489,9 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
       })
       await refetchMoodboards()
       setPage(1)
-      message.success("Moodboard deleted")
+      message.success("Collection deleted")
     } catch {
-      message.error("Could not delete moodboard")
+      message.error("Could not delete collection")
     }
   }, [confirmDanger, message, refetchMoodboards, selectedMoodboard])
 
@@ -598,7 +598,7 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
   const createNotebookFromCurrentKeywords = React.useCallback(async () => {
     const normalizedKeywords = normalizeNotebookKeywords(keywordTokens)
     if (normalizedKeywords.length === 0) {
-      message.info('Select at least one keyword before saving a notebook.')
+      message.info('Select at least one tag before saving a filter.')
       return
     }
     if (typeof window === 'undefined') return
@@ -615,7 +615,7 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
 
     const notebookName = normalizeNotebookName(rawName)
     if (!notebookName) {
-      message.warning('Smart collection name cannot be empty.')
+      message.warning('Saved filter name cannot be empty.')
       return
     }
 
@@ -653,7 +653,7 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
     }
     setKeywordTokens([])
     setPage(1)
-    message.success(`Saved smart collection "${notebookName}"`)
+    message.success(`Saved filter "${notebookName}"`)
 
     if (isOnline && selectedNotebookAfterSave) {
       try {
@@ -675,7 +675,7 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
           setSelectedNotebookId(persisted.id)
         }
       } catch {
-        message.warning('Saved locally, but failed to sync notebook to server.')
+        message.warning('Saved locally, but failed to sync saved filter to server.')
       }
     }
   }, [isOnline, keywordTokens, message, notebookOptions, setKeywordTokens, upsertNotebookOnServer])
@@ -689,8 +689,8 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
       return
     }
     const ok = await confirmDanger({
-      title: 'Remove notebook?',
-      content: `Remove "${notebookToRemove.name}" from notebook filters? This does not delete any notes.`,
+      title: 'Remove saved filter?',
+      content: `Remove "${notebookToRemove.name}" from saved filters? This does not delete any notes.`,
       okText: 'Remove',
       cancelText: 'Cancel'
     })
@@ -700,12 +700,12 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
     )
     setSelectedNotebookId(null)
     setPage(1)
-    message.success(`Removed notebook "${notebookToRemove.name}"`)
+    message.success(`Removed saved filter "${notebookToRemove.name}"`)
     if (isOnline) {
       try {
         await deleteNotebookOnServer(notebookToRemove.id)
       } catch {
-        message.warning('Removed locally, but failed to remove notebook on server.')
+        message.warning('Removed locally, but failed to remove saved filter on server.')
       }
     }
   }, [confirmDanger, deleteNotebookOnServer, isOnline, message, notebookOptions, selectedNotebookId])

--- a/apps/packages/ui/src/components/Notes/hooks/useNotesListManagement.tsx
+++ b/apps/packages/ui/src/components/Notes/hooks/useNotesListManagement.tsx
@@ -30,6 +30,7 @@ import {
   normalizeNotebookCollectionsResponse,
   buildNotebookDefaultName,
   NOTE_SEARCH_DEBOUNCE_MS,
+  promptModal,
 } from '../notes-manager-utils'
 import type { ConfirmDangerOptions } from '@/components/Common/confirm-danger'
 
@@ -415,7 +416,11 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
   }, [moodboards, selectedMoodboardId])
 
   const createMoodboard = React.useCallback(async () => {
-    const name = String(window.prompt("Moodboard name") || "").trim()
+    const name = await promptModal({
+      title: 'Create collection',
+      placeholder: 'Collection name',
+      okText: 'Create',
+    })
     if (!name) return
     try {
       const created = await bgRequest<any>({
@@ -441,7 +446,12 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
       message.warning("Select a moodboard first")
       return
     }
-    const nextName = String(window.prompt("Rename moodboard", selectedMoodboard.name) || "").trim()
+    const nextName = await promptModal({
+      title: 'Rename collection',
+      defaultValue: selectedMoodboard.name,
+      placeholder: 'Collection name',
+      okText: 'Rename',
+    })
     if (!nextName || nextName === selectedMoodboard.name) return
     const expectedVersion = selectedMoodboard.version ?? 1
     try {
@@ -594,7 +604,13 @@ export function useNotesListManagement(deps: UseNotesListManagementDeps) {
     if (typeof window === 'undefined') return
 
     const defaultName = buildNotebookDefaultName(normalizedKeywords)
-    const rawName = window.prompt('Smart collection name', defaultName)
+    const rawName = await promptModal({
+      title: 'Save filter',
+      label: 'Save the current tag filters as a reusable preset.',
+      defaultValue: defaultName,
+      placeholder: 'Filter name',
+      okText: 'Save',
+    })
     if (rawName == null) return
 
     const notebookName = normalizeNotebookName(rawName)

--- a/apps/packages/ui/src/components/Notes/notes-manager-utils.ts
+++ b/apps/packages/ui/src/components/Notes/notes-manager-utils.ts
@@ -1,8 +1,12 @@
 import React from 'react'
 import { Modal, Input } from 'antd'
 import type { NotesTitleSuggestStrategy, NotesNotebookSetting } from '@/services/settings/ui-settings'
+import { createSafeStorage } from '@/utils/safe-storage'
 import type { NotesStudioHandwritingMode, NotesStudioTemplateType } from './notes-studio-types'
 import type { NoteListItem } from './types'
+
+export const NOTES_TUTORIAL_SHOWN_STORAGE_KEY = 'notes-tutorial-shown'
+export const notesUiStorage = createSafeStorage({ area: 'local' })
 
 /**
  * Replacement for window.prompt() using Ant Design modal.
@@ -18,6 +22,12 @@ export function promptModal(options: {
 }): Promise<string | null> {
   return new Promise((resolve) => {
     let currentValue = options.defaultValue ?? ''
+    let settled = false
+    const finish = (value: string | null) => {
+      if (settled) return
+      settled = true
+      resolve(value)
+    }
     const modal = Modal.confirm({
       title: options.title,
       icon: null,
@@ -32,14 +42,14 @@ export function promptModal(options: {
           onChange: (e: React.ChangeEvent<HTMLInputElement>) => { currentValue = e.target.value },
           onPressEnter: () => {
             modal.destroy()
-            resolve(currentValue.trim() || null)
+            finish(currentValue.trim())
           },
         }),
       ),
       okText: options.okText ?? 'OK',
       cancelText: options.cancelText ?? 'Cancel',
-      onOk: () => resolve(currentValue.trim() || null),
-      onCancel: () => resolve(null),
+      onOk: () => finish(currentValue.trim()),
+      onCancel: () => finish(null),
     })
   })
 }

--- a/apps/packages/ui/src/components/Notes/notes-manager-utils.ts
+++ b/apps/packages/ui/src/components/Notes/notes-manager-utils.ts
@@ -1,6 +1,48 @@
+import React from 'react'
+import { Modal, Input } from 'antd'
 import type { NotesTitleSuggestStrategy, NotesNotebookSetting } from '@/services/settings/ui-settings'
 import type { NotesStudioHandwritingMode, NotesStudioTemplateType } from './notes-studio-types'
 import type { NoteListItem } from './types'
+
+/**
+ * Replacement for window.prompt() using Ant Design modal.
+ * Returns the entered string, or null if cancelled.
+ */
+export function promptModal(options: {
+  title: string
+  label?: string
+  defaultValue?: string
+  placeholder?: string
+  okText?: string
+  cancelText?: string
+}): Promise<string | null> {
+  return new Promise((resolve) => {
+    let currentValue = options.defaultValue ?? ''
+    const modal = Modal.confirm({
+      title: options.title,
+      icon: null,
+      content: React.createElement('div', { className: 'mt-2' },
+        options.label
+          ? React.createElement('div', { className: 'mb-1 text-xs text-text-muted' }, options.label)
+          : null,
+        React.createElement(Input, {
+          autoFocus: true,
+          defaultValue: currentValue,
+          placeholder: options.placeholder,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => { currentValue = e.target.value },
+          onPressEnter: () => {
+            modal.destroy()
+            resolve(currentValue.trim() || null)
+          },
+        }),
+      ),
+      okText: options.okText ?? 'OK',
+      cancelText: options.cancelText ?? 'Cancel',
+      onOk: () => resolve(currentValue.trim() || null),
+      onCancel: () => resolve(null),
+    })
+  })
+}
 
 export type NoteWithKeywords = {
   metadata?: { keywords?: any[] }

--- a/apps/packages/ui/src/tutorials/__tests__/p1-target-contracts.test.ts
+++ b/apps/packages/ui/src/tutorials/__tests__/p1-target-contracts.test.ts
@@ -181,21 +181,32 @@ describe("P0/P1 tutorial selector contracts", () => {
   })
 
   it("keeps required notes tutorial anchors in source", () => {
-    const managerContent = readSource("components/Notes/NotesManagerPage.tsx")
     const headerContent = readSource("components/Notes/NotesEditorHeader.tsx")
-    const managerAnchors = [
+    const editorPaneContent = readSource("components/Notes/NotesEditorPane.tsx")
+    const sidebarContent = readSource("components/Notes/NotesSidebar.tsx")
+
+    // Sidebar anchors
+    const sidebarAnchors = [
       'data-testid="notes-list-region"',
       'data-testid="notes-mode-active"',
       'data-testid="notes-mode-trash"',
       'data-testid="notes-sort-select"',
-      'data-testid="notes-notebook-select"',
-      'data-testid="notes-editor-region"'
+      'data-testid="notes-notebook-select"'
     ]
-
-    for (const anchor of managerAnchors) {
-      expect(managerContent).toContain(anchor)
+    for (const anchor of sidebarAnchors) {
+      expect(sidebarContent).toContain(anchor)
     }
+
+    // Editor pane anchors
+    expect(editorPaneContent).toContain('data-testid="notes-editor-region"')
+    expect(editorPaneContent).toContain('data-testid="notes-keywords-editor"')
+    expect(editorPaneContent).toContain('testId="notes-section-connections"')
+
+    // Header anchors
     expect(headerContent).toContain('data-testid="notes-save-button"')
+
+    // Organize section anchor
+    expect(sidebarContent).toContain('testId="notes-section-organize"')
   })
 
   it("keeps required flashcards tutorial anchors in source", () => {

--- a/apps/packages/ui/src/tutorials/definitions/notes.ts
+++ b/apps/packages/ui/src/tutorials/definitions/notes.ts
@@ -41,7 +41,7 @@ const notesBasics: TutorialDefinition = {
       titleFallback: "Sort and Filter",
       contentKey: "tutorials:notes.basics.filtersContent",
       contentFallback:
-        "Sort by date/title and use notebook/keyword filters to narrow your working set.",
+        "Sort by date/title and use saved filter or tag filters to narrow your working set.",
       placement: "bottom"
     },
     {

--- a/apps/packages/ui/src/tutorials/definitions/notes.ts
+++ b/apps/packages/ui/src/tutorials/definitions/notes.ts
@@ -61,6 +61,33 @@ const notesBasics: TutorialDefinition = {
       contentFallback:
         "Save updates, duplicate notes, export content, and run helper actions from the header.",
       placement: "bottom"
+    },
+    {
+      target: '[data-testid="notes-keywords-editor"]',
+      titleKey: "tutorials:notes.basics.tagsTitle",
+      titleFallback: "Tags",
+      contentKey: "tutorials:notes.basics.tagsContent",
+      contentFallback:
+        "Add tags to organize your notes. Use the filter in the sidebar to find notes by tag.",
+      placement: "bottom"
+    },
+    {
+      target: '[data-testid="notes-section-connections"]',
+      titleKey: "tutorials:notes.basics.connectionsTitle",
+      titleFallback: "Note Connections",
+      contentKey: "tutorials:notes.basics.connectionsContent",
+      contentFallback:
+        "See how notes relate to each other. Type [[ in a note to create a link, or add manual connections here.",
+      placement: "left"
+    },
+    {
+      target: '[data-testid="notes-section-organize"]',
+      titleKey: "tutorials:notes.basics.organizeTitle",
+      titleFallback: "Collections and Filters",
+      contentKey: "tutorials:notes.basics.organizeContent",
+      contentFallback:
+        "Group notes into collections, or save tag filters for quick access to related notes.",
+      placement: "bottom"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Complete the remaining /notes NNG UX audit fixes (Rounds 3-6)
- Unify terminology: Keywords→Tags, Smart collection→Saved filter (106 string replacements)
- Add progressive disclosure to reduce information density
- Expand help infrastructure with info icons, tutorial steps, and contextual tooltips
- Add keyboard shortcuts, mobile editor mode, touch targets, and AI undo

## Changes

**Round 3 — Terminology (N4, N6, N14, X2):**
- 106 `defaultValue` string replacements across 10 source files
- "Keywords" → "Tags", "Smart collection" → "Saved filter", "Moodboard" → "Collection"
- Frontend-only — API/code names unchanged

**Round 4 — Progressive disclosure (N16, N27, N28, X1):**
- Sidebar Collection/Saved filter controls collapsed behind "Organize" expander (default closed)
- Editor graph/relations panels wrapped in "Connections" collapsible
- New editor empty state with welcome panel, create button, and wikilink tip

**Round 5 — Help infrastructure (N9, N21, N22, N23, N35, N36, N37, X3):**
- HelpCircle info icons with tooltips on Connections, Organize, and Tags sections
- Tutorial expanded from 5 → 8 steps (Tags, Connections, Collections)
- Wikilink syntax hint in editor empty state

**Round 6 — Keyboard, mobile, AI undo (N11, N24, X4, X5):**
- New shortcuts: Alt+N (new note), Ctrl+K (search), Ctrl+Shift+E/S/P (editor modes)
- Mobile: editor mode toggle in overflow menu (was completely hidden)
- Mobile: 44px touch targets on bulk action buttons
- AI undo button appears for 30s after AI assist actions

**Files changed:** 26 files, +421/-137 lines

## Test plan

- [x] `NotesEditorHeader.stage2.touch-layout` — 4/4 passing
- [x] `NotesGraphModal.stage2.graph-view` — 5/5 passing
- [x] `NotesManagerPage.stage42.moodboard-view` — tests passing
- [x] `NotesManagerPage.stage16.bulk-actions` — tests passing
- [x] Tutorial anchor contract tests updated for 3 new steps
- [x] 12 test files updated for new terminology
- [ ] Manual smoke test: verify collapsed sections, info icons, keyboard shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)