### PR TITLE
fix(prompts): code review fixes — staleTime, ARIA, WS cleanup

### DIFF
--- a/apps/packages/ui/src/components/Option/Prompt/PromptBulkActionBar.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptBulkActionBar.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Download, Star, Tag, Trash2 } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 type PromptBulkActionBarV1Props = {
   mode?: "v1"
@@ -24,11 +25,14 @@ type PromptBulkActionBarProps =
   | PromptBulkActionBarLegacyProps
 
 export const PromptBulkActionBar: React.FC<PromptBulkActionBarProps> = (props) => {
+  const { t } = useTranslation(["option"])
+  const bulkActionsLabel = t("option:bulkActions", { defaultValue: "Bulk actions" })
+
   if (props.mode === "legacy") {
     return (
       <div
         role="toolbar"
-        aria-label="Bulk actions"
+        aria-label={bulkActionsLabel}
         data-testid={props.testId || "prompts-bulk-action-bar-legacy"}
         className={
           props.className ||
@@ -57,7 +61,7 @@ export const PromptBulkActionBar: React.FC<PromptBulkActionBarProps> = (props) =
   return (
     <div
       role="toolbar"
-      aria-label="Bulk actions"
+      aria-label={bulkActionsLabel}
       data-testid="prompts-bulk-action-bar-scaffold"
       className="flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/10 p-2"
     >

--- a/apps/packages/ui/src/components/Option/Prompt/PromptBulkActionBar.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptBulkActionBar.tsx
@@ -27,6 +27,8 @@ export const PromptBulkActionBar: React.FC<PromptBulkActionBarProps> = (props) =
   if (props.mode === "legacy") {
     return (
       <div
+        role="toolbar"
+        aria-label="Bulk actions"
         data-testid={props.testId || "prompts-bulk-action-bar-legacy"}
         className={
           props.className ||
@@ -54,6 +56,8 @@ export const PromptBulkActionBar: React.FC<PromptBulkActionBarProps> = (props) =
 
   return (
     <div
+      role="toolbar"
+      aria-label="Bulk actions"
       data-testid="prompts-bulk-action-bar-scaffold"
       className="flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/10 p-2"
     >

--- a/apps/packages/ui/src/components/Option/Prompt/PromptSidebar.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptSidebar.tsx
@@ -101,6 +101,7 @@ export const PromptSidebar: React.FC<PromptSidebarProps> = ({
           onClick={onToggleCollapsed}
           className="rounded p-1.5 text-text-muted hover:bg-surface2 hover:text-text"
           aria-label="Expand sidebar"
+          aria-expanded={false}
           data-testid="prompt-sidebar-expand"
         >
           <PanelLeftOpen className="size-4" />
@@ -146,6 +147,7 @@ export const PromptSidebar: React.FC<PromptSidebarProps> = ({
           onClick={onToggleCollapsed}
           className="rounded p-1 text-text-muted hover:bg-surface2 hover:text-text"
           aria-label="Collapse sidebar"
+          aria-expanded={true}
           data-testid="prompt-sidebar-collapse"
         >
           <PanelLeftClose className="size-4" />

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/StudioTabContainer.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/StudioTabContainer.tsx
@@ -314,7 +314,9 @@ export const StudioTabContainer: React.FC = () => {
       if (ws && ws.readyState < WebSocket.CLOSING) {
         ws.close()
       }
-      setWsConnected(true)
+      // Don't reset wsConnected here — let onopen set it when the next
+      // connection attempt succeeds. Resetting to true in cleanup would
+      // flash-hide the disconnected banner between effect re-runs.
     }
   }, [isOnline, hasStudio, selectedProjectId, queryClient])
 

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptBulkActionBar.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptBulkActionBar.test.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { PromptBulkActionBar } from "../PromptBulkActionBar"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      key === "option:bulkActions" ? "Translated bulk actions" : options?.defaultValue ?? key
+  })
+}))
+
+describe("PromptBulkActionBar", () => {
+  it("uses the localized bulk actions aria-label for the legacy toolbar", () => {
+    render(
+      <PromptBulkActionBar mode="legacy">
+        <button type="button">Legacy action</button>
+      </PromptBulkActionBar>
+    )
+
+    expect(screen.getByTestId("prompts-bulk-action-bar-legacy")).toHaveAttribute(
+      "aria-label",
+      "Translated bulk actions"
+    )
+  })
+
+  it("uses the localized bulk actions aria-label for the scaffold toolbar", () => {
+    render(
+      <PromptBulkActionBar
+        selectedCount={2}
+        onBulkExport={vi.fn()}
+        onBulkTag={vi.fn()}
+        onBulkFavoriteToggle={vi.fn()}
+        onBulkDelete={vi.fn()}
+        onClearSelection={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId("prompts-bulk-action-bar-scaffold")).toHaveAttribute(
+      "aria-label",
+      "Translated bulk actions"
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
@@ -77,7 +77,7 @@ describe("PromptDrawer structured prompts", () => {
       screen.getByRole("button", { name: /convert to structured/i })
     )
 
-    expect(await screen.findByText("Structured prompt")).toBeInTheDocument()
+    expect(await screen.findByText("Multi-section prompt mode")).toBeInTheDocument()
     expect(screen.getByTestId("prompt-drawer-system")).toBeDisabled()
     expect(screen.getByTestId("prompt-drawer-user")).toBeDisabled()
     expect(screen.getByTestId("structured-block-list")).toBeInTheDocument()

--- a/apps/packages/ui/src/components/Option/Prompt/usePromptPaletteCommands.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/usePromptPaletteCommands.ts
@@ -52,7 +52,7 @@ export function usePromptPaletteCommands(
         includeDeleted: false
       }),
     enabled: enabled && isSearching && isOnline,
-    staleTime: 300
+    staleTime: 10_000
   })
 
   return useMemo(() => {


### PR DESCRIPTION
## Summary
Addresses code review findings from the prompts NNG UX audit work (PRs #1052 and #1057, both already merged to dev).

- **staleTime**: Increase server search `staleTime` from 300ms to 10s in `usePromptPaletteCommands` to reduce redundant HTTP requests during Cmd+K typing
- **Accessibility**: Add `role="toolbar"` + `aria-label` on both `PromptBulkActionBar` variants; add `aria-expanded` on sidebar expand/collapse buttons
- **WS cleanup**: Remove incorrect `setWsConnected(true)` from StudioTabContainer effect cleanup (was causing flash-hide of the disconnected banner between re-runs)
- **Test fix**: Update structured prompt test assertion to match "Multi-section prompt mode" label (changed in prior PR but test not updated)

## Test plan
- [x] 142/142 tests passing, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)