### PR TITLE
Wave 1: data and bootstrap hardening

### DIFF
--- a/Docs/Plans/IMPLEMENTATION_PLAN_pr_1092_review_followups_2026_04_16.md
+++ b/Docs/Plans/IMPLEMENTATION_PLAN_pr_1092_review_followups_2026_04_16.md
@@ -1,0 +1,26 @@
+# PR 1092 Review Follow-Ups Implementation Plan
+
+## Stage 1: Review Triage
+**Goal**: Verify every still-open PR #1092 review item against the current branch head and isolate the changes that are still technically required.
+**Success Criteria**: Remaining work is reduced to a concrete, code-backed list; already-fixed comments are explicitly ruled out.
+**Tests**: `gh pr view 1092 --repo rmusser01/tldw_server --json headRefOid,latestReviews,comments,reviews`
+**Status**: Complete
+
+## Stage 2: Shared Content Backend Retirement Safety
+**Goal**: Replace immediate close-on-rotation with retire-then-drain behavior so in-flight borrowers can finish on the superseded backend.
+**Success Criteria**: Rotating or clearing the shared content backend no longer closes an old pool while live references still exist, and pools still close once the retired backend is no longer referenced.
+**Tests**: `python -m pytest tldw_Server_API/tests/DB_Management/test_content_backend_cache.py -k "content_backend or reset_media_runtime_defaults" -v`
+**Status**: Complete
+
+## Stage 3: Watchlists Operation-Scoped Backend Pinning
+**Goal**: Ensure public Watchlists operations use one resolved backend for the full method call, including multi-query read and write paths.
+**Success Criteria**: Mid-operation backend refreshes do not split a single Watchlists API call across old and new backends.
+**Tests**: `python -m pytest tldw_Server_API/tests/DB_Management/test_content_backend_cache.py -k "watchlists" -v`
+**Status**: Complete
+
+## Stage 4: Verification and Security Gate
+**Goal**: Re-run the touched DB-management tests and Bandit on the modified scope before closing out the PR work.
+**Success Criteria**: Targeted pytest commands pass; Bandit reports no new findings in touched files.
+**Tests**: `python -m pytest tldw_Server_API/tests/DB_Management/test_content_backend_cache.py tldw_Server_API/tests/DB_Management/test_db_migration_verification.py -v`
+**Tests**: `python -m bandit -r tldw_Server_API/app/core/DB_Management/content_backend.py tldw_Server_API/app/core/DB_Management/Watchlists_DB.py tldw_Server_API/tests/DB_Management/test_content_backend_cache.py -f json -o /tmp/bandit_pr1092_review_followups.json`
+**Status**: Complete

--- a/Docs/superpowers/reviews/db-management/2026-04-15-rebaseline.md
+++ b/Docs/superpowers/reviews/db-management/2026-04-15-rebaseline.md
@@ -1,0 +1,27 @@
+## Provenance
+
+- Reviewed branch: `codex/wave1-data-bootstrap-hardening`
+- Reviewed head: `02e6ec1e9`
+- Focused suite: 47 passed, 2 skipped, 2 failed
+- Remaining red tests: `test_content_backend_cache.py::test_get_content_backend_closes_superseded_cached_backend` and `test_content_backend_cache.py::test_reset_media_runtime_defaults_closes_cached_backend`
+- Cache slice rerun: 2 failed, 2 passed; the same two cache-close assertions remained red
+
+## Rebaseline Summary
+
+- Closed in current tree:
+  - RLS fail-closed contract (`test_pg_rls_policies_contract.py`)
+  - migration loader and planning contract (`test_db_migration_loader.py`, `test_db_migration_planning.py`)
+  - CLI no-backup passthrough (`test_migration_cli_integration.py`)
+  - UserDatabase_v2 fail-closed bootstrap checks (`test_userdatabase_v2_bootstrap_failclosed.py`)
+  - trusted-path contract (`test_db_path_utils.py`)
+  - media_db API DB-error propagation (`test_media_db_api_error_contracts.py`)
+  - backend FTS normalization (`test_database_backend_fts_normalization.py`)
+
+- Still live:
+  - shared content-backend cache close semantics
+
+- Follow-up, non-defect:
+  - add migration verification gap coverage
+
+- Next action:
+  - fix deterministic cache-close behavior

--- a/Docs/superpowers/reviews/db-management/README.md
+++ b/Docs/superpowers/reviews/db-management/README.md
@@ -8,6 +8,8 @@ Stage order:
 3. [`Docs/superpowers/reviews/db-management/2026-04-07-stage3-paths-tenancy-migrations-backups.md`](./2026-04-07-stage3-paths-tenancy-migrations-backups.md)
 4. [`Docs/superpowers/reviews/db-management/2026-04-07-stage4-media-db-and-representative-helpers.md`](./2026-04-07-stage4-media-db-and-representative-helpers.md)
 5. [`Docs/superpowers/reviews/db-management/2026-04-07-stage5-test-gaps-and-synthesis.md`](./2026-04-07-stage5-test-gaps-and-synthesis.md)
+6. [`Docs/superpowers/reviews/db-management/2026-04-15-rebaseline.md`](./2026-04-15-rebaseline.md)
+   - Current-tree rebaseline for Wave 1; identifies already-closed April findings and the remaining live cache-contract failure.
 
 Rules for using these reports:
 - Write findings before remediation ideas.

--- a/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts
@@ -75,9 +75,7 @@ async function openSpeechInputSourcePicker(page: Page) {
     }
   }
   await expect(inputSourcePicker).toBeVisible({ timeout: LOAD_TIMEOUT })
-  // Click the parent .ant-select-selector — the combobox input is covered by
-  // the ant-select-content-value overlay that intercepts pointer events.
-  await inputSourcePicker.locator('xpath=ancestor::div[contains(@class, "ant-select-selector")]').click()
+  await inputSourcePicker.click({ force: true })
 }
 
 test.describe("Stage 7 audio regression gate", () => {

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -46,7 +46,7 @@ import uuid  # noqa: E402
 from configparser import ConfigParser  # noqa: E402
 from datetime import datetime, timedelta, timezone  # noqa: E402
 from pathlib import Path  # noqa: E402
-from typing import Any  # noqa: E402
+from typing import Any, Protocol, TypeAlias  # noqa: E402
 
 from loguru import logger  # noqa: E402
 
@@ -459,6 +459,21 @@ class BackendConnectionWrapper:
 
     def __getattr__(self, item):
         return getattr(self._connection, item)
+
+
+class SupportsRawBackendConnection(Protocol):
+    """Protocol for pooled backend connections handled outside sqlite3."""
+
+    def close(self) -> Any: ...
+
+    def commit(self) -> Any: ...
+
+    def rollback(self) -> Any: ...
+
+    def cursor(self) -> Any: ...
+
+
+RawBackendConnection: TypeAlias = sqlite3.Connection | SupportsRawBackendConnection
 
 
 class BackendManagedTransaction:
@@ -5321,7 +5336,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         return transform_sqlite_query_for_postgres(query)
 
 
-    def _open_new_connection(self, backend: DatabaseBackend | None = None) -> Any:
+    def _open_new_connection(self, backend: DatabaseBackend | None = None) -> RawBackendConnection:
         active_backend = backend or self.backend
         try:
             pool = active_backend.get_pool()
@@ -5333,7 +5348,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except BackendDatabaseError as exc:
             raise CharactersRAGDBError(f"Failed to acquire database connection: {exc}") from exc  # noqa: TRY003
 
-    def _apply_postgres_client_scope(self, conn, pool):
+    def _apply_postgres_client_scope(
+        self,
+        conn: RawBackendConnection,
+        pool,
+    ) -> RawBackendConnection:
         """Best-effort helper to set session-scoped client_id in PostgreSQL.
 
         Ensures failed SET/COMMIT attempts do not leave pooled connections in a
@@ -5354,7 +5373,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     (user_value,),
                 )
 
-        def _replace_connection(bad_conn) -> Any:
+        def _replace_connection(bad_conn: RawBackendConnection) -> RawBackendConnection:
             with contextlib.suppress(_CHACHA_NONCRITICAL_EXCEPTIONS):
                 bad_conn.close()
             with contextlib.suppress(_CHACHA_NONCRITICAL_EXCEPTIONS):
@@ -5411,7 +5430,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     _safe_rollback(conn, "retry failure")
         return conn
 
-    def _release_connection(self, connection: Any, backend: DatabaseBackend | None = None) -> None:
+    def _release_connection(
+        self,
+        connection: RawBackendConnection,
+        backend: DatabaseBackend | None = None,
+    ) -> None:
         active_backend = backend or self._get_pinned_backend() or self._backend
         try:
             if active_backend.backend_type == BackendType.SQLITE:

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -354,9 +354,10 @@ class BackendCursorAdapter:
 class BackendCursorWrapper:
     """Cursor wrapper that routes operations through the configured backend."""
 
-    def __init__(self, db: CharactersRAGDB, connection):
+    def __init__(self, db: CharactersRAGDB, connection, backend: DatabaseBackend):
         self._db = db
         self._connection = connection
+        self._backend = backend
         self._result: QueryResult | None = None
         self._adapter: BackendCursorAdapter | None = None
         self.rowcount: int = -1
@@ -365,7 +366,7 @@ class BackendCursorWrapper:
 
     def execute(self, query: str, params: tuple | list | dict | None = None):
         prepared_query, prepared_params = self._db._prepare_backend_statement(query, params)
-        self._result = self._db.backend.execute(
+        self._result = self._backend.execute(
             prepared_query,
             prepared_params,
             connection=self._connection,
@@ -378,7 +379,7 @@ class BackendCursorWrapper:
 
     def executemany(self, query: str, params_list: list[tuple | list | dict]):
         prepared_query, prepared_params_list = self._db._prepare_backend_many_statement(query, params_list)
-        self._result = self._db.backend.execute_many(
+        self._result = self._backend.execute_many(
             prepared_query,
             prepared_params_list,
             connection=self._connection,
@@ -419,14 +420,15 @@ class BackendCursorWrapper:
 class BackendConnectionWrapper:
     """Connection wrapper that returns backend-aware cursors."""
 
-    def __init__(self, db: CharactersRAGDB, connection):
+    def __init__(self, db: CharactersRAGDB, connection, backend: DatabaseBackend):
         self._db = db
         self._connection = connection
+        self._backend = backend
 
     def cursor(self):
-        if self._db.backend_type == BackendType.SQLITE:
+        if self._backend.backend_type == BackendType.SQLITE:
             return self._connection.cursor()
-        return BackendCursorWrapper(self._db, self._connection)
+        return BackendCursorWrapper(self._db, self._connection, self._backend)
 
     def execute(self, query: str, params: tuple | list | dict | None = None):
         cursor = self.cursor()
@@ -451,7 +453,7 @@ class BackendConnectionWrapper:
 
     @property
     def in_transaction(self) -> bool:
-        if self._db.backend_type == BackendType.SQLITE:
+        if self._backend.backend_type == BackendType.SQLITE:
             return self._connection.in_transaction
         return True
 
@@ -474,7 +476,8 @@ class BackendManagedTransaction:
         self._depth = getattr(self._db._local, "tx_depth", 0)
         self._managed = self._depth == 0
         self._db._local.tx_depth = self._depth + 1
-        self._wrapper = BackendConnectionWrapper(self._db, self._raw_conn)
+        backend = self._db._get_pinned_backend() or self._db.backend
+        self._wrapper = BackendConnectionWrapper(self._db, self._raw_conn, backend)
         return self._wrapper
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -5111,13 +5114,19 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if not client_id:
             raise ValueError("Client ID cannot be empty or None.")  # noqa: TRY003
         self.client_id = client_id
+        self._local = threading.local()
+        self._schema_lock = threading.RLock()
+        self._bootstrapped_backend_targets: set[str] = set()
+        self._backend_refresh_suspended = False
         # Ownership marker for backend lifecycle:
         # - True: this wrapper directly owns the backend lifecycle and cleanup.
         # - False: lifecycle is managed externally (factory-managed shared backend or injected backend).
         self._owner_managed_backend = False
-
-        self.backend = self._resolve_backend(backend=backend, config=config)
-        self.backend_type = self.backend.backend_type
+        self._uses_shared_content_backend = False
+        self._backend, self._uses_shared_content_backend = self._resolve_backend(
+            backend=backend,
+            config=config,
+        )
 
         if self.backend_type != BackendType.SQLITE:
             self.is_memory_db = False
@@ -5140,10 +5149,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             f"Initializing CharactersRAGDB for path: {self.db_path_str} "
             f"[Client ID: {self.client_id}] (backend={self.backend_type.value})"
         )
-        self._local = threading.local()
-        self._schema_lock = threading.RLock()
         try:
             self._initialize_schema()
+            self._mark_backend_bootstrapped(self._backend)
             logger.debug(f"CharactersRAGDB initialization completed successfully for {self.db_path_str}")
         except (CharactersRAGDBError, sqlite3.Error) as e:
             logger.critical(f"FATAL: DB Initialization failed for {self.db_path_str}: {e}", exc_info=True)
@@ -5161,11 +5169,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         *,
         backend: DatabaseBackend | None,
         config: ConfigParser | None,
-    ) -> DatabaseBackend:
+    ) -> tuple[DatabaseBackend, bool]:
         """Select the database backend instance for this content store."""
         if backend is not None:
             self._owner_managed_backend = False
-            return backend
+            return backend, False
 
         parser: ConfigParser | None = config
         if parser is None:
@@ -5178,7 +5186,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             candidate = get_content_backend(parser)
             if candidate and candidate.backend_type == BackendType.POSTGRESQL:
                 self._owner_managed_backend = False
-                return candidate
+                return candidate, True
 
         fallback_config = DatabaseConfig(
             backend_type=BackendType.SQLITE,
@@ -5189,9 +5197,85 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             # isolated from the global factory registry. This wrapper owns cleanup for
             # that backend and it is not affected by factory-wide reset/close calls.
             self._owner_managed_backend = True
-            return SQLiteBackend(fallback_config)
+            return SQLiteBackend(fallback_config), False
         self._owner_managed_backend = False
-        return DatabaseBackendFactory.create_backend(fallback_config)
+        return DatabaseBackendFactory.create_backend(fallback_config), False
+
+    def _backend_target_key(self, backend: DatabaseBackend | None) -> str | None:
+        if backend is None:
+            return None
+        config = getattr(backend, "config", None)
+        if backend.backend_type == BackendType.POSTGRESQL:
+            if config and getattr(config, "connection_string", None):
+                return str(config.connection_string)
+            if config:
+                host = getattr(config, "pg_host", None) or "localhost"
+                port = getattr(config, "pg_port", None) or 5432
+                database = getattr(config, "pg_database", None) or "<postgres>"
+                return f"{host}:{port}/{database}"
+            return f"postgres:{id(backend)}"
+        if config and getattr(config, "sqlite_path", None):
+            return str(config.sqlite_path)
+        return f"sqlite:{id(backend)}"
+
+    def _get_pinned_backend(self) -> DatabaseBackend | None:
+        return getattr(self._local, "backend_ref", None)
+
+    def _mark_backend_bootstrapped(self, backend: DatabaseBackend | None) -> None:
+        key = self._backend_target_key(backend)
+        if key:
+            self._bootstrapped_backend_targets.add(key)
+
+    def _ensure_bootstrap_for_backend(self, backend: DatabaseBackend) -> None:
+        if backend.backend_type != BackendType.POSTGRESQL:
+            return
+        key = self._backend_target_key(backend)
+        if key in self._bootstrapped_backend_targets:
+            return
+        previous_suspend = self._backend_refresh_suspended
+        self._backend_refresh_suspended = True
+        try:
+            self._backend = backend
+            self._initialize_schema()
+        finally:
+            self._backend_refresh_suspended = previous_suspend
+        if key:
+            self._bootstrapped_backend_targets.add(key)
+
+    @property
+    def backend(self) -> DatabaseBackend:
+        pinned_backend = self._get_pinned_backend()
+        if pinned_backend is not None:
+            return pinned_backend
+        if not self._uses_shared_content_backend:
+            return self._backend
+        if self._backend_refresh_suspended:
+            return self._backend
+        with self._schema_lock:
+            pinned_backend = self._get_pinned_backend()
+            if pinned_backend is not None:
+                return pinned_backend
+            if not self._uses_shared_content_backend:
+                return self._backend
+            if self._backend_refresh_suspended:
+                return self._backend
+
+            current_key = self._backend_target_key(self._backend)
+            refreshed_backend, uses_shared_backend = self._resolve_backend(backend=None, config=None)
+            self._uses_shared_content_backend = uses_shared_backend
+            self._backend = refreshed_backend
+            refreshed_key = self._backend_target_key(refreshed_backend)
+            if (
+                uses_shared_backend
+                and refreshed_backend.backend_type == BackendType.POSTGRESQL
+                and refreshed_key != current_key
+            ):
+                self._ensure_bootstrap_for_backend(refreshed_backend)
+            return self._backend
+
+    @property
+    def backend_type(self) -> BackendType:
+        return self.backend.backend_type
 
 
     def _prepare_backend_statement(
@@ -5237,12 +5321,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         return transform_sqlite_query_for_postgres(query)
 
 
-    def _open_new_connection(self):
+    def _open_new_connection(self, backend: DatabaseBackend | None = None) -> Any:
+        active_backend = backend or self.backend
         try:
-            pool = self.backend.get_pool()
+            pool = active_backend.get_pool()
             conn = pool.get_connection()
             # Apply per-tenant session guard for PostgreSQL (RLS via current_setting('app.current_user_id'))
-            if self.backend_type == BackendType.POSTGRESQL and self.client_id:
+            if active_backend.backend_type == BackendType.POSTGRESQL and self.client_id:
                 conn = self._apply_postgres_client_scope(conn, pool)
             return conn  # noqa: TRY300
         except BackendDatabaseError as exc:
@@ -5326,12 +5411,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     _safe_rollback(conn, "retry failure")
         return conn
 
-    def _release_connection(self, connection) -> None:
+    def _release_connection(self, connection: Any, backend: DatabaseBackend | None = None) -> None:
+        active_backend = backend or self._get_pinned_backend() or self._backend
         try:
-            if self.backend_type == BackendType.SQLITE:
+            if active_backend.backend_type == BackendType.SQLITE:
                 thread_id = threading.get_ident()
                 try:
-                    pool = self.backend.get_pool()
+                    pool = active_backend.get_pool()
                     pool._connections[thread_id] = None  # type: ignore[attr-defined]
                     if hasattr(pool._local, 'connection'):  # type: ignore[attr-defined]
                         pool._local.connection = None  # type: ignore[attr-defined]
@@ -5340,7 +5426,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 with contextlib.suppress(sqlite3.Error):
                     connection.close()
             else:
-                self.backend.get_pool().return_connection(connection)
+                active_backend.get_pool().return_connection(connection)
         except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:  # noqa: BLE001
             logger.warning("Error while releasing connection: {}", exc)
 
@@ -5365,9 +5451,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             CharactersRAGDBError: If acquiring a connection from the backend fails.
         """
         conn = getattr(self._local, 'conn', None)
+        backend = self._get_pinned_backend() or self.backend
 
-        if self.backend_type == BackendType.SQLITE:
-            pool = self.backend.get_pool()
+        if backend.backend_type == BackendType.SQLITE:
+            pool = backend.get_pool()
             if conn is not None:
                 try:
                     conn.execute("SELECT 1")
@@ -5392,7 +5479,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     self._local.conn = None
 
             if conn is None:
-                conn = self._open_new_connection()
+                conn = self._open_new_connection(backend)
                 self._local.conn = conn
                 logger.debug(
                     'Opened/Reopened SQLite connection to {} for thread {}',
@@ -5403,16 +5490,19 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
         # Non-SQLite backend: reuse connection if still open, otherwise borrow anew.
         if conn is not None and getattr(conn, "closed", False):
-            self._release_connection(conn)
+            self._release_connection(conn, backend=backend)
             conn = None
             self._local.conn = None
+            self._local.backend_ref = None
+            backend = self.backend
 
         if conn is None:
-            conn = self._open_new_connection()
+            conn = self._open_new_connection(backend)
             self._local.conn = conn
+            self._local.backend_ref = backend
             logger.debug(
                 'Acquired backend connection ({}) for thread {}',
-                self.backend_type.value,
+                backend.backend_type.value,
                 threading.get_ident(),
             )
         return conn
@@ -5420,9 +5510,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def get_connection(self) -> Any:
         """Return the active connection wrapper for the current thread."""
         raw_conn = self._get_thread_connection()
-        if self.backend_type == BackendType.SQLITE:
+        backend = self._get_pinned_backend() or self.backend
+        if backend.backend_type == BackendType.SQLITE:
             return raw_conn
-        return BackendConnectionWrapper(self, raw_conn)
+        return BackendConnectionWrapper(self, raw_conn, backend)
 
     def close_connection(self):
         """
@@ -5437,9 +5528,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         conn = getattr(self._local, 'conn', None)
         if conn is None:
             return
+        backend = self._get_pinned_backend() or self._backend
 
         try:
-            if self.backend_type == BackendType.SQLITE:
+            if backend.backend_type == BackendType.SQLITE:
                 if not self.is_memory_db:
                     if conn.in_transaction:
                         try:
@@ -5476,10 +5568,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     self.db_path_str,
                 )
             else:
-                self.backend.get_pool().return_connection(conn)
+                backend.get_pool().return_connection(conn)
                 logger.debug(
                     'Returned backend connection ({}) for thread {}.',
-                    self.backend_type.value,
+                    backend.backend_type.value,
                     threading.get_ident(),
                 )
         except sqlite3.Error as exc:
@@ -5492,9 +5584,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         finally:
             if hasattr(self._local, 'conn'):
                 self._local.conn = None
-            if self.backend_type == BackendType.SQLITE:
+            if hasattr(self._local, 'backend_ref'):
+                self._local.backend_ref = None
+            if backend.backend_type == BackendType.SQLITE:
                 try:
-                    pool = self.backend.get_pool()
+                    pool = backend.get_pool()
                     if hasattr(pool, 'clear_thread_local_connection'):
                         pool.clear_thread_local_connection()  # type: ignore[attr-defined]
                 except _CHACHA_NONCRITICAL_EXCEPTIONS:

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -14,10 +14,12 @@ Notes:
 from __future__ import annotations
 
 import contextlib
+import functools
 import json
 import os
 import re
-from collections.abc import Iterable
+import threading
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -35,6 +37,7 @@ from tldw_Server_API.app.core.Collections.utils import (
 from tldw_Server_API.app.core.config import load_comprehensive_config, settings
 from tldw_Server_API.app.core.testing import is_truthy
 from tldw_Server_API.app.core.DB_Management.content_backend import (
+    backend_target_key,
     get_content_backend,
     load_content_db_settings,
 )
@@ -383,21 +386,52 @@ class AudiobookArtifactRow:
     metadata_json: str | None
 
 
+def _pin_collections_public_operation(method):
+    @functools.wraps(method)
+    def wrapper(self: "CollectionsDatabase", *args: Any, **kwargs: Any):
+        with self._operation_backend_pin():
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
+def _decorate_collections_public_operations(cls: type["CollectionsDatabase"]) -> type["CollectionsDatabase"]:
+    for name, attribute in list(vars(cls).items()):
+        if name.startswith("_") or name in {"ensure_schema", "transaction"}:
+            continue
+        if isinstance(attribute, (classmethod, staticmethod, property)):
+            continue
+        if not callable(attribute):
+            continue
+        setattr(cls, name, _pin_collections_public_operation(attribute))
+    return cls
+
+
+@_decorate_collections_public_operations
 class CollectionsDatabase:
     """Adapter for Collections tables stored in the per-user Media DB."""
+
+    _bootstrapped_backend_targets: set[str] = set()
 
     def __init__(self, user_id: int | str, backend: DatabaseBackend | None = None):
         self.user_id = str(user_id)
         self._owns_backend = False
+        self._local = threading.local()
+        self._backend: DatabaseBackend
+        self._uses_shared_content_backend = False
+        self._backend_refresh_suspended = False
         if backend is None:
-            backend = self._resolve_backend()
+            backend, uses_shared_backend = self._resolve_backend()
+            self._uses_shared_content_backend = uses_shared_backend
         else:
             self._owns_backend = False
-        self.backend = backend
+        self._backend = backend
         self._fts_available = True
         self._fts_supports_direct_delete = True
-        self.ensure_schema()
-        self._seed_watchlists_output_templates()
+        if self._backend.backend_type == BackendType.POSTGRESQL:
+            self._ensure_bootstrap_for_backend(self._backend)
+        else:
+            self._run_backend_bootstrap()
 
     @classmethod
     def for_user(cls, user_id: int | str) -> CollectionsDatabase:
@@ -408,7 +442,84 @@ class CollectionsDatabase:
         """Construct using an existing backend (avoids path resolution and int casting)."""
         return cls(user_id=user_id, backend=backend)
 
-    def _resolve_backend(self) -> DatabaseBackend:
+    @property
+    def backend(self) -> DatabaseBackend:
+        pinned_backend = self._get_pinned_backend()
+        if pinned_backend is not None:
+            return pinned_backend
+        return self._refresh_backend_if_needed()
+
+    @property
+    def backend_type(self) -> BackendType:
+        return self.backend.backend_type
+
+    def _refresh_backend_if_needed(self) -> DatabaseBackend:
+        if not self._uses_shared_content_backend:
+            return self._backend
+        if self._backend_refresh_suspended:
+            return self._backend
+
+        previous_owns_backend = self._owns_backend
+        current_key = self._backend_target_key(self._backend)
+        refreshed_backend, uses_shared_backend = self._resolve_backend()
+        refreshed_key = self._backend_target_key(refreshed_backend)
+
+        # A transient refresh failure must not demote an active shared backend
+        # to a new SQLite backend mid-operation.
+        if not uses_shared_backend or refreshed_backend.backend_type != BackendType.POSTGRESQL:
+            self._owns_backend = previous_owns_backend
+            if refreshed_backend is not self._backend:
+                with contextlib.suppress(_COLLECTIONS_NONCRITICAL_EXCEPTIONS):
+                    refreshed_backend.get_pool().close_all()
+            logger.warning(
+                "CollectionsDatabase refresh fell back to a non-shared backend while {} remained active; keeping the current backend",
+                current_key or "<unknown>",
+            )
+            return self._backend
+
+        if (
+            uses_shared_backend
+            and refreshed_backend.backend_type == BackendType.POSTGRESQL
+            and refreshed_key != current_key
+        ):
+            self._ensure_bootstrap_for_backend(refreshed_backend)
+
+        self._uses_shared_content_backend = uses_shared_backend
+        self._backend = refreshed_backend
+        return self._backend
+
+    def _backend_target_key(self, backend: DatabaseBackend | None) -> str | None:
+        return backend_target_key(backend)
+
+    def _get_pinned_backend(self) -> DatabaseBackend | None:
+        return getattr(self._local, "backend_pin", None)
+
+    def _run_backend_bootstrap(self) -> None:
+        self.ensure_schema()
+        self._seed_watchlists_output_templates()
+
+    def _mark_backend_bootstrapped(self, backend: DatabaseBackend | None) -> None:
+        key = self._backend_target_key(backend)
+        if key:
+            type(self)._bootstrapped_backend_targets.add(key)
+
+    def _ensure_bootstrap_for_backend(self, backend: DatabaseBackend) -> None:
+        if backend.backend_type != BackendType.POSTGRESQL:
+            return
+        key = self._backend_target_key(backend)
+        if key in type(self)._bootstrapped_backend_targets:
+            return
+        previous_suspend = self._backend_refresh_suspended
+        self._backend_refresh_suspended = True
+        try:
+            self._backend = backend
+            self._run_backend_bootstrap()
+        finally:
+            self._backend_refresh_suspended = previous_suspend
+        if key:
+            type(self)._bootstrapped_backend_targets.add(key)
+
+    def _resolve_backend(self) -> tuple[DatabaseBackend, bool]:
         backend_mode_env = (os.getenv("TLDW_CONTENT_DB_BACKEND") or "").strip().lower()
         if backend_mode_env in {"postgres", "postgresql"}:
             parser = load_comprehensive_config()
@@ -416,7 +527,7 @@ class CollectionsDatabase:
             if resolved is None:
                 raise DatabaseError("PostgreSQL content backend requested but not initialized")
             self._owns_backend = False
-            return resolved
+            return resolved, True
 
         try:
             parser = load_comprehensive_config()
@@ -431,14 +542,14 @@ class CollectionsDatabase:
                     if resolved is None:
                         raise DatabaseError("PostgreSQL content backend requested but not initialized")
                     self._owns_backend = False
-                    return resolved
+                    return resolved, True
             except _COLLECTIONS_NONCRITICAL_EXCEPTIONS:
                 pass
 
         db_path = str(DatabasePaths.get_media_db_path(int(self.user_id)))
         cfg = DatabaseConfig(backend_type=BackendType.SQLITE, sqlite_path=db_path)
         self._owns_backend = True
-        return DatabaseBackendFactory.create_backend(cfg)
+        return DatabaseBackendFactory.create_backend(cfg), False
 
     def close(self) -> None:
         """Release backend connections if this instance owns the backend."""
@@ -446,13 +557,13 @@ class CollectionsDatabase:
             return
         self._owns_backend = False
         if (
-            getattr(self.backend, "backend_type", None) == BackendType.SQLITE
-            and is_factory_managed_backend(self.backend)
+            getattr(self._backend, "backend_type", None) == BackendType.SQLITE
+            and is_factory_managed_backend(self._backend)
         ):
-            release_managed_backend(self.backend)
+            release_managed_backend(self._backend)
             return
         try:
-            self.backend.get_pool().close_all()
+            self._backend.get_pool().close_all()
         except _COLLECTIONS_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug("collections_db: failed to close backend for user {}: {}", self.user_id, exc)
 
@@ -461,6 +572,36 @@ class CollectionsDatabase:
 
     def __exit__(self, exc_type, exc, traceback) -> None:
         self.close()
+
+    @contextlib.contextmanager
+    def _operation_backend_pin(self) -> Generator[DatabaseBackend, None, None]:
+        previous_backend = self._get_pinned_backend()
+        if previous_backend is None:
+            self._local.backend_pin = self._refresh_backend_if_needed()
+        try:
+            yield self._local.backend_pin
+        finally:
+            if previous_backend is None:
+                with contextlib.suppress(AttributeError):
+                    del self._local.backend_pin
+            else:
+                self._local.backend_pin = previous_backend
+
+    @contextlib.contextmanager
+    def transaction(self) -> Generator[Any, None, None]:
+        """Pin the active backend for the duration of a transactional operation."""
+        backend = self.backend
+        previous_backend = self._get_pinned_backend()
+        self._local.backend_pin = backend
+        try:
+            with backend.transaction() as conn:
+                yield conn
+        finally:
+            if previous_backend is None:
+                with contextlib.suppress(AttributeError):
+                    del self._local.backend_pin
+            else:
+                self._local.backend_pin = previous_backend
 
     def _execute_insert(self, query: str, params: tuple[Any, ...]) -> Any:
         if self.backend.backend_type == BackendType.POSTGRESQL:

--- a/tldw_Server_API/app/core/DB_Management/DB_Manager.py
+++ b/tldw_Server_API/app/core/DB_Management/DB_Manager.py
@@ -269,6 +269,10 @@ def reset_content_backend(
       reconfiguration at runtime (useful in tests or dynamic reloads).
     - Recomputes module-level settings and paths derived from config.
     - Optionally rebuilds the backend immediately when reload=True.
+
+    This API is intended for controlled reconfiguration windows. Callers
+    should only rotate the shared backend after in-flight operations have been
+    allowed to finish or are prepared to retry against a refreshed backend.
     """
     global _CONTENT_DB_BACKEND
     global single_user_backup_path, single_user_backup_dir

--- a/tldw_Server_API/app/core/DB_Management/Evaluations_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Evaluations_DB.py
@@ -12,6 +12,7 @@ import json
 import importlib.util
 import os
 import sqlite3
+import threading
 import uuid
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
@@ -38,7 +39,10 @@ from tldw_Server_API.app.core.DB_Management.backends.query_utils import (
     prepare_backend_many_statement,
     prepare_backend_statement,
 )
-from tldw_Server_API.app.core.DB_Management.content_backend import get_content_backend
+from tldw_Server_API.app.core.DB_Management.content_backend import (
+    backend_target_key,
+    get_content_backend,
+)
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 
 _EVAL_DB_NONCRITICAL_EXCEPTIONS = (
@@ -208,6 +212,8 @@ class _EvaluationsBackendConnection:
 class EvaluationsDatabase:
     """Database manager for evaluations system (SQLite or PostgreSQL)."""
 
+    _bootstrapped_backend_targets: set[str] = set()
+
     def __init__(self, db_path: Optional[str], *, backend: Optional[DatabaseBackend] = None):
         # Default to per-user evaluations DB path when not provided
         if not db_path:
@@ -218,15 +224,12 @@ class EvaluationsDatabase:
                 db_path = "Databases/evaluations.db"
         self.db_path = db_path
         # Resolve backend (content backend by default)
-        self.backend: Optional[DatabaseBackend] = backend
-        if self.backend is None:
-            try:
-                cfg = load_comprehensive_config()
-                self.backend = get_content_backend(cfg)
-            except _EVAL_DB_NONCRITICAL_EXCEPTIONS:
-                self.backend = None
-
-        self.backend_type: BackendType = self.backend.backend_type if self.backend else BackendType.SQLITE
+        self._backend: Optional[DatabaseBackend] = backend
+        self._uses_shared_content_backend = False
+        self._local = threading.local()
+        self._backend_refresh_suspended = False
+        if self._backend is None:
+            self._backend, self._uses_shared_content_backend = self._resolve_backend()
 
         self._abtest_store = None
 
@@ -234,7 +237,9 @@ class EvaluationsDatabase:
             self._initialize_database()
             self._apply_migrations()
         else:
-            self._initialize_database_postgres()
+            if self._backend is None:
+                raise RuntimeError("Evaluations backend is not configured")
+            self._ensure_bootstrap_for_backend(self._backend)
         self._init_abtest_store()
 
     @contextmanager
@@ -256,12 +261,88 @@ class EvaluationsDatabase:
 
         if self.backend is None:
             raise RuntimeError("Evaluations backend is not configured")
-        raw = self.backend.get_pool().get_connection()
+        backend = self.backend
+        raw = backend.get_pool().get_connection()
+        previous_backend = getattr(self._local, "backend_pin", None)
+        self._local.backend_pin = backend
         try:
             yield _EvaluationsBackendConnection(self, raw)
         finally:
             with suppress(_EVAL_DB_NONCRITICAL_EXCEPTIONS):
-                self.backend.get_pool().return_connection(raw)
+                backend.get_pool().return_connection(raw)
+            if previous_backend is None:
+                with suppress(AttributeError):
+                    del self._local.backend_pin
+            else:
+                self._local.backend_pin = previous_backend
+
+    @property
+    def backend(self) -> Optional[DatabaseBackend]:
+        pinned_backend = getattr(self._local, "backend_pin", None)
+        if pinned_backend is not None:
+            return pinned_backend
+        if not self._uses_shared_content_backend:
+            return self._backend
+        if self._backend_refresh_suspended:
+            return self._backend
+        current_key = self._backend_target_key(self._backend)
+        refreshed_backend, uses_shared_backend = self._resolve_backend()
+        self._uses_shared_content_backend = uses_shared_backend
+        self._backend = refreshed_backend
+        refreshed_key = self._backend_target_key(refreshed_backend)
+        if (
+            uses_shared_backend
+            and refreshed_backend is not None
+            and refreshed_backend.backend_type == BackendType.POSTGRESQL
+            and refreshed_key != current_key
+        ):
+            self._ensure_bootstrap_for_backend(refreshed_backend)
+            self._abtest_store = None
+            self._init_abtest_store()
+        return self._backend
+
+    @property
+    def backend_type(self) -> BackendType:
+        backend = self.backend
+        return backend.backend_type if backend else BackendType.SQLITE
+
+    def _resolve_backend(self) -> tuple[Optional[DatabaseBackend], bool]:
+        try:
+            cfg = load_comprehensive_config()
+        except _EVAL_DB_NONCRITICAL_EXCEPTIONS:
+            return None, False
+
+        try:
+            backend = get_content_backend(cfg)
+        except _EVAL_DB_NONCRITICAL_EXCEPTIONS:
+            return None, False
+        if backend is None:
+            return None, False
+        return backend, backend.backend_type == BackendType.POSTGRESQL
+
+    def _backend_target_key(self, backend: Optional[DatabaseBackend]) -> str | None:
+        return backend_target_key(backend)
+
+    def _mark_backend_bootstrapped(self, backend: Optional[DatabaseBackend]) -> None:
+        key = self._backend_target_key(backend)
+        if key:
+            type(self)._bootstrapped_backend_targets.add(key)
+
+    def _ensure_bootstrap_for_backend(self, backend: DatabaseBackend) -> None:
+        if backend.backend_type != BackendType.POSTGRESQL:
+            return
+        key = self._backend_target_key(backend)
+        if key in type(self)._bootstrapped_backend_targets:
+            return
+        previous_suspend = self._backend_refresh_suspended
+        self._backend_refresh_suspended = True
+        try:
+            self._backend = backend
+            self._initialize_database_postgres()
+        finally:
+            self._backend_refresh_suspended = previous_suspend
+        if key:
+            type(self)._bootstrapped_backend_targets.add(key)
 
     # --- Backend helpers ---
     def _prepare_backend_statement(self, query: str, params: Optional[Any] = None) -> tuple[str, Optional[Any]]:

--- a/tldw_Server_API/app/core/DB_Management/README.md
+++ b/tldw_Server_API/app/core/DB_Management/README.md
@@ -2,6 +2,12 @@
 
 Central data stores and database abstractions for content, prompts, notes, evaluations, workflows, and per-user DB paths. Provides a unified backend interface for SQLite and PostgreSQL, full-text search helpers, migrations, and factories used across the API.
 
+## Wave 1 Contract Notes
+
+- The current tree already closes the April 2026 RLS, migration-loader, UserDatabase_v2, trusted-path, media_db API, and backend-FTS findings covered by the Wave 1 rebaseline.
+- Shared content-backend cache replacement and reset must close superseded backends deterministically.
+- `verify_migrations()` reports missing migration files, checksum mismatches, and non-contiguous available-version gaps.
+
 ## 1. Descriptive of Current Feature Set
 
 - Purpose: Provide consistent, secure, and scalable database access for content (Media DB v2), ChaCha Notes/Characters, Prompts/Prompt Studio, Evaluations, Workflows, Collections, Watchlists, and related utilities (paths, backups, migrations).

--- a/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
@@ -33,16 +33,19 @@ Notes:
 from __future__ import annotations
 
 import contextlib
+import functools
 import json
 import os
 import sqlite3
-from collections.abc import Iterable
+import threading
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from tldw_Server_API.app.core.config import load_comprehensive_config
 from tldw_Server_API.app.core.DB_Management.content_backend import (
+    backend_target_key,
     get_content_backend,
     load_content_db_settings,
 )
@@ -219,24 +222,50 @@ class WatchlistOnboardingEventRow:
     created_at: str
 
 
+def _pin_watchlists_public_operation(method):
+    @functools.wraps(method)
+    def wrapper(self: "WatchlistsDatabase", *args: Any, **kwargs: Any):
+        with self._operation_backend_pin():
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
+def _decorate_watchlists_public_operations(cls: type["WatchlistsDatabase"]) -> type["WatchlistsDatabase"]:
+    for name, attribute in list(vars(cls).items()):
+        if name.startswith("_") or name in {"ensure_schema", "transaction"}:
+            continue
+        if isinstance(attribute, (classmethod, staticmethod, property)):
+            continue
+        if not callable(attribute):
+            continue
+        setattr(cls, name, _pin_watchlists_public_operation(attribute))
+    return cls
+
+
+@_decorate_watchlists_public_operations
 class WatchlistsDatabase:
     # Keep track of schema initialization per DB path to avoid redundant ALTER checks/noise
     _schema_init_keys: set[str] = set()
 
     def __init__(self, user_id: int | str, backend: DatabaseBackend | None = None):
         self.user_id = str(user_id)
+        self._local = threading.local()
+        self._backend_refresh_suspended = False
         db_key: str | None = None
+        self._backend: DatabaseBackend
+        self._uses_shared_content_backend = False
         if backend is None:
-            backend, db_key = self._resolve_backend()
+            backend, db_key, uses_shared_backend = self._resolve_backend()
+            self._uses_shared_content_backend = uses_shared_backend
         else:
             # Fallback key when external backend is supplied (best-effort de-dupe)
             db_key = f"backend:{id(backend)}"
-        self.backend = backend
+        self._backend = backend
         # De-duplicate schema ensures across startup/requests
-        if db_key and db_key not in WatchlistsDatabase._schema_init_keys:
-            self.ensure_schema()
-            WatchlistsDatabase._schema_init_keys.add(db_key)
-        elif not db_key:
+        if db_key:
+            self._ensure_schema_for_key(self._backend, db_key)
+        else:
             # If we couldn't derive a key, fall back to ensuring schema once here
             self.ensure_schema()
 
@@ -244,14 +273,88 @@ class WatchlistsDatabase:
     def for_user(cls, user_id: int | str) -> WatchlistsDatabase:
         return cls(user_id=user_id)
 
-    def _resolve_backend(self) -> tuple[DatabaseBackend, str | None]:
+    @property
+    def backend(self) -> DatabaseBackend:
+        pinned_backend = getattr(self._local, "backend_pin", None)
+        if pinned_backend is not None:
+            return pinned_backend
+        return self._refresh_backend_if_needed()
+
+    def _refresh_backend_if_needed(self) -> DatabaseBackend:
+        if not self._uses_shared_content_backend:
+            return self._backend
+        if self._backend_refresh_suspended:
+            return self._backend
+
+        current_key = self._backend_target_key(self._backend)
+        refreshed_backend, refreshed_key, uses_shared_backend = self._resolve_backend()
+        self._uses_shared_content_backend = uses_shared_backend
+        self._backend = refreshed_backend
+        if (
+            uses_shared_backend
+            and refreshed_backend.backend_type == BackendType.POSTGRESQL
+            and refreshed_key != current_key
+        ):
+            self._ensure_schema_for_key(refreshed_backend, refreshed_key)
+        return self._backend
+
+    def _backend_target_key(self, backend: DatabaseBackend | None) -> str | None:
+        return backend_target_key(backend)
+
+    def _ensure_schema_for_key(self, backend: DatabaseBackend, db_key: str | None) -> None:
+        if not db_key or db_key in WatchlistsDatabase._schema_init_keys:
+            return
+        previous_suspend = self._backend_refresh_suspended
+        self._backend_refresh_suspended = True
+        try:
+            self._backend = backend
+            self.ensure_schema()
+        finally:
+            self._backend_refresh_suspended = previous_suspend
+        WatchlistsDatabase._schema_init_keys.add(db_key)
+
+    @contextlib.contextmanager
+    def _operation_backend_pin(self) -> Generator[DatabaseBackend, None, None]:
+        previous_backend = getattr(self._local, "backend_pin", None)
+        if previous_backend is None:
+            self._local.backend_pin = self._refresh_backend_if_needed()
+        try:
+            yield self._local.backend_pin
+        finally:
+            if previous_backend is None:
+                with contextlib.suppress(AttributeError):
+                    del self._local.backend_pin
+            else:
+                self._local.backend_pin = previous_backend
+
+    @contextlib.contextmanager
+    def transaction(self) -> Generator[Any, None, None]:
+        """Pin the active backend for the duration of a transactional operation."""
+        backend = self.backend
+        previous_backend = getattr(self._local, "backend_pin", None)
+        self._local.backend_pin = backend
+        try:
+            with backend.transaction() as conn:
+                yield conn
+        finally:
+            if previous_backend is None:
+                with contextlib.suppress(AttributeError):
+                    del self._local.backend_pin
+            else:
+                self._local.backend_pin = previous_backend
+
+    def _resolve_backend(self) -> tuple[DatabaseBackend, str | None, bool]:
         backend_mode_env = (os.getenv("TLDW_CONTENT_DB_BACKEND") or "").strip().lower()
         if backend_mode_env in {"postgres", "postgresql"}:
             parser = load_comprehensive_config()
             resolved = get_content_backend(parser)
             if resolved is None:
                 raise RuntimeError("PostgreSQL content backend requested but not initialized")
-            return resolved, f"postgres:{resolved.config.connection_string or resolved.config.pg_database}"
+            return (
+                resolved,
+                self._backend_target_key(resolved),
+                True,
+            )
 
         try:
             parser = load_comprehensive_config()
@@ -265,13 +368,17 @@ class WatchlistsDatabase:
                     resolved = get_content_backend(parser)
                     if resolved is None:
                         raise RuntimeError("PostgreSQL content backend requested but not initialized")
-                    return resolved, f"postgres:{resolved.config.connection_string or resolved.config.pg_database}"
+                    return (
+                        resolved,
+                        self._backend_target_key(resolved),
+                        True,
+                    )
             except _WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS:
                 pass
 
         db_path = str(DatabasePaths.get_media_db_path(int(self.user_id)))
         cfg = DatabaseConfig(backend_type=BackendType.SQLITE, sqlite_path=db_path)
-        return DatabaseBackendFactory.create_backend(cfg), f"sqlite:{db_path}"
+        return DatabaseBackendFactory.create_backend(cfg), f"sqlite:{db_path}", False
 
     def _execute_insert(self, query: str, params: tuple[Any, ...]) -> Any:
         if self.backend.backend_type == BackendType.POSTGRESQL:
@@ -1222,7 +1329,7 @@ class WatchlistsDatabase:
         return result
 
     def delete_source(self, source_id: int) -> bool:
-        with self.backend.transaction() as conn:
+        with self.transaction() as conn:
             self.backend.execute("DELETE FROM source_groups WHERE source_id = ?", (source_id,), connection=conn)
             self.backend.execute("DELETE FROM source_tags WHERE source_id = ?", (source_id,), connection=conn)
             self.backend.execute(
@@ -1271,7 +1378,7 @@ class WatchlistsDatabase:
         deleted_at = _utcnow_iso()
         expires_at = self._restore_expires_at(undo_window_seconds)
 
-        with self.backend.transaction() as conn:
+        with self.transaction() as conn:
             self.backend.execute(
                 """
                 INSERT INTO deleted_sources (user_id, source_id, payload_json, deleted_at, expires_at)
@@ -1353,7 +1460,7 @@ class WatchlistsDatabase:
             except _WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS:
                 continue
 
-        with self.backend.transaction() as conn:
+        with self.transaction() as conn:
             conflict = self.backend.execute(
                 "SELECT id FROM sources WHERE user_id = ? AND url = ?",
                 (self.user_id, url),
@@ -1750,7 +1857,7 @@ class WatchlistsDatabase:
         deleted_at = _utcnow_iso()
         expires_at = self._restore_expires_at(undo_window_seconds)
 
-        with self.backend.transaction() as conn:
+        with self.transaction() as conn:
             self.backend.execute(
                 """
                 INSERT INTO deleted_jobs (user_id, job_id, payload_json, deleted_at, expires_at)
@@ -1816,7 +1923,7 @@ class WatchlistsDatabase:
         created_at = str(payload.get("created_at") or _utcnow_iso())
         updated_at = str(payload.get("updated_at") or created_at)
 
-        with self.backend.transaction() as conn:
+        with self.transaction() as conn:
             existing = self.backend.execute(
                 "SELECT id FROM scrape_jobs WHERE id = ? AND user_id = ?",
                 (job_id, self.user_id),

--- a/tldw_Server_API/app/core/DB_Management/content_backend.py
+++ b/tldw_Server_API/app/core/DB_Management/content_backend.py
@@ -8,6 +8,7 @@ shared DatabaseBackend abstraction.
 from __future__ import annotations
 
 import os
+import weakref
 from configparser import ConfigParser
 from dataclasses import dataclass
 
@@ -153,18 +154,36 @@ def load_content_db_settings(config: ConfigParser) -> ContentDatabaseSettings:
     )
 
 
+def backend_target_key(backend: DatabaseBackend | None) -> str | None:
+    """Return a stable identifier for a backend target across wrapper instances."""
+    if backend is None:
+        return None
+
+    config = getattr(backend, "config", None)
+    if backend.backend_type == BackendType.POSTGRESQL:
+        if config and getattr(config, "connection_string", None):
+            return str(config.connection_string)
+        if config:
+            host = getattr(config, "pg_host", None) or "localhost"
+            port = getattr(config, "pg_port", None) or 5432
+            database = getattr(config, "pg_database", None) or "<postgres>"
+            return f"{host}:{port}/{database}"
+        return f"postgres:{id(backend)}"
+
+    if config and getattr(config, "sqlite_path", None):
+        return str(config.sqlite_path)
+    return f"sqlite:{id(backend)}"
+
+
 _cached_backend = None
 _cached_backend_signature: tuple | None = None
+_retired_backend_finalizers: dict[int, weakref.finalize] = {}
 try:
-    from threading import RLock, Thread
+    from threading import RLock
+
     _cache_lock = RLock()
 except Exception:  # pragma: no cover
     _cache_lock = None  # type: ignore
-
-# Grace period (seconds) before closing a superseded backend pool.  This gives
-# in-flight requests that already hold a reference to the old backend time to
-# finish before its connection pool is torn down.
-_EVICTION_GRACE_SECONDS: float = 5.0
 
 
 def _close_backend_pool(backend: DatabaseBackend | None) -> None:
@@ -179,34 +198,69 @@ def _close_backend_pool(backend: DatabaseBackend | None) -> None:
         logger.warning("Failed to close superseded content backend pool: {}", exc)
 
 
-def _schedule_deferred_close(backend) -> None:
-    """Close *backend* after a short grace period in a background thread.
-
-    Instead of closing the pool immediately (which races with in-flight
-    callers that already obtained a reference), we wait
-    ``_EVICTION_GRACE_SECONDS`` before tearing it down.  The thread is
-    daemonic so it won't block interpreter shutdown.
-    """
+def _retire_backend_pool(backend: DatabaseBackend | None) -> None:
+    """Close a superseded backend only after active references release it."""
     if backend is None:
         return
 
-    import time
+    backend_id = id(backend)
 
-    def _deferred() -> None:
-        time.sleep(_EVICTION_GRACE_SECONDS)
-        _close_backend_pool(backend)
+    try:
+        pool = backend.get_pool()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to retire superseded content backend pool: {}", exc)
+        return
 
-    t = Thread(target=_deferred, daemon=True)
-    t.start()
+    def _close_retired_pool() -> None:
+        try:
+            pool.close_all()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to close retired content backend pool: {}", exc)
+        finally:
+            if _cache_lock is not None:
+                with _cache_lock:
+                    _retired_backend_finalizers.pop(backend_id, None)
+            else:
+                _retired_backend_finalizers.pop(backend_id, None)
+
+    if _cache_lock is not None:
+        with _cache_lock:
+            existing_finalizer = _retired_backend_finalizers.get(backend_id)
+            if existing_finalizer is not None and existing_finalizer.alive:
+                return
+            try:
+                _retired_backend_finalizers[backend_id] = weakref.finalize(
+                    backend,
+                    _close_retired_pool,
+                )
+            except TypeError:
+                _close_retired_pool()
+        return
+
+    existing_finalizer = _retired_backend_finalizers.get(backend_id)
+    if existing_finalizer is not None and existing_finalizer.alive:
+        return
+    try:
+        _retired_backend_finalizers[backend_id] = weakref.finalize(
+            backend,
+            _close_retired_pool,
+        )
+    except TypeError:
+        _close_retired_pool()
 
 
 def clear_cached_backend() -> None:
-    """Clear and close the currently cached shared content backend.
+    """Clear and retire the currently cached shared content backend.
 
     Acquires ``_cache_lock`` to avoid racing with concurrent
-    ``get_content_backend()`` calls that also mutate the cache.  The actual
-    pool close is deferred so that in-flight users of the old backend are
-    not disrupted.
+    ``get_content_backend()`` calls that also mutate the cache. The previous
+    backend is retired after being removed from the cache so future callers
+    cannot observe stale cached state while in-flight borrowers finish cleanly.
+
+    This is a controlled reconfiguration hook for tests, startup, and
+    admin-driven reloads. Consumers are expected to refresh shared PostgreSQL
+    backends between operations; callers should not rotate the cache while an
+    active operation is still holding a concrete backend reference.
     """
     global _cached_backend, _cached_backend_signature
 
@@ -220,7 +274,7 @@ def clear_cached_backend() -> None:
         _cached_backend = None
         _cached_backend_signature = None
 
-    _schedule_deferred_close(old_backend)
+    _retire_backend_pool(old_backend)
 
 
 def get_content_backend(config: ConfigParser):
@@ -259,10 +313,11 @@ def get_content_backend(config: ConfigParser):
             backend = DatabaseBackendFactory.create_backend(settings.database_config)
             _cached_backend = backend
             _cached_backend_signature = signature
-        # Deferred close *outside* the lock so the grace-period sleep does
-        # not block other cache operations.
+        # Retire the superseded backend after the cache update so callers no
+        # longer retrieve it from shared state, while existing borrowers can
+        # finish on their captured backend instance.
         if old_backend is not None and old_backend is not backend:
-            _schedule_deferred_close(old_backend)
+            _retire_backend_pool(old_backend)
         return backend
 
     # Fallback without lock (environments without threading)
@@ -273,5 +328,5 @@ def get_content_backend(config: ConfigParser):
     _cached_backend = backend
     _cached_backend_signature = signature
     if old_backend is not None and old_backend is not backend:
-        _schedule_deferred_close(old_backend)
+        _retire_backend_pool(old_backend)
     return backend

--- a/tldw_Server_API/app/core/DB_Management/db_migration.py
+++ b/tldw_Server_API/app/core/DB_Management/db_migration.py
@@ -732,27 +732,53 @@ class DatabaseMigrator:
         issues = []
         applied = self.get_applied_migrations()
         available = {m.version: m for m in self.load_migrations()}
+        applied_versions = {migration_record["version"] for migration_record in applied}
+
+        if available:
+            available_versions = sorted(available)
+            expected_versions = range(available_versions[0], available_versions[-1] + 1)
+            missing_versions = [
+                version
+                for version in expected_versions
+                if version not in available and version not in applied_versions
+            ]
+
+            for version in missing_versions:
+                issues.append(
+                    {
+                        "version": version,
+                        "issue": "migration_version_gap",
+                        "message": (
+                            f"Migration file for version {version} "
+                            "is missing from the available set"
+                        ),
+                    }
+                )
 
         for migration_record in applied:
             version = migration_record["version"]
 
             if version not in available:
-                issues.append({
-                    "version": version,
-                    "issue": "migration_file_missing",
-                    "message": f"Migration file for version {version} not found"
-                })
+                issues.append(
+                    {
+                        "version": version,
+                        "issue": "migration_file_missing",
+                        "message": f"Migration file for version {version} not found",
+                    }
+                )
                 continue
 
             migration = available[version]
             if migration.checksum != migration_record["checksum"]:
-                issues.append({
-                    "version": version,
-                    "issue": "checksum_mismatch",
-                    "message": f"Checksum mismatch for migration {version}",
-                    "expected": migration.checksum,
-                    "actual": migration_record["checksum"]
-                })
+                issues.append(
+                    {
+                        "version": version,
+                        "issue": "checksum_mismatch",
+                        "message": f"Checksum mismatch for migration {version}",
+                        "expected": migration.checksum,
+                        "actual": migration_record["checksum"],
+                    }
+                )
 
         return issues
 

--- a/tldw_Server_API/app/core/DB_Management/media_db/runtime/defaults.py
+++ b/tldw_Server_API/app/core/DB_Management/media_db/runtime/defaults.py
@@ -70,17 +70,13 @@ def _clear_content_backend_cache_unlocked() -> None:
 
     Intended to be called from within a ``_runtime_state_context()`` block.
     Swallows import and runtime errors so callers can proceed with reset.
+    The shared cache module owns its own cache lock, so callers should invoke
+    ``clear_cached_backend()`` directly.
     """
     try:
         import tldw_Server_API.app.core.DB_Management.content_backend as cb
 
-        # clear_cached_backend() acquires _cache_lock internally, so no
-        # external lock acquisition is needed here.
-        if hasattr(cb, "_cache_lock") and cb._cache_lock:
-            with cb._cache_lock:  # type: ignore[attr-defined]
-                cb.clear_cached_backend()
-        else:
-            cb.clear_cached_backend()
+        cb.clear_cached_backend()
     except ImportError as exc:
         logger.debug(f"reset_media_runtime_defaults: unable to import content_backend: {exc}")
     except MEDIA_DB_RUNTIME_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/core/RAG/rag_service/analytics_db.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/analytics_db.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import hashlib
 import json
 import threading
+from collections.abc import Generator
 from configparser import ConfigParser
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -34,7 +35,10 @@ from tldw_Server_API.app.core.DB_Management.backends.factory import DatabaseBack
 from tldw_Server_API.app.core.DB_Management.backends.query_utils import (
     prepare_backend_statement,
 )
-from tldw_Server_API.app.core.DB_Management.content_backend import get_content_backend
+from tldw_Server_API.app.core.DB_Management.content_backend import (
+    backend_target_key,
+    get_content_backend,
+)
 
 DEFAULT_ANALYTICS_DB_PATH = "Databases/Analytics.db"
 
@@ -86,6 +90,8 @@ class AnalyticsDatabase:
     as the content backend, analytics automatically use the same backend to
     ensure all large-scale deployments avoid SQLite.
     """
+
+    _bootstrapped_backend_targets: set[str] = set()
 
     _SCHEMA_SQLITE = """
     CREATE TABLE IF NOT EXISTS search_analytics (
@@ -364,8 +370,12 @@ class AnalyticsDatabase:
         self._lock = threading.RLock()
         self._local = threading.local()
 
-        self.backend = self._resolve_backend(db_path=db_path, backend=backend, config=config)
-        self.backend_type = self.backend.backend_type
+        self._backend, self._uses_shared_content_backend = self._resolve_backend(
+            db_path=db_path,
+            backend=backend,
+            config=config,
+        )
+        self._backend_refresh_suspended = False
         self._db_identifier = self._describe_backend()
 
         if self.backend_type == BackendType.SQLITE:
@@ -378,7 +388,10 @@ class AnalyticsDatabase:
             self.backend_type.value,
             self._db_identifier,
         )
-        self._initialize_database()
+        if self._backend.backend_type == BackendType.POSTGRESQL:
+            self._ensure_bootstrap_for_backend(self._backend)
+        else:
+            self._initialize_database()
 
     def _load_config(self) -> ConfigParser | None:
         try:
@@ -386,6 +399,36 @@ class AnalyticsDatabase:
             return cfg if isinstance(cfg, ConfigParser) else None
         except Exception:  # noqa: BLE001 - best-effort config loading
             return None
+
+    @property
+    def backend(self) -> DatabaseBackend:
+        pinned_backend = getattr(self._local, "backend_pin", None)
+        if pinned_backend is not None:
+            return pinned_backend
+        if not self._uses_shared_content_backend:
+            return self._backend
+        if self._backend_refresh_suspended:
+            return self._backend
+        current_key = self._backend_target_key(self._backend)
+        refreshed_backend, uses_shared_backend = self._resolve_backend(
+            db_path=self.db_path,
+            backend=None,
+            config=None,
+        )
+        self._uses_shared_content_backend = uses_shared_backend
+        self._backend = refreshed_backend
+        refreshed_key = self._backend_target_key(refreshed_backend)
+        if (
+            uses_shared_backend
+            and refreshed_backend.backend_type == BackendType.POSTGRESQL
+            and refreshed_key != current_key
+        ):
+            self._ensure_bootstrap_for_backend(refreshed_backend)
+        return self._backend
+
+    @property
+    def backend_type(self) -> BackendType:
+        return self.backend.backend_type
 
     def _describe_backend(self) -> str:
         if self.backend_type == BackendType.SQLITE:
@@ -403,27 +446,57 @@ class AnalyticsDatabase:
         db_path: str,
         backend: DatabaseBackend | None,
         config: ConfigParser | None,
-    ) -> DatabaseBackend:
+    ) -> tuple[DatabaseBackend, bool]:
         if backend is not None:
-            return backend
+            return backend, False
 
         parser = config or self._load_config()
         if parser is not None:
             candidate: DatabaseBackend | None = get_content_backend(parser)
             if candidate and candidate.backend_type == BackendType.POSTGRESQL:
-                return candidate
+                return candidate, True
 
         sqlite_config = DatabaseConfig(
             backend_type=BackendType.SQLITE,
             sqlite_path=str(Path(db_path).expanduser()),
         )
-        return DatabaseBackendFactory.create_backend(sqlite_config)
+        return DatabaseBackendFactory.create_backend(sqlite_config), False
+
+    def _backend_target_key(self, backend: DatabaseBackend | None) -> str | None:
+        return backend_target_key(backend)
+
+    def _mark_backend_bootstrapped(self, backend: DatabaseBackend | None) -> None:
+        key = self._backend_target_key(backend)
+        if key:
+            type(self)._bootstrapped_backend_targets.add(key)
+
+    def _ensure_bootstrap_for_backend(self, backend: DatabaseBackend) -> None:
+        if backend.backend_type != BackendType.POSTGRESQL:
+            return
+        key = self._backend_target_key(backend)
+        if key in type(self)._bootstrapped_backend_targets:
+            return
+        previous_suspend = self._backend_refresh_suspended
+        self._backend_refresh_suspended = True
+        try:
+            self._backend = backend
+            self._db_identifier = self._describe_backend()
+            self._initialize_database()
+        finally:
+            self._backend_refresh_suspended = previous_suspend
+        if key:
+            type(self)._bootstrapped_backend_targets.add(key)
 
     def _initialize_database(self) -> None:
-        schema = self._SCHEMA_SQLITE if self.backend_type == BackendType.SQLITE else self._SCHEMA_POSTGRES
         try:
-            with self.backend.transaction() as conn:
-                self.backend.create_tables(schema, connection=conn)
+            with self.transaction() as conn:
+                backend = self.backend
+                schema = (
+                    self._SCHEMA_SQLITE
+                    if backend.backend_type == BackendType.SQLITE
+                    else self._SCHEMA_POSTGRES
+                )
+                backend.create_tables(schema, connection=conn)
                 for statement in self._INDEX_STATEMENTS:
                     self._execute(conn, statement)
             logger.info("Analytics database initialized at {}", self._db_identifier)
@@ -490,9 +563,20 @@ class AnalyticsDatabase:
         return [dict(r) for r in rows]
 
     @contextmanager
-    def transaction(self):
-        with self.backend.transaction() as conn:
-            yield conn
+    def transaction(self) -> Generator[Any, None, None]:
+        """Pin the resolved backend for the lifetime of a transaction."""
+        backend = self.backend
+        previous_backend = getattr(self._local, "backend_pin", None)
+        self._local.backend_pin = backend
+        try:
+            with backend.transaction() as conn:
+                yield conn
+        finally:
+            if previous_backend is None:
+                with suppress(AttributeError):
+                    del self._local.backend_pin
+            else:
+                self._local.backend_pin = previous_backend
 
     def record_search(self, search_data: dict[str, Any]) -> None:
         try:

--- a/tldw_Server_API/tests/DB_Management/test_chacha_connection_typing.py
+++ b/tldw_Server_API/tests/DB_Management/test_chacha_connection_typing.py
@@ -1,0 +1,21 @@
+from typing import get_type_hints
+
+from tldw_Server_API.app.core.DB_Management import ChaChaNotes_DB as chacha_module
+
+
+def test_connection_lifecycle_helpers_use_named_raw_connection_alias() -> None:
+    alias = getattr(chacha_module, "RawBackendConnection", None)
+
+    assert alias is not None
+
+    release_hints = get_type_hints(
+        chacha_module.CharactersRAGDB._release_connection,
+        globalns=vars(chacha_module),
+    )
+    open_hints = get_type_hints(
+        chacha_module.CharactersRAGDB._open_new_connection,
+        globalns=vars(chacha_module),
+    )
+
+    assert release_hints["connection"] == alias
+    assert open_hints["return"] == alias

--- a/tldw_Server_API/tests/DB_Management/test_content_backend_cache.py
+++ b/tldw_Server_API/tests/DB_Management/test_content_backend_cache.py
@@ -1,28 +1,130 @@
 import configparser
+import gc
 import threading
+import weakref
+from contextlib import contextmanager
 
 import pytest
 
+from tldw_Server_API.app.core.DB_Management import ChaChaNotes_DB as chacha_db
 from tldw_Server_API.app.core.DB_Management import content_backend
+from tldw_Server_API.app.core.DB_Management import Collections_DB as collections_db
+from tldw_Server_API.app.core.DB_Management import Evaluations_DB as evaluations_db
+from tldw_Server_API.app.core.DB_Management import Watchlists_DB as watchlists_db
+from tldw_Server_API.app.core.DB_Management.backends.base import BackendType
+from tldw_Server_API.app.core.DB_Management.backends.base import QueryResult
 from tldw_Server_API.app.core.DB_Management.media_db.runtime import (
     defaults as media_runtime_defaults,
 )
+from tldw_Server_API.app.core.RAG.rag_service import analytics_db
 
 
 class _FakePool:
-    def __init__(self) -> None:
+    def __init__(self, label: str = "backend") -> None:
         self.closed = 0
+        self.label = label
+        self.issued: list[_FakeConnection] = []
+        self.returned: list[_FakeConnection] = []
+
+    def get_connection(self):
+        conn = _FakeConnection(self.label)
+        self.issued.append(conn)
+        return conn
+
+    def return_connection(self, conn) -> None:
+        self.returned.append(conn)
 
     def close_all(self) -> None:
         self.closed += 1
 
 
+class _FakeConnection:
+    def __init__(self, origin: str) -> None:
+        self.origin = origin
+        self.closed = False
+        self.commit_calls = 0
+        self.rollback_calls = 0
+
+    def commit(self) -> None:
+        self.commit_calls += 1
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
 class _FakeBackend:
-    def __init__(self) -> None:
-        self.pool = _FakePool()
+    def __init__(
+        self,
+        *,
+        backend_type: BackendType = BackendType.POSTGRESQL,
+        label: str = "backend",
+    ) -> None:
+        self.pool = _FakePool(label)
+        self.backend_type = backend_type
+        self.label = label
+        self.execute_calls: list[tuple[str, tuple | None, _FakeConnection | None]] = []
+        self.execute_many_calls: list[tuple[str, list | None, _FakeConnection | None]] = []
+        self.create_tables_calls: list[tuple[str, _FakeConnection | None]] = []
+        self.config = type(
+            "_FakeConfig",
+            (),
+            {
+                "connection_string": f"postgresql:///{label}",
+                "pg_host": "localhost",
+                "pg_port": 5432,
+                "pg_database": label,
+                "pg_user": "tldw_user",
+                "pg_sslmode": "prefer",
+            },
+        )()
 
     def get_pool(self):
         return self.pool
+
+    def execute(self, query: str, params=None, connection=None):
+        self.execute_calls.append((query, params, connection))
+        if connection is not None:
+            return QueryResult(rows=[{"backend": self.label}], rowcount=1)
+        return self.label
+
+    def execute_many(self, query: str, params_list=None, connection=None):
+        self.execute_many_calls.append((query, params_list, connection))
+        return QueryResult(rows=[{"backend": self.label}], rowcount=len(params_list or []))
+
+    def create_tables(self, ddl: str, connection=None) -> None:
+        self.create_tables_calls.append((ddl, connection))
+
+    def get_table_info(self, _table: str):
+        return []
+
+    def vacuum(self) -> None:
+        return None
+
+    @contextmanager
+    def transaction(self):
+        connection = self.pool.get_connection()
+        try:
+            yield connection
+        finally:
+            self.pool.return_connection(connection)
+
+
+def _set_fake_pg_target(
+    backend: _FakeBackend,
+    *,
+    host: str,
+    port: int,
+    database: str,
+    connection_string: str | None = None,
+) -> _FakeBackend:
+    backend.config.pg_host = host
+    backend.config.pg_port = port
+    backend.config.pg_database = database
+    backend.config.connection_string = connection_string
+    return backend
 
 
 def _make_config(password: str, sslmode: str) -> configparser.ConfigParser:
@@ -46,9 +148,13 @@ def _make_sqlite_config(sqlite_path: str) -> configparser.ConfigParser:
     return cfg
 
 
-def test_get_content_backend_closes_superseded_cached_backend(monkeypatch) -> None:
+def test_get_content_backend_retires_superseded_cached_backend_until_references_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     old_backend = _FakeBackend()
     new_backend = _FakeBackend()
+    old_pool = old_backend.pool
+    old_ref = weakref.ref(old_backend)
 
     monkeypatch.setattr(content_backend, "_cached_backend", old_backend)
     monkeypatch.setattr(content_backend, "_cached_backend_signature", ("old",))
@@ -63,20 +169,40 @@ def test_get_content_backend_closes_superseded_cached_backend(monkeypatch) -> No
 
     if backend is not new_backend:
         pytest.fail("expected replacement backend to be returned")
-    if old_backend.pool.closed != 1:
-        pytest.fail("expected superseded cached backend pool to close exactly once")
+    if old_pool.closed != 0:
+        pytest.fail("expected superseded cached backend pool to remain open while references exist")
+
+    del old_backend
+    gc.collect()
+
+    if old_ref() is not None:
+        pytest.fail("expected superseded backend to be garbage collected after references release")
+    if old_pool.closed != 1:
+        pytest.fail("expected retired backend pool to close after the last reference is released")
 
 
-def test_reset_media_runtime_defaults_closes_cached_backend(monkeypatch) -> None:
+def test_reset_media_runtime_defaults_retires_cached_backend_until_references_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     cached_backend = _FakeBackend()
+    cached_pool = cached_backend.pool
+    cached_ref = weakref.ref(cached_backend)
 
     monkeypatch.setattr(content_backend, "_cached_backend", cached_backend)
     monkeypatch.setattr(content_backend, "_cached_backend_signature", ("cached",))
 
     media_runtime_defaults._clear_content_backend_cache()
 
-    if cached_backend.pool.closed != 1:
-        pytest.fail("expected clearing cached backend to close the pool exactly once")
+    if cached_pool.closed != 0:
+        pytest.fail("expected cache clear to retire the backend without closing active references")
+
+    del cached_backend
+    gc.collect()
+
+    if cached_ref() is not None:
+        pytest.fail("expected retired cached backend to be collectible after references release")
+    if cached_pool.closed != 1:
+        pytest.fail("expected retired cached backend pool to close after references release")
 
 
 def test_reset_media_runtime_defaults_blocks_stale_backend_reads_during_clear(
@@ -169,3 +295,676 @@ def test_content_backend_cache_includes_password_and_sslmode(monkeypatch) -> Non
     backend_d = content_backend.get_content_backend(cfg)
     if backend_d is backend_c:
         pytest.fail("expected sslmode change to invalidate cached backend signature")
+
+
+def test_collections_database_refreshes_shared_backend_after_cache_rotation(monkeypatch) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    monkeypatch.setenv("TLDW_CONTENT_DB_BACKEND", "postgresql")
+    monkeypatch.setattr(collections_db, "load_comprehensive_config", lambda: _make_config("pw1", "prefer"))
+    monkeypatch.setattr(collections_db, "get_content_backend", lambda _cfg: holder["backend"])
+    monkeypatch.setattr(collections_db.CollectionsDatabase, "ensure_schema", lambda self: None)
+    monkeypatch.setattr(
+        collections_db.CollectionsDatabase,
+        "_seed_watchlists_output_templates",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        collections_db,
+        "prepare_backend_statement",
+        lambda *_args, **_kwargs: ("SELECT 1", ()),
+    )
+
+    db = collections_db.CollectionsDatabase(user_id="1")
+
+    holder["backend"] = new_backend
+    result = db._execute_insert("INSERT INTO collections VALUES (?)", ("value",))
+
+    assert result == "new"
+    assert [(query, params) for query, params, _conn in new_backend.execute_calls] == [("SELECT 1", ())]
+    assert old_backend.execute_calls == []
+
+
+def test_collections_database_keeps_existing_shared_backend_when_refresh_falls_back_to_sqlite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_backend = _FakeBackend(label="old")
+    sqlite_fallback = _FakeBackend(backend_type=BackendType.SQLITE, label="sqlite-fallback")
+    resolve_calls = {"count": 0}
+
+    def fake_resolve(self):
+        resolve_calls["count"] += 1
+        if resolve_calls["count"] == 1:
+            return old_backend, True
+        return sqlite_fallback, False
+
+    monkeypatch.setattr(collections_db.CollectionsDatabase, "_resolve_backend", fake_resolve)
+    monkeypatch.setattr(collections_db.CollectionsDatabase, "_run_backend_bootstrap", lambda self: None)
+    monkeypatch.setattr(
+        collections_db,
+        "prepare_backend_statement",
+        lambda *_args, **_kwargs: ("SELECT 1", ()),
+    )
+
+    db = collections_db.CollectionsDatabase(user_id="1")
+
+    result = db._execute_insert("INSERT INTO collections VALUES (?)", ("value",))
+
+    assert result == "old"
+    assert db._backend is old_backend
+    assert db._uses_shared_content_backend is True
+    assert sqlite_fallback.execute_calls == []
+    assert [(query, params) for query, params, _conn in old_backend.execute_calls] == [("SELECT 1", ())]
+
+
+def test_collections_database_keeps_previous_backend_when_rotated_bootstrap_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    monkeypatch.setattr(collections_db.CollectionsDatabase, "_bootstrapped_backend_targets", set())
+    monkeypatch.setattr(
+        collections_db.CollectionsDatabase,
+        "_resolve_backend",
+        lambda self: (holder["backend"], True),
+    )
+    monkeypatch.setattr(collections_db.CollectionsDatabase, "_run_backend_bootstrap", lambda self: None)
+
+    def fail_bootstrap(self, backend) -> None:
+        if backend is new_backend:
+            raise RuntimeError(f"bootstrap failed for {backend.label}")
+
+    monkeypatch.setattr(
+        collections_db.CollectionsDatabase,
+        "_ensure_bootstrap_for_backend",
+        fail_bootstrap,
+    )
+
+    db = collections_db.CollectionsDatabase(user_id="1")
+
+    holder["backend"] = new_backend
+
+    with pytest.raises(RuntimeError, match="bootstrap failed for new"):
+        _ = db.backend
+
+    assert db._backend is old_backend
+    assert db._uses_shared_content_backend is True
+
+
+def test_collections_database_pins_backend_for_multi_query_read_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    row_template = {
+        "id": 1,
+        "user_id": "1",
+        "name": "old",
+        "type": "summary",
+        "format": "markdown",
+        "body": "template",
+        "description": None,
+        "is_default": True,
+        "created_at": "2026-04-16T00:00:00+00:00",
+        "updated_at": "2026-04-16T00:00:00+00:00",
+        "metadata_json": None,
+    }
+
+    def make_execute(backend: _FakeBackend):
+        def execute(query: str, params=None, connection=None) -> QueryResult:
+            backend.execute_calls.append((query, params, connection))
+            if "COUNT(*) AS cnt FROM output_templates" in query:
+                if backend is old_backend:
+                    holder["backend"] = new_backend
+                return QueryResult(rows=[{"cnt": 1}], rowcount=1)
+            if "FROM output_templates" in query:
+                row = {**row_template, "name": backend.label}
+                return QueryResult(rows=[row], rowcount=1)
+            return QueryResult(rows=[], rowcount=0)
+
+        return execute
+
+    old_backend.execute = make_execute(old_backend)  # type: ignore[assignment]
+    new_backend.execute = make_execute(new_backend)  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        collections_db.CollectionsDatabase,
+        "_resolve_backend",
+        lambda self: (holder["backend"], True),
+    )
+    monkeypatch.setattr(collections_db.CollectionsDatabase, "_run_backend_bootstrap", lambda self: None)
+
+    db = collections_db.CollectionsDatabase(user_id="1")
+
+    rows, total = db.list_output_templates(None, 10, 0)
+
+    assert total == 1
+    assert [row.name for row in rows] == ["old"]
+    assert len(old_backend.execute_calls) == 2
+    assert new_backend.execute_calls == []
+
+
+def test_characters_rag_db_pins_backend_for_thread_local_connection_until_close(monkeypatch) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    monkeypatch.setattr(
+        chacha_db.CharactersRAGDB,
+        "_resolve_backend",
+        lambda self, *, backend, config: (holder["backend"], True),
+    )
+    monkeypatch.setattr(chacha_db.CharactersRAGDB, "_initialize_schema", lambda self: None)
+    monkeypatch.setattr(
+        chacha_db.CharactersRAGDB,
+        "_apply_postgres_client_scope",
+        lambda self, conn, pool: conn,
+    )
+
+    db = chacha_db.CharactersRAGDB(db_path=":memory:", client_id="tester")
+
+    conn = db.get_connection()
+    raw = db._local.conn
+
+    holder["backend"] = new_backend
+    cursor = conn.cursor()
+    cursor.execute("SELECT 1")
+    db.close_connection()
+
+    assert [issued.origin for issued in old_backend.pool.issued] == ["old"]
+    assert old_backend.pool.returned == [raw]
+    assert new_backend.pool.returned == []
+    assert [
+        (query, params, connection.origin if connection else None)
+        for query, params, connection in old_backend.execute_calls
+    ] == [("SELECT 1", None, "old")]
+    assert new_backend.execute_calls == []
+
+
+def test_characters_rag_db_transaction_path_uses_pinned_backend_wrapper(monkeypatch) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    monkeypatch.setattr(
+        chacha_db.CharactersRAGDB,
+        "_resolve_backend",
+        lambda self, *, backend, config: (holder["backend"], True),
+    )
+    monkeypatch.setattr(chacha_db.CharactersRAGDB, "_initialize_schema", lambda self: None)
+    monkeypatch.setattr(
+        chacha_db.CharactersRAGDB,
+        "_apply_postgres_client_scope",
+        lambda self, conn, pool: conn,
+    )
+
+    db = chacha_db.CharactersRAGDB(db_path=":memory:", client_id="tester")
+
+    with db.transaction() as conn:
+        raw = db._local.conn
+        holder["backend"] = new_backend
+        conn.cursor().execute("SELECT 1")
+
+    assert raw.commit_calls == 1
+    assert old_backend.pool.returned == []
+    assert [
+        (query, params, connection.origin if connection else None)
+        for query, params, connection in old_backend.execute_calls
+    ] == [("SELECT 1", None, "old")]
+    assert new_backend.execute_calls == []
+
+
+def test_characters_rag_db_serializes_shared_backend_refresh_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+    first_refresh_started = threading.Event()
+    release_refresh = threading.Event()
+    bootstrap_keys: list[str] = []
+
+    def fake_resolve(self, *, backend, config):
+        if holder["backend"] is new_backend:
+            if not first_refresh_started.is_set():
+                first_refresh_started.set()
+                release_refresh.wait(timeout=0.1)
+            else:
+                release_refresh.set()
+        return holder["backend"], True
+
+    def slow_initialize_schema(self) -> None:
+        bootstrap_keys.append(self._backend_target_key(self._backend) or "<none>")
+        threading.Event().wait(0.1)
+
+    monkeypatch.setattr(chacha_db.CharactersRAGDB, "_resolve_backend", fake_resolve)
+    monkeypatch.setattr(chacha_db.CharactersRAGDB, "_initialize_schema", slow_initialize_schema)
+    monkeypatch.setattr(
+        chacha_db.CharactersRAGDB,
+        "_apply_postgres_client_scope",
+        lambda self, conn, pool: conn,
+    )
+
+    db = chacha_db.CharactersRAGDB(db_path=":memory:", client_id="tester")
+    bootstrap_keys.clear()
+    holder["backend"] = new_backend
+
+    errors: list[BaseException] = []
+
+    def read_backend() -> None:
+        try:
+            _ = db.backend
+        except BaseException as exc:  # pragma: no cover - surfaced by assert below
+            errors.append(exc)
+
+    first = threading.Thread(target=read_backend)
+    second = threading.Thread(target=read_backend)
+
+    first.start()
+    second.start()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert bootstrap_keys == ["postgresql:///new"]
+
+
+def test_evaluations_database_keeps_borrowed_backend_pinned_across_rotation(monkeypatch) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    monkeypatch.setattr(
+        evaluations_db.EvaluationsDatabase,
+        "_resolve_backend",
+        lambda self: (holder["backend"], True),
+    )
+    monkeypatch.setattr(evaluations_db.EvaluationsDatabase, "_initialize_database_postgres", lambda self: None)
+    monkeypatch.setattr(evaluations_db.EvaluationsDatabase, "_init_abtest_store", lambda self: None)
+
+    db = evaluations_db.EvaluationsDatabase(db_path=None)
+
+    with db.get_connection() as conn:
+        raw = conn._conn
+        holder["backend"] = new_backend
+        conn.cursor().execute("SELECT 1")
+
+    assert [issued.origin for issued in old_backend.pool.issued] == ["old"]
+    assert old_backend.pool.returned == [raw]
+    assert new_backend.pool.returned == []
+    assert [
+        (query, params, connection.origin if connection else None)
+        for query, params, connection in old_backend.execute_calls
+    ] == [("SELECT 1", None, "old")]
+    assert new_backend.execute_calls == []
+
+
+def test_evaluations_database_reinitializes_abtest_store_when_shared_backend_rotates(monkeypatch) -> None:
+    old_backend = _set_fake_pg_target(_FakeBackend(label="old"), host="pg-a", port=5432, database="shared", connection_string=None)
+    new_backend = _set_fake_pg_target(_FakeBackend(label="new"), host="pg-b", port=6432, database="shared", connection_string=None)
+    holder = {"backend": old_backend}
+    stamps: list[str] = []
+
+    monkeypatch.setattr(
+        evaluations_db.EvaluationsDatabase,
+        "_resolve_backend",
+        lambda self: (holder["backend"], True),
+    )
+    monkeypatch.setattr(evaluations_db.EvaluationsDatabase, "_initialize_database_postgres", lambda self: None)
+
+    def stamp_abtest_store(self) -> None:
+        stamp = self._backend_target_key(self._backend) or "<none>"
+        self._abtest_store = stamp
+        stamps.append(stamp)
+
+    monkeypatch.setattr(evaluations_db.EvaluationsDatabase, "_init_abtest_store", stamp_abtest_store)
+
+    db = evaluations_db.EvaluationsDatabase(db_path=None)
+
+    holder["backend"] = new_backend
+    _ = db.backend  # Trigger backend refresh side effect.  # noqa: B018
+
+    assert stamps == ["pg-a:5432/shared", "pg-b:6432/shared"]
+    assert db._abtest_store == "pg-b:6432/shared"
+
+
+def test_analytics_database_keeps_transaction_backend_pinned_across_rotation(monkeypatch) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    monkeypatch.setattr(
+        analytics_db.AnalyticsDatabase,
+        "_resolve_backend",
+        lambda self, *, db_path, backend, config: (holder["backend"], True),
+    )
+    monkeypatch.setattr(analytics_db.AnalyticsDatabase, "_initialize_database", lambda self: None)
+
+    db = analytics_db.AnalyticsDatabase(db_path="analytics.db")
+
+    with db.transaction() as conn:
+        raw = conn
+        holder["backend"] = new_backend
+        db._execute(conn, "SELECT 1")
+
+    assert [issued.origin for issued in old_backend.pool.issued] == ["old"]
+    assert old_backend.pool.returned == [raw]
+    assert new_backend.pool.returned == []
+    assert [
+        (query, params, connection.origin if connection else None)
+        for query, params, connection in old_backend.execute_calls
+    ] == [("SELECT 1", None, "old")]
+    assert new_backend.execute_calls == []
+
+
+def test_analytics_database_initialization_uses_pinned_backend_during_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    @contextmanager
+    def rotating_transaction():
+        connection = old_backend.pool.get_connection()
+        holder["backend"] = new_backend
+        try:
+            yield connection
+        finally:
+            old_backend.pool.returned.append(connection)
+
+    old_backend.transaction = rotating_transaction  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        analytics_db.AnalyticsDatabase,
+        "_resolve_backend",
+        lambda self, *, db_path, backend, config: (holder["backend"], True),
+    )
+    monkeypatch.setattr(analytics_db.AnalyticsDatabase, "_bootstrapped_backend_targets", set())
+
+    _ = analytics_db.AnalyticsDatabase(db_path="analytics.db")
+
+    assert len(old_backend.create_tables_calls) == 1
+    assert len(old_backend.execute_calls) == len(analytics_db.AnalyticsDatabase._INDEX_STATEMENTS)
+    assert new_backend.create_tables_calls == []
+    assert new_backend.execute_calls == []
+
+
+def test_collections_database_reruns_bootstrap_when_shared_backend_target_changes(monkeypatch) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+    schema_calls: list[str] = []
+    seed_calls: list[str] = []
+
+    monkeypatch.setattr(collections_db.CollectionsDatabase, "_bootstrapped_backend_targets", set())
+    monkeypatch.setenv("TLDW_CONTENT_DB_BACKEND", "postgresql")
+    monkeypatch.setattr(collections_db, "load_comprehensive_config", lambda: _make_config("pw1", "prefer"))
+    monkeypatch.setattr(collections_db, "get_content_backend", lambda _cfg: holder["backend"])
+    monkeypatch.setattr(
+        collections_db.CollectionsDatabase,
+        "ensure_schema",
+        lambda self: schema_calls.append(self._backend.label),
+    )
+    monkeypatch.setattr(
+        collections_db.CollectionsDatabase,
+        "_seed_watchlists_output_templates",
+        lambda self: seed_calls.append(self._backend.label),
+    )
+    monkeypatch.setattr(
+        collections_db,
+        "prepare_backend_statement",
+        lambda *_args, **_kwargs: ("SELECT 1", ()),
+    )
+
+    db = collections_db.CollectionsDatabase(user_id="1")
+
+    holder["backend"] = new_backend
+    db._execute_insert("INSERT INTO collections VALUES (?)", ("value",))
+
+    assert schema_calls == ["old", "new"]
+    assert seed_calls == ["old", "new"]
+
+
+def test_collections_database_bootstrap_runs_once_per_shared_target_across_instances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared_backend = _FakeBackend(label="shared")
+    bootstrap_calls: list[str] = []
+
+    monkeypatch.setattr(collections_db.CollectionsDatabase, "_bootstrapped_backend_targets", set())
+    monkeypatch.setattr(
+        collections_db.CollectionsDatabase,
+        "_resolve_backend",
+        lambda self: (shared_backend, True),
+    )
+    monkeypatch.setattr(
+        collections_db.CollectionsDatabase,
+        "_run_backend_bootstrap",
+        lambda self: bootstrap_calls.append(self._backend_target_key(self._backend) or "<none>"),
+    )
+
+    _ = collections_db.CollectionsDatabase(user_id="1")
+    _ = collections_db.CollectionsDatabase(user_id="1")
+
+    assert bootstrap_calls == ["postgresql:///shared"]
+
+
+def test_evaluations_database_bootstrap_runs_once_per_shared_target_across_instances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared_backend = _FakeBackend(label="shared")
+    bootstrap_calls: list[str] = []
+
+    monkeypatch.setattr(evaluations_db.EvaluationsDatabase, "_bootstrapped_backend_targets", set())
+    monkeypatch.setattr(
+        evaluations_db.EvaluationsDatabase,
+        "_resolve_backend",
+        lambda self: (shared_backend, True),
+    )
+    monkeypatch.setattr(
+        evaluations_db.EvaluationsDatabase,
+        "_initialize_database_postgres",
+        lambda self: bootstrap_calls.append(self._backend_target_key(self._backend) or "<none>"),
+    )
+    monkeypatch.setattr(evaluations_db.EvaluationsDatabase, "_init_abtest_store", lambda self: None)
+
+    _ = evaluations_db.EvaluationsDatabase(db_path=None)
+    _ = evaluations_db.EvaluationsDatabase(db_path=None)
+
+    assert bootstrap_calls == ["postgresql:///shared"]
+
+
+def test_analytics_database_bootstrap_runs_once_per_shared_target_across_instances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared_backend = _FakeBackend(label="shared")
+    bootstrap_calls: list[str] = []
+
+    monkeypatch.setattr(analytics_db.AnalyticsDatabase, "_bootstrapped_backend_targets", set())
+    monkeypatch.setattr(
+        analytics_db.AnalyticsDatabase,
+        "_resolve_backend",
+        lambda self, *, db_path, backend, config: (shared_backend, True),
+    )
+    monkeypatch.setattr(
+        analytics_db.AnalyticsDatabase,
+        "_initialize_database",
+        lambda self: bootstrap_calls.append(self._backend_target_key(self._backend) or "<none>"),
+    )
+
+    _ = analytics_db.AnalyticsDatabase(db_path="analytics.db")
+    _ = analytics_db.AnalyticsDatabase(db_path="analytics.db")
+
+    assert bootstrap_calls == ["postgresql:///shared"]
+
+
+def test_watchlists_database_reruns_bootstrap_when_pg_host_changes_with_same_db_name(monkeypatch) -> None:
+    old_backend = _set_fake_pg_target(_FakeBackend(label="old"), host="pg-a", port=5432, database="shared", connection_string=None)
+    new_backend = _set_fake_pg_target(_FakeBackend(label="new"), host="pg-b", port=6432, database="shared", connection_string=None)
+    holder = {"backend": old_backend}
+    schema_calls: list[str] = []
+
+    monkeypatch.setenv("TLDW_CONTENT_DB_BACKEND", "postgresql")
+    monkeypatch.setattr(watchlists_db, "load_comprehensive_config", lambda: _make_config("pw1", "prefer"))
+    monkeypatch.setattr(watchlists_db, "get_content_backend", lambda _cfg: holder["backend"])
+    monkeypatch.setattr(
+        watchlists_db.WatchlistsDatabase,
+        "ensure_schema",
+        lambda self: schema_calls.append(self._backend_target_key(self._backend) or "<none>"),
+    )
+    monkeypatch.setattr(watchlists_db.WatchlistsDatabase, "_schema_init_keys", set())
+
+    db = watchlists_db.WatchlistsDatabase(user_id="1")
+
+    holder["backend"] = new_backend
+    _ = db.backend  # Trigger backend refresh side effect.  # noqa: B018
+
+    assert schema_calls == ["pg-a:5432/shared", "pg-b:6432/shared"]
+
+
+def test_watchlists_database_pins_backend_for_multi_query_read_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    source_row = {
+        "id": 1,
+        "user_id": "1",
+        "name": "Example source",
+        "url": "https://example.invalid/feed",
+        "source_type": "rss",
+        "active": 1,
+        "settings_json": None,
+        "last_scraped_at": None,
+        "etag": None,
+        "last_modified": None,
+        "defer_until": None,
+        "status": None,
+        "consec_not_modified": 0,
+        "consec_errors": 0,
+        "created_at": "2026-04-16T00:00:00+00:00",
+        "updated_at": "2026-04-16T00:00:00+00:00",
+    }
+
+    def make_execute(backend: _FakeBackend):
+        def execute(query: str, params=None, connection=None) -> QueryResult:
+            backend.execute_calls.append((query, params, connection))
+            if "FROM sources WHERE id" in query:
+                if backend is old_backend:
+                    holder["backend"] = new_backend
+                return QueryResult(rows=[source_row], rowcount=1)
+            if "FROM source_tags" in query:
+                return QueryResult(rows=[{"name": backend.label}], rowcount=1)
+            return QueryResult(rows=[], rowcount=0)
+
+        return execute
+
+    old_backend.execute = make_execute(old_backend)  # type: ignore[assignment]
+    new_backend.execute = make_execute(new_backend)  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        watchlists_db.WatchlistsDatabase,
+        "_resolve_backend",
+        lambda self: (
+            holder["backend"],
+            f"postgresql:///{holder['backend'].label}",
+            True,
+        ),
+    )
+    monkeypatch.setattr(watchlists_db.WatchlistsDatabase, "_ensure_schema_for_key", lambda self, backend, db_key: None)
+
+    db = watchlists_db.WatchlistsDatabase(user_id="1")
+
+    source = db.get_source(1)
+
+    assert source.tags == ["old"]
+    assert len(old_backend.execute_calls) == 2
+    assert new_backend.execute_calls == []
+
+
+def test_watchlists_database_pins_backend_for_multi_query_write_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_backend = _FakeBackend(label="old")
+    new_backend = _FakeBackend(label="new")
+    holder = {"backend": old_backend}
+
+    source_row = {
+        "id": 101,
+        "user_id": "1",
+        "name": "Created source",
+        "url": "https://example.invalid/created",
+        "source_type": "rss",
+        "active": 1,
+        "settings_json": None,
+        "last_scraped_at": None,
+        "etag": None,
+        "last_modified": None,
+        "defer_until": None,
+        "status": None,
+        "consec_not_modified": 0,
+        "consec_errors": 0,
+        "created_at": "2026-04-16T00:00:00+00:00",
+        "updated_at": "2026-04-16T00:00:00+00:00",
+    }
+
+    def make_execute(backend: _FakeBackend):
+        def execute(query: str, params=None, connection=None) -> QueryResult:
+            backend.execute_calls.append((query, params, connection))
+            if query.startswith("INSERT INTO sources"):
+                if backend is old_backend:
+                    holder["backend"] = new_backend
+                return QueryResult(rows=[{"id": 101}], rowcount=1, lastrowid=101)
+            if "FROM sources WHERE id" in query:
+                return QueryResult(rows=[source_row], rowcount=1)
+            if "FROM source_tags" in query:
+                return QueryResult(rows=[], rowcount=0)
+            return QueryResult(rows=[], rowcount=0)
+
+        return execute
+
+    old_backend.execute = make_execute(old_backend)  # type: ignore[assignment]
+    new_backend.execute = make_execute(new_backend)  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        watchlists_db.WatchlistsDatabase,
+        "_resolve_backend",
+        lambda self: (
+            holder["backend"],
+            f"postgresql:///{holder['backend'].label}",
+            True,
+        ),
+    )
+    monkeypatch.setattr(watchlists_db.WatchlistsDatabase, "_ensure_schema_for_key", lambda self, backend, db_key: None)
+    monkeypatch.setattr(
+        watchlists_db,
+        "prepare_backend_statement",
+        lambda *_args, **_kwargs: ("INSERT INTO sources", ()),
+    )
+
+    db = watchlists_db.WatchlistsDatabase(user_id="1")
+
+    source = db.create_source(
+        name="Created source",
+        url="https://example.invalid/created",
+        source_type="rss",
+    )
+
+    assert source.id == 101
+    assert [query for query, _params, _connection in old_backend.execute_calls] == [
+        "INSERT INTO sources",
+        "SELECT id, user_id, name, url, source_type, active, settings_json, last_scraped_at, etag, last_modified, defer_until, status, consec_not_modified, consec_errors, created_at, updated_at FROM sources WHERE id = ? AND user_id = ?",
+        "SELECT t.name FROM source_tags st JOIN tags t ON st.tag_id = t.id WHERE st.source_id = ?",
+    ]
+    assert new_backend.execute_calls == []

--- a/tldw_Server_API/tests/DB_Management/test_db_migration_verification.py
+++ b/tldw_Server_API/tests/DB_Management/test_db_migration_verification.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.db_migration import DatabaseMigrator
+
+
+def test_verify_migrations_reports_noncontiguous_available_versions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "app.db"
+    db_path.touch()
+    migrator = DatabaseMigrator(str(db_path), str(tmp_path / "unused"))
+
+    monkeypatch.setattr(
+        migrator,
+        "get_applied_migrations",
+        lambda: [{"version": 1, "checksum": "a"}],
+    )
+    monkeypatch.setattr(
+        migrator,
+        "load_migrations",
+        lambda: [
+            SimpleNamespace(version=1, checksum="a"),
+            SimpleNamespace(version=3, checksum="c"),
+        ],
+    )
+
+    issues = migrator.verify_migrations()
+
+    assert any(issue["issue"] == "migration_version_gap" for issue in issues)
+    assert any(issue["version"] == 2 for issue in issues)
+
+
+def test_verify_migrations_returns_empty_list_when_no_migration_files_exist(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "app.db"
+    db_path.touch()
+    migrator = DatabaseMigrator(str(db_path), str(tmp_path / "missing"))
+
+    assert migrator.verify_migrations() == []
+
+
+def test_verify_migrations_reports_missing_files_when_applied_migrations_exist_and_no_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "app.db"
+    db_path.touch()
+    migrator = DatabaseMigrator(str(db_path), str(tmp_path / "missing"))
+
+    monkeypatch.setattr(
+        migrator,
+        "get_applied_migrations",
+        lambda: [{"version": 1, "checksum": "a"}],
+    )
+    monkeypatch.setattr(migrator, "load_migrations", list)
+
+    issues = migrator.verify_migrations()
+
+    assert any(issue["issue"] == "migration_file_missing" for issue in issues)
+    assert not any(issue["issue"] == "migration_version_gap" for issue in issues)
+
+
+def test_verify_migrations_does_not_duplicate_gap_and_missing_file_for_applied_versions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "app.db"
+    db_path.touch()
+    migrator = DatabaseMigrator(str(db_path), str(tmp_path / "unused"))
+
+    monkeypatch.setattr(
+        migrator,
+        "get_applied_migrations",
+        lambda: [{"version": 2, "checksum": "abc"}],
+    )
+    monkeypatch.setattr(
+        migrator,
+        "load_migrations",
+        lambda: [
+            SimpleNamespace(version=1, checksum="aaa"),
+            SimpleNamespace(version=3, checksum="ccc"),
+        ],
+    )
+
+    issues = migrator.verify_migrations()
+
+    assert any(issue["issue"] == "migration_file_missing" and issue["version"] == 2 for issue in issues)
+    assert not any(issue["issue"] == "migration_version_gap" and issue["version"] == 2 for issue in issues)
+
+
+def test_verify_migrations_preserves_existing_missing_file_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "app.db"
+    db_path.touch()
+    migrator = DatabaseMigrator(str(db_path), str(tmp_path / "unused"))
+
+    monkeypatch.setattr(
+        migrator,
+        "get_applied_migrations",
+        lambda: [{"version": 2, "checksum": "abc"}],
+    )
+    monkeypatch.setattr(
+        migrator,
+        "load_migrations",
+        lambda: [SimpleNamespace(version=1, checksum="aaa")],
+    )
+
+    issues = migrator.verify_migrations()
+
+    assert any(issue["issue"] == "migration_file_missing" for issue in issues)
+
+
+def test_verify_migrations_preserves_existing_checksum_mismatch_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "app.db"
+    db_path.touch()
+    migrator = DatabaseMigrator(str(db_path), str(tmp_path / "unused"))
+
+    monkeypatch.setattr(
+        migrator,
+        "get_applied_migrations",
+        lambda: [{"version": 1, "checksum": "abc"}],
+    )
+    monkeypatch.setattr(
+        migrator,
+        "load_migrations",
+        lambda: [SimpleNamespace(version=1, checksum="def")],
+    )
+
+    issues = migrator.verify_migrations()
+
+    assert any(issue["issue"] == "checksum_mismatch" for issue in issues)

--- a/tldw_Server_API/tests/Watchlists/conftest.py
+++ b/tldw_Server_API/tests/Watchlists/conftest.py
@@ -7,6 +7,7 @@ before any tests import the FastAPI app.
 """
 
 import os
+import sys
 import importlib
 import types
 import importlib.machinery


### PR DESCRIPTION
## Summary
- rebaseline DB-management Wave 1 findings against the current tree and document the remaining live issues
- harden shared PostgreSQL content-backend refresh and bootstrap lifetimes across DB wrappers
- add migration verification gap coverage and Wave 1 contract documentation

## Testing
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/DB_Management/test_pg_rls_policies_contract.py tldw_Server_API/tests/DB_Management/test_db_migration_loader.py tldw_Server_API/tests/DB_Management/test_db_migration_planning.py tldw_Server_API/tests/DB_Management/test_migration_cli_integration.py tldw_Server_API/tests/DB_Management/test_userdatabase_v2_bootstrap_failclosed.py tldw_Server_API/tests/DB_Management/test_content_backend_cache.py tldw_Server_API/tests/DB_Management/test_db_path_utils.py tldw_Server_API/tests/DB_Management/test_media_db_api_error_contracts.py tldw_Server_API/tests/DB_Management/test_database_backend_fts_normalization.py tldw_Server_API/tests/DB_Management/test_db_migration_verification.py
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/DB_Management/Collections_DB.py tldw_Server_API/app/core/DB_Management/Evaluations_DB.py tldw_Server_API/app/core/DB_Management/Watchlists_DB.py tldw_Server_API/app/core/RAG/rag_service/analytics_db.py -f json -o /tmp/bandit_wave1_pr_branch.json
