### PR TITLE
fix: address PR 1087 review feedback

### DIFF
--- a/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
+++ b/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
@@ -2,6 +2,18 @@ import React from "react"
 import { act, render, screen, waitFor } from "@testing-library/react"
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
 
+vi.mock("@web/lib/i18n-web", () => ({}))
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    storage: {
+      local: {
+        get: vi.fn(async () => ({}))
+      }
+    }
+  }
+}))
+
 import App from "@web/pages/_app"
 
 const mockRouter = {

--- a/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
+++ b/apps/tldw-frontend/__tests__/app/app-layout.test.tsx
@@ -106,9 +106,9 @@ describe("App layout routing", () => {
     expect(screen.getByTestId("page-content")).toBeInTheDocument()
   })
 
-  it("skips OptionLayout for /login", () => {
+  it("skips OptionLayout for /login but keeps ServerReadinessGate mounted", () => {
     renderApp("/login")
-    expect(screen.queryByTestId("server-readiness-gate")).toBeNull()
+    expect(screen.getByTestId("server-readiness-gate")).toBeInTheDocument()
     expect(screen.queryByTestId("first-run-gate")).toBeNull()
     expect(screen.queryByTestId("option-layout")).toBeNull()
     expect(screen.getByTestId("page-content")).toBeInTheDocument()
@@ -128,6 +128,7 @@ describe("App layout routing", () => {
 
     renderApp("/settings/tldw")
     const layout = await screen.findByTestId("option-layout")
+    expect(screen.getByTestId("server-readiness-gate")).toBeInTheDocument()
     expect(screen.queryByTestId("first-run-gate")).toBeNull()
     await waitFor(() => {
       expect(layout).toHaveAttribute("data-hide-header", "false")

--- a/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
+++ b/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
@@ -32,9 +32,10 @@ async function checkHealth(): Promise<boolean> {
   }
 }
 
-export const ServerReadinessGate: React.FC<{ children: React.ReactNode }> = ({
-  children
-}) => {
+export const ServerReadinessGate: React.FC<{
+  children: React.ReactNode
+  bypass?: boolean
+}> = ({ children, bypass }) => {
   const [gate, setGate] = React.useState<GateState>("checking")
 
   React.useEffect(() => {
@@ -72,7 +73,7 @@ export const ServerReadinessGate: React.FC<{ children: React.ReactNode }> = ({
     }
   }, [])
 
-  if (gate === "ready" || gate === "timeout") {
+  if (bypass || gate === "ready" || gate === "timeout") {
     return <>{children}</>
   }
 

--- a/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
+++ b/apps/tldw-frontend/components/networking/ServerReadinessGate.tsx
@@ -40,6 +40,12 @@ export const ServerReadinessGate: React.FC<{
 
   React.useEffect(() => {
     if (typeof window === "undefined") return
+    if (bypass) {
+      setGate((current) => (current === "ready" ? current : "checking"))
+      return
+    }
+
+    setGate((current) => (current === "ready" ? current : "checking"))
 
     let cancelled = false
     let retryTimer: number | undefined
@@ -71,7 +77,7 @@ export const ServerReadinessGate: React.FC<{
       cancelled = true
       if (retryTimer) window.clearTimeout(retryTimer)
     }
-  }, [])
+  }, [bypass])
 
   if (bypass || gate === "ready" || gate === "timeout") {
     return <>{children}</>

--- a/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
+++ b/apps/tldw-frontend/components/networking/__tests__/ServerReadinessGate.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 describe("ServerReadinessGate", () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.useRealTimers()
     vi.unstubAllEnvs()
   })
 
@@ -30,5 +31,40 @@ describe("ServerReadinessGate", () => {
       "http://127.0.0.1:8000/api/v1/health",
       expect.objectContaining({ method: "GET" })
     )
+  })
+
+  it("restarts readiness checks when leaving a bypass route after timing out", async () => {
+    vi.useFakeTimers()
+    vi.stubEnv("NEXT_PUBLIC_TLDW_DEPLOYMENT_MODE", "advanced")
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://127.0.0.1:8000")
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false
+    } as Response)
+
+    const { ServerReadinessGate } = await import("../ServerReadinessGate")
+
+    const { rerender } = render(
+      <ServerReadinessGate bypass>
+        <div>Settings ready</div>
+      </ServerReadinessGate>
+    )
+
+    expect(screen.getByText("Settings ready")).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16_000)
+    })
+
+    await act(async () => {
+      rerender(
+        <ServerReadinessGate bypass={false}>
+          <div>App ready</div>
+        </ServerReadinessGate>
+      )
+    })
+
+    expect(screen.getByText("Waiting for server...")).toBeInTheDocument()
+    expect(screen.queryByText("App ready")).toBeNull()
   })
 })

--- a/apps/tldw-frontend/lib/__tests__/api.credentials.test.ts
+++ b/apps/tldw-frontend/lib/__tests__/api.credentials.test.ts
@@ -92,6 +92,7 @@ describe("shouldIncludeBrowserCredentials", () => {
   it("keeps auth recovery routes out of the unauthorized login redirect loop", () => {
     return loadApiHelpers().then((apiModule) => {
       expect(apiModule.shouldRedirectUnauthorizedToLogin("/login")).toBe(false)
+      expect(apiModule.shouldRedirectUnauthorizedToLogin("/settings")).toBe(false)
       expect(apiModule.shouldRedirectUnauthorizedToLogin("/settings/tldw")).toBe(false)
       expect(apiModule.shouldRedirectUnauthorizedToLogin("/settings/health/")).toBe(false)
       expect(apiModule.shouldRedirectUnauthorizedToLogin("/auth/reset-password")).toBe(false)

--- a/apps/tldw-frontend/lib/__tests__/api.credentials.test.ts
+++ b/apps/tldw-frontend/lib/__tests__/api.credentials.test.ts
@@ -2,7 +2,12 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
-import { clearRuntimeAuth, setRuntimeApiBearer, setRuntimeApiKey } from "../authStorage"
+import {
+  clearRuntimeAuth,
+  hasEnvApiAuth,
+  setRuntimeApiBearer,
+  setRuntimeApiKey
+} from "../authStorage"
 
 async function loadShouldIncludeBrowserCredentials() {
   process.env.NEXT_PUBLIC_API_URL = "http://127.0.0.1:8000"
@@ -70,6 +75,15 @@ describe("shouldIncludeBrowserCredentials", () => {
     return loadShouldIncludeBrowserCredentials().then((shouldIncludeBrowserCredentials) => {
       expect(shouldIncludeBrowserCredentials()).toBe(true)
     })
+  })
+
+  it("normalizes env API auth detection through a shared helper", () => {
+    expect(hasEnvApiAuth()).toBe(false)
+
+    process.env.NEXT_PUBLIC_X_API_KEY = "   "
+    process.env.NEXT_PUBLIC_API_BEARER = "  Bearer env-token  "
+
+    expect(hasEnvApiAuth()).toBe(true)
   })
 
   it("reuses stored single-user api keys from localStorage config for browser requests", () => {

--- a/apps/tldw-frontend/lib/api.ts
+++ b/apps/tldw-frontend/lib/api.ts
@@ -209,7 +209,7 @@ api.interceptors.response.use(
         localStorage.removeItem('access_token');
         localStorage.removeItem('user');
         // Redirect to login only if not using env-based API auth
-        const hasEnvAuth = !!(process.env.NEXT_PUBLIC_X_API_KEY || process.env.NEXT_PUBLIC_API_BEARER);
+        const hasEnvAuth = !!((process.env.NEXT_PUBLIC_X_API_KEY || "").trim() || (process.env.NEXT_PUBLIC_API_BEARER || "").trim());
         const hasStoredAuth = !!(getApiKey() || getApiBearer());
         if (
           !hasEnvAuth &&

--- a/apps/tldw-frontend/lib/api.ts
+++ b/apps/tldw-frontend/lib/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
 import { addRequestHistory } from '@web/lib/history';
-import { getApiBearer, getApiKey } from '@web/lib/authStorage';
+import { getApiBearer, getApiKey, hasEnvApiAuth } from '@web/lib/authStorage';
 import { buildApiBaseUrl, resolvePublicApiOrigin } from '@web/lib/api-base';
 import { captureSessionIdFromHeaders, getOrCreateSessionId, SESSION_HEADER_NAME } from '@web/lib/session';
 import type { AxiosConfigWithMetadata, ApiErrorResponse } from '@web/types/common';
@@ -209,10 +209,9 @@ api.interceptors.response.use(
         localStorage.removeItem('access_token');
         localStorage.removeItem('user');
         // Redirect to login only if not using env-based API auth
-        const hasEnvAuth = !!((process.env.NEXT_PUBLIC_X_API_KEY || "").trim() || (process.env.NEXT_PUBLIC_API_BEARER || "").trim());
         const hasStoredAuth = !!(getApiKey() || getApiBearer());
         if (
-          !hasEnvAuth &&
+          !hasEnvApiAuth() &&
           !hasStoredAuth &&
           shouldRedirectUnauthorizedToLogin(window.location.pathname)
         ) {

--- a/apps/tldw-frontend/lib/authStorage.ts
+++ b/apps/tldw-frontend/lib/authStorage.ts
@@ -99,6 +99,10 @@ export const getApiBearer = (): string | null => {
   return normalizeBearerValue(readStoredLocalValue("accessToken"));
 };
 
+export const hasEnvApiAuth = (): boolean =>
+  normalizeApiKeyValue(process.env.NEXT_PUBLIC_X_API_KEY || null) !== null ||
+  normalizeBearerValue(process.env.NEXT_PUBLIC_API_BEARER || null) !== null;
+
 export const clearRuntimeAuth = (): void => {
   runtimeApiKey = null;
   runtimeApiBearer = null;

--- a/apps/tldw-frontend/pages/_app.tsx
+++ b/apps/tldw-frontend/pages/_app.tsx
@@ -13,6 +13,7 @@ import { AppProviders } from "@web/components/AppProviders"
 import ErrorBoundary from "@web/components/ErrorBoundary"
 import { ConfigurationGuard } from "@web/components/networking/ConfigurationGuard"
 import { ServerReadinessGate } from "@web/components/networking/ServerReadinessGate"
+import { hasEnvApiAuth } from "@web/lib/authStorage"
 import { loadTldwAuth, loadTldwClient } from "@web/lib/configured-auth-state"
 
 const OptionLayout = dynamic(
@@ -45,12 +46,6 @@ const PREFETCH_STEP_DELAY_MS = 250
 const PREFETCH_IDLE_TIMEOUT_MS = 2000
 const PREFETCH_FALLBACK_DELAY_MS = 1200
 const SLOW_EFFECTIVE_TYPES = new Set(["slow-2g", "2g"])
-
-const hasEnvAuth = () => {
-  const envApiKey = (process.env.NEXT_PUBLIC_X_API_KEY || "").trim()
-  const envBearer = (process.env.NEXT_PUBLIC_API_BEARER || "").trim()
-  return envApiKey.length > 0 || envBearer.length > 0
-}
 
 type ConfiguredAuthState = {
   hasConfig: boolean
@@ -131,7 +126,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
     let cancelled = false
     const refreshAuthState = async () => {
-      const envAuthed = hasEnvAuth()
+      const envAuthed = hasEnvApiAuth()
       const configuredAuth = await getConfiguredAuthState()
       const authed = configuredAuth.hasConfig
         ? configuredAuth.authMode === "multi-user"

--- a/apps/tldw-frontend/pages/_app.tsx
+++ b/apps/tldw-frontend/pages/_app.tsx
@@ -254,49 +254,45 @@ export default function App({ Component, pageProps }: AppProps) {
   }, [authResolved, isAuthenticated, isPublicAuthRoute, routePath, router])
 
   const hideShellNav = !authResolved || !isAuthenticated
-  const shouldBypassFirstRunGate = isPublicAuthRoute || isSettingsRoute
+  const shouldBypassGates = isPublicAuthRoute || isSettingsRoute
 
   const handleStartSetup = React.useCallback(() => {
     void router.push("/persona")
   }, [router])
 
-  const appContent = (
-    <ConfigurationGuard>
-      <BackendRecoveryUiProvider routeRecoveryEnabled>
-        <ErrorBoundary>
-          {isPublicAuthRoute ? (
-            <Component {...pageProps} />
-          ) : shouldBypassFirstRunGate ? (
-            <OptionLayout
-              hideHeader={hideShellNav}
-              hideSidebar={hideShellNav || isSettingsRoute}
-              allowNestedHideHeader={!isSettingsRoute}
-            >
-              <Component {...pageProps} />
-            </OptionLayout>
-          ) : (
-            <FirstRunGate onStartSetup={handleStartSetup}>
-              <OptionLayout
-                hideHeader={hideShellNav}
-                hideSidebar={hideShellNav || isSettingsRoute}
-                allowNestedHideHeader={!isSettingsRoute}
-              >
-                <Component {...pageProps} />
-              </OptionLayout>
-            </FirstRunGate>
-          )}
-        </ErrorBoundary>
-      </BackendRecoveryUiProvider>
-    </ConfigurationGuard>
+  const layoutProps = {
+    hideHeader: hideShellNav,
+    hideSidebar: hideShellNav || isSettingsRoute,
+    allowNestedHideHeader: !isSettingsRoute,
+  }
+
+  const layoutContent = (
+    <OptionLayout {...layoutProps}>
+      <Component {...pageProps} />
+    </OptionLayout>
+  )
+
+  const gatedContent = isPublicAuthRoute ? (
+    <Component {...pageProps} />
+  ) : shouldBypassGates ? (
+    layoutContent
+  ) : (
+    <FirstRunGate onStartSetup={handleStartSetup}>
+      {layoutContent}
+    </FirstRunGate>
   )
 
   return (
     <AppProviders>
-      {isPublicAuthRoute ? (
-        appContent
-      ) : (
-        <ServerReadinessGate>{appContent}</ServerReadinessGate>
-      )}
+      <ConfigurationGuard>
+        <BackendRecoveryUiProvider routeRecoveryEnabled>
+          <ErrorBoundary>
+            <ServerReadinessGate bypass={shouldBypassGates}>
+              {gatedContent}
+            </ServerReadinessGate>
+          </ErrorBoundary>
+        </BackendRecoveryUiProvider>
+      </ConfigurationGuard>
     </AppProviders>
   )
 }

--- a/apps/tldw-frontend/vitest.config.ts
+++ b/apps/tldw-frontend/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, '../packages/ui/src'),
       '~': path.resolve(__dirname, '../packages/ui/src'),
       '@web': path.resolve(__dirname, '.'),
+      'wxt/browser': path.resolve(__dirname, './extension/shims/wxt-browser.ts'),
       'react-router-dom': path.resolve(
         __dirname,
         '../packages/ui/node_modules/react-router-dom'


### PR DESCRIPTION
## Summary
- Stabilize provider tree in `_app.tsx` to prevent `ConfigurationGuard`/`BackendRecoveryUiProvider` remounting during route changes (Gemini high-priority finding)
- Add `bypass` prop to `ServerReadinessGate` so settings routes aren't blocked by the 15s health-check spinner — users can reach `/settings/tldw` to fix misconfigured API URLs
- Extract shared `OptionLayout` props to eliminate duplication
- Align `hasEnvAuth` whitespace trimming in `api.ts` 401 interceptor with `_app.tsx`
- Add missing `/settings` exact-match test for redirect bypass coverage

## Context
These are the review fixes from PR #1087 that were committed after the PR was already merged.

## Test plan
- [x] `bunx vitest run lib/__tests__/api.credentials.test.ts` — 6/6 pass
- [x] `bunx eslint` on all 5 changed files — clean
- [ ] Verify `/login` → `/settings/tldw` redirect works without spinner block
- [ ] Verify navigation from `/login` to `/chat` doesn't remount providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)