### PR TITLE
fix: harden evaluations shutdown completion

### DIFF
--- a/tldw_Server_API/app/core/Evaluations/connection_pool.py
+++ b/tldw_Server_API/app/core/Evaluations/connection_pool.py
@@ -539,15 +539,13 @@ class ConnectionPool:
 
         self._shutdown = True
         self._maintenance_shutdown_event.set()
+        maintenance_stopped = True
 
         # Wait for maintenance to exit before mutating pool state so the
         # normal shutdown path does not race with an in-flight cleanup cycle.
         if self._maintenance_task and self._maintenance_task.is_alive():
             self._maintenance_task.join(timeout=1.0)
-            if self._maintenance_task.is_alive():
-                logger.warning(
-                    "Connection pool maintenance thread still alive after 1.0s shutdown wait"
-                )
+            maintenance_stopped = not self._maintenance_task.is_alive()
 
         with self._condition:
             # Close all pooled connections
@@ -562,7 +560,16 @@ class ConnectionPool:
             self._overflow_connections.clear()
             self._condition.notify_all()
 
-        logger.info("Connection pool shutdown complete")
+        if not maintenance_stopped and self._maintenance_task and self._maintenance_task.is_alive():
+            self._maintenance_task.join(timeout=0.1)
+            maintenance_stopped = not self._maintenance_task.is_alive()
+
+        if maintenance_stopped:
+            logger.info("Connection pool shutdown complete")
+        else:
+            logger.warning(
+                "Connection pool shutdown finished with maintenance thread still alive after bounded waits"
+            )
 
     def __enter__(self):
         return self

--- a/tldw_Server_API/app/core/Evaluations/connection_pool.py
+++ b/tldw_Server_API/app/core/Evaluations/connection_pool.py
@@ -546,6 +546,11 @@ class ConnectionPool:
         if self._maintenance_task and self._maintenance_task.is_alive():
             self._maintenance_task.join(timeout=1.0)
             maintenance_stopped = not self._maintenance_task.is_alive()
+            if not maintenance_stopped:
+                logger.info(
+                    "Connection pool maintenance thread still alive after 1.0s; "
+                    "proceeding with shutdown cleanup and will recheck"
+                )
 
         with self._condition:
             # Close all pooled connections

--- a/tldw_Server_API/app/core/Evaluations/connection_pool.py
+++ b/tldw_Server_API/app/core/Evaluations/connection_pool.py
@@ -560,8 +560,9 @@ class ConnectionPool:
             self._overflow_connections.clear()
             self._condition.notify_all()
 
-        if not maintenance_stopped and self._maintenance_task and self._maintenance_task.is_alive():
-            self._maintenance_task.join(timeout=0.1)
+        if not maintenance_stopped and self._maintenance_task:
+            if self._maintenance_task.is_alive():
+                self._maintenance_task.join(timeout=0.1)
             maintenance_stopped = not self._maintenance_task.is_alive()
 
         if maintenance_stopped:

--- a/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
+++ b/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
@@ -167,6 +167,29 @@ class TestConnectionPoolShutdown:
         if any(args and args[0] == "Connection pool shutdown complete" for args in infos):
             pytest.fail("shutdown should not claim clean completion while maintenance thread is still alive")
 
+    def test_shutdown_logs_breadcrumb_before_cleanup_when_maintenance_is_still_alive(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_db_path,
+    ):
+        pool = ConnectionPool(db_path=str(temp_db_path), enable_monitoring=False)
+        maintenance_task = _StuckMaintenanceTask()
+        infos: list[tuple[object, ...]] = []
+        pool._maintenance_task = maintenance_task
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Evaluations.connection_pool.logger.info",
+            lambda *args, **_kwargs: infos.append(args),
+        )
+
+        pool.shutdown()
+
+        if not any(
+            args and args[0] == "Connection pool maintenance thread still alive after 1.0s; proceeding with shutdown cleanup and will recheck"
+            for args in infos
+        ):
+            pytest.fail("expected shutdown to log an intermediate breadcrumb before cleanup when maintenance is still alive")
+
     def test_shutdown_rechecks_maintenance_thread_after_cleanup_before_clean_completion(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
+++ b/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
@@ -13,41 +13,61 @@ class _ShutdownAwareMaintenanceTask:
 
     def __init__(self, wakeup_event: threading.Event):
         self._wakeup_event = wakeup_event
+        self._alive = True
         self.join_timeout = None
 
     def is_alive(self) -> bool:
-        return True
+        return self._alive
 
     def join(self, timeout: float | None = None) -> None:
         if not self._wakeup_event.is_set():
             pytest.fail("shutdown must wake maintenance before joining")
         self.join_timeout = timeout
+        self._alive = False
 
 
 class _TimeoutRecordingMaintenanceTask:
     """Test double that records the shutdown join timeout."""
 
     def __init__(self):
+        self._alive = True
         self.join_timeout = None
 
     def is_alive(self) -> bool:
-        return True
+        return self._alive
 
     def join(self, timeout: float | None = None) -> None:
         self.join_timeout = timeout
+        self._alive = False
 
 
 class _StuckMaintenanceTask:
     """Test double that remains alive after the bounded join."""
 
     def __init__(self):
-        self.join_timeout = None
+        self.join_timeouts: list[float | None] = []
 
     def is_alive(self) -> bool:
         return True
 
     def join(self, timeout: float | None = None) -> None:
-        self.join_timeout = timeout
+        self.join_timeouts.append(timeout)
+
+
+class _StopsAfterFinalJoinMaintenanceTask:
+    """Test double that only exits after the post-cleanup join."""
+
+    def __init__(self):
+        self.join_timeouts: list[float | None] = []
+        self._alive = True
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeouts.append(timeout)
+        if len(self.join_timeouts) >= 2:
+            self._alive = False
 
 
 @pytest.mark.unit
@@ -111,9 +131,14 @@ class TestConnectionPoolShutdown:
     ):
         pool = ConnectionPool(db_path=str(temp_db_path), enable_monitoring=False)
         maintenance_task = _StuckMaintenanceTask()
+        infos: list[tuple[object, ...]] = []
         warnings: list[tuple[object, ...]] = []
         pool._maintenance_task = maintenance_task
 
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Evaluations.connection_pool.logger.info",
+            lambda *args, **kwargs: infos.append(args),
+        )
         monkeypatch.setattr(
             "tldw_Server_API.app.core.Evaluations.connection_pool.logger.warning",
             lambda *args, **kwargs: warnings.append(args),
@@ -121,7 +146,38 @@ class TestConnectionPoolShutdown:
 
         pool.shutdown()
 
-        if maintenance_task.join_timeout != 1.0:
-            pytest.fail(f"expected join timeout 1.0, got {maintenance_task.join_timeout!r}")
+        if maintenance_task.join_timeouts != [1.0, 0.1]:
+            pytest.fail(f"expected join timeouts [1.0, 0.1], got {maintenance_task.join_timeouts!r}")
         if not warnings:
             pytest.fail("expected shutdown to warn when maintenance thread remains alive")
+        if any(args and args[0] == "Connection pool shutdown complete" for args in infos):
+            pytest.fail("shutdown should not claim clean completion while maintenance thread is still alive")
+
+    def test_shutdown_rechecks_maintenance_thread_after_cleanup_before_clean_completion(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_db_path,
+    ):
+        pool = ConnectionPool(db_path=str(temp_db_path), enable_monitoring=False)
+        maintenance_task = _StopsAfterFinalJoinMaintenanceTask()
+        infos: list[tuple[object, ...]] = []
+        warnings: list[tuple[object, ...]] = []
+        pool._maintenance_task = maintenance_task
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Evaluations.connection_pool.logger.info",
+            lambda *args, **kwargs: infos.append(args),
+        )
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Evaluations.connection_pool.logger.warning",
+            lambda *args, **kwargs: warnings.append(args),
+        )
+
+        pool.shutdown()
+
+        if maintenance_task.join_timeouts != [1.0, 0.1]:
+            pytest.fail(f"expected join timeouts [1.0, 0.1], got {maintenance_task.join_timeouts!r}")
+        if warnings:
+            pytest.fail(f"expected clean completion without warnings, got {warnings!r}")
+        if not any(args and args[0] == "Connection pool shutdown complete" for args in infos):
+            pytest.fail("expected shutdown to report clean completion after the maintenance thread exits")

--- a/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
+++ b/tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py
@@ -70,6 +70,20 @@ class _StopsAfterFinalJoinMaintenanceTask:
             self._alive = False
 
 
+class _DiesDuringCleanupMaintenanceTask:
+    """Test double that stops before the post-cleanup retry join."""
+
+    def __init__(self):
+        self.join_timeouts: list[float | None] = []
+        self._alive_states = iter([True, True, False, False])
+
+    def is_alive(self) -> bool:
+        return next(self._alive_states)
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeouts.append(timeout)
+
+
 @pytest.mark.unit
 class TestConnectionPoolShutdown:
     """Shutdown behavior should wake maintenance and avoid long joins."""
@@ -137,11 +151,11 @@ class TestConnectionPoolShutdown:
 
         monkeypatch.setattr(
             "tldw_Server_API.app.core.Evaluations.connection_pool.logger.info",
-            lambda *args, **kwargs: infos.append(args),
+            lambda *args, **_kwargs: infos.append(args),
         )
         monkeypatch.setattr(
             "tldw_Server_API.app.core.Evaluations.connection_pool.logger.warning",
-            lambda *args, **kwargs: warnings.append(args),
+            lambda *args, **_kwargs: warnings.append(args),
         )
 
         pool.shutdown()
@@ -166,11 +180,11 @@ class TestConnectionPoolShutdown:
 
         monkeypatch.setattr(
             "tldw_Server_API.app.core.Evaluations.connection_pool.logger.info",
-            lambda *args, **kwargs: infos.append(args),
+            lambda *args, **_kwargs: infos.append(args),
         )
         monkeypatch.setattr(
             "tldw_Server_API.app.core.Evaluations.connection_pool.logger.warning",
-            lambda *args, **kwargs: warnings.append(args),
+            lambda *args, **_kwargs: warnings.append(args),
         )
 
         pool.shutdown()
@@ -181,3 +195,32 @@ class TestConnectionPoolShutdown:
             pytest.fail(f"expected clean completion without warnings, got {warnings!r}")
         if not any(args and args[0] == "Connection pool shutdown complete" for args in infos):
             pytest.fail("expected shutdown to report clean completion after the maintenance thread exits")
+
+    def test_shutdown_reports_clean_completion_when_maintenance_dies_during_cleanup(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_db_path,
+    ):
+        pool = ConnectionPool(db_path=str(temp_db_path), enable_monitoring=False)
+        maintenance_task = _DiesDuringCleanupMaintenanceTask()
+        infos: list[tuple[object, ...]] = []
+        warnings: list[tuple[object, ...]] = []
+        pool._maintenance_task = maintenance_task
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Evaluations.connection_pool.logger.info",
+            lambda *args, **_kwargs: infos.append(args),
+        )
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.Evaluations.connection_pool.logger.warning",
+            lambda *args, **_kwargs: warnings.append(args),
+        )
+
+        pool.shutdown()
+
+        if maintenance_task.join_timeouts != [1.0]:
+            pytest.fail(f"expected only the initial bounded join, got {maintenance_task.join_timeouts!r}")
+        if warnings:
+            pytest.fail(f"expected clean completion without warnings, got {warnings!r}")
+        if not any(args and args[0] == "Connection pool shutdown complete" for args in infos):
+            pytest.fail("expected shutdown to report clean completion after the maintenance thread dies during cleanup")


### PR DESCRIPTION
## Summary
- prevent Evaluations pool shutdown from reporting clean completion while the maintenance thread is still alive
- add a short bounded post-cleanup recheck so shutdown can still complete cleanly if the maintenance thread exits during cleanup
- add focused regression coverage for degraded and late-exit shutdown paths

## Test Plan
- [x] `source .venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Evaluations/unit/test_connection_pool_shutdown.py tldw_Server_API/tests/Evaluations/unit/test_connection_pool.py tldw_Server_API/tests/Evaluations/test_connection_pool.py tldw_Server_API/tests/DB_Management/test_sqlite_policy_integrations.py -k "connection_pool or evaluations_connection_pool_runtime_connection_uses_standard_sqlite_pragmas"`
- [x] `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Evaluations/connection_pool.py -f json -o /tmp/bandit_evaluations_shutdown_hardening_pr.json`

## Change summary
Human-written change summary required before merge by repository policy. Replace this section with your own explanation of what changed and why these implementation choices were made before marking the PR ready.