### PR TITLE
Fix idle shutdown wind-down and ACP runner HOME portability

### DIFF
--- a/Docs/Development/Agent_Client_Protocol.md
+++ b/Docs/Development/Agent_Client_Protocol.md
@@ -197,9 +197,11 @@ enable = tools, jobs, acp
 runner_command = go
 runner_args = ["run", "./cmd/tldw-agent-acp"]
 runner_cwd = ../tldw-agent
-runner_env = HOME=/absolute/path/to/tldw_Server_API/Config_Files/acp_runner_home,PYTHONUNBUFFERED=1
+runner_env = HOME=./acp_runner_home,PYTHONUNBUFFERED=1
 startup_timeout_ms = 10000
 ```
+
+Relative `HOME` values in `runner_env` are resolved against `tldw_Server_API/Config_Files`, so the checked-in example stays portable across machines.
 
 ### Environment Overrides
 

--- a/Docs/User_Guides/Integrations_Experiments/Getting_Started_with_ACP.md
+++ b/Docs/User_Guides/Integrations_Experiments/Getting_Started_with_ACP.md
@@ -73,9 +73,11 @@ enable = tools, jobs, acp
 runner_command = go
 runner_args = ["run", "./cmd/tldw-agent-acp"]
 runner_cwd = ../tldw-agent
-runner_env = HOME=/absolute/path/to/.tldw-agent-home,PYTHONUNBUFFERED=1
+runner_env = HOME=./acp_runner_home,PYTHONUNBUFFERED=1
 startup_timeout_ms = 10000
 ```
+
+Relative `HOME` values in `runner_env` are resolved against `tldw_Server_API/Config_Files`.
 
 Install ACP dependencies:
 
@@ -464,7 +466,7 @@ Then restart tldw_server.
    ```bash
    echo $ANTHROPIC_API_KEY
    ```
-4. Check the HOME environment in `runner_env` points to the config directory
+4. Check the HOME environment in `runner_env` points to the config directory. Relative values resolve from `tldw_Server_API/Config_Files`.
 
 ### WebSocket Connection Fails
 

--- a/Docs/superpowers/plans/2026-04-18-idle-shutdown-winddown-remediation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-18-idle-shutdown-winddown-remediation-implementation-plan.md
@@ -1,0 +1,600 @@
+# Idle Shutdown Wind-Down Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce idle local `uvicorn` and Docker/container shutdown latency by removing the fixed Evaluations shutdown stall, explicitly stopping every owned in-process job poller at the right point in teardown, and emitting timing data that makes the remaining shutdown cost attributable.
+
+**Architecture:** Execute this remediation in three narrow code batches. First make the Evaluations connection-pool maintenance thread wakeable so idle shutdown stops paying a synthetic five-second join tax. Then close the current shutdown-ownership gaps for helper-started job pollers and register all owned pollers in one inventory that `main.py` can quiesce immediately after the drain handoff on the zero-active path while preserving the existing bounded lease-wait branch when active processing jobs exist. Finally add lightweight timing helpers in `main.py` so the idle-shutdown path records the required segment durations and total teardown time without introducing a broader shutdown refactor.
+
+**Tech Stack:** Python 3, FastAPI lifespan, asyncio, threading, Loguru, pytest, SQLite, Bandit, Markdown
+
+---
+
+## Current-Tree Evidence
+
+- Captured idle shutdown trace from `2026-04-18 12:13:11.551` to `12:13:16.556` shows the Evaluations connection-pool shutdown alone consuming about five seconds before the rest of teardown resumes.
+- `tldw_Server_API/app/core/Evaluations/connection_pool.py` currently runs the maintenance worker with `time.sleep(60)` and joins it with `join(timeout=5)`, which matches the observed fixed stall.
+- `tldw_Server_API/app/main.py` applies the drain handoff first, then optionally waits for leases, but only reaches the per-worker stop block much later, which matches the repeated `Jobs acquire gate enabled; declining new acquisition` log spam during idle shutdown.
+- `tldw_Server_API/app/main.py` starts helper-owned pollers that do not all have explicit teardown ownership today:
+  - `audiobook_jobs_task` is started with a stop event but is not stopped in the current shutdown block.
+  - `start_connectors_worker()` currently creates its own stop event internally and returns only a task.
+  - `start_reminder_jobs_worker()` returns only a task and is cancelled late instead of being stop-signaled.
+  - `start_admin_backup_jobs_worker()` wraps `WorkerSDK` but exposes no stop signal.
+  - `start_admin_byok_validation_jobs_worker()` wraps `WorkerSDK` and is started in `main.py`, but currently has no matching shutdown path in `main.py`.
+- The app already stores shutdown coordinator artifacts on `app.state`, so exposing a job-poller inventory and shutdown timing summary there is consistent with current lifecycle observability patterns and avoids brittle full-log assertions in tests.
+
+## Initial Poller Inventory To Preserve Or Fix
+
+- Explicit stop-event pollers already started in `main.py` and expected to remain explicitly owned:
+  - `core_jobs_task`
+  - `files_jobs_task`
+  - `data_tables_jobs_task`
+  - `prompt_studio_jobs_task`
+  - `privilege_snapshot_task`
+  - `audio_jobs_task`
+  - `audiobook_jobs_task`
+  - `presentation_render_jobs_task`
+  - `media_ingest_jobs_task`
+  - `media_ingest_heavy_jobs_task`
+  - `reading_digest_jobs_task`
+  - `study_pack_jobs_task`
+  - `study_suggestions_jobs_task`
+  - `companion_reflection_jobs_task`
+  - `evals_abtest_jobs_task`
+- Helper-started or currently underspecified pollers that must gain explicit ownership in this slice:
+  - `reminder_jobs_task`
+  - `admin_backup_jobs_task`
+  - `admin_byok_validation_jobs_task`
+  - connectors worker task currently stored as `_conn_task`
+- Non-poller background tasks, schedulers, and the larger shutdown coordinator remain out of scope except where the timing logs need to wrap their existing teardown blocks.
+
+## Implementation File Map
+
+**Create:**
+- `tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py`: Focused unit coverage for wakeable maintenance-thread shutdown and the shorter defensive join fallback.
+- `tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py`: Focused lifecycle tests for job-poller inventory capture, zero-active versus active-processing sequencing, and required timing-segment recording.
+
+**Modify:**
+- `tldw_Server_API/app/core/Evaluations/connection_pool.py`: Replace the fixed-sleep maintenance loop with a shutdown-wakeable wait and reduce the defensive join fallback.
+- `tldw_Server_API/app/main.py`: Build and expose an owned job-poller inventory, stop pollers immediately after the drain handoff on the zero-active path, preserve the bounded lease-wait branch for active processing jobs, remove duplicated late stop handling for moved pollers, and emit shutdown timing summaries.
+- `tldw_Server_API/app/services/connectors_worker.py`: Accept a caller-supplied stop event so `main.py` owns shutdown for the helper-started connectors poller.
+- `tldw_Server_API/app/services/reminder_jobs_worker.py`: Accept a caller-supplied stop event so `main.py` can stop the reminder worker cleanly instead of relying on late cancellation.
+- `tldw_Server_API/app/services/admin_backup_jobs_worker.py`: Add stop-event-aware `WorkerSDK` shutdown wiring and expose that stop path to `main.py`.
+- `tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py`: Add stop-event-aware `WorkerSDK` shutdown wiring and expose that stop path to `main.py`.
+- `tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py`: Keep the helper start-function truthiness coverage aligned with the new optional `stop_event` signature.
+
+## Implementation Notes
+
+- Keep this slice narrow. Do not move the broader legacy teardown tail into the shutdown coordinator and do not redesign busy-shutdown semantics beyond preserving the existing `JOBS_SHUTDOWN_WAIT_FOR_LEASES_SEC` contract.
+- Treat the numeric target as a manual acceptance gate, not a brittle CI runtime assertion. Automated tests should assert ordering, ownership, and bounded behavior rather than wall-clock totals across machines.
+- Use `time.monotonic()` for shutdown timing segments. Record each segment to `app.state._tldw_shutdown_timing_segments` as a list of dictionaries with at least `segment` and `duration_ms`.
+- Use a consistent timing log format so grep-friendly manual validation is possible:
+  - `App Shutdown Timing: segment=<segment_name> duration_ms=<ms> ...`
+  - `App Shutdown Timing: total duration_ms=<ms> slowest_segment=<segment_name> slowest_duration_ms=<ms>`
+- Record the owned poller inventory on `app.state._tldw_shutdown_job_poller_inventory` as dictionaries with at least `name`, `task_name`, `has_stop_event`, and `timeout_sec`. Tests should assert against this state instead of relying on log text.
+- For the optional lease-wait timing segment, record a zero-duration or skipped entry when no wait is applied so the required segment set is always visible in the summary.
+- Keep Evaluations shutdown synchronous in this slice. Only move it behind `asyncio.to_thread(...)` in a follow-up if the new timing summary still shows a material blocking cost after the wakeable maintenance change lands.
+
+### Task 1: Make Evaluations Maintenance Shutdown Wakeable
+
+**Files:**
+- Create: `tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py`
+- Modify: `tldw_Server_API/app/core/Evaluations/connection_pool.py`
+
+- [ ] **Step 1: Write the failing Evaluations shutdown tests**
+
+```python
+import threading
+import time
+
+from tldw_Server_API.app.core.Evaluations.connection_pool import ConnectionPool
+
+
+def test_shutdown_sets_maintenance_wakeup_before_join(temp_db_path):
+    pool = ConnectionPool(str(temp_db_path), enable_monitoring=False)
+    pool._maintenance_shutdown_event = threading.Event()
+
+    observed: dict[str, object] = {}
+
+    class _FakeThread:
+        def is_alive(self) -> bool:
+            return True
+
+        def join(self, timeout: float | None = None) -> None:
+            observed["timeout"] = timeout
+            observed["event_is_set"] = pool._maintenance_shutdown_event.is_set()
+
+    pool._maintenance_task = _FakeThread()
+
+    pool.shutdown()
+
+    assert observed == {"timeout": 1.0, "event_is_set": True}
+
+
+def test_shutdown_no_longer_pays_fixed_five_second_join(monkeypatch, temp_db_path):
+    pool = ConnectionPool(str(temp_db_path), enable_monitoring=False)
+    pool._maintenance_shutdown_event = threading.Event()
+
+    class _FastExitThread:
+        def is_alive(self) -> bool:
+            return True
+
+        def join(self, timeout: float | None = None) -> None:
+            return None
+
+    pool._maintenance_task = _FastExitThread()
+
+    started = time.perf_counter()
+    pool.shutdown()
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 0.25
+```
+
+- [ ] **Step 2: Run the new shutdown tests to confirm the current implementation fails**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
+```
+
+Expected: FAIL because `ConnectionPool` does not yet create a maintenance shutdown event and still joins the maintenance thread with the existing five-second fallback.
+
+- [ ] **Step 3: Implement the wakeable maintenance shutdown**
+
+Update `tldw_Server_API/app/core/Evaluations/connection_pool.py` so the maintenance worker waits on an event instead of sleeping blindly:
+
+```python
+import threading
+
+
+class ConnectionPool:
+    def __init__(...):
+        ...
+        self._maintenance_shutdown_event = threading.Event()
+
+    def _start_maintenance(self):
+        if self._maintenance_task is not None:
+            return
+
+        def maintenance_worker() -> None:
+            while not self._shutdown:
+                try:
+                    self._perform_maintenance()
+                    if self._maintenance_shutdown_event.wait(timeout=60.0):
+                        return
+                except Exception as exc:
+                    logger.error(f"Pool maintenance error: {exc}")
+                    if self._maintenance_shutdown_event.wait(timeout=30.0):
+                        return
+
+        self._maintenance_task = threading.Thread(target=maintenance_worker, daemon=True)
+        self._maintenance_task.start()
+
+    def shutdown(self):
+        logger.info("Shutting down connection pool")
+        self._shutdown = True
+        self._maintenance_shutdown_event.set()
+        ...
+        if self._maintenance_task and self._maintenance_task.is_alive():
+            self._maintenance_task.join(timeout=1.0)
+```
+
+Keep the join fallback bounded and defensive. Do not remove the join entirely.
+
+- [ ] **Step 4: Re-run the focused Evaluations shutdown tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py tldw_Server_API/tests/Evaluations/unit/test_connection_pool.py
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Evaluations/connection_pool.py tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
+git commit -m "fix: wake evaluations pool shutdown promptly"
+```
+
+### Task 2: Give Helper-Started Job Pollers Explicit Stop Ownership
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/connectors_worker.py`
+- Modify: `tldw_Server_API/app/services/reminder_jobs_worker.py`
+- Modify: `tldw_Server_API/app/services/admin_backup_jobs_worker.py`
+- Modify: `tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py`
+- Modify: `tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py`
+- Test: `tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py`
+
+- [ ] **Step 1: Write the failing helper-start ownership tests**
+
+Add focused tests in `tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py` for helper-started workers:
+
+```python
+import asyncio
+
+import pytest
+
+from tldw_Server_API.app.services import connectors_worker
+from tldw_Server_API.app.services import reminder_jobs_worker
+from tldw_Server_API.app.services import admin_backup_jobs_worker
+from tldw_Server_API.app.services import admin_byok_validation_jobs_worker
+
+
+@pytest.mark.asyncio
+async def test_start_connectors_worker_uses_caller_stop_event(monkeypatch):
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+
+    async def _fake_run(stop_event: asyncio.Event | None = None) -> None:
+        started.set()
+        await stop_event.wait()
+        stopped.set()
+
+    monkeypatch.setenv("CONNECTORS_WORKER_ENABLED", "true")
+    monkeypatch.setattr(connectors_worker, "run_connectors_worker", _fake_run)
+
+    stop_event = asyncio.Event()
+    task = await connectors_worker.start_connectors_worker(stop_event=stop_event)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert stopped.is_set()
+
+
+@pytest.mark.asyncio
+async def test_admin_backup_worker_stops_worker_sdk_when_stop_event_is_set(monkeypatch):
+    stop_called = asyncio.Event()
+
+    class _FakeSDK:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self._stopped = asyncio.Event()
+
+        def stop(self) -> None:
+            stop_called.set()
+            self._stopped.set()
+
+        async def run(self, **_kwargs) -> None:
+            await self._stopped.wait()
+
+    monkeypatch.setenv("ADMIN_BACKUP_JOBS_WORKER_ENABLED", "true")
+    monkeypatch.setattr(admin_backup_jobs_worker, "WorkerSDK", _FakeSDK)
+
+    stop_event = asyncio.Event()
+    task = await admin_backup_jobs_worker.start_admin_backup_jobs_worker(stop_event=stop_event)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert stop_called.is_set()
+```
+
+- [ ] **Step 2: Run the helper-start ownership tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_start_connectors_worker_uses_caller_stop_event tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_admin_backup_worker_stops_worker_sdk_when_stop_event_is_set tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py
+```
+
+Expected: FAIL because the helper start functions do not yet accept a caller-supplied stop event and the `WorkerSDK`-based helpers do not yet wire `stop_event` to `sdk.stop()`.
+
+- [ ] **Step 3: Implement caller-owned stop events for helper-started pollers**
+
+Thread a caller-supplied `stop_event` through the helper start functions. For simple loop-based workers:
+
+```python
+async def start_reminder_jobs_worker(stop_event: asyncio.Event | None = None) -> asyncio.Task | None:
+    if not env_flag_enabled("REMINDER_JOBS_WORKER_ENABLED"):
+        return None
+    managed_stop_event = stop_event or asyncio.Event()
+    return asyncio.create_task(
+        run_reminder_jobs_worker(managed_stop_event),
+        name="reminder_jobs_worker",
+    )
+```
+
+Apply the same pattern to `start_connectors_worker()`.
+
+For `WorkerSDK`-based helpers, add a stop watcher inside the run wrapper:
+
+```python
+async def run_admin_backup_jobs_worker(stop_event: asyncio.Event | None = None) -> None:
+    sdk = WorkerSDK(jm, cfg)
+    stop_watcher = None
+    if stop_event is not None:
+        async def _watch_for_stop() -> None:
+            await stop_event.wait()
+            sdk.stop()
+
+        stop_watcher = asyncio.create_task(_watch_for_stop(), name="admin_backup_jobs_worker_stop_watch")
+
+    try:
+        await sdk.run(handler=handle_backup_schedule_job)
+    finally:
+        if stop_watcher is not None:
+            stop_watcher.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stop_watcher
+```
+
+Mirror the same `stop_event` pattern in `admin_byok_validation_jobs_worker.py`.
+
+Keep the existing no-argument call contract intact so current startup truthiness tests and any external callers remain valid.
+
+- [ ] **Step 4: Re-run the helper-start ownership tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/services/connectors_worker.py tldw_Server_API/app/services/reminder_jobs_worker.py tldw_Server_API/app/services/admin_backup_jobs_worker.py tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py
+git commit -m "fix: expose explicit stop ownership for jobs pollers"
+```
+
+### Task 3: Reorder Idle Shutdown Poller Quiesce And Add Timed Segments
+
+**Files:**
+- Modify: `tldw_Server_API/app/main.py`
+- Test: `tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py`
+
+- [ ] **Step 1: Write the failing shutdown sequencing and timing tests**
+
+Add focused helper-level tests in `tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py`:
+
+```python
+import asyncio
+from fastapi import FastAPI
+
+from tldw_Server_API.app import main as main_module
+
+
+@pytest.mark.asyncio
+async def test_zero_active_processing_quiesces_job_pollers_without_lease_wait(monkeypatch):
+    app = FastAPI()
+    handles = [
+        main_module._ManagedJobPoller(
+            name="audiobook_jobs_task",
+            task=asyncio.create_task(asyncio.sleep(3600)),
+            stop_event=asyncio.Event(),
+        )
+    ]
+    stop_calls: list[str] = []
+
+    async def _fake_stop_pollers(_app, _handles):
+        stop_calls.append("stop")
+
+    monkeypatch.setattr(main_module, "_stop_registered_job_pollers", _fake_stop_pollers)
+
+    await main_module._quiesce_owned_job_pollers_for_shutdown(
+        app,
+        handles,
+        wait_for_leases_sec=30,
+        count_active_processing=lambda: 0,
+    )
+
+    assert stop_calls == ["stop"]
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments")
+    assert [entry["segment"] for entry in segments][:2] == ["optional_lease_wait", "job_poller_quiesce"]
+    assert segments[0]["duration_ms"] == 0
+
+
+@pytest.mark.asyncio
+async def test_active_processing_preserves_bounded_lease_wait_before_quiesce(monkeypatch):
+    app = FastAPI()
+    handles: list[main_module._ManagedJobPoller] = []
+    counts = iter([2, 1, 0])
+    observed_sleeps: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        observed_sleeps.append(delay)
+
+    monkeypatch.setattr(main_module._asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(main_module, "_stop_registered_job_pollers", lambda *_args, **_kwargs: asyncio.sleep(0))
+
+    await main_module._quiesce_owned_job_pollers_for_shutdown(
+        app,
+        handles,
+        wait_for_leases_sec=5,
+        count_active_processing=lambda: next(counts),
+    )
+
+    assert observed_sleeps != []
+```
+
+- [ ] **Step 2: Run the sequencing tests to confirm the current lifecycle path does not satisfy them**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
+```
+
+Expected: FAIL because `main.py` does not yet expose a unified owned-poller inventory, does not quiesce pollers immediately after the zero-active drain handoff, and does not yet record the required timing segments.
+
+- [ ] **Step 3: Implement the owned-poller inventory, early quiesce helper, and timing logs**
+
+Add narrow lifecycle helpers in `tldw_Server_API/app/main.py`:
+
+```python
+from contextlib import contextmanager
+from dataclasses import dataclass
+import time
+
+
+@dataclass
+class _ManagedJobPoller:
+    name: str
+    task: asyncio.Task
+    stop_event: asyncio.Event | None = None
+    timeout_sec: float = 5.0
+
+
+def _record_shutdown_timing_segment(app: FastAPI, segment: str, duration_ms: int, **extra: object) -> None:
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments", None)
+    if not isinstance(segments, list):
+        segments = []
+        app.state._tldw_shutdown_timing_segments = segments
+    payload = {"segment": segment, "duration_ms": duration_ms, **extra}
+    segments.append(payload)
+    logger.info("App Shutdown Timing: segment={} duration_ms={} {}", segment, duration_ms, extra)
+
+
+@contextmanager
+def _timed_shutdown_segment(app: FastAPI, segment: str, **extra: object):
+    started = time.monotonic()
+    try:
+        yield
+    finally:
+        duration_ms = int((time.monotonic() - started) * 1000)
+        _record_shutdown_timing_segment(app, segment, duration_ms, **extra)
+
+
+async def _stop_registered_job_pollers(app: FastAPI, handles: list[_ManagedJobPoller]) -> None:
+    for handle in handles:
+        if handle.stop_event is not None:
+            handle.stop_event.set()
+        try:
+            await asyncio.wait_for(handle.task, timeout=handle.timeout_sec)
+        except asyncio.TimeoutError:
+            handle.task.cancel()
+```
+
+Then wire startup registration in `main.py` so every owned in-process poller is appended to one `owned_job_pollers` list and mirrored onto `app.state._tldw_shutdown_job_poller_inventory`. This registration must include the previously missed or underspecified pollers:
+
+```python
+owned_job_pollers: list[_ManagedJobPoller] = []
+
+if _enabled:
+    audiobook_jobs_stop_event = _asyncio.Event()
+    audiobook_jobs_task = _asyncio.create_task(_run_audiobook_jobs(audiobook_jobs_stop_event))
+    owned_job_pollers.append(
+        _ManagedJobPoller(
+            name="audiobook_jobs_task",
+            task=audiobook_jobs_task,
+            stop_event=audiobook_jobs_stop_event,
+        )
+    )
+
+reminder_jobs_stop_event = _asyncio.Event()
+reminder_jobs_task = await start_reminder_jobs_worker(reminder_jobs_stop_event)
+...
+admin_backup_jobs_stop_event = _asyncio.Event()
+admin_backup_jobs_task = await start_admin_backup_jobs_worker(admin_backup_jobs_stop_event)
+...
+admin_byok_validation_jobs_stop_event = _asyncio.Event()
+admin_byok_validation_jobs_task = await start_admin_byok_validation_jobs_worker(admin_byok_validation_jobs_stop_event)
+...
+connectors_jobs_stop_event = _asyncio.Event()
+connectors_jobs_task = await start_connectors_worker(connectors_jobs_stop_event)
+```
+
+Move poller quiesce to immediately after the drain handoff:
+
+```python
+with _timed_shutdown_segment(app, "transition_handoff"):
+    ...
+
+await _quiesce_owned_job_pollers_for_shutdown(
+    app,
+    owned_job_pollers,
+    wait_for_leases_sec=_max_wait,
+    count_active_processing=jm_chk.count_active_processing,
+)
+```
+
+Required behavior of `_quiesce_owned_job_pollers_for_shutdown(...)`:
+
+- Record the `optional_lease_wait` segment every time.
+- If `wait_for_leases_sec <= 0`, or if `count_active_processing()` is already `0`, do not sleep; record a zero-duration or skipped lease-wait segment and immediately stop pollers.
+- If active processing jobs exist and `wait_for_leases_sec > 0`, preserve the existing bounded 0.5-second polling lease-wait loop before stopping pollers.
+- Record `job_poller_quiesce` around the actual stop phase.
+
+After the early quiesce path is in place, delete or guard the duplicated late-stop branches for those moved pollers so shutdown does not double-await the same task later in teardown.
+
+Wrap the remaining required blocks with timing helpers:
+
+- `evaluations_pool_shutdown`
+- `unified_audit_and_executor_shutdown`
+- `telemetry_shutdown`
+- total app teardown
+
+Store the final total summary on `app.state._tldw_shutdown_timing_total` with at least `duration_ms`, `slowest_segment`, and `slowest_duration_ms`.
+
+- [ ] **Step 4: Re-run the shutdown sequencing tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/main.py tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
+git commit -m "fix: quiesce idle jobs pollers earlier on shutdown"
+```
+
+### Task 4: Final Verification And Manual Acceptance
+
+**Files:**
+- Modify only if verification exposes a real defect. Do not widen scope for style-only cleanups.
+
+- [ ] **Step 1: Run the focused automated regression suite**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py tldw_Server_API/tests/Evaluations/unit/test_connection_pool.py tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py tldw_Server_API/tests/Services/test_main_lifecycle_contract.py tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run Bandit on the touched Python scope**
+
+Run:
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/main.py tldw_Server_API/app/core/Evaluations/connection_pool.py tldw_Server_API/app/services/connectors_worker.py tldw_Server_API/app/services/reminder_jobs_worker.py tldw_Server_API/app/services/admin_backup_jobs_worker.py tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py -f json -o /tmp/bandit_idle_shutdown_winddown.json
+```
+
+Expected: `No issues identified` in the CLI summary or only pre-existing accepted findings outside the touched logic.
+
+- [ ] **Step 3: Manual idle `uvicorn` acceptance**
+
+Run the same local path already reproducing the issue:
+
+```bash
+source .venv/bin/activate && python -m uvicorn tldw_Server_API.app.main:app
+```
+
+Then trigger shutdown with `Ctrl-C` while the server is idle and confirm all of the following in the logs:
+
+- `App Shutdown Timing: total duration_ms=<ms>` is `<= 8000`
+- `App Shutdown Timing: segment=evaluations_pool_shutdown duration_ms=<ms>` is `<= 1000`
+- `App Shutdown Timing: segment=optional_lease_wait duration_ms=0` or equivalent skipped metadata appears on the zero-active path
+- repeated `Jobs acquire gate enabled; declining new acquisition` log spam does not continue once shutdown begins
+- the owned poller inventory on `app.state._tldw_shutdown_job_poller_inventory` includes the previously missing `audiobook`, `connectors`, `admin_backup`, and `admin_byok_validation` workers when they are enabled
+
+- [ ] **Step 4: Manual idle Docker/container-stop acceptance**
+
+Use the same local container launch path already reproducing the issue, then stop that container while the server is idle:
+
+```bash
+docker stop <your-local-tldw-container-name>
+```
+
+Confirm the container logs show the same acceptance criteria as the local `uvicorn` path and that total idle shutdown also completes within `<= 8000 ms` from the first shutdown transition log to `Application shutdown complete.`
+
+- [ ] **Step 5: Commit only if verification required a real code change**
+
+```bash
+git add <verification-fix-paths>
+git commit -m "fix: address idle shutdown verification regressions"
+```

--- a/Docs/superpowers/specs/2026-04-18-idle-shutdown-winddown-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-18-idle-shutdown-winddown-remediation-design.md
@@ -39,6 +39,7 @@ This design covers:
 This design includes:
 
 - removing the synthetic Evaluations pool shutdown wait
+- inventorying started in-process job pollers and closing shutdown-ownership gaps
 - stopping jobs workers earlier in the shutdown sequence
 - adding lightweight shutdown duration logging around major teardown blocks
 
@@ -58,7 +59,8 @@ This design does not include:
 Fix the proven idle-shutdown hotspots first:
 
 - make the Evaluations pool maintenance thread interruptible on shutdown
-- move jobs-worker stop signaling earlier in `main.py`
+- inventory all started `acquire_next_job()` pollers and close missing stop ownership
+- move jobs-worker stop signaling earlier in `main.py` for the idle path while preserving lease-drain behavior
 - add timing logs around major teardown blocks
 
 Why this is preferred:
@@ -96,7 +98,8 @@ Use the recommended targeted remediation with targeted instrumentation.
 The design is intentionally narrow:
 
 - eliminate the fixed Evaluations pool shutdown wait
-- quiesce jobs workers earlier so they stop polling once draining begins
+- make shutdown ownership explicit for started in-process job pollers
+- quiesce jobs workers earlier on the idle path so they stop polling once draining begins
 - make the remaining shutdown path legible through per-block duration logs
 
 ## Architecture And Change Boundaries
@@ -114,20 +117,40 @@ The desired shape is:
 
 The critical behavioral change is that shutdown no longer pays a fixed five-second tax just because the maintenance thread happens to be in its sleep window.
 
+For this slice, the Evaluations shutdown invocation should remain synchronous in the lifespan path after the synthetic join wait is removed. The remaining work is a bounded close of SQLite connections and maintenance-thread teardown, which should be measured directly via shutdown timing logs. Moving this shutdown behind `asyncio.to_thread(...)` is not part of this slice unless post-fix timing still shows material event-loop blocking.
+
 ### 2. Worker Quiescing Order
 
-Change the shutdown order in `tldw_Server_API/app/main.py` so worker stop events are set immediately after the transition-to-draining handoff rather than much later in the teardown tail.
+Change the shutdown order in `tldw_Server_API/app/main.py` so the idle-shutdown path reaches worker stop signaling much earlier than it does today, while preserving the current bounded lease-drain behavior for non-idle shutdowns.
+
+Before changing order, build an inventory of all started in-process `acquire_next_job()` pollers and ensure each one has explicit shutdown ownership from `main.py` or an equivalent registered stop hook. This includes:
+
+- workers started directly with an explicit stop event
+- workers started through helper functions that currently return only a task or hide the stop signal internally
+
+The remediation is not just a reorder of the existing stop block. It must also close ownership gaps so that every started poller is either:
+
+- explicitly stop-signaled,
+- explicitly cancelled as documented fallback behavior, or
+- intentionally excluded with a written rationale
+
+Examples already visible in the current code include:
+
+- `audiobook_jobs_task`, which is started with a stop event but is not currently handled in the existing teardown block
+- helper-started workers such as reminder and connectors workers, where shutdown ownership is not exposed in the same way as the directly managed pollers
 
 The desired shape is:
 
 - mark lifecycle as draining
 - enable the Jobs acquire gate
-- signal jobs workers to stop
+- inspect whether active processing jobs exist
+- if `JOBS_SHUTDOWN_WAIT_FOR_LEASES_SEC > 0` and active processing jobs exist, preserve the existing bounded lease wait
+- once the lease wait completes, or immediately when there are no active processing jobs, signal or stop all inventoried job pollers
 - only then continue through the rest of teardown
 
 This should prevent idle workers from continuing their one-second polling loops during shutdown and reduce log noise such as repeated `Jobs acquire gate enabled; declining new acquisition` messages.
 
-This is a sequencing change, not a change to the logical shutdown contract. The workers should still stop using their existing stop-event paths where available.
+This is a sequencing and ownership-hardening change, not a change to the logical shutdown contract. The idle path should stop pollers immediately after the drain handoff, while the non-idle path should preserve the existing lease-drain semantics when configured.
 
 ### 3. Shutdown Observability
 
@@ -139,17 +162,31 @@ This does not need a new metrics system or a full tracing model. The requirement
 - surface any materially slow block in a single pass through the logs
 - record total app-teardown wall time
 
+At minimum, the logged timing segments should cover:
+
+- transition handoff / drain gate
+- optional lease wait
+- job poller quiesce
+- Evaluations pool shutdown
+- unified audit plus executor shutdown
+- telemetry shutdown
+- total app teardown
+
 This should make future shutdown regressions attributable without needing to manually reconstruct timing from raw log timestamps.
 
 ## Expected Behavior
 
 After this change, the idle shutdown sequence should behave like:
 
-`mark draining` -> `set acquire gate` -> `signal jobs workers to stop immediately` -> `run remaining teardown` -> `emit per-block durations` -> `complete uvicorn shutdown`
+`mark draining` -> `set acquire gate` -> `observe zero active processing jobs` -> `stop all owned job pollers` -> `run remaining teardown` -> `emit per-block durations` -> `complete uvicorn shutdown`
 
 The important difference is that idle workers should stop because they were explicitly told to stop, not because they keep waking up, discovering the gate is closed, and polling again until a later shutdown phase reaches them.
 
 For the Evaluations pool, the maintenance-thread shutdown path should become signal-driven and near-immediate in the normal case.
+
+When active processing jobs exist and `JOBS_SHUTDOWN_WAIT_FOR_LEASES_SEC` is configured, the expected sequence should remain:
+
+`mark draining` -> `set acquire gate` -> `perform bounded lease wait` -> `stop all owned job pollers` -> `run remaining teardown` -> `emit per-block durations` -> `complete uvicorn shutdown`
 
 ## Failure Handling
 
@@ -158,6 +195,7 @@ Shutdown must remain best-effort and should not become more brittle because of t
 Required behavior:
 
 - if early worker stop signaling fails for a specific worker, log the failure and continue shutdown
+- if a started poller lacks clean shutdown ownership today, this slice must either add that ownership explicitly or document and use an explicit cancel fallback
 - if the Evaluations maintenance thread does not exit promptly after being signaled, retain a bounded join fallback
 - if duration logging itself fails, it must not affect shutdown correctness
 
@@ -175,8 +213,10 @@ Add focused tests for:
   - verify shutdown does not spend about five seconds waiting on a sleeping maintenance thread in the normal case
   - verify the maintenance worker exits after receiving the shutdown signal
 - lifespan shutdown sequencing:
-  - verify worker stop signaling happens before the long resource-cleanup tail
+  - verify the zero-active-processing path reaches poller quiesce before the long resource-cleanup tail
+  - verify the active-processing path preserves bounded lease-wait behavior when `JOBS_SHUTDOWN_WAIT_FOR_LEASES_SEC` is configured
   - verify idle workers do not continue repeated acquire-gate polling after shutdown begins
+  - verify all started in-process `acquire_next_job()` pollers have explicit shutdown ownership or a documented intentional exclusion
 
 Tests should stay narrow and behavior-oriented rather than trying to assert every log line in the full lifespan teardown.
 
@@ -189,20 +229,24 @@ Run manual verification for:
 
 The validation should confirm:
 
+- idle shutdown completes within the numeric target defined below
 - idle shutdown no longer spends about five seconds in Evaluations pool shutdown
-- jobs workers stop promptly after drain begins
+- jobs workers stop promptly after drain begins on the zero-active-processing path
+- non-idle shutdown still preserves bounded lease-wait behavior when configured
 - repeated acquire-gate polling log spam disappears or is substantially reduced
-- the logs clearly identify the slowest remaining shutdown block, if any
+- the required timing segments appear in the logs and clearly identify the slowest remaining shutdown block, if any
 
 ## Acceptance Criteria
 
 This design is complete when the implementation achieves all of the following:
 
-- idle local plain `uvicorn` shutdown completes materially faster than the current baseline
-- idle Docker/container stop completes materially faster than the current baseline
-- the fixed five-second Evaluations pool shutdown stall is removed in the normal case
-- jobs workers are quiesced early enough that they do not continue polling through most of shutdown
-- shutdown logs identify the slowest remaining teardown block and total shutdown wall time
+- idle local plain `uvicorn` shutdown completes in 8 seconds or less from the first shutdown transition log to `Application shutdown complete.` under default config with zero active processing jobs
+- idle Docker/container stop completes in 8 seconds or less under the same zero-active-processing conditions
+- the Evaluations pool shutdown timing segment completes in 1 second or less in the normal idle case
+- the zero-active-processing path reaches poller quiesce immediately after the drain handoff without first spending time in a lease-wait loop
+- the active-processing path preserves the existing bounded lease-wait semantics when `JOBS_SHUTDOWN_WAIT_FOR_LEASES_SEC` is configured
+- every started in-process `acquire_next_job()` poller has explicit shutdown ownership or a documented intentional exclusion with rationale
+- shutdown logs include durations for transition handoff, optional lease wait, job poller quiesce, Evaluations pool shutdown, unified audit plus executor shutdown, telemetry shutdown, and total app teardown
 
 ## Risks
 

--- a/Docs/superpowers/specs/2026-04-18-idle-shutdown-winddown-remediation-design.md
+++ b/Docs/superpowers/specs/2026-04-18-idle-shutdown-winddown-remediation-design.md
@@ -1,0 +1,228 @@
+# Idle Shutdown Wind-Down Remediation Design
+
+Date: 2026-04-18
+Topic: Idle shutdown latency for local `uvicorn` and Docker/container stop
+Status: Approved design
+
+## Goal
+
+Reduce the long wind-down time during idle shutdown for the local plain `uvicorn` path and Docker/container stop path.
+
+This slice is specifically about shutdowns where the server is effectively idle. The target is to remove fixed or avoidable teardown waits so the process exits promptly when there is no meaningful work left to drain.
+
+## Observed Behavior And Evidence
+
+The current code and the captured shutdown log point to two concrete contributors:
+
+1. The Evaluations connection pool shutdown blocks for about five seconds even on an idle shutdown.
+   - In the captured log, `tldw_Server_API.app.core.Evaluations.connection_pool:shutdown` starts at `2026-04-18 12:13:11.551` and completes at `2026-04-18 12:13:16.556`.
+   - This aligns with `tldw_Server_API/app/core/Evaluations/connection_pool.py`, where shutdown sets `_shutdown = True` and then calls `self._maintenance_task.join(timeout=5)`.
+   - The maintenance worker itself sleeps in a loop for up to 60 seconds between maintenance passes, which strongly suggests the five-second stall is synthetic waiting rather than real cleanup work.
+
+2. Jobs workers continue polling during shutdown after the acquire gate has already closed.
+   - The captured log shows repeated `Jobs acquire gate enabled; declining new acquisition` messages at one-second intervals during shutdown.
+   - The same span also shows repeated `Ensured user directory exists` log lines, which indicates worker activity is still happening even though the app is already draining.
+   - This means the drain gate is being enabled earlier than worker stop signaling, so idle workers continue their polling loops until a later shutdown step finally stops them.
+
+The captured shutdown also shows that the app eventually exits immediately after `Application shutdown complete.` from uvicorn, so in this trace the dominant delay is inside the application lifespan teardown rather than uvicorn's outer graceful-shutdown timer.
+
+## Scope
+
+This design covers:
+
+- idle shutdown for local plain `uvicorn`
+- idle shutdown for Docker/container stop
+- the FastAPI lifespan teardown path in `tldw_Server_API/app/main.py`
+- the Evaluations connection pool maintenance-thread shutdown path in `tldw_Server_API/app/core/Evaluations/connection_pool.py`
+- shutdown timing logs needed to identify the next slow teardown block quickly
+
+This design includes:
+
+- removing the synthetic Evaluations pool shutdown wait
+- stopping jobs workers earlier in the shutdown sequence
+- adding lightweight shutdown duration logging around major teardown blocks
+
+## Out Of Scope
+
+This design does not include:
+
+- a full rewrite of the shutdown coordinator model
+- reworking busy shutdown semantics for active requests, active jobs, or active WebSocket sessions
+- converting every legacy teardown step in `main.py` into a coordinated shutdown component
+- general performance cleanup outside the shutdown path
+
+## Approaches Considered
+
+### Recommended: Targeted remediation with targeted instrumentation
+
+Fix the proven idle-shutdown hotspots first:
+
+- make the Evaluations pool maintenance thread interruptible on shutdown
+- move jobs-worker stop signaling earlier in `main.py`
+- add timing logs around major teardown blocks
+
+Why this is preferred:
+
+- directly addresses the two concrete issues proven by the captured log
+- keeps the write scope narrow and lower risk
+- improves both behavior and future diagnosis
+- avoids turning a bounded remediation into a large shutdown architecture project
+
+### Alternative: Instrumentation-first, behavior changes later
+
+Add detailed shutdown timing logs first, ship that alone, and defer behavioral changes until after another data-gathering round.
+
+Trade-offs:
+
+- lower initial behavior risk
+- slower to deliver relief for the already-proven five-second stall
+- leaves the repeated worker polling noise in place
+
+### Alternative: Full shutdown refactor
+
+Move the long direct teardown tail in `main.py` into the shutdown coordinator so all shutdown work becomes centrally budgeted and summarized.
+
+Trade-offs:
+
+- best long-term architecture
+- much larger change surface
+- higher regression risk
+- not necessary to solve the concrete idle-shutdown problem already isolated
+
+## Chosen Design
+
+Use the recommended targeted remediation with targeted instrumentation.
+
+The design is intentionally narrow:
+
+- eliminate the fixed Evaluations pool shutdown wait
+- quiesce jobs workers earlier so they stop polling once draining begins
+- make the remaining shutdown path legible through per-block duration logs
+
+## Architecture And Change Boundaries
+
+### 1. Evaluations Pool Shutdown
+
+Change `tldw_Server_API/app/core/Evaluations/connection_pool.py` so the maintenance thread is wakeable on shutdown rather than relying on a long sleep and a fixed `join(timeout=5)`.
+
+The desired shape is:
+
+- the maintenance worker waits on a shutdown signal instead of only `time.sleep(...)`
+- `shutdown()` triggers that signal before joining the thread
+- the normal idle-shutdown path exits near-immediately after signaling
+- a bounded join remains as a defensive fallback in case the thread still does not exit cleanly
+
+The critical behavioral change is that shutdown no longer pays a fixed five-second tax just because the maintenance thread happens to be in its sleep window.
+
+### 2. Worker Quiescing Order
+
+Change the shutdown order in `tldw_Server_API/app/main.py` so worker stop events are set immediately after the transition-to-draining handoff rather than much later in the teardown tail.
+
+The desired shape is:
+
+- mark lifecycle as draining
+- enable the Jobs acquire gate
+- signal jobs workers to stop
+- only then continue through the rest of teardown
+
+This should prevent idle workers from continuing their one-second polling loops during shutdown and reduce log noise such as repeated `Jobs acquire gate enabled; declining new acquisition` messages.
+
+This is a sequencing change, not a change to the logical shutdown contract. The workers should still stop using their existing stop-event paths where available.
+
+### 3. Shutdown Observability
+
+Add lightweight duration logging around the major teardown blocks that remain in `main.py`.
+
+This does not need a new metrics system or a full tracing model. The requirement is simpler:
+
+- log start and end durations for the major shutdown blocks
+- surface any materially slow block in a single pass through the logs
+- record total app-teardown wall time
+
+This should make future shutdown regressions attributable without needing to manually reconstruct timing from raw log timestamps.
+
+## Expected Behavior
+
+After this change, the idle shutdown sequence should behave like:
+
+`mark draining` -> `set acquire gate` -> `signal jobs workers to stop immediately` -> `run remaining teardown` -> `emit per-block durations` -> `complete uvicorn shutdown`
+
+The important difference is that idle workers should stop because they were explicitly told to stop, not because they keep waking up, discovering the gate is closed, and polling again until a later shutdown phase reaches them.
+
+For the Evaluations pool, the maintenance-thread shutdown path should become signal-driven and near-immediate in the normal case.
+
+## Failure Handling
+
+Shutdown must remain best-effort and should not become more brittle because of these changes.
+
+Required behavior:
+
+- if early worker stop signaling fails for a specific worker, log the failure and continue shutdown
+- if the Evaluations maintenance thread does not exit promptly after being signaled, retain a bounded join fallback
+- if duration logging itself fails, it must not affect shutdown correctness
+
+The overall principle is that observability and optimization must not be allowed to block process exit or mask the original shutdown flow.
+
+## Testing Strategy
+
+The implementation plan should include both focused tests and manual validation.
+
+### Automated Tests
+
+Add focused tests for:
+
+- Evaluations pool shutdown:
+  - verify shutdown does not spend about five seconds waiting on a sleeping maintenance thread in the normal case
+  - verify the maintenance worker exits after receiving the shutdown signal
+- lifespan shutdown sequencing:
+  - verify worker stop signaling happens before the long resource-cleanup tail
+  - verify idle workers do not continue repeated acquire-gate polling after shutdown begins
+
+Tests should stay narrow and behavior-oriented rather than trying to assert every log line in the full lifespan teardown.
+
+### Manual Validation
+
+Run manual verification for:
+
+- local plain `uvicorn`
+- Docker/container stop
+
+The validation should confirm:
+
+- idle shutdown no longer spends about five seconds in Evaluations pool shutdown
+- jobs workers stop promptly after drain begins
+- repeated acquire-gate polling log spam disappears or is substantially reduced
+- the logs clearly identify the slowest remaining shutdown block, if any
+
+## Acceptance Criteria
+
+This design is complete when the implementation achieves all of the following:
+
+- idle local plain `uvicorn` shutdown completes materially faster than the current baseline
+- idle Docker/container stop completes materially faster than the current baseline
+- the fixed five-second Evaluations pool shutdown stall is removed in the normal case
+- jobs workers are quiesced early enough that they do not continue polling through most of shutdown
+- shutdown logs identify the slowest remaining teardown block and total shutdown wall time
+
+## Risks
+
+The main risks are:
+
+- changing shutdown ordering could surface latent assumptions about workers still running deeper into teardown
+- the Evaluations pool maintenance thread may have hidden coupling that assumes periodic sleep instead of signal-driven wakeup
+- overly chatty duration logging could reduce readability if applied too broadly
+
+These risks are contained by keeping the scope narrow, preserving bounded fallbacks, and instrumenting only the major teardown blocks rather than every line of shutdown code.
+
+## Non-Goals
+
+This design is not a mandate to:
+
+- coordinator-ize all legacy shutdown logic
+- optimize every teardown block in one pass
+- tune outer uvicorn graceful-shutdown settings
+- change busy-shutdown semantics for in-flight work
+
+## Next Step
+
+The next step after spec approval is to write a concrete implementation plan for the remediation work itself. No implementation changes are authorized by this design document alone.

--- a/tldw_Server_API/Config_Files/config.txt
+++ b/tldw_Server_API/Config_Files/config.txt
@@ -105,8 +105,8 @@ runner_args = ["run", "./cmd/tldw-agent-acp"]
 # Working directory for the runner process (e.g. ../tldw-agent).
 runner_cwd = ../tldw-agent
 # Runner environment (comma-separated key=value or JSON).
-# If you point HOME at a local ACP stub config, use an absolute path to avoid Go GOMODCACHE errors.
-runner_env = HOME=/Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/Config_Files/acp_runner_home,PYTHONUNBUFFERED=1
+# Relative HOME values are resolved against this Config_Files directory.
+runner_env = HOME=./acp_runner_home,PYTHONUNBUFFERED=1
 # Startup timeout for runner initialize.
 startup_timeout_ms = 10000
 # Phase 2b default-on rollout for the stable provider:model cohort.

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
@@ -197,8 +197,11 @@ def load_acp_runner_config() -> ACPRunnerConfig:
     command = os.getenv("ACP_RUNNER_COMMAND") or section.get("runner_command", "")
     args_raw = os.getenv("ACP_RUNNER_ARGS") or section.get("runner_args", "")
     env_override = os.getenv("ACP_RUNNER_ENV")
-    env_raw = env_override or section.get("runner_env", "")
-    cwd = os.getenv("ACP_RUNNER_CWD") or section.get("runner_cwd")
+    has_env_override = env_override is not None
+    env_raw = env_override if has_env_override else section.get("runner_env", "")
+    cwd_override = os.getenv("ACP_RUNNER_CWD")
+    has_cwd_override = cwd_override is not None
+    cwd = cwd_override if has_cwd_override else section.get("runner_cwd")
 
     # If binary_path is set, use it as the command directly (shortcut)
     if binary_path and not command:
@@ -217,7 +220,7 @@ def load_acp_runner_config() -> ACPRunnerConfig:
     resolved_cwd = _resolve_cwd(str(cwd) if cwd else None)
     runner_env = _resolve_runner_env_paths(
         _parse_env(env_raw),
-        resolve_relative_home=env_override is None,
+        resolve_relative_home=not has_env_override,
     )
 
     return ACPRunnerConfig(

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
@@ -161,12 +161,43 @@ def _parse_env(raw: str | None) -> dict[str, str]:
     return env
 
 
+def _resolve_runner_env_paths(
+    raw_env: dict[str, str],
+    *,
+    resolve_relative_home: bool = True,
+) -> dict[str, str]:
+    """Normalize ACP runner env paths that are config-relative by convention."""
+    if not raw_env:
+        return {}
+
+    env = dict(raw_env)
+    home = env.get("HOME")
+    if not resolve_relative_home or not home:
+        return env
+
+    home = home.strip()
+    if not home or os.path.isabs(home):
+        return env
+
+    config_dir = _get_config_file_dir()
+    resolved_home = os.path.normpath(os.path.join(config_dir, home))
+    env["HOME"] = resolved_home
+    logger.debug(
+        "ACP runner_env HOME resolved: '{}' -> '{}' (config dir: {})",
+        home,
+        resolved_home,
+        config_dir,
+    )
+    return env
+
+
 def load_acp_runner_config() -> ACPRunnerConfig:
     section = get_config_section("ACP")
     binary_path = os.getenv("ACP_RUNNER_BINARY_PATH") or section.get("runner_binary_path")
     command = os.getenv("ACP_RUNNER_COMMAND") or section.get("runner_command", "")
     args_raw = os.getenv("ACP_RUNNER_ARGS") or section.get("runner_args", "")
-    env_raw = os.getenv("ACP_RUNNER_ENV") or section.get("runner_env", "")
+    env_override = os.getenv("ACP_RUNNER_ENV")
+    env_raw = env_override or section.get("runner_env", "")
     cwd = os.getenv("ACP_RUNNER_CWD") or section.get("runner_cwd")
 
     # If binary_path is set, use it as the command directly (shortcut)
@@ -184,11 +215,15 @@ def load_acp_runner_config() -> ACPRunnerConfig:
             timeout_sec = float(timeout_raw) / 1000.0
 
     resolved_cwd = _resolve_cwd(str(cwd) if cwd else None)
+    runner_env = _resolve_runner_env_paths(
+        _parse_env(env_raw),
+        resolve_relative_home=env_override is None,
+    )
 
     return ACPRunnerConfig(
         command=str(command or ""),
         args=_parse_args(args_raw),
-        env=_parse_env(env_raw),
+        env=runner_env,
         cwd=resolved_cwd,
         startup_timeout_sec=timeout_sec,
         binary_path=str(binary_path) if binary_path else None,

--- a/tldw_Server_API/app/core/Evaluations/connection_pool.py
+++ b/tldw_Server_API/app/core/Evaluations/connection_pool.py
@@ -540,6 +540,15 @@ class ConnectionPool:
         self._shutdown = True
         self._maintenance_shutdown_event.set()
 
+        # Wait for maintenance to exit before mutating pool state so the
+        # normal shutdown path does not race with an in-flight cleanup cycle.
+        if self._maintenance_task and self._maintenance_task.is_alive():
+            self._maintenance_task.join(timeout=1.0)
+            if self._maintenance_task.is_alive():
+                logger.warning(
+                    "Connection pool maintenance thread still alive after 1.0s shutdown wait"
+                )
+
         with self._condition:
             # Close all pooled connections
             while self._pool:
@@ -552,10 +561,6 @@ class ConnectionPool:
 
             self._overflow_connections.clear()
             self._condition.notify_all()
-
-        # Wait for maintenance task to finish
-        if self._maintenance_task and self._maintenance_task.is_alive():
-            self._maintenance_task.join(timeout=1.0)
 
         logger.info("Connection pool shutdown complete")
 

--- a/tldw_Server_API/app/core/Evaluations/connection_pool.py
+++ b/tldw_Server_API/app/core/Evaluations/connection_pool.py
@@ -171,6 +171,7 @@ class ConnectionPool:
         # Background maintenance
         self._maintenance_task = None
         self._shutdown = False
+        self._maintenance_shutdown_event = threading.Event()
 
         # Initialize pool
         self._initialize_pool()
@@ -390,10 +391,12 @@ class ConnectionPool:
             while not self._shutdown:
                 try:
                     self._perform_maintenance()
-                    time.sleep(60)  # Run every minute
+                    if self._maintenance_shutdown_event.wait(timeout=60.0):
+                        return
                 except Exception as e:
                     logger.error(f"Pool maintenance error: {e}")
-                    time.sleep(30)
+                    if self._maintenance_shutdown_event.wait(timeout=30.0):
+                        return
 
         self._maintenance_task = threading.Thread(target=maintenance_worker, daemon=True)
         self._maintenance_task.start()
@@ -535,6 +538,7 @@ class ConnectionPool:
         logger.info("Shutting down connection pool")
 
         self._shutdown = True
+        self._maintenance_shutdown_event.set()
 
         with self._condition:
             # Close all pooled connections
@@ -551,7 +555,7 @@ class ConnectionPool:
 
         # Wait for maintenance task to finish
         if self._maintenance_task and self._maintenance_task.is_alive():
-            self._maintenance_task.join(timeout=5)
+            self._maintenance_task.join(timeout=1.0)
 
         logger.info("Connection pool shutdown complete")
 

--- a/tldw_Server_API/app/core/Evaluations/recipe_runs_jobs_worker.py
+++ b/tldw_Server_API/app/core/Evaluations/recipe_runs_jobs_worker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 import time
@@ -1049,7 +1050,7 @@ async def handle_recipe_run_job_async(job: dict[str, Any]) -> dict[str, Any]:
     return await asyncio.to_thread(handle_recipe_run_job, job)
 
 
-async def run_recipe_run_jobs_worker() -> None:
+async def run_recipe_run_jobs_worker(stop_event: asyncio.Event | None = None) -> None:
     """Run the WorkerSDK loop for recipe-run Jobs."""
     worker_id = (os.getenv("EVALUATIONS_RECIPE_RUN_JOBS_WORKER_ID") or f"recipe-run-{os.getpid()}").strip()
     cfg = WorkerConfig(
@@ -1059,8 +1060,24 @@ async def run_recipe_run_jobs_worker() -> None:
     )
     jm = JobManager()
     sdk = WorkerSDK(jm, cfg)
+    stop_task: asyncio.Task[None] | None = None
+    if stop_event is not None:
+        async def _watch_stop() -> None:
+            await stop_event.wait()
+            sdk.stop()
+
+        stop_task = asyncio.create_task(
+            _watch_stop(),
+            name="recipe_run_jobs_worker_stop_watch",
+        )
     logger.info("Recipe run Jobs worker starting: queue={} worker_id={}", cfg.queue, worker_id)
-    await sdk.run(handler=handle_recipe_run_job_async)
+    try:
+        await sdk.run(handler=handle_recipe_run_job_async)
+    finally:
+        if stop_task is not None:
+            stop_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stop_task
 
 
 def recipe_run_jobs_worker_enabled() -> bool:
@@ -1070,12 +1087,14 @@ def recipe_run_jobs_worker_enabled() -> bool:
     )
 
 
-async def start_recipe_run_jobs_worker() -> asyncio.Task[None] | None:
+async def start_recipe_run_jobs_worker(
+    stop_event: asyncio.Event | None = None,
+) -> asyncio.Task[None] | None:
     """Start the recipe-run worker as a background task."""
     if not recipe_run_jobs_worker_enabled():
         return None
     return asyncio.create_task(
-        run_recipe_run_jobs_worker(),
+        run_recipe_run_jobs_worker(stop_event),
         name="recipe_run_jobs_worker",
     )
 

--- a/tldw_Server_API/app/core/Jobs/worker_sdk.py
+++ b/tldw_Server_API/app/core/Jobs/worker_sdk.py
@@ -73,12 +73,32 @@ class WorkerSDK:
             self._max_iters = 0
 
     async def _sleep_chunked(self, total_seconds: float) -> None:
-        """Compatibility helper retained for potential future use.
+        """Sleep until the delay elapses or stop() is requested.
 
-        Tests patch `self._sleep` to a stub that yields immediately, so using
-        direct sleeps in code paths under test is safe and deterministic.
+        The worker loop spends most of its idle time in backoff sleeps. When
+        shutdown calls stop(), we need those sleeps to wake promptly instead of
+        waiting out the full backoff interval.
         """
-        await self._sleep(max(0.0, float(total_seconds)))
+        delay = max(0.0, float(total_seconds))
+        if delay <= 0 or self._stop.is_set():
+            return
+
+        sleep_task = asyncio.create_task(self._sleep(delay))
+        stop_task = asyncio.create_task(self._stop.wait())
+        try:
+            done, _ = await asyncio.wait(
+                {sleep_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if sleep_task in done:
+                await sleep_task
+        finally:
+            for task in (sleep_task, stop_task):
+                if task.done():
+                    continue
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
 
     def stop(self) -> None:
         self._stop.set()
@@ -93,7 +113,7 @@ class WorkerSDK:
         while not self._stop.is_set():
             # Sleep for lease - threshold, plus small jitter
             sleep_for = max(1, lease - threshold) + (random.randint(0, jitter) if jitter else 0)
-            await self._sleep(float(sleep_for))
+            await self._sleep_chunked(float(sleep_for))
             if self._stop.is_set():
                 return
             kwargs = {"job_id": job_id, "seconds": lease, "worker_id": self.cfg.worker_id, "lease_id": lease_id}
@@ -149,7 +169,9 @@ class WorkerSDK:
                 job = None
             if not job:
                 # Sleep with backoff
-                await self._sleep(float(min(backoff, backoff_max)))
+                await self._sleep_chunked(float(min(backoff, backoff_max)))
+                if self._stop.is_set():
+                    break
                 backoff = min(backoff * 2, backoff_max)
                 continue
             backoff = max(1, int(self.cfg.backoff_base_seconds))

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
 
 #
 # Local Imports
@@ -18,6 +19,7 @@ import os as _env_os
 # 3rd-party Libraries
 import sys
 import threading
+import time
 from contextlib import asynccontextmanager, contextmanager, suppress
 from pathlib import Path
 from typing import Any
@@ -293,6 +295,257 @@ async def _run_coordinated_shutdown(
         coordinated_legacy_summary.wall_time_ms,
     )
     return coordinated_legacy_component_names
+
+
+@dataclass
+class _ManagedJobPoller:
+    """Shutdown-owned in-process job poller handle."""
+
+    name: str
+    task: asyncio.Task[Any]
+    stop_event: asyncio.Event | None = None
+    timeout_sec: float = 5.0
+
+
+def _publish_shutdown_job_poller_inventory(
+    app: FastAPI,
+    handles: list[_ManagedJobPoller],
+) -> None:
+    """Expose shutdown-owned job poller metadata on app.state."""
+    inventory = [
+        {
+            "name": handle.name,
+            "task_name": handle.task.get_name(),
+            "has_stop_event": handle.stop_event is not None,
+            "timeout_sec": handle.timeout_sec,
+        }
+        for handle in handles
+    ]
+    try:
+        app.state._tldw_shutdown_job_poller_inventory = inventory
+    except _STARTUP_GUARD_EXCEPTIONS:
+        pass
+
+
+def _register_owned_job_poller(
+    app: FastAPI,
+    handles: list[_ManagedJobPoller],
+    *,
+    name: str,
+    task: asyncio.Task[Any] | None,
+    stop_event: asyncio.Event | None = None,
+    timeout_sec: float = 5.0,
+) -> None:
+    """Register one shutdown-owned job poller and refresh app-state inventory."""
+    if task is None:
+        return
+    handles.append(
+        _ManagedJobPoller(
+            name=name,
+            task=task,
+            stop_event=stop_event,
+            timeout_sec=timeout_sec,
+        )
+    )
+    _publish_shutdown_job_poller_inventory(app, handles)
+
+
+def _replace_owned_job_poller_inventory(
+    app: FastAPI,
+    handles: list[_ManagedJobPoller],
+    *,
+    registrations: list[tuple[str, asyncio.Task[Any] | None, asyncio.Event | None, float]],
+) -> None:
+    """Replace the managed job-poller inventory with the current owned poller set."""
+    handles.clear()
+    _publish_shutdown_job_poller_inventory(app, handles)
+    for name, task, stop_event, timeout_sec in registrations:
+        _register_owned_job_poller(
+            app,
+            handles,
+            name=name,
+            task=task,
+            stop_event=stop_event,
+            timeout_sec=timeout_sec,
+        )
+
+
+def _record_shutdown_timing_segment(
+    app: FastAPI,
+    segment: str,
+    duration_ms: int,
+    **extra: object,
+) -> None:
+    """Store one shutdown timing segment and emit a consistent log line."""
+    payload = {"segment": segment, "duration_ms": max(int(duration_ms), 0), **extra}
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments", None)
+    if not isinstance(segments, list):
+        segments = []
+        try:
+            app.state._tldw_shutdown_timing_segments = segments
+        except _STARTUP_GUARD_EXCEPTIONS:
+            return
+    segments.append(payload)
+    extra_text = " ".join(f"{key}={value}" for key, value in extra.items())
+    if extra_text:
+        logger.info(f"App Shutdown Timing: segment={segment} duration_ms={payload['duration_ms']} {extra_text}")
+    else:
+        logger.info(f"App Shutdown Timing: segment={segment} duration_ms={payload['duration_ms']}")
+
+
+@contextmanager
+def _timed_shutdown_segment(
+    app: FastAPI,
+    segment: str,
+    **extra: object,
+) -> Iterator[None]:
+    """Measure a shutdown block with monotonic time and record it on app.state."""
+    started = time.monotonic()
+    try:
+        yield
+    finally:
+        duration_ms = int((time.monotonic() - started) * 1000)
+        _record_shutdown_timing_segment(app, segment, duration_ms, **extra)
+
+
+def _record_shutdown_timing_total(app: FastAPI, duration_ms: int) -> None:
+    """Record total teardown time and summarize the slowest non-total segment."""
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments", [])
+    non_total_segments = [
+        entry
+        for entry in segments
+        if isinstance(entry, dict) and entry.get("segment") != "total app teardown"
+    ]
+    if non_total_segments:
+        slowest = max(non_total_segments, key=lambda entry: int(entry.get("duration_ms", 0)))
+        slowest_segment = str(slowest.get("segment", ""))
+        slowest_duration_ms = int(slowest.get("duration_ms", 0))
+    else:
+        slowest_segment = "total app teardown"
+        slowest_duration_ms = max(int(duration_ms), 0)
+    _record_shutdown_timing_segment(app, "total app teardown", duration_ms)
+    summary = {
+        "duration_ms": max(int(duration_ms), 0),
+        "slowest_segment": slowest_segment,
+        "slowest_duration_ms": slowest_duration_ms,
+    }
+    try:
+        app.state._tldw_shutdown_timing_total = summary
+    except _STARTUP_GUARD_EXCEPTIONS:
+        pass
+    logger.info(
+        "App Shutdown Timing: total duration_ms={} slowest_segment={} slowest_duration_ms={}",
+        summary["duration_ms"],
+        summary["slowest_segment"],
+        summary["slowest_duration_ms"],
+    )
+
+
+async def _stop_registered_job_pollers(
+    app: FastAPI,
+    handles: list[_ManagedJobPoller],
+) -> None:
+    """Stop registered job pollers, preferring explicit stop events."""
+    for handle in handles:
+        if handle.stop_event is not None:
+            handle.stop_event.set()
+        else:
+            with suppress(_STARTUP_GUARD_EXCEPTIONS):
+                handle.task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(handle.task), timeout=handle.timeout_sec)
+        except asyncio.CancelledError:
+            pass
+        except asyncio.TimeoutError:
+            logger.warning(
+                "App Shutdown: Timed out waiting for job poller {} after {}s; cancelling",
+                handle.name,
+                handle.timeout_sec,
+            )
+            handle.task.cancel()
+            try:
+                await asyncio.wait_for(handle.task, timeout=1.0)
+            except asyncio.CancelledError:
+                pass
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "App Shutdown: Job poller {} did not cancel within 1.0s after timeout",
+                    handle.name,
+                )
+            except _STARTUP_GUARD_EXCEPTIONS as exc:
+                logger.debug(f"App Shutdown: Job poller cancel guard triggered for {handle.name}: {exc}")
+        except _STARTUP_GUARD_EXCEPTIONS as exc:
+            logger.debug(f"App Shutdown: Job poller stop guard triggered for {handle.name}: {exc}")
+        except Exception as exc:
+            logger.warning(f"App Shutdown: Job poller {handle.name} exited during shutdown: {exc}")
+    try:
+        app.state._tldw_shutdown_quiesced_job_poller_names = [handle.name for handle in handles]
+    except _STARTUP_GUARD_EXCEPTIONS:
+        pass
+
+
+async def _quiesce_owned_job_pollers_for_shutdown(
+    app: FastAPI,
+    handles: list[_ManagedJobPoller],
+    *,
+    wait_for_leases_sec: int | float,
+    count_active_processing: Any,
+) -> None:
+    """Optionally wait for active leases, then quiesce owned job pollers.
+
+    This helper runs only after the shutdown transition handoff has enabled the
+    Jobs acquire gate, so the bounded wait drains already-leased work rather
+    than allowing new in-process pollers to claim fresh jobs.
+    """
+    lease_wait_started = time.monotonic()
+    initial_active = 0
+    if wait_for_leases_sec > 0:
+        try:
+            initial_active = max(int(count_active_processing()), 0)
+        except _STARTUP_GUARD_EXCEPTIONS:
+            initial_active = 0
+        if initial_active > 0:
+            deadline = time.monotonic() + float(wait_for_leases_sec)
+            active = initial_active
+            while active > 0:
+                remaining_sec = deadline - time.monotonic()
+                if remaining_sec <= 0:
+                    break
+                await asyncio.sleep(min(0.5, remaining_sec))
+                try:
+                    active = max(int(count_active_processing()), 0)
+                except _STARTUP_GUARD_EXCEPTIONS:
+                    active = 0
+            duration_ms = int((time.monotonic() - lease_wait_started) * 1000)
+            _record_shutdown_timing_segment(
+                app,
+                "optional_lease_wait",
+                duration_ms,
+                skipped=False,
+                initial_active=initial_active,
+                wait_for_leases_sec=float(wait_for_leases_sec),
+            )
+        else:
+            _record_shutdown_timing_segment(
+                app,
+                "optional_lease_wait",
+                0,
+                skipped=True,
+                initial_active=0,
+                wait_for_leases_sec=float(wait_for_leases_sec),
+            )
+    else:
+        _record_shutdown_timing_segment(
+            app,
+            "optional_lease_wait",
+            0,
+            skipped=True,
+            initial_active=0,
+            wait_for_leases_sec=float(wait_for_leases_sec),
+        )
+
+    with _timed_shutdown_segment(app, "job_poller_quiesce", poller_count=len(handles)):
+        await _stop_registered_job_pollers(app, handles)
 
 _early_os.environ.setdefault("MCP_INHERIT_GLOBAL_LOGGER", "1")
 try:
@@ -2559,6 +2812,7 @@ async def lifespan(app: FastAPI):
     cleanup_task = None
     chatbooks_cleanup_task = None
     core_jobs_task = None
+    audiobook_jobs_task = None
     files_jobs_task = None
     data_tables_jobs_task = None
     prompt_studio_jobs_task = None
@@ -2570,23 +2824,60 @@ async def lifespan(app: FastAPI):
     reading_digest_jobs_task = None
     study_pack_jobs_task = None
     study_suggestions_jobs_task = None
+    companion_reflection_jobs_task = None
     reminder_jobs_task = None
     admin_backup_jobs_task = None
+    admin_byok_validation_jobs_task = None
+    connectors_jobs_task = None
+    evals_abtest_jobs_task = None
+    jobs_metrics_reconcile_task = None
+    loop_lag_task = None
+    jobs_crypto_rotate_task = None
+    jobs_webhooks_task = None
+    meetings_webhook_dlq_task = None
+    workflows_dlq_task = None
+    workflows_gc_task = None
+    workflows_maint_task = None
+    jobs_integrity_task = None
+    _tts_history_cleanup_task = None
     jobs_notifications_bridge_task = None
     chatbooks_cleanup_stop_event = None
+    audiobook_jobs_stop_event = None
+    core_jobs_stop_event = None
     files_jobs_stop_event = None
     data_tables_jobs_stop_event = None
     prompt_studio_jobs_stop_event = None
     privilege_snapshot_stop_event = None
+    embeddings_compactor_stop_event = None
+    audio_jobs_stop_event = None
     presentation_render_jobs_stop_event = None
     media_ingest_jobs_stop_event = None
     media_ingest_heavy_jobs_stop_event = None
     reading_digest_jobs_stop_event = None
     study_pack_jobs_stop_event = None
     study_suggestions_jobs_stop_event = None
+    companion_reflection_jobs_stop_event = None
+    reminder_jobs_stop_event = None
+    admin_backup_jobs_stop_event = None
+    admin_byok_validation_jobs_stop_event = None
+    connectors_jobs_stop_event = None
+    evals_abtest_jobs_stop_event = None
+    jobs_metrics_stop_event = None
+    jobs_metrics_reconcile_stop = None
+    loop_lag_stop_event = None
+    jobs_crypto_rotate_stop_event = None
+    jobs_webhooks_stop_event = None
+    meetings_webhook_dlq_stop_event = None
+    workflows_dlq_stop_event = None
+    workflows_gc_stop_event = None
+    workflows_maint_stop_event = None
+    jobs_integrity_stop_event = None
+    _tts_history_cleanup_stop_event = None
     claims_task = None
     jobs_metrics_task = None
     reminders_sched_task = None
+    owned_job_pollers: list[_ManagedJobPoller] = []
+    _publish_shutdown_job_poller_inventory(app, owned_job_pollers)
     try:
         import asyncio as _asyncio
         import os as _os
@@ -2733,6 +3024,13 @@ async def lifespan(app: FastAPI):
             core_jobs_stop_event = _asyncio.Event()
             core_jobs_task = _asyncio.create_task(_run_cb_jobs(core_jobs_stop_event))
             logger.info("Core Jobs worker (Chatbooks) started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="core_jobs_task",
+                task=core_jobs_task,
+                stop_event=core_jobs_stop_event,
+            )
         else:
             logger.info("Core Jobs worker (Chatbooks) disabled by backend selection or flag")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2752,6 +3050,13 @@ async def lifespan(app: FastAPI):
             files_jobs_stop_event = _asyncio.Event()
             files_jobs_task = _asyncio.create_task(_run_files_jobs(files_jobs_stop_event))
             logger.info("File Artifacts Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="files_jobs_task",
+                task=files_jobs_task,
+                stop_event=files_jobs_stop_event,
+            )
         else:
             logger.info("File Artifacts Jobs worker disabled by flag (FILES_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2772,6 +3077,13 @@ async def lifespan(app: FastAPI):
             data_tables_jobs_stop_event = _asyncio.Event()
             data_tables_jobs_task = _asyncio.create_task(_run_data_tables_jobs(data_tables_jobs_stop_event))
             logger.info("Data Tables Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="data_tables_jobs_task",
+                task=data_tables_jobs_task,
+                stop_event=data_tables_jobs_stop_event,
+            )
         else:
             logger.info("Data Tables Jobs worker disabled by flag (DATA_TABLES_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2792,6 +3104,13 @@ async def lifespan(app: FastAPI):
             prompt_studio_jobs_stop_event = _asyncio.Event()
             prompt_studio_jobs_task = _asyncio.create_task(_run_prompt_studio_jobs(prompt_studio_jobs_stop_event))
             logger.info("Prompt Studio Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="prompt_studio_jobs_task",
+                task=prompt_studio_jobs_task,
+                stop_event=prompt_studio_jobs_stop_event,
+            )
         else:
             logger.info("Prompt Studio Jobs worker disabled by flag (PROMPT_STUDIO_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2811,6 +3130,13 @@ async def lifespan(app: FastAPI):
             study_pack_jobs_stop_event = _asyncio.Event()
             study_pack_jobs_task = _asyncio.create_task(_run_study_pack_jobs(study_pack_jobs_stop_event))
             logger.info("Study-pack Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="study_pack_jobs_task",
+                task=study_pack_jobs_task,
+                stop_event=study_pack_jobs_stop_event,
+            )
         else:
             logger.info("Study-pack Jobs worker disabled by flag (STUDY_PACK_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2831,6 +3157,13 @@ async def lifespan(app: FastAPI):
                 _run_study_suggestions_jobs(study_suggestions_jobs_stop_event)
             )
             logger.info("Study-suggestions Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="study_suggestions_jobs_task",
+                task=study_suggestions_jobs_task,
+                stop_event=study_suggestions_jobs_stop_event,
+            )
         else:
             logger.info("Study-suggestions Jobs worker disabled by flag (STUDY_SUGGESTIONS_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2850,6 +3183,13 @@ async def lifespan(app: FastAPI):
             privilege_snapshot_stop_event = _asyncio.Event()
             privilege_snapshot_task = _asyncio.create_task(_run_priv_snapshot(privilege_snapshot_stop_event))
             logger.info("Privilege snapshot worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="privilege_snapshot_task",
+                task=privilege_snapshot_task,
+                stop_event=privilege_snapshot_stop_event,
+            )
         else:
             logger.info("Privilege snapshot worker disabled by flag (PRIVILEGE_SNAPSHOT_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2902,6 +3242,13 @@ async def lifespan(app: FastAPI):
             audio_jobs_stop_event = _asyncio.Event()
             audio_jobs_task = _asyncio.create_task(_run_audio_jobs(audio_jobs_stop_event))
             logger.info("Audio Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="audio_jobs_task",
+                task=audio_jobs_task,
+                stop_event=audio_jobs_stop_event,
+            )
         else:
             logger.info("Audio Jobs worker disabled by flag (AUDIO_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2920,6 +3267,13 @@ async def lifespan(app: FastAPI):
             audiobook_jobs_stop_event = _asyncio.Event()
             audiobook_jobs_task = _asyncio.create_task(_run_audiobook_jobs(audiobook_jobs_stop_event))
             logger.info("Audiobook Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="audiobook_jobs_task",
+                task=audiobook_jobs_task,
+                stop_event=audiobook_jobs_stop_event,
+            )
         else:
             logger.info("Audiobook Jobs worker disabled by flag (AUDIOBOOK_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -2940,6 +3294,13 @@ async def lifespan(app: FastAPI):
                 _run_presentation_render_jobs(presentation_render_jobs_stop_event)
             )
             logger.info("Presentation Render Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="presentation_render_jobs_task",
+                task=presentation_render_jobs_task,
+                stop_event=presentation_render_jobs_stop_event,
+            )
         else:
             logger.info(
                 "Presentation Render Jobs worker disabled by flag (PRESENTATION_RENDER_JOBS_WORKER_ENABLED)"
@@ -2960,13 +3321,20 @@ async def lifespan(app: FastAPI):
             media_ingest_jobs_stop_event = _asyncio.Event()
             media_ingest_jobs_task = _asyncio.create_task(_run_media_jobs(media_ingest_jobs_stop_event))
             logger.info("Media Ingest Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="media_ingest_jobs_task",
+                task=media_ingest_jobs_task,
+                stop_event=media_ingest_jobs_stop_event,
+            )
         else:
             logger.info("Media Ingest Jobs worker disabled by flag (MEDIA_INGEST_JOBS_WORKER_ENABLED)")
 
         _heavy_enabled = _should_start_worker(
             "MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED",
             "media-ingest-heavy-jobs",
-            default_enabled=False,
+            default_stable=False,
         )
         if _heavy_enabled:
             from tldw_Server_API.app.services.media_ingest_jobs_worker import (
@@ -2978,6 +3346,13 @@ async def lifespan(app: FastAPI):
                 _run_media_heavy_jobs(media_ingest_heavy_jobs_stop_event)
             )
             logger.info("Media Ingest Heavy Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="media_ingest_heavy_jobs_task",
+                task=media_ingest_heavy_jobs_task,
+                stop_event=media_ingest_heavy_jobs_stop_event,
+            )
         else:
             logger.info(
                 "Media Ingest Heavy Jobs worker disabled by flag (MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED)"
@@ -3000,6 +3375,13 @@ async def lifespan(app: FastAPI):
                 _run_reading_digest_jobs(reading_digest_jobs_stop_event)
             )
             logger.info("Reading digest Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="reading_digest_jobs_task",
+                task=reading_digest_jobs_task,
+                stop_event=reading_digest_jobs_stop_event,
+            )
         else:
             logger.info("Reading digest Jobs worker disabled by flag (READING_DIGEST_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -3020,6 +3402,13 @@ async def lifespan(app: FastAPI):
                 _run_companion_reflection_jobs(companion_reflection_jobs_stop_event)
             )
             logger.info("Companion reflection Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="companion_reflection_jobs_task",
+                task=companion_reflection_jobs_task,
+                stop_event=companion_reflection_jobs_stop_event,
+            )
         else:
             logger.info(
                 "Companion reflection Jobs worker disabled by flag (COMPANION_REFLECTION_JOBS_WORKER_ENABLED)"
@@ -3034,9 +3423,17 @@ async def lifespan(app: FastAPI):
         else:
             from tldw_Server_API.app.services.reminder_jobs_worker import start_reminder_jobs_worker
 
-            reminder_jobs_task = await start_reminder_jobs_worker()
+            reminder_jobs_stop_event = _asyncio.Event()
+            reminder_jobs_task = await start_reminder_jobs_worker(stop_event=reminder_jobs_stop_event)
             if reminder_jobs_task:
                 logger.info("Reminder Jobs worker started")
+                _register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="reminder_jobs_task",
+                    task=reminder_jobs_task,
+                    stop_event=reminder_jobs_stop_event,
+                )
             else:
                 logger.info("Reminder Jobs worker disabled (REMINDER_JOBS_WORKER_ENABLED != true)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -3049,9 +3446,19 @@ async def lifespan(app: FastAPI):
         else:
             from tldw_Server_API.app.services.admin_backup_jobs_worker import start_admin_backup_jobs_worker
 
-            admin_backup_jobs_task = await start_admin_backup_jobs_worker()
+            admin_backup_jobs_stop_event = _asyncio.Event()
+            admin_backup_jobs_task = await start_admin_backup_jobs_worker(
+                stop_event=admin_backup_jobs_stop_event
+            )
             if admin_backup_jobs_task:
                 logger.info("Admin backup Jobs worker started")
+                _register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="admin_backup_jobs_task",
+                    task=admin_backup_jobs_task,
+                    stop_event=admin_backup_jobs_stop_event,
+                )
             else:
                 logger.info("Admin backup Jobs worker disabled (ADMIN_BACKUP_JOBS_WORKER_ENABLED != true)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -3066,9 +3473,19 @@ async def lifespan(app: FastAPI):
                 start_admin_byok_validation_jobs_worker,
             )
 
-            admin_byok_validation_jobs_task = await start_admin_byok_validation_jobs_worker()
+            admin_byok_validation_jobs_stop_event = _asyncio.Event()
+            admin_byok_validation_jobs_task = await start_admin_byok_validation_jobs_worker(
+                stop_event=admin_byok_validation_jobs_stop_event
+            )
             if admin_byok_validation_jobs_task:
                 logger.info("Admin BYOK validation Jobs worker started")
+                _register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="admin_byok_validation_jobs_task",
+                    task=admin_byok_validation_jobs_task,
+                    stop_event=admin_byok_validation_jobs_stop_event,
+                )
             else:
                 logger.info(
                     "Admin BYOK validation Jobs worker disabled "
@@ -3172,6 +3589,13 @@ async def lifespan(app: FastAPI):
             evals_abtest_jobs_stop_event = _asyncio.Event()
             evals_abtest_jobs_task = _asyncio.create_task(_run_abtest_jobs(evals_abtest_jobs_stop_event))
             logger.info("Embeddings A/B Jobs worker started with explicit stop_event signal")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="evals_abtest_jobs_task",
+                task=evals_abtest_jobs_task,
+                stop_event=evals_abtest_jobs_stop_event,
+            )
         else:
             logger.info("Embeddings A/B Jobs worker disabled by flag")
     except _STARTUP_GUARD_EXCEPTIONS as e:
@@ -3221,7 +3645,7 @@ async def lifespan(app: FastAPI):
         _enabled_recon = _os.getenv("JOBS_METRICS_RECONCILE_ENABLE", "false").lower() in {"true", "1", "yes", "y", "on"}
         if _enabled_recon:
             jobs_metrics_reconcile_stop = _asyncio.Event()
-            _ = _asyncio.create_task(_run_jobs_reconcile(jobs_metrics_reconcile_stop))
+            jobs_metrics_reconcile_task = _asyncio.create_task(_run_jobs_reconcile(jobs_metrics_reconcile_stop))
             logger.info("Jobs metrics reconcile worker started with explicit stop_event signal")
         else:
             logger.info("Jobs metrics reconcile worker disabled by flag (JOBS_METRICS_RECONCILE_ENABLE)")
@@ -3635,15 +4059,76 @@ async def lifespan(app: FastAPI):
 
     # Start Connectors worker (scaffold; opt-in via env)
     try:
+        import asyncio as _asyncio
+
         from tldw_Server_API.app.services.connectors_worker import start_connectors_worker
 
-        _conn_task = await start_connectors_worker()
-        if _conn_task:
+        connectors_jobs_stop_event = _asyncio.Event()
+        connectors_jobs_task = await start_connectors_worker(stop_event=connectors_jobs_stop_event)
+        if connectors_jobs_task:
             logger.info("Connectors worker started")
+            _register_owned_job_poller(
+                app,
+                owned_job_pollers,
+                name="connectors_jobs_task",
+                task=connectors_jobs_task,
+                stop_event=connectors_jobs_stop_event,
+            )
         else:
             logger.info("Connectors worker disabled (CONNECTORS_WORKER_ENABLED != true)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
         logger.warning(f"Failed to start Connectors worker: {e}")
+
+    _replace_owned_job_poller_inventory(
+        app,
+        owned_job_pollers,
+        registrations=[
+            ("core_jobs_task", core_jobs_task, core_jobs_stop_event, 5.0),
+            ("files_jobs_task", files_jobs_task, files_jobs_stop_event, 5.0),
+            ("data_tables_jobs_task", data_tables_jobs_task, data_tables_jobs_stop_event, 5.0),
+            ("prompt_studio_jobs_task", prompt_studio_jobs_task, prompt_studio_jobs_stop_event, 5.0),
+            ("study_pack_jobs_task", study_pack_jobs_task, study_pack_jobs_stop_event, 5.0),
+            (
+                "study_suggestions_jobs_task",
+                study_suggestions_jobs_task,
+                study_suggestions_jobs_stop_event,
+                5.0,
+            ),
+            ("privilege_snapshot_task", privilege_snapshot_task, privilege_snapshot_stop_event, 5.0),
+            ("audio_jobs_task", audio_jobs_task, audio_jobs_stop_event, 5.0),
+            ("audiobook_jobs_task", audiobook_jobs_task, audiobook_jobs_stop_event, 5.0),
+            (
+                "presentation_render_jobs_task",
+                presentation_render_jobs_task,
+                presentation_render_jobs_stop_event,
+                5.0,
+            ),
+            ("media_ingest_jobs_task", media_ingest_jobs_task, media_ingest_jobs_stop_event, 5.0),
+            (
+                "media_ingest_heavy_jobs_task",
+                media_ingest_heavy_jobs_task,
+                media_ingest_heavy_jobs_stop_event,
+                5.0,
+            ),
+            ("reading_digest_jobs_task", reading_digest_jobs_task, reading_digest_jobs_stop_event, 5.0),
+            (
+                "companion_reflection_jobs_task",
+                companion_reflection_jobs_task,
+                companion_reflection_jobs_stop_event,
+                5.0,
+            ),
+            ("reminder_jobs_task", reminder_jobs_task, reminder_jobs_stop_event, 5.0),
+            ("admin_backup_jobs_task", admin_backup_jobs_task, admin_backup_jobs_stop_event, 5.0),
+            (
+                "admin_byok_validation_jobs_task",
+                admin_byok_validation_jobs_task,
+                admin_byok_validation_jobs_stop_event,
+                5.0,
+            ),
+            ("evals_abtest_jobs_task", evals_abtest_jobs_task, evals_abtest_jobs_stop_event, 5.0),
+            ("connectors_jobs_task", connectors_jobs_task, connectors_jobs_stop_event, 5.0),
+        ],
+    )
 
     # Start AuthNZ scheduler (retention/cleanup tasks) with env guard
     _authnz_sched_started = False
@@ -3906,84 +4391,96 @@ async def lifespan(app: FastAPI):
     # Build and record the legacy shutdown inventory first.
     # Execute only the narrow transition gate handoff through the coordinator;
     # the remaining legacy teardown paths stay on the existing direct teardown path.
+    shutdown_started = time.monotonic()
+    try:
+        app.state._tldw_shutdown_timing_segments = []
+    except _STARTUP_GUARD_EXCEPTIONS:
+        pass
     transition_gate_applied = False
     legacy_shutdown_plan: list[Any] = []
     coordinated_legacy_component_names: set[str] = set()
-    try:
-        from tldw_Server_API.app.services.shutdown_coordinator import ShutdownCoordinator, ShutdownPhase
-        from tldw_Server_API.app.services.shutdown_legacy_adapters import (
-            build_legacy_shutdown_plan,
-        )
-
-        shutdown_context = _build_legacy_shutdown_context(
-            readiness_state=READINESS_STATE,
-            usage_task=usage_task,
-            llm_usage_task=llm_usage_task,
-            authnz_scheduler_started=_authnz_sched_started,
-            chatbooks_cleanup_task=chatbooks_cleanup_task,
-            chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
-            storage_cleanup_service=storage_cleanup_service,
-        )
-        legacy_shutdown_plan = build_legacy_shutdown_plan(app, shutdown_context)
-        legacy_phase_groups: dict[str, list[str]] = {}
-        for component in legacy_shutdown_plan:
-            legacy_phase_groups.setdefault(component.phase.value, []).append(component.name)
-
+    with _timed_shutdown_segment(app, "transition_handoff"):
         try:
-            app.state._tldw_shutdown_legacy_plan = legacy_shutdown_plan
-            app.state._tldw_shutdown_legacy_phase_groups = legacy_phase_groups
-            app.state._tldw_shutdown_legacy_inventory_visible = bool(legacy_shutdown_plan)
-        except _STARTUP_GUARD_EXCEPTIONS:
-            pass
-
-        logger.info(
-            "App Shutdown: legacy inventory visible={} phase_groups={}",
-            bool(legacy_shutdown_plan),
-            legacy_phase_groups,
-        )
-
-        transition_coordinator = ShutdownCoordinator(profile="dev_fast")
-        for component in legacy_shutdown_plan:
-            if component.phase == ShutdownPhase.TRANSITION:
-                transition_coordinator.register(component)
-        if legacy_shutdown_plan:
-            transition_summary = await transition_coordinator.shutdown()
-            transition_gate_summary = transition_summary.components.get("lifecycle_gate")
-            transition_gate_applied = bool(
-                transition_gate_summary is not None and transition_gate_summary.result == "stopped"
+            from tldw_Server_API.app.services.shutdown_coordinator import ShutdownCoordinator, ShutdownPhase
+            from tldw_Server_API.app.services.shutdown_legacy_adapters import (
+                build_legacy_shutdown_plan,
             )
-            if transition_gate_applied:
-                logger.info("App Shutdown: legacy transition gate handoff executed via coordinator")
-            else:
-                logger.warning(
-                    "App Shutdown: legacy transition gate handoff did not complete cleanly; "
-                    "falling back to direct drain",
+
+            shutdown_context = _build_legacy_shutdown_context(
+                readiness_state=READINESS_STATE,
+                usage_task=usage_task,
+                llm_usage_task=llm_usage_task,
+                authnz_scheduler_started=_authnz_sched_started,
+                chatbooks_cleanup_task=chatbooks_cleanup_task,
+                chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
+                storage_cleanup_service=storage_cleanup_service,
+            )
+            legacy_shutdown_plan = build_legacy_shutdown_plan(app, shutdown_context)
+            legacy_phase_groups: dict[str, list[str]] = {}
+            for component in legacy_shutdown_plan:
+                legacy_phase_groups.setdefault(component.phase.value, []).append(component.name)
+
+            try:
+                app.state._tldw_shutdown_legacy_plan = legacy_shutdown_plan
+                app.state._tldw_shutdown_legacy_phase_groups = legacy_phase_groups
+                app.state._tldw_shutdown_legacy_inventory_visible = bool(legacy_shutdown_plan)
+            except _STARTUP_GUARD_EXCEPTIONS:
+                pass
+
+            logger.info(
+                "App Shutdown: legacy inventory visible={} phase_groups={}",
+                bool(legacy_shutdown_plan),
+                legacy_phase_groups,
+            )
+
+            transition_coordinator = ShutdownCoordinator(profile="dev_fast")
+            for component in legacy_shutdown_plan:
+                if component.phase == ShutdownPhase.TRANSITION:
+                    transition_coordinator.register(component)
+            if legacy_shutdown_plan:
+                transition_summary = await transition_coordinator.shutdown()
+                transition_gate_summary = transition_summary.components.get("lifecycle_gate")
+                transition_gate_applied = bool(
+                    transition_gate_summary is not None and transition_gate_summary.result == "stopped"
                 )
-    except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _legacy_shutdown_err:
-        logger.debug(f"Legacy shutdown inventory skipped: {_legacy_shutdown_err}")
-    finally:
-        if not transition_gate_applied:
-            _apply_shutdown_transition_gate(app, READINESS_STATE)
+                if transition_gate_applied:
+                    logger.info("App Shutdown: legacy transition gate handoff executed via coordinator")
+                else:
+                    logger.warning(
+                        "App Shutdown: legacy transition gate handoff did not complete cleanly; "
+                        "falling back to direct drain",
+                    )
+        except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _legacy_shutdown_err:
+            logger.debug(f"Legacy shutdown inventory skipped: {_legacy_shutdown_err}")
+        finally:
+            if not transition_gate_applied:
+                _apply_shutdown_transition_gate(app, READINESS_STATE)
 
-    # Optionally wait for leases to finish (bounded wait)
+    _max_wait = 0
+    _count_active_processing = lambda: 0
     try:
-        import asyncio as _asyncio
-        import os as _os
-
-        _max_wait = int(_os.getenv("JOBS_SHUTDOWN_WAIT_FOR_LEASES_SEC", "0") or "0")
-        if _max_wait > 0:
-            jm_chk = _JM()
-            deadline = _asyncio.get_event_loop().time() + float(_max_wait)
-            while _asyncio.get_event_loop().time() < deadline:
-                try:
-                    active = jm_chk.count_active_processing()
-                except _STARTUP_GUARD_EXCEPTIONS:
-                    active = 0
-                if active <= 0:
-                    break
-                await _asyncio.sleep(0.5)
+        _max_wait = int(_env_os.getenv("JOBS_SHUTDOWN_WAIT_FOR_LEASES_SEC", "0") or "0")
     except _STARTUP_GUARD_EXCEPTIONS:
+        _max_wait = 0
+    try:
+        from tldw_Server_API.app.core.Jobs.manager import JobManager as _ShutdownJM
+
+        _count_active_processing = _ShutdownJM().count_active_processing
+    except _IMPORT_EXCEPTIONS:
         pass
+
+    await _quiesce_owned_job_pollers_for_shutdown(
+        app,
+        owned_job_pollers,
+        wait_for_leases_sec=_max_wait,
+        count_active_processing=_count_active_processing,
+    )
+    early_quiesced_job_poller_names = set(
+        getattr(app.state, "_tldw_shutdown_quiesced_job_poller_names", [])
+    )
+
+    def _should_run_late_stop(task_name: str, task: Any) -> bool:
+        return bool(task) and task_name not in early_quiesced_job_poller_names
 
     # Execute the migrated legacy shutdown components through the coordinator.
     try:
@@ -4047,7 +4544,7 @@ async def lifespan(app: FastAPI):
             logger.info("AuthNZ limiter singletons reset")
         except _STARTUP_GUARD_EXCEPTIONS:
             pass
-        if "core_jobs_task" in locals() and core_jobs_task:
+        if "core_jobs_task" in locals() and _should_run_late_stop("core_jobs_task", core_jobs_task):
             # Prefer graceful stop via explicit stop_event
             if "core_jobs_stop_event" in locals() and core_jobs_stop_event:
                 try:
@@ -4058,7 +4555,7 @@ async def lifespan(app: FastAPI):
                     core_jobs_task.cancel()
             else:
                 core_jobs_task.cancel()
-        if "files_jobs_task" in locals() and files_jobs_task:
+        if "files_jobs_task" in locals() and _should_run_late_stop("files_jobs_task", files_jobs_task):
             # Prefer graceful stop via explicit stop_event
             if "files_jobs_stop_event" in locals() and files_jobs_stop_event:
                 try:
@@ -4070,7 +4567,7 @@ async def lifespan(app: FastAPI):
                     files_jobs_task.cancel()
             else:
                 files_jobs_task.cancel()
-        if "data_tables_jobs_task" in locals() and data_tables_jobs_task:
+        if "data_tables_jobs_task" in locals() and _should_run_late_stop("data_tables_jobs_task", data_tables_jobs_task):
             # Prefer graceful stop via explicit stop_event
             if "data_tables_jobs_stop_event" in locals() and data_tables_jobs_stop_event:
                 try:
@@ -4081,7 +4578,7 @@ async def lifespan(app: FastAPI):
                     data_tables_jobs_task.cancel()
             else:
                 data_tables_jobs_task.cancel()
-        if "prompt_studio_jobs_task" in locals() and prompt_studio_jobs_task:
+        if "prompt_studio_jobs_task" in locals() and _should_run_late_stop("prompt_studio_jobs_task", prompt_studio_jobs_task):
             # Prefer graceful stop via explicit stop_event
             if "prompt_studio_jobs_stop_event" in locals() and prompt_studio_jobs_stop_event:
                 try:
@@ -4092,7 +4589,7 @@ async def lifespan(app: FastAPI):
                     prompt_studio_jobs_task.cancel()
             else:
                 prompt_studio_jobs_task.cancel()
-        if "privilege_snapshot_task" in locals() and privilege_snapshot_task:
+        if "privilege_snapshot_task" in locals() and _should_run_late_stop("privilege_snapshot_task", privilege_snapshot_task):
             # Prefer graceful stop via explicit stop_event
             if "privilege_snapshot_stop_event" in locals() and privilege_snapshot_stop_event:
                 try:
@@ -4103,7 +4600,7 @@ async def lifespan(app: FastAPI):
                     privilege_snapshot_task.cancel()
             else:
                 privilege_snapshot_task.cancel()
-        if "audio_jobs_task" in locals() and audio_jobs_task:
+        if "audio_jobs_task" in locals() and _should_run_late_stop("audio_jobs_task", audio_jobs_task):
             # Prefer graceful stop via explicit stop_event
             if "audio_jobs_stop_event" in locals() and audio_jobs_stop_event:
                 try:
@@ -4122,7 +4619,7 @@ async def lifespan(app: FastAPI):
                         audio_jobs_task.cancel()
             else:
                 audio_jobs_task.cancel()
-        if "presentation_render_jobs_task" in locals() and presentation_render_jobs_task:
+        if "presentation_render_jobs_task" in locals() and _should_run_late_stop("presentation_render_jobs_task", presentation_render_jobs_task):
             if "presentation_render_jobs_stop_event" in locals() and presentation_render_jobs_stop_event:
                 try:
                     presentation_render_jobs_stop_event.set()
@@ -4140,7 +4637,7 @@ async def lifespan(app: FastAPI):
                         presentation_render_jobs_task.cancel()
             else:
                 presentation_render_jobs_task.cancel()
-        if "media_ingest_jobs_task" in locals() and media_ingest_jobs_task:
+        if "media_ingest_jobs_task" in locals() and _should_run_late_stop("media_ingest_jobs_task", media_ingest_jobs_task):
             # Prefer graceful stop via explicit stop_event
             if "media_ingest_jobs_stop_event" in locals() and media_ingest_jobs_stop_event:
                 try:
@@ -4151,7 +4648,7 @@ async def lifespan(app: FastAPI):
                     media_ingest_jobs_task.cancel()
             else:
                 media_ingest_jobs_task.cancel()
-        if "media_ingest_heavy_jobs_task" in locals() and media_ingest_heavy_jobs_task:
+        if "media_ingest_heavy_jobs_task" in locals() and _should_run_late_stop("media_ingest_heavy_jobs_task", media_ingest_heavy_jobs_task):
             if (
                 "media_ingest_heavy_jobs_stop_event" in locals()
                 and media_ingest_heavy_jobs_stop_event
@@ -4164,7 +4661,7 @@ async def lifespan(app: FastAPI):
                     media_ingest_heavy_jobs_task.cancel()
             else:
                 media_ingest_heavy_jobs_task.cancel()
-        if "reading_digest_jobs_task" in locals() and reading_digest_jobs_task:
+        if "reading_digest_jobs_task" in locals() and _should_run_late_stop("reading_digest_jobs_task", reading_digest_jobs_task):
             if "reading_digest_jobs_stop_event" in locals() and reading_digest_jobs_stop_event:
                 try:
                     reading_digest_jobs_stop_event.set()
@@ -4174,7 +4671,7 @@ async def lifespan(app: FastAPI):
                     reading_digest_jobs_task.cancel()
             else:
                 reading_digest_jobs_task.cancel()
-        if "study_pack_jobs_task" in locals() and study_pack_jobs_task:
+        if "study_pack_jobs_task" in locals() and _should_run_late_stop("study_pack_jobs_task", study_pack_jobs_task):
             if "study_pack_jobs_stop_event" in locals() and study_pack_jobs_stop_event:
                 try:
                     study_pack_jobs_stop_event.set()
@@ -4184,7 +4681,7 @@ async def lifespan(app: FastAPI):
                     study_pack_jobs_task.cancel()
             else:
                 study_pack_jobs_task.cancel()
-        if "study_suggestions_jobs_task" in locals() and study_suggestions_jobs_task:
+        if "study_suggestions_jobs_task" in locals() and _should_run_late_stop("study_suggestions_jobs_task", study_suggestions_jobs_task):
             if "study_suggestions_jobs_stop_event" in locals() and study_suggestions_jobs_stop_event:
                 try:
                     study_suggestions_jobs_stop_event.set()
@@ -4194,7 +4691,7 @@ async def lifespan(app: FastAPI):
                     study_suggestions_jobs_task.cancel()
             else:
                 study_suggestions_jobs_task.cancel()
-        if "companion_reflection_jobs_task" in locals() and companion_reflection_jobs_task:
+        if "companion_reflection_jobs_task" in locals() and _should_run_late_stop("companion_reflection_jobs_task", companion_reflection_jobs_task):
             if "companion_reflection_jobs_stop_event" in locals() and companion_reflection_jobs_stop_event:
                 try:
                     companion_reflection_jobs_stop_event.set()
@@ -4204,7 +4701,7 @@ async def lifespan(app: FastAPI):
                     companion_reflection_jobs_task.cancel()
             else:
                 companion_reflection_jobs_task.cancel()
-        if "reminder_jobs_task" in locals() and reminder_jobs_task:
+        if "reminder_jobs_task" in locals() and _should_run_late_stop("reminder_jobs_task", reminder_jobs_task):
             try:
                 reminder_jobs_task.cancel()
                 await _asyncio.wait_for(reminder_jobs_task, timeout=5.0)
@@ -4214,7 +4711,7 @@ async def lifespan(app: FastAPI):
             except _STARTUP_GUARD_EXCEPTIONS:
                 with suppress(_STARTUP_GUARD_EXCEPTIONS):
                     reminder_jobs_task.cancel()
-        if "admin_backup_jobs_task" in locals() and admin_backup_jobs_task:
+        if "admin_backup_jobs_task" in locals() and _should_run_late_stop("admin_backup_jobs_task", admin_backup_jobs_task):
             try:
                 admin_backup_jobs_task.cancel()
                 await _asyncio.wait_for(admin_backup_jobs_task, timeout=5.0)
@@ -4244,7 +4741,7 @@ async def lifespan(app: FastAPI):
             except _STARTUP_GUARD_EXCEPTIONS:
                 with suppress(_STARTUP_GUARD_EXCEPTIONS):
                     recipe_run_jobs_task.cancel()
-        if "evals_abtest_jobs_task" in locals() and evals_abtest_jobs_task:
+        if "evals_abtest_jobs_task" in locals() and _should_run_late_stop("evals_abtest_jobs_task", evals_abtest_jobs_task):
             if "evals_abtest_jobs_stop_event" in locals() and evals_abtest_jobs_stop_event:
                 try:
                     evals_abtest_jobs_stop_event.set()
@@ -4678,94 +5175,96 @@ async def lifespan(app: FastAPI):
     except _STARTUP_GUARD_EXCEPTIONS as e:
         logger.exception(f"App Shutdown: Error cleaning up local LLM manager: {e}")
 
-    # Shutdown Evaluations pool via lazy helper (no-op if never initialized)
-    try:
-        from tldw_Server_API.app.core.Evaluations.connection_pool import (
-            shutdown_evaluations_pool_if_initialized as _shutdown_evals,
-        )
-
-        _shutdown_evals()
-        logger.info("App Shutdown: Evaluations connection manager shutdown (lazy)")
-    except _IMPORT_EXCEPTIONS as e:
-        logger.debug(f"App Shutdown: Evaluations pool shutdown skipped/failed: {e}")
-
-    # Shutdown Evaluations webhook manager (no-op if never initialized)
-    try:
-        from tldw_Server_API.app.core.Evaluations.webhook_manager import (
-            shutdown_webhook_manager_if_initialized as _shutdown_webhooks,
-        )
-
-        _shutdown_webhooks()
-        logger.info("App Shutdown: Evaluations webhook manager shutdown (lazy)")
-    except _IMPORT_EXCEPTIONS as e:
-        logger.debug(f"App Shutdown: Evaluations webhook manager shutdown skipped/failed: {e}")
-
-    # Shutdown Unified Audit Services (via DI cache)
-    try:
-        from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
-            shutdown_all_audit_services,
-        )
-
-        logger.info("App Shutdown: Shutting down unified audit services...")
-        await shutdown_all_audit_services()
-        logger.info("App Shutdown: Unified audit services stopped")
-
+    with _timed_shutdown_segment(app, "evaluations_pool_shutdown"):
+        # Shutdown Evaluations pool via lazy helper (no-op if never initialized)
         try:
-            from tldw_Server_API.app.api.v1.endpoints.sharing import (
-                shutdown_sharing_audit_service,
+            from tldw_Server_API.app.core.Evaluations.connection_pool import (
+                shutdown_evaluations_pool_if_initialized as _shutdown_evals,
             )
 
-            await shutdown_sharing_audit_service()
-            logger.info("App Shutdown: Sharing audit service stopped")
-        except (*_STARTUP_GUARD_EXCEPTIONS, ImportError, ModuleNotFoundError) as _e:
-            logger.debug(f"Sharing audit service shutdown skipped: {_e}")
+            _shutdown_evals()
+            logger.info("App Shutdown: Evaluations connection manager shutdown (lazy)")
+        except _IMPORT_EXCEPTIONS as e:
+            logger.debug(f"App Shutdown: Evaluations pool shutdown skipped/failed: {e}")
 
+        # Shutdown Evaluations webhook manager (no-op if never initialized)
         try:
-            from tldw_Server_API.app.core.Embeddings.audit_adapter import (
-                shutdown_local_audit_adapter_loop,
+            from tldw_Server_API.app.core.Evaluations.webhook_manager import (
+                shutdown_webhook_manager_if_initialized as _shutdown_webhooks,
             )
 
-            shutdown_local_audit_adapter_loop()
-            logger.info("App Shutdown: Embeddings audit adapter loop stopped")
-        except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _e:
-            logger.debug("Embeddings audit adapter loop shutdown skipped: {}", _e)
+            _shutdown_webhooks()
+            logger.info("App Shutdown: Evaluations webhook manager shutdown (lazy)")
+        except _IMPORT_EXCEPTIONS as e:
+            logger.debug(f"App Shutdown: Evaluations webhook manager shutdown skipped/failed: {e}")
 
+    with _timed_shutdown_segment(app, "unified_audit_and_executor_shutdown"):
+        # Shutdown Unified Audit Services (via DI cache)
         try:
-            from tldw_Server_API.app.core.Evaluations.audit_adapter import (
-                shutdown_local_evaluations_audit_loop,
+            from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
+                shutdown_all_audit_services,
             )
 
-            shutdown_local_evaluations_audit_loop()
-            logger.info("App Shutdown: Evaluations audit adapter loop stopped")
-        except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _e:
-            logger.debug("Evaluations audit adapter loop shutdown skipped: {}", _e)
-    except _IMPORT_EXCEPTIONS as e:
-        logger.exception(f"App Shutdown: Error stopping unified audit services: {e}")
+            logger.info("App Shutdown: Shutting down unified audit services...")
+            await shutdown_all_audit_services()
+            logger.info("App Shutdown: Unified audit services stopped")
 
-    # Shutdown registered executors (thread/process pools)
-    try:
-        from tldw_Server_API.app.core.Utils.executor_registry import shutdown_all_registered_executors
+            try:
+                from tldw_Server_API.app.api.v1.endpoints.sharing import (
+                    shutdown_sharing_audit_service,
+                )
 
-        await shutdown_all_registered_executors(wait=True, cancel_futures=True)
-        logger.info("App Shutdown: Registered executors shutdown")
+                await shutdown_sharing_audit_service()
+                logger.info("App Shutdown: Sharing audit service stopped")
+            except (*_STARTUP_GUARD_EXCEPTIONS, ImportError, ModuleNotFoundError) as _e:
+                logger.debug(f"Sharing audit service shutdown skipped: {_e}")
+
+            try:
+                from tldw_Server_API.app.core.Embeddings.audit_adapter import (
+                    shutdown_local_audit_adapter_loop,
+                )
+
+                shutdown_local_audit_adapter_loop()
+                logger.info("App Shutdown: Embeddings audit adapter loop stopped")
+            except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _e:
+                logger.debug("Embeddings audit adapter loop shutdown skipped: {}", _e)
+
+            try:
+                from tldw_Server_API.app.core.Evaluations.audit_adapter import (
+                    shutdown_local_evaluations_audit_loop,
+                )
+
+                shutdown_local_evaluations_audit_loop()
+                logger.info("App Shutdown: Evaluations audit adapter loop stopped")
+            except (_STARTUP_GUARD_EXCEPTIONS + _IMPORT_EXCEPTIONS) as _e:
+                logger.debug("Evaluations audit adapter loop shutdown skipped: {}", _e)
+        except _IMPORT_EXCEPTIONS as e:
+            logger.exception(f"App Shutdown: Error stopping unified audit services: {e}")
+
+        # Shutdown registered executors (thread/process pools)
         try:
-            loop = asyncio.get_running_loop()
-            if hasattr(loop, "shutdown_default_executor"):
-                await loop.shutdown_default_executor()
-                logger.info("App Shutdown: Default executor shutdown")
+            from tldw_Server_API.app.core.Utils.executor_registry import shutdown_all_registered_executors
+
+            await shutdown_all_registered_executors(wait=True, cancel_futures=True)
+            logger.info("App Shutdown: Registered executors shutdown")
+            try:
+                loop = asyncio.get_running_loop()
+                if hasattr(loop, "shutdown_default_executor"):
+                    await loop.shutdown_default_executor()
+                    logger.info("App Shutdown: Default executor shutdown")
+            except _STARTUP_GUARD_EXCEPTIONS as e:
+                logger.debug(f"App Shutdown: Default executor shutdown skipped/failed: {e}")
+        except _IMPORT_EXCEPTIONS as e:
+            logger.exception(f"App Shutdown: Error shutting down executors: {e}")
+
+        # Cleanup CPU pools
+        try:
+            from tldw_Server_API.app.core.Utils.cpu_bound_handler import cleanup_pools
+
+            cleanup_pools()
+            logger.info("App Shutdown: CPU pools cleaned up")
         except _STARTUP_GUARD_EXCEPTIONS as e:
-            logger.debug(f"App Shutdown: Default executor shutdown skipped/failed: {e}")
-    except _IMPORT_EXCEPTIONS as e:
-        logger.exception(f"App Shutdown: Error shutting down executors: {e}")
-
-    # Cleanup CPU pools
-    try:
-        from tldw_Server_API.app.core.Utils.cpu_bound_handler import cleanup_pools
-
-        cleanup_pools()
-        logger.info("App Shutdown: CPU pools cleaned up")
-    except _STARTUP_GUARD_EXCEPTIONS as e:
-        logger.exception(f"App Shutdown: Error cleaning up CPU pools: {e}")
+            logger.exception(f"App Shutdown: Error cleaning up CPU pools: {e}")
 
     # Stop usage aggregator
     try:
@@ -4779,26 +5278,27 @@ async def lifespan(app: FastAPI):
     except _STARTUP_GUARD_EXCEPTIONS as e:
         logger.exception(f"App Shutdown: Error stopping usage aggregator: {e}")
 
-    # Shutdown telemetry
-    try:
-        # Stop AuthNZ scheduler if started
+    with _timed_shutdown_segment(app, "telemetry_shutdown"):
+        # Shutdown telemetry
         try:
-            if (
-                "_authnz_sched_started" in locals()
-                and _authnz_sched_started
-                and "authnz_scheduler" not in coordinated_legacy_component_names
-            ):
-                from tldw_Server_API.app.core.AuthNZ.scheduler import stop_authnz_scheduler
+            # Stop AuthNZ scheduler if started
+            try:
+                if (
+                    "_authnz_sched_started" in locals()
+                    and _authnz_sched_started
+                    and "authnz_scheduler" not in coordinated_legacy_component_names
+                ):
+                    from tldw_Server_API.app.core.AuthNZ.scheduler import stop_authnz_scheduler
 
-                await stop_authnz_scheduler()
-                logger.info("AuthNZ scheduler stopped")
-        except _IMPORT_EXCEPTIONS as _e:
-            logger.debug(f"AuthNZ scheduler shutdown skipped: {_e}")
+                    await stop_authnz_scheduler()
+                    logger.info("AuthNZ scheduler stopped")
+            except _IMPORT_EXCEPTIONS as _e:
+                logger.debug(f"AuthNZ scheduler shutdown skipped: {_e}")
 
-        shutdown_telemetry()
-        logger.info("App Shutdown: Telemetry shutdown")
-    except _IMPORT_EXCEPTIONS as e:
-        logger.exception(f"App Shutdown: Error shutting down telemetry: {e}")
+            shutdown_telemetry()
+            logger.info("App Shutdown: Telemetry shutdown")
+        except _IMPORT_EXCEPTIONS as e:
+            logger.exception(f"App Shutdown: Error shutting down telemetry: {e}")
 
     # Close cached MediaDatabase instances so Postgres pooled connections are released
     try:
@@ -4837,6 +5337,10 @@ async def lifespan(app: FastAPI):
         _JM.set_acquire_gate(False)
     except _STARTUP_GUARD_EXCEPTIONS:
         pass
+    _record_shutdown_timing_total(
+        app,
+        int((time.monotonic() - shutdown_started) * 1000),
+    )
 
 
 #

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -350,26 +350,6 @@ def _register_owned_job_poller(
     _publish_shutdown_job_poller_inventory(app, handles)
 
 
-def _replace_owned_job_poller_inventory(
-    app: FastAPI,
-    handles: list[_ManagedJobPoller],
-    *,
-    registrations: list[tuple[str, asyncio.Task[Any] | None, asyncio.Event | None, float]],
-) -> None:
-    """Replace the managed job-poller inventory with the current owned poller set."""
-    handles.clear()
-    _publish_shutdown_job_poller_inventory(app, handles)
-    for name, task, stop_event, timeout_sec in registrations:
-        _register_owned_job_poller(
-            app,
-            handles,
-            name=name,
-            task=task,
-            stop_event=stop_event,
-            timeout_sec=timeout_sec,
-        )
-
-
 def _record_shutdown_timing_segment(
     app: FastAPI,
     segment: str,
@@ -4089,64 +4069,6 @@ async def lifespan(app: FastAPI):
             logger.info("Connectors worker disabled (CONNECTORS_WORKER_ENABLED != true)")
     except _STARTUP_GUARD_EXCEPTIONS as e:
         logger.warning(f"Failed to start Connectors worker: {e}")
-
-    _replace_owned_job_poller_inventory(
-        app,
-        owned_job_pollers,
-        registrations=[
-            ("core_jobs_task", core_jobs_task, core_jobs_stop_event, 5.0),
-            ("files_jobs_task", files_jobs_task, files_jobs_stop_event, 5.0),
-            ("data_tables_jobs_task", data_tables_jobs_task, data_tables_jobs_stop_event, 5.0),
-            ("prompt_studio_jobs_task", prompt_studio_jobs_task, prompt_studio_jobs_stop_event, 5.0),
-            ("study_pack_jobs_task", study_pack_jobs_task, study_pack_jobs_stop_event, 5.0),
-            (
-                "study_suggestions_jobs_task",
-                study_suggestions_jobs_task,
-                study_suggestions_jobs_stop_event,
-                5.0,
-            ),
-            ("privilege_snapshot_task", privilege_snapshot_task, privilege_snapshot_stop_event, 5.0),
-            ("audio_jobs_task", audio_jobs_task, audio_jobs_stop_event, 5.0),
-            ("audiobook_jobs_task", audiobook_jobs_task, audiobook_jobs_stop_event, 5.0),
-            (
-                "presentation_render_jobs_task",
-                presentation_render_jobs_task,
-                presentation_render_jobs_stop_event,
-                5.0,
-            ),
-            ("media_ingest_jobs_task", media_ingest_jobs_task, media_ingest_jobs_stop_event, 5.0),
-            (
-                "media_ingest_heavy_jobs_task",
-                media_ingest_heavy_jobs_task,
-                media_ingest_heavy_jobs_stop_event,
-                5.0,
-            ),
-            ("reading_digest_jobs_task", reading_digest_jobs_task, reading_digest_jobs_stop_event, 5.0),
-            (
-                "companion_reflection_jobs_task",
-                companion_reflection_jobs_task,
-                companion_reflection_jobs_stop_event,
-                5.0,
-            ),
-            ("reminder_jobs_task", reminder_jobs_task, reminder_jobs_stop_event, 5.0),
-            ("admin_backup_jobs_task", admin_backup_jobs_task, admin_backup_jobs_stop_event, 5.0),
-            (
-                "admin_byok_validation_jobs_task",
-                admin_byok_validation_jobs_task,
-                admin_byok_validation_jobs_stop_event,
-                5.0,
-            ),
-            (
-                "admin_maintenance_rotation_jobs_task",
-                admin_maintenance_rotation_jobs_task,
-                admin_maintenance_rotation_jobs_stop_event,
-                5.0,
-            ),
-            ("recipe_run_jobs_task", recipe_run_jobs_task, recipe_run_jobs_stop_event, 5.0),
-            ("evals_abtest_jobs_task", evals_abtest_jobs_task, evals_abtest_jobs_stop_event, 5.0),
-            ("connectors_jobs_task", connectors_jobs_task, connectors_jobs_stop_event, 5.0),
-        ],
-    )
 
     # Start AuthNZ scheduler (retention/cleanup tasks) with env guard
     _authnz_sched_started = False

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -446,12 +446,7 @@ async def _stop_registered_job_pollers(
     handles: list[_ManagedJobPoller],
 ) -> None:
     """Stop registered job pollers, preferring explicit stop events."""
-    for handle in handles:
-        if handle.stop_event is not None:
-            handle.stop_event.set()
-        else:
-            with suppress(_STARTUP_GUARD_EXCEPTIONS):
-                handle.task.cancel()
+    async def _await_job_poller_shutdown(handle: _ManagedJobPoller) -> None:
         try:
             await asyncio.wait_for(asyncio.shield(handle.task), timeout=handle.timeout_sec)
         except asyncio.CancelledError:
@@ -478,6 +473,18 @@ async def _stop_registered_job_pollers(
             logger.debug(f"App Shutdown: Job poller stop guard triggered for {handle.name}: {exc}")
         except Exception as exc:
             logger.warning(f"App Shutdown: Job poller {handle.name} exited during shutdown: {exc}")
+
+    for handle in handles:
+        if handle.stop_event is not None:
+            handle.stop_event.set()
+        else:
+            with suppress(_STARTUP_GUARD_EXCEPTIONS):
+                handle.task.cancel()
+
+    await asyncio.gather(
+        *(_await_job_poller_shutdown(handle) for handle in handles),
+        return_exceptions=False,
+    )
     try:
         app.state._tldw_shutdown_quiesced_job_poller_names = [handle.name for handle in handles]
     except _STARTUP_GUARD_EXCEPTIONS:
@@ -4891,6 +4898,19 @@ async def lifespan(app: FastAPI):
             except _STARTUP_GUARD_EXCEPTIONS:
                 with suppress(_STARTUP_GUARD_EXCEPTIONS):
                     jobs_metrics_task.cancel()
+
+        # Jobs metrics reconcile worker shutdown
+        if "jobs_metrics_reconcile_task" in locals() and jobs_metrics_reconcile_task:
+            try:
+                if "jobs_metrics_reconcile_stop" in locals() and jobs_metrics_reconcile_stop:
+                    jobs_metrics_reconcile_stop.set()
+                    await _asyncio.wait_for(jobs_metrics_reconcile_task, timeout=5.0)
+                    logger.info("Jobs metrics reconcile worker stopped via stop_event")
+                else:
+                    jobs_metrics_reconcile_task.cancel()
+            except _STARTUP_GUARD_EXCEPTIONS:
+                with suppress(_STARTUP_GUARD_EXCEPTIONS):
+                    jobs_metrics_reconcile_task.cancel()
 
         # Event loop lag watchdog shutdown
         if "loop_lag_task" in locals() and loop_lag_task:

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -426,11 +426,11 @@ async def _stop_registered_job_pollers(
     handles: list[_ManagedJobPoller],
 ) -> None:
     """Stop registered job pollers, preferring explicit stop events."""
-    async def _await_job_poller_shutdown(handle: _ManagedJobPoller) -> None:
+    async def _await_job_poller_shutdown(handle: _ManagedJobPoller) -> bool:
         try:
             await asyncio.wait_for(asyncio.shield(handle.task), timeout=handle.timeout_sec)
         except asyncio.CancelledError:
-            pass
+            return bool(handle.task.done())
         except asyncio.TimeoutError:
             logger.warning(
                 "App Shutdown: Timed out waiting for job poller {} after {}s; cancelling",
@@ -447,12 +447,31 @@ async def _stop_registered_job_pollers(
                     "App Shutdown: Job poller {} did not cancel within 1.0s after timeout",
                     handle.name,
                 )
+            except Exception as exc:
+                logger.warning(
+                    "App Shutdown: Job poller {} raised after cancellation: {}",
+                    handle.name,
+                    exc,
+                )
             except _STARTUP_GUARD_EXCEPTIONS as exc:
-                logger.debug(f"App Shutdown: Job poller cancel guard triggered for {handle.name}: {exc}")
+                logger.debug(
+                    "App Shutdown: Job poller cancel guard triggered for {}: {}",
+                    handle.name,
+                    exc,
+                )
         except _STARTUP_GUARD_EXCEPTIONS as exc:
-            logger.debug(f"App Shutdown: Job poller stop guard triggered for {handle.name}: {exc}")
+            logger.debug(
+                "App Shutdown: Job poller stop guard triggered for {}: {}",
+                handle.name,
+                exc,
+            )
         except Exception as exc:
-            logger.warning(f"App Shutdown: Job poller {handle.name} exited during shutdown: {exc}")
+            logger.warning(
+                "App Shutdown: Job poller {} exited during shutdown: {}",
+                handle.name,
+                exc,
+            )
+        return bool(handle.task.done())
 
     for handle in handles:
         if handle.stop_event is not None:
@@ -461,12 +480,16 @@ async def _stop_registered_job_pollers(
             with suppress(_STARTUP_GUARD_EXCEPTIONS):
                 handle.task.cancel()
 
-    await asyncio.gather(
+    quiesce_results = await asyncio.gather(
         *(_await_job_poller_shutdown(handle) for handle in handles),
         return_exceptions=False,
     )
     try:
-        app.state._tldw_shutdown_quiesced_job_poller_names = [handle.name for handle in handles]
+        app.state._tldw_shutdown_quiesced_job_poller_names = [
+            handle.name
+            for handle, quiesced in zip(handles, quiesce_results)
+            if quiesced
+        ]
     except _STARTUP_GUARD_EXCEPTIONS:
         pass
 
@@ -486,7 +509,7 @@ async def _quiesce_owned_job_pollers_for_shutdown(
     """
     lease_wait_started = time.monotonic()
     initial_active = 0
-    if wait_for_leases_sec > 0:
+    if wait_for_leases_sec > 0 and handles:
         try:
             initial_active = max(int(count_active_processing()), 0)
         except _STARTUP_GUARD_EXCEPTIONS:

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -2837,6 +2837,8 @@ async def lifespan(app: FastAPI):
     admin_byok_validation_jobs_task = None
     connectors_jobs_task = None
     evals_abtest_jobs_task = None
+    admin_maintenance_rotation_jobs_task = None
+    recipe_run_jobs_task = None
     jobs_metrics_reconcile_task = None
     loop_lag_task = None
     jobs_crypto_rotate_task = None
@@ -2867,8 +2869,10 @@ async def lifespan(app: FastAPI):
     reminder_jobs_stop_event = None
     admin_backup_jobs_stop_event = None
     admin_byok_validation_jobs_stop_event = None
+    admin_maintenance_rotation_jobs_stop_event = None
     connectors_jobs_stop_event = None
     evals_abtest_jobs_stop_event = None
+    recipe_run_jobs_stop_event = None
     jobs_metrics_stop_event = None
     jobs_metrics_reconcile_stop = None
     loop_lag_stop_event = None
@@ -3510,9 +3514,19 @@ async def lifespan(app: FastAPI):
                 start_admin_maintenance_rotation_jobs_worker,
             )
 
-            admin_maintenance_rotation_jobs_task = await start_admin_maintenance_rotation_jobs_worker()
+            admin_maintenance_rotation_jobs_stop_event = _asyncio.Event()
+            admin_maintenance_rotation_jobs_task = await start_admin_maintenance_rotation_jobs_worker(
+                stop_event=admin_maintenance_rotation_jobs_stop_event
+            )
             if admin_maintenance_rotation_jobs_task:
                 logger.info("Admin maintenance rotation Jobs worker started")
+                _register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="admin_maintenance_rotation_jobs_task",
+                    task=admin_maintenance_rotation_jobs_task,
+                    stop_event=admin_maintenance_rotation_jobs_stop_event,
+                )
             else:
                 logger.info(
                     "Admin maintenance rotation Jobs worker disabled "
@@ -3530,29 +3544,19 @@ async def lifespan(app: FastAPI):
                 start_recipe_run_jobs_worker,
             )
 
-            recipe_run_jobs_task = await start_recipe_run_jobs_worker()
-            if recipe_run_jobs_task:
-                logger.info("Evaluation recipe-run Jobs worker started")
-            else:
-                logger.info(
-                    "Evaluation recipe-run Jobs worker disabled "
-                    "(EVALUATIONS_RECIPE_RUN_JOBS_WORKER_ENABLED != true)"
-                )
-    except _STARTUP_GUARD_EXCEPTIONS as e:
-        logger.warning("Failed to start evaluation recipe-run Jobs worker: {}", e)
-
-    # Evaluations recipe-run Jobs worker
-    try:
-        if _sidecar_mode:
-            logger.info("Evaluation recipe-run Jobs worker disabled in sidecar mode")
-        else:
-            from tldw_Server_API.app.core.Evaluations.recipe_runs_jobs_worker import (
-                start_recipe_run_jobs_worker,
+            recipe_run_jobs_stop_event = _asyncio.Event()
+            recipe_run_jobs_task = await start_recipe_run_jobs_worker(
+                stop_event=recipe_run_jobs_stop_event
             )
-
-            recipe_run_jobs_task = await start_recipe_run_jobs_worker()
             if recipe_run_jobs_task:
                 logger.info("Evaluation recipe-run Jobs worker started")
+                _register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="recipe_run_jobs_task",
+                    task=recipe_run_jobs_task,
+                    stop_event=recipe_run_jobs_stop_event,
+                )
             else:
                 logger.info(
                     "Evaluation recipe-run Jobs worker disabled "
@@ -4132,6 +4136,13 @@ async def lifespan(app: FastAPI):
                 admin_byok_validation_jobs_stop_event,
                 5.0,
             ),
+            (
+                "admin_maintenance_rotation_jobs_task",
+                admin_maintenance_rotation_jobs_task,
+                admin_maintenance_rotation_jobs_stop_event,
+                5.0,
+            ),
+            ("recipe_run_jobs_task", recipe_run_jobs_task, recipe_run_jobs_stop_event, 5.0),
             ("evals_abtest_jobs_task", evals_abtest_jobs_task, evals_abtest_jobs_stop_event, 5.0),
             ("connectors_jobs_task", connectors_jobs_task, connectors_jobs_stop_event, 5.0),
         ],
@@ -4728,6 +4739,25 @@ async def lifespan(app: FastAPI):
             except _STARTUP_GUARD_EXCEPTIONS:
                 with suppress(_STARTUP_GUARD_EXCEPTIONS):
                     admin_backup_jobs_task.cancel()
+        if (
+            "admin_maintenance_rotation_jobs_task" in locals()
+            and _should_run_late_stop(
+                "admin_maintenance_rotation_jobs_task",
+                admin_maintenance_rotation_jobs_task,
+            )
+        ):
+            if (
+                "admin_maintenance_rotation_jobs_stop_event" in locals()
+                and admin_maintenance_rotation_jobs_stop_event
+            ):
+                try:
+                    admin_maintenance_rotation_jobs_stop_event.set()
+                    await _asyncio.wait_for(admin_maintenance_rotation_jobs_task, timeout=5.0)
+                    logger.info("Admin maintenance rotation Jobs worker stopped via stop_event")
+                except _STARTUP_GUARD_EXCEPTIONS:
+                    admin_maintenance_rotation_jobs_task.cancel()
+            else:
+                admin_maintenance_rotation_jobs_task.cancel()
         if "jobs_notifications_bridge_task" in locals() and jobs_notifications_bridge_task:
             try:
                 jobs_notifications_bridge_task.cancel()
@@ -4738,16 +4768,16 @@ async def lifespan(app: FastAPI):
             except _STARTUP_GUARD_EXCEPTIONS:
                 with suppress(_STARTUP_GUARD_EXCEPTIONS):
                     jobs_notifications_bridge_task.cancel()
-        if "recipe_run_jobs_task" in locals() and recipe_run_jobs_task:
-            try:
-                recipe_run_jobs_task.cancel()
-                await _asyncio.wait_for(recipe_run_jobs_task, timeout=5.0)
-                logger.info("Evaluation recipe-run Jobs worker cancelled")
-            except _asyncio.CancelledError:
-                pass
-            except _STARTUP_GUARD_EXCEPTIONS:
-                with suppress(_STARTUP_GUARD_EXCEPTIONS):
+        if "recipe_run_jobs_task" in locals() and _should_run_late_stop("recipe_run_jobs_task", recipe_run_jobs_task):
+            if "recipe_run_jobs_stop_event" in locals() and recipe_run_jobs_stop_event:
+                try:
+                    recipe_run_jobs_stop_event.set()
+                    await _asyncio.wait_for(recipe_run_jobs_task, timeout=5.0)
+                    logger.info("Evaluation recipe-run Jobs worker stopped via stop_event")
+                except _STARTUP_GUARD_EXCEPTIONS:
                     recipe_run_jobs_task.cancel()
+            else:
+                recipe_run_jobs_task.cancel()
         if "evals_abtest_jobs_task" in locals() and _should_run_late_stop("evals_abtest_jobs_task", evals_abtest_jobs_task):
             if "evals_abtest_jobs_stop_event" in locals() and evals_abtest_jobs_stop_event:
                 try:

--- a/tldw_Server_API/app/services/admin_backup_jobs_worker.py
+++ b/tldw_Server_API/app/services/admin_backup_jobs_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -92,7 +93,7 @@ async def handle_backup_schedule_job(
     }
 
 
-async def run_admin_backup_jobs_worker() -> None:
+async def run_admin_backup_jobs_worker(stop_event: asyncio.Event | None = None) -> None:
     worker_id = (os.getenv("ADMIN_BACKUP_JOBS_WORKER_ID") or f"admin-backup-{os.getpid()}").strip()
     cfg = WorkerConfig(
         domain=BACKUP_SCHEDULE_DOMAIN,
@@ -101,14 +102,33 @@ async def run_admin_backup_jobs_worker() -> None:
     )
     jm = JobManager()
     sdk = WorkerSDK(jm, cfg)
+    stop_task: asyncio.Task[None] | None = None
+    if stop_event is not None:
+        async def _watch_stop() -> None:
+            await stop_event.wait()
+            sdk.stop()
+
+        stop_task = asyncio.create_task(
+            _watch_stop(),
+            name="admin_backup_jobs_worker_stop_watch",
+        )
     logger.info("Admin backup Jobs worker starting: queue={} worker_id={}", cfg.queue, worker_id)
-    await sdk.run(handler=handle_backup_schedule_job)
+    try:
+        await sdk.run(handler=handle_backup_schedule_job)
+    finally:
+        if stop_task is not None:
+            stop_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stop_task
 
 
-async def start_admin_backup_jobs_worker() -> asyncio.Task | None:
+async def start_admin_backup_jobs_worker(stop_event: asyncio.Event | None = None) -> asyncio.Task | None:
     if not env_flag_enabled("ADMIN_BACKUP_JOBS_WORKER_ENABLED"):
         return None
-    return asyncio.create_task(run_admin_backup_jobs_worker(), name="admin_backup_jobs_worker")
+    return asyncio.create_task(
+        run_admin_backup_jobs_worker(stop_event),
+        name="admin_backup_jobs_worker",
+    )
 
 
 __all__ = [

--- a/tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py
+++ b/tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass
 from json import JSONDecodeError
 import os
@@ -490,7 +491,7 @@ async def handle_byok_validation_job(
     }
 
 
-async def run_admin_byok_validation_jobs_worker() -> None:
+async def run_admin_byok_validation_jobs_worker(stop_event: asyncio.Event | None = None) -> None:
     """Run the WorkerSDK loop for authoritative BYOK validation jobs."""
     worker_id = (
         os.getenv("ADMIN_BYOK_VALIDATION_JOBS_WORKER_ID") or f"admin-byok-validation-{os.getpid()}"
@@ -502,20 +503,38 @@ async def run_admin_byok_validation_jobs_worker() -> None:
     )
     jm = JobManager()
     sdk = WorkerSDK(jm, cfg)
+    stop_task: asyncio.Task[None] | None = None
+    if stop_event is not None:
+        async def _watch_stop() -> None:
+            await stop_event.wait()
+            sdk.stop()
+
+        stop_task = asyncio.create_task(
+            _watch_stop(),
+            name="admin_byok_validation_jobs_worker_stop_watch",
+        )
     logger.info(
         "Admin BYOK validation Jobs worker starting: queue={} worker_id={}",
         cfg.queue,
         worker_id,
     )
-    await sdk.run(handler=handle_byok_validation_job)
+    try:
+        await sdk.run(handler=handle_byok_validation_job)
+    finally:
+        if stop_task is not None:
+            stop_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stop_task
 
 
-async def start_admin_byok_validation_jobs_worker() -> asyncio.Task | None:
+async def start_admin_byok_validation_jobs_worker(
+    stop_event: asyncio.Event | None = None,
+) -> asyncio.Task | None:
     """Start the BYOK validation Jobs worker when explicitly enabled."""
     if not byok_validation_worker_enabled():
         return None
     return asyncio.create_task(
-        run_admin_byok_validation_jobs_worker(),
+        run_admin_byok_validation_jobs_worker(stop_event),
         name="admin_byok_validation_jobs_worker",
     )
 

--- a/tldw_Server_API/app/services/admin_maintenance_rotation_jobs_worker.py
+++ b/tldw_Server_API/app/services/admin_maintenance_rotation_jobs_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 from typing import TYPE_CHECKING, Any, Callable
@@ -135,7 +136,9 @@ async def handle_maintenance_rotation_job(
     }
 
 
-async def run_admin_maintenance_rotation_jobs_worker() -> None:
+async def run_admin_maintenance_rotation_jobs_worker(
+    stop_event: asyncio.Event | None = None,
+) -> None:
     """Run the WorkerSDK loop for authoritative maintenance rotation jobs."""
     worker_id = (
         os.getenv("ADMIN_MAINTENANCE_ROTATION_JOBS_WORKER_ID") or f"admin-maintenance-{os.getpid()}"
@@ -147,20 +150,38 @@ async def run_admin_maintenance_rotation_jobs_worker() -> None:
     )
     jm = JobManager()
     sdk = WorkerSDK(jm, cfg)
+    stop_task: asyncio.Task[None] | None = None
+    if stop_event is not None:
+        async def _watch_stop() -> None:
+            await stop_event.wait()
+            sdk.stop()
+
+        stop_task = asyncio.create_task(
+            _watch_stop(),
+            name="admin_maintenance_rotation_jobs_worker_stop_watch",
+        )
     logger.info(
         "Admin maintenance rotation Jobs worker starting: queue={} worker_id={}",
         cfg.queue,
         worker_id,
     )
-    await sdk.run(handler=handle_maintenance_rotation_job)
+    try:
+        await sdk.run(handler=handle_maintenance_rotation_job)
+    finally:
+        if stop_task is not None:
+            stop_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stop_task
 
 
-async def start_admin_maintenance_rotation_jobs_worker() -> asyncio.Task | None:
+async def start_admin_maintenance_rotation_jobs_worker(
+    stop_event: asyncio.Event | None = None,
+) -> asyncio.Task | None:
     """Start the maintenance rotation Jobs worker when explicitly enabled."""
     if not maintenance_rotation_worker_enabled():
         return None
     return asyncio.create_task(
-        run_admin_maintenance_rotation_jobs_worker(),
+        run_admin_maintenance_rotation_jobs_worker(stop_event),
         name="admin_maintenance_rotation_jobs_worker",
     )
 

--- a/tldw_Server_API/app/services/connectors_worker.py
+++ b/tldw_Server_API/app/services/connectors_worker.py
@@ -648,12 +648,12 @@ async def run_connectors_worker(stop_event: asyncio.Event | None = None) -> None
             await asyncio.sleep(poll_sleep)
 
 
-async def start_connectors_worker() -> asyncio.Task | None:
+async def start_connectors_worker(stop_event: asyncio.Event | None = None) -> asyncio.Task | None:
     enabled = env_flag_enabled("CONNECTORS_WORKER_ENABLED")
     if not enabled:
         return None
-    stop = asyncio.Event()
-    task = asyncio.create_task(run_connectors_worker(stop), name="connectors-worker")
+    managed_stop_event = stop_event or asyncio.Event()
+    task = asyncio.create_task(run_connectors_worker(managed_stop_event), name="connectors-worker")
     return task
 
 

--- a/tldw_Server_API/app/services/jobs_metrics_service.py
+++ b/tldw_Server_API/app/services/jobs_metrics_service.py
@@ -52,7 +52,7 @@ def _is_truthy(v: str | None) -> bool:
     return is_truthy(v)
 
 
-async def _wait_for_stop_or_timeout(stop_event, timeout: float) -> None:
+async def _wait_for_stop_or_timeout(stop_event: asyncio.Event, timeout: float) -> None:
     """Sleep until timeout elapses or a stop_event is set, whichever comes first."""
     import asyncio
 

--- a/tldw_Server_API/app/services/jobs_metrics_service.py
+++ b/tldw_Server_API/app/services/jobs_metrics_service.py
@@ -52,6 +52,17 @@ def _is_truthy(v: str | None) -> bool:
     return is_truthy(v)
 
 
+async def _wait_for_stop_or_timeout(stop_event, timeout: float) -> None:
+    """Sleep until timeout elapses or a stop_event is set, whichever comes first."""
+    import asyncio
+
+    timeout = max(float(timeout), 0.0)
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        return
+
+
 class JobsMetricsService:
     def __init__(self) -> None:
         self.interval = float(os.getenv("JOBS_METRICS_RECONCILE_INTERVAL_SEC", "10") or "10")
@@ -193,13 +204,12 @@ async def run_jobs_metrics_reconcile(stop_event) -> None:
         return
     svc = JobsMetricsService()
     interval = svc.interval
-    import asyncio
     while not stop_event.is_set():
         try:
             svc.reconcile_once()
         except _JOBS_METRICS_BEST_EFFORT_EXCEPTIONS as e:
             logger.debug(f"Jobs reconcile loop error: {e}")
-        await asyncio.sleep(interval)
+        await _wait_for_stop_or_timeout(stop_event, interval)
 
 
 async def run_jobs_metrics_gauges(stop_event) -> None:
@@ -211,7 +221,6 @@ async def run_jobs_metrics_gauges(stop_event) -> None:
       - JOBS_METRICS_INTERVAL_SEC: interval between computations (default 5)
       - JOBS_SLO_MAX_GROUPS: max owner groups per window (default 100)
     """
-    import asyncio
     if not _is_truthy(os.getenv("JOBS_SLO_ENABLE")):
         return
     try:
@@ -314,4 +323,4 @@ async def run_jobs_metrics_gauges(stop_event) -> None:
                     conn.close()
         except _JOBS_METRICS_BEST_EFFORT_EXCEPTIONS as e:
             logger.debug(f"Jobs SLO gauges loop error: {e}")
-        await asyncio.sleep(interval)
+        await _wait_for_stop_or_timeout(stop_event, interval)

--- a/tldw_Server_API/app/services/reminder_jobs_worker.py
+++ b/tldw_Server_API/app/services/reminder_jobs_worker.py
@@ -86,10 +86,14 @@ async def run_reminder_jobs_worker(stop_event: asyncio.Event | None = None) -> N
             await asyncio.sleep(poll_sleep)
 
 
-async def start_reminder_jobs_worker() -> asyncio.Task | None:
+async def start_reminder_jobs_worker(stop_event: asyncio.Event | None = None) -> asyncio.Task | None:
     if not env_flag_enabled("REMINDER_JOBS_WORKER_ENABLED"):
         return None
-    return asyncio.create_task(run_reminder_jobs_worker(), name="reminder_jobs_worker")
+    managed_stop_event = stop_event or asyncio.Event()
+    return asyncio.create_task(
+        run_reminder_jobs_worker(managed_stop_event),
+        name="reminder_jobs_worker",
+    )
 
 
 __all__ = [

--- a/tldw_Server_API/tests/Admin/test_admin_maintenance_rotation_jobs.py
+++ b/tldw_Server_API/tests/Admin/test_admin_maintenance_rotation_jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -157,3 +158,59 @@ async def test_handle_maintenance_rotation_job_marks_failure(
     assert stored["job_id"] == "job-execute"
     assert stored["error_message"] == "rotation exploded"
     assert stored["completed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_run_admin_maintenance_rotation_jobs_worker_stops_sdk_when_stop_event_is_set(
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.services import admin_maintenance_rotation_jobs_worker as worker
+
+    stop_event = asyncio.Event()
+    observed = {"stopped": False}
+
+    class _FakeWorkerSDK:
+        def __init__(self, _jm, _cfg) -> None:
+            pass
+
+        def stop(self) -> None:
+            observed["stopped"] = True
+
+        async def run(self, *, handler) -> None:
+            while not observed["stopped"]:
+                await asyncio.sleep(0)
+
+    monkeypatch.setattr(worker, "WorkerSDK", _FakeWorkerSDK)
+
+    task = asyncio.create_task(worker.run_admin_maintenance_rotation_jobs_worker(stop_event))
+    await asyncio.sleep(0)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert observed["stopped"] is True
+
+
+@pytest.mark.asyncio
+async def test_start_admin_maintenance_rotation_jobs_worker_forwards_caller_owned_stop_event(
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.services import admin_maintenance_rotation_jobs_worker as worker
+
+    observed: dict[str, object] = {}
+    stop_event = asyncio.Event()
+
+    async def _fake_run(stop_event_arg: asyncio.Event | None = None) -> None:
+        observed["stop_event"] = stop_event_arg
+        await stop_event_arg.wait()
+
+    monkeypatch.setenv("ADMIN_MAINTENANCE_ROTATION_JOBS_WORKER_ENABLED", "1")
+    monkeypatch.setattr(worker, "run_admin_maintenance_rotation_jobs_worker", _fake_run)
+
+    task = await worker.start_admin_maintenance_rotation_jobs_worker(stop_event=stop_event)
+    assert task is not None
+    await asyncio.sleep(0)
+
+    assert observed["stop_event"] is stop_event
+
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_config_cwd.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_config_cwd.py
@@ -113,3 +113,96 @@ class TestLoadAcpRunnerConfigCwd:
             cfg = load_acp_runner_config()
 
         assert cfg.cwd is None
+
+
+class TestLoadAcpRunnerConfigEnv:
+    """Integration-level tests verifying runner_env path handling."""
+
+    def test_relative_home_in_runner_env_resolved_against_config_dir(self):
+        """A relative HOME in runner_env should be resolved against the config dir."""
+        fake_config_dir = "/srv/tldw/Config_Files"
+        fake_section = {
+            "runner_command": "node",
+            "runner_env": "HOME=./acp_runner_home,PYTHONUNBUFFERED=1",
+        }
+
+        with patch(
+            "tldw_Server_API.app.core.Agent_Client_Protocol.config.get_config_section",
+            return_value=fake_section,
+        ), patch(
+            "tldw_Server_API.app.core.Agent_Client_Protocol.config._get_config_file_dir",
+            return_value=fake_config_dir,
+        ), patch.dict(os.environ, {}, clear=False):
+            for key in (
+                "ACP_RUNNER_CWD",
+                "ACP_RUNNER_COMMAND",
+                "ACP_RUNNER_ARGS",
+                "ACP_RUNNER_ENV",
+                "ACP_RUNNER_BINARY_PATH",
+                "ACP_RUNNER_STARTUP_TIMEOUT_MS",
+            ):
+                os.environ.pop(key, None)
+
+            cfg = load_acp_runner_config()
+
+        expected_home = os.path.normpath(os.path.join(fake_config_dir, "./acp_runner_home"))
+        assert cfg.env["HOME"] == expected_home
+        assert cfg.env["PYTHONUNBUFFERED"] == "1"
+
+    def test_absolute_home_in_runner_env_is_unchanged(self):
+        """An absolute HOME in runner_env should be preserved as-is."""
+        fake_section = {
+            "runner_command": "node",
+            "runner_env": "HOME=/opt/acp_runner_home,PYTHONUNBUFFERED=1",
+        }
+
+        with patch(
+            "tldw_Server_API.app.core.Agent_Client_Protocol.config.get_config_section",
+            return_value=fake_section,
+        ), patch.dict(os.environ, {}, clear=False):
+            for key in (
+                "ACP_RUNNER_CWD",
+                "ACP_RUNNER_COMMAND",
+                "ACP_RUNNER_ARGS",
+                "ACP_RUNNER_ENV",
+                "ACP_RUNNER_BINARY_PATH",
+                "ACP_RUNNER_STARTUP_TIMEOUT_MS",
+            ):
+                os.environ.pop(key, None)
+
+            cfg = load_acp_runner_config()
+
+        assert cfg.env["HOME"] == "/opt/acp_runner_home"
+
+    def test_relative_home_in_env_override_is_preserved(self):
+        """An explicit ACP_RUNNER_ENV override should keep its original HOME value."""
+        fake_config_dir = "/srv/tldw/Config_Files"
+        fake_section = {
+            "runner_command": "node",
+            "runner_env": "HOME=./acp_runner_home,PYTHONUNBUFFERED=1",
+        }
+
+        with patch(
+            "tldw_Server_API.app.core.Agent_Client_Protocol.config.get_config_section",
+            return_value=fake_section,
+        ), patch(
+            "tldw_Server_API.app.core.Agent_Client_Protocol.config._get_config_file_dir",
+            return_value=fake_config_dir,
+        ), patch.dict(
+            os.environ,
+            {"ACP_RUNNER_ENV": "HOME=./override_home,PYTHONUNBUFFERED=1"},
+            clear=False,
+        ):
+            for key in (
+                "ACP_RUNNER_CWD",
+                "ACP_RUNNER_COMMAND",
+                "ACP_RUNNER_ARGS",
+                "ACP_RUNNER_BINARY_PATH",
+                "ACP_RUNNER_STARTUP_TIMEOUT_MS",
+            ):
+                os.environ.pop(key, None)
+
+            cfg = load_acp_runner_config()
+
+        assert cfg.env["HOME"] == "./override_home"
+        assert cfg.env["PYTHONUNBUFFERED"] == "1"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_config_cwd.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_config_cwd.py
@@ -206,3 +206,51 @@ class TestLoadAcpRunnerConfigEnv:
 
         assert cfg.env["HOME"] == "./override_home"
         assert cfg.env["PYTHONUNBUFFERED"] == "1"
+
+    def test_empty_env_override_clears_config_runner_env(self):
+        """An explicit empty ACP_RUNNER_ENV should override the config runner_env."""
+        fake_section = {
+            "runner_command": "node",
+            "runner_env": "HOME=./acp_runner_home,PYTHONUNBUFFERED=1",
+        }
+
+        with patch(
+            "tldw_Server_API.app.core.Agent_Client_Protocol.config.get_config_section",
+            return_value=fake_section,
+        ), patch.dict(os.environ, {"ACP_RUNNER_ENV": ""}, clear=False):
+            for key in (
+                "ACP_RUNNER_CWD",
+                "ACP_RUNNER_COMMAND",
+                "ACP_RUNNER_ARGS",
+                "ACP_RUNNER_BINARY_PATH",
+                "ACP_RUNNER_STARTUP_TIMEOUT_MS",
+            ):
+                os.environ.pop(key, None)
+
+            cfg = load_acp_runner_config()
+
+        assert cfg.env == {}
+
+    def test_empty_cwd_override_clears_config_runner_cwd(self):
+        """An explicit empty ACP_RUNNER_CWD should override the config runner_cwd."""
+        fake_section = {
+            "runner_command": "node",
+            "runner_cwd": "../agent-workspace",
+        }
+
+        with patch(
+            "tldw_Server_API.app.core.Agent_Client_Protocol.config.get_config_section",
+            return_value=fake_section,
+        ), patch.dict(os.environ, {"ACP_RUNNER_CWD": ""}, clear=False):
+            for key in (
+                "ACP_RUNNER_COMMAND",
+                "ACP_RUNNER_ARGS",
+                "ACP_RUNNER_ENV",
+                "ACP_RUNNER_BINARY_PATH",
+                "ACP_RUNNER_STARTUP_TIMEOUT_MS",
+            ):
+                os.environ.pop(key, None)
+
+            cfg = load_acp_runner_config()
+
+        assert cfg.cwd is None

--- a/tldw_Server_API/tests/Evaluations/test_recipe_runs_jobs_worker.py
+++ b/tldw_Server_API/tests/Evaluations/test_recipe_runs_jobs_worker.py
@@ -1178,7 +1178,7 @@ async def test_start_recipe_run_jobs_worker_returns_task_when_enabled(monkeypatc
     started = asyncio.Event()
     finished = asyncio.Event()
 
-    async def _fake_run():
+    async def _fake_run(_stop_event: asyncio.Event | None = None):
         started.set()
         try:
             await asyncio.sleep(60)
@@ -1199,3 +1199,55 @@ async def test_start_recipe_run_jobs_worker_returns_task_when_enabled(monkeypatc
     with pytest.raises(asyncio.CancelledError):
         await task
     assert finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_recipe_run_jobs_worker_stops_sdk_when_stop_event_is_set(monkeypatch) -> None:
+    import tldw_Server_API.app.core.Evaluations.recipe_runs_jobs_worker as worker
+
+    stop_event = asyncio.Event()
+    observed = {"stopped": False}
+
+    class _FakeWorkerSDK:
+        def __init__(self, _jm, _cfg) -> None:
+            pass
+
+        def stop(self) -> None:
+            observed["stopped"] = True
+
+        async def run(self, *, handler) -> None:
+            while not observed["stopped"]:
+                await asyncio.sleep(0)
+
+    monkeypatch.setattr(worker, "WorkerSDK", _FakeWorkerSDK)
+
+    task = asyncio.create_task(worker.run_recipe_run_jobs_worker(stop_event))
+    await asyncio.sleep(0)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert observed["stopped"] is True
+
+
+@pytest.mark.asyncio
+async def test_start_recipe_run_jobs_worker_forwards_caller_owned_stop_event(monkeypatch) -> None:
+    import tldw_Server_API.app.core.Evaluations.recipe_runs_jobs_worker as worker
+
+    observed: dict[str, object] = {}
+    stop_event = asyncio.Event()
+
+    async def _fake_run(stop_event_arg: asyncio.Event | None = None) -> None:
+        observed["stop_event"] = stop_event_arg
+        await stop_event_arg.wait()
+
+    monkeypatch.setenv("EVALUATIONS_RECIPE_RUN_JOBS_WORKER_ENABLED", "true")
+    monkeypatch.setattr(worker, "run_recipe_run_jobs_worker", _fake_run)
+
+    task = await worker.start_recipe_run_jobs_worker(stop_event=stop_event)
+    assert task is not None
+    await asyncio.sleep(0)
+
+    assert observed["stop_event"] is stop_event
+
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)

--- a/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
+++ b/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
@@ -37,6 +37,19 @@ class _TimeoutRecordingMaintenanceTask:
         self.join_timeout = timeout
 
 
+class _StuckMaintenanceTask:
+    """Test double that remains alive after the bounded join."""
+
+    def __init__(self):
+        self.join_timeout = None
+
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeout = timeout
+
+
 @pytest.mark.unit
 class TestConnectionPoolShutdown:
     """Shutdown behavior should wake maintenance and avoid long joins."""
@@ -90,3 +103,25 @@ class TestConnectionPoolShutdown:
             pytest.fail("maintenance worker did not stop during shutdown")
         if shutdown_duration >= 0.5:
             pytest.fail(f"shutdown did not interrupt maintenance wait promptly: {shutdown_duration:.3f}s")
+
+    def test_shutdown_warns_if_maintenance_thread_is_still_alive_after_join(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_db_path,
+    ):
+        pool = ConnectionPool(db_path=str(temp_db_path), enable_monitoring=False)
+        maintenance_task = _StuckMaintenanceTask()
+        warnings: list[tuple[object, ...]] = []
+        pool._maintenance_task = maintenance_task
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Evaluations.connection_pool.logger.warning",
+            lambda *args, **kwargs: warnings.append(args),
+        )
+
+        pool.shutdown()
+
+        if maintenance_task.join_timeout != 1.0:
+            pytest.fail(f"expected join timeout 1.0, got {maintenance_task.join_timeout!r}")
+        if not warnings:
+            pytest.fail("expected shutdown to warn when maintenance thread remains alive")

--- a/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
+++ b/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
@@ -1,0 +1,92 @@
+"""Focused tests for connection pool shutdown behavior."""
+
+import time
+import threading
+
+import pytest
+
+from tldw_Server_API.app.core.Evaluations.connection_pool import ConnectionPool
+
+
+class _ShutdownAwareMaintenanceTask:
+    """Test double that validates shutdown ordering."""
+
+    def __init__(self, wakeup_event: threading.Event):
+        self._wakeup_event = wakeup_event
+        self.join_timeout = None
+
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        if not self._wakeup_event.is_set():
+            pytest.fail("shutdown must wake maintenance before joining")
+        self.join_timeout = timeout
+
+
+class _TimeoutRecordingMaintenanceTask:
+    """Test double that records the shutdown join timeout."""
+
+    def __init__(self):
+        self.join_timeout = None
+
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeout = timeout
+
+
+@pytest.mark.unit
+class TestConnectionPoolShutdown:
+    """Shutdown behavior should wake maintenance and avoid long joins."""
+
+    def test_shutdown_sets_maintenance_wakeup_before_join(self, temp_db_path):
+        pool = ConnectionPool(db_path=str(temp_db_path), enable_monitoring=False)
+        wakeup_event = threading.Event()
+        maintenance_task = _ShutdownAwareMaintenanceTask(wakeup_event)
+        pool._maintenance_shutdown_event = wakeup_event
+        pool._maintenance_task = maintenance_task
+
+        pool.shutdown()
+
+        if not wakeup_event.is_set():
+            pytest.fail("maintenance wakeup event was not set during shutdown")
+        if maintenance_task.join_timeout != 1.0:
+            pytest.fail(f"expected join timeout 1.0, got {maintenance_task.join_timeout!r}")
+
+    def test_shutdown_uses_short_join_timeout_for_maintenance(self, temp_db_path):
+        pool = ConnectionPool(db_path=str(temp_db_path), enable_monitoring=False)
+        maintenance_task = _TimeoutRecordingMaintenanceTask()
+        pool._maintenance_task = maintenance_task
+
+        pool.shutdown()
+
+        if maintenance_task.join_timeout is None:
+            pytest.fail("maintenance thread was not joined during shutdown")
+        if not pytest.approx(1.0, abs=0.05) == maintenance_task.join_timeout:
+            pytest.fail(f"expected join timeout around 1.0, got {maintenance_task.join_timeout!r}")
+
+    def test_shutdown_interrupts_real_maintenance_wait_promptly(self, temp_db_path):
+        pool = ConnectionPool(db_path=str(temp_db_path), enable_monitoring=False)
+        maintenance_started = threading.Event()
+        original_perform_maintenance = pool._perform_maintenance
+
+        def _recording_perform_maintenance() -> None:
+            maintenance_started.set()
+            original_perform_maintenance()
+
+        pool._perform_maintenance = _recording_perform_maintenance  # type: ignore[method-assign]
+        pool._start_maintenance()
+
+        if not maintenance_started.wait(timeout=2.0):
+            pytest.fail("maintenance worker did not start")
+
+        start = time.perf_counter()
+        pool.shutdown()
+        shutdown_duration = time.perf_counter() - start
+
+        if pool._maintenance_task is None or pool._maintenance_task.is_alive():
+            pytest.fail("maintenance worker did not stop during shutdown")
+        if shutdown_duration >= 0.5:
+            pytest.fail(f"shutdown did not interrupt maintenance wait promptly: {shutdown_duration:.3f}s")

--- a/tldw_Server_API/tests/Jobs/test_jobs_metrics_service_shutdown.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_metrics_service_shutdown.py
@@ -1,0 +1,31 @@
+import asyncio
+
+import pytest
+
+from tldw_Server_API.app.services import jobs_metrics_service
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_run_jobs_metrics_reconcile_stop_event_interrupts_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_event = asyncio.Event()
+
+    class _FakeService:
+        def __init__(self) -> None:
+            self.interval = 60.0
+
+        def reconcile_once(self) -> int:
+            stop_event.set()
+            return 1
+
+    monkeypatch.setenv("JOBS_METRICS_RECONCILE_ENABLE", "1")
+    monkeypatch.setattr(jobs_metrics_service, "JobsMetricsService", _FakeService)
+
+    task = asyncio.create_task(jobs_metrics_service.run_jobs_metrics_reconcile(stop_event))
+    await asyncio.wait_for(task, timeout=0.2)
+
+    assert stop_event.is_set() is True

--- a/tldw_Server_API/tests/Jobs/test_worker_sdk.py
+++ b/tldw_Server_API/tests/Jobs/test_worker_sdk.py
@@ -39,8 +39,11 @@ async def test_auto_renew_jitter_and_progress(monkeypatch, tmp_path):
 
     # Capture renew calls and progress fields
     calls = []
+    renewed = asyncio.Event()
+
     def fake_renew(**kwargs):
         calls.append(kwargs)
+        renewed.set()
         return True
 
     # Capture original sleep; use it inside the stub and assign to sdk._sleep
@@ -54,9 +57,7 @@ async def test_auto_renew_jitter_and_progress(monkeypatch, tmp_path):
         return {"progress_percent": 12.5, "progress_message": "tick"}
 
     task = asyncio.create_task(sdk._auto_renew(acq, progress_cb=progress_cb))
-    # Let it loop twice then stop
-    await _orig_sleep(0)  # enter loop
-    await _orig_sleep(0)
+    await asyncio.wait_for(renewed.wait(), timeout=1)
     sdk.stop()
     try:
         await asyncio.wait_for(task, timeout=1)
@@ -122,6 +123,38 @@ async def test_run_retryable_exception_and_backoff(monkeypatch, tmp_path):
     # Verify backoff sleeps used exponential sequence up to max
     # After job handled and no further jobs, loop should sleep at least base once
     assert any(int(s) in (2, 4, 8) for s in sleep_stub.calls)
+
+
+@pytest.mark.asyncio
+async def test_run_stop_interrupts_idle_backoff_sleep(monkeypatch, tmp_path):
+    db_path = tmp_path / "jobs_wsdk_stop.db"
+    ensure_jobs_tables(db_path)
+    jm = JobManager(db_path)
+
+    cfg = WorkerConfig(
+        domain="chatbooks",
+        queue="default",
+        worker_id="w-stop",
+        backoff_base_seconds=30,
+        backoff_max_seconds=30,
+    )
+    sdk = WorkerSDK(jm, cfg)
+    sleep_started = asyncio.Event()
+
+    async def blocking_sleep(_seconds: float) -> None:
+        sleep_started.set()
+        await asyncio.Future()
+
+    async def handler(_job):
+        pytest.fail("Handler should not run when there are no jobs")
+
+    monkeypatch.setattr(jm, "acquire_next_job", lambda **kwargs: None)
+    sdk._sleep = blocking_sleep
+
+    task = asyncio.create_task(sdk.run(handler=handler))
+    await asyncio.wait_for(sleep_started.wait(), timeout=1)
+    sdk.stop()
+    await asyncio.wait_for(task, timeout=1)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
+++ b/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.services import admin_backup_jobs_worker
 from tldw_Server_API.app.services import admin_byok_validation_jobs_worker
 from tldw_Server_API.app.services import connectors_worker
 from tldw_Server_API.app.services import core_jobs_worker
+from tldw_Server_API.app.services import jobs_metrics_service
 from tldw_Server_API.app.services import media_ingest_jobs_worker
 from tldw_Server_API.app.services import reminder_jobs_worker
 
@@ -192,6 +193,50 @@ async def test_stop_registered_job_pollers_timeout_fallback_stays_bounded(
 
 
 @pytest.mark.asyncio
+async def test_stop_registered_job_pollers_waits_for_pollers_concurrently() -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+
+    async def _delayed_shutdown(stop_event: asyncio.Event, delay: float) -> None:
+        await stop_event.wait()
+        await asyncio.sleep(delay)
+
+    stop_a = asyncio.Event()
+    stop_b = asyncio.Event()
+    task_a = asyncio.create_task(_delayed_shutdown(stop_a, 0.2))
+    task_b = asyncio.create_task(_delayed_shutdown(stop_b, 0.2))
+
+    started = asyncio.get_running_loop().time()
+    await main_module._stop_registered_job_pollers(
+        app,
+        [
+            main_module._ManagedJobPoller(
+                name="poller_a",
+                task=task_a,
+                stop_event=stop_a,
+                timeout_sec=1.0,
+            ),
+            main_module._ManagedJobPoller(
+                name="poller_b",
+                task=task_b,
+                stop_event=stop_b,
+                timeout_sec=1.0,
+            ),
+        ],
+    )
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert stop_a.is_set() is True
+    assert stop_b.is_set() is True
+    assert elapsed < 0.35
+    assert getattr(app.state, "_tldw_shutdown_quiesced_job_poller_names") == [
+        "poller_a",
+        "poller_b",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_publish_shutdown_job_poller_inventory_captures_registered_metadata() -> None:
     from tldw_Server_API.app import main as main_module
 
@@ -357,6 +402,35 @@ def test_lifespan_startup_publishes_owned_job_poller_inventory_for_enabled_worke
     assert all(isinstance(entry["task_name"], str) and entry["task_name"] for entry in inventory)
     assert all(entry["has_stop_event"] is True for entry in inventory)
     assert all(entry["timeout_sec"] == 5.0 for entry in inventory)
+
+
+@pytest.mark.integration
+def test_lifespan_shutdown_stops_jobs_metrics_reconcile_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = main_module.app
+    observed: dict[str, object] = {"stop_event": None, "stopped": False}
+
+    async def _fake_reconcile(stop_event: asyncio.Event) -> None:
+        observed["stop_event"] = stop_event
+        await stop_event.wait()
+        observed["stopped"] = True
+
+    monkeypatch.setenv("JOBS_METRICS_RECONCILE_ENABLE", "1")
+    monkeypatch.setattr(jobs_metrics_service, "run_jobs_metrics_reconcile", _fake_reconcile)
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        stop_event = observed["stop_event"]
+        assert isinstance(stop_event, asyncio.Event)
+        assert stop_event.is_set() is False
+
+    stop_event = observed["stop_event"]
+    assert isinstance(stop_event, asyncio.Event)
+    assert stop_event.is_set() is True
+    assert observed["stopped"] is True
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
+++ b/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
@@ -91,6 +91,8 @@ async def test_active_processing_preserves_bounded_lease_wait_before_quiesce(
     counts = iter([2, 1, 0])
     observed_sleeps: list[float] = []
     stop_calls: list[str] = []
+    dummy_stop_event = asyncio.Event()
+    dummy_task = asyncio.create_task(_wait_for_stop(dummy_stop_event))
 
     async def _fake_sleep(delay: float) -> None:
         observed_sleeps.append(delay)
@@ -103,7 +105,13 @@ async def test_active_processing_preserves_bounded_lease_wait_before_quiesce(
 
     await main_module._quiesce_owned_job_pollers_for_shutdown(
         app,
-        [],
+        [
+            main_module._ManagedJobPoller(
+                name="owned_poller",
+                task=dummy_task,
+                stop_event=dummy_stop_event,
+            )
+        ],
         wait_for_leases_sec=5,
         count_active_processing=lambda: next(counts),
     )
@@ -119,6 +127,40 @@ async def test_active_processing_preserves_bounded_lease_wait_before_quiesce(
 
 
 @pytest.mark.asyncio
+async def test_no_owned_job_pollers_skips_global_lease_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    observed_sleeps: list[float] = []
+    stop_calls: list[str] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        observed_sleeps.append(delay)
+
+    async def _fake_stop_pollers(_app: FastAPI, _handles: list[object]) -> None:
+        stop_calls.append("stop")
+
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(main_module, "_stop_registered_job_pollers", _fake_stop_pollers)
+
+    await main_module._quiesce_owned_job_pollers_for_shutdown(
+        app,
+        [],
+        wait_for_leases_sec=30,
+        count_active_processing=lambda: (_ for _ in ()).throw(AssertionError("count should not be called")),
+    )
+
+    assert observed_sleeps == []
+    assert stop_calls == ["stop"]
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments")
+    assert segments[0]["segment"] == "optional_lease_wait"
+    assert segments[0]["skipped"] is True
+    assert segments[0]["initial_active"] == 0
+
+
+@pytest.mark.asyncio
 async def test_active_processing_deadline_uses_remaining_budget_before_quiesce(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -128,6 +170,8 @@ async def test_active_processing_deadline_uses_remaining_budget_before_quiesce(
     observed_sleeps: list[float] = []
     stop_calls: list[str] = []
     monotonic_values = iter([100.0, 100.0, 100.1, 100.25])
+    dummy_stop_event = asyncio.Event()
+    dummy_task = asyncio.create_task(_wait_for_stop(dummy_stop_event))
 
     async def _fake_sleep(delay: float) -> None:
         observed_sleeps.append(delay)
@@ -141,7 +185,13 @@ async def test_active_processing_deadline_uses_remaining_budget_before_quiesce(
 
     await main_module._quiesce_owned_job_pollers_for_shutdown(
         app,
-        [],
+        [
+            main_module._ManagedJobPoller(
+                name="owned_poller",
+                task=dummy_task,
+                stop_event=dummy_stop_event,
+            )
+        ],
         wait_for_leases_sec=0.2,
         count_active_processing=lambda: 2,
     )
@@ -192,6 +242,110 @@ async def test_stop_registered_job_pollers_timeout_fallback_stays_bounded(
     assert wait_calls[1] == (task, 1.0)
     assert getattr(app.state, "_tldw_shutdown_quiesced_job_poller_names") == ["stuck_poller"]
     assert warnings
+
+
+@pytest.mark.asyncio
+async def test_stop_registered_job_pollers_continues_when_cancelled_task_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    warnings: list[tuple[object, ...]] = []
+    cooperative_stop_event = asyncio.Event()
+
+    async def _raise_after_cancel() -> None:
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError as exc:
+            raise RuntimeError("cancel boom") from exc
+
+    async def _cooperative(stop_event: asyncio.Event) -> None:
+        await stop_event.wait()
+
+    async def _fake_wait_for(awaitable: object, timeout: float):
+        if timeout == 0.01:
+            raise asyncio.TimeoutError
+        return await awaitable
+
+    monkeypatch.setattr(main_module.asyncio, "wait_for", _fake_wait_for)
+    monkeypatch.setattr(main_module.logger, "warning", lambda *args, **kwargs: warnings.append(args))
+
+    raising_task = asyncio.create_task(_raise_after_cancel(), name="raising-poller")
+    cooperative_task = asyncio.create_task(_cooperative(cooperative_stop_event), name="cooperative-poller")
+    await asyncio.sleep(0)
+
+    await main_module._stop_registered_job_pollers(
+        app,
+        [
+            main_module._ManagedJobPoller(
+                name="raising_poller",
+                task=raising_task,
+                timeout_sec=0.01,
+            ),
+            main_module._ManagedJobPoller(
+                name="cooperative_poller",
+                task=cooperative_task,
+                stop_event=cooperative_stop_event,
+                timeout_sec=0.25,
+            ),
+        ],
+    )
+
+    assert cooperative_stop_event.is_set() is True
+    assert raising_task.done() is True
+    assert cooperative_task.done() is True
+    assert getattr(app.state, "_tldw_shutdown_quiesced_job_poller_names") == [
+        "raising_poller",
+        "cooperative_poller",
+    ]
+    assert any("raised after cancellation" in str(args[0]) for args in warnings)
+
+
+@pytest.mark.asyncio
+async def test_stop_registered_job_pollers_only_marks_completed_pollers_as_quiesced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    real_wait_for = asyncio.wait_for
+    release_event = asyncio.Event()
+
+    async def _ignores_cancel_until_released() -> None:
+        while not release_event.is_set():
+            try:
+                await release_event.wait()
+            except asyncio.CancelledError:
+                continue
+
+    async def _fake_wait_for(awaitable: object, timeout: float):
+        if timeout in {0.01, 1.0}:
+            raise asyncio.TimeoutError
+        return await awaitable
+
+    monkeypatch.setattr(main_module.asyncio, "wait_for", _fake_wait_for)
+
+    task = asyncio.create_task(_ignores_cancel_until_released(), name="stubborn-poller")
+    await asyncio.sleep(0)
+
+    await main_module._stop_registered_job_pollers(
+        app,
+        [
+            main_module._ManagedJobPoller(
+                name="stubborn_poller",
+                task=task,
+                timeout_sec=0.01,
+            )
+        ],
+    )
+
+    assert task.done() is False
+    assert getattr(app.state, "_tldw_shutdown_quiesced_job_poller_names") == []
+
+    release_event.set()
+    task.cancel()
+    await real_wait_for(task, timeout=1)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
+++ b/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
@@ -1,14 +1,362 @@
 import asyncio
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.core.Collections import reading_digest_jobs_worker
+from tldw_Server_API.app.core.File_Artifacts import jobs_worker as file_artifacts_jobs_worker
+from tldw_Server_API.app.core.Personalization import companion_reflection_jobs_worker
+from tldw_Server_API.app.services import audio_jobs_worker
+from tldw_Server_API.app.services import audiobook_jobs_worker
 from tldw_Server_API.app.services import admin_backup_jobs_worker
 from tldw_Server_API.app.services import admin_byok_validation_jobs_worker
 from tldw_Server_API.app.services import connectors_worker
+from tldw_Server_API.app.services import core_jobs_worker
+from tldw_Server_API.app.services import media_ingest_jobs_worker
 from tldw_Server_API.app.services import reminder_jobs_worker
 
 
 pytestmark = pytest.mark.unit
+
+
+async def _wait_for_stop(stop_event: asyncio.Event) -> None:
+    await stop_event.wait()
+
+
+async def _wait_for_optional_stop_event(stop_event_arg: asyncio.Event | None = None) -> None:
+    assert stop_event_arg is not None
+    await stop_event_arg.wait()
+
+
+@pytest.mark.asyncio
+async def test_zero_active_processing_quiesces_job_pollers_without_lease_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(_wait_for_stop(stop_event))
+    handles = [
+        main_module._ManagedJobPoller(
+            name="audiobook_jobs_task",
+            task=task,
+            stop_event=stop_event,
+        )
+    ]
+    stop_calls: list[list[str]] = []
+    sleep_calls: list[float] = []
+
+    async def _fake_stop_pollers(_app: FastAPI, poller_handles: list[object]) -> None:
+        stop_calls.append([handle.name for handle in poller_handles])
+        for handle in poller_handles:
+            if handle.stop_event is not None:
+                handle.stop_event.set()
+            await handle.task
+
+    async def _fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(main_module, "_stop_registered_job_pollers", _fake_stop_pollers)
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+
+    await main_module._quiesce_owned_job_pollers_for_shutdown(
+        app,
+        handles,
+        wait_for_leases_sec=30,
+        count_active_processing=lambda: 0,
+    )
+
+    assert stop_calls == [["audiobook_jobs_task"]]
+    assert sleep_calls == []
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments")
+    assert [entry["segment"] for entry in segments][:2] == [
+        "optional_lease_wait",
+        "job_poller_quiesce",
+    ]
+    assert segments[0]["duration_ms"] == 0
+
+
+@pytest.mark.asyncio
+async def test_active_processing_preserves_bounded_lease_wait_before_quiesce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    counts = iter([2, 1, 0])
+    observed_sleeps: list[float] = []
+    stop_calls: list[str] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        observed_sleeps.append(delay)
+
+    async def _fake_stop_pollers(_app: FastAPI, _handles: list[object]) -> None:
+        stop_calls.append("stop")
+
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(main_module, "_stop_registered_job_pollers", _fake_stop_pollers)
+
+    await main_module._quiesce_owned_job_pollers_for_shutdown(
+        app,
+        [],
+        wait_for_leases_sec=5,
+        count_active_processing=lambda: next(counts),
+    )
+
+    assert observed_sleeps == [0.5, 0.5]
+    assert stop_calls == ["stop"]
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments")
+    assert [entry["segment"] for entry in segments][:2] == [
+        "optional_lease_wait",
+        "job_poller_quiesce",
+    ]
+    assert segments[0]["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_active_processing_deadline_uses_remaining_budget_before_quiesce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    observed_sleeps: list[float] = []
+    stop_calls: list[str] = []
+    monotonic_values = iter([100.0, 100.0, 100.1, 100.25])
+
+    async def _fake_sleep(delay: float) -> None:
+        observed_sleeps.append(delay)
+
+    async def _fake_stop_pollers(_app: FastAPI, _handles: list[object]) -> None:
+        stop_calls.append("stop")
+
+    monkeypatch.setattr(main_module.time, "monotonic", lambda: next(monotonic_values, 100.25))
+    monkeypatch.setattr(main_module.asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(main_module, "_stop_registered_job_pollers", _fake_stop_pollers)
+
+    await main_module._quiesce_owned_job_pollers_for_shutdown(
+        app,
+        [],
+        wait_for_leases_sec=0.2,
+        count_active_processing=lambda: 2,
+    )
+
+    assert observed_sleeps == pytest.approx([0.1])
+    assert stop_calls == ["stop"]
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments")
+    assert segments[0]["segment"] == "optional_lease_wait"
+    assert segments[0]["skipped"] is False
+    assert segments[0]["initial_active"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_registered_job_pollers_timeout_fallback_stays_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    stop_event = asyncio.Event()
+    wait_calls: list[tuple[object, float]] = []
+    warnings: list[tuple[object, ...]] = []
+    task = asyncio.get_running_loop().create_future()
+
+    async def _fake_wait_for(awaitable: object, timeout: float) -> None:
+        wait_calls.append((awaitable, timeout))
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(main_module.asyncio, "wait_for", _fake_wait_for)
+    monkeypatch.setattr(main_module.logger, "warning", lambda *args, **kwargs: warnings.append(args))
+
+    await main_module._stop_registered_job_pollers(
+        app,
+        [
+            main_module._ManagedJobPoller(
+                name="stuck_poller",
+                task=task,
+                stop_event=stop_event,
+                timeout_sec=0.25,
+            )
+        ],
+    )
+
+    assert stop_event.is_set()
+    assert task.cancelled() is True
+    assert wait_calls[0][1] == 0.25
+    assert wait_calls[0][0] is not task
+    assert wait_calls[1] == (task, 1.0)
+    assert getattr(app.state, "_tldw_shutdown_quiesced_job_poller_names") == ["stuck_poller"]
+    assert warnings
+
+
+@pytest.mark.asyncio
+async def test_publish_shutdown_job_poller_inventory_captures_registered_metadata() -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(_wait_for_stop(stop_event), name="connectors-worker")
+    handles = [
+        main_module._ManagedJobPoller(
+            name="connectors_jobs_task",
+            task=task,
+            stop_event=stop_event,
+            timeout_sec=7.5,
+        )
+    ]
+
+    main_module._publish_shutdown_job_poller_inventory(app, handles)
+
+    assert getattr(app.state, "_tldw_shutdown_job_poller_inventory") == [
+        {
+            "name": "connectors_jobs_task",
+            "task_name": "connectors-worker",
+            "has_stop_event": True,
+            "timeout_sec": 7.5,
+        }
+    ]
+
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)
+
+
+def test_shutdown_timing_helpers_record_segments_and_total_summary() -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = FastAPI()
+
+    for segment, duration_ms in (
+        ("transition_handoff", 1),
+        ("optional_lease_wait", 0),
+        ("job_poller_quiesce", 2),
+        ("evaluations_pool_shutdown", 3),
+        ("unified_audit_and_executor_shutdown", 4),
+        ("telemetry_shutdown", 5),
+    ):
+        main_module._record_shutdown_timing_segment(app, segment, duration_ms)
+
+    main_module._record_shutdown_timing_total(app, duration_ms=21)
+
+    segments = getattr(app.state, "_tldw_shutdown_timing_segments")
+    assert [entry["segment"] for entry in segments] == [
+        "transition_handoff",
+        "optional_lease_wait",
+        "job_poller_quiesce",
+        "evaluations_pool_shutdown",
+        "unified_audit_and_executor_shutdown",
+        "telemetry_shutdown",
+        "total app teardown",
+    ]
+    assert getattr(app.state, "_tldw_shutdown_timing_total") == {
+        "duration_ms": 21,
+        "slowest_segment": "telemetry_shutdown",
+        "slowest_duration_ms": 5,
+    }
+
+
+@pytest.mark.integration
+def test_lifespan_startup_publishes_owned_job_poller_inventory_for_enabled_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = main_module.app
+    if hasattr(app.state, "_tldw_shutdown_job_poller_inventory"):
+        delattr(app.state, "_tldw_shutdown_job_poller_inventory")
+
+    for key in (
+        "CHATBOOKS_CORE_WORKER_ENABLED",
+        "FILES_JOBS_WORKER_ENABLED",
+        "AUDIO_JOBS_WORKER_ENABLED",
+        "AUDIOBOOK_JOBS_WORKER_ENABLED",
+        "MEDIA_INGEST_JOBS_WORKER_ENABLED",
+        "READING_DIGEST_JOBS_WORKER_ENABLED",
+        "COMPANION_REFLECTION_JOBS_WORKER_ENABLED",
+        "REMINDER_JOBS_WORKER_ENABLED",
+        "ADMIN_BACKUP_JOBS_WORKER_ENABLED",
+        "ADMIN_BYOK_VALIDATION_JOBS_WORKER_ENABLED",
+        "CONNECTORS_WORKER_ENABLED",
+    ):
+        monkeypatch.setenv(key, "1")
+    for key in (
+        "DATA_TABLES_JOBS_WORKER_ENABLED",
+        "PROMPT_STUDIO_JOBS_WORKER_ENABLED",
+        "STUDY_PACK_JOBS_WORKER_ENABLED",
+        "STUDY_SUGGESTIONS_JOBS_WORKER_ENABLED",
+        "PRIVILEGE_SNAPSHOT_WORKER_ENABLED",
+        "PRESENTATION_RENDER_JOBS_WORKER_ENABLED",
+        "MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED",
+        "EVALUATIONS_ABTEST_JOBS_WORKER_ENABLED",
+        "EVALS_ABTEST_JOBS_WORKER_ENABLED",
+    ):
+        monkeypatch.setenv(key, "0")
+
+    monkeypatch.setattr(
+        core_jobs_worker,
+        "run_chatbooks_core_jobs_worker",
+        _wait_for_optional_stop_event,
+    )
+    monkeypatch.setattr(
+        file_artifacts_jobs_worker,
+        "run_file_artifacts_jobs_worker",
+        _wait_for_optional_stop_event,
+    )
+    monkeypatch.setattr(audio_jobs_worker, "run_audio_jobs_worker", _wait_for_optional_stop_event)
+    monkeypatch.setattr(audiobook_jobs_worker, "run_audiobook_jobs_worker", _wait_for_optional_stop_event)
+    monkeypatch.setattr(
+        media_ingest_jobs_worker,
+        "run_media_ingest_jobs_worker",
+        _wait_for_optional_stop_event,
+    )
+    monkeypatch.setattr(
+        reading_digest_jobs_worker,
+        "run_reading_digest_jobs_worker",
+        _wait_for_optional_stop_event,
+    )
+    monkeypatch.setattr(
+        companion_reflection_jobs_worker,
+        "run_companion_reflection_jobs_worker",
+        _wait_for_optional_stop_event,
+    )
+    monkeypatch.setattr(reminder_jobs_worker, "run_reminder_jobs_worker", _wait_for_optional_stop_event)
+    monkeypatch.setattr(
+        admin_backup_jobs_worker,
+        "run_admin_backup_jobs_worker",
+        _wait_for_optional_stop_event,
+    )
+    monkeypatch.setattr(
+        admin_byok_validation_jobs_worker,
+        "run_admin_byok_validation_jobs_worker",
+        _wait_for_optional_stop_event,
+    )
+    monkeypatch.setattr(connectors_worker, "run_connectors_worker", _wait_for_optional_stop_event)
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        inventory = list(getattr(app.state, "_tldw_shutdown_job_poller_inventory", []))
+
+    assert {entry["name"] for entry in inventory} == {
+        "core_jobs_task",
+        "files_jobs_task",
+        "audio_jobs_task",
+        "audiobook_jobs_task",
+        "media_ingest_jobs_task",
+        "reading_digest_jobs_task",
+        "companion_reflection_jobs_task",
+        "reminder_jobs_task",
+        "admin_backup_jobs_task",
+        "admin_byok_validation_jobs_task",
+        "connectors_jobs_task",
+    }
+    assert all(
+        {"name", "task_name", "has_stop_event", "timeout_sec"} <= set(entry)
+        for entry in inventory
+    )
+    assert all(isinstance(entry["task_name"], str) and entry["task_name"] for entry in inventory)
+    assert all(entry["has_stop_event"] is True for entry in inventory)
+    assert all(entry["timeout_sec"] == 5.0 for entry in inventory)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
+++ b/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
@@ -11,11 +11,13 @@ from tldw_Server_API.app.services import audio_jobs_worker
 from tldw_Server_API.app.services import audiobook_jobs_worker
 from tldw_Server_API.app.services import admin_backup_jobs_worker
 from tldw_Server_API.app.services import admin_byok_validation_jobs_worker
+from tldw_Server_API.app.services import admin_maintenance_rotation_jobs_worker
 from tldw_Server_API.app.services import connectors_worker
 from tldw_Server_API.app.services import core_jobs_worker
 from tldw_Server_API.app.services import jobs_metrics_service
 from tldw_Server_API.app.services import media_ingest_jobs_worker
 from tldw_Server_API.app.services import reminder_jobs_worker
+from tldw_Server_API.app.core.Evaluations import recipe_runs_jobs_worker
 
 
 pytestmark = pytest.mark.unit
@@ -299,6 +301,58 @@ def test_shutdown_timing_helpers_record_segments_and_total_summary() -> None:
         "slowest_segment": "telemetry_shutdown",
         "slowest_duration_ms": 5,
     }
+
+
+@pytest.mark.integration
+def test_lifespan_startup_registers_recipe_and_maintenance_pollers_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app import main as main_module
+
+    app = main_module.app
+    if hasattr(app.state, "_tldw_shutdown_job_poller_inventory"):
+        delattr(app.state, "_tldw_shutdown_job_poller_inventory")
+
+    start_counts = {"recipe": 0, "maintenance": 0}
+
+    async def _short_lived_task() -> None:
+        await asyncio.sleep(0)
+
+    async def _fake_start_recipe_run_jobs_worker(*, stop_event: asyncio.Event | None = None):
+        start_counts["recipe"] += 1
+        return asyncio.create_task(_short_lived_task(), name="recipe_run_jobs_worker")
+
+    async def _fake_start_admin_maintenance_rotation_jobs_worker(
+        *,
+        stop_event: asyncio.Event | None = None,
+    ):
+        start_counts["maintenance"] += 1
+        return asyncio.create_task(
+            _short_lived_task(),
+            name="admin_maintenance_rotation_jobs_worker",
+        )
+
+    monkeypatch.setenv("ADMIN_MAINTENANCE_ROTATION_JOBS_WORKER_ENABLED", "1")
+    monkeypatch.setenv("EVALUATIONS_RECIPE_RUN_JOBS_WORKER_ENABLED", "1")
+    monkeypatch.setattr(
+        admin_maintenance_rotation_jobs_worker,
+        "start_admin_maintenance_rotation_jobs_worker",
+        _fake_start_admin_maintenance_rotation_jobs_worker,
+    )
+    monkeypatch.setattr(
+        recipe_runs_jobs_worker,
+        "start_recipe_run_jobs_worker",
+        _fake_start_recipe_run_jobs_worker,
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        inventory = list(getattr(app.state, "_tldw_shutdown_job_poller_inventory", []))
+
+    inventory_names = {entry["name"] for entry in inventory}
+    assert "admin_maintenance_rotation_jobs_task" in inventory_names
+    assert "recipe_run_jobs_task" in inventory_names
+    assert start_counts == {"recipe": 1, "maintenance": 1}
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
+++ b/tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py
@@ -1,0 +1,171 @@
+import asyncio
+
+import pytest
+
+from tldw_Server_API.app.services import admin_backup_jobs_worker
+from tldw_Server_API.app.services import admin_byok_validation_jobs_worker
+from tldw_Server_API.app.services import connectors_worker
+from tldw_Server_API.app.services import reminder_jobs_worker
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_start_connectors_worker_uses_caller_owned_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+    stop_event = asyncio.Event()
+
+    async def _fake_run(stop_event_arg: asyncio.Event | None = None) -> None:
+        observed["stop_event"] = stop_event_arg
+        await stop_event_arg.wait()
+
+    monkeypatch.setenv("CONNECTORS_WORKER_ENABLED", "1")
+    monkeypatch.setattr(connectors_worker, "run_connectors_worker", _fake_run)
+
+    task = await connectors_worker.start_connectors_worker(stop_event=stop_event)
+    assert task is not None
+    await asyncio.sleep(0)
+
+    assert observed["stop_event"] is stop_event
+
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_start_reminder_jobs_worker_uses_caller_owned_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+    stop_event = asyncio.Event()
+
+    async def _fake_run(stop_event_arg: asyncio.Event | None = None) -> None:
+        observed["stop_event"] = stop_event_arg
+        await stop_event_arg.wait()
+
+    monkeypatch.setenv("REMINDER_JOBS_WORKER_ENABLED", "1")
+    monkeypatch.setattr(reminder_jobs_worker, "run_reminder_jobs_worker", _fake_run)
+
+    task = await reminder_jobs_worker.start_reminder_jobs_worker(stop_event=stop_event)
+    assert task is not None
+    await asyncio.sleep(0)
+
+    assert observed["stop_event"] is stop_event
+
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_run_admin_backup_jobs_worker_stops_sdk_when_stop_event_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_event = asyncio.Event()
+    observed = {"stopped": False}
+
+    class _FakeWorkerSDK:
+        def __init__(self, _jm, _cfg) -> None:
+            pass
+
+        def stop(self) -> None:
+            observed["stopped"] = True
+
+        async def run(self, *, handler) -> None:
+            while not observed["stopped"]:
+                await asyncio.sleep(0)
+
+    monkeypatch.setattr(admin_backup_jobs_worker, "WorkerSDK", _FakeWorkerSDK)
+
+    task = asyncio.create_task(admin_backup_jobs_worker.run_admin_backup_jobs_worker(stop_event))
+    await asyncio.sleep(0)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert observed["stopped"] is True
+
+
+@pytest.mark.asyncio
+async def test_start_admin_backup_jobs_worker_forwards_caller_owned_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+    stop_event = asyncio.Event()
+
+    async def _fake_run(stop_event_arg: asyncio.Event | None = None) -> None:
+        observed["stop_event"] = stop_event_arg
+        await stop_event_arg.wait()
+
+    monkeypatch.setenv("ADMIN_BACKUP_JOBS_WORKER_ENABLED", "1")
+    monkeypatch.setattr(admin_backup_jobs_worker, "run_admin_backup_jobs_worker", _fake_run)
+
+    task = await admin_backup_jobs_worker.start_admin_backup_jobs_worker(stop_event=stop_event)
+    assert task is not None
+    await asyncio.sleep(0)
+
+    assert observed["stop_event"] is stop_event
+
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_run_admin_byok_validation_jobs_worker_stops_sdk_when_stop_event_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_event = asyncio.Event()
+    observed = {"stopped": False}
+
+    class _FakeWorkerSDK:
+        def __init__(self, _jm, _cfg) -> None:
+            pass
+
+        def stop(self) -> None:
+            observed["stopped"] = True
+
+        async def run(self, *, handler) -> None:
+            while not observed["stopped"]:
+                await asyncio.sleep(0)
+
+    monkeypatch.setattr(admin_byok_validation_jobs_worker, "WorkerSDK", _FakeWorkerSDK)
+
+    task = asyncio.create_task(
+        admin_byok_validation_jobs_worker.run_admin_byok_validation_jobs_worker(stop_event)
+    )
+    await asyncio.sleep(0)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert observed["stopped"] is True
+
+
+@pytest.mark.asyncio
+async def test_start_admin_byok_validation_jobs_worker_forwards_caller_owned_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+    stop_event = asyncio.Event()
+
+    async def _fake_run(stop_event_arg: asyncio.Event | None = None) -> None:
+        observed["stop_event"] = stop_event_arg
+        await stop_event_arg.wait()
+
+    monkeypatch.setenv("ADMIN_BYOK_VALIDATION_JOBS_WORKER_ENABLED", "1")
+    monkeypatch.setattr(
+        admin_byok_validation_jobs_worker,
+        "run_admin_byok_validation_jobs_worker",
+        _fake_run,
+    )
+
+    task = await admin_byok_validation_jobs_worker.start_admin_byok_validation_jobs_worker(
+        stop_event=stop_event
+    )
+    assert task is not None
+    await asyncio.sleep(0)
+
+    assert observed["stop_event"] is stop_event
+
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1)

--- a/tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py
+++ b/tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py
@@ -5,6 +5,8 @@ import pytest
 
 from tldw_Server_API.app.services import claims_alerts_scheduler
 from tldw_Server_API.app.services import claims_review_metrics_scheduler
+from tldw_Server_API.app.services import admin_backup_jobs_worker
+from tldw_Server_API.app.services import admin_byok_validation_jobs_worker
 from tldw_Server_API.app.services import connectors_worker
 from tldw_Server_API.app.services import file_artifacts_export_gc_service
 from tldw_Server_API.app.services import ingestion_sources_cleanup_service
@@ -12,6 +14,7 @@ from tldw_Server_API.app.services import kanban_activity_cleanup_service
 from tldw_Server_API.app.services import kanban_purge_service
 from tldw_Server_API.app.services import notifications_prune_service
 from tldw_Server_API.app.services import quality_eval_scheduler
+from tldw_Server_API.app.services import reminder_jobs_worker
 from tldw_Server_API.app.services import reminders_scheduler
 
 
@@ -29,6 +32,12 @@ pytestmark = pytest.mark.unit
         ("NOTIFICATIONS_PRUNE_ENABLED", notifications_prune_service.start_notifications_prune_scheduler),
         ("REMINDERS_SCHEDULER_ENABLED", reminders_scheduler.start_reminders_scheduler),
         ("RAG_QUALITY_EVAL_ENABLED", quality_eval_scheduler.start_quality_eval_scheduler),
+        ("REMINDER_JOBS_WORKER_ENABLED", reminder_jobs_worker.start_reminder_jobs_worker),
+        ("ADMIN_BACKUP_JOBS_WORKER_ENABLED", admin_backup_jobs_worker.start_admin_backup_jobs_worker),
+        (
+            "ADMIN_BYOK_VALIDATION_JOBS_WORKER_ENABLED",
+            admin_byok_validation_jobs_worker.start_admin_byok_validation_jobs_worker,
+        ),
         ("CONNECTORS_WORKER_ENABLED", connectors_worker.start_connectors_worker),
         ("CLAIMS_ALERTS_SCHEDULER_ENABLED", claims_alerts_scheduler.start_claims_alerts_scheduler),
         ("CLAIMS_REVIEW_METRICS_SCHEDULER_ENABLED", claims_review_metrics_scheduler.start_claims_review_metrics_scheduler),
@@ -42,6 +51,33 @@ async def test_service_startup_flags_accept_single_letter_y(monkeypatch: pytest.
             await asyncio.sleep(3600)
 
         monkeypatch.setattr(connectors_worker, "run_connectors_worker", _fake_connectors_worker)
+    elif start_fn is reminder_jobs_worker.start_reminder_jobs_worker:
+        async def _fake_reminder_jobs_worker(_stop_event=None):
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(
+            reminder_jobs_worker,
+            "run_reminder_jobs_worker",
+            _fake_reminder_jobs_worker,
+        )
+    elif start_fn is admin_backup_jobs_worker.start_admin_backup_jobs_worker:
+        async def _fake_admin_backup_jobs_worker(_stop_event=None):
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(
+            admin_backup_jobs_worker,
+            "run_admin_backup_jobs_worker",
+            _fake_admin_backup_jobs_worker,
+        )
+    elif start_fn is admin_byok_validation_jobs_worker.start_admin_byok_validation_jobs_worker:
+        async def _fake_admin_byok_jobs_worker(_stop_event=None):
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(
+            admin_byok_validation_jobs_worker,
+            "run_admin_byok_validation_jobs_worker",
+            _fake_admin_byok_jobs_worker,
+        )
 
     task = await start_fn()
     assert task is not None
@@ -61,6 +97,12 @@ async def test_service_startup_flags_accept_single_letter_y(monkeypatch: pytest.
         ("NOTIFICATIONS_PRUNE_ENABLED", notifications_prune_service.start_notifications_prune_scheduler),
         ("REMINDERS_SCHEDULER_ENABLED", reminders_scheduler.start_reminders_scheduler),
         ("RAG_QUALITY_EVAL_ENABLED", quality_eval_scheduler.start_quality_eval_scheduler),
+        ("REMINDER_JOBS_WORKER_ENABLED", reminder_jobs_worker.start_reminder_jobs_worker),
+        ("ADMIN_BACKUP_JOBS_WORKER_ENABLED", admin_backup_jobs_worker.start_admin_backup_jobs_worker),
+        (
+            "ADMIN_BYOK_VALIDATION_JOBS_WORKER_ENABLED",
+            admin_byok_validation_jobs_worker.start_admin_byok_validation_jobs_worker,
+        ),
         ("CONNECTORS_WORKER_ENABLED", connectors_worker.start_connectors_worker),
     ],
 )
@@ -72,6 +114,25 @@ async def test_service_startup_flags_remain_disabled_when_unset(monkeypatch: pyt
             raise AssertionError("connectors worker should not start when disabled")
 
         monkeypatch.setattr(connectors_worker, "run_connectors_worker", _should_not_run)
+    elif start_fn is reminder_jobs_worker.start_reminder_jobs_worker:
+        async def _should_not_run(*_args, **_kwargs):
+            raise AssertionError("reminder jobs worker should not start when disabled")
+
+        monkeypatch.setattr(reminder_jobs_worker, "run_reminder_jobs_worker", _should_not_run)
+    elif start_fn is admin_backup_jobs_worker.start_admin_backup_jobs_worker:
+        async def _should_not_run(*_args, **_kwargs):
+            raise AssertionError("admin backup jobs worker should not start when disabled")
+
+        monkeypatch.setattr(admin_backup_jobs_worker, "run_admin_backup_jobs_worker", _should_not_run)
+    elif start_fn is admin_byok_validation_jobs_worker.start_admin_byok_validation_jobs_worker:
+        async def _should_not_run(*_args, **_kwargs):
+            raise AssertionError("admin byok validation jobs worker should not start when disabled")
+
+        monkeypatch.setattr(
+            admin_byok_validation_jobs_worker,
+            "run_admin_byok_validation_jobs_worker",
+            _should_not_run,
+        )
 
     task = await start_fn()
     assert task is None


### PR DESCRIPTION
## Summary
- reduce idle shutdown wind-down time by shutting down idle jobs pollers earlier, preserving the lease-drain path for in-flight work, and adding focused shutdown timing coverage
- remove the fixed evaluations pool shutdown delay and expand shutdown tests around jobs pollers, worker ownership, and metrics teardown
- make ACP runner `HOME` config-relative so tracked ACP config and docs no longer depend on a machine-specific absolute path

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py tldw_Server_API/tests/Services/test_service_startup_truthiness_batch2.py tldw_Server_API/tests/Jobs/test_jobs_metrics_service_shutdown.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_config_cwd.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_config_validation.py` (`62 passed`)
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Evaluations/connection_pool.py tldw_Server_API/app/main.py tldw_Server_API/app/services/jobs_metrics_service.py tldw_Server_API/app/services/admin_backup_jobs_worker.py tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py tldw_Server_API/app/services/connectors_worker.py tldw_Server_API/app/services/reminder_jobs_worker.py tldw_Server_API/app/core/Agent_Client_Protocol/config.py -f json -o /tmp/bandit_idle_shutdown_pr.json` (`0 findings`)

## Change summary (Required before merge)
Human requester must replace this section with their own explanation of what changed and why these implementation choices were made, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.
