### PR TITLE
feat: Scion-inspired improvements — templates, policy conditions, multiplexer

### DIFF
--- a/tldw_Server_API/app/api/v1/endpoints/acp_multiplex.py
+++ b/tldw_Server_API/app/api/v1/endpoints/acp_multiplex.py
@@ -1,0 +1,49 @@
+"""ACP Multiplex sub-module.
+
+Provides a single WebSocket endpoint that multiplexes event streams for
+multiple agent sessions over one connection.
+
+``WS /acp/multiplex`` -- send ``STREAM_OPEN`` / ``STREAM_CLOSE`` frames to
+subscribe / unsubscribe from session event buses.  Events arrive as
+``STREAM_DATA`` frames.  30-second ``PING`` / ``PONG`` keepalive.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.endpoints.agent_client_protocol import get_session_event_bus
+from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.manager import MultiplexManager
+
+router = APIRouter(prefix="/acp", tags=["acp-multiplex"])
+
+
+@router.websocket("/multiplex")
+async def acp_multiplex_ws(websocket: WebSocket) -> None:
+    """Multi-session event multiplexer.
+
+    Accepts a WebSocket, creates a :class:`MultiplexManager` backed by the
+    shared session event-bus registry, and loops reading client frames until
+    disconnect.
+    """
+    await websocket.accept()
+    connection_id = uuid.uuid4().hex[:12]
+    logger.info("Multiplex WS connected: {}", connection_id)
+
+    manager = MultiplexManager(
+        connection_id=connection_id,
+        send_fn=websocket.send_text,
+        get_bus_fn=get_session_event_bus,
+    )
+    manager.start()
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            await manager.handle_message(raw)
+    except WebSocketDisconnect:
+        logger.info("Multiplex WS disconnected: {}", connection_id)
+    finally:
+        await manager.stop()

--- a/tldw_Server_API/app/api/v1/endpoints/acp_multiplex.py
+++ b/tldw_Server_API/app/api/v1/endpoints/acp_multiplex.py
@@ -9,40 +9,117 @@ subscribe / unsubscribe from session event buses.  Events arrive as
 """
 from __future__ import annotations
 
+import contextlib
 import uuid
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.endpoints.agent_client_protocol import get_session_event_bus
+from tldw_Server_API.app.api.v1.endpoints.agent_client_protocol import (
+    _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS,
+    _acp_ws_release_quota,
+    _acp_ws_try_acquire_quota,
+    _authenticate_ws,
+    _require_session_access,
+    _resolve_acp_session_persona_id,
+    get_runner_client,
+    get_session_event_bus,
+)
 from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.manager import MultiplexManager
+from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.protocol import MultiplexMessage
 
 router = APIRouter(prefix="/acp", tags=["acp-multiplex"])
 
 
 @router.websocket("/multiplex")
-async def acp_multiplex_ws(websocket: WebSocket) -> None:
+async def acp_multiplex_ws(
+    websocket: WebSocket,
+    token: str | None = Query(None),
+    api_key: str | None = Query(None),
+) -> None:
     """Multi-session event multiplexer.
 
     Accepts a WebSocket, creates a :class:`MultiplexManager` backed by the
     shared session event-bus registry, and loops reading client frames until
     disconnect.
     """
+    user_id = await _authenticate_ws(
+        websocket,
+        token=token,
+        api_key=api_key,
+        required_scope="write",
+    )
+    if user_id is None:
+        with contextlib.suppress(_ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS):
+            await websocket.close(code=4401)
+        return
+
+    try:
+        client = await get_runner_client()
+    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning("Multiplex WS runner client unavailable: {}", exc)
+        with contextlib.suppress(_ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS):
+            await websocket.close(code=4404)
+        return
+
     await websocket.accept()
     connection_id = uuid.uuid4().hex[:12]
     logger.info("Multiplex WS connected: {}", connection_id)
+
+    async def _authorize_stream(
+        stream_id: str,
+    ) -> tuple[bool, str | None, dict[str, str | None] | None]:
+        try:
+            await _require_session_access(client, session_id=stream_id, user_id=int(user_id))
+        except HTTPException:
+            return False, "Unknown session or access denied", None
+        except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(
+                "Multiplex WS {} access check failed for stream {}: {}",
+                connection_id,
+                stream_id,
+                exc,
+            )
+            return False, "Unable to authorize stream", None
+
+        persona_id = await _resolve_acp_session_persona_id(
+            client,
+            session_id=stream_id,
+            user_id=int(user_id),
+        )
+        quota_token, _quota_reason = _acp_ws_try_acquire_quota(
+            user_id=int(user_id),
+            session_id=stream_id,
+            persona_id=persona_id,
+        )
+        if quota_token is None:
+            return False, "ACP WebSocket quota exceeded", None
+        return True, None, quota_token
+
+    def _release_stream(stream_id: str, quota_token: dict[str, str | None] | None) -> None:
+        del stream_id
+        _acp_ws_release_quota(quota_token)
 
     manager = MultiplexManager(
         connection_id=connection_id,
         send_fn=websocket.send_text,
         get_bus_fn=get_session_event_bus,
+        authorize_stream_fn=_authorize_stream,
+        release_stream_fn=_release_stream,
     )
     manager.start()
 
     try:
         while True:
             raw = await websocket.receive_text()
-            await manager.handle_message(raw)
+            try:
+                await manager.handle_message(raw)
+            except Exception:
+                logger.exception("Multiplex WS {} handler failure", connection_id)
+                with contextlib.suppress(_ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS):
+                    await websocket.send_text(
+                        MultiplexMessage.error("Internal multiplex error").to_json()
+                    )
     except WebSocketDisconnect:
         logger.info("Multiplex WS disconnected: {}", connection_id)
     finally:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -20,6 +20,10 @@ from loguru import logger
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
 from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.policy_conditions import (
+    PolicyConditions,
+    evaluate_conditions,
+)
 from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
 from tldw_Server_API.app.core.Agent_Client_Protocol.tool_gate import ToolGate, ToolGateResult
 
@@ -100,20 +104,16 @@ class GovernanceFilter:
         if not doc or not isinstance(doc, dict):
             return None
 
-        # 0. Evaluate policy conditions -- if they fail the policy doesn't apply
-        from tldw_Server_API.app.core.Agent_Client_Protocol.policy_conditions import (
-            PolicyConditions,
-            evaluate_conditions,
-        )
-
         conditions = PolicyConditions.from_dict(doc.get("conditions"))
         if not conditions.is_empty():
             resource_labels = self._session_metadata.get("labels", {})
             ancestry_chain = self._session_metadata.get("ancestry_chain", [])
+            source_ip = self._session_metadata.get("client_ip")
             if not evaluate_conditions(
                 conditions,
                 resource_labels=resource_labels,
                 ancestry_chain=ancestry_chain,
+                source_ip=source_ip,
             ):
                 return None  # Conditions failed, policy doesn't apply
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -100,6 +100,23 @@ class GovernanceFilter:
         if not doc or not isinstance(doc, dict):
             return None
 
+        # 0. Evaluate policy conditions -- if they fail the policy doesn't apply
+        from tldw_Server_API.app.core.Agent_Client_Protocol.policy_conditions import (
+            PolicyConditions,
+            evaluate_conditions,
+        )
+
+        conditions = PolicyConditions.from_dict(doc.get("conditions"))
+        if not conditions.is_empty():
+            resource_labels = self._session_metadata.get("labels", {})
+            ancestry_chain = self._session_metadata.get("ancestry_chain", [])
+            if not evaluate_conditions(
+                conditions,
+                resource_labels=resource_labels,
+                ancestry_chain=ancestry_chain,
+            ):
+                return None  # Conditions failed, policy doesn't apply
+
         # 1. Check denied_tools (highest priority)
         for pattern in doc.get("denied_tools", []):
             if fnmatch.fnmatch(tool_name, pattern):

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/merge_utils.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/merge_utils.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+_MISSING = object()
+
 # Keys whose values are treated as lists and merged via append+dedup.
 UNION_LIST_KEYS: frozenset[str] = frozenset({
     "allowed_tools",
@@ -59,26 +61,37 @@ def _as_dict(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
 
 
-def merge_config(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+def merge_config(
+    base: dict[str, Any],
+    overlay: dict[str, Any],
+    *,
+    skip_none: bool = True,
+) -> dict[str, Any]:
     """Merge *overlay* on top of *base* with field-type-aware semantics.
 
     Rules:
-    1. ``None`` values in *overlay* are skipped (base value preserved).
+    1. ``None`` values in *overlay* are skipped when ``skip_none`` is true.
     2. Keys in :data:`UNION_LIST_KEYS` are appended and de-duplicated.
     3. If both sides are dicts the merge recurses.
     4. Everything else: overlay value replaces base value (deep-copied).
 
     Neither *base* nor *overlay* is mutated.
     """
-    merged = deepcopy(base)
+    merged = dict(base)
     for key, value in overlay.items():
-        if value is None:
+        base_value = base.get(key, _MISSING)
+        if value is None and skip_none:
+            if base_value is not _MISSING:
+                merged[key] = deepcopy(base_value)
             continue
         if key in UNION_LIST_KEYS:
-            merged[key] = _unique(_as_str_list(merged.get(key)) + _as_str_list(value))
+            merged[key] = _unique(_as_str_list(base_value) + _as_str_list(value))
             continue
-        if isinstance(merged.get(key), dict) and isinstance(value, dict):
-            merged[key] = merge_config(_as_dict(merged.get(key)), value)
+        if isinstance(base_value, dict) and isinstance(value, dict):
+            merged[key] = merge_config(base_value, value, skip_none=skip_none)
             continue
         merged[key] = deepcopy(value)
+    for key, value in base.items():
+        if key not in overlay:
+            merged[key] = deepcopy(value)
     return merged

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/merge_utils.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/merge_utils.py
@@ -1,0 +1,84 @@
+"""Field-type-aware config merging utilities.
+
+Shared logic extracted from ``mcp_hub_policy_resolver._merge_policy_documents``
+so that both the policy resolver and the template inheritance system can reuse
+the same semantics:
+
+* **Scalars** in *overlay* override values in *base*.
+* **Dicts** are merged recursively.
+* **Union-list keys** (e.g. ``allowed_tools``, ``capabilities``) are appended
+  with deduplication.
+* ``None`` values in *overlay* are silently skipped (the base value is kept).
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+# Keys whose values are treated as lists and merged via append+dedup.
+UNION_LIST_KEYS: frozenset[str] = frozenset({
+    "allowed_tools",
+    "denied_tools",
+    "tool_names",
+    "tool_patterns",
+    "capabilities",
+    "tool_modules",
+    "module_ids",
+})
+
+
+def _as_str_list(value: Any) -> list[str]:
+    """Normalize a scalar or iterable value into a list of non-empty strings."""
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    out: list[str] = []
+    for entry in value:
+        cleaned = str(entry or "").strip()
+        if cleaned:
+            out.append(cleaned)
+    return out
+
+
+def _unique(items: list[str]) -> list[str]:
+    """Preserve order while removing duplicate strings."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Return a shallow dict copy for mapping values, otherwise an empty dict."""
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def merge_config(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge *overlay* on top of *base* with field-type-aware semantics.
+
+    Rules:
+    1. ``None`` values in *overlay* are skipped (base value preserved).
+    2. Keys in :data:`UNION_LIST_KEYS` are appended and de-duplicated.
+    3. If both sides are dicts the merge recurses.
+    4. Everything else: overlay value replaces base value (deep-copied).
+
+    Neither *base* nor *overlay* is mutated.
+    """
+    merged = deepcopy(base)
+    for key, value in overlay.items():
+        if value is None:
+            continue
+        if key in UNION_LIST_KEYS:
+            merged[key] = _unique(_as_str_list(merged.get(key)) + _as_str_list(value))
+            continue
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = merge_config(_as_dict(merged.get(key)), value)
+            continue
+        merged[key] = deepcopy(value)
+    return merged

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/__init__.py
@@ -1,0 +1,4 @@
+from .protocol import MultiplexMessage, MultiplexMessageType
+from .manager import MultiplexManager
+
+__all__ = ["MultiplexMessage", "MultiplexMessageType", "MultiplexManager"]

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/__init__.py
@@ -1,4 +1,10 @@
-from .protocol import MultiplexMessage, MultiplexMessageType
-from .manager import MultiplexManager
+"""Public exports for ACP multiplexing primitives.
 
-__all__ = ["MultiplexMessage", "MultiplexMessageType", "MultiplexManager"]
+This package re-exports the multiplex protocol types and manager used by the
+ACP multi-session WebSocket endpoint.
+"""
+
+from .manager import MultiplexManager
+from .protocol import MultiplexMessage, MultiplexMessageType
+
+__all__ = ["MultiplexManager", "MultiplexMessage", "MultiplexMessageType"]

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/manager.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/manager.py
@@ -1,0 +1,247 @@
+"""MultiplexManager -- manages one client's multiplexed WebSocket connection.
+
+Allows a single WebSocket to carry events for multiple agent sessions.
+Each session is identified by a *stream_id* (== session_id).  The client
+sends ``STREAM_OPEN`` / ``STREAM_CLOSE`` to subscribe / unsubscribe.
+Events are forwarded as ``STREAM_DATA`` frames.  A periodic ``PING`` /
+``PONG`` keepalive keeps the connection alive through proxies.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Callable, Awaitable, Optional
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.protocol import (
+    MultiplexMessage,
+    MultiplexMessageType,
+)
+
+# Type aliases for the two callables injected at construction time.
+SendFn = Callable[[str], Awaitable[None]]
+GetBusFn = Callable[[str], Optional[SessionEventBus]]
+
+
+class MultiplexManager:
+    """Manages stream subscriptions and keepalive for one WebSocket client.
+
+    Parameters
+    ----------
+    connection_id:
+        Human-readable identifier for logging.
+    send_fn:
+        ``async (str) -> None`` -- sends a text frame over the WebSocket.
+    get_bus_fn:
+        ``(session_id) -> SessionEventBus | None`` -- looks up a session's
+        event bus.  Returns ``None`` when the session is unknown.
+    ping_interval:
+        Seconds between keepalive ``PING`` frames.  Set to ``0`` to disable.
+    """
+
+    def __init__(
+        self,
+        connection_id: str,
+        send_fn: SendFn,
+        get_bus_fn: GetBusFn,
+        ping_interval: float = 30,
+    ) -> None:
+        self._connection_id = connection_id
+        self._send_fn = send_fn
+        self._get_bus_fn = get_bus_fn
+        self._ping_interval = ping_interval
+
+        # stream_id -> {bus, consumer_id, task}
+        self._streams: dict[str, dict[str, Any]] = {}
+        self._ping_task: Optional[asyncio.Task[None]] = None
+        self._stopped = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background ping loop (if interval > 0)."""
+        if self._ping_interval > 0:
+            self._ping_task = asyncio.ensure_future(self._ping_loop())
+
+    async def stop(self) -> None:
+        """Close all streams and cancel the ping task."""
+        self._stopped = True
+        # Cancel ping first
+        if self._ping_task is not None:
+            self._ping_task.cancel()
+            with _suppress_cancelled():
+                await self._ping_task
+            self._ping_task = None
+
+        # Close every open stream
+        stream_ids = list(self._streams.keys())
+        for sid in stream_ids:
+            await self._close_stream(sid)
+
+    # ------------------------------------------------------------------
+    # Message dispatch
+    # ------------------------------------------------------------------
+
+    async def handle_message(self, raw: str) -> None:
+        """Parse *raw* JSON and dispatch by message type."""
+        try:
+            msg = MultiplexMessage.from_json(raw)
+        except (json.JSONDecodeError, ValueError, KeyError) as exc:
+            logger.warning(
+                "Multiplex {}: invalid message: {}", self._connection_id, exc,
+            )
+            await self._send(MultiplexMessage.error(f"Invalid message: {exc}"))
+            return
+
+        dispatch = {
+            MultiplexMessageType.STREAM_OPEN: self._open_stream,
+            MultiplexMessageType.STREAM_CLOSE: self._handle_close,
+            MultiplexMessageType.PING: self._handle_ping,
+            MultiplexMessageType.PONG: self._handle_pong,
+        }
+        handler = dispatch.get(msg.type)
+        if handler is not None:
+            await handler(msg)
+        else:
+            await self._send(
+                MultiplexMessage.error(f"Unsupported message type: {msg.type.value}"),
+            )
+
+    # ------------------------------------------------------------------
+    # Stream management
+    # ------------------------------------------------------------------
+
+    async def _open_stream(self, msg: MultiplexMessage) -> None:
+        """Subscribe to a session's event bus and start forwarding."""
+        stream_id = msg.stream_id
+        if stream_id is None:
+            await self._send(MultiplexMessage.error("stream_open requires stream_id"))
+            return
+
+        if stream_id in self._streams:
+            # Already subscribed -- idempotent
+            return
+
+        bus = self._get_bus_fn(stream_id)
+        if bus is None:
+            await self._send(
+                MultiplexMessage.error(f"Unknown session: {stream_id}", stream_id=stream_id),
+            )
+            return
+
+        last_sequence = 0
+        if msg.payload and "last_sequence" in msg.payload:
+            last_sequence = int(msg.payload["last_sequence"])
+
+        consumer_id = f"mpx-{self._connection_id}-{stream_id}"
+        queue = bus.subscribe(consumer_id, from_sequence=last_sequence)
+        task = asyncio.ensure_future(self._forward_events(stream_id, queue))
+
+        self._streams[stream_id] = {
+            "bus": bus,
+            "consumer_id": consumer_id,
+            "task": task,
+        }
+        logger.debug(
+            "Multiplex {}: opened stream {} (last_seq={})",
+            self._connection_id,
+            stream_id,
+            last_sequence,
+        )
+
+    async def _handle_close(self, msg: MultiplexMessage) -> None:
+        """Handle a STREAM_CLOSE request."""
+        stream_id = msg.stream_id
+        if stream_id is None:
+            await self._send(MultiplexMessage.error("stream_close requires stream_id"))
+            return
+        await self._close_stream(stream_id)
+
+    async def _close_stream(self, stream_id: str) -> None:
+        """Unsubscribe from a session's event bus and cancel the forwarding task."""
+        info = self._streams.pop(stream_id, None)
+        if info is None:
+            return
+
+        # Unsubscribe from the bus
+        bus: SessionEventBus = info["bus"]
+        bus.unsubscribe(info["consumer_id"])
+
+        # Cancel the forwarding task
+        task: asyncio.Task[None] = info["task"]
+        task.cancel()
+        with _suppress_cancelled():
+            await task
+
+        logger.debug("Multiplex {}: closed stream {}", self._connection_id, stream_id)
+
+    # ------------------------------------------------------------------
+    # Event forwarding
+    # ------------------------------------------------------------------
+
+    async def _forward_events(self, stream_id: str, queue: asyncio.Queue) -> None:  # type: ignore[type-arg]
+        """Read events from *queue* and send as STREAM_DATA frames."""
+        try:
+            while not self._stopped:
+                event = await queue.get()
+                data_msg = MultiplexMessage.stream_data(stream_id, event.to_dict())
+                await self._send(data_msg)
+        except asyncio.CancelledError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Keepalive
+    # ------------------------------------------------------------------
+
+    async def _ping_loop(self) -> None:
+        """Periodically send PING frames."""
+        try:
+            while not self._stopped:
+                await asyncio.sleep(self._ping_interval)
+                if self._stopped:
+                    break
+                await self._send(MultiplexMessage.ping())
+        except asyncio.CancelledError:
+            pass
+
+    async def _handle_ping(self, msg: MultiplexMessage) -> None:
+        """Respond to client PING with PONG."""
+        await self._send(MultiplexMessage.pong())
+
+    async def _handle_pong(self, msg: MultiplexMessage) -> None:
+        """Client acknowledged our PING -- nothing to do."""
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def active_streams(self) -> list[str]:
+        """Return currently subscribed stream IDs."""
+        return list(self._streams.keys())
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _send(self, msg: MultiplexMessage) -> None:
+        """Serialize and send a message via the injected send function."""
+        await self._send_fn(msg.to_json())
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+class _suppress_cancelled:
+    """Tiny context manager that swallows ``CancelledError``."""
+
+    def __enter__(self) -> _suppress_cancelled:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, tb: Any) -> bool:
+        return exc_type is asyncio.CancelledError

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/manager.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/manager.py
@@ -9,8 +9,9 @@ Events are forwarded as ``STREAM_DATA`` frames.  A periodic ``PING`` /
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
-from typing import Any, Callable, Awaitable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from loguru import logger
 
@@ -23,6 +24,8 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.protocol import (
 # Type aliases for the two callables injected at construction time.
 SendFn = Callable[[str], Awaitable[None]]
 GetBusFn = Callable[[str], Optional[SessionEventBus]]
+AuthorizeStreamFn = Callable[[str], Awaitable[tuple[bool, str | None, Any | None]]]
+ReleaseStreamFn = Callable[[str, Any | None], None | Awaitable[None]]
 
 
 class MultiplexManager:
@@ -46,14 +49,18 @@ class MultiplexManager:
         connection_id: str,
         send_fn: SendFn,
         get_bus_fn: GetBusFn,
+        authorize_stream_fn: AuthorizeStreamFn | None = None,
+        release_stream_fn: ReleaseStreamFn | None = None,
         ping_interval: float = 30,
     ) -> None:
         self._connection_id = connection_id
         self._send_fn = send_fn
         self._get_bus_fn = get_bus_fn
+        self._authorize_stream_fn = authorize_stream_fn
+        self._release_stream_fn = release_stream_fn
         self._ping_interval = ping_interval
 
-        # stream_id -> {bus, consumer_id, task}
+        # stream_id -> {bus, consumer_id, task, release_state}
         self._streams: dict[str, dict[str, Any]] = {}
         self._ping_task: Optional[asyncio.Task[None]] = None
         self._stopped = False
@@ -72,9 +79,7 @@ class MultiplexManager:
         self._stopped = True
         # Cancel ping first
         if self._ping_task is not None:
-            self._ping_task.cancel()
-            with _suppress_cancelled():
-                await self._ping_task
+            await self._cancel_task(self._ping_task, label="ping loop")
             self._ping_task = None
 
         # Close every open stream
@@ -126,16 +131,53 @@ class MultiplexManager:
             # Already subscribed -- idempotent
             return
 
+        if msg.payload is not None and not isinstance(msg.payload, dict):
+            await self._send(
+                MultiplexMessage.error("stream_open payload must be an object", stream_id=stream_id),
+            )
+            return
+
         bus = self._get_bus_fn(stream_id)
+
+        last_sequence = 0
+        if isinstance(msg.payload, dict) and "last_sequence" in msg.payload:
+            try:
+                last_sequence = int(msg.payload["last_sequence"])
+            except (TypeError, ValueError):
+                await self._send(
+                    MultiplexMessage.error(
+                        "stream_open last_sequence must be a non-negative integer",
+                        stream_id=stream_id,
+                    ),
+                )
+                return
+            if last_sequence < 0:
+                await self._send(
+                    MultiplexMessage.error(
+                        "stream_open last_sequence must be a non-negative integer",
+                        stream_id=stream_id,
+                    ),
+                )
+                return
+
+        release_state: Any | None = None
+        if self._authorize_stream_fn is not None:
+            allowed, error_message, release_state = await self._authorize_stream_fn(stream_id)
+            if not allowed:
+                await self._send(
+                    MultiplexMessage.error(
+                        error_message or "stream_open not authorized",
+                        stream_id=stream_id,
+                    ),
+                )
+                return
+
         if bus is None:
+            await self._release_stream(stream_id, release_state)
             await self._send(
                 MultiplexMessage.error(f"Unknown session: {stream_id}", stream_id=stream_id),
             )
             return
-
-        last_sequence = 0
-        if msg.payload and "last_sequence" in msg.payload:
-            last_sequence = int(msg.payload["last_sequence"])
 
         consumer_id = f"mpx-{self._connection_id}-{stream_id}"
         queue = bus.subscribe(consumer_id, from_sequence=last_sequence)
@@ -145,6 +187,7 @@ class MultiplexManager:
             "bus": bus,
             "consumer_id": consumer_id,
             "task": task,
+            "release_state": release_state,
         }
         logger.debug(
             "Multiplex {}: opened stream {} (last_seq={})",
@@ -173,9 +216,8 @@ class MultiplexManager:
 
         # Cancel the forwarding task
         task: asyncio.Task[None] = info["task"]
-        task.cancel()
-        with _suppress_cancelled():
-            await task
+        await self._cancel_task(task, label=f"stream {stream_id}")
+        await self._release_stream(stream_id, info.get("release_state"))
 
         logger.debug("Multiplex {}: closed stream {}", self._connection_id, stream_id)
 
@@ -192,6 +234,13 @@ class MultiplexManager:
                 await self._send(data_msg)
         except asyncio.CancelledError:
             pass
+        except Exception as exc:
+            logger.warning(
+                "Multiplex {}: stopping forwarder for stream {} after send failure: {}",
+                self._connection_id,
+                stream_id,
+                exc,
+            )
 
     # ------------------------------------------------------------------
     # Keepalive
@@ -231,6 +280,36 @@ class MultiplexManager:
     async def _send(self, msg: MultiplexMessage) -> None:
         """Serialize and send a message via the injected send function."""
         await self._send_fn(msg.to_json())
+
+    async def _cancel_task(self, task: asyncio.Task[None], *, label: str) -> None:
+        """Cancel a background task, logging any non-cancellation failure."""
+        task.cancel()
+        with _suppress_cancelled():
+            try:
+                await task
+            except Exception as exc:
+                logger.warning(
+                    "Multiplex {}: background {} exited with error during cleanup: {}",
+                    self._connection_id,
+                    label,
+                    exc,
+                )
+
+    async def _release_stream(self, stream_id: str, release_state: Any | None) -> None:
+        """Release any stream-scoped resource allocations such as quota tokens."""
+        if self._release_stream_fn is None or release_state is None:
+            return
+        try:
+            maybe_awaitable = self._release_stream_fn(stream_id, release_state)
+            if inspect.isawaitable(maybe_awaitable):
+                await maybe_awaitable
+        except Exception as exc:
+            logger.warning(
+                "Multiplex {}: failed to release stream {} resources: {}",
+                self._connection_id,
+                stream_id,
+                exc,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/protocol.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/multiplex/protocol.py
@@ -1,0 +1,122 @@
+"""Multiplex protocol -- message types for multi-session WebSocket multiplexing."""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class MultiplexMessageType(str, Enum):
+    """Wire-level message types for the multiplex WebSocket."""
+
+    STREAM_OPEN = "stream_open"
+    STREAM_DATA = "stream_data"
+    STREAM_CLOSE = "stream_close"
+    PING = "ping"
+    PONG = "pong"
+    ERROR = "error"
+
+
+@dataclass
+class MultiplexMessage:
+    """Single message on the multiplexed WebSocket.
+
+    Fields *stream_id* and *payload* are optional -- ``to_dict`` omits them
+    when ``None`` so that keepalive frames stay tiny.
+    """
+
+    type: MultiplexMessageType
+    stream_id: Optional[str] = None
+    payload: Optional[dict[str, Any]] = None
+    timestamp: float = field(default_factory=time.time)
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly dict, omitting ``None`` optional fields."""
+        d: dict[str, Any] = {
+            "type": self.type.value,
+            "timestamp": self.timestamp,
+        }
+        if self.stream_id is not None:
+            d["stream_id"] = self.stream_id
+        if self.payload is not None:
+            d["payload"] = self.payload
+        return d
+
+    def to_json(self) -> str:
+        """Serialize to a compact JSON string."""
+        return json.dumps(self.to_dict(), separators=(",", ":"))
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MultiplexMessage:
+        """Reconstruct a message from a dict."""
+        if "type" not in data:
+            raise ValueError("MultiplexMessage.from_dict: missing required key 'type'")
+        return cls(
+            type=MultiplexMessageType(data["type"]),
+            stream_id=data.get("stream_id"),
+            payload=data.get("payload"),
+            timestamp=data.get("timestamp", time.time()),
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> MultiplexMessage:
+        """Deserialize from a JSON string."""
+        return cls.from_dict(json.loads(raw))
+
+    # ------------------------------------------------------------------
+    # Factory methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def stream_open(cls, session_id: str, last_sequence: int = 0) -> MultiplexMessage:
+        """Request to subscribe to *session_id*'s event stream."""
+        payload: dict[str, Any] = {"session_id": session_id}
+        if last_sequence > 0:
+            payload["last_sequence"] = last_sequence
+        return cls(
+            type=MultiplexMessageType.STREAM_OPEN,
+            stream_id=session_id,
+            payload=payload,
+        )
+
+    @classmethod
+    def stream_data(cls, stream_id: str, event_data: dict[str, Any]) -> MultiplexMessage:
+        """Wrap an event for delivery over the multiplexed socket."""
+        return cls(
+            type=MultiplexMessageType.STREAM_DATA,
+            stream_id=stream_id,
+            payload=event_data,
+        )
+
+    @classmethod
+    def stream_close(cls, session_id: str) -> MultiplexMessage:
+        """Request to unsubscribe from *session_id*'s event stream."""
+        return cls(
+            type=MultiplexMessageType.STREAM_CLOSE,
+            stream_id=session_id,
+        )
+
+    @classmethod
+    def ping(cls) -> MultiplexMessage:
+        """Keepalive ping."""
+        return cls(type=MultiplexMessageType.PING)
+
+    @classmethod
+    def pong(cls) -> MultiplexMessage:
+        """Keepalive pong (response to ping)."""
+        return cls(type=MultiplexMessageType.PONG)
+
+    @classmethod
+    def error(cls, message: str, stream_id: Optional[str] = None) -> MultiplexMessage:
+        """Error message, optionally scoped to a stream."""
+        return cls(
+            type=MultiplexMessageType.ERROR,
+            stream_id=stream_id,
+            payload={"error": message},
+        )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/policy_conditions.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/policy_conditions.py
@@ -5,6 +5,7 @@ GovernanceFilter evaluates them synchronously (no DB lookups at call time).
 """
 from __future__ import annotations
 
+from ipaddress import ip_address, ip_network
 import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -58,6 +59,24 @@ def _format_datetime(dt: datetime | None) -> str | None:
     return dt.isoformat()
 
 
+def _normalize_source_ips(value: Any) -> list[str] | None:
+    """Normalize source IP conditions to a list of non-empty IP/CIDR strings."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else None
+    if not isinstance(value, (list, tuple, set)):
+        return None
+    out = [str(entry).strip() for entry in value if str(entry).strip()]
+    return out or None
+
+
+def _normalize_required_labels(value: Any) -> dict[str, str] | None:
+    """Normalize required_labels to a mapping, or None when the payload is invalid."""
+    return dict(value) if isinstance(value, dict) else None
+
+
 @dataclass
 class PolicyConditions:
     """Conditions attached to a policy that must be satisfied for it to apply.
@@ -104,8 +123,8 @@ class PolicyConditions:
         return cls(
             valid_from=_parse_datetime(data.get("valid_from")),
             valid_until=_parse_datetime(data.get("valid_until")),
-            source_ips=data.get("source_ips"),
-            required_labels=data.get("required_labels"),
+            source_ips=_normalize_source_ips(data.get("source_ips")),
+            required_labels=_normalize_required_labels(data.get("required_labels")),
             delegation=DelegationCondition.from_dict(data.get("delegation")),
         )
 
@@ -127,6 +146,7 @@ def evaluate_conditions(
     *,
     resource_labels: dict[str, str] | None = None,
     ancestry_chain: list[str] | None = None,
+    source_ip: str | None = None,
     now: datetime | None = None,
 ) -> bool:
     """Evaluate policy conditions synchronously.
@@ -134,7 +154,8 @@ def evaluate_conditions(
     Returns ``True`` if all conditions are satisfied (or no conditions are set).
 
     Notes:
-        - ``source_ips`` is NOT evaluated here; that is an endpoint-layer concern.
+        - ``source_ips`` supports both individual IP addresses and CIDR ranges.
+        - Missing or invalid request IP context causes IP-scoped policies to fail closed.
         - Empty conditions always pass.
     """
     if conditions.is_empty():
@@ -148,6 +169,26 @@ def evaluate_conditions(
         return False
     if conditions.valid_until is not None and now > conditions.valid_until:
         return False
+
+    # --- Source IP allowlist ---
+    if conditions.source_ips is not None:
+        if not source_ip:
+            return False
+        try:
+            client_ip = ip_address(str(source_ip).strip())
+        except ValueError:
+            return False
+
+        ip_match = False
+        for allowed_entry in conditions.source_ips:
+            try:
+                if client_ip in ip_network(str(allowed_entry).strip(), strict=False):
+                    ip_match = True
+                    break
+            except ValueError:
+                continue
+        if not ip_match:
+            return False
 
     # --- Required labels (AND semantics) ---
     if conditions.required_labels is not None:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/policy_conditions.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/policy_conditions.py
@@ -1,0 +1,165 @@
+"""Policy conditions for RBAC enrichment.
+
+Conditions are pre-resolved into the policy snapshot at build time.
+GovernanceFilter evaluates them synchronously (no DB lookups at call time).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass
+class DelegationCondition:
+    """Identifies the delegating principal whose ancestry must be present."""
+
+    principal_type: str  # "user" | "agent"
+    principal_id: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "principal_type": self.principal_type,
+            "principal_id": self.principal_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> DelegationCondition | None:
+        if not data or not isinstance(data, dict):
+            return None
+        principal_type = str(data.get("principal_type") or "").strip()
+        principal_id = str(data.get("principal_id") or "").strip()
+        if not principal_type or not principal_id:
+            return None
+        return cls(principal_type=principal_type, principal_id=principal_id)
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    """Parse an ISO-format datetime string, returning None on failure."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        dt = datetime.fromisoformat(str(value))
+        # Ensure timezone-aware (assume UTC if naive)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _format_datetime(dt: datetime | None) -> str | None:
+    """Format a datetime as ISO string, or None."""
+    if dt is None:
+        return None
+    return dt.isoformat()
+
+
+@dataclass
+class PolicyConditions:
+    """Conditions attached to a policy that must be satisfied for it to apply.
+
+    All fields are optional.  An empty ``PolicyConditions`` (all None) means
+    the policy applies unconditionally.
+    """
+
+    valid_from: datetime | None = None
+    valid_until: datetime | None = None
+    source_ips: list[str] | None = None
+    required_labels: dict[str, str] | None = None
+    delegation: DelegationCondition | None = None
+
+    def is_empty(self) -> bool:
+        """Return True when no conditions are set (unconditional policy)."""
+        return (
+            self.valid_from is None
+            and self.valid_until is None
+            and self.source_ips is None
+            and self.required_labels is None
+            and self.delegation is None
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        if self.valid_from is not None:
+            d["valid_from"] = _format_datetime(self.valid_from)
+        if self.valid_until is not None:
+            d["valid_until"] = _format_datetime(self.valid_until)
+        if self.source_ips is not None:
+            d["source_ips"] = list(self.source_ips)
+        if self.required_labels is not None:
+            d["required_labels"] = dict(self.required_labels)
+        if self.delegation is not None:
+            d["delegation"] = self.delegation.to_dict()
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> PolicyConditions:
+        """Deserialize from a plain dict.  ``None`` / empty dict yields empty conditions."""
+        if not data or not isinstance(data, dict):
+            return cls()
+        return cls(
+            valid_from=_parse_datetime(data.get("valid_from")),
+            valid_until=_parse_datetime(data.get("valid_until")),
+            source_ips=data.get("source_ips"),
+            required_labels=data.get("required_labels"),
+            delegation=DelegationCondition.from_dict(data.get("delegation")),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, raw: str | None) -> PolicyConditions:
+        if not raw:
+            return cls()
+        try:
+            return cls.from_dict(json.loads(raw))
+        except (json.JSONDecodeError, TypeError):
+            return cls()
+
+
+def evaluate_conditions(
+    conditions: PolicyConditions,
+    *,
+    resource_labels: dict[str, str] | None = None,
+    ancestry_chain: list[str] | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Evaluate policy conditions synchronously.
+
+    Returns ``True`` if all conditions are satisfied (or no conditions are set).
+
+    Notes:
+        - ``source_ips`` is NOT evaluated here; that is an endpoint-layer concern.
+        - Empty conditions always pass.
+    """
+    if conditions.is_empty():
+        return True
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    # --- Time window ---
+    if conditions.valid_from is not None and now < conditions.valid_from:
+        return False
+    if conditions.valid_until is not None and now > conditions.valid_until:
+        return False
+
+    # --- Required labels (AND semantics) ---
+    if conditions.required_labels is not None:
+        labels = resource_labels or {}
+        for key, expected_value in conditions.required_labels.items():
+            if labels.get(key) != expected_value:
+                return False
+
+    # --- Delegation ancestry ---
+    if conditions.delegation is not None:
+        chain = ancestry_chain or []
+        if conditions.delegation.principal_id not in chain:
+            return False
+
+    return True

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/templates.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/templates.py
@@ -1,0 +1,228 @@
+"""Inheritable ACP config template system.
+
+Three-tier scoping: **system** -> **persona** -> **session**.  Templates stored
+in the ``config_templates`` table are resolved via inheritance chains and merged
+using :func:`merge_config` from ``merge_utils``.
+
+When no DB templates are found the module falls back to the flat
+:data:`PERMISSION_POLICY_TEMPLATES` dict from ``config.py`` so existing
+deployments continue to work without migration.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.merge_utils import merge_config
+
+# Re-export merge_config for convenience of callers that import from templates.
+__all__ = [
+    "ACPConfigTemplate",
+    "resolve_template_chain",
+    "resolve_for_session",
+    "seed_system_templates",
+]
+
+_MAX_INHERITANCE_DEPTH = 20
+
+
+@dataclass
+class ACPConfigTemplate:
+    """A single config template record."""
+
+    id: int | None = None
+    name: str = ""
+    description: str = ""
+    scope: str = "system"  # system | persona | session
+    scope_id: str | None = None
+    base_template_id: int | None = None
+    schema_version: str = "1"
+    config: dict[str, Any] = field(default_factory=dict)
+
+    # Timestamps (populated from DB rows)
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Row conversion
+# ---------------------------------------------------------------------------
+
+
+def _row_to_template(row: dict[str, Any]) -> ACPConfigTemplate:
+    """Convert a DB row dict to an :class:`ACPConfigTemplate`."""
+    config_raw = row.get("config_json", "{}")
+    if isinstance(config_raw, str):
+        try:
+            config = json.loads(config_raw)
+        except (json.JSONDecodeError, TypeError):
+            config = {}
+    elif isinstance(config_raw, dict):
+        config = config_raw
+    else:
+        config = {}
+
+    return ACPConfigTemplate(
+        id=row.get("id"),
+        name=str(row.get("name", "")),
+        description=str(row.get("description", "")),
+        scope=str(row.get("scope", "system")),
+        scope_id=row.get("scope_id"),
+        base_template_id=row.get("base_template_id"),
+        schema_version=str(row.get("schema_version", "1")),
+        config=config,
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inheritance resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_inheritance(
+    db: Any,
+    template: ACPConfigTemplate,
+) -> list[ACPConfigTemplate]:
+    """Walk the ``base_template_id`` chain, returning templates from root to *template*.
+
+    Raises :class:`ValueError` on circular references.
+    """
+    chain: list[ACPConfigTemplate] = [template]
+    seen_ids: set[int] = set()
+    if template.id is not None:
+        seen_ids.add(template.id)
+
+    current = template
+    for _ in range(_MAX_INHERITANCE_DEPTH):
+        base_id = current.base_template_id
+        if base_id is None:
+            break
+        if base_id in seen_ids:
+            raise ValueError(
+                f"Circular template inheritance detected: "
+                f"template {current.id} references ancestor {base_id} "
+                f"which is already in the chain"
+            )
+        seen_ids.add(base_id)
+        parent_row = db.get_config_template(base_id)
+        if parent_row is None:
+            logger.warning(
+                "Template {} references missing base_template_id {}",
+                current.id,
+                base_id,
+            )
+            break
+        parent = _row_to_template(parent_row)
+        chain.append(parent)
+        current = parent
+
+    chain.reverse()  # root-first
+    return chain
+
+
+# ---------------------------------------------------------------------------
+# Chain merging
+# ---------------------------------------------------------------------------
+
+
+def resolve_template_chain(templates: list[ACPConfigTemplate]) -> dict[str, Any]:
+    """Merge a list of templates (least-to-most specific) using :func:`merge_config`.
+
+    Returns the fully merged config dict.
+    """
+    merged: dict[str, Any] = {}
+    for tpl in templates:
+        merged = merge_config(merged, tpl.config)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Session resolution (full three-tier)
+# ---------------------------------------------------------------------------
+
+
+def resolve_for_session(
+    db: Any,
+    session_id: str | None,
+    persona_id: str | None,
+    template_name: str | None,
+) -> dict[str, Any] | None:
+    """Load and merge templates for a session following system -> persona -> session scoping.
+
+    Returns the merged config dict, or ``None`` if no templates were found
+    (caller should fall back to flat ``PERMISSION_POLICY_TEMPLATES``).
+    """
+    layers: list[ACPConfigTemplate] = []
+
+    # 1. System-scope template (by name)
+    if template_name:
+        system_rows = db.list_config_templates(scope="system", name=template_name)
+        if system_rows:
+            system_tpl = _row_to_template(system_rows[0])
+            chain = _resolve_inheritance(db, system_tpl)
+            layers.extend(chain)
+
+    # 2. Persona-scope override (by persona_id + template_name)
+    if persona_id and template_name:
+        persona_rows = db.list_config_templates(
+            scope="persona", scope_id=persona_id, name=template_name,
+        )
+        if persona_rows:
+            persona_tpl = _row_to_template(persona_rows[0])
+            chain = _resolve_inheritance(db, persona_tpl)
+            layers.extend(chain)
+
+    # 3. Session-scope override (by session_id + template_name)
+    if session_id and template_name:
+        session_rows = db.list_config_templates(
+            scope="session", scope_id=session_id, name=template_name,
+        )
+        if session_rows:
+            session_tpl = _row_to_template(session_rows[0])
+            chain = _resolve_inheritance(db, session_tpl)
+            layers.extend(chain)
+
+    if not layers:
+        return None
+
+    return resolve_template_chain(layers)
+
+
+# ---------------------------------------------------------------------------
+# Seeding from flat PERMISSION_POLICY_TEMPLATES
+# ---------------------------------------------------------------------------
+
+
+def seed_system_templates(db: Any) -> int:
+    """Populate the config_templates table from the flat PERMISSION_POLICY_TEMPLATES dict.
+
+    Idempotent: existing templates with the same name and scope='system' are
+    skipped.  Returns the number of templates actually inserted.
+    """
+    from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
+        PERMISSION_POLICY_TEMPLATES,
+    )
+
+    inserted = 0
+    for name, config in PERMISSION_POLICY_TEMPLATES.items():
+        existing = db.list_config_templates(scope="system", name=name)
+        if existing:
+            continue
+        db.create_config_template(
+            name=name,
+            description=config.get("description", ""),
+            scope="system",
+            scope_id=None,
+            base_template_id=None,
+            schema_version="1",
+            config_json=json.dumps(config),
+        )
+        inserted += 1
+        logger.debug("Seeded system template: {}", name)
+
+    return inserted

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -18,7 +18,7 @@ from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection,
 )
 
-_SCHEMA_VERSION = 10
+_SCHEMA_VERSION = 12
 
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS sessions (
@@ -52,7 +52,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     model TEXT,
     token_budget INTEGER DEFAULT NULL,
     auto_terminate_at_budget INTEGER NOT NULL DEFAULT 0,
-    budget_exhausted INTEGER NOT NULL DEFAULT 0
+    budget_exhausted INTEGER NOT NULL DEFAULT 0,
+    ancestry_chain_json TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_user_status ON sessions(user_id, status);
 CREATE INDEX IF NOT EXISTS idx_sessions_created ON sessions(created_at DESC);
@@ -111,6 +112,7 @@ CREATE TABLE IF NOT EXISTS permission_policies (
     name TEXT NOT NULL,
     description TEXT DEFAULT '',
     rules_json TEXT NOT NULL,
+    conditions_json TEXT,
     org_id TEXT,
     team_id TEXT,
     priority INTEGER DEFAULT 0,
@@ -147,6 +149,23 @@ CREATE TABLE IF NOT EXISTS webhook_triggers (
 );
 CREATE INDEX IF NOT EXISTS idx_webhook_triggers_owner
     ON webhook_triggers(owner_user_id);
+
+CREATE TABLE IF NOT EXISTS config_templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    scope TEXT NOT NULL DEFAULT 'system',
+    scope_id TEXT,
+    base_template_id INTEGER,
+    schema_version TEXT NOT NULL DEFAULT '1',
+    config_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_config_templates_scope
+    ON config_templates(scope, scope_id);
+CREATE INDEX IF NOT EXISTS idx_config_templates_name
+    ON config_templates(name);
 """
 
 # Columns that are stored as INTEGER 0/1 but should be returned as bool
@@ -160,7 +179,7 @@ _BOOL_FIELDS = frozenset({
 })
 
 # Columns that are stored as JSON TEXT but should be returned as parsed objects
-_JSON_LIST_FIELDS = frozenset({"tags", "mcp_servers"})
+_JSON_LIST_FIELDS = frozenset({"tags", "mcp_servers", "ancestry_chain_json"})
 _JSON_OBJECT_FIELDS = frozenset({"policy_summary", "policy_provenance_summary"})
 _ALLOWED_MIGRATION_COLUMNS = {
     "sessions": {
@@ -174,6 +193,7 @@ _ALLOWED_MIGRATION_COLUMNS = {
         "token_budget": "token_budget INTEGER DEFAULT NULL",
         "auto_terminate_at_budget": "auto_terminate_at_budget INTEGER NOT NULL DEFAULT 0",
         "budget_exhausted": "budget_exhausted INTEGER NOT NULL DEFAULT 0",
+        "ancestry_chain_json": "ancestry_chain_json TEXT",
     },
     "agent_registry": {
         "mcp_orchestration": "mcp_orchestration TEXT NOT NULL DEFAULT 'agent_driven'",
@@ -183,6 +203,9 @@ _ALLOWED_MIGRATION_COLUMNS = {
         "mcp_llm_model": "mcp_llm_model TEXT",
         "mcp_max_iterations": "mcp_max_iterations INTEGER NOT NULL DEFAULT 20",
         "mcp_refresh_tools": "mcp_refresh_tools INTEGER NOT NULL DEFAULT 0",
+    },
+    "permission_policies": {
+        "conditions_json": "conditions_json TEXT",
     },
 }
 
@@ -446,6 +469,38 @@ class ACPSessionsDB:
                     CREATE INDEX IF NOT EXISTS idx_webhook_triggers_owner
                         ON webhook_triggers(owner_user_id);
                 """)
+            if current_version < 11:
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS config_templates (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        name TEXT NOT NULL,
+                        description TEXT NOT NULL DEFAULT '',
+                        scope TEXT NOT NULL DEFAULT 'system',
+                        scope_id TEXT,
+                        base_template_id INTEGER,
+                        schema_version TEXT NOT NULL DEFAULT '1',
+                        config_json TEXT NOT NULL DEFAULT '{}',
+                        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_config_templates_scope
+                        ON config_templates(scope, scope_id);
+                    CREATE INDEX IF NOT EXISTS idx_config_templates_name
+                        ON config_templates(name);
+                """)
+            if current_version < 12:
+                _ensure_column(
+                    conn,
+                    "permission_policies",
+                    "conditions_json",
+                    "conditions_json TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "sessions",
+                    "ancestry_chain_json",
+                    "ancestry_chain_json TEXT",
+                )
             conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
             conn.commit()
             self._initialized = True
@@ -1828,6 +1883,111 @@ class ACPSessionsDB:
         conn = self._get_conn()
         cursor = conn.execute(
             "DELETE FROM webhook_triggers WHERE id = ?", (trigger_id,)
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Config Template CRUD
+    # ------------------------------------------------------------------
+
+    def create_config_template(
+        self,
+        name: str,
+        description: str = "",
+        scope: str = "system",
+        scope_id: str | None = None,
+        base_template_id: int | None = None,
+        schema_version: str = "1",
+        config_json: str = "{}",
+    ) -> int:
+        """Insert a new config template. Returns the new row ID."""
+        conn = self._get_conn()
+        now = _utcnow_iso()
+        cursor = conn.execute(
+            """
+            INSERT INTO config_templates
+                (name, description, scope, scope_id, base_template_id,
+                 schema_version, config_json, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                name, description, scope, scope_id, base_template_id,
+                schema_version, config_json, now, now,
+            ),
+        )
+        conn.commit()
+        return cursor.lastrowid  # type: ignore[return-value]
+
+    def get_config_template(self, template_id: int) -> dict[str, Any] | None:
+        """Fetch a single config template by ID, or None."""
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT * FROM config_templates WHERE id = ?", (template_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return dict(row)
+
+    def list_config_templates(
+        self,
+        *,
+        scope: str | None = None,
+        scope_id: str | None = None,
+        name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List config templates with optional filters.
+
+        Filters are AND-combined when provided.
+        """
+        conn = self._get_conn()
+        clauses: list[str] = []
+        params: list[Any] = []
+        if scope is not None:
+            clauses.append("scope = ?")
+            params.append(scope)
+        if scope_id is not None:
+            clauses.append("scope_id = ?")
+            params.append(scope_id)
+        if name is not None:
+            clauses.append("name = ?")
+            params.append(name)
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        rows = conn.execute(
+            f"SELECT * FROM config_templates{where} ORDER BY id",
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    _CONFIG_TEMPLATE_UPDATABLE_COLS = frozenset({
+        "name", "description", "scope", "scope_id", "base_template_id",
+        "schema_version", "config_json",
+    })
+
+    def update_config_template(self, template_id: int, **kwargs: Any) -> bool:
+        """Update fields on a config template.
+
+        Returns True if the row was found and updated.
+        """
+        updates = {k: v for k, v in kwargs.items() if k in self._CONFIG_TEMPLATE_UPDATABLE_COLS}
+        if not updates:
+            return False
+        updates["updated_at"] = _utcnow_iso()
+        set_clause = ", ".join(f"{col} = ?" for col in updates)
+        values = list(updates.values()) + [template_id]
+        conn = self._get_conn()
+        cursor = conn.execute(
+            f"UPDATE config_templates SET {set_clause} WHERE id = ?",
+            values,
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+    def delete_config_template(self, template_id: int) -> bool:
+        """Delete a config template by ID. Returns True if a row was removed."""
+        conn = self._get_conn()
+        cursor = conn.execute(
+            "DELETE FROM config_templates WHERE id = ?", (template_id,)
         )
         conn.commit()
         return cursor.rowcount > 0

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -18,7 +18,7 @@ from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection,
 )
 
-_SCHEMA_VERSION = 12
+_SCHEMA_VERSION = 13
 
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS sessions (
@@ -230,6 +230,32 @@ def _ensure_column(
     if column_name in existing_columns:
         return
     conn.execute(f'ALTER TABLE "{table_name}" ADD COLUMN {column_sql}')
+
+
+def _ensure_config_template_unique_index(conn: sqlite3.Connection) -> None:
+    """Enforce deterministic template lookup within a scope."""
+    duplicate = conn.execute(
+        """
+        SELECT name, scope, COALESCE(scope_id, '') AS normalized_scope_id, COUNT(*) AS duplicate_count
+        FROM config_templates
+        GROUP BY name, scope, COALESCE(scope_id, '')
+        HAVING COUNT(*) > 1
+        LIMIT 1
+        """
+    ).fetchone()
+    if duplicate is not None:
+        raise sqlite3.IntegrityError(
+            "Duplicate config_templates rows detected for "
+            f"name={duplicate['name']!r}, scope={duplicate['scope']!r}, "
+            f"scope_id={duplicate['normalized_scope_id']!r}"
+        )
+
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_config_templates_name_scope_unique
+        ON config_templates(name, scope, COALESCE(scope_id, ''))
+        """
+    )
 
 
 class ACPSessionsDB:
@@ -501,6 +527,8 @@ class ACPSessionsDB:
                     "ancestry_chain_json",
                     "ancestry_chain_json TEXT",
                 )
+            if current_version < 13:
+                _ensure_config_template_unique_index(conn)
             conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
             conn.commit()
             self._initialized = True
@@ -1904,18 +1932,21 @@ class ACPSessionsDB:
         """Insert a new config template. Returns the new row ID."""
         conn = self._get_conn()
         now = _utcnow_iso()
-        cursor = conn.execute(
-            """
-            INSERT INTO config_templates
-                (name, description, scope, scope_id, base_template_id,
-                 schema_version, config_json, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                name, description, scope, scope_id, base_template_id,
-                schema_version, config_json, now, now,
-            ),
-        )
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO config_templates
+                    (name, description, scope, scope_id, base_template_id,
+                     schema_version, config_json, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name, description, scope, scope_id, base_template_id,
+                    schema_version, config_json, now, now,
+                ),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError("Config template already exists for this scope") from exc
         conn.commit()
         return cursor.lastrowid  # type: ignore[return-value]
 
@@ -1976,10 +2007,13 @@ class ACPSessionsDB:
         set_clause = ", ".join(f"{col} = ?" for col in updates)
         values = list(updates.values()) + [template_id]
         conn = self._get_conn()
-        cursor = conn.execute(
-            f"UPDATE config_templates SET {set_clause} WHERE id = ?",
-            values,
-        )
+        try:
+            cursor = conn.execute(
+                f"UPDATE config_templates SET {set_clause} WHERE id = ?",  # nosec B608
+                values,
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError("Config template already exists for this scope") from exc
         conn.commit()
         return cursor.rowcount > 0
 

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1445,6 +1445,11 @@ else:
     except _IMPORT_EXCEPTIONS as _acp_perm_err:
         logger.warning(f"ACP permissions endpoints unavailable at import time; deferring: {_acp_perm_err}")
         acp_permissions_router = None  # type: ignore[assignment]
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.acp_multiplex import router as acp_multiplex_router
+    except _IMPORT_EXCEPTIONS as _acp_mpx_err:
+        logger.warning(f"ACP multiplex endpoints unavailable at import time; deferring: {_acp_mpx_err}")
+        acp_multiplex_router = None  # type: ignore[assignment]
     # Users Endpoint (NEW)
     # Chatbooks Endpoint
     from tldw_Server_API.app.api.v1.endpoints.chatbooks import router as chatbooks_router
@@ -6655,6 +6660,12 @@ elif _MINIMAL_TEST_APP:
         app.include_router(acp_permissions_router, prefix=f"{API_V1_PREFIX}", tags=["acp-permissions"])
     except _IMPORT_EXCEPTIONS as _acp_perm_min_err:
         logger.debug(f"Skipping ACP permissions router in minimal test app: {_acp_perm_min_err}")
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.acp_multiplex import router as acp_multiplex_router
+
+        app.include_router(acp_multiplex_router, prefix=f"{API_V1_PREFIX}", tags=["acp-multiplex"])
+    except _IMPORT_EXCEPTIONS as _acp_mpx_min_err:
+        logger.debug(f"Skipping ACP multiplex router in minimal test app: {_acp_mpx_min_err}")
     # Agent Orchestration endpoints
     try:
         from tldw_Server_API.app.api.v1.endpoints.agent_orchestration import router as orch_router
@@ -6914,6 +6925,8 @@ else:
         _include_if_enabled("acp", acp_triggers_router, prefix=f"{API_V1_PREFIX}", tags=["acp-triggers"], default_stable=False)
     if "acp_permissions_router" in locals() and acp_permissions_router is not None:
         _include_if_enabled("acp", acp_permissions_router, prefix=f"{API_V1_PREFIX}", tags=["acp-permissions"], default_stable=False)
+    if "acp_multiplex_router" in locals() and acp_multiplex_router is not None:
+        _include_if_enabled("acp", acp_multiplex_router, prefix=f"{API_V1_PREFIX}", tags=["acp-multiplex"], default_stable=False)
     if "character_router" in locals():
         _include_if_enabled("characters", character_router, prefix=f"{API_V1_PREFIX}/characters", tags=["characters"])
     if "character_memory_router" in locals():

--- a/tldw_Server_API/app/services/acp_runtime_policy_service.py
+++ b/tldw_Server_API/app/services/acp_runtime_policy_service.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
+from loguru import logger
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
@@ -196,8 +197,13 @@ class ACPRuntimePolicyService:
             if result is not None:
                 return result
         except Exception:
-            # DB templates not available; fall through to flat lookup.
-            pass
+            logger.exception(
+                "ACP runtime policy template lookup failed for template_name={} session_id={} persona_id={}; "
+                "falling back to flat templates",
+                template_name,
+                session_id,
+                persona_id,
+            )
 
         # Fallback: use the flat PERMISSION_POLICY_TEMPLATES dict.
         from tldw_Server_API.app.core.Agent_Client_Protocol.config import (

--- a/tldw_Server_API/app/services/acp_runtime_policy_service.py
+++ b/tldw_Server_API/app/services/acp_runtime_policy_service.py
@@ -176,6 +176,35 @@ class ACPRuntimePolicyService:
 
         return metadata, execution_config
 
+    def _resolve_template_config(
+        self,
+        *,
+        template_name: str,
+        session_id: str | None = None,
+        persona_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Resolve a template config dict, trying DB templates first then flat fallback."""
+        # Try DB-backed templates if a session store is available.
+        try:
+            from tldw_Server_API.app.core.Agent_Client_Protocol.templates import (
+                resolve_for_session,
+            )
+            from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+            db = ACPSessionsDB()
+            result = resolve_for_session(db, session_id, persona_id, template_name)
+            if result is not None:
+                return result
+        except Exception:
+            # DB templates not available; fall through to flat lookup.
+            pass
+
+        # Fallback: use the flat PERMISSION_POLICY_TEMPLATES dict.
+        from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
+            PERMISSION_POLICY_TEMPLATES,
+        )
+        return PERMISSION_POLICY_TEMPLATES.get(template_name)
+
     async def build_snapshot(
         self,
         *,
@@ -207,15 +236,15 @@ class ACPRuntimePolicyService:
         # User / MCP-Hub overrides that are already in the resolved document
         # take precedence over template defaults.
         if template_name:
-            from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
-                PERMISSION_POLICY_TEMPLATES,
+            template_config = self._resolve_template_config(
+                template_name=template_name,
+                session_id=str(getattr(session_record, "session_id", "")),
+                persona_id=getattr(session_record, "persona_id", None),
             )
-
-            template = PERMISSION_POLICY_TEMPLATES.get(template_name)
-            if template:
+            if template_config:
                 existing_overrides = resolved_policy_document.get("tool_tier_overrides", {})
                 # Template is the base layer -- merge user overrides on top.
-                merged = {**template.get("tool_tier_overrides", {}), **existing_overrides}
+                merged = {**template_config.get("tool_tier_overrides", {}), **existing_overrides}
                 resolved_policy_document["tool_tier_overrides"] = merged
         allowed_tools = _unique(_as_str_list(resolved_policy_document.get("allowed_tools")))
         denied_tools = _unique(_as_str_list(resolved_policy_document.get("denied_tools")))

--- a/tldw_Server_API/app/services/admin_acp_sessions_service.py
+++ b/tldw_Server_API/app/services/admin_acp_sessions_service.py
@@ -75,6 +75,7 @@ class SessionRecord:
     needs_bootstrap: bool = False
     # Forking lineage
     forked_from: str | None = None
+    ancestry_chain: list[str] = field(default_factory=list)
     # Model used for cost estimation
     model: str | None = None
     # Token budget fields
@@ -106,6 +107,7 @@ class SessionRecord:
             "policy_provenance_summary": self.policy_provenance_summary,
             "policy_refresh_error": self.policy_refresh_error,
             "forked_from": self.forked_from,
+            "ancestry_chain": list(self.ancestry_chain),
             "model": self.model,
             "estimated_cost_usd": compute_token_cost(
                 model=self.model,
@@ -355,6 +357,7 @@ class ACPSessionStore:
             bootstrap_ready=d.get("bootstrap_ready", True),
             needs_bootstrap=d.get("needs_bootstrap", False),
             forked_from=d.get("forked_from"),
+            ancestry_chain=d.get("ancestry_chain_json") or [],
             model=d.get("model"),
             token_budget=d.get("token_budget"),
             auto_terminate_at_budget=d.get("auto_terminate_at_budget", False),

--- a/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
@@ -84,18 +84,8 @@ def _candidate_scope_filters(user_id: int | None, metadata: dict[str, Any]) -> l
 
 
 def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
-    """Merge policy documents with union semantics for list-based capability fields.
-
-    Delegates to :func:`merge_config` from ``merge_utils``.  Unlike
-    ``merge_config``, this function preserves the original behaviour of
-    *not* skipping ``None`` overlay values (the resolver never passes None
-    values in overlay dicts so the difference is academic, but we keep it
-    explicit for backward safety).
-    """
-    # merge_config skips None overlay values; the original implementation
-    # did not.  Since the resolver never puts None into overlay dicts the
-    # semantics are identical, but we call merge_config directly.
-    return merge_config(base, overlay)
+    """Merge policy documents with union semantics and explicit-null overrides."""
+    return merge_config(base, overlay, skip_none=False)
 
 
 def _has_explicit_scalar_value(value: Any) -> bool:

--- a/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
@@ -5,6 +5,13 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_Server_API.app.core.Agent_Client_Protocol.merge_utils import (
+    UNION_LIST_KEYS as _UNION_LIST_KEYS,
+    _as_dict,
+    _as_str_list,
+    _unique,
+    merge_config,
+)
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
@@ -14,47 +21,6 @@ from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
 
 _TARGET_ORDER = {"default": 0, "group": 1, "persona": 2}
 _SCOPE_ORDER = {"global": 0, "org": 1, "team": 2, "user": 3}
-_UNION_LIST_KEYS = {
-    "allowed_tools",
-    "denied_tools",
-    "tool_names",
-    "tool_patterns",
-    "capabilities",
-    "tool_modules",
-    "module_ids",
-}
-
-
-def _as_dict(value: Any) -> dict[str, Any]:
-    """Return a shallow dict copy for mapping values, otherwise an empty dict."""
-    return dict(value) if isinstance(value, dict) else {}
-
-
-def _as_str_list(value: Any) -> list[str]:
-    """Normalize a scalar or iterable value into a list of non-empty strings."""
-    if isinstance(value, str):
-        cleaned = value.strip()
-        return [cleaned] if cleaned else []
-    if not isinstance(value, (list, tuple, set)):
-        return []
-    out: list[str] = []
-    for entry in value:
-        cleaned = str(entry or "").strip()
-        if cleaned:
-            out.append(cleaned)
-    return out
-
-
-def _unique(items: list[str]) -> list[str]:
-    """Preserve order while removing duplicate strings."""
-    seen: set[str] = set()
-    out: list[str] = []
-    for item in items:
-        if item in seen:
-            continue
-        seen.add(item)
-        out.append(item)
-    return out
 
 
 def _collect_scope_ids(metadata: dict[str, Any], singular_key: str, plural_key: str) -> list[int]:
@@ -118,17 +84,18 @@ def _candidate_scope_filters(user_id: int | None, metadata: dict[str, Any]) -> l
 
 
 def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
-    """Merge policy documents with union semantics for list-based capability fields."""
-    merged = deepcopy(base)
-    for key, value in overlay.items():
-        if key in _UNION_LIST_KEYS:
-            merged[key] = _unique(_as_str_list(merged.get(key)) + _as_str_list(value))
-            continue
-        if isinstance(merged.get(key), dict) and isinstance(value, dict):
-            merged[key] = _merge_policy_documents(_as_dict(merged.get(key)), value)
-            continue
-        merged[key] = deepcopy(value)
-    return merged
+    """Merge policy documents with union semantics for list-based capability fields.
+
+    Delegates to :func:`merge_config` from ``merge_utils``.  Unlike
+    ``merge_config``, this function preserves the original behaviour of
+    *not* skipping ``None`` overlay values (the resolver never passes None
+    values in overlay dicts so the difference is academic, but we keep it
+    explicit for backward safety).
+    """
+    # merge_config skips None overlay values; the original implementation
+    # did not.  Since the resolver never puts None into overlay dicts the
+    # semantics are identical, but we call merge_config directly.
+    return merge_config(base, overlay)
 
 
 def _has_explicit_scalar_value(value: Any) -> bool:
@@ -600,6 +567,9 @@ class McpHubPolicyResolver:
         # Ensure tool_tier_overrides is present in the resolved document so
         # downstream consumers (GovernanceFilter, runner_client) can rely on it.
         resolved_policy_document.setdefault("tool_tier_overrides", {})
+
+        # Ensure conditions key is present so GovernanceFilter can always read it.
+        resolved_policy_document.setdefault("conditions", {})
 
         return {
             "enabled": True,

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_runtime_policy_service.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_runtime_policy_service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -38,7 +40,7 @@ async def test_build_snapshot_uses_normalized_context_and_profile_hints():
         user_id=42,
         agent_type="codex",
         name="Policy Session",
-        cwd="/tmp/project",
+        cwd="/workspace/project",
         usage=SessionTokenUsage(),
         mcp_servers=[{"name": "filesystem", "type": "stdio"}],
         persona_id="persona-1",
@@ -113,3 +115,41 @@ async def test_build_snapshot_fingerprint_changes_when_effective_policy_changes(
 
     assert first.policy_snapshot_fingerprint != second.policy_snapshot_fingerprint
 
+
+@pytest.mark.asyncio
+async def test_build_snapshot_logs_and_falls_back_when_db_template_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.core.Agent_Client_Protocol.templates as templates_module
+    import tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB as sessions_db_module
+    import tldw_Server_API.app.services.acp_runtime_policy_service as runtime_policy_service_module
+    from tldw_Server_API.app.services.acp_runtime_policy_service import ACPRuntimePolicyService
+
+    session = SessionRecord(
+        session_id="session-3",
+        user_id=1,
+        usage=SessionTokenUsage(),
+    )
+    resolver = _StubPolicyResolver([{"policy_document": {}, "sources": [], "provenance": []}])
+    service = ACPRuntimePolicyService(policy_resolver=resolver)
+    log_exception = MagicMock()
+
+    def _raise_resolution_error(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("db template lookup failed")
+
+    monkeypatch.setattr(templates_module, "resolve_for_session", _raise_resolution_error)
+    monkeypatch.setattr(sessions_db_module, "ACPSessionsDB", lambda: object())
+    monkeypatch.setattr(
+        runtime_policy_service_module,
+        "logger",
+        SimpleNamespace(exception=log_exception),
+    )
+
+    snapshot = await service.build_snapshot(
+        session_record=session,
+        user_id=1,
+        template_name="lockdown",
+    )
+
+    assert snapshot.resolved_policy_document["tool_tier_overrides"] == {"*": "individual"}
+    assert log_exception.call_count == 1

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_websocket.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_websocket.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import WebSocketDisconnect
 from fastapi.testclient import TestClient
 from starlette.testclient import WebSocketTestSession
 
@@ -23,6 +24,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     PendingPermission,
     SessionWebSocketRegistry,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
 from tldw_Server_API.app.services.acp_runtime_policy_service import (
     ACPRuntimePolicySnapshot,
@@ -144,6 +146,31 @@ class MockRunnerClient:
         if session_id in self._ws_callbacks:
             for callback in self._ws_callbacks[session_id]:
                 await callback(message)
+
+
+class _FakeMultiplexWebSocket:
+    """Minimal async WebSocket stub for direct multiplex endpoint tests."""
+
+    def __init__(self, incoming: list[str] | None = None, headers: dict[str, str] | None = None) -> None:
+        self._incoming = list(incoming or [])
+        self.headers = headers or {}
+        self.accepted = False
+        self.closed_codes: list[int] = []
+        self.sent_text: list[str] = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed_codes.append(code)
+
+    async def receive_text(self) -> str:
+        if self._incoming:
+            return self._incoming.pop(0)
+        raise WebSocketDisconnect(code=1000)
+
+    async def send_text(self, raw: str) -> None:
+        self.sent_text.append(raw)
 
 
 @pytest.fixture
@@ -927,3 +954,142 @@ class TestACPRunnerClientPermissions:
         assert prompts[0]["approval_requirement"] == "approval_required"
         assert prompts[0]["provenance_summary"] == {"source_kinds": ["profile"]}
         assert prompts[0]["policy_snapshot_fingerprint"] == "snapshot-message"
+
+
+class TestACPMultiplexWebSocket:
+    @pytest.mark.asyncio
+    async def test_multiplex_rejects_unauthenticated_client(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import tldw_Server_API.app.api.v1.endpoints.acp_multiplex as multiplex_endpoints
+
+        async def _fake_authenticate_ws(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        monkeypatch.setattr(multiplex_endpoints, "_authenticate_ws", _fake_authenticate_ws)
+        ws = _FakeMultiplexWebSocket()
+
+        await multiplex_endpoints.acp_multiplex_ws(ws, token="bad-token")
+
+        assert ws.accepted is False
+        assert ws.closed_codes == [4401]
+
+    @pytest.mark.asyncio
+    async def test_multiplex_stream_open_checks_access_and_releases_quota(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import tldw_Server_API.app.api.v1.endpoints.acp_multiplex as multiplex_endpoints
+
+        quota_acquire_calls: list[dict[str, Any]] = []
+        quota_release_calls: list[dict[str, str | None]] = []
+        bus = SessionEventBus("sess-1")
+
+        class _StubClient:
+            def __init__(self) -> None:
+                self.access_checks: list[tuple[str, int]] = []
+
+            async def verify_session_access(self, session_id: str, user_id: int) -> bool:
+                self.access_checks.append((session_id, user_id))
+                return True
+
+            async def get_session_metadata(
+                self,
+                session_id: str,
+                user_id: int | None = None,
+            ) -> dict[str, Any]:
+                return {"persona_id": "persona-1"}
+
+        stub_client = _StubClient()
+
+        async def _fake_authenticate_ws(*args: Any, **kwargs: Any) -> int:
+            return 7
+
+        async def _fake_get_runner_client() -> _StubClient:
+            return stub_client
+
+        def _fake_get_session_event_bus(session_id: str) -> SessionEventBus | None:
+            return bus if session_id == "sess-1" else None
+
+        def _fake_try_acquire_quota(*, user_id: int, session_id: str, persona_id: str | None):
+            quota_acquire_calls.append(
+                {"user_id": user_id, "session_id": session_id, "persona_id": persona_id}
+            )
+            return {
+                "user_key": f"user:{user_id}",
+                "persona_key": f"persona:{persona_id}",
+                "session_key": f"session:{session_id}",
+            }, None
+
+        def _fake_release_quota(token: dict[str, str | None] | None) -> None:
+            if token is not None:
+                quota_release_calls.append(token)
+
+        monkeypatch.setattr(multiplex_endpoints, "_authenticate_ws", _fake_authenticate_ws)
+        monkeypatch.setattr(multiplex_endpoints, "get_runner_client", _fake_get_runner_client)
+        monkeypatch.setattr(multiplex_endpoints, "get_session_event_bus", _fake_get_session_event_bus)
+        monkeypatch.setattr(multiplex_endpoints, "_acp_ws_try_acquire_quota", _fake_try_acquire_quota)
+        monkeypatch.setattr(multiplex_endpoints, "_acp_ws_release_quota", _fake_release_quota)
+
+        ws = _FakeMultiplexWebSocket(
+            incoming=[multiplex_endpoints.MultiplexMessage.stream_open("sess-1").to_json()],
+        )
+
+        await multiplex_endpoints.acp_multiplex_ws(ws, token="valid-token")
+
+        assert ws.accepted is True
+        assert stub_client.access_checks == [("sess-1", 7)]
+        assert quota_acquire_calls == [
+            {"user_id": 7, "session_id": "sess-1", "persona_id": "persona-1"}
+        ]
+        assert quota_release_calls == [
+            {
+                "user_key": "user:7",
+                "persona_key": "persona:persona-1",
+                "session_key": "session:sess-1",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_multiplex_sends_error_frame_for_handler_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import tldw_Server_API.app.api.v1.endpoints.acp_multiplex as multiplex_endpoints
+
+        lifecycle = {"started": 0, "stopped": 0}
+
+        class _StubManager:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            def start(self) -> None:
+                lifecycle["started"] += 1
+
+            async def handle_message(self, raw: str) -> None:
+                raise RuntimeError("boom")
+
+            async def stop(self) -> None:
+                lifecycle["stopped"] += 1
+
+        async def _fake_authenticate_ws(*args: Any, **kwargs: Any) -> int:
+            return 1
+
+        async def _fake_get_runner_client() -> MockRunnerClient:
+            return MockRunnerClient()
+
+        monkeypatch.setattr(multiplex_endpoints, "_authenticate_ws", _fake_authenticate_ws)
+        monkeypatch.setattr(multiplex_endpoints, "get_runner_client", _fake_get_runner_client)
+        monkeypatch.setattr(multiplex_endpoints, "MultiplexManager", _StubManager)
+
+        ws = _FakeMultiplexWebSocket(
+            incoming=[multiplex_endpoints.MultiplexMessage.ping().to_json()],
+        )
+
+        await multiplex_endpoints.acp_multiplex_ws(ws, token="valid-token")
+
+        assert lifecycle == {"started": 1, "stopped": 1}
+        assert len(ws.sent_text) == 1
+        error_message = multiplex_endpoints.MultiplexMessage.from_json(ws.sent_text[0])
+        assert error_message.type.value == "error"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_conditions_integration.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_conditions_integration.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import tempfile
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -187,14 +187,11 @@ async def test_no_conditions_backward_compat():
 # ---------------------------------------------------------------------------
 
 
-def test_ancestry_chain_db_column():
+def test_ancestry_chain_db_column(tmp_path: Path) -> None:
     """The sessions table should have an ancestry_chain_json column after migration."""
     from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
 
-    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-        db_path = f.name
-
-    db = ACPSessionsDB(db_path=db_path)
+    db = ACPSessionsDB(db_path=str(tmp_path / "test-ancestry.db"))
     # register_session triggers schema init
     d = db.register_session(
         session_id="test-anc",
@@ -212,14 +209,11 @@ def test_ancestry_chain_db_column():
 # ---------------------------------------------------------------------------
 
 
-def test_conditions_json_db_column():
+def test_conditions_json_db_column(tmp_path: Path) -> None:
     """The permission_policies table should have a conditions_json column."""
     from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
 
-    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-        db_path = f.name
-
-    db = ACPSessionsDB(db_path=db_path)
+    db = ACPSessionsDB(db_path=str(tmp_path / "test-conditions.db"))
     # Create a permission policy to trigger schema init
     policy_id = db.create_permission_policy(
         name="test-policy",
@@ -255,3 +249,50 @@ async def test_empty_conditions_dict_applies_policy():
     published = bus.publish.call_args[0][0]
     assert published.kind == AgentEventKind.TOOL_RESULT
     assert published.metadata.get("governance_action") == "denied_by_snapshot"
+
+
+@pytest.mark.asyncio
+async def test_source_ip_match_applies_policy() -> None:
+    """A policy restricted by source IP should apply when client_ip matches."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(
+        denied_tools=["restricted_*"],
+        conditions={"source_ips": ["10.0.0.0/24"]},
+    )
+    gov = GovernanceFilter(
+        bus=bus,
+        policy_snapshot=snapshot,
+        session_metadata={"client_ip": "10.0.0.42"},
+    )
+
+    event = _make_tool_event(tool_name="restricted_tool")
+    await gov.process(event)
+
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_RESULT
+    assert published.metadata.get("governance_action") == "denied_by_snapshot"
+
+
+@pytest.mark.asyncio
+async def test_source_ip_mismatch_skips_policy() -> None:
+    """A policy restricted by source IP should be skipped when client_ip mismatches."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(
+        denied_tools=["restricted_*"],
+        conditions={"source_ips": ["10.0.0.0/24"]},
+    )
+    gov = GovernanceFilter(
+        bus=bus,
+        policy_snapshot=snapshot,
+        session_metadata={"client_ip": "192.168.1.20"},
+    )
+
+    event = _make_tool_event(tool_name="restricted_tool")
+    await gov.process(event)
+
+    published = bus.publish.call_args[0][0]
+    assert published.metadata.get("governance_action") != "denied_by_snapshot"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_conditions_integration.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_conditions_integration.py
@@ -1,0 +1,257 @@
+"""Integration tests for policy conditions wiring.
+
+Covers GovernanceFilter condition evaluation, DB schema migration for
+conditions_json and ancestry_chain_json columns, and backward compat.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 4, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_event(
+    tool_name: str,
+    session_id: str = "s1",
+    tool_call_id: str = "tc1",
+) -> AgentEvent:
+    return AgentEvent(
+        session_id=session_id,
+        kind=AgentEventKind.TOOL_CALL,
+        payload={
+            "tool_id": tool_call_id,
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "arguments": {},
+        },
+    )
+
+
+def _make_snapshot(
+    denied_tools: list[str] | None = None,
+    allowed_tools: list[str] | None = None,
+    conditions: dict | None = None,
+) -> MagicMock:
+    snapshot = MagicMock()
+    doc: dict = {}
+    if denied_tools is not None:
+        doc["denied_tools"] = denied_tools
+    if allowed_tools is not None:
+        doc["allowed_tools"] = allowed_tools
+    if conditions is not None:
+        doc["conditions"] = conditions
+    snapshot.resolved_policy_document = doc
+    return snapshot
+
+
+def _make_bus() -> MagicMock:
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    return bus
+
+
+# ---------------------------------------------------------------------------
+# GovernanceFilter: expired policy skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expired_policy_skipped():
+    """A policy with an expired time window should be skipped (fall through)."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(
+        denied_tools=["dangerous_*"],
+        conditions={
+            "valid_from": (_NOW - timedelta(hours=2)).isoformat(),
+            "valid_until": (_NOW - timedelta(hours=1)).isoformat(),
+        },
+    )
+    gov = GovernanceFilter(bus=bus, policy_snapshot=snapshot)
+
+    # Tool would be denied if conditions passed, but they should fail
+    event = _make_tool_event(tool_name="dangerous_delete")
+    await gov.process(event)
+
+    # With expired conditions, snapshot returns None -> falls through to heuristic.
+    # "dangerous_delete" isn't recognized as a known tool by heuristics, so it
+    # should default to some tier. The key thing is it should NOT be denied_by_snapshot.
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.metadata.get("governance_action") != "denied_by_snapshot"
+
+
+# ---------------------------------------------------------------------------
+# GovernanceFilter: valid policy applies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_valid_policy_applies():
+    """A policy with valid conditions should apply its rules."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(
+        allowed_tools=["safe_*"],
+        conditions={
+            "valid_from": (_NOW - timedelta(hours=1)).isoformat(),
+            "valid_until": (_NOW + timedelta(hours=1)).isoformat(),
+        },
+    )
+    gov = GovernanceFilter(bus=bus, policy_snapshot=snapshot)
+
+    event = _make_tool_event(tool_name="safe_read")
+    await gov.process(event)
+
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_CALL
+    assert published.payload["tool_name"] == "safe_read"
+
+
+# ---------------------------------------------------------------------------
+# GovernanceFilter: label mismatch skips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_label_mismatch_skips_policy():
+    """A policy requiring labels that don't match session metadata should be skipped."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(
+        denied_tools=["*"],
+        conditions={"required_labels": {"env": "prod"}},
+    )
+    # Session metadata says env=staging, so conditions fail
+    gov = GovernanceFilter(
+        bus=bus,
+        policy_snapshot=snapshot,
+        session_metadata={"labels": {"env": "staging"}},
+    )
+
+    event = _make_tool_event(tool_name="anything")
+    await gov.process(event)
+
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    # Policy should not apply, so not denied_by_snapshot
+    assert published.metadata.get("governance_action") != "denied_by_snapshot"
+
+
+# ---------------------------------------------------------------------------
+# GovernanceFilter: no-conditions backward compat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_conditions_backward_compat():
+    """A snapshot without any conditions key should behave as before (apply unconditionally)."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(denied_tools=["bad_*"])
+    # No conditions key in snapshot at all
+    gov = GovernanceFilter(bus=bus, policy_snapshot=snapshot)
+
+    event = _make_tool_event(tool_name="bad_tool")
+    await gov.process(event)
+
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_RESULT
+    assert "denied by policy" in published.payload.get("error", "").lower()
+    assert published.metadata.get("governance_action") == "denied_by_snapshot"
+
+
+# ---------------------------------------------------------------------------
+# DB: ancestry_chain_json column exists
+# ---------------------------------------------------------------------------
+
+
+def test_ancestry_chain_db_column():
+    """The sessions table should have an ancestry_chain_json column after migration."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+
+    db = ACPSessionsDB(db_path=db_path)
+    # register_session triggers schema init
+    d = db.register_session(
+        session_id="test-anc",
+        user_id=1,
+        agent_type="custom",
+    )
+    assert "ancestry_chain_json" in d
+    # Column defaults to NULL; not set means None (deserialized as [])
+    # When NULL in DB, the JSON list deserializer leaves it as None
+    assert d["ancestry_chain_json"] is None or d["ancestry_chain_json"] == []
+
+
+# ---------------------------------------------------------------------------
+# DB: conditions_json column exists
+# ---------------------------------------------------------------------------
+
+
+def test_conditions_json_db_column():
+    """The permission_policies table should have a conditions_json column."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+
+    db = ACPSessionsDB(db_path=db_path)
+    # Create a permission policy to trigger schema init
+    policy_id = db.create_permission_policy(
+        name="test-policy",
+        rules_json="[]",
+    )
+    row = db.get_permission_policy(policy_id)
+    assert row is not None
+    assert "conditions_json" in row
+    assert row["conditions_json"] is None  # not set
+
+
+# ---------------------------------------------------------------------------
+# GovernanceFilter: empty conditions dict acts like no conditions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_conditions_dict_applies_policy():
+    """An empty conditions dict {} should not block the policy."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = _make_bus()
+    snapshot = _make_snapshot(
+        denied_tools=["blocked_*"],
+        conditions={},
+    )
+    gov = GovernanceFilter(bus=bus, policy_snapshot=snapshot)
+
+    event = _make_tool_event(tool_name="blocked_tool")
+    await gov.process(event)
+
+    bus.publish.assert_called_once()
+    published = bus.publish.call_args[0][0]
+    assert published.kind == AgentEventKind.TOOL_RESULT
+    assert published.metadata.get("governance_action") == "denied_by_snapshot"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_merge_utils.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_merge_utils.py
@@ -1,0 +1,198 @@
+"""Tests for the shared merge_utils module.
+
+Covers: scalar override, dict merge, union-list append+dedup, nested merge,
+None skip, and non-union list replacement.
+"""
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.merge_utils import (
+    UNION_LIST_KEYS,
+    merge_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Scalar override
+# ---------------------------------------------------------------------------
+
+
+class TestScalarOverride:
+    def test_string_override(self) -> None:
+        base = {"approval_mode": "require"}
+        overlay = {"approval_mode": "auto"}
+        result = merge_config(base, overlay)
+        assert result["approval_mode"] == "auto"
+
+    def test_int_override(self) -> None:
+        base = {"max_retries": 3}
+        overlay = {"max_retries": 5}
+        result = merge_config(base, overlay)
+        assert result["max_retries"] == 5
+
+    def test_bool_override(self) -> None:
+        base = {"enabled": False}
+        overlay = {"enabled": True}
+        result = merge_config(base, overlay)
+        assert result["enabled"] is True
+
+    def test_new_key_added(self) -> None:
+        base = {"a": 1}
+        overlay = {"b": 2}
+        result = merge_config(base, overlay)
+        assert result == {"a": 1, "b": 2}
+
+
+# ---------------------------------------------------------------------------
+# 2. Dict merge (recursive)
+# ---------------------------------------------------------------------------
+
+
+class TestDictMerge:
+    def test_nested_dicts_merge(self) -> None:
+        base = {"tool_tier_overrides": {"Read(*)": "auto", "Write(*)": "batch"}}
+        overlay = {"tool_tier_overrides": {"Write(*)": "individual", "Bash(*)": "auto"}}
+        result = merge_config(base, overlay)
+        assert result["tool_tier_overrides"] == {
+            "Read(*)": "auto",
+            "Write(*)": "individual",
+            "Bash(*)": "auto",
+        }
+
+    def test_deeply_nested_merge(self) -> None:
+        base = {"level1": {"level2": {"a": 1, "b": 2}}}
+        overlay = {"level1": {"level2": {"b": 3, "c": 4}}}
+        result = merge_config(base, overlay)
+        assert result["level1"]["level2"] == {"a": 1, "b": 3, "c": 4}
+
+    def test_overlay_dict_replaces_scalar(self) -> None:
+        """When base has a scalar and overlay has a dict, overlay wins."""
+        base = {"x": "old"}
+        overlay = {"x": {"nested": True}}
+        result = merge_config(base, overlay)
+        assert result["x"] == {"nested": True}
+
+    def test_overlay_scalar_replaces_dict(self) -> None:
+        """When base has a dict and overlay has a non-dict, overlay wins."""
+        base = {"x": {"nested": True}}
+        overlay = {"x": "flat"}
+        result = merge_config(base, overlay)
+        assert result["x"] == "flat"
+
+
+# ---------------------------------------------------------------------------
+# 3. Union-list append + dedup
+# ---------------------------------------------------------------------------
+
+
+class TestUnionListAppendDedup:
+    @pytest.mark.parametrize("key", sorted(UNION_LIST_KEYS))
+    def test_all_union_keys_append(self, key: str) -> None:
+        base = {key: ["a", "b"]}
+        overlay = {key: ["b", "c"]}
+        result = merge_config(base, overlay)
+        assert result[key] == ["a", "b", "c"]
+
+    def test_allowed_tools_dedup(self) -> None:
+        base = {"allowed_tools": ["web.search", "file.read"]}
+        overlay = {"allowed_tools": ["file.read", "db.query"]}
+        result = merge_config(base, overlay)
+        assert result["allowed_tools"] == ["web.search", "file.read", "db.query"]
+
+    def test_union_list_from_string(self) -> None:
+        base = {"capabilities": "read"}
+        overlay = {"capabilities": "write"}
+        result = merge_config(base, overlay)
+        assert result["capabilities"] == ["read", "write"]
+
+    def test_union_list_empty_base(self) -> None:
+        base: dict = {}
+        overlay = {"denied_tools": ["rm", "kill"]}
+        result = merge_config(base, overlay)
+        assert result["denied_tools"] == ["rm", "kill"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Nested merge (combines dict + union-list inside nested)
+# ---------------------------------------------------------------------------
+
+
+class TestNestedMerge:
+    def test_nested_with_union_list(self) -> None:
+        base = {
+            "policy": {
+                "allowed_tools": ["a"],
+                "mode": "strict",
+            },
+        }
+        overlay = {
+            "policy": {
+                "allowed_tools": ["b"],
+                "timeout": 30,
+            },
+        }
+        result = merge_config(base, overlay)
+        assert result["policy"]["allowed_tools"] == ["a", "b"]
+        assert result["policy"]["mode"] == "strict"
+        assert result["policy"]["timeout"] == 30
+
+
+# ---------------------------------------------------------------------------
+# 5. None values in overlay are skipped
+# ---------------------------------------------------------------------------
+
+
+class TestNoneSkip:
+    def test_none_value_preserves_base(self) -> None:
+        base = {"approval_mode": "require", "max_retries": 3}
+        overlay = {"approval_mode": None, "max_retries": 5}
+        result = merge_config(base, overlay)
+        assert result["approval_mode"] == "require"
+        assert result["max_retries"] == 5
+
+    def test_none_for_missing_key_does_not_add(self) -> None:
+        base = {"a": 1}
+        overlay = {"b": None}
+        result = merge_config(base, overlay)
+        assert "b" not in result
+
+    def test_none_union_list_preserves_base(self) -> None:
+        base = {"allowed_tools": ["x"]}
+        overlay = {"allowed_tools": None}
+        result = merge_config(base, overlay)
+        assert result["allowed_tools"] == ["x"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Non-union list is replaced (not appended)
+# ---------------------------------------------------------------------------
+
+
+class TestNonUnionListReplaced:
+    def test_regular_list_replaced(self) -> None:
+        base = {"tags": ["old1", "old2"]}
+        overlay = {"tags": ["new1"]}
+        result = merge_config(base, overlay)
+        assert result["tags"] == ["new1"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Immutability
+# ---------------------------------------------------------------------------
+
+
+class TestImmutability:
+    def test_base_not_mutated(self) -> None:
+        base = {"allowed_tools": ["a"], "nested": {"x": 1}}
+        original = copy.deepcopy(base)
+        merge_config(base, {"allowed_tools": ["b"], "nested": {"y": 2}})
+        assert base == original
+
+    def test_overlay_not_mutated(self) -> None:
+        overlay = {"nested": {"x": 1}}
+        original = copy.deepcopy(overlay)
+        merge_config({"nested": {"y": 2}}, overlay)
+        assert overlay == original

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_multiplex_manager.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_multiplex_manager.py
@@ -39,6 +39,13 @@ class FakeSender:
         self._raw.clear()
 
 
+class FailingSender:
+    """Raises on send to simulate a broken WebSocket transport."""
+
+    async def __call__(self, raw: str) -> None:
+        raise RuntimeError("send failed")
+
+
 def _make_buses(*session_ids: str) -> dict[str, SessionEventBus]:
     return {sid: SessionEventBus(sid) for sid in session_ids}
 
@@ -109,6 +116,25 @@ class TestOpenStream:
 
         assert mgr.active_streams == ["sess-1"]
         assert len(sender.messages) == 0
+        await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_invalid_last_sequence_sends_error(self) -> None:
+        sender = FakeSender()
+        buses = _make_buses("sess-1")
+        mgr = _make_manager(sender, buses)
+
+        raw = MultiplexMessage(
+            type=MultiplexMessageType.STREAM_OPEN,
+            stream_id="sess-1",
+            payload={"session_id": "sess-1", "last_sequence": "not-an-int"},
+        ).to_json()
+        await mgr.handle_message(raw)
+
+        assert mgr.active_streams == []
+        assert len(sender.messages) == 1
+        assert sender.last().type == MultiplexMessageType.ERROR
+        assert "last_sequence" in sender.last().payload["error"]
         await mgr.stop()
 
 
@@ -225,6 +251,26 @@ class TestStopCleansUp:
 
         await mgr.stop()
         assert mgr._ping_task is None
+
+    @pytest.mark.asyncio
+    async def test_stop_continues_after_forwarder_failure(self) -> None:
+        sender = FailingSender()
+        buses = _make_buses("a", "b")
+        mgr = _make_manager(sender, buses)
+
+        await mgr.handle_message(MultiplexMessage.stream_open("a").to_json())
+        await mgr.handle_message(MultiplexMessage.stream_open("b").to_json())
+
+        await buses["a"].publish(
+            AgentEvent(session_id="a", kind=AgentEventKind.THINKING, payload={"step": 1}),
+        )
+        await asyncio.sleep(0.05)
+
+        await mgr.stop()
+
+        assert mgr.active_streams == []
+        assert len(buses["a"]._subscribers) == 0
+        assert len(buses["b"]._subscribers) == 0
 
 
 class TestEventForwarding:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_multiplex_manager.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_multiplex_manager.py
@@ -1,0 +1,308 @@
+"""Tests for MultiplexManager."""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Optional
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.manager import MultiplexManager
+from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.protocol import (
+    MultiplexMessage,
+    MultiplexMessageType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeSender:
+    """Collects messages sent by the manager."""
+
+    def __init__(self) -> None:
+        self.messages: list[MultiplexMessage] = []
+        self._raw: list[str] = []
+
+    async def __call__(self, raw: str) -> None:
+        self._raw.append(raw)
+        self.messages.append(MultiplexMessage.from_json(raw))
+
+    def last(self) -> MultiplexMessage:
+        return self.messages[-1]
+
+    def clear(self) -> None:
+        self.messages.clear()
+        self._raw.clear()
+
+
+def _make_buses(*session_ids: str) -> dict[str, SessionEventBus]:
+    return {sid: SessionEventBus(sid) for sid in session_ids}
+
+
+def _get_bus_fn(buses: dict[str, SessionEventBus]):
+    """Return a lookup function matching the ``get_bus_fn`` signature."""
+    def fn(session_id: str) -> Optional[SessionEventBus]:
+        return buses.get(session_id)
+    return fn
+
+
+def _make_manager(
+    sender: FakeSender,
+    buses: dict[str, SessionEventBus],
+    ping_interval: float = 0,
+) -> MultiplexManager:
+    return MultiplexManager(
+        connection_id="test",
+        send_fn=sender,
+        get_bus_fn=_get_bus_fn(buses),
+        ping_interval=ping_interval,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOpenStream:
+    @pytest.mark.asyncio
+    async def test_open_known_session(self):
+        sender = FakeSender()
+        buses = _make_buses("sess-1")
+        mgr = _make_manager(sender, buses)
+
+        msg = MultiplexMessage.stream_open("sess-1").to_json()
+        await mgr.handle_message(msg)
+
+        assert "sess-1" in mgr.active_streams
+        # No error sent
+        assert len(sender.messages) == 0
+        await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_open_unknown_session_sends_error(self):
+        sender = FakeSender()
+        mgr = _make_manager(sender, {})
+
+        msg = MultiplexMessage.stream_open("nonexistent").to_json()
+        await mgr.handle_message(msg)
+
+        assert len(sender.messages) == 1
+        assert sender.last().type == MultiplexMessageType.ERROR
+        assert "Unknown session" in sender.last().payload["error"]
+        assert sender.last().stream_id == "nonexistent"
+        assert mgr.active_streams == []
+        await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_open_idempotent(self):
+        sender = FakeSender()
+        buses = _make_buses("sess-1")
+        mgr = _make_manager(sender, buses)
+
+        msg = MultiplexMessage.stream_open("sess-1").to_json()
+        await mgr.handle_message(msg)
+        await mgr.handle_message(msg)
+
+        assert mgr.active_streams == ["sess-1"]
+        assert len(sender.messages) == 0
+        await mgr.stop()
+
+
+class TestCloseStream:
+    @pytest.mark.asyncio
+    async def test_close_unsubscribes(self):
+        sender = FakeSender()
+        buses = _make_buses("sess-1")
+        mgr = _make_manager(sender, buses)
+
+        await mgr.handle_message(MultiplexMessage.stream_open("sess-1").to_json())
+        assert "sess-1" in mgr.active_streams
+
+        # Verify subscription exists on the bus
+        bus = buses["sess-1"]
+        consumer_id = f"mpx-test-sess-1"
+        assert consumer_id in bus._subscribers
+
+        await mgr.handle_message(MultiplexMessage.stream_close("sess-1").to_json())
+        assert mgr.active_streams == []
+        assert consumer_id not in bus._subscribers
+
+        await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_close_nonexistent_is_noop(self):
+        sender = FakeSender()
+        mgr = _make_manager(sender, {})
+
+        await mgr.handle_message(MultiplexMessage.stream_close("nope").to_json())
+        # No error -- closing a non-open stream is harmless
+        assert len(sender.messages) == 0
+        await mgr.stop()
+
+
+class TestPingPong:
+    @pytest.mark.asyncio
+    async def test_client_ping_gets_pong(self):
+        sender = FakeSender()
+        mgr = _make_manager(sender, {})
+
+        await mgr.handle_message(MultiplexMessage.ping().to_json())
+
+        assert len(sender.messages) == 1
+        assert sender.last().type == MultiplexMessageType.PONG
+        await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_ping_loop_sends_ping(self):
+        sender = FakeSender()
+        mgr = _make_manager(sender, {}, ping_interval=0.05)
+        mgr.start()
+
+        # Wait long enough for at least one ping
+        await asyncio.sleep(0.15)
+        await mgr.stop()
+
+        ping_msgs = [m for m in sender.messages if m.type == MultiplexMessageType.PING]
+        assert len(ping_msgs) >= 1
+
+
+class TestInvalidMessages:
+    @pytest.mark.asyncio
+    async def test_invalid_json_sends_error(self):
+        sender = FakeSender()
+        mgr = _make_manager(sender, {})
+
+        await mgr.handle_message("not json!!!")
+
+        assert len(sender.messages) == 1
+        assert sender.last().type == MultiplexMessageType.ERROR
+        assert "Invalid message" in sender.last().payload["error"]
+        await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_type_sends_error(self):
+        sender = FakeSender()
+        mgr = _make_manager(sender, {})
+
+        # STREAM_DATA is server->client only
+        raw = MultiplexMessage.stream_data("s", {"x": 1}).to_json()
+        await mgr.handle_message(raw)
+
+        assert len(sender.messages) == 1
+        assert sender.last().type == MultiplexMessageType.ERROR
+        assert "Unsupported" in sender.last().payload["error"]
+        await mgr.stop()
+
+
+class TestStopCleansUp:
+    @pytest.mark.asyncio
+    async def test_stop_closes_all_streams(self):
+        sender = FakeSender()
+        buses = _make_buses("a", "b")
+        mgr = _make_manager(sender, buses)
+
+        await mgr.handle_message(MultiplexMessage.stream_open("a").to_json())
+        await mgr.handle_message(MultiplexMessage.stream_open("b").to_json())
+        assert len(mgr.active_streams) == 2
+
+        await mgr.stop()
+        assert mgr.active_streams == []
+
+        # Subscribers should be removed from both buses
+        assert len(buses["a"]._subscribers) == 0
+        assert len(buses["b"]._subscribers) == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_ping(self):
+        sender = FakeSender()
+        mgr = _make_manager(sender, {}, ping_interval=0.05)
+        mgr.start()
+        assert mgr._ping_task is not None
+
+        await mgr.stop()
+        assert mgr._ping_task is None
+
+
+class TestEventForwarding:
+    @pytest.mark.asyncio
+    async def test_published_event_forwarded(self):
+        sender = FakeSender()
+        buses = _make_buses("sess-1")
+        mgr = _make_manager(sender, buses)
+
+        await mgr.handle_message(MultiplexMessage.stream_open("sess-1").to_json())
+
+        # Publish an event to the bus
+        event = AgentEvent(
+            session_id="sess-1",
+            kind=AgentEventKind.THINKING,
+            payload={"text": "reasoning..."},
+        )
+        await buses["sess-1"].publish(event)
+
+        # Give the forwarding task a moment to pick it up
+        await asyncio.sleep(0.05)
+
+        assert len(sender.messages) >= 1
+        data_msgs = [m for m in sender.messages if m.type == MultiplexMessageType.STREAM_DATA]
+        assert len(data_msgs) == 1
+        assert data_msgs[0].stream_id == "sess-1"
+        assert data_msgs[0].payload["kind"] == "thinking"
+        assert data_msgs[0].payload["session_id"] == "sess-1"
+
+        await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_multiple_events_forwarded(self):
+        sender = FakeSender()
+        buses = _make_buses("sess-1")
+        mgr = _make_manager(sender, buses)
+
+        await mgr.handle_message(MultiplexMessage.stream_open("sess-1").to_json())
+
+        for i in range(3):
+            event = AgentEvent(
+                session_id="sess-1",
+                kind=AgentEventKind.THINKING,
+                payload={"step": i},
+            )
+            await buses["sess-1"].publish(event)
+
+        await asyncio.sleep(0.1)
+
+        data_msgs = [m for m in sender.messages if m.type == MultiplexMessageType.STREAM_DATA]
+        assert len(data_msgs) == 3
+        steps = [m.payload["payload"]["step"] for m in data_msgs]
+        assert steps == [0, 1, 2]
+
+        await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_events_only_for_subscribed_streams(self):
+        """Events from un-subscribed sessions must not leak."""
+        sender = FakeSender()
+        buses = _make_buses("a", "b")
+        mgr = _make_manager(sender, buses)
+
+        # Only subscribe to "a"
+        await mgr.handle_message(MultiplexMessage.stream_open("a").to_json())
+
+        # Publish to both
+        await buses["a"].publish(
+            AgentEvent(session_id="a", kind=AgentEventKind.THINKING, payload={"from": "a"}),
+        )
+        await buses["b"].publish(
+            AgentEvent(session_id="b", kind=AgentEventKind.THINKING, payload={"from": "b"}),
+        )
+
+        await asyncio.sleep(0.05)
+
+        data_msgs = [m for m in sender.messages if m.type == MultiplexMessageType.STREAM_DATA]
+        assert len(data_msgs) == 1
+        assert data_msgs[0].stream_id == "a"
+
+        await mgr.stop()

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_multiplex_protocol.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_multiplex_protocol.py
@@ -17,11 +17,11 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.protocol import (
 # ---------------------------------------------------------------------------
 
 class TestMultiplexMessageType:
-    def test_all_values(self):
+    def test_all_values(self) -> None:
         expected = {"stream_open", "stream_data", "stream_close", "ping", "pong", "error"}
         assert {e.value for e in MultiplexMessageType} == expected
 
-    def test_str_mixin(self):
+    def test_str_mixin(self) -> None:
         assert MultiplexMessageType.PING == "ping"
         assert isinstance(MultiplexMessageType.PING, str)
 
@@ -31,52 +31,52 @@ class TestMultiplexMessageType:
 # ---------------------------------------------------------------------------
 
 class TestFactoryMethods:
-    def test_stream_open_basic(self):
+    def test_stream_open_basic(self) -> None:
         msg = MultiplexMessage.stream_open("sess-1")
         assert msg.type == MultiplexMessageType.STREAM_OPEN
         assert msg.stream_id == "sess-1"
         assert msg.payload == {"session_id": "sess-1"}
 
-    def test_stream_open_with_last_sequence(self):
+    def test_stream_open_with_last_sequence(self) -> None:
         msg = MultiplexMessage.stream_open("sess-1", last_sequence=42)
         assert msg.payload == {"session_id": "sess-1", "last_sequence": 42}
 
-    def test_stream_open_last_sequence_zero_omitted(self):
+    def test_stream_open_last_sequence_zero_omitted(self) -> None:
         msg = MultiplexMessage.stream_open("sess-1", last_sequence=0)
         assert "last_sequence" not in msg.payload
 
-    def test_stream_data(self):
+    def test_stream_data(self) -> None:
         data = {"kind": "thinking", "text": "hmm"}
         msg = MultiplexMessage.stream_data("sess-1", data)
         assert msg.type == MultiplexMessageType.STREAM_DATA
         assert msg.stream_id == "sess-1"
         assert msg.payload == data
 
-    def test_stream_close(self):
+    def test_stream_close(self) -> None:
         msg = MultiplexMessage.stream_close("sess-1")
         assert msg.type == MultiplexMessageType.STREAM_CLOSE
         assert msg.stream_id == "sess-1"
         assert msg.payload is None
 
-    def test_ping(self):
+    def test_ping(self) -> None:
         msg = MultiplexMessage.ping()
         assert msg.type == MultiplexMessageType.PING
         assert msg.stream_id is None
         assert msg.payload is None
 
-    def test_pong(self):
+    def test_pong(self) -> None:
         msg = MultiplexMessage.pong()
         assert msg.type == MultiplexMessageType.PONG
         assert msg.stream_id is None
         assert msg.payload is None
 
-    def test_error_no_stream(self):
+    def test_error_no_stream(self) -> None:
         msg = MultiplexMessage.error("bad request")
         assert msg.type == MultiplexMessageType.ERROR
         assert msg.stream_id is None
         assert msg.payload == {"error": "bad request"}
 
-    def test_error_with_stream(self):
+    def test_error_with_stream(self) -> None:
         msg = MultiplexMessage.error("not found", stream_id="sess-99")
         assert msg.type == MultiplexMessageType.ERROR
         assert msg.stream_id == "sess-99"
@@ -88,7 +88,7 @@ class TestFactoryMethods:
 # ---------------------------------------------------------------------------
 
 class TestSerialization:
-    def test_to_dict_omits_none_fields(self):
+    def test_to_dict_omits_none_fields(self) -> None:
         msg = MultiplexMessage.ping()
         d = msg.to_dict()
         assert "stream_id" not in d
@@ -96,13 +96,13 @@ class TestSerialization:
         assert d["type"] == "ping"
         assert "timestamp" in d
 
-    def test_to_dict_includes_present_fields(self):
+    def test_to_dict_includes_present_fields(self) -> None:
         msg = MultiplexMessage.stream_data("s1", {"key": "val"})
         d = msg.to_dict()
         assert d["stream_id"] == "s1"
         assert d["payload"] == {"key": "val"}
 
-    def test_roundtrip_dict(self):
+    def test_roundtrip_dict(self) -> None:
         msg = MultiplexMessage.stream_open("sess-abc", last_sequence=7)
         recovered = MultiplexMessage.from_dict(msg.to_dict())
         assert recovered.type == msg.type
@@ -110,38 +110,38 @@ class TestSerialization:
         assert recovered.payload == msg.payload
         assert abs(recovered.timestamp - msg.timestamp) < 0.01
 
-    def test_roundtrip_json(self):
+    def test_roundtrip_json(self) -> None:
         msg = MultiplexMessage.error("oops", stream_id="s2")
         recovered = MultiplexMessage.from_json(msg.to_json())
         assert recovered.type == msg.type
         assert recovered.stream_id == msg.stream_id
         assert recovered.payload == msg.payload
 
-    def test_to_json_compact(self):
+    def test_to_json_compact(self) -> None:
         msg = MultiplexMessage.pong()
         raw = msg.to_json()
         # No spaces after separators
         assert " " not in raw
 
-    def test_from_dict_missing_type_raises(self):
+    def test_from_dict_missing_type_raises(self) -> None:
         with pytest.raises(ValueError, match="missing required key 'type'"):
             MultiplexMessage.from_dict({"stream_id": "x"})
 
-    def test_from_dict_invalid_type_raises(self):
+    def test_from_dict_invalid_type_raises(self) -> None:
         with pytest.raises(ValueError):
             MultiplexMessage.from_dict({"type": "nonexistent"})
 
-    def test_from_json_invalid_json_raises(self):
+    def test_from_json_invalid_json_raises(self) -> None:
         with pytest.raises(json.JSONDecodeError):
             MultiplexMessage.from_json("not-json{{{")
 
-    def test_timestamp_defaults_to_now(self):
+    def test_timestamp_defaults_to_now(self) -> None:
         before = time.time()
         msg = MultiplexMessage.ping()
         after = time.time()
         assert before <= msg.timestamp <= after
 
-    def test_from_dict_default_timestamp(self):
+    def test_from_dict_default_timestamp(self) -> None:
         """When timestamp is absent, from_dict uses current time."""
         before = time.time()
         msg = MultiplexMessage.from_dict({"type": "pong"})

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_multiplex_protocol.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_multiplex_protocol.py
@@ -1,0 +1,149 @@
+"""Tests for MultiplexMessage and MultiplexMessageType."""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.multiplex.protocol import (
+    MultiplexMessage,
+    MultiplexMessageType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Enum values
+# ---------------------------------------------------------------------------
+
+class TestMultiplexMessageType:
+    def test_all_values(self):
+        expected = {"stream_open", "stream_data", "stream_close", "ping", "pong", "error"}
+        assert {e.value for e in MultiplexMessageType} == expected
+
+    def test_str_mixin(self):
+        assert MultiplexMessageType.PING == "ping"
+        assert isinstance(MultiplexMessageType.PING, str)
+
+
+# ---------------------------------------------------------------------------
+# Factory methods
+# ---------------------------------------------------------------------------
+
+class TestFactoryMethods:
+    def test_stream_open_basic(self):
+        msg = MultiplexMessage.stream_open("sess-1")
+        assert msg.type == MultiplexMessageType.STREAM_OPEN
+        assert msg.stream_id == "sess-1"
+        assert msg.payload == {"session_id": "sess-1"}
+
+    def test_stream_open_with_last_sequence(self):
+        msg = MultiplexMessage.stream_open("sess-1", last_sequence=42)
+        assert msg.payload == {"session_id": "sess-1", "last_sequence": 42}
+
+    def test_stream_open_last_sequence_zero_omitted(self):
+        msg = MultiplexMessage.stream_open("sess-1", last_sequence=0)
+        assert "last_sequence" not in msg.payload
+
+    def test_stream_data(self):
+        data = {"kind": "thinking", "text": "hmm"}
+        msg = MultiplexMessage.stream_data("sess-1", data)
+        assert msg.type == MultiplexMessageType.STREAM_DATA
+        assert msg.stream_id == "sess-1"
+        assert msg.payload == data
+
+    def test_stream_close(self):
+        msg = MultiplexMessage.stream_close("sess-1")
+        assert msg.type == MultiplexMessageType.STREAM_CLOSE
+        assert msg.stream_id == "sess-1"
+        assert msg.payload is None
+
+    def test_ping(self):
+        msg = MultiplexMessage.ping()
+        assert msg.type == MultiplexMessageType.PING
+        assert msg.stream_id is None
+        assert msg.payload is None
+
+    def test_pong(self):
+        msg = MultiplexMessage.pong()
+        assert msg.type == MultiplexMessageType.PONG
+        assert msg.stream_id is None
+        assert msg.payload is None
+
+    def test_error_no_stream(self):
+        msg = MultiplexMessage.error("bad request")
+        assert msg.type == MultiplexMessageType.ERROR
+        assert msg.stream_id is None
+        assert msg.payload == {"error": "bad request"}
+
+    def test_error_with_stream(self):
+        msg = MultiplexMessage.error("not found", stream_id="sess-99")
+        assert msg.type == MultiplexMessageType.ERROR
+        assert msg.stream_id == "sess-99"
+        assert msg.payload == {"error": "not found"}
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trips
+# ---------------------------------------------------------------------------
+
+class TestSerialization:
+    def test_to_dict_omits_none_fields(self):
+        msg = MultiplexMessage.ping()
+        d = msg.to_dict()
+        assert "stream_id" not in d
+        assert "payload" not in d
+        assert d["type"] == "ping"
+        assert "timestamp" in d
+
+    def test_to_dict_includes_present_fields(self):
+        msg = MultiplexMessage.stream_data("s1", {"key": "val"})
+        d = msg.to_dict()
+        assert d["stream_id"] == "s1"
+        assert d["payload"] == {"key": "val"}
+
+    def test_roundtrip_dict(self):
+        msg = MultiplexMessage.stream_open("sess-abc", last_sequence=7)
+        recovered = MultiplexMessage.from_dict(msg.to_dict())
+        assert recovered.type == msg.type
+        assert recovered.stream_id == msg.stream_id
+        assert recovered.payload == msg.payload
+        assert abs(recovered.timestamp - msg.timestamp) < 0.01
+
+    def test_roundtrip_json(self):
+        msg = MultiplexMessage.error("oops", stream_id="s2")
+        recovered = MultiplexMessage.from_json(msg.to_json())
+        assert recovered.type == msg.type
+        assert recovered.stream_id == msg.stream_id
+        assert recovered.payload == msg.payload
+
+    def test_to_json_compact(self):
+        msg = MultiplexMessage.pong()
+        raw = msg.to_json()
+        # No spaces after separators
+        assert " " not in raw
+
+    def test_from_dict_missing_type_raises(self):
+        with pytest.raises(ValueError, match="missing required key 'type'"):
+            MultiplexMessage.from_dict({"stream_id": "x"})
+
+    def test_from_dict_invalid_type_raises(self):
+        with pytest.raises(ValueError):
+            MultiplexMessage.from_dict({"type": "nonexistent"})
+
+    def test_from_json_invalid_json_raises(self):
+        with pytest.raises(json.JSONDecodeError):
+            MultiplexMessage.from_json("not-json{{{")
+
+    def test_timestamp_defaults_to_now(self):
+        before = time.time()
+        msg = MultiplexMessage.ping()
+        after = time.time()
+        assert before <= msg.timestamp <= after
+
+    def test_from_dict_default_timestamp(self):
+        """When timestamp is absent, from_dict uses current time."""
+        before = time.time()
+        msg = MultiplexMessage.from_dict({"type": "pong"})
+        after = time.time()
+        assert before <= msg.timestamp <= after

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_persistence.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_permission_persistence.py
@@ -465,6 +465,8 @@ class TestPermissionDecisionsDB:
         assert tmp_db.list_permission_decisions(user_id=1) == []
 
     def test_schema_version_is_9(self, tmp_db):
+        from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import _SCHEMA_VERSION
+
         conn = tmp_db._get_conn()
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 9
+        assert version == _SCHEMA_VERSION

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_policy_conditions.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_policy_conditions.py
@@ -110,6 +110,37 @@ def test_label_missing_fails():
     assert evaluate_conditions(cond, resource_labels=None, now=_NOW) is False
 
 
+def test_required_labels_non_mapping_deserializes_to_none() -> None:
+    cond = PolicyConditions.from_dict({"required_labels": ["not", "a", "mapping"]})
+    assert cond.required_labels is None
+    assert cond.is_empty()
+
+
+# ---------------------------------------------------------------------------
+# Source IPs
+# ---------------------------------------------------------------------------
+
+
+def test_source_ip_exact_match_passes() -> None:
+    cond = PolicyConditions(source_ips=["10.0.0.7"])
+    assert evaluate_conditions(cond, source_ip="10.0.0.7", now=_NOW) is True
+
+
+def test_source_ip_cidr_match_passes() -> None:
+    cond = PolicyConditions(source_ips=["10.0.0.0/24"])
+    assert evaluate_conditions(cond, source_ip="10.0.0.42", now=_NOW) is True
+
+
+def test_source_ip_missing_context_fails() -> None:
+    cond = PolicyConditions(source_ips=["10.0.0.0/24"])
+    assert evaluate_conditions(cond, source_ip=None, now=_NOW) is False
+
+
+def test_source_ip_outside_allowlist_fails() -> None:
+    cond = PolicyConditions(source_ips=["10.0.0.0/24"])
+    assert evaluate_conditions(cond, source_ip="192.168.1.10", now=_NOW) is False
+
+
 # ---------------------------------------------------------------------------
 # Delegation
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_policy_conditions.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_policy_conditions.py
@@ -1,0 +1,260 @@
+"""Unit tests for PolicyConditions and evaluate_conditions."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.policy_conditions import (
+    DelegationCondition,
+    PolicyConditions,
+    evaluate_conditions,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 4, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Empty / is_empty
+# ---------------------------------------------------------------------------
+
+
+def test_empty_conditions_pass():
+    """Empty conditions (all None) should always evaluate to True."""
+    cond = PolicyConditions()
+    assert cond.is_empty()
+    assert evaluate_conditions(cond, now=_NOW) is True
+
+
+def test_non_empty_conditions_is_empty_false():
+    cond = PolicyConditions(valid_from=_NOW)
+    assert not cond.is_empty()
+
+
+# ---------------------------------------------------------------------------
+# Time window
+# ---------------------------------------------------------------------------
+
+
+def test_valid_time_window_passes():
+    cond = PolicyConditions(
+        valid_from=_NOW - timedelta(hours=1),
+        valid_until=_NOW + timedelta(hours=1),
+    )
+    assert evaluate_conditions(cond, now=_NOW) is True
+
+
+def test_expired_time_window_fails():
+    cond = PolicyConditions(
+        valid_from=_NOW - timedelta(hours=2),
+        valid_until=_NOW - timedelta(hours=1),
+    )
+    assert evaluate_conditions(cond, now=_NOW) is False
+
+
+def test_future_time_window_fails():
+    cond = PolicyConditions(
+        valid_from=_NOW + timedelta(hours=1),
+        valid_until=_NOW + timedelta(hours=2),
+    )
+    assert evaluate_conditions(cond, now=_NOW) is False
+
+
+def test_valid_from_only_passes_when_after():
+    cond = PolicyConditions(valid_from=_NOW - timedelta(hours=1))
+    assert evaluate_conditions(cond, now=_NOW) is True
+
+
+def test_valid_from_only_fails_when_before():
+    cond = PolicyConditions(valid_from=_NOW + timedelta(hours=1))
+    assert evaluate_conditions(cond, now=_NOW) is False
+
+
+def test_valid_until_only_passes_when_before():
+    cond = PolicyConditions(valid_until=_NOW + timedelta(hours=1))
+    assert evaluate_conditions(cond, now=_NOW) is True
+
+
+def test_valid_until_only_fails_when_after():
+    cond = PolicyConditions(valid_until=_NOW - timedelta(hours=1))
+    assert evaluate_conditions(cond, now=_NOW) is False
+
+
+# ---------------------------------------------------------------------------
+# Labels
+# ---------------------------------------------------------------------------
+
+
+def test_label_match_passes():
+    cond = PolicyConditions(required_labels={"env": "prod", "team": "alpha"})
+    labels = {"env": "prod", "team": "alpha", "extra": "ignored"}
+    assert evaluate_conditions(cond, resource_labels=labels, now=_NOW) is True
+
+
+def test_label_mismatch_fails():
+    cond = PolicyConditions(required_labels={"env": "prod"})
+    labels = {"env": "staging"}
+    assert evaluate_conditions(cond, resource_labels=labels, now=_NOW) is False
+
+
+def test_label_missing_fails():
+    cond = PolicyConditions(required_labels={"env": "prod"})
+    assert evaluate_conditions(cond, resource_labels={}, now=_NOW) is False
+    assert evaluate_conditions(cond, resource_labels=None, now=_NOW) is False
+
+
+# ---------------------------------------------------------------------------
+# Delegation
+# ---------------------------------------------------------------------------
+
+
+def test_delegation_match_passes():
+    cond = PolicyConditions(
+        delegation=DelegationCondition(principal_type="user", principal_id="u-42"),
+    )
+    assert evaluate_conditions(cond, ancestry_chain=["u-42", "u-1"], now=_NOW) is True
+
+
+def test_delegation_mismatch_fails():
+    cond = PolicyConditions(
+        delegation=DelegationCondition(principal_type="agent", principal_id="a-99"),
+    )
+    assert evaluate_conditions(cond, ancestry_chain=["u-42", "u-1"], now=_NOW) is False
+
+
+def test_delegation_empty_ancestry_fails():
+    cond = PolicyConditions(
+        delegation=DelegationCondition(principal_type="user", principal_id="u-42"),
+    )
+    assert evaluate_conditions(cond, ancestry_chain=[], now=_NOW) is False
+    assert evaluate_conditions(cond, ancestry_chain=None, now=_NOW) is False
+
+
+# ---------------------------------------------------------------------------
+# Combined conditions
+# ---------------------------------------------------------------------------
+
+
+def test_combined_conditions_all_pass():
+    cond = PolicyConditions(
+        valid_from=_NOW - timedelta(hours=1),
+        valid_until=_NOW + timedelta(hours=1),
+        required_labels={"env": "prod"},
+        delegation=DelegationCondition(principal_type="user", principal_id="u-42"),
+    )
+    assert evaluate_conditions(
+        cond,
+        resource_labels={"env": "prod"},
+        ancestry_chain=["u-42"],
+        now=_NOW,
+    ) is True
+
+
+def test_combined_conditions_time_fails():
+    """Time window expired, even though labels and delegation match."""
+    cond = PolicyConditions(
+        valid_from=_NOW - timedelta(hours=2),
+        valid_until=_NOW - timedelta(hours=1),
+        required_labels={"env": "prod"},
+        delegation=DelegationCondition(principal_type="user", principal_id="u-42"),
+    )
+    assert evaluate_conditions(
+        cond,
+        resource_labels={"env": "prod"},
+        ancestry_chain=["u-42"],
+        now=_NOW,
+    ) is False
+
+
+def test_combined_conditions_label_fails():
+    """Labels mismatch, even though time and delegation match."""
+    cond = PolicyConditions(
+        valid_from=_NOW - timedelta(hours=1),
+        valid_until=_NOW + timedelta(hours=1),
+        required_labels={"env": "prod"},
+        delegation=DelegationCondition(principal_type="user", principal_id="u-42"),
+    )
+    assert evaluate_conditions(
+        cond,
+        resource_labels={"env": "staging"},
+        ancestry_chain=["u-42"],
+        now=_NOW,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# Serialization roundtrips
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_from_dict_roundtrip():
+    cond = PolicyConditions(
+        valid_from=_NOW,
+        valid_until=_NOW + timedelta(hours=2),
+        source_ips=["10.0.0.1"],
+        required_labels={"env": "prod"},
+        delegation=DelegationCondition(principal_type="agent", principal_id="a-7"),
+    )
+    d = cond.to_dict()
+    restored = PolicyConditions.from_dict(d)
+    assert restored.valid_from == cond.valid_from
+    assert restored.valid_until == cond.valid_until
+    assert restored.source_ips == cond.source_ips
+    assert restored.required_labels == cond.required_labels
+    assert restored.delegation is not None
+    assert restored.delegation.principal_type == "agent"
+    assert restored.delegation.principal_id == "a-7"
+
+
+def test_to_json_from_json_roundtrip():
+    cond = PolicyConditions(
+        valid_from=_NOW,
+        required_labels={"tier": "premium"},
+    )
+    raw = cond.to_json()
+    restored = PolicyConditions.from_json(raw)
+    assert restored.valid_from == cond.valid_from
+    assert restored.required_labels == cond.required_labels
+    assert restored.delegation is None
+
+
+def test_from_dict_none_yields_empty():
+    assert PolicyConditions.from_dict(None).is_empty()
+
+
+def test_from_dict_empty_dict_yields_empty():
+    assert PolicyConditions.from_dict({}).is_empty()
+
+
+def test_from_json_none_yields_empty():
+    assert PolicyConditions.from_json(None).is_empty()
+
+
+def test_from_json_invalid_yields_empty():
+    assert PolicyConditions.from_json("not-json!!").is_empty()
+
+
+def test_is_empty_source_ips_only():
+    """source_ips alone makes it non-empty (even though not evaluated)."""
+    cond = PolicyConditions(source_ips=["192.168.1.1"])
+    assert not cond.is_empty()
+
+
+def test_delegation_from_dict_missing_fields():
+    """DelegationCondition.from_dict returns None when required fields are missing."""
+    assert DelegationCondition.from_dict(None) is None
+    assert DelegationCondition.from_dict({}) is None
+    assert DelegationCondition.from_dict({"principal_type": "user"}) is None
+    assert DelegationCondition.from_dict({"principal_id": "u-1"}) is None
+
+
+def test_empty_conditions_to_dict_is_empty_dict():
+    cond = PolicyConditions()
+    assert cond.to_dict() == {}

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_templates.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_templates.py
@@ -1,0 +1,490 @@
+"""Tests for the inheritable ACP config template system.
+
+Covers: system template resolution, persona overrides system, session overrides
+persona, inheritance chain, merge rules, seed idempotent, circular inheritance
+prevented, and empty fallback.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.templates import (
+    ACPConfigTemplate,
+    _resolve_inheritance,
+    _row_to_template,
+    resolve_for_session,
+    resolve_template_chain,
+    seed_system_templates,
+)
+from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db(tmp_path: Any) -> ACPSessionsDB:
+    """Create a fresh in-memory-style DB in a temp dir."""
+    db_path = os.path.join(str(tmp_path), "test_acp.db")
+    return ACPSessionsDB(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# 1. System template resolution
+# ---------------------------------------------------------------------------
+
+
+class TestSystemTemplateResolution:
+    def test_system_template_found(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(
+            name="developer",
+            scope="system",
+            config_json=json.dumps({"tool_tier_overrides": {"Bash(git:*)": "auto"}}),
+        )
+        result = resolve_for_session(db, session_id=None, persona_id=None, template_name="developer")
+        assert result is not None
+        assert result["tool_tier_overrides"]["Bash(git:*)"] == "auto"
+
+    def test_system_template_not_found_returns_none(self, db: ACPSessionsDB) -> None:
+        result = resolve_for_session(db, session_id=None, persona_id=None, template_name="nonexistent")
+        assert result is None
+
+    def test_no_template_name_returns_none(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(
+            name="developer",
+            scope="system",
+            config_json=json.dumps({"x": 1}),
+        )
+        result = resolve_for_session(db, session_id=None, persona_id=None, template_name=None)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Persona overrides system
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaOverridesSystem:
+    def test_persona_overrides_system_values(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(
+            name="developer",
+            scope="system",
+            config_json=json.dumps({
+                "tool_tier_overrides": {"Read(*)": "auto", "Write(*)": "batch"},
+                "approval_mode": "require",
+            }),
+        )
+        db.create_config_template(
+            name="developer",
+            scope="persona",
+            scope_id="persona-abc",
+            config_json=json.dumps({
+                "tool_tier_overrides": {"Write(*)": "individual"},
+            }),
+        )
+        result = resolve_for_session(
+            db,
+            session_id=None,
+            persona_id="persona-abc",
+            template_name="developer",
+        )
+        assert result is not None
+        assert result["tool_tier_overrides"]["Read(*)"] == "auto"
+        assert result["tool_tier_overrides"]["Write(*)"] == "individual"
+        assert result["approval_mode"] == "require"
+
+
+# ---------------------------------------------------------------------------
+# 3. Session overrides persona
+# ---------------------------------------------------------------------------
+
+
+class TestSessionOverridesPersona:
+    def test_session_overrides_persona(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(
+            name="dev",
+            scope="system",
+            config_json=json.dumps({"mode": "system", "tool_tier_overrides": {"*": "auto"}}),
+        )
+        db.create_config_template(
+            name="dev",
+            scope="persona",
+            scope_id="p1",
+            config_json=json.dumps({"mode": "persona"}),
+        )
+        db.create_config_template(
+            name="dev",
+            scope="session",
+            scope_id="s1",
+            config_json=json.dumps({"mode": "session", "extra": True}),
+        )
+        result = resolve_for_session(db, session_id="s1", persona_id="p1", template_name="dev")
+        assert result is not None
+        assert result["mode"] == "session"
+        assert result["extra"] is True
+        assert result["tool_tier_overrides"]["*"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# 4. Inheritance chain (base_template_id)
+# ---------------------------------------------------------------------------
+
+
+class TestInheritanceChain:
+    def test_single_parent_inheritance(self, db: ACPSessionsDB) -> None:
+        parent_id = db.create_config_template(
+            name="base-strict",
+            scope="system",
+            config_json=json.dumps({"approval_mode": "require", "max_retries": 3}),
+        )
+        db.create_config_template(
+            name="child",
+            scope="system",
+            base_template_id=parent_id,
+            config_json=json.dumps({"max_retries": 5}),
+        )
+        result = resolve_for_session(db, session_id=None, persona_id=None, template_name="child")
+        assert result is not None
+        assert result["approval_mode"] == "require"
+        assert result["max_retries"] == 5
+
+    def test_multi_level_inheritance(self, db: ACPSessionsDB) -> None:
+        grandparent_id = db.create_config_template(
+            name="gp",
+            scope="system",
+            config_json=json.dumps({"a": 1, "b": 2}),
+        )
+        parent_id = db.create_config_template(
+            name="parent",
+            scope="system",
+            base_template_id=grandparent_id,
+            config_json=json.dumps({"b": 20, "c": 3}),
+        )
+        db.create_config_template(
+            name="child",
+            scope="system",
+            base_template_id=parent_id,
+            config_json=json.dumps({"c": 30}),
+        )
+        result = resolve_for_session(db, session_id=None, persona_id=None, template_name="child")
+        assert result is not None
+        assert result["a"] == 1
+        assert result["b"] == 20
+        assert result["c"] == 30
+
+    def test_missing_parent_gracefully_skipped(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(
+            name="orphan",
+            scope="system",
+            base_template_id=99999,
+            config_json=json.dumps({"x": 1}),
+        )
+        result = resolve_for_session(db, session_id=None, persona_id=None, template_name="orphan")
+        assert result is not None
+        assert result["x"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Merge rules (via merge_config)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeRules:
+    def test_union_list_append_dedup(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(
+            name="t",
+            scope="system",
+            config_json=json.dumps({"allowed_tools": ["a", "b"]}),
+        )
+        db.create_config_template(
+            name="t",
+            scope="persona",
+            scope_id="p1",
+            config_json=json.dumps({"allowed_tools": ["b", "c"]}),
+        )
+        result = resolve_for_session(db, session_id=None, persona_id="p1", template_name="t")
+        assert result is not None
+        assert result["allowed_tools"] == ["a", "b", "c"]
+
+    def test_nested_dict_merge(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(
+            name="t",
+            scope="system",
+            config_json=json.dumps({"tool_tier_overrides": {"Read(*)": "auto", "*": "individual"}}),
+        )
+        db.create_config_template(
+            name="t",
+            scope="persona",
+            scope_id="p1",
+            config_json=json.dumps({"tool_tier_overrides": {"Write(*)": "batch"}}),
+        )
+        result = resolve_for_session(db, session_id=None, persona_id="p1", template_name="t")
+        assert result is not None
+        tto = result["tool_tier_overrides"]
+        assert tto["Read(*)"] == "auto"
+        assert tto["*"] == "individual"
+        assert tto["Write(*)"] == "batch"
+
+
+# ---------------------------------------------------------------------------
+# 6. Seed system templates (idempotent)
+# ---------------------------------------------------------------------------
+
+
+class TestSeedSystemTemplates:
+    def test_seed_inserts_all_templates(self, db: ACPSessionsDB) -> None:
+        from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
+            PERMISSION_POLICY_TEMPLATES,
+        )
+        count = seed_system_templates(db)
+        assert count == len(PERMISSION_POLICY_TEMPLATES)
+        for name in PERMISSION_POLICY_TEMPLATES:
+            rows = db.list_config_templates(scope="system", name=name)
+            assert len(rows) == 1
+            assert rows[0]["scope"] == "system"
+
+    def test_seed_is_idempotent(self, db: ACPSessionsDB) -> None:
+        count1 = seed_system_templates(db)
+        count2 = seed_system_templates(db)
+        assert count1 > 0
+        assert count2 == 0
+
+    def test_seeded_templates_contain_correct_config(self, db: ACPSessionsDB) -> None:
+        from tldw_Server_API.app.core.Agent_Client_Protocol.config import (
+            PERMISSION_POLICY_TEMPLATES,
+        )
+        seed_system_templates(db)
+        rows = db.list_config_templates(scope="system", name="lockdown")
+        assert len(rows) == 1
+        config = json.loads(rows[0]["config_json"])
+        assert config == PERMISSION_POLICY_TEMPLATES["lockdown"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Circular inheritance prevented
+# ---------------------------------------------------------------------------
+
+
+class TestCircularInheritancePrevented:
+    def test_direct_self_reference(self, db: ACPSessionsDB) -> None:
+        tid = db.create_config_template(
+            name="self-ref",
+            scope="system",
+            config_json=json.dumps({"x": 1}),
+        )
+        db.update_config_template(tid, base_template_id=tid)
+        row = db.get_config_template(tid)
+        tpl = _row_to_template(row)
+        with pytest.raises(ValueError, match="Circular"):
+            _resolve_inheritance(db, tpl)
+
+    def test_indirect_cycle(self, db: ACPSessionsDB) -> None:
+        id_a = db.create_config_template(
+            name="a", scope="system", config_json="{}",
+        )
+        id_b = db.create_config_template(
+            name="b", scope="system", base_template_id=id_a, config_json="{}",
+        )
+        # Create cycle: a -> b -> a
+        db.update_config_template(id_a, base_template_id=id_b)
+        row = db.get_config_template(id_b)
+        tpl = _row_to_template(row)
+        with pytest.raises(ValueError, match="Circular"):
+            _resolve_inheritance(db, tpl)
+
+
+# ---------------------------------------------------------------------------
+# 8. Empty fallback
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyFallback:
+    def test_empty_db_returns_none(self, db: ACPSessionsDB) -> None:
+        result = resolve_for_session(db, session_id="s1", persona_id="p1", template_name="whatever")
+        assert result is None
+
+    def test_wrong_scope_returns_none(self, db: ACPSessionsDB) -> None:
+        """A persona template with no matching system template still resolves."""
+        db.create_config_template(
+            name="t",
+            scope="persona",
+            scope_id="p1",
+            config_json=json.dumps({"x": 1}),
+        )
+        result = resolve_for_session(db, session_id=None, persona_id="p1", template_name="t")
+        assert result is not None
+        assert result["x"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 9. resolve_template_chain standalone
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTemplateChain:
+    def test_empty_list(self) -> None:
+        assert resolve_template_chain([]) == {}
+
+    def test_single_template(self) -> None:
+        tpl = ACPConfigTemplate(config={"a": 1})
+        assert resolve_template_chain([tpl]) == {"a": 1}
+
+    def test_ordered_merge(self) -> None:
+        t1 = ACPConfigTemplate(config={"a": 1, "b": 2})
+        t2 = ACPConfigTemplate(config={"b": 20, "c": 3})
+        result = resolve_template_chain([t1, t2])
+        assert result == {"a": 1, "b": 20, "c": 3}
+
+
+# ---------------------------------------------------------------------------
+# 10. _row_to_template
+# ---------------------------------------------------------------------------
+
+
+class TestRowToTemplate:
+    def test_valid_row(self) -> None:
+        row = {
+            "id": 42,
+            "name": "test",
+            "description": "desc",
+            "scope": "persona",
+            "scope_id": "p1",
+            "base_template_id": 10,
+            "schema_version": "2",
+            "config_json": json.dumps({"x": 1}),
+            "created_at": "2024-01-01",
+            "updated_at": "2024-01-02",
+        }
+        tpl = _row_to_template(row)
+        assert tpl.id == 42
+        assert tpl.name == "test"
+        assert tpl.scope == "persona"
+        assert tpl.scope_id == "p1"
+        assert tpl.base_template_id == 10
+        assert tpl.config == {"x": 1}
+
+    def test_invalid_json_defaults_to_empty(self) -> None:
+        row = {"config_json": "not-json{{{"}
+        tpl = _row_to_template(row)
+        assert tpl.config == {}
+
+    def test_dict_config_json(self) -> None:
+        row = {"config_json": {"already": "parsed"}}
+        tpl = _row_to_template(row)
+        assert tpl.config == {"already": "parsed"}
+
+
+# ---------------------------------------------------------------------------
+# 11. DB CRUD operations
+# ---------------------------------------------------------------------------
+
+
+class TestDBCrud:
+    def test_create_and_get(self, db: ACPSessionsDB) -> None:
+        tid = db.create_config_template(
+            name="test",
+            description="A test template",
+            scope="session",
+            scope_id="s1",
+            config_json=json.dumps({"mode": "test"}),
+        )
+        row = db.get_config_template(tid)
+        assert row is not None
+        assert row["name"] == "test"
+        assert row["scope"] == "session"
+        assert row["scope_id"] == "s1"
+
+    def test_list_with_filters(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(name="a", scope="system", config_json="{}")
+        db.create_config_template(name="b", scope="system", config_json="{}")
+        db.create_config_template(name="a", scope="persona", scope_id="p1", config_json="{}")
+
+        all_rows = db.list_config_templates()
+        assert len(all_rows) == 3
+
+        system_rows = db.list_config_templates(scope="system")
+        assert len(system_rows) == 2
+
+        named_rows = db.list_config_templates(name="a")
+        assert len(named_rows) == 2
+
+        specific = db.list_config_templates(scope="persona", scope_id="p1", name="a")
+        assert len(specific) == 1
+
+    def test_update(self, db: ACPSessionsDB) -> None:
+        tid = db.create_config_template(
+            name="original", scope="system", config_json="{}",
+        )
+        updated = db.update_config_template(tid, name="renamed", config_json='{"x":1}')
+        assert updated is True
+        row = db.get_config_template(tid)
+        assert row["name"] == "renamed"
+        assert json.loads(row["config_json"]) == {"x": 1}
+
+    def test_delete(self, db: ACPSessionsDB) -> None:
+        tid = db.create_config_template(name="ephemeral", scope="system", config_json="{}")
+        assert db.delete_config_template(tid) is True
+        assert db.get_config_template(tid) is None
+        assert db.delete_config_template(tid) is False
+
+    def test_get_nonexistent_returns_none(self, db: ACPSessionsDB) -> None:
+        assert db.get_config_template(99999) is None
+
+
+# ---------------------------------------------------------------------------
+# 12. build_snapshot uses DB templates with fallback
+# ---------------------------------------------------------------------------
+
+
+class _StubPolicyResolver:
+    """Minimal stub that returns a canned resolved policy."""
+
+    def __init__(self, policy_document: dict[str, Any] | None = None) -> None:
+        self._doc = policy_document or {}
+
+    async def resolve_for_context(
+        self,
+        *,
+        user_id: int | str | None,
+        metadata: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        return {
+            "policy_document": dict(self._doc),
+            "sources": [],
+            "provenance": [],
+        }
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_falls_back_to_flat_templates() -> None:
+    """When no DB templates exist, build_snapshot uses flat PERMISSION_POLICY_TEMPLATES."""
+    from tldw_Server_API.app.services.admin_acp_sessions_service import (
+        SessionRecord,
+        SessionTokenUsage,
+    )
+    from tldw_Server_API.app.services.acp_runtime_policy_service import (
+        ACPRuntimePolicyService,
+    )
+
+    resolver = _StubPolicyResolver(policy_document={})
+    service = ACPRuntimePolicyService(policy_resolver=resolver)
+    session = SessionRecord(
+        session_id="test-session",
+        user_id=1,
+        usage=SessionTokenUsage(),
+    )
+
+    snapshot = await service.build_snapshot(
+        session_record=session,
+        user_id=1,
+        template_name="lockdown",
+    )
+    merged = snapshot.resolved_policy_document.get("tool_tier_overrides", {})
+    assert merged == {"*": "individual"}

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_templates.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_templates.py
@@ -437,6 +437,12 @@ class TestDBCrud:
     def test_get_nonexistent_returns_none(self, db: ACPSessionsDB) -> None:
         assert db.get_config_template(99999) is None
 
+    def test_duplicate_name_within_same_scope_is_rejected(self, db: ACPSessionsDB) -> None:
+        db.create_config_template(name="dupe", scope="system", config_json="{}")
+
+        with pytest.raises(ValueError, match="already exists"):
+            db.create_config_template(name="dupe", scope="system", config_json="{}")
+
 
 # ---------------------------------------------------------------------------
 # 12. build_snapshot uses DB templates with fallback

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_webhook_triggers.py
@@ -669,12 +669,12 @@ def test_acp_sessions_db_webhook_trigger_crud(tmp_path):
 
 
 def test_acp_sessions_db_schema_version(tmp_path):
-    """Verify the schema version is bumped to 10."""
-    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+    """Verify the schema version matches the current ACP sessions DB migration level."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB, _SCHEMA_VERSION
 
     db_path = str(tmp_path / "test_version.db")
     db = ACPSessionsDB(db_path=db_path)
     conn = db._get_conn()
     version = conn.execute("PRAGMA user_version").fetchone()[0]
-    assert version == 10
+    assert version == _SCHEMA_VERSION
     db.close()

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
@@ -181,7 +181,9 @@ async def test_policy_resolver_merges_default_group_and_persona_targets() -> Non
     assert policy["denied_tools"] == ["external.tools.refresh"]
     assert policy["capabilities"] == ["filesystem.read", "network.external"]
     assert policy["approval_mode"] == "ask_every_time"
-    assert policy["authored_policy_document"] == policy["policy_document"]
+    # resolved_policy_document gains setdefault keys (tool_tier_overrides, conditions)
+    for key in policy["authored_policy_document"]:
+        assert policy["authored_policy_document"][key] == policy["policy_document"][key]
     assert policy["resolved_policy_document"] == policy["policy_document"]
     assert policy["policy_document"]["path_scope_mode"] == "cwd_descendants"
     assert policy["policy_document"]["path_scope_enforcement"] == "approval_required_when_unenforceable"
@@ -501,7 +503,11 @@ async def test_policy_resolver_keeps_unresolved_capabilities_visible_without_gra
 
     assert policy["allowed_tools"] == []
     assert policy["authored_policy_document"] == {"capabilities": ["tool.invoke.unmapped"]}
-    assert policy["resolved_policy_document"] == {"capabilities": ["tool.invoke.unmapped"]}
+    assert policy["resolved_policy_document"] == {
+        "capabilities": ["tool.invoke.unmapped"],
+        "tool_tier_overrides": {},
+        "conditions": {},
+    }
     assert policy["resolved_capabilities"] == []
     assert policy["unresolved_capabilities"] == ["tool.invoke.unmapped"]
     assert policy["capability_warnings"] == [

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
@@ -335,6 +335,28 @@ async def test_policy_resolver_allows_assignment_override_to_replace_path_scope_
 
 
 @pytest.mark.asyncio
+async def test_policy_resolver_allows_null_override_to_clear_inherited_field() -> None:
+    from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+    repo = _FakeRepo()
+    repo.overrides[10] = {
+        "id": 501,
+        "assignment_id": 10,
+        "override_policy_document": {"path_scope_mode": None},
+        "is_active": True,
+    }
+    resolver = McpHubPolicyResolver(repo=repo)
+
+    policy = await resolver.resolve_for_context(
+        user_id=7,
+        metadata={"mcp_policy_context_enabled": True},
+    )
+
+    assert "path_scope_mode" in policy["policy_document"]
+    assert policy["policy_document"]["path_scope_mode"] is None
+
+
+@pytest.mark.asyncio
 async def test_policy_resolver_replaces_path_allowlist_prefixes_in_assignment_override() -> None:
     from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
 


### PR DESCRIPTION
## Summary

Adapts 3 backend patterns from Scion for tldw_server2's ACP modules. State machine (Area 1 from original PR #1074) was **dropped** — the existing Kanban + Agent Orchestration + Workflow Engine systems already cover session/task lifecycle tracking.

- **Template Inheritance:** Three-tier scoping (system→persona→session) with field-type-aware merging via extracted `merge_utils.py`. `config_templates` DB table replaces flat `PERMISSION_POLICY_TEMPLATES` with gradual migration (flat dict kept as fallback).
- **Policy Conditions:** `PolicyConditions` with time windows (valid_from/valid_until), label matching (AND semantics), and delegation via ancestry chains. Pre-resolved at snapshot build time, evaluated synchronously in GovernanceFilter.
- **WebSocket Multiplexer:** Single WS connection carries events for multiple sessions via stream IDs. `WS /api/v1/acp/multiplex` with STREAM_OPEN/DATA/CLOSE + PING/PONG. Descoped from Scion's full broker protocol (no handshake, no HTTP tunneling).

## What was dropped vs #1074

Area 1 (state machine with SessionPhase/SessionActivity) was removed because:
- Agent Orchestration already has the Ralph Loop pattern (todo→inprogress→review→complete/triage)
- Kanban Workflow already has optimistic locking via lease TTL and approval gates
- Sandbox RunPhase already covers execution lifecycle
- Workflow Engine already has waiting_human/waiting_approval states

## Stats

- 20 files changed, ~2,822 lines added
- ~120+ new tests, 0 regressions
- ACP_Sessions_DB schema v10 → v12

## Test plan

- [ ] `.venv/bin/python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/ -x -q`
- [ ] Templates: system → persona → session resolution with field-type merging
- [ ] Policy conditions: expired policies skipped, label mismatches skip
- [ ] Multiplexer: STREAM_OPEN subscribes, STREAM_DATA forwards, PING/PONG works
- [ ] Existing ACP tests pass (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)