### PR TITLE
fix(ui): surface chat stream timeout and abort errors correctly

### DIFF
--- a/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
+++ b/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
@@ -387,9 +387,7 @@ describe("background proxy fallback safety", () => {
             return
           }
           const onAbort = () => {
-            try {
-              signal.removeEventListener("abort", onAbort)
-            } catch {}
+            signal.removeEventListener("abort", onAbort)
             const abortError = new Error("The operation was aborted.")
             abortError.name = "AbortError"
             reject(abortError)

--- a/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
+++ b/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
@@ -359,6 +359,90 @@ describe("background proxy fallback safety", () => {
     expect(chunks.some((chunk) => chunk.includes('"event":"run_started"'))).toBe(true)
   })
 
+  it("classifies direct stream aborts as AbortError", async () => {
+    mocks.sendMessage.mockResolvedValue({ ok: false })
+    mocks.storageGet.mockImplementation(async (key: string) => {
+      if (key === "tldwConfig") {
+        return {
+          serverUrl: "http://127.0.0.1:8000",
+          authMode: "single-user",
+          apiKey: "test-key-not-placeholder"
+        }
+      }
+      return null
+    })
+
+    let activeSignal: AbortSignal | null = null
+    let resolveReadStarted: (() => void) | null = null
+    const readStarted = new Promise<void>((resolve) => {
+      resolveReadStarted = resolve
+    })
+    const reader = {
+      read: vi.fn(() => {
+        resolveReadStarted?.()
+        return new Promise<never>((_, reject) => {
+          const signal = activeSignal
+          if (!signal) {
+            reject(new Error("Missing abort signal"))
+            return
+          }
+          const onAbort = () => {
+            try {
+              signal.removeEventListener("abort", onAbort)
+            } catch {}
+            const abortError = new Error("The operation was aborted.")
+            abortError.name = "AbortError"
+            reject(abortError)
+          }
+          signal.addEventListener("abort", onAbort, { once: true })
+        })
+      }),
+      cancel: vi.fn()
+    }
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      activeSignal = (init?.signal as AbortSignal | undefined) || null
+      return {
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => reader
+        }
+      } as Response
+    })
+    vi.stubGlobal("fetch", fetchSpy as any)
+
+    const { bgStream } = await importProxy()
+    const controller = new AbortController()
+    const consume = async () => {
+      for await (const _chunk of bgStream({
+        path: "/api/v1/chat/completions",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: { stream: true, messages: [] },
+        abortSignal: controller.signal
+      })) {
+        // no-op
+      }
+    }
+
+    const pending = consume()
+
+    try {
+      await readStarted
+      controller.abort()
+
+      await expect(pending).rejects.toMatchObject({
+        name: "AbortError",
+        status: 0,
+        code: "REQUEST_ABORTED"
+      })
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(reader.cancel).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it("treats post-first-chunk transport disconnect as graceful end", async () => {
     mocks.sendMessage.mockResolvedValue({ ok: true })
     const onMessageListeners = new Set<(msg: any) => void>()

--- a/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
@@ -361,6 +361,40 @@ describe("TldwChatService message sanitization", () => {
     })
   })
 
+  it("rejects with AbortError when the stream exits cleanly after cancellation", async () => {
+    mocks.streamChatCompletion.mockImplementation(
+      async function* (
+        _request: unknown,
+        options?: { signal?: AbortSignal }
+      ) {
+        yield {
+          choices: [{ index: 0, delta: { content: "hello" }, finish_reason: null }]
+        }
+        while (!options?.signal?.aborted) {
+          await new Promise((resolve) => setTimeout(resolve, 5))
+        }
+      }
+    )
+
+    const service = new TldwChatService()
+    const streamRun = (async () => {
+      const tokens: string[] = []
+      for await (const token of service.streamMessage(
+        [{ role: "user", content: "stop after one token" }],
+        { model: "gpt-test" }
+      )) {
+        tokens.push(token)
+        service.cancelStream()
+      }
+      return tokens
+    })()
+
+    await expect(streamRun).rejects.toMatchObject({
+      name: "AbortError",
+      message: expect.stringMatching(/abort/i)
+    })
+  })
+
   it("uses dedicated startup timeout instead of chat request timeout", async () => {
     vi.useFakeTimers()
     mocks.getConfig.mockResolvedValue({

--- a/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
@@ -299,6 +299,68 @@ describe("TldwChatService message sanitization", () => {
     })
   })
 
+  it("maps thrown aborts caused by startup timeout to the timeout error", async () => {
+    vi.useFakeTimers()
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://localhost:8000",
+      authMode: "single-user",
+      chatRequestTimeoutMs: 50,
+      chatStartupTimeoutMs: 50,
+      chatStreamIdleTimeoutMs: 500
+    })
+    mocks.streamChatCompletion.mockImplementation(
+      async function* (
+        _request: unknown,
+        options?: { signal?: AbortSignal }
+      ) {
+        let seq = 0
+        while (true) {
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          if (options?.signal?.aborted) {
+            const abortError = new Error("The operation was aborted.")
+            abortError.name = "AbortError"
+            throw abortError
+          }
+          seq += 1
+          yield {
+            event: "run_started",
+            run_id: "run_abort",
+            seq,
+            data: {}
+          }
+        }
+      }
+    )
+
+    const service = new TldwChatService()
+    const streamRun = (async () => {
+      const tokens: string[] = []
+      for await (const token of service.streamMessage(
+        [{ role: "user", content: "why did the stream abort?" }],
+        { model: "gpt-test" }
+      )) {
+        tokens.push(token)
+      }
+      return tokens
+    })()
+    const settled = streamRun.then(
+      (value) => ({ status: "resolved" as const, value }),
+      (error) => ({ status: "rejected" as const, error })
+    )
+
+    await vi.advanceTimersByTimeAsync(80)
+
+    await expect(settled).resolves.toMatchObject({
+      status: "rejected",
+      error: {
+        message: "Stream completion failed",
+        cause: expect.objectContaining({
+          message: expect.stringContaining("visible output")
+        })
+      }
+    })
+  })
+
   it("uses dedicated startup timeout instead of chat request timeout", async () => {
     vi.useFakeTimers()
     mocks.getConfig.mockResolvedValue({

--- a/apps/packages/ui/src/services/background-proxy.ts
+++ b/apps/packages/ui/src/services/background-proxy.ts
@@ -267,6 +267,30 @@ const isExtensionTransportFailure = (error: unknown): boolean => {
   )
 }
 
+type RequestAbortError = Error & {
+  status?: number
+  code?: string
+  details?: unknown
+}
+
+const isAbortErrorMessage = (value?: string) =>
+  typeof value === "string" && value.toLowerCase().includes("abort")
+
+const createAbortError = (
+  message?: string,
+  status?: number,
+  details?: unknown
+): RequestAbortError => {
+  const abortError = new Error(message || "Aborted") as RequestAbortError
+  abortError.name = "AbortError"
+  abortError.status = typeof status === "number" ? status : 0
+  abortError.code = "REQUEST_ABORTED"
+  if (typeof details !== "undefined") {
+    abortError.details = sanitizeResponseData(details)
+  }
+  return abortError
+}
+
 const shouldNotifyBackendUnavailable = (entry: {
   method: string
   path: string
@@ -383,26 +407,13 @@ export async function bgRequest<
       // best-effort logging only
     }
   }
-  const isAbortErrorMessage = (value?: string) =>
-    typeof value === "string" && value.toLowerCase().includes("abort")
   const buildRequestError = (
     msg: string,
     status?: number,
     details?: unknown
   ): (Error & { status?: number; code?: string; details?: unknown }) => {
     if (isAbortErrorMessage(msg)) {
-      const abortError = new Error(msg || "Aborted") as Error & {
-        status?: number
-        code?: string
-        details?: unknown
-      }
-      abortError.name = "AbortError"
-      abortError.status = typeof status === "number" ? status : 0
-      abortError.code = "REQUEST_ABORTED"
-      if (typeof details !== "undefined") {
-        abortError.details = sanitizeResponseData(details)
-      }
-      return abortError
+      return createAbortError(msg, status, details)
     }
     const error = new Error(`${msg} (${method} ${path})`) as Error & {
       status?: number
@@ -999,7 +1010,9 @@ async function* bgStreamDirect<
       throw idleError
     }
     if (abortSignal?.aborted) {
-      throw new Error("Aborted")
+      throw createAbortError(
+        e instanceof Error && e.message ? e.message : "Aborted"
+      )
     }
     throw e
   } finally {

--- a/apps/packages/ui/src/services/tldw/TldwChat.ts
+++ b/apps/packages/ui/src/services/tldw/TldwChat.ts
@@ -643,6 +643,9 @@ export class TldwChatService {
         if (timeoutError) {
           throw timeoutError
         }
+        if (controller?.signal.aborted) {
+          throw createAbortError()
+        }
       } finally {
         clearIdleTimer()
         clearStartupTimer()

--- a/apps/packages/ui/src/services/tldw/TldwChat.ts
+++ b/apps/packages/ui/src/services/tldw/TldwChat.ts
@@ -97,6 +97,41 @@ const hasReasoningProgress = (chunk: unknown): boolean => {
 const hasVisibleAssistantProgress = (chunk: unknown): boolean =>
   extractTokenFromChunk(chunk).length > 0 || hasReasoningProgress(chunk)
 
+const isAbortLikeError = (error: unknown): boolean => {
+  if (!error) return false
+  if (error instanceof Error) {
+    if (error.name === "AbortError") return true
+    if (error.message.toLowerCase().includes("abort")) return true
+  }
+  const cause = (error as { cause?: unknown } | null)?.cause
+  if (cause instanceof Error) {
+    return (
+      cause.name === "AbortError" ||
+      cause.message.toLowerCase().includes("abort")
+    )
+  }
+  return false
+}
+
+const createAbortError = (message = "Aborted"): Error => {
+  const abortError = new Error(message)
+  abortError.name = "AbortError"
+  return abortError
+}
+
+const resolveStreamTimeoutError = (
+  reason: "startup" | "idle" | null,
+  sawVisibleProgress: boolean
+): Error | null => {
+  if (reason === "startup" && !sawVisibleProgress) {
+    return new Error("Chat response timed out before any visible output arrived.")
+  }
+  if (reason === "idle") {
+    return new Error("Chat response stalled after visible output began.")
+  }
+  return null
+}
+
 const sanitizeUserContent = (
   content: string | ChatCompletionContentPart[]
 ): string | ChatCompletionContentPart[] | null => {
@@ -563,33 +598,50 @@ export class TldwChatService {
 
       try {
         armStartupTimer()
-        for await (const chunk of stream) {
-          if (hasVisibleAssistantProgress(chunk)) {
-            sawVisibleProgress = true
-            clearStartupTimer()
-            resetIdleTimer()
-          }
+        try {
+          for await (const chunk of stream) {
+            if (hasVisibleAssistantProgress(chunk)) {
+              sawVisibleProgress = true
+              clearStartupTimer()
+              resetIdleTimer()
+            }
 
-          // Check if stream was cancelled
-          if (controller?.signal.aborted) {
-            break
-          }
+            // Check if stream was cancelled
+            if (controller?.signal.aborted) {
+              break
+            }
 
-          // Call the onChunk callback if provided
-          if (onChunk) {
-            onChunk(chunk)
-          }
+            // Call the onChunk callback if provided
+            if (onChunk) {
+              onChunk(chunk)
+            }
 
-          const token = extractTokenFromChunk(chunk)
-          if (token) {
-            yield token
+            const token = extractTokenFromChunk(chunk)
+            if (token) {
+              yield token
+            }
           }
+        } catch (error) {
+          const timeoutError = resolveStreamTimeoutError(
+            timeoutReason,
+            sawVisibleProgress
+          )
+          if (timeoutError) {
+            throw timeoutError
+          }
+          if (controller?.signal.aborted && isAbortLikeError(error)) {
+            throw createAbortError(
+              error instanceof Error && error.message ? error.message : "Aborted"
+            )
+          }
+          throw error
         }
-        if (timeoutReason === "startup" && !sawVisibleProgress) {
-          throw new Error("Chat response timed out before any visible output arrived.")
-        }
-        if (timeoutReason === "idle") {
-          throw new Error("Chat response stalled after visible output began.")
+        const timeoutError = resolveStreamTimeoutError(
+          timeoutReason,
+          sawVisibleProgress
+        )
+        if (timeoutError) {
+          throw timeoutError
         }
       } finally {
         clearIdleTimer()
@@ -597,6 +649,11 @@ export class TldwChatService {
       }
     } catch (error) {
       console.error('Stream completion failed:', error)
+      if (isAbortLikeError(error)) {
+        throw createAbortError(
+          error instanceof Error && error.message ? error.message : "Aborted"
+        )
+      }
       throw new Error('Stream completion failed', { cause: error })
     } finally {
       this.currentController = null


### PR DESCRIPTION
## Summary
- normalize timeout-driven chat stream aborts so startup and idle timeouts surface correctly instead of generic aborted runtime errors
- preserve AbortError classification for direct stream fallback aborts to match other request paths
- add regression coverage for thrown startup-timeout aborts and direct stream abort classification

## Test Plan
- bunx vitest run src/services/__tests__/tldw-chat.message-sanitization.test.ts src/services/__tests__/background-proxy.test.ts -c vitest.config.ts