### PR TITLE
fix: harden chat abort handling and ingest db messaging

### DIFF
--- a/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
+++ b/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
@@ -322,7 +322,7 @@ describe("background proxy fallback safety", () => {
         return {
           serverUrl: "http://127.0.0.1:8000",
           authMode: "single-user",
-          apiKey: "test-key-not-placeholder"
+          apiKey: "not-a-real-key"
         }
       }
       return null
@@ -387,9 +387,7 @@ describe("background proxy fallback safety", () => {
             return
           }
           const onAbort = () => {
-            try {
-              signal.removeEventListener("abort", onAbort)
-            } catch {}
+            signal.removeEventListener("abort", onAbort)
             const abortError = new Error("The operation was aborted.")
             abortError.name = "AbortError"
             reject(abortError)

--- a/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
+++ b/apps/packages/ui/src/services/__tests__/background-proxy.test.ts
@@ -359,6 +359,90 @@ describe("background proxy fallback safety", () => {
     expect(chunks.some((chunk) => chunk.includes('"event":"run_started"'))).toBe(true)
   })
 
+  it("classifies direct stream aborts as AbortError", async () => {
+    mocks.sendMessage.mockResolvedValue({ ok: false })
+    mocks.storageGet.mockImplementation(async (key: string) => {
+      if (key === "tldwConfig") {
+        return {
+          serverUrl: "http://127.0.0.1:8000",
+          authMode: "single-user",
+          apiKey: "test-key-not-placeholder"
+        }
+      }
+      return null
+    })
+
+    let activeSignal: AbortSignal | null = null
+    let resolveReadStarted: (() => void) | null = null
+    const readStarted = new Promise<void>((resolve) => {
+      resolveReadStarted = resolve
+    })
+    const reader = {
+      read: vi.fn(() => {
+        resolveReadStarted?.()
+        return new Promise<never>((_, reject) => {
+          const signal = activeSignal
+          if (!signal) {
+            reject(new Error("Missing abort signal"))
+            return
+          }
+          const onAbort = () => {
+            try {
+              signal.removeEventListener("abort", onAbort)
+            } catch {}
+            const abortError = new Error("The operation was aborted.")
+            abortError.name = "AbortError"
+            reject(abortError)
+          }
+          signal.addEventListener("abort", onAbort, { once: true })
+        })
+      }),
+      cancel: vi.fn()
+    }
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      activeSignal = (init?.signal as AbortSignal | undefined) || null
+      return {
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => reader
+        }
+      } as Response
+    })
+    vi.stubGlobal("fetch", fetchSpy as any)
+
+    const { bgStream } = await importProxy()
+    const controller = new AbortController()
+    const consume = async () => {
+      for await (const _chunk of bgStream({
+        path: "/api/v1/chat/completions",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: { stream: true, messages: [] },
+        abortSignal: controller.signal
+      })) {
+        // no-op
+      }
+    }
+
+    const pending = consume()
+
+    try {
+      await readStarted
+      controller.abort()
+
+      await expect(pending).rejects.toMatchObject({
+        name: "AbortError",
+        status: 0,
+        code: "REQUEST_ABORTED"
+      })
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(reader.cancel).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it("treats post-first-chunk transport disconnect as graceful end", async () => {
     mocks.sendMessage.mockResolvedValue({ ok: true })
     const onMessageListeners = new Set<(msg: any) => void>()

--- a/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
@@ -361,6 +361,65 @@ describe("TldwChatService message sanitization", () => {
     })
   })
 
+  it("detects nested abort causes during stream cancellation", async () => {
+    vi.useFakeTimers()
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://localhost:8000",
+      authMode: "single-user",
+      chatRequestTimeoutMs: 500,
+      chatStartupTimeoutMs: 500,
+      chatStreamIdleTimeoutMs: 500
+    })
+    mocks.streamChatCompletion.mockImplementation(
+      async function* (
+        _request: unknown,
+        options?: { signal?: AbortSignal }
+      ) {
+        yield {
+          event: "run_started",
+          run_id: "run_nested_abort",
+          seq: 1,
+          data: {}
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        if (options?.signal?.aborted) {
+          const abortError = new Error("The operation was aborted.")
+          abortError.name = "AbortError"
+          const wrappedAbort = new Error("inner wrapper", { cause: abortError })
+          throw new Error("outer wrapper", { cause: wrappedAbort })
+        }
+      }
+    )
+
+    const service = new TldwChatService()
+    const streamRun = (async () => {
+      const tokens: string[] = []
+      for await (const token of service.streamMessage(
+        [{ role: "user", content: "cancel with nested abort" }],
+        { model: "gpt-test" }
+      )) {
+        tokens.push(token)
+      }
+      return tokens
+    })()
+    const settled = streamRun.then(
+      (value) => ({ status: "resolved" as const, value }),
+      (error) => ({ status: "rejected" as const, error })
+    )
+
+    await vi.advanceTimersByTimeAsync(5)
+    service.cancelStream()
+    await vi.advanceTimersByTimeAsync(40)
+
+    await expect(settled).resolves.toMatchObject({
+      status: "rejected",
+      error: {
+        name: "AbortError",
+        message: expect.stringContaining("aborted")
+      }
+    })
+  })
+
   it("uses dedicated startup timeout instead of chat request timeout", async () => {
     vi.useFakeTimers()
     mocks.getConfig.mockResolvedValue({

--- a/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
@@ -299,6 +299,68 @@ describe("TldwChatService message sanitization", () => {
     })
   })
 
+  it("maps thrown aborts caused by startup timeout to the timeout error", async () => {
+    vi.useFakeTimers()
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://localhost:8000",
+      authMode: "single-user",
+      chatRequestTimeoutMs: 50,
+      chatStartupTimeoutMs: 50,
+      chatStreamIdleTimeoutMs: 500
+    })
+    mocks.streamChatCompletion.mockImplementation(
+      async function* (
+        _request: unknown,
+        options?: { signal?: AbortSignal }
+      ) {
+        let seq = 0
+        while (true) {
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          if (options?.signal?.aborted) {
+            const abortError = new Error("The operation was aborted.")
+            abortError.name = "AbortError"
+            throw abortError
+          }
+          seq += 1
+          yield {
+            event: "run_started",
+            run_id: "run_abort",
+            seq,
+            data: {}
+          }
+        }
+      }
+    )
+
+    const service = new TldwChatService()
+    const streamRun = (async () => {
+      const tokens: string[] = []
+      for await (const token of service.streamMessage(
+        [{ role: "user", content: "why did the stream abort?" }],
+        { model: "gpt-test" }
+      )) {
+        tokens.push(token)
+      }
+      return tokens
+    })()
+    const settled = streamRun.then(
+      (value) => ({ status: "resolved" as const, value }),
+      (error) => ({ status: "rejected" as const, error })
+    )
+
+    await vi.advanceTimersByTimeAsync(80)
+
+    await expect(settled).resolves.toMatchObject({
+      status: "rejected",
+      error: {
+        message: "Stream completion failed",
+        cause: expect.objectContaining({
+          message: expect.stringContaining("visible output")
+        })
+      }
+    })
+  })
+
   it("uses dedicated startup timeout instead of chat request timeout", async () => {
     vi.useFakeTimers()
     mocks.getConfig.mockResolvedValue({

--- a/apps/packages/ui/src/services/background-proxy.ts
+++ b/apps/packages/ui/src/services/background-proxy.ts
@@ -276,6 +276,9 @@ type RequestAbortError = Error & {
 const isAbortErrorMessage = (value?: string) =>
   typeof value === "string" && value.toLowerCase().includes("abort")
 
+const readErrorMessage = (error: unknown, fallback = "Aborted") =>
+  error instanceof Error && error.message ? error.message : fallback
+
 const createAbortError = (
   message?: string,
   status?: number,
@@ -1010,9 +1013,7 @@ async function* bgStreamDirect<
       throw idleError
     }
     if (abortSignal?.aborted) {
-      throw createAbortError(
-        e instanceof Error && e.message ? e.message : "Aborted"
-      )
+      throw createAbortError(readErrorMessage(e))
     }
     throw e
   } finally {

--- a/apps/packages/ui/src/services/background-proxy.ts
+++ b/apps/packages/ui/src/services/background-proxy.ts
@@ -267,6 +267,30 @@ const isExtensionTransportFailure = (error: unknown): boolean => {
   )
 }
 
+type RequestAbortError = Error & {
+  status?: number
+  code?: string
+  details?: unknown
+}
+
+const isAbortErrorMessage = (value?: string) =>
+  typeof value === "string" && value.toLowerCase().includes("abort")
+
+const createAbortError = (
+  message?: string,
+  status?: number,
+  details?: unknown
+): RequestAbortError => {
+  const abortError = new Error(message || "Aborted") as RequestAbortError
+  abortError.name = "AbortError"
+  abortError.status = typeof status === "number" ? status : 0
+  abortError.code = "REQUEST_ABORTED"
+  if (typeof details !== "undefined") {
+    abortError.details = sanitizeResponseData(details)
+  }
+  return abortError
+}
+
 const shouldNotifyBackendUnavailable = (entry: {
   method: string
   path: string
@@ -383,26 +407,13 @@ export async function bgRequest<
       // best-effort logging only
     }
   }
-  const isAbortErrorMessage = (value?: string) =>
-    typeof value === "string" && value.toLowerCase().includes("abort")
   const buildRequestError = (
     msg: string,
     status?: number,
     details?: unknown
   ): (Error & { status?: number; code?: string; details?: unknown }) => {
     if (isAbortErrorMessage(msg)) {
-      const abortError = new Error(msg || "Aborted") as Error & {
-        status?: number
-        code?: string
-        details?: unknown
-      }
-      abortError.name = "AbortError"
-      abortError.status = typeof status === "number" ? status : 0
-      abortError.code = "REQUEST_ABORTED"
-      if (typeof details !== "undefined") {
-        abortError.details = sanitizeResponseData(details)
-      }
-      return abortError
+      return createAbortError(msg, status, details)
     }
     const error = new Error(`${msg} (${method} ${path})`) as Error & {
       status?: number
@@ -999,7 +1010,9 @@ async function* bgStreamDirect<
       throw idleError
     }
     if (abortSignal?.aborted) {
-      throw new Error("Aborted")
+      throw createAbortError(
+        e instanceof Error && e.message ? e.message : "Aborted"
+      )
     }
     throw e
   } finally {

--- a/apps/packages/ui/src/services/tldw/TldwChat.ts
+++ b/apps/packages/ui/src/services/tldw/TldwChat.ts
@@ -97,19 +97,37 @@ const hasReasoningProgress = (chunk: unknown): boolean => {
 const hasVisibleAssistantProgress = (chunk: unknown): boolean =>
   extractTokenFromChunk(chunk).length > 0 || hasReasoningProgress(chunk)
 
+const readErrorMessage = (error: unknown, fallback = "Aborted"): string => {
+  const seen = new Set<unknown>()
+  let current: unknown = error
+  let firstMessage: string | null = null
+
+  while (current && !seen.has(current)) {
+    seen.add(current)
+    if (current instanceof Error && current.message) {
+      firstMessage ??= current.message
+      if (current.name === "AbortError") return current.message
+      if (current.message.toLowerCase().includes("abort")) return current.message
+    }
+    current = (current as { cause?: unknown } | null)?.cause
+  }
+
+  return firstMessage ?? fallback
+}
+
 const isAbortLikeError = (error: unknown): boolean => {
-  if (!error) return false
-  if (error instanceof Error) {
-    if (error.name === "AbortError") return true
-    if (error.message.toLowerCase().includes("abort")) return true
+  const seen = new Set<unknown>()
+  let current: unknown = error
+
+  while (current && !seen.has(current)) {
+    seen.add(current)
+    if (current instanceof Error) {
+      if (current.name === "AbortError") return true
+      if (current.message.toLowerCase().includes("abort")) return true
+    }
+    current = (current as { cause?: unknown } | null)?.cause
   }
-  const cause = (error as { cause?: unknown } | null)?.cause
-  if (cause instanceof Error) {
-    return (
-      cause.name === "AbortError" ||
-      cause.message.toLowerCase().includes("abort")
-    )
-  }
+
   return false
 }
 
@@ -630,9 +648,7 @@ export class TldwChatService {
             throw timeoutError
           }
           if (controller?.signal.aborted && isAbortLikeError(error)) {
-            throw createAbortError(
-              error instanceof Error && error.message ? error.message : "Aborted"
-            )
+            throw createAbortError(readErrorMessage(error))
           }
           throw error
         }
@@ -650,9 +666,7 @@ export class TldwChatService {
     } catch (error) {
       console.error('Stream completion failed:', error)
       if (isAbortLikeError(error)) {
-        throw createAbortError(
-          error instanceof Error && error.message ? error.message : "Aborted"
-        )
+        throw createAbortError(readErrorMessage(error))
       }
       throw new Error('Stream completion failed', { cause: error })
     } finally {

--- a/apps/packages/ui/src/services/tldw/TldwChat.ts
+++ b/apps/packages/ui/src/services/tldw/TldwChat.ts
@@ -97,6 +97,41 @@ const hasReasoningProgress = (chunk: unknown): boolean => {
 const hasVisibleAssistantProgress = (chunk: unknown): boolean =>
   extractTokenFromChunk(chunk).length > 0 || hasReasoningProgress(chunk)
 
+const isAbortLikeError = (error: unknown): boolean => {
+  if (!error) return false
+  if (error instanceof Error) {
+    if (error.name === "AbortError") return true
+    if (error.message.toLowerCase().includes("abort")) return true
+  }
+  const cause = (error as { cause?: unknown } | null)?.cause
+  if (cause instanceof Error) {
+    return (
+      cause.name === "AbortError" ||
+      cause.message.toLowerCase().includes("abort")
+    )
+  }
+  return false
+}
+
+const createAbortError = (message = "Aborted"): Error => {
+  const abortError = new Error(message)
+  abortError.name = "AbortError"
+  return abortError
+}
+
+const resolveStreamTimeoutError = (
+  reason: "startup" | "idle" | null,
+  sawVisibleProgress: boolean
+): Error | null => {
+  if (reason === "startup" && !sawVisibleProgress) {
+    return new Error("Chat response timed out before any visible output arrived.")
+  }
+  if (reason === "idle") {
+    return new Error("Chat response stalled after visible output began.")
+  }
+  return null
+}
+
 const sanitizeUserContent = (
   content: string | ChatCompletionContentPart[]
 ): string | ChatCompletionContentPart[] | null => {
@@ -563,33 +598,50 @@ export class TldwChatService {
 
       try {
         armStartupTimer()
-        for await (const chunk of stream) {
-          if (hasVisibleAssistantProgress(chunk)) {
-            sawVisibleProgress = true
-            clearStartupTimer()
-            resetIdleTimer()
-          }
+        try {
+          for await (const chunk of stream) {
+            if (hasVisibleAssistantProgress(chunk)) {
+              sawVisibleProgress = true
+              clearStartupTimer()
+              resetIdleTimer()
+            }
 
-          // Check if stream was cancelled
-          if (controller?.signal.aborted) {
-            break
-          }
+            // Check if stream was cancelled
+            if (controller?.signal.aborted) {
+              break
+            }
 
-          // Call the onChunk callback if provided
-          if (onChunk) {
-            onChunk(chunk)
-          }
+            // Call the onChunk callback if provided
+            if (onChunk) {
+              onChunk(chunk)
+            }
 
-          const token = extractTokenFromChunk(chunk)
-          if (token) {
-            yield token
+            const token = extractTokenFromChunk(chunk)
+            if (token) {
+              yield token
+            }
           }
+        } catch (error) {
+          const timeoutError = resolveStreamTimeoutError(
+            timeoutReason,
+            sawVisibleProgress
+          )
+          if (timeoutError) {
+            throw timeoutError
+          }
+          if (controller?.signal.aborted && isAbortLikeError(error)) {
+            throw createAbortError(
+              error instanceof Error && error.message ? error.message : "Aborted"
+            )
+          }
+          throw error
         }
-        if (timeoutReason === "startup" && !sawVisibleProgress) {
-          throw new Error("Chat response timed out before any visible output arrived.")
-        }
-        if (timeoutReason === "idle") {
-          throw new Error("Chat response stalled after visible output began.")
+        const timeoutError = resolveStreamTimeoutError(
+          timeoutReason,
+          sawVisibleProgress
+        )
+        if (timeoutError) {
+          throw timeoutError
         }
       } finally {
         clearIdleTimer()
@@ -597,6 +649,11 @@ export class TldwChatService {
       }
     } catch (error) {
       console.error('Stream completion failed:', error)
+      if (isAbortLikeError(error)) {
+        throw createAbortError(
+          error instanceof Error && error.message ? error.message : "Aborted"
+        )
+      }
       throw new Error('Stream completion failed', { cause: error })
     } finally {
       this.currentController = null

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -347,6 +347,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
                 "media_uuid": result_item.get("media_uuid"),
                 "error": result_item.get("error"),
                 "warnings": result_item.get("warnings"),
+                "db_message": result_item.get("db_message"),
             }
         return {"status": "Error", "error": "No result produced"}
 

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
@@ -74,6 +74,7 @@ async def test_media_ingest_worker_updates_progress_fields(monkeypatch, tmp_path
             "db_id": 123,
             "media_uuid": "media-uuid-123",
             "warnings": None,
+            "db_message": "Media added to database.",
         }
 
     monkeypatch.setattr(worker, "_create_db", _fake_create_db, raising=True)
@@ -102,6 +103,7 @@ async def test_media_ingest_worker_updates_progress_fields(monkeypatch, tmp_path
     result = await worker._handle_job(job, jm, progress)
 
     assert result.get("status") == "Success"
+    assert result.get("db_message") == "Media added to database."
     updated = jm.get_job(int(row.get("id")))
     assert updated is not None
     assert updated.get("progress_message") == "completed"
@@ -169,6 +171,7 @@ async def test_media_ingest_worker_returns_existing_media_id_for_skipped_dedupe_
         "media_uuid": "existing-media-uuid",
         "error": None,
         "warnings": None,
+        "db_message": None,
     }
 
 


### PR DESCRIPTION
## Summary
- normalize abort handling in the WebUI service layer so direct fallback requests and streams surface a consistent `AbortError` shape
- make `TldwChatService.streamMessage()` distinguish startup timeout, idle stall, and user abort scenarios instead of collapsing them into generic stream failures
- preserve `db_message` in media ingest worker results and extend unit coverage for both success and skipped-dedupe worker responses

## Why
- aborts and timeouts were being classified differently depending on whether the failure came from background proxy fallback or chat stream iteration
- the ingest worker was already returning the rest of the item envelope but dropped `db_message`, which made worker callers lose useful persistence context

## Test Plan
- `cd apps/packages/ui && bunx vitest run src/services/__tests__/background-proxy.test.ts src/services/__tests__/tldw-chat.message-sanitization.test.ts`
- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py -q`
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/media_ingest_jobs_worker.py -f json -o /tmp/bandit_abort_ingest_branch.json`