### PR TITLE
Prototype workspace collaboration MVP

### DIFF
--- a/Docs/API-related/Prototype_Workspaces_API.md
+++ b/Docs/API-related/Prototype_Workspaces_API.md
@@ -1,0 +1,250 @@
+# Prototype Workspaces API
+
+## Overview
+
+`Prototype Workspace` is the app-prototyping collaboration surface built on top of the existing ACP and Sandbox infrastructure.
+
+The current slice supports:
+
+- owner-created prototype workspaces with a canonical snapshot
+- isolated owner and external collaborator branch sessions
+- private-link exchange into a `Prototype Shared Actor`
+- brokered preview grants and renewals
+- promotion request submission and owner review
+- a minimal WebUI route at `/prototype-workspaces`
+
+The product model stays explicit:
+
+- `Prototype Workspace`: the canonical artifact and promotion boundary
+- `Prototype Session`: an isolated owner or collaborator branch
+- `Prototype Snapshot`: a saved revision in the workspace lineage
+- `Prototype Shared Actor`: an external collaborator identity created from a private link
+- `Promotion Request`: a request to move a candidate snapshot into the canonical line
+
+ACP and Sandbox remain execution backends, not the user-facing product model.
+
+## Lifecycle
+
+1. The owner creates a prototype workspace with a title, prompt, and runtime/share policy.
+2. The service seeds the workspace with an initial canonical snapshot.
+3. The owner can request an owner branch session for guided work on top of the canonical snapshot.
+4. The owner can create a private share token for `prototype_workspace`.
+5. A stakeholder opens `/share/:token`, verifies any password, and exchanges the token for a `Prototype Shared Actor` session token.
+6. The collaborator uses that session token to create or reuse an isolated branch session.
+7. The collaborator produces a candidate snapshot and submits a promotion request.
+8. The owner reviews the request and either rejects it or promotes the candidate after validation.
+9. Preview access is always brokered through a preview handle rather than exposing raw runtime URLs.
+
+## Runtime Profiles
+
+The design references several runtime policy profiles:
+
+- `template_demo`: constrained demo-oriented runtime for seeded prototypes
+- `repo_bootstrap`: profile for repository-backed scaffolds or richer bootstrap flows
+- `locked_collab`: the default external collaborator runtime profile
+
+The current code path actively uses these runtime-policy keys:
+
+- `runtime_policy.owner_profile`
+- `runtime_policy.external_collaborator_profile`
+- preview-broker defaults such as `canonical_preview` and `owner_collab`
+
+Important implementation note:
+
+- external collaborator exchange defaults to `locked_collab` when no explicit external profile is set
+- preview brokering resolves owner vs external runtime profiles from workspace/runtime context instead of trusting the client
+
+## API Surface
+
+### Create workspace
+
+`POST /api/v1/prototype-workspaces`
+
+Creates a new prototype workspace and its seed canonical snapshot.
+
+Request highlights:
+
+- `title`
+- `creation_source`
+- `description`
+- `prompt`
+- `preview_policy`
+- `share_policy`
+- `runtime_policy`
+- `designated_promoter_ids`
+
+Response highlights:
+
+- workspace metadata
+- canonical and last-known-good snapshot ids
+- canonical preview and publish-validation state
+
+### Get owner detail
+
+`GET /api/v1/prototype-workspaces/{prototype_workspace_id}`
+
+Owner-only detail response used by the minimal WebUI.
+
+Response includes:
+
+- workspace metadata
+- `viewer_role`
+- branch-session inventory
+- snapshot inventory
+- canonical and last-known-good markers on snapshots
+
+### Create owner branch session
+
+`POST /api/v1/prototype-workspaces/{prototype_workspace_id}/sessions`
+
+Owner-only route that creates or reuses a branch session rooted at the canonical snapshot and enqueues bootstrap work.
+
+Response highlights:
+
+- `job_id`
+- `job_type = "branch_session_bootstrap"`
+- `prototype_session_id`
+- `actor_type = "owner"`
+
+### Create collaborator branch session
+
+`POST /api/v1/prototype-sessions`
+
+Consumes a collaborator `session_token` minted by the private-link exchange flow and creates or reuses the stakeholder branch session.
+
+Response highlights:
+
+- `prototype_workspace_id`
+- `prototype_session_id`
+- `shared_actor_id`
+- `actor_type = "external_collaborator"`
+
+### Submit promotion request
+
+`POST /api/v1/prototype-promotions`
+
+Creates a promotion request for a candidate snapshot.
+
+Server-side validation binds the request to:
+
+- the prototype workspace in the session token
+- the branch session referenced by the request
+- the candidate snapshot lineage
+- the `Prototype Shared Actor` that owns the branch and snapshot
+
+### Review promotion request
+
+`POST /api/v1/prototype-promotions/{promotion_request_id}/review`
+
+Owner-only approval or rejection flow.
+
+Approval path:
+
+- validates the requested baseline
+- runs promotion validation
+- updates canonical pointers only on success
+- can return a refreshed preview handle for the promoted snapshot
+
+Rejection path:
+
+- records reviewer id and notes
+- does not advance canonical state
+
+### Renew preview grant
+
+`POST /api/v1/prototype-previews/{preview_handle}/renew`
+
+Renews a brokered preview grant for an active preview handle.
+
+Response highlights:
+
+- short-lived preview token
+- preview URL
+- expiry
+- resolved runtime policy profile
+
+### Private-link exchange
+
+`POST /api/v1/sharing/public/{token}/prototype-session`
+
+Turns a private share link into a `Prototype Shared Actor` and collaborator session token.
+
+Request highlights:
+
+- `display_name`
+- `password` when the token is protected
+
+Response highlights:
+
+- `shared_actor_id`
+- `actor_type = "external_collaborator"`
+- `session_token`
+- `runtime_policy_profile`
+
+## Prototype Shared Actor Model
+
+External stakeholders do not become first-class AuthNZ users.
+
+Instead, the exchange flow creates or resumes a `Prototype Shared Actor` that is scoped to:
+
+- one prototype workspace
+- one share-link id
+- a session binding / resume cookie chain
+- an external runtime policy profile
+
+This preserves auditability and keeps owner-only controls separate from collaborator capabilities.
+
+## Preview Broker Guarantees
+
+Preview access is brokered through `preview_handle` records and signed preview grants.
+
+Guardrails:
+
+- raw runtime target URLs are not exposed to clients
+- stale or revoked preview handles do not renew successfully
+- grants are short-lived and scoped to a workspace/session/snapshot tuple
+- runtime policy resolution happens server-side
+
+## Promotion And Publish Guarantees
+
+Promotion is intentionally explicit and validation-gated.
+
+Guardrails:
+
+- only the owner or a designated promoter can approve
+- candidate snapshots must belong to the same workspace
+- candidate snapshots must belong to the referenced branch session
+- stale baselines do not silently overwrite canonical state
+- failed validation does not update canonical or last-known-good pointers
+
+## Minimal WebUI
+
+Current frontend surfaces:
+
+- option route: `/prototype-workspaces`
+- public share route: `/share/:token`
+
+Owner flow includes:
+
+- workspace creation
+- canonical preview state
+- owner branch-session creation
+- private-link generation
+- branch inventory
+- candidate snapshot inventory
+
+Collaborator flow includes:
+
+- private-link exchange
+- collaborator branch-session creation
+- candidate snapshot selection
+- promotion request submission
+
+## Verification Notes
+
+Verified in the current implementation worktree with:
+
+- `python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q`
+- `python -m pytest tldw_Server_API/tests/Sharing/test_sharing_endpoints.py -q`
+- `bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx src/routes/__tests__/option-prototype-workspaces.route.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx`
+- `python -m bandit -f json -o /tmp/bandit_prototype_task6.json tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py`

--- a/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
@@ -56,7 +56,7 @@ Do not split this into separate plans unless implementation stalls on infrastruc
 **Tests**:
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py -q`
 - `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/routes/__tests__/option-prototype-workspaces.route.test.tsx`
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 5: Harden, Document, And Verify The Slice End-To-End
 **Goal**: Close the loop with audit/security checks, docs, and targeted end-to-end verification, including Bandit on the touched Python scope.
@@ -65,7 +65,7 @@ Do not split this into separate plans unless implementation stalls on infrastruc
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q`
 - `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/routes/__tests__/option-prototype-workspaces.route.test.tsx`
 - `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/core/Prototype_Workspaces tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_workspaces.json`
-**Status**: Not Started
+**Status**: Complete
 
 ## File Map
 
@@ -526,7 +526,7 @@ git commit -m "feat: add prototype workspace api endpoints"
 - Modify: `apps/packages/ui/src/hooks/useSharing.ts`
 - Modify: `apps/packages/ui/src/types/sharing.ts`
 
-- [ ] **Step 1: Write failing client and component tests**
+- [x] **Step 1: Write failing client and component tests**
 
 ```tsx
 it("renders owner controls when the current viewer owns the prototype", async () => {
@@ -547,13 +547,13 @@ Also cover:
 - private-link exchange hook calls the new sharing endpoint
 - route component mounts the feature inside `OptionLayout`/`PageShell`
 
-- [ ] **Step 2: Run the new frontend tests to verify they fail**
+- [x] **Step 2: Run the new frontend tests to verify they fail**
 
 Run: `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/routes/__tests__/option-prototype-workspaces.route.test.tsx`
 
 Expected: FAIL because the new hooks, types, and route do not exist yet.
 
-- [ ] **Step 3: Implement the minimal domain methods, hooks, store, and screens**
+- [x] **Step 3: Implement the minimal domain methods, hooks, store, and screens**
 
 ```ts
 export const prototypeWorkspaceMethods = {
@@ -573,13 +573,13 @@ Implementation requirements:
 - reuse existing ACP UI primitives instead of inventing a parallel terminal/chat system
 - keep the first UI intentionally narrow: canonical preview, branch session entry, candidate list, promotion request action, and share controls
 
-- [ ] **Step 4: Re-run the frontend tests**
+- [x] **Step 4: Re-run the frontend tests**
 
 Run: `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/routes/__tests__/option-prototype-workspaces.route.test.tsx`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the frontend MVP**
+- [x] **Step 5: Commit the frontend MVP**
 
 ```bash
 git add apps/packages/ui/src/types/prototype-workspace.ts \
@@ -603,7 +603,7 @@ git commit -m "feat: add prototype workspace web ui"
 - Create: `Docs/API-related/Prototype_Workspaces_API.md`
 - Modify: `Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md`
 
-- [ ] **Step 1: Write the operator/developer doc**
+- [x] **Step 1: Write the operator/developer doc**
 
 Document:
 - prototype workspace lifecycle
@@ -612,25 +612,25 @@ Document:
 - preview broker behavior
 - promotion and publish-validation guarantees
 
-- [ ] **Step 2: Run the targeted backend test suite**
+- [x] **Step 2: Run the targeted backend test suite**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces tldw_Server_API/tests/Sharing/test_sharing_endpoints.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 3: Run the targeted frontend test suite**
+- [x] **Step 3: Run the targeted frontend test suite**
 
-Run: `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/routes/__tests__/option-prototype-workspaces.route.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx`
+Run: `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/routes/__tests__/option-prototype-workspaces.route.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx src/components/Option/__tests__/PublicShare.test.tsx`
 
 Expected: PASS.
 
-- [ ] **Step 4: Run Bandit on the touched Python scope**
+- [x] **Step 4: Run Bandit on the touched Python scope**
 
 Run: `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/core/Prototype_Workspaces tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py -f json -o /tmp/bandit_prototype_workspaces.json`
 
 Expected: JSON output written to `/tmp/bandit_prototype_workspaces.json` with no new findings in touched code.
 
-- [ ] **Step 5: Commit docs and verification notes**
+- [x] **Step 5: Commit docs and verification notes**
 
 ```bash
 git add Docs/API-related/Prototype_Workspaces_API.md \
@@ -640,13 +640,13 @@ git commit -m "docs: add prototype workspace api and verification notes"
 
 ## Verification Checklist
 
-- [ ] Shared AuthNZ migration creates and indexes all prototype tables.
-- [ ] External private-link exchange yields a `Prototype Shared Actor`, not a full AuthNZ user.
-- [ ] Branch session bootstrap and promotion jobs are idempotent and cleanup-aware.
-- [ ] Preview access is brokered by `preview_handle` rather than leaked raw runtime URLs.
-- [ ] Publish validation must succeed before canonical pointer updates.
-- [ ] Frontend owner and collaborator views both work against the same backend contracts.
-- [ ] Bandit is green on touched Python scope.
+- [x] Shared AuthNZ migration creates and indexes all prototype tables.
+- [x] External private-link exchange yields a `Prototype Shared Actor`, not a full AuthNZ user.
+- [x] Branch session bootstrap and promotion jobs are idempotent and cleanup-aware.
+- [x] Preview access is brokered by `preview_handle` rather than leaked raw runtime URLs.
+- [x] Publish validation must succeed before canonical pointer updates.
+- [x] Frontend owner and collaborator views both work against the same backend contracts.
+- [x] Bandit is green on touched Python scope.
 
 ## Open Decisions To Confirm During Execution
 

--- a/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
@@ -445,7 +445,7 @@ git commit -m "feat: add prototype runtime jobs and preview broker"
 - Create: `tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py`
 - Modify: `tldw_Server_API/app/main.py`
 
-- [ ] **Step 1: Write failing endpoint integration tests for the owner and collaborator flows**
+- [x] **Step 1: Write failing endpoint integration tests for the owner and collaborator flows**
 
 ```python
 def test_owner_can_create_workspace_and_request_branch_session(client):
@@ -468,13 +468,13 @@ Also cover:
 - preview grant renewal
 - stale promotion response shape
 
-- [ ] **Step 2: Run the endpoint tests to verify they fail**
+- [x] **Step 2: Run the endpoint tests to verify they fail**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py -q`
 
 Expected: FAIL because the router and schemas do not exist yet.
 
-- [ ] **Step 3: Implement the router and schemas with minimal happy-path behavior first**
+- [x] **Step 3: Implement the router and schemas with minimal happy-path behavior first**
 
 ```python
 @router.post("/prototype-workspaces", response_model=PrototypeWorkspaceResponse, status_code=201)
@@ -490,7 +490,7 @@ Implementation requirements:
 - use explicit Pydantic models for job responses, preview responses, and promotion responses
 - include the new router in `main.py` using the same conditional include style already used for sharing/sandbox routers
 
-- [ ] **Step 4: Re-run the endpoint integration tests**
+- [x] **Step 4: Re-run the endpoint integration tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py -q`
 

--- a/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
@@ -31,7 +31,7 @@ Do not split this into separate plans unless implementation stalls on infrastruc
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Sharing/test_sharing_endpoints.py -q`
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Sharing/test_sharing_integration.py -q`
 - `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/useSharing.auth.test.tsx src/store/__tests__/acp-sessions.test.ts`
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 2: Build Shared Prototype Metadata And External Collaboration Identity
 **Goal**: Add prototype tables, repo access, and the `Prototype Shared Actor` collaboration identity flow before touching ACP/Sandbox orchestration.
@@ -39,7 +39,7 @@ Do not split this into separate plans unless implementation stalls on infrastruc
 **Tests**:
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py -q`
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py -q`
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 3: Add Jobs-Backed Runtime, Snapshot, Preview, And Publish Validation
 **Goal**: Implement idempotent branch-session creation, snapshot save, brokered preview handles, and publish validation against a fresh canonical runtime.
@@ -48,7 +48,7 @@ Do not split this into separate plans unless implementation stalls on infrastruc
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py -q`
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py -q`
 - `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py -q`
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 4: Expose The Prototype API Surface And Minimal WebUI
 **Goal**: Ship the backend endpoints and a minimal owner/collaborator frontend flow that can create, share, enter, operate, and request promotion for a prototype workspace.
@@ -157,7 +157,7 @@ Do not split this into separate plans unless implementation stalls on infrastruc
 **Files:**
 - Modify: `Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md`
 
-- [ ] **Step 1: Create or switch to an isolated worktree**
+- [x] **Step 1: Create or switch to an isolated worktree**
 
 ```bash
 git worktree add ../tldw_server2-prototype-workspaces -b codex/prototype-workspace-collaboration
@@ -165,7 +165,7 @@ git worktree add ../tldw_server2-prototype-workspaces -b codex/prototype-workspa
 
 Expected: a new worktree exists on branch `codex/prototype-workspace-collaboration`.
 
-- [ ] **Step 2: Install backend and frontend dependencies in the new worktree**
+- [x] **Step 2: Install backend and frontend dependencies in the new worktree**
 
 Run: `source .venv/bin/activate && python -V`
 
@@ -173,19 +173,19 @@ Run: `cd apps && bun install --frozen-lockfile`
 
 Expected: Python commands resolve inside the repo virtualenv and frontend packages are ready without lockfile drift.
 
-- [ ] **Step 3: Run the baseline backend sharing tests**
+- [x] **Step 3: Run the baseline backend sharing tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Sharing/test_sharing_endpoints.py tldw_Server_API/tests/Sharing/test_sharing_integration.py -q`
 
 Expected: PASS. This confirms the existing sharing path is stable before prototype-specific extension work starts.
 
-- [ ] **Step 4: Run the baseline frontend sharing/ACP store tests**
+- [x] **Step 4: Run the baseline frontend sharing/ACP store tests**
 
 Run: `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/useSharing.auth.test.tsx src/store/__tests__/acp-sessions.test.ts`
 
 Expected: PASS. This confirms the existing client sharing and ACP session store contracts are stable before adding prototype flows.
 
-- [ ] **Step 5: Commit the clean-room baseline checkpoint**
+- [x] **Step 5: Commit the clean-room baseline checkpoint**
 
 ```bash
 git add Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
@@ -201,7 +201,7 @@ git commit -m "docs: add prototype workspace implementation plan"
 - Modify: `tldw_Server_API/app/core/AuthNZ/migrations.py`
 - Modify: `tldw_Server_API/app/core/AuthNZ/repos/__init__.py`
 
-- [ ] **Step 1: Write the failing repo and migration tests**
+- [x] **Step 1: Write the failing repo and migration tests**
 
 ```python
 async def test_create_workspace_snapshot_and_session_enforce_single_actor_identity(repo):
@@ -231,13 +231,13 @@ Also add a migration test asserting the next AuthNZ migration creates:
 - `prototype_shared_actors`
 - `prototype_promotion_requests`
 
-- [ ] **Step 2: Run the new repo tests to verify they fail**
+- [x] **Step 2: Run the new repo tests to verify they fail**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py -q`
 
 Expected: FAIL because the migration and repo do not exist yet.
 
-- [ ] **Step 3: Implement the minimal migration and repo**
+- [x] **Step 3: Implement the minimal migration and repo**
 
 ```python
 async def create_session(
@@ -259,13 +259,13 @@ Implementation requirements:
 - keep repo JSON loading/boolean normalization patterns consistent with `shared_workspace_repo.py`
 - add indexes for `(prototype_workspace_id, updated_at)` and `(share_link_id, revoked_at)`
 
-- [ ] **Step 4: Re-run the repo tests**
+- [x] **Step 4: Re-run the repo tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the metadata foundation**
+- [x] **Step 5: Commit the metadata foundation**
 
 ```bash
 git add tldw_Server_API/app/core/AuthNZ/migrations.py \
@@ -285,7 +285,7 @@ git commit -m "feat: add prototype workspace shared metadata store"
 - Modify: `tldw_Server_API/app/api/v1/endpoints/sharing.py`
 - Modify: `tldw_Server_API/app/core/Sharing/share_token_service.py`
 
-- [ ] **Step 1: Add failing tests for private-link to shared-actor exchange**
+- [x] **Step 1: Add failing tests for private-link to shared-actor exchange**
 
 ```python
 def test_public_prototype_exchange_creates_shared_actor(client, prototype_share_token):
@@ -307,13 +307,13 @@ Also cover:
 - non-prototype token returns 422
 - repeated exchange on the same browser session resumes the same shared actor when allowed by policy
 
-- [ ] **Step 2: Run the exchange tests to verify they fail**
+- [x] **Step 2: Run the exchange tests to verify they fail**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py -q`
 
 Expected: FAIL because the endpoint and response schema do not exist yet.
 
-- [ ] **Step 3: Implement the prototype exchange endpoint and access context helper**
+- [x] **Step 3: Implement the prototype exchange endpoint and access context helper**
 
 ```python
 class PrototypeLinkExchangeResponse(BaseModel):
@@ -329,13 +329,13 @@ Implementation requirements:
 - require password verification when the token is protected
 - create or resume a `Prototype Shared Actor` and return a short-lived collaboration token
 
-- [ ] **Step 4: Re-run sharing and exchange tests**
+- [x] **Step 4: Re-run sharing and exchange tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py tldw_Server_API/tests/Sharing/test_sharing_endpoints.py -q`
 
 Expected: PASS. Existing sharing tests should remain green.
 
-- [ ] **Step 5: Commit the sharing extension checkpoint**
+- [x] **Step 5: Commit the sharing extension checkpoint**
 
 ```bash
 git add tldw_Server_API/app/core/Prototype_Workspaces/access.py \
@@ -358,7 +358,7 @@ git commit -m "feat: add prototype private-link collaboration exchange"
 - Create: `tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py`
 - Create: `tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py`
 
-- [ ] **Step 1: Write failing runtime and publish-validation tests**
+- [x] **Step 1: Write failing runtime and publish-validation tests**
 
 ```python
 async def test_promote_candidate_requires_publish_validation(repo, prototype_service):
@@ -387,13 +387,13 @@ Also add tests for:
 - stale candidate never advances canonical state
 - failed validation preserves `last_known_good_snapshot_id`
 
-- [ ] **Step 2: Run the new runtime tests to verify they fail**
+- [x] **Step 2: Run the new runtime tests to verify they fail**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py -q`
 
 Expected: FAIL because the runtime services and worker do not exist yet.
 
-- [ ] **Step 3: Implement the service, preview broker, and worker skeleton**
+- [x] **Step 3: Implement the service, preview broker, and worker skeleton**
 
 ```python
 PROTOTYPE_JOB_TYPES = {
@@ -417,7 +417,7 @@ Implementation requirements:
 - publish validation must restore a snapshot into a fresh runtime profile before flipping the canonical pointer
 - cleanup retries must terminate orphan preview/runtime resources before creating replacements
 
-- [ ] **Step 4: Re-run the runtime tests**
+- [x] **Step 4: Re-run the runtime tests**
 
 Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py -q`
 

--- a/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
@@ -255,7 +255,7 @@ async def create_session(
 ```
 
 Implementation requirements:
-- use the next AuthNZ migration number after `083`
+- use the next unused AuthNZ migration version without renumbering historical migrations already present in the repo
 - keep repo JSON loading/boolean normalization patterns consistent with `shared_workspace_repo.py`
 - add indexes for `(prototype_workspace_id, updated_at)` and `(share_link_id, revoked_at)`
 

--- a/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-18-acp-prototype-workspace-collaboration-implementation-plan.md
@@ -423,7 +423,7 @@ Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Protot
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the runtime orchestration layer**
+- [x] **Step 5: Commit the runtime orchestration layer**
 
 ```bash
 git add tldw_Server_API/app/core/Prototype_Workspaces/models.py \

--- a/IMPLEMENTATION_PLAN_pr1104_async_sharing_repo_review_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_async_sharing_repo_review_slice.md
@@ -1,0 +1,24 @@
+## Stage 1: Verify Review Finding
+**Goal**: Confirm PR #1104 sharing endpoint lazy repo factories await the async AuthNZ DB pool before constructing repositories.
+**Success Criteria**: Focused tests fail when `_get_repo()` or `_get_prototype_repo()` stores the coroutine returned by `get_db_pool()`.
+**Tests**: Focused pytest for sharing endpoint factory helpers.
+**Status**: Complete
+
+## Stage 2: Implement Awaitable Factory Resolution
+**Goal**: Make sharing endpoint repo/service factories awaitable while preserving existing sync test monkeypatches.
+**Success Criteria**: Shared and prototype repositories receive the resolved DB pool object, and endpoint call sites resolve patched sync or async factories consistently.
+**Tests**: Focused sharing endpoint tests and prototype link exchange tests.
+**Status**: Complete
+
+## Stage 3: Verify and Publish
+**Goal**: Run focused backend tests, Bandit on touched backend code, diff checks, then push/reply to the relevant PR thread.
+**Success Criteria**: Local verification passes and the addressed PR #1104 review thread has a reply.
+**Tests**: Focused pytest, Bandit, `git diff --check`.
+**Status**: In Progress
+
+### Verification
+- Red: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sharing/test_sharing_endpoints.py::test_lazy_shared_repo_awaits_db_pool tldw_Server_API/tests/Sharing/test_sharing_endpoints.py::test_lazy_prototype_repo_awaits_db_pool -q` failed because both repos stored the coroutine from `get_db_pool()`.
+- Green: the same focused command passed with 2 tests.
+- Regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Sharing/test_sharing_endpoints.py tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py -q` passed with 50 tests.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/sharing.py -f json -o /tmp/bandit_pr1104_async_sharing_repo.json` reported no results and no errors.
+- Diff: `git diff --check` passed.

--- a/IMPLEMENTATION_PLAN_pr1104_collaborator_workspace_fallback_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_collaborator_workspace_fallback_slice.md
@@ -1,0 +1,28 @@
+## Stage 1: Verify Review Finding
+**Goal**: Confirm token-only collaborator entry can inherit a stale active owner workspace id.
+**Success Criteria**: A focused frontend test fails when `PrototypeWorkspaceSessionView` receives the previous `activeWorkspaceId` for a share-token entry without a `workspace` query param.
+**Tests**: Focused Vitest for `PrototypeWorkspacePage`.
+**Status**: Complete
+
+## Stage 2: Implement Collaborator-Safe Resolution
+**Goal**: Prevent collaborator-entry flows from falling back to the owner active workspace id.
+**Success Criteria**: Owner views still resolve `workspace ?? activeWorkspaceId`, while collaborator entries pass only explicit `workspace` or `null`.
+**Tests**: Focused Vitest and frontend typecheck where practical.
+**Status**: Complete
+
+Notes:
+- Regression test first failed with `Workspace:pw_stale_owner` for a token-only share entry.
+- Implementation now uses `workspaceId ?? null` for collaborator entries and preserves `workspaceId ?? activeWorkspaceId` for owner entries.
+
+## Stage 3: Verify and Publish
+**Goal**: Run focused frontend tests, TypeScript check if available, diff checks, then push/reply to the relevant PR thread.
+**Success Criteria**: Local verification passes and the addressed PR #1104 review thread has a reply.
+**Tests**: Focused Vitest, TypeScript check, `git diff --check`.
+**Status**: Complete
+
+Notes:
+- `bun run --cwd packages/ui test -- src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx` passed with 1 file and 4 tests.
+- `git diff --check` passed.
+- `apps/packages/ui` exposes `test` but no package-local `typecheck` script or `tsc` binary was available in this worktree.
+- `bun install` in `apps` was interrupted after `node scripts/wxt-prepare.mjs` hung, but the partial install provided enough dependencies for focused Vitest.
+- Backlog MCP was unavailable in this session; tracking task `TASK-61` was created with the CLI in the Backlog-enabled default checkout because this old PR worktree has no Backlog project files.

--- a/IMPLEMENTATION_PLAN_pr1104_designated_promoter_review_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_designated_promoter_review_slice.md
@@ -1,0 +1,24 @@
+## Stage 1: Verify Review Finding
+**Goal**: Confirm PR #1104 blocks designated promoters at the promotion-review API layer.
+**Success Criteria**: A focused endpoint test fails when a user listed in `designated_promoter_ids` reviews a promotion request.
+**Tests**: Focused pytest for prototype promotion review endpoint.
+**Status**: Complete
+
+## Stage 2: Implement Service-Aligned Permission Check
+**Goal**: Use the prototype service promoter policy for promotion-review authorization instead of owner-only endpoint logic.
+**Success Criteria**: Workspace owners and designated promoters can review promotion requests; other users remain forbidden.
+**Tests**: Focused prototype endpoint test.
+**Status**: Complete
+
+## Stage 3: Verify and Publish
+**Goal**: Run focused backend tests, Bandit on touched backend code, diff checks, then push/reply to the relevant PR thread.
+**Success Criteria**: Local verification passes and the addressed PR #1104 review thread has a reply.
+**Tests**: Focused pytest, Bandit, `git diff --check`.
+**Status**: In Progress
+
+### Verification
+- Red: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py::TestPrototypeWorkspaceEndpoints::test_designated_promoter_can_review_promotion_request -q` failed with HTTP 403 from the owner-only endpoint guard.
+- Green: the same focused command passed with 1 test.
+- Regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py -q` passed with 10 tests.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py -f json -o /tmp/bandit_pr1104_designated_promoter_review.json` reported no results and no errors.
+- Diff: `git diff --check` passed.

--- a/IMPLEMENTATION_PLAN_pr1104_prototype_endpoint_repo_cleanup_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_prototype_endpoint_repo_cleanup_slice.md
@@ -1,0 +1,17 @@
+## Stage 1: Cleanup Regressions
+**Goal**: Capture the preview-renew endpoint and row-conversion review comments with focused tests.
+**Success Criteria**: Tests fail against the existing implementation for loose renew-body validation, string-based renewal error mapping, and silent row-conversion failures.
+**Tests**: `test_prototype_endpoints.py`, `test_prototype_repo.py`
+**Status**: Complete
+
+## Stage 2: Endpoint And Repo Fixes
+**Goal**: Make preview-renew request handling strict and typed, and make row-conversion failures debuggable without broad exception catches.
+**Success Criteria**: Focused tests pass with narrow production changes.
+**Tests**: Focused endpoint/repo tests plus full PrototypeWorkspaces suite.
+**Status**: Complete
+
+## Stage 3: Verification And Thread Closeout
+**Goal**: Run lint/security/diff checks, commit, push, and close the addressed PR threads.
+**Success Criteria**: Verification evidence is fresh and PR threads are replied to and resolved.
+**Tests**: Ruff, Bandit touched scope, diff checks.
+**Status**: In Progress

--- a/IMPLEMENTATION_PLAN_pr1104_prototype_frontend_share_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_prototype_frontend_share_slice.md
@@ -1,0 +1,17 @@
+## Stage 1: Frontend Regressions
+**Goal**: Capture the remaining frontend review comments for prototype query keys and password-protected public-share entry.
+**Success Criteria**: Tests fail against the existing placeholder key and password-dropping navigation behavior.
+**Tests**: `usePrototypeWorkspaces.test.tsx`, `PublicShare.test.tsx`, `PrototypeWorkspacePage.test.tsx`
+**Status**: Complete
+
+## Stage 2: Frontend Fixes
+**Goal**: Use semantic disabled query keys and preserve verified prototype-share passwords across the redirect without exposing them in the URL.
+**Success Criteria**: Focused frontend tests pass.
+**Tests**: Focused Vitest files for the touched hooks/components.
+**Status**: Complete
+
+## Stage 3: Verification And Thread Closeout
+**Goal**: Run available frontend checks, commit, push, and resolve the PR threads.
+**Success Criteria**: Verification evidence is recorded and the addressed frontend threads are resolved.
+**Tests**: Focused Vitest, diff checks, TypeScript if available.
+**Status**: In Progress

--- a/IMPLEMENTATION_PLAN_pr1104_prototype_jobs_review_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_prototype_jobs_review_slice.md
@@ -1,0 +1,17 @@
+## Stage 1: Jobs Review Regressions
+**Goal**: Capture the PR review issues around prototype job manager construction and publish-promotion reviewer validation.
+**Success Criteria**: Focused tests fail against the existing implementation for default jobs-manager sharing and missing reviewer id handling.
+**Tests**: `tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py`
+**Status**: Complete
+
+## Stage 2: Jobs Review Fixes
+**Goal**: Make prototype jobs reuse a stable default Jobs manager and validate publish-promotion reviewer ids before service dispatch.
+**Success Criteria**: The focused regressions pass without changing public endpoint behavior.
+**Tests**: Focused runtime jobs tests plus the full PrototypeWorkspaces suite.
+**Status**: Complete
+
+## Stage 3: Verification And PR Thread Closeout
+**Goal**: Run lint/security/diff checks, commit the slice, push it, and reply to the resolved PR threads.
+**Success Criteria**: Verification commands have fresh passing evidence or documented pre-existing unrelated failures; GitHub review threads are answered and resolved.
+**Tests**: Ruff, Bandit touched scope, `git diff --check`, cached diff check.
+**Status**: In Progress

--- a/IMPLEMENTATION_PLAN_pr1104_prototype_repo_sql_review_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_prototype_repo_sql_review_slice.md
@@ -1,0 +1,33 @@
+## Stage 1: Verify Repository SQL Review Findings
+**Goal**: Confirm the actionable prototype repository comments against current code.
+**Success Criteria**: Focused tests fail for PostgreSQL table discovery, pre-read state updates, and Python-side active-session filtering.
+**Tests**: Focused pytest tests in `tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py`.
+**Status**: Complete
+
+Notes:
+- Focused red run failed all three new tests for the expected query-shape/pre-read reasons.
+
+## Stage 2: Implement Backend-Aware Repository Queries
+**Goal**: Keep placeholder handling delegated to `DatabasePool` while fixing backend-specific table discovery and query-level filtering/update behavior.
+**Success Criteria**: `ensure_tables()` uses `information_schema` on PostgreSQL, state updates preserve existing values with SQL-level `COALESCE`, and `find_active_session()` filters active candidates in SQL.
+**Tests**: Focused pytest and full `PrototypeWorkspaces` regression.
+**Status**: Complete
+
+Notes:
+- `DatabasePool` already translates `?` placeholders to `$n` on the PostgreSQL path, so the placeholder-only review item is addressed with a technical reply rather than duplicating placeholder conversion in this repo.
+- `ensure_tables()` now branches table discovery for PostgreSQL instead of querying `sqlite_master`.
+- `update_workspace_state()` now preserves unspecified fields with SQL-level `COALESCE` instead of reading the row and writing a merged copy.
+- `find_active_session()` now uses a static SQL query with optional actor filters and active-session predicates, avoiding broad workspace reads and dynamic SQL construction.
+
+## Stage 3: Verify and Publish
+**Goal**: Run focused/regression tests, Bandit on touched backend code, diff checks, then push/reply to relevant PR threads.
+**Success Criteria**: Local verification passes and repo SQL review threads have technical replies or fixes.
+**Tests**: Focused pytest, full PrototypeWorkspaces pytest, Bandit, `git diff --check`.
+**Status**: Complete
+
+Notes:
+- Focused pytest for the three new repository tests passed.
+- Full `tldw_Server_API/tests/PrototypeWorkspaces` regression passed with 63 tests.
+- `ruff check` passed for the touched repository and test files.
+- Bandit passed on `tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py` after replacing the dynamic query with a static optional-filter query.
+- `git diff --check` passed.

--- a/IMPLEMENTATION_PLAN_pr1104_prototype_service_consistency_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_prototype_service_consistency_slice.md
@@ -1,0 +1,17 @@
+## Stage 1: Service Consistency Regressions
+**Goal**: Capture partial-write failure modes in prototype workspace service orchestration.
+**Success Criteria**: Tests fail against the current implementation for workspace seed failures, session snapshot state failures, and promotion request failures after preview grant issuance.
+**Tests**: `test_promotion_service.py`
+**Status**: Complete
+
+## Stage 2: Compensation Fixes
+**Goal**: Add explicit repository cleanup helpers and service compensation paths for the reviewed multi-step writes.
+**Success Criteria**: Failed service writes leave archived/deleted/revoked or reverted state instead of usable partial state.
+**Tests**: Focused promotion/service tests plus full PrototypeWorkspaces suite.
+**Status**: Complete
+
+## Stage 3: Verification And Thread Closeout
+**Goal**: Run lint/security/diff checks, commit, push, and resolve the service consistency PR threads.
+**Success Criteria**: Fresh verification is recorded and the addressed review threads are closed.
+**Tests**: Ruff, Bandit touched scope, diff checks.
+**Status**: In Progress

--- a/IMPLEMENTATION_PLAN_pr1104_prototype_signing_secret_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_prototype_signing_secret_slice.md
@@ -1,0 +1,32 @@
+## Stage 1: Verify Signing Secret Review Finding
+**Goal**: Confirm preview/access token services currently fall back to a per-process random signing secret.
+**Success Criteria**: Focused tests fail because services instantiate without a configured stable signing secret.
+**Tests**: Focused pytest tests for `PrototypePreviewBroker` and `PrototypeAccessService`.
+**Status**: Complete
+
+Notes:
+- Focused red run failed both new tests because the services did not raise when all configured signing-secret sources were absent.
+
+## Stage 2: Require Stable Signing Secrets
+**Goal**: Remove process-local random fallback signing secrets while preserving explicit constructor injection and existing JWT/API-key configuration fallbacks.
+**Success Criteria**: Preview and access services resolve only explicit/configured secrets and raise a clear error when none are available.
+**Tests**: Focused pytest and full `PrototypeWorkspaces` regression.
+**Status**: Complete
+
+Notes:
+- `PrototypePreviewBroker` now resolves only an explicit secret, `PROTOTYPE_PREVIEW_SIGNING_SECRET`, `JWT_SECRET_KEY`, or `SINGLE_USER_API_KEY`.
+- `PrototypeAccessService` now resolves only an explicit secret, `JWT_SECRET_KEY`, or `SINGLE_USER_API_KEY`.
+- Both services raise a clear `RuntimeError` instead of creating a per-process random fallback secret when no stable source exists.
+
+## Stage 3: Verify and Publish
+**Goal**: Run focused/regression tests, Bandit on touched backend code, diff checks, then push/reply to relevant PR threads.
+**Success Criteria**: Local verification passes and stable-signing-secret review threads have replies.
+**Tests**: Focused pytest, full PrototypeWorkspaces pytest, Bandit, `git diff --check`.
+**Status**: Complete
+
+Notes:
+- Focused signing-secret tests passed.
+- Full `tldw_Server_API/tests/PrototypeWorkspaces` regression passed with 65 tests.
+- Ruff passed for touched signing/test files.
+- Bandit passed with 0 results on `preview_broker.py` and `access.py`.
+- `git diff --check` passed.

--- a/IMPLEMENTATION_PLAN_pr1104_revoked_at_review_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_revoked_at_review_slice.md
@@ -1,0 +1,25 @@
+## Stage 1: Verify Review Findings
+**Goal**: Confirm the PR #1104 `revoked_at` authorization and Loguru lint comments still apply on the current branch.
+**Success Criteria**: A focused test fails for a `revoked_at`-only actor/session, and Ruff can target the logger format issue.
+**Tests**: Focused pytest for prototype workspace service authorization helpers; targeted Ruff PLE1205 check on `tldw_Server_API/app/main.py`.
+**Status**: Complete
+
+## Stage 2: Implement Narrow Fix
+**Goal**: Treat `revoked_at` as revoked anywhere branch actor/session activity is checked, and convert the minimal-router Loguru call to supported formatting.
+**Success Criteria**: Revoked collaborators cannot create/reuse branch sessions or save snapshots when only `revoked_at` is present; Ruff PLE1205 no longer flags the main.py line.
+**Tests**: Focused pytest and Ruff target pass.
+**Status**: Complete
+
+## Stage 3: Verify and Publish
+**Goal**: Run focused backend tests, Bandit on touched backend code, diff checks, then push/reply to the relevant PR threads.
+**Success Criteria**: Local verification passes and the addressed PR #1104 review threads have replies.
+**Tests**: Focused pytest, Ruff PLE1205, Bandit, `git diff --check`.
+**Status**: In Progress
+
+### Verification
+- Red: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_service_authorization.py -q` failed with all three `revoked_at`-only cases not raising.
+- Green: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_service_authorization.py -q` passed with 3 tests.
+- Regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces -q` passed with 59 tests.
+- Ruff: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check --select PLE1205 tldw_Server_API/app/main.py` dropped from 27 to 26 existing findings after removing the reviewed prototype-workspaces warning; remaining findings are unrelated pre-existing logger calls.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Prototype_Workspaces/service.py tldw_Server_API/app/main.py -f json -o /tmp/bandit_pr1104_revoked_at_slice.json` reported no results and no errors.
+- Diff: `git diff --check` passed.

--- a/IMPLEMENTATION_PLAN_pr1104_revoked_at_review_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_revoked_at_review_slice.md
@@ -14,7 +14,7 @@
 **Goal**: Run focused backend tests, Bandit on touched backend code, diff checks, then push/reply to the relevant PR threads.
 **Success Criteria**: Local verification passes and the addressed PR #1104 review threads have replies.
 **Tests**: Focused pytest, Ruff PLE1205, Bandit, `git diff --check`.
-**Status**: In Progress
+**Status**: Complete
 
 ### Verification
 - Red: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_service_authorization.py -q` failed with all three `revoked_at`-only cases not raising.
@@ -23,3 +23,4 @@
 - Ruff: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check --select PLE1205 tldw_Server_API/app/main.py` dropped from 27 to 26 existing findings after removing the reviewed prototype-workspaces warning; remaining findings are unrelated pre-existing logger calls.
 - Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Prototype_Workspaces/service.py tldw_Server_API/app/main.py -f json -o /tmp/bandit_pr1104_revoked_at_slice.json` reported no results and no errors.
 - Diff: `git diff --check` passed.
+- Published: committed as `5355b4857`, pushed to PR #1104, replied to and resolved review threads `PRRT_kwDOL1aGf859uo71` and `PRRT_kwDOL1aGf859uo8D`.

--- a/IMPLEMENTATION_PLAN_pr1104_share_token_migration_retry_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_share_token_migration_retry_slice.md
@@ -1,0 +1,30 @@
+## Stage 1: Verify Migration Retry Finding
+**Goal**: Confirm migration 087 fails or duplicates data when a partial `share_tokens_new` rebuild table is left behind.
+**Success Criteria**: A focused migration test fails against the current `CREATE TABLE IF NOT EXISTS` retry path.
+**Tests**: Focused pytest for migration 087 retry behavior.
+**Status**: Complete
+
+Notes:
+- Focused red run failed with `sqlite3.IntegrityError: UNIQUE constraint failed: share_tokens_new.id`.
+
+## Stage 2: Make Migration 087 Rerunnable
+**Goal**: Ensure each migration retry starts from a clean scratch table.
+**Success Criteria**: Migration 087 drops any stale `share_tokens_new` table before rebuilding and leaves no scratch table behind.
+**Tests**: Focused migration test and relevant sharing/prototype link tests.
+**Status**: Complete
+
+Notes:
+- Migration 087 now drops a stale `share_tokens_new` scratch table before skip/rebuild decisions when the source `share_tokens` table still exists.
+
+## Stage 3: Verify and Publish
+**Goal**: Run focused tests, Bandit on touched migration code, diff checks, then push/reply to the review thread.
+**Success Criteria**: Local verification passes and the migration review thread has a reply.
+**Tests**: Focused pytest, Bandit, `git diff --check`.
+**Status**: Complete
+
+Notes:
+- Focused migration retry test passed.
+- `tldw_Server_API/tests/Sharing` plus `tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py` passed with 141 tests.
+- Ruff passed for the new migration test file. Ruff on full `migrations.py` still reports unrelated existing SIM118 findings around line 4617.
+- Bandit on `migrations.py` still reports one unrelated existing B608 at line 616; no findings were reported near migration 087.
+- `git diff --check` passed.

--- a/IMPLEMENTATION_PLAN_pr1104_token_claim_release_slice.md
+++ b/IMPLEMENTATION_PLAN_pr1104_token_claim_release_slice.md
@@ -1,0 +1,24 @@
+## Stage 1: Verify Review Finding
+**Goal**: Confirm PR #1104 releases a token claim after a collaborator has already been provisioned.
+**Success Criteria**: A focused prototype link exchange test fails when post-provision audit failure decrements a single-use token.
+**Tests**: Focused pytest for prototype public link exchange claim accounting.
+**Status**: Complete
+
+## Stage 2: Implement Provisioning-Aware Release
+**Goal**: Release claimed token uses only before provisioning succeeds; retain the consumed claim once a shared actor/session exists.
+**Success Criteria**: Pre-provision failures still release the claim, while post-provision failures do not allow minting another actor through a retry.
+**Tests**: Focused prototype link exchange tests.
+**Status**: Complete
+
+## Stage 3: Verify and Publish
+**Goal**: Run focused backend tests, Bandit on touched backend code, diff checks, then push/reply to the relevant PR threads.
+**Success Criteria**: Local verification passes and the addressed PR #1104 review threads have replies.
+**Tests**: Focused pytest, Bandit, `git diff --check`.
+**Status**: In Progress
+
+### Verification
+- Red: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py::test_public_prototype_exchange_retains_claim_on_post_exchange_failure -q` failed because `use_count` was released back to 0 after provisioning.
+- Green: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py::test_public_prototype_exchange_releases_claim_on_unexpected_error tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py::test_public_prototype_exchange_retains_claim_on_post_exchange_failure -q` passed with 2 tests.
+- Regression: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py -q` passed with 20 tests.
+- Bandit: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/sharing.py -f json -o /tmp/bandit_pr1104_token_claim_release.json` reported no results and no errors.
+- Diff: `git diff --check` passed.

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceOwnerView.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceOwnerView.tsx
@@ -1,0 +1,245 @@
+import { useMemo, useState } from "react"
+import { useCreateToken } from "@/hooks/useSharing"
+import { useCreateOwnerBranchSession, useCreatePrototypeWorkspace } from "@/hooks/usePrototypeWorkspaces"
+import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
+import type { PrototypeWorkspaceDetail } from "@/types/prototype-workspace"
+
+interface PrototypeWorkspaceOwnerViewProps {
+  prototypeWorkspaceId?: string | null
+  workspace?: PrototypeWorkspaceDetail | null
+}
+
+export const PrototypeWorkspaceOwnerView = ({
+  prototypeWorkspaceId,
+  workspace
+}: PrototypeWorkspaceOwnerViewProps) => {
+  const activeWorkspaceId = usePrototypeWorkspaceStore(
+    (state) => state.activeWorkspaceId
+  )
+  const setActiveWorkspaceId = usePrototypeWorkspaceStore(
+    (state) => state.setActiveWorkspaceId
+  )
+  const ownerSessionId = usePrototypeWorkspaceStore((state) => state.ownerSessionId)
+  const setOwnerSessionId = usePrototypeWorkspaceStore(
+    (state) => state.setOwnerSessionId
+  )
+
+  const [title, setTitle] = useState("Prototype Workspace")
+  const [prompt, setPrompt] = useState("")
+  const [shareToken, setShareToken] = useState<string | null>(null)
+  const createWorkspace = useCreatePrototypeWorkspace()
+
+  const resolvedWorkspaceId = prototypeWorkspaceId ?? activeWorkspaceId
+  const createOwnerSession = useCreateOwnerBranchSession(resolvedWorkspaceId ?? "")
+  const createToken = useCreateToken()
+
+  const shareUrl = useMemo(() => {
+    if (!shareToken) {
+      return null
+    }
+    const origin =
+      typeof window !== "undefined" ? window.location.origin : "http://localhost"
+    return `${origin}/share/${shareToken}`
+  }, [shareToken])
+
+  const handleCreateWorkspace = async () => {
+    const workspace = await createWorkspace.mutateAsync({
+      title,
+      creation_source: "prompt",
+      prompt: prompt || undefined
+    })
+    setActiveWorkspaceId(workspace.id)
+  }
+
+  const handleCreateOwnerSession = async () => {
+    if (!resolvedWorkspaceId) {
+      return
+    }
+    const session = await createOwnerSession.mutateAsync({})
+    setOwnerSessionId(session.prototype_session_id)
+  }
+
+  const handleCreateShareLink = async () => {
+    if (!resolvedWorkspaceId) {
+      return
+    }
+    const token = await createToken.mutateAsync({
+      resource_type: "prototype_workspace",
+      resource_id: resolvedWorkspaceId,
+      access_level: "full_edit",
+      allow_clone: false
+    })
+    setShareToken(token.raw_token ?? token.token ?? token.token_prefix)
+  }
+
+  return (
+    <div
+      data-testid="prototype-workspace-owner-view"
+      className="flex h-full w-full flex-col gap-4 overflow-auto p-4"
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">Prototype Workspace</h1>
+        <p className="text-sm text-muted-foreground">
+          Create a canonical prototype, start an owner session, and mint a private
+          stakeholder link.
+        </p>
+      </div>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Create workspace</h2>
+          <p className="text-sm text-muted-foreground">
+            Seed a new prototype workspace from a prompt-oriented artifact brief.
+          </p>
+        </div>
+        <div className="grid gap-3">
+          <label className="grid gap-1 text-sm">
+            <span>Title</span>
+            <input
+              className="rounded border px-3 py-2"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </label>
+          <label className="grid gap-1 text-sm">
+            <span>Prompt</span>
+            <textarea
+              className="min-h-24 rounded border px-3 py-2"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Describe the B2B artifact you want the prototype workspace to seed."
+            />
+          </label>
+          <div className="flex flex-wrap gap-3">
+            <button
+              className="rounded bg-primary px-4 py-2 text-primary-foreground"
+              onClick={() => void handleCreateWorkspace()}
+              disabled={createWorkspace.isPending || !title.trim()}
+            >
+              {createWorkspace.isPending ? "Creating..." : "Create workspace"}
+            </button>
+            {resolvedWorkspaceId ? (
+              <span className="self-center text-sm text-muted-foreground">
+                Workspace: {resolvedWorkspaceId}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Canonical preview</h2>
+          <p className="text-sm text-muted-foreground">
+            Track the currently promoted prototype surface and its preview health.
+          </p>
+        </div>
+        <div className="grid gap-2 text-sm text-muted-foreground md:grid-cols-3">
+          <span>Preview status: {workspace?.canonical_preview_status ?? "unknown"}</span>
+          <span>Canonical snapshot: {workspace?.canonical_snapshot_id ?? "not set"}</span>
+          <span>Last known good: {workspace?.last_known_good_snapshot_id ?? "not set"}</span>
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Owner session</h2>
+          <p className="text-sm text-muted-foreground">
+            Boot an ACP-backed owner branch session against the canonical snapshot.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            className="rounded border px-4 py-2"
+            onClick={() => void handleCreateOwnerSession()}
+            disabled={createOwnerSession.isPending || !resolvedWorkspaceId}
+          >
+            {createOwnerSession.isPending ? "Starting..." : "Start owner session"}
+          </button>
+          {ownerSessionId ? (
+            <span className="self-center text-sm text-muted-foreground">
+              Session: {ownerSessionId}
+            </span>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Private share link</h2>
+          <p className="text-sm text-muted-foreground">
+            Generate a prototype-specific private link that external stakeholders can
+            exchange for their own collaborator session.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            className="rounded border px-4 py-2"
+            onClick={() => void handleCreateShareLink()}
+            disabled={createToken.isPending || !resolvedWorkspaceId}
+          >
+            {createToken.isPending ? "Creating..." : "Create private link"}
+          </button>
+          {shareUrl ? (
+            <code className="self-center break-all rounded bg-muted px-2 py-1 text-xs">
+              {shareUrl}
+            </code>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Branch inventory</h2>
+          <p className="text-sm text-muted-foreground">
+            Review active branch sessions attached to this prototype workspace.
+          </p>
+        </div>
+        <div className="space-y-2 text-sm">
+          {(workspace?.sessions ?? []).length === 0 ? (
+            <p className="text-muted-foreground">No branch sessions yet.</p>
+          ) : (
+            workspace?.sessions.map((session) => (
+              <div
+                key={session.id}
+                className="rounded border px-3 py-2"
+              >
+                <div className="font-medium">{session.id}</div>
+                <div className="text-muted-foreground">
+                  {session.actor_type} · {session.runtime_status} · preview {session.preview_status}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Candidate revisions</h2>
+          <p className="text-sm text-muted-foreground">
+            Snapshot inventory for owner review and promotion decisions.
+          </p>
+        </div>
+        <div className="space-y-2 text-sm">
+          {(workspace?.snapshots ?? []).length === 0 ? (
+            <p className="text-muted-foreground">No snapshots recorded yet.</p>
+          ) : (
+            workspace?.snapshots.map((snapshot) => (
+              <div
+                key={snapshot.snapshot_id}
+                className="rounded border px-3 py-2"
+              >
+                <div className="font-medium">{snapshot.snapshot_id}</div>
+                <div className="text-muted-foreground">
+                  {snapshot.is_canonical ? "canonical" : "candidate"} ·{" "}
+                  {snapshot.prompt_summary ?? "No summary provided"}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
@@ -37,8 +37,10 @@ export const PrototypeWorkspacePage = () => {
     }
   }, [sessionToken, shareToken, setCollaboratorEntry])
 
-  const resolvedWorkspaceId = workspaceId ?? activeWorkspaceId
   const isCollaboratorEntry = Boolean(sessionToken || shareToken)
+  const resolvedWorkspaceId = isCollaboratorEntry
+    ? workspaceId ?? null
+    : workspaceId ?? activeWorkspaceId
   const workspaceDetail = usePrototypeWorkspace(
     isCollaboratorEntry ? null : resolvedWorkspaceId
   )

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
@@ -1,10 +1,64 @@
-import React from "react"
+import { useEffect } from "react"
+import { useSearchParams } from "react-router-dom"
+import { usePrototypeWorkspace } from "@/hooks/usePrototypeWorkspaces"
+import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
+import { PrototypeWorkspaceOwnerView } from "./PrototypeWorkspaceOwnerView"
+import { PrototypeWorkspaceSessionView } from "./PrototypeWorkspaceSessionView"
 
-export function PrototypeWorkspacePage() {
-  const params = new URLSearchParams(window.location.search)
-  const mode = params.get("prototype_session_token")
-    ? "collaborator"
-    : "owner"
+export const PrototypeWorkspacePage = () => {
+  const [searchParams] = useSearchParams()
 
-  return <div data-testid="prototype-workspace-mode">{mode}</div>
+  const activeWorkspaceId = usePrototypeWorkspaceStore(
+    (state) => state.activeWorkspaceId
+  )
+  const setActiveWorkspaceId = usePrototypeWorkspaceStore(
+    (state) => state.setActiveWorkspaceId
+  )
+  const setCollaboratorEntry = usePrototypeWorkspaceStore(
+    (state) => state.setCollaboratorEntry
+  )
+
+  const workspaceId = searchParams.get("workspace")
+  const sessionToken = searchParams.get("session_token")
+  const shareToken = searchParams.get("share_token")
+
+  useEffect(() => {
+    if (workspaceId) {
+      setActiveWorkspaceId(workspaceId)
+    }
+  }, [workspaceId, setActiveWorkspaceId])
+
+  useEffect(() => {
+    if (sessionToken || shareToken) {
+      setCollaboratorEntry({
+        collaboratorSessionToken: sessionToken,
+        collaboratorShareToken: shareToken
+      })
+    }
+  }, [sessionToken, shareToken, setCollaboratorEntry])
+
+  const resolvedWorkspaceId = workspaceId ?? activeWorkspaceId
+  const isCollaboratorEntry = Boolean(sessionToken || shareToken)
+  const workspaceDetail = usePrototypeWorkspace(
+    isCollaboratorEntry ? null : resolvedWorkspaceId
+  )
+  const viewerRole = workspaceDetail.data?.viewer_role ?? "owner"
+
+  if (isCollaboratorEntry || viewerRole !== "owner") {
+    return (
+      <PrototypeWorkspaceSessionView
+        prototypeWorkspaceId={resolvedWorkspaceId}
+        sessionToken={sessionToken}
+        shareToken={shareToken}
+        workspace={workspaceDetail.data}
+      />
+    )
+  }
+
+  return (
+    <PrototypeWorkspaceOwnerView
+      prototypeWorkspaceId={resolvedWorkspaceId}
+      workspace={workspaceDetail.data}
+    />
+  )
 }

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspacePage.tsx
@@ -1,12 +1,17 @@
 import { useEffect } from "react"
-import { useSearchParams } from "react-router-dom"
+import { useLocation, useSearchParams } from "react-router-dom"
 import { usePrototypeWorkspace } from "@/hooks/usePrototypeWorkspaces"
 import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
 import { PrototypeWorkspaceOwnerView } from "./PrototypeWorkspaceOwnerView"
 import { PrototypeWorkspaceSessionView } from "./PrototypeWorkspaceSessionView"
 
+interface PrototypeWorkspaceLocationState {
+  prototypeSharePassword?: unknown
+}
+
 export const PrototypeWorkspacePage = () => {
   const [searchParams] = useSearchParams()
+  const location = useLocation()
 
   const activeWorkspaceId = usePrototypeWorkspaceStore(
     (state) => state.activeWorkspaceId
@@ -21,6 +26,11 @@ export const PrototypeWorkspacePage = () => {
   const workspaceId = searchParams.get("workspace")
   const sessionToken = searchParams.get("session_token")
   const shareToken = searchParams.get("share_token")
+  const navigationState = location.state as PrototypeWorkspaceLocationState | null
+  const initialSharePassword =
+    typeof navigationState?.prototypeSharePassword === "string"
+      ? navigationState.prototypeSharePassword
+      : null
 
   useEffect(() => {
     if (workspaceId) {
@@ -52,6 +62,7 @@ export const PrototypeWorkspacePage = () => {
         prototypeWorkspaceId={resolvedWorkspaceId}
         sessionToken={sessionToken}
         shareToken={shareToken}
+        initialPassword={initialSharePassword}
         workspace={workspaceDetail.data}
       />
     )

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
@@ -12,6 +12,7 @@ interface PrototypeWorkspaceSessionViewProps {
   prototypeWorkspaceId?: string | null
   sessionToken?: string | null
   shareToken?: string | null
+  initialPassword?: string | null
   workspace?: PrototypeWorkspaceDetail | null
 }
 
@@ -19,6 +20,7 @@ export const PrototypeWorkspaceSessionView = ({
   prototypeWorkspaceId,
   sessionToken,
   shareToken,
+  initialPassword,
   workspace
 }: PrototypeWorkspaceSessionViewProps) => {
   const activeWorkspaceId = usePrototypeWorkspaceStore(
@@ -44,7 +46,7 @@ export const PrototypeWorkspaceSessionView = ({
   )
 
   const [displayName, setDisplayName] = useState("Stakeholder")
-  const [password, setPassword] = useState("")
+  const [password, setPassword] = useState(initialPassword ?? "")
   const [candidateSnapshotId, setCandidateSnapshotId] = useState("")
   const [requestReason, setRequestReason] = useState("")
 

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/PrototypeWorkspaceSessionView.tsx
@@ -1,0 +1,315 @@
+import { useState } from "react"
+import { usePrototypePrivateLinkExchange } from "@/hooks/useSharing"
+import {
+  usePrototypeWorkspace,
+  useCreateCollaboratorBranchSession,
+  useCreatePromotionRequest
+} from "@/hooks/usePrototypeWorkspaces"
+import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
+import type { PrototypeWorkspaceDetail } from "@/types/prototype-workspace"
+
+interface PrototypeWorkspaceSessionViewProps {
+  prototypeWorkspaceId?: string | null
+  sessionToken?: string | null
+  shareToken?: string | null
+  workspace?: PrototypeWorkspaceDetail | null
+}
+
+export const PrototypeWorkspaceSessionView = ({
+  prototypeWorkspaceId,
+  sessionToken,
+  shareToken,
+  workspace
+}: PrototypeWorkspaceSessionViewProps) => {
+  const activeWorkspaceId = usePrototypeWorkspaceStore(
+    (state) => state.activeWorkspaceId
+  )
+  const collaboratorSessionId = usePrototypeWorkspaceStore(
+    (state) => state.collaboratorSessionId
+  )
+  const collaboratorSessionToken = usePrototypeWorkspaceStore(
+    (state) => state.collaboratorSessionToken
+  )
+  const setActiveWorkspaceId = usePrototypeWorkspaceStore(
+    (state) => state.setActiveWorkspaceId
+  )
+  const setCollaboratorEntry = usePrototypeWorkspaceStore(
+    (state) => state.setCollaboratorEntry
+  )
+  const lastPromotionRequestId = usePrototypeWorkspaceStore(
+    (state) => state.lastPromotionRequestId
+  )
+  const setLastPromotionRequestId = usePrototypeWorkspaceStore(
+    (state) => state.setLastPromotionRequestId
+  )
+
+  const [displayName, setDisplayName] = useState("Stakeholder")
+  const [password, setPassword] = useState("")
+  const [candidateSnapshotId, setCandidateSnapshotId] = useState("")
+  const [requestReason, setRequestReason] = useState("")
+
+  const exchangeLink = usePrototypePrivateLinkExchange()
+  const createSession = useCreateCollaboratorBranchSession()
+  const createPromotion = useCreatePromotionRequest()
+
+  const effectiveSessionToken = sessionToken ?? collaboratorSessionToken
+  const resolvedWorkspaceId =
+    prototypeWorkspaceId ??
+    activeWorkspaceId ??
+    createSession.data?.prototype_workspace_id ??
+    null
+  const resolvedSessionId =
+    collaboratorSessionId ?? createSession.data?.prototype_session_id ?? null
+  const workspaceQuery = usePrototypeWorkspace(
+    workspace ? null : resolvedWorkspaceId
+  )
+  const resolvedWorkspace = workspace ?? workspaceQuery.data ?? null
+
+  const handleExchangeLink = async () => {
+    if (!shareToken) {
+      return
+    }
+    const result = await exchangeLink.mutateAsync({
+      token: shareToken,
+      display_name: displayName,
+      password: password || undefined
+    })
+    setCollaboratorEntry({
+      collaboratorSessionToken: result.session_token,
+      collaboratorShareToken: shareToken,
+      sharedActorId: result.shared_actor_id
+    })
+  }
+
+  const handleCreateSession = async () => {
+    if (!effectiveSessionToken) {
+      return
+    }
+    const result = await createSession.mutateAsync({
+      session_token: effectiveSessionToken
+    })
+    setActiveWorkspaceId(result.prototype_workspace_id)
+    setCollaboratorEntry({
+      collaboratorSessionId: result.prototype_session_id,
+      collaboratorSessionToken: effectiveSessionToken,
+      collaboratorShareToken: shareToken,
+      sharedActorId: result.shared_actor_id ?? null
+    })
+  }
+
+  const handleCreatePromotionRequest = async () => {
+    if (!effectiveSessionToken || !resolvedWorkspaceId || !resolvedSessionId) {
+      return
+    }
+    const promotion = await createPromotion.mutateAsync({
+      prototype_workspace_id: resolvedWorkspaceId,
+      prototype_session_id: resolvedSessionId,
+      candidate_snapshot_id: candidateSnapshotId,
+      session_token: effectiveSessionToken,
+      request_reason: requestReason || undefined
+    })
+    setLastPromotionRequestId(promotion.id)
+  }
+
+  return (
+    <div
+      data-testid="prototype-workspace-session-view"
+      className="flex h-full w-full flex-col gap-4 overflow-auto p-4"
+    >
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">Collaborator Session</h1>
+        <p className="text-sm text-muted-foreground">
+          Exchange a private stakeholder link, create a collaborator branch session,
+          and submit a promotion request back to the canonical prototype.
+        </p>
+      </div>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Private link exchange</h2>
+          <p className="text-sm text-muted-foreground">
+            Use the public prototype share token to mint an external collaborator
+            session token.
+          </p>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="grid gap-1 text-sm">
+            <span>Display name</span>
+            <input
+              className="rounded border px-3 py-2"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+            />
+          </label>
+          <label className="grid gap-1 text-sm">
+            <span>Password</span>
+            <input
+              className="rounded border px-3 py-2"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-3">
+          <button
+            className="rounded border px-4 py-2"
+            onClick={() => void handleExchangeLink()}
+            disabled={exchangeLink.isPending || !shareToken}
+          >
+            {exchangeLink.isPending ? "Exchanging..." : "Exchange private link"}
+          </button>
+          {effectiveSessionToken ? (
+            <code className="self-center break-all rounded bg-muted px-2 py-1 text-xs">
+              Session token: {effectiveSessionToken}
+            </code>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Canonical preview</h2>
+          <p className="text-sm text-muted-foreground">
+            The current promoted prototype remains visible while collaborator
+            revisions are developed in isolated branch sessions.
+          </p>
+        </div>
+        <div className="grid gap-2 text-sm text-muted-foreground md:grid-cols-3">
+          <span>Preview status: {resolvedWorkspace?.canonical_preview_status ?? "unknown"}</span>
+          <span>Canonical snapshot: {resolvedWorkspace?.canonical_snapshot_id ?? "not set"}</span>
+          <span>Last known good: {resolvedWorkspace?.last_known_good_snapshot_id ?? "not set"}</span>
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Collaborator branch session</h2>
+          <p className="text-sm text-muted-foreground">
+            Start or reuse the ACP-backed branch session for this stakeholder actor.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            className="rounded border px-4 py-2"
+            onClick={() => void handleCreateSession()}
+            disabled={createSession.isPending || !effectiveSessionToken}
+          >
+            {createSession.isPending ? "Starting..." : "Start collaborator session"}
+          </button>
+          {resolvedWorkspaceId ? (
+            <span className="self-center text-sm text-muted-foreground">
+              Workspace: {resolvedWorkspaceId}
+            </span>
+          ) : null}
+          {resolvedSessionId ? (
+            <span className="self-center text-sm text-muted-foreground">
+              Session: {resolvedSessionId}
+            </span>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Promotion request</h2>
+          <p className="text-sm text-muted-foreground">
+            Submit a candidate snapshot back to the owner review path once the
+            collaborator branch produces a viable artifact revision.
+          </p>
+        </div>
+        <div className="grid gap-3">
+          <label className="grid gap-1 text-sm">
+            <span>Candidate snapshot id</span>
+            {resolvedWorkspace && resolvedWorkspace.snapshots.length > 0 ? (
+              <select
+                className="rounded border px-3 py-2"
+                value={candidateSnapshotId}
+                onChange={(event) => setCandidateSnapshotId(event.target.value)}
+              >
+                <option value="">Select a candidate snapshot</option>
+                {resolvedWorkspace.snapshots
+                  .filter((snapshot) => !snapshot.is_canonical)
+                  .map((snapshot) => (
+                    <option key={snapshot.snapshot_id} value={snapshot.snapshot_id}>
+                      {snapshot.snapshot_id}
+                    </option>
+                  ))}
+              </select>
+            ) : (
+              <input
+                className="rounded border px-3 py-2"
+                value={candidateSnapshotId}
+                onChange={(event) => setCandidateSnapshotId(event.target.value)}
+                placeholder="psnap_..."
+              />
+            )}
+          </label>
+          <label className="grid gap-1 text-sm">
+            <span>Request reason</span>
+            <textarea
+              className="min-h-20 rounded border px-3 py-2"
+              value={requestReason}
+              onChange={(event) => setRequestReason(event.target.value)}
+              placeholder="Summarize the stakeholder change request and why it should be promoted."
+            />
+          </label>
+          <div className="flex flex-wrap gap-3">
+            <button
+              className="rounded border px-4 py-2"
+              onClick={() => void handleCreatePromotionRequest()}
+              disabled={
+                createPromotion.isPending ||
+                !effectiveSessionToken ||
+                !resolvedWorkspaceId ||
+                !resolvedSessionId ||
+                !candidateSnapshotId.trim()
+              }
+            >
+              {createPromotion.isPending
+                ? "Submitting..."
+                : "Submit promotion request"}
+            </button>
+            {lastPromotionRequestId ? (
+              <span className="self-center text-sm text-muted-foreground">
+                Promotion: {lastPromotionRequestId}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border p-4">
+        <div className="mb-3 space-y-1">
+          <h2 className="font-medium">Snapshot candidates</h2>
+          <p className="text-sm text-muted-foreground">
+            Review candidate revisions that can be promoted back into the
+            canonical prototype.
+          </p>
+        </div>
+        <div className="space-y-2 text-sm">
+          {(resolvedWorkspace?.snapshots ?? []).filter((snapshot) => !snapshot.is_canonical)
+            .length === 0 ? (
+            <p className="text-muted-foreground">No candidate snapshots available yet.</p>
+          ) : (
+            resolvedWorkspace?.snapshots
+              .filter((snapshot) => !snapshot.is_canonical)
+              .map((snapshot) => (
+                <button
+                  key={snapshot.snapshot_id}
+                  type="button"
+                  className="block w-full rounded border px-3 py-2 text-left"
+                  onClick={() => setCandidateSnapshotId(snapshot.snapshot_id)}
+                >
+                  <div className="font-medium">{snapshot.snapshot_id}</div>
+                  <div className="text-muted-foreground">
+                    {snapshot.prompt_summary ?? "No summary provided"}
+                  </div>
+                </button>
+              ))
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
@@ -1,35 +1,125 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { PrototypeWorkspacePage } from "../PrototypeWorkspacePage"
 
+const searchParamsState = vi.hoisted(() => ({
+  value: new URLSearchParams()
+}))
+
+const hookState = vi.hoisted(() => ({
+  usePrototypeWorkspace: vi.fn()
+}))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom"
+  )
+  return {
+    ...actual,
+    useSearchParams: () => [searchParamsState.value, vi.fn()]
+  }
+})
+
+vi.mock("@/hooks/usePrototypeWorkspaces", () => ({
+  usePrototypeWorkspace: (...args: unknown[]) =>
+    hookState.usePrototypeWorkspace(...args)
+}))
+
+vi.mock("../PrototypeWorkspaceOwnerView", () => ({
+  PrototypeWorkspaceOwnerView: ({
+    prototypeWorkspaceId
+  }: {
+    prototypeWorkspaceId?: string | null
+  }) => (
+    <div data-testid="prototype-workspace-owner-view">
+      Owner:{prototypeWorkspaceId ?? "none"}
+    </div>
+  )
+}))
+
+vi.mock("../PrototypeWorkspaceSessionView", () => ({
+  PrototypeWorkspaceSessionView: ({
+    sessionToken,
+    shareToken
+  }: {
+    sessionToken?: string | null
+    shareToken?: string | null
+  }) => (
+    <div data-testid="prototype-workspace-session-view">
+      Session:{sessionToken ?? "none"} Share:{shareToken ?? "none"}
+    </div>
+  )
+}))
+
 describe("PrototypeWorkspacePage", () => {
-  afterEach(() => {
-    window.history.replaceState({}, "", "/")
+  beforeEach(() => {
+    searchParamsState.value = new URLSearchParams()
+    hookState.usePrototypeWorkspace.mockReturnValue({
+      data: null
+    })
   })
 
-  it("defaults to owner mode when no prototype session token is present", () => {
-    window.history.pushState({}, "", "/prototype-workspaces")
+  it("renders the owner workspace view when the workspace detail resolves the viewer as owner", () => {
+    searchParamsState.value = new URLSearchParams({
+      workspace: "pw_1"
+    })
+    hookState.usePrototypeWorkspace.mockReturnValue({
+      data: {
+        id: "pw_1",
+        viewer_role: "owner",
+        sessions: [],
+        snapshots: []
+      }
+    })
 
     render(<PrototypeWorkspacePage />)
 
-    expect(screen.getByTestId("prototype-workspace-mode")).toHaveTextContent(
-      "owner"
-    )
+    expect(
+      screen.getByTestId("prototype-workspace-owner-view")
+    ).toHaveTextContent("Owner:pw_1")
+    expect(
+      screen.queryByTestId("prototype-workspace-session-view")
+    ).not.toBeInTheDocument()
   })
 
-  it("switches to collaborator mode when a prototype session token is present", () => {
-    window.history.pushState(
-      {},
-      "",
-      "/prototype-workspaces?prototype_session_token=proto-123"
-    )
+  it("renders the collaborator session view when workspace detail resolves a non-owner viewer", () => {
+    searchParamsState.value = new URLSearchParams({
+      workspace: "pw_1"
+    })
+    hookState.usePrototypeWorkspace.mockReturnValue({
+      data: {
+        id: "pw_1",
+        viewer_role: "internal_collaborator",
+        sessions: [],
+        snapshots: []
+      }
+    })
 
     render(<PrototypeWorkspacePage />)
 
-    expect(screen.getByTestId("prototype-workspace-mode")).toHaveTextContent(
-      "collaborator"
-    )
+    expect(
+      screen.getByTestId("prototype-workspace-session-view")
+    ).toHaveTextContent("Session:none Share:none")
+    expect(
+      screen.queryByTestId("prototype-workspace-owner-view")
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders the collaborator session view when the page is entered with a prototype session token", () => {
+    searchParamsState.value = new URLSearchParams({
+      session_token: "session-token-1",
+      share_token: "share-token-1"
+    })
+
+    render(<PrototypeWorkspacePage />)
+
+    expect(
+      screen.getByTestId("prototype-workspace-session-view")
+    ).toHaveTextContent("Session:session-token-1 Share:share-token-1")
+    expect(
+      screen.queryByTestId("prototype-workspace-owner-view")
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { usePrototypeWorkspaceStore } from "@/store/prototype-workspace"
 import { PrototypeWorkspacePage } from "../PrototypeWorkspacePage"
 
 const searchParamsState = vi.hoisted(() => ({
@@ -41,14 +42,17 @@ vi.mock("../PrototypeWorkspaceOwnerView", () => ({
 
 vi.mock("../PrototypeWorkspaceSessionView", () => ({
   PrototypeWorkspaceSessionView: ({
+    prototypeWorkspaceId,
     sessionToken,
     shareToken
   }: {
+    prototypeWorkspaceId?: string | null
     sessionToken?: string | null
     shareToken?: string | null
   }) => (
     <div data-testid="prototype-workspace-session-view">
-      Session:{sessionToken ?? "none"} Share:{shareToken ?? "none"}
+      Workspace:{prototypeWorkspaceId ?? "none"} Session:{sessionToken ?? "none"}{" "}
+      Share:{shareToken ?? "none"}
     </div>
   )
 }))
@@ -56,6 +60,7 @@ vi.mock("../PrototypeWorkspaceSessionView", () => ({
 describe("PrototypeWorkspacePage", () => {
   beforeEach(() => {
     searchParamsState.value = new URLSearchParams()
+    usePrototypeWorkspaceStore.getState().reset()
     hookState.usePrototypeWorkspace.mockReturnValue({
       data: null
     })
@@ -121,5 +126,19 @@ describe("PrototypeWorkspacePage", () => {
     expect(
       screen.queryByTestId("prototype-workspace-owner-view")
     ).not.toBeInTheDocument()
+  })
+
+  it("does not pass a stale active workspace id to token-only collaborator entries", () => {
+    usePrototypeWorkspaceStore.getState().setActiveWorkspaceId("pw_stale_owner")
+    searchParamsState.value = new URLSearchParams({
+      share_token: "share-token-1"
+    })
+
+    render(<PrototypeWorkspacePage />)
+
+    expect(hookState.usePrototypeWorkspace).toHaveBeenCalledWith(null)
+    expect(
+      screen.getByTestId("prototype-workspace-session-view")
+    ).toHaveTextContent("Workspace:none Session:none Share:share-token-1")
   })
 })

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx
@@ -9,6 +9,10 @@ const searchParamsState = vi.hoisted(() => ({
   value: new URLSearchParams()
 }))
 
+const locationState = vi.hoisted(() => ({
+  value: null as unknown
+}))
+
 const hookState = vi.hoisted(() => ({
   usePrototypeWorkspace: vi.fn()
 }))
@@ -19,6 +23,7 @@ vi.mock("react-router-dom", async () => {
   )
   return {
     ...actual,
+    useLocation: () => ({ state: locationState.value }),
     useSearchParams: () => [searchParamsState.value, vi.fn()]
   }
 })
@@ -44,15 +49,17 @@ vi.mock("../PrototypeWorkspaceSessionView", () => ({
   PrototypeWorkspaceSessionView: ({
     prototypeWorkspaceId,
     sessionToken,
-    shareToken
+    shareToken,
+    initialPassword
   }: {
     prototypeWorkspaceId?: string | null
     sessionToken?: string | null
     shareToken?: string | null
+    initialPassword?: string | null
   }) => (
     <div data-testid="prototype-workspace-session-view">
       Workspace:{prototypeWorkspaceId ?? "none"} Session:{sessionToken ?? "none"}{" "}
-      Share:{shareToken ?? "none"}
+      Share:{shareToken ?? "none"} Password:{initialPassword ?? "none"}
     </div>
   )
 }))
@@ -60,6 +67,7 @@ vi.mock("../PrototypeWorkspaceSessionView", () => ({
 describe("PrototypeWorkspacePage", () => {
   beforeEach(() => {
     searchParamsState.value = new URLSearchParams()
+    locationState.value = null
     usePrototypeWorkspaceStore.getState().reset()
     hookState.usePrototypeWorkspace.mockReturnValue({
       data: null
@@ -140,5 +148,20 @@ describe("PrototypeWorkspacePage", () => {
     expect(
       screen.getByTestId("prototype-workspace-session-view")
     ).toHaveTextContent("Workspace:none Session:none Share:share-token-1")
+  })
+
+  it("passes prototype share passwords from navigation state into collaborator entry", () => {
+    searchParamsState.value = new URLSearchParams({
+      share_token: "share-token-1"
+    })
+    locationState.value = {
+      prototypeSharePassword: "demo-pass"
+    }
+
+    render(<PrototypeWorkspacePage />)
+
+    expect(
+      screen.getByTestId("prototype-workspace-session-view")
+    ).toHaveTextContent("Password:demo-pass")
   })
 })

--- a/apps/packages/ui/src/components/Option/PrototypeWorkspace/index.tsx
+++ b/apps/packages/ui/src/components/Option/PrototypeWorkspace/index.tsx
@@ -1,0 +1,3 @@
+export { PrototypeWorkspaceOwnerView } from "./PrototypeWorkspaceOwnerView"
+export { PrototypeWorkspacePage } from "./PrototypeWorkspacePage"
+export { PrototypeWorkspaceSessionView } from "./PrototypeWorkspaceSessionView"

--- a/apps/packages/ui/src/components/Option/PublicShare/index.tsx
+++ b/apps/packages/ui/src/components/Option/PublicShare/index.tsx
@@ -62,7 +62,16 @@ export const PublicShare: React.FC<PublicShareProps> = ({ token }) => {
   const isPrototypeWorkspace = data.resource_type === "prototype_workspace"
 
   const handlePrototypeContinue = () => {
-    navigate(`/prototype-workspaces?share_token=${encodeURIComponent(token)}`)
+    const target = `/prototype-workspaces?share_token=${encodeURIComponent(token)}`
+    if (data.is_password_protected && passwordVerified && password) {
+      navigate(target, {
+        state: {
+          prototypeSharePassword: password
+        }
+      })
+      return
+    }
+    navigate(target)
   }
 
   return (

--- a/apps/packages/ui/src/components/Option/PublicShare/index.tsx
+++ b/apps/packages/ui/src/components/Option/PublicShare/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import { Card, Button, Input, Spin, Empty, Tag, message } from "antd"
 import { Lock, Download } from "lucide-react"
+import { useNavigate } from "react-router-dom"
 import {
   usePublicPreview,
   useVerifySharePassword,
@@ -13,6 +14,7 @@ interface PublicShareProps {
 }
 
 export const PublicShare: React.FC<PublicShareProps> = ({ token }) => {
+  const navigate = useNavigate()
   const { data, isLoading, error } = usePublicPreview(token)
   const verifyPassword = useVerifySharePassword()
   const importToken = useImportFromToken()
@@ -57,6 +59,11 @@ export const PublicShare: React.FC<PublicShareProps> = ({ token }) => {
   }
 
   const needsPassword = data.is_password_protected && !passwordVerified
+  const isPrototypeWorkspace = data.resource_type === "prototype_workspace"
+
+  const handlePrototypeContinue = () => {
+    navigate(`/prototype-workspaces?share_token=${encodeURIComponent(token)}`)
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
@@ -75,7 +82,11 @@ export const PublicShare: React.FC<PublicShareProps> = ({ token }) => {
 
           <div className="flex justify-center gap-2">
             <Tag color="blue">
-              {data.resource_type === "workspace" ? "Workspace" : "Chatbook"}
+              {data.resource_type === "workspace"
+                ? "Workspace"
+                : data.resource_type === "prototype_workspace"
+                  ? "Prototype Workspace"
+                  : "Chatbook"}
             </Tag>
             <Tag>
               {ACCESS_LEVEL_LABELS[data.access_level as AccessLevel] ||
@@ -106,18 +117,36 @@ export const PublicShare: React.FC<PublicShareProps> = ({ token }) => {
             </div>
           ) : (
             <div className="space-y-3">
-              <Button
-                type="primary"
-                block
-                icon={<Download className="h-4 w-4" />}
-                loading={importToken.isPending}
-                onClick={handleImport}
-              >
-                Import to My Account
-              </Button>
-              <p className="text-center text-xs text-text-muted">
-                You must be logged in to import this resource.
-              </p>
+              {isPrototypeWorkspace ? (
+                <>
+                  <Button
+                    type="primary"
+                    block
+                    onClick={handlePrototypeContinue}
+                  >
+                    Open Prototype Collaboration
+                  </Button>
+                  <p className="text-center text-xs text-text-muted">
+                    Continue into the prototype workspace flow to exchange the
+                    share link and start a collaborator session.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <Button
+                    type="primary"
+                    block
+                    icon={<Download className="h-4 w-4" />}
+                    loading={importToken.isPending}
+                    onClick={handleImport}
+                  >
+                    Import to My Account
+                  </Button>
+                  <p className="text-center text-xs text-text-muted">
+                    You must be logged in to import this resource.
+                  </p>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/apps/packages/ui/src/components/Option/__tests__/PublicShare.test.tsx
+++ b/apps/packages/ui/src/components/Option/__tests__/PublicShare.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { PublicShare } from "../PublicShare"
@@ -66,6 +66,53 @@ describe("PublicShare", () => {
 
     expect(routerMocks.navigate).toHaveBeenCalledWith(
       "/prototype-workspaces?share_token=prototype-token"
+    )
+  })
+
+  it("passes a verified prototype share password through navigation state", async () => {
+    const verifyPassword = vi.fn().mockResolvedValue({ verified: true })
+    hookMocks.usePublicPreview.mockReturnValue({
+      data: {
+        resource_type: "prototype_workspace",
+        resource_name: "Sales dashboard",
+        resource_description: "Stakeholder prototype",
+        is_password_protected: true,
+        access_level: "full_edit",
+        allow_clone: false
+      },
+      isLoading: false,
+      error: null
+    })
+    hookMocks.useVerifySharePassword.mockReturnValue({
+      isPending: false,
+      mutateAsync: verifyPassword
+    })
+
+    render(<PublicShare token="prototype-token" />)
+
+    fireEvent.change(screen.getByPlaceholderText("Enter password"), {
+      target: { value: "demo-pass" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Verify Password" }))
+
+    await waitFor(() => {
+      expect(verifyPassword).toHaveBeenCalledWith({
+        token: "prototype-token",
+        password: "demo-pass"
+      })
+    })
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Prototype Collaboration" })
+    )
+
+    expect(routerMocks.navigate).toHaveBeenCalledWith(
+      "/prototype-workspaces?share_token=prototype-token",
+      {
+        state: {
+          prototypeSharePassword: "demo-pass"
+        }
+      }
     )
   })
 })

--- a/apps/packages/ui/src/components/Option/__tests__/PublicShare.test.tsx
+++ b/apps/packages/ui/src/components/Option/__tests__/PublicShare.test.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { PublicShare } from "../PublicShare"
+
+const hookMocks = vi.hoisted(() => ({
+  usePublicPreview: vi.fn(),
+  useVerifySharePassword: vi.fn(),
+  useImportFromToken: vi.fn()
+}))
+
+const routerMocks = vi.hoisted(() => ({
+  navigate: vi.fn()
+}))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom"
+  )
+  return {
+    ...actual,
+    useNavigate: () => routerMocks.navigate
+  }
+})
+
+vi.mock("@/hooks/useSharing", () => ({
+  usePublicPreview: (...args: unknown[]) => hookMocks.usePublicPreview(...args),
+  useVerifySharePassword: (...args: unknown[]) =>
+    hookMocks.useVerifySharePassword(...args),
+  useImportFromToken: (...args: unknown[]) => hookMocks.useImportFromToken(...args)
+}))
+
+describe("PublicShare", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hookMocks.useVerifySharePassword.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    })
+    hookMocks.useImportFromToken.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    })
+  })
+
+  it("routes prototype workspace tokens into the prototype collaboration flow", () => {
+    hookMocks.usePublicPreview.mockReturnValue({
+      data: {
+        resource_type: "prototype_workspace",
+        resource_name: "Sales dashboard",
+        resource_description: "Stakeholder prototype",
+        is_password_protected: false,
+        access_level: "full_edit",
+        allow_clone: false
+      },
+      isLoading: false,
+      error: null
+    })
+
+    render(<PublicShare token="prototype-token" />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Prototype Collaboration" })
+    )
+
+    expect(routerMocks.navigate).toHaveBeenCalledWith(
+      "/prototype-workspaces?share_token=prototype-token"
+    )
+  })
+})

--- a/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
@@ -35,6 +35,19 @@ const buildWrapper = () => {
   )
 }
 
+const buildWrapperWithClient = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  return { queryClient, wrapper }
+}
+
 describe("usePrototypeWorkspaces", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -144,6 +157,23 @@ describe("usePrototypeWorkspaces", () => {
     expect(fetchWithTldwAuthMock).toHaveBeenCalledWith(
       "http://127.0.0.1:8000/api/v1/prototype-workspaces/pw_1"
     )
+  })
+
+  it("uses a semantic null detail key while the workspace id is unavailable", () => {
+    const { queryClient, wrapper } = buildWrapperWithClient()
+
+    renderHook(() => usePrototypeWorkspace(null), { wrapper })
+
+    expect(fetchWithTldwAuthMock).not.toHaveBeenCalled()
+    expect(queryClient.getQueryCache().getAll().map((query) => query.queryKey)).toContainEqual([
+      "prototype-workspaces",
+      "workspaces",
+      "detail",
+      null
+    ])
+    expect(queryClient.getQueryCache().find({
+      queryKey: ["prototype-workspaces", "workspaces", "detail", "unknown"]
+    })).toBeUndefined()
   })
 
   it("creates an owner branch session through the authenticated tldw fetch helper", async () => {

--- a/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePrototypeWorkspaces.test.tsx
@@ -1,0 +1,288 @@
+import React from "react"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const fetchWithTldwAuthMock = vi.hoisted(() => vi.fn())
+const getTldwServerURLMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/services/tldw/auth-fetch", () => ({
+  fetchWithTldwAuth: fetchWithTldwAuthMock
+}))
+
+vi.mock("@/services/tldw-server", () => ({
+  getTldwServerURL: getTldwServerURLMock
+}))
+
+import {
+  prototypeWorkspaceQueryKeys,
+  usePrototypeWorkspace,
+  useCreateCollaboratorBranchSession,
+  useCreateOwnerBranchSession,
+  useCreatePromotionRequest,
+  useCreatePrototypeWorkspace
+} from "@/hooks/usePrototypeWorkspaces"
+
+const buildWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe("usePrototypeWorkspaces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getTldwServerURLMock.mockResolvedValue("http://127.0.0.1:8000")
+  })
+
+  it("exposes stable query keys for prototype workspace collections and mutations", () => {
+    expect(prototypeWorkspaceQueryKeys.all()).toEqual(["prototype-workspaces"])
+    expect(prototypeWorkspaceQueryKeys.workspaces()).toEqual([
+      "prototype-workspaces",
+      "workspaces"
+    ])
+    expect(prototypeWorkspaceQueryKeys.workspace("pw_1")).toEqual([
+      "prototype-workspaces",
+      "workspaces",
+      "detail",
+      "pw_1"
+    ])
+    expect(prototypeWorkspaceQueryKeys.sessions("pw_1")).toEqual([
+      "prototype-workspaces",
+      "sessions",
+      "pw_1"
+    ])
+    expect(prototypeWorkspaceQueryKeys.promotions("pw_1")).toEqual([
+      "prototype-workspaces",
+      "promotions",
+      "pw_1"
+    ])
+  })
+
+  it("creates a prototype workspace through the authenticated tldw fetch helper", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(JSON.stringify({ id: "pw_1", title: "Sales dashboard" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" }
+      })
+    )
+
+    const { result } = renderHook(() => useCreatePrototypeWorkspace(), {
+      wrapper: buildWrapper()
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        title: "Sales dashboard",
+        creation_source: "prompt",
+        prompt: "Build a B2B dashboard"
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetchWithTldwAuthMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/api/v1/prototype-workspaces",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json"
+          }),
+          body: JSON.stringify({
+            title: "Sales dashboard",
+            creation_source: "prompt",
+            prompt: "Build a B2B dashboard"
+          })
+        })
+      )
+    })
+  })
+
+  it("loads prototype workspace detail through the authenticated tldw fetch helper", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "pw_1",
+          title: "Sales dashboard",
+          owner_user_id: 1,
+          creation_source: "prompt",
+          canonical_snapshot_id: "psnap_seed_1",
+          last_known_good_snapshot_id: "psnap_seed_1",
+          canonical_preview_status: "ready",
+          publish_validation_status: "passed",
+          preview_policy: {},
+          share_policy: {},
+          runtime_policy: {},
+          designated_promoter_ids: [],
+          created_at: "2026-04-19T00:00:00Z",
+          updated_at: "2026-04-19T00:00:00Z",
+          is_archived: false,
+          viewer_role: "owner",
+          sessions: [],
+          snapshots: []
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { result } = renderHook(() => usePrototypeWorkspace("pw_1"), {
+      wrapper: buildWrapper()
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(fetchWithTldwAuthMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8000/api/v1/prototype-workspaces/pw_1"
+    )
+  })
+
+  it("creates an owner branch session through the authenticated tldw fetch helper", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          job_id: "job-1",
+          job_type: "branch_session_bootstrap",
+          prototype_workspace_id: "pw_1",
+          prototype_session_id: "pss_1",
+          actor_type: "owner"
+        }),
+        {
+          status: 202,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { result } = renderHook(() => useCreateOwnerBranchSession("pw_1"), {
+      wrapper: buildWrapper()
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        request_nonce: "owner-nonce-1"
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetchWithTldwAuthMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/api/v1/prototype-workspaces/pw_1/sessions",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json"
+          }),
+          body: JSON.stringify({
+            request_nonce: "owner-nonce-1"
+          })
+        })
+      )
+    })
+  })
+
+  it("creates a collaborator branch session through the authenticated tldw fetch helper", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          job_id: "job-2",
+          job_type: "branch_session_bootstrap",
+          prototype_workspace_id: "pw_1",
+          prototype_session_id: "pss_2",
+          actor_type: "external_collaborator",
+          shared_actor_id: "psa_1"
+        }),
+        {
+          status: 202,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { result } = renderHook(() => useCreateCollaboratorBranchSession(), {
+      wrapper: buildWrapper()
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        session_token: "session-token-1",
+        request_nonce: "collab-nonce-1"
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetchWithTldwAuthMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/api/v1/prototype-sessions",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json"
+          }),
+          body: JSON.stringify({
+            session_token: "session-token-1",
+            request_nonce: "collab-nonce-1"
+          })
+        })
+      )
+    })
+  })
+
+  it("creates a prototype promotion request through the authenticated tldw fetch helper", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "pr_1",
+          prototype_workspace_id: "pw_1",
+          prototype_session_id: "pss_1",
+          candidate_snapshot_id: "psnap_1",
+          status: "pending"
+        }),
+        {
+          status: 201,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { result } = renderHook(() => useCreatePromotionRequest(), {
+      wrapper: buildWrapper()
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        prototype_workspace_id: "pw_1",
+        prototype_session_id: "pss_1",
+        candidate_snapshot_id: "psnap_1",
+        session_token: "session-token-1",
+        request_reason: "Ready for review"
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetchWithTldwAuthMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/api/v1/prototype-promotions",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json"
+          }),
+          body: JSON.stringify({
+            prototype_workspace_id: "pw_1",
+            prototype_session_id: "pss_1",
+            candidate_snapshot_id: "psnap_1",
+            session_token: "session-token-1",
+            request_reason: "Ready for review"
+          })
+        })
+      )
+    })
+  })
+})

--- a/apps/packages/ui/src/hooks/__tests__/useSharing.auth.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useSharing.auth.test.tsx
@@ -14,7 +14,11 @@ vi.mock("@/services/tldw-server", () => ({
   getTldwServerURL: getTldwServerURLMock
 }))
 
-import { useCloneWorkspace, useSharedWithMe } from "@/hooks/useSharing"
+import {
+  useCloneWorkspace,
+  usePrototypePrivateLinkExchange,
+  useSharedWithMe
+} from "@/hooks/useSharing"
 
 const buildWrapper = () => {
   const queryClient = new QueryClient({
@@ -85,6 +89,48 @@ describe("useSharing auth wiring", () => {
           "Content-Type": "application/json"
         }),
         body: JSON.stringify({ new_name: "My Clone" })
+      })
+    )
+  })
+
+  it("exchanges a prototype share token for a collaborator session through the authenticated tldw fetch helper", async () => {
+    fetchWithTldwAuthMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          actor_type: "external_collaborator",
+          shared_actor_id: "psa_1",
+          session_token: "session-token"
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        }
+      )
+    )
+
+    const { result } = renderHook(() => usePrototypePrivateLinkExchange(), {
+      wrapper: buildWrapper()
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        token: "prototype-token",
+        display_name: "Acme PM",
+        password: "demo-pass"
+      })
+    })
+
+    expect(fetchWithTldwAuthMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8000/api/v1/sharing/public/prototype-token/prototype-session",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json"
+        }),
+        body: JSON.stringify({
+          display_name: "Acme PM",
+          password: "demo-pass"
+        })
       })
     )
   })

--- a/apps/packages/ui/src/hooks/usePrototypeWorkspaces.ts
+++ b/apps/packages/ui/src/hooks/usePrototypeWorkspaces.ts
@@ -20,11 +20,11 @@ import {
 export const prototypeWorkspaceQueryKeys = {
   all: () => ["prototype-workspaces"] as const,
   workspaces: () => [...prototypeWorkspaceQueryKeys.all(), "workspaces"] as const,
-  workspace: (prototypeWorkspaceId: string) =>
+  workspace: (prototypeWorkspaceId: string | null | undefined) =>
     [
       ...prototypeWorkspaceQueryKeys.workspaces(),
       "detail",
-      String(prototypeWorkspaceId)
+      prototypeWorkspaceId ?? null
     ] as const,
   sessions: (prototypeWorkspaceId: string) =>
     [
@@ -57,10 +57,9 @@ export const useCreatePrototypeWorkspace = () => {
 }
 
 export const usePrototypeWorkspace = (prototypeWorkspaceId: string | null | undefined) => {
+  const queryWorkspaceId = prototypeWorkspaceId ?? null
   return useQuery<PrototypeWorkspaceDetail, Error>({
-    queryKey: prototypeWorkspaceQueryKeys.workspace(
-      prototypeWorkspaceId ?? "unknown"
-    ),
+    queryKey: prototypeWorkspaceQueryKeys.workspace(queryWorkspaceId),
     queryFn: () => getPrototypeWorkspaceRequest(String(prototypeWorkspaceId)),
     enabled: Boolean(prototypeWorkspaceId)
   })

--- a/apps/packages/ui/src/hooks/usePrototypeWorkspaces.ts
+++ b/apps/packages/ui/src/hooks/usePrototypeWorkspaces.ts
@@ -1,0 +1,124 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import type {
+  PrototypeCollaboratorSessionCreateInput,
+  PrototypeWorkspaceDetail,
+  PrototypePromotionCreateInput,
+  PrototypePromotionRequest,
+  PrototypeSessionJob,
+  PrototypeWorkspace,
+  PrototypeWorkspaceCreateInput,
+  PrototypeWorkspaceSessionCreateInput
+} from "@/types/prototype-workspace"
+import {
+  createPrototypeCollaboratorBranchSessionRequest,
+  createPrototypeOwnerBranchSessionRequest,
+  createPrototypePromotionRequestRequest,
+  createPrototypeWorkspaceRequest,
+  getPrototypeWorkspaceRequest
+} from "@/services/tldw/domains/prototype-workspaces"
+
+export const prototypeWorkspaceQueryKeys = {
+  all: () => ["prototype-workspaces"] as const,
+  workspaces: () => [...prototypeWorkspaceQueryKeys.all(), "workspaces"] as const,
+  workspace: (prototypeWorkspaceId: string) =>
+    [
+      ...prototypeWorkspaceQueryKeys.workspaces(),
+      "detail",
+      String(prototypeWorkspaceId)
+    ] as const,
+  sessions: (prototypeWorkspaceId: string) =>
+    [
+      ...prototypeWorkspaceQueryKeys.all(),
+      "sessions",
+      String(prototypeWorkspaceId)
+    ] as const,
+  promotions: (prototypeWorkspaceId: string) =>
+    [
+      ...prototypeWorkspaceQueryKeys.all(),
+      "promotions",
+      String(prototypeWorkspaceId)
+    ] as const
+}
+
+export const useCreatePrototypeWorkspace = () => {
+  const queryClient = useQueryClient()
+  return useMutation<PrototypeWorkspace, Error, PrototypeWorkspaceCreateInput>({
+    mutationFn: createPrototypeWorkspaceRequest,
+    onSuccess: async (workspace) => {
+      queryClient.setQueryData(
+        prototypeWorkspaceQueryKeys.workspace(workspace.id),
+        workspace
+      )
+      await queryClient.invalidateQueries({
+        queryKey: prototypeWorkspaceQueryKeys.workspaces()
+      })
+    }
+  })
+}
+
+export const usePrototypeWorkspace = (prototypeWorkspaceId: string | null | undefined) => {
+  return useQuery<PrototypeWorkspaceDetail, Error>({
+    queryKey: prototypeWorkspaceQueryKeys.workspace(
+      prototypeWorkspaceId ?? "unknown"
+    ),
+    queryFn: () => getPrototypeWorkspaceRequest(String(prototypeWorkspaceId)),
+    enabled: Boolean(prototypeWorkspaceId)
+  })
+}
+
+export const useCreateOwnerBranchSession = (prototypeWorkspaceId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation<
+    PrototypeSessionJob,
+    Error,
+    PrototypeWorkspaceSessionCreateInput
+  >({
+    mutationFn: async (body) => {
+      if (!prototypeWorkspaceId) {
+        throw new Error("prototype_workspace_id is required")
+      }
+      return createPrototypeOwnerBranchSessionRequest(prototypeWorkspaceId, body)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: prototypeWorkspaceQueryKeys.sessions(prototypeWorkspaceId)
+      })
+    }
+  })
+}
+
+export const useCreateCollaboratorBranchSession = () => {
+  const queryClient = useQueryClient()
+  return useMutation<
+    PrototypeSessionJob,
+    Error,
+    PrototypeCollaboratorSessionCreateInput
+  >({
+    mutationFn: createPrototypeCollaboratorBranchSessionRequest,
+    onSuccess: async (sessionJob) => {
+      await queryClient.invalidateQueries({
+        queryKey: prototypeWorkspaceQueryKeys.sessions(
+          sessionJob.prototype_workspace_id
+        )
+      })
+    }
+  })
+}
+
+export const useCreatePromotionRequest = () => {
+  const queryClient = useQueryClient()
+  return useMutation<
+    PrototypePromotionRequest,
+    Error,
+    PrototypePromotionCreateInput
+  >({
+    mutationFn: createPrototypePromotionRequestRequest,
+    onSuccess: async (_promotion, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: prototypeWorkspaceQueryKeys.promotions(
+          variables.prototype_workspace_id
+        )
+      })
+    }
+  })
+}

--- a/apps/packages/ui/src/hooks/useSharing.ts
+++ b/apps/packages/ui/src/hooks/useSharing.ts
@@ -10,6 +10,7 @@ import type {
   ShareListResponse,
   SharedWithMeResponse,
   CreateTokenRequest,
+  PrototypeLinkExchangeResponse,
   TokenResponse,
   TokenListResponse,
   PublicSharePreview,
@@ -217,5 +218,16 @@ export function useImportFromToken() {
     string
   >({
     mutationFn: (token) => jsonPost(`/public/${token}/import`, {}),
+  })
+}
+
+export function usePrototypePrivateLinkExchange() {
+  return useMutation<
+    PrototypeLinkExchangeResponse,
+    Error,
+    { token: string; display_name?: string; password?: string }
+  >({
+    mutationFn: ({ token, ...body }) =>
+      jsonPost(`/public/${token}/prototype-session`, body)
   })
 }

--- a/apps/packages/ui/src/routes/__tests__/option-prototype-workspaces.route.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-prototype-workspaces.route.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
 
 import OptionPrototypeWorkspaces from "../option-prototype-workspaces"
 
@@ -8,25 +9,55 @@ vi.mock("~/components/Layouts/Layout", () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="option-layout">{children}</div>
-  ),
+  )
 }))
 
 vi.mock("@/components/Option/PrototypeWorkspace", () => ({
   PrototypeWorkspacePage: () => (
-    <div data-testid="prototype-workspace-page">Prototype workspace</div>
-  ),
+    <div data-testid="prototype-workspace-page">Prototype Workspace</div>
+  )
 }))
 
+vi.mock("../option-index", () => ({
+  __esModule: true,
+  default: () => <div data-testid="option-index" />
+}))
+
+vi.mock("../settings-route", () => ({
+  __esModule: true,
+  createSettingsRoute: () => () => <div data-testid="settings-route-stub" />
+}))
+
+import { ROUTE_DEFINITIONS } from "../route-registry"
+
 describe("option prototype workspaces route", () => {
-  it("uses the standard option shell with flex/min-h-0 layout", () => {
+  it("uses the standard option layout with a flex shell for the prototype workspace page", () => {
     render(<OptionPrototypeWorkspaces />)
 
-    const shell = screen.getByTestId("prototype-workspace-route-shell")
+    const shell = screen.getByTestId("prototype-workspaces-route-shell")
     expect(shell.className).toContain("flex")
     expect(shell.className).toContain("flex-1")
     expect(shell.className).toContain("min-h-0")
     expect(shell.className).toContain("overflow-hidden")
     expect(screen.getByTestId("option-layout")).toBeInTheDocument()
     expect(screen.getByTestId("prototype-workspace-page")).toBeVisible()
+  })
+
+  it("registers the prototype workspace route in the main route registry", async () => {
+    const route = ROUTE_DEFINITIONS.find(
+      (candidate) => candidate.path === "/prototype-workspaces"
+    )
+
+    expect(route).toBeDefined()
+
+    render(
+      <MemoryRouter initialEntries={["/prototype-workspaces"]}>
+        <Routes>
+          <Route path="*" element={route!.element} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByTestId("prototype-workspace-page")).toBeVisible()
   })
 })

--- a/apps/packages/ui/src/routes/option-prototype-workspaces.tsx
+++ b/apps/packages/ui/src/routes/option-prototype-workspaces.tsx
@@ -1,5 +1,3 @@
-import React from "react"
-
 import OptionLayout from "~/components/Layouts/Layout"
 import { PrototypeWorkspacePage } from "@/components/Option/PrototypeWorkspace"
 
@@ -7,8 +5,8 @@ const OptionPrototypeWorkspaces = () => {
   return (
     <OptionLayout>
       <div
-        data-testid="prototype-workspace-route-shell"
-        className="flex flex-1 min-h-0 overflow-hidden"
+        data-testid="prototype-workspaces-route-shell"
+        className="flex flex-1 min-h-0 w-full overflow-hidden"
       >
         <PrototypeWorkspacePage />
       </div>

--- a/apps/packages/ui/src/routes/route-paths.ts
+++ b/apps/packages/ui/src/routes/route-paths.ts
@@ -6,6 +6,7 @@ import {
 export const CHAT_PATH = "/chat"
 export const CHAT_WORKSPACE_PATH = "/chat-workspace"
 export const RESEARCH_PATH = "/research"
+export const PROTOTYPE_WORKSPACES_PATH = "/prototype-workspaces"
 export const WORKSPACE_PLAYGROUND_PATH = "/workspace-playground"
 export const DOCUMENT_WORKSPACE_PATH = "/document-workspace"
 export const PRESENTATION_STUDIO_PATH = "/presentation-studio"

--- a/apps/packages/ui/src/routes/route-registry.tsx
+++ b/apps/packages/ui/src/routes/route-registry.tsx
@@ -6,6 +6,7 @@ import { Navigate } from "react-router-dom"
 import {
   CHAT_WORKSPACE_PATH,
   DOCUMENT_WORKSPACE_PATH,
+  PROTOTYPE_WORKSPACES_PATH,
   REPO2TXT_PATH
 } from "@/routes/route-paths"
 import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
@@ -173,6 +174,7 @@ const OptionSetup = lazy(() => import("./option-setup"))
 const OptionOnboardingTest = lazy(() => import("./option-onboarding-test"))
 const OptionWorkspacePlayground = lazy(() => import("./option-workspace-playground"))
 const OptionChatWorkspace = lazy(() => import("./option-chat-workspace"))
+const OptionPrototypeWorkspaces = lazy(() => import("./option-prototype-workspaces"))
 const OptionSharedWithMe = lazy(() => import("./option-shared-with-me"))
 const OptionPublicShare = lazy(() => import("./option-public-share"))
 
@@ -469,6 +471,11 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
     kind: "options",
     path: CHAT_WORKSPACE_PATH,
     element: <OptionChatWorkspace />,
+  },
+  {
+    kind: "options",
+    path: PROTOTYPE_WORKSPACES_PATH,
+    element: <OptionPrototypeWorkspaces />,
   },
   {
     kind: "options",

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -7163,6 +7163,7 @@ import { chatRagMethods } from "./domains/chat-rag"
 import { collectionsMethods } from "./domains/collections"
 import { modelsAudioMethods } from "./domains/models-audio"
 import { presentationsMethods } from "./domains/presentations"
+import { prototypeWorkspaceMethods } from "./domains/prototype-workspaces"
 import { workspaceApiMethods } from "./domains/workspace-api"
 import { webClipperMethods } from "./domains/web-clipper"
 
@@ -7185,6 +7186,7 @@ export interface TldwApiClient
     TldwDomainMethods<typeof collectionsMethods>,
     TldwDomainMethods<typeof modelsAudioMethods>,
     TldwDomainMethods<typeof presentationsMethods>,
+    TldwDomainMethods<typeof prototypeWorkspaceMethods>,
     TldwDomainMethods<typeof workspaceApiMethods>,
     TldwDomainMethods<typeof webClipperMethods> {}
 
@@ -7198,6 +7200,7 @@ Object.assign(
   collectionsMethods,
   modelsAudioMethods,
   presentationsMethods,
+  prototypeWorkspaceMethods,
   workspaceApiMethods,
   webClipperMethods
 )

--- a/apps/packages/ui/src/services/tldw/domains/index.ts
+++ b/apps/packages/ui/src/services/tldw/domains/index.ts
@@ -5,5 +5,9 @@ export { chatRagMethods, type ChatRagMethods } from "./chat-rag"
 export { collectionsMethods, type CollectionsMethods } from "./collections"
 export { modelsAudioMethods, type ModelsAudioMethods } from "./models-audio"
 export { presentationsMethods, type PresentationsMethods } from "./presentations"
+export {
+  prototypeWorkspaceMethods,
+  type PrototypeWorkspaceMethods
+} from "./prototype-workspaces"
 export { workspaceApiMethods, type WorkspaceApiMethods } from "./workspace-api"
 export { webClipperMethods, type WebClipperMethods } from "./web-clipper"

--- a/apps/packages/ui/src/services/tldw/domains/prototype-workspaces.ts
+++ b/apps/packages/ui/src/services/tldw/domains/prototype-workspaces.ts
@@ -1,0 +1,134 @@
+import { fetchWithTldwAuth } from "@/services/tldw/auth-fetch"
+import { getTldwServerURL } from "@/services/tldw-server"
+import type {
+  PrototypeCollaboratorSessionCreateInput,
+  PrototypeWorkspaceDetail,
+  PrototypePromotionCreateInput,
+  PrototypePromotionRequest,
+  PrototypeSessionJob,
+  PrototypeWorkspace,
+  PrototypeWorkspaceCreateInput,
+  PrototypeWorkspaceSessionCreateInput
+} from "@/types/prototype-workspace"
+import type {
+  PrototypeLinkExchangeRequest,
+  PrototypeLinkExchangeResponse
+} from "@/types/sharing"
+
+type TldwApiClientCore = object
+
+const apiUrl = async (path: string) => {
+  const base = await getTldwServerURL()
+  return `${base}/api/v1${path}`
+}
+
+const jsonPost = async <T>(path: string, body: unknown): Promise<T> => {
+  const url = await apiUrl(path)
+  const res = await fetchWithTldwAuth(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  })
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }))
+    throw new Error(err.detail || "Request failed")
+  }
+
+  return res.json()
+}
+
+const jsonGet = async <T>(path: string): Promise<T> => {
+  const url = await apiUrl(path)
+  const res = await fetchWithTldwAuth(url)
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }))
+    throw new Error(err.detail || "Request failed")
+  }
+
+  return res.json()
+}
+
+export const createPrototypeWorkspaceRequest = (
+  body: PrototypeWorkspaceCreateInput
+) => jsonPost<PrototypeWorkspace>("/prototype-workspaces", body)
+
+export const getPrototypeWorkspaceRequest = (prototypeWorkspaceId: string) =>
+  jsonGet<PrototypeWorkspaceDetail>(
+    `/prototype-workspaces/${encodeURIComponent(prototypeWorkspaceId)}`
+  )
+
+export const createPrototypeOwnerBranchSessionRequest = (
+  prototypeWorkspaceId: string,
+  body: PrototypeWorkspaceSessionCreateInput
+) =>
+  jsonPost<PrototypeSessionJob>(
+    `/prototype-workspaces/${encodeURIComponent(prototypeWorkspaceId)}/sessions`,
+    body
+  )
+
+export const createPrototypeCollaboratorBranchSessionRequest = (
+  body: PrototypeCollaboratorSessionCreateInput
+) => jsonPost<PrototypeSessionJob>("/prototype-sessions", body)
+
+export const createPrototypePromotionRequestRequest = (
+  body: PrototypePromotionCreateInput
+) => jsonPost<PrototypePromotionRequest>("/prototype-promotions", body)
+
+export const exchangePrototypePrivateLinkRequest = (
+  token: string,
+  body: PrototypeLinkExchangeRequest
+) =>
+  jsonPost<PrototypeLinkExchangeResponse>(
+    `/sharing/public/${encodeURIComponent(token)}/prototype-session`,
+    body
+  )
+
+export const prototypeWorkspaceMethods = {
+  async createPrototypeWorkspace(
+    this: TldwApiClientCore,
+    body: PrototypeWorkspaceCreateInput
+  ): Promise<PrototypeWorkspace> {
+    return createPrototypeWorkspaceRequest(body)
+  },
+
+  async getPrototypeWorkspace(
+    this: TldwApiClientCore,
+    prototypeWorkspaceId: string
+  ): Promise<PrototypeWorkspaceDetail> {
+    return getPrototypeWorkspaceRequest(prototypeWorkspaceId)
+  },
+
+  async createPrototypeOwnerBranchSession(
+    this: TldwApiClientCore,
+    prototypeWorkspaceId: string,
+    body: PrototypeWorkspaceSessionCreateInput = {}
+  ): Promise<PrototypeSessionJob> {
+    return createPrototypeOwnerBranchSessionRequest(prototypeWorkspaceId, body)
+  },
+
+  async createPrototypeCollaboratorBranchSession(
+    this: TldwApiClientCore,
+    body: PrototypeCollaboratorSessionCreateInput
+  ): Promise<PrototypeSessionJob> {
+    return createPrototypeCollaboratorBranchSessionRequest(body)
+  },
+
+  async createPrototypePromotionRequest(
+    this: TldwApiClientCore,
+    body: PrototypePromotionCreateInput
+  ): Promise<PrototypePromotionRequest> {
+    return createPrototypePromotionRequestRequest(body)
+  },
+
+  async exchangePrototypePrivateLink(
+    this: TldwApiClientCore,
+    token: string,
+    body: PrototypeLinkExchangeRequest
+  ): Promise<PrototypeLinkExchangeResponse> {
+    return exchangePrototypePrivateLinkRequest(token, body)
+  }
+}
+
+export type PrototypeWorkspaceMethods = typeof prototypeWorkspaceMethods

--- a/apps/packages/ui/src/store/prototype-workspace.ts
+++ b/apps/packages/ui/src/store/prototype-workspace.ts
@@ -1,0 +1,60 @@
+import { createWithEqualityFn } from "zustand/traditional"
+
+type PrototypeWorkspaceStoreState = {
+  activeWorkspaceId: string | null
+  ownerSessionId: string | null
+  collaboratorSessionId: string | null
+  collaboratorSessionToken: string | null
+  collaboratorShareToken: string | null
+  sharedActorId: string | null
+  lastPromotionRequestId: string | null
+  setActiveWorkspaceId: (workspaceId: string | null) => void
+  setOwnerSessionId: (sessionId: string | null) => void
+  setCollaboratorEntry: (entry: {
+    collaboratorSessionId?: string | null
+    collaboratorSessionToken?: string | null
+    collaboratorShareToken?: string | null
+    sharedActorId?: string | null
+  }) => void
+  setLastPromotionRequestId: (promotionRequestId: string | null) => void
+  reset: () => void
+}
+
+const initialState = {
+  activeWorkspaceId: null,
+  ownerSessionId: null,
+  collaboratorSessionId: null,
+  collaboratorSessionToken: null,
+  collaboratorShareToken: null,
+  sharedActorId: null,
+  lastPromotionRequestId: null
+}
+
+export const usePrototypeWorkspaceStore =
+  createWithEqualityFn<PrototypeWorkspaceStoreState>((set) => ({
+    ...initialState,
+    setActiveWorkspaceId: (activeWorkspaceId) => set({ activeWorkspaceId }),
+    setOwnerSessionId: (ownerSessionId) => set({ ownerSessionId }),
+    setCollaboratorEntry: (entry) =>
+      set({
+        collaboratorSessionId:
+          entry.collaboratorSessionId !== undefined
+            ? entry.collaboratorSessionId
+            : initialState.collaboratorSessionId,
+        collaboratorSessionToken:
+          entry.collaboratorSessionToken !== undefined
+            ? entry.collaboratorSessionToken
+            : initialState.collaboratorSessionToken,
+        collaboratorShareToken:
+          entry.collaboratorShareToken !== undefined
+            ? entry.collaboratorShareToken
+            : initialState.collaboratorShareToken,
+        sharedActorId:
+          entry.sharedActorId !== undefined
+            ? entry.sharedActorId
+            : initialState.sharedActorId
+      }),
+    setLastPromotionRequestId: (lastPromotionRequestId) =>
+      set({ lastPromotionRequestId }),
+    reset: () => set(initialState)
+  }))

--- a/apps/packages/ui/src/types/prototype-workspace.ts
+++ b/apps/packages/ui/src/types/prototype-workspace.ts
@@ -1,0 +1,120 @@
+export interface PrototypeWorkspaceCreateInput {
+  title: string
+  creation_source: string
+  description?: string | null
+  prompt?: string | null
+  preview_policy?: Record<string, unknown>
+  share_policy?: Record<string, unknown>
+  runtime_policy?: Record<string, unknown>
+  designated_promoter_ids?: number[]
+}
+
+export interface PrototypeWorkspace {
+  id: string
+  owner_user_id: number
+  title: string
+  description?: string | null
+  creation_source: string
+  canonical_snapshot_id?: string | null
+  last_known_good_snapshot_id?: string | null
+  canonical_preview_status?: string | null
+  publish_validation_status?: string | null
+  preview_policy: Record<string, unknown>
+  share_policy: Record<string, unknown>
+  runtime_policy: Record<string, unknown>
+  designated_promoter_ids: number[]
+  created_at: string
+  updated_at: string
+  archived_at?: string | null
+  is_archived: boolean
+}
+
+export type PrototypeWorkspaceViewerRole = "owner" | "internal_collaborator"
+
+export interface PrototypeWorkspaceSessionSummary {
+  id: string
+  prototype_workspace_id: string
+  base_snapshot_id: string
+  actor_user_id?: number | null
+  actor_shared_actor_id?: string | null
+  actor_type: string
+  share_link_id?: number | null
+  acp_session_id?: string | null
+  sandbox_session_id?: string | null
+  sandbox_run_id?: string | null
+  runtime_status: string
+  preview_handle?: string | null
+  preview_status: string
+  last_saved_snapshot_id?: string | null
+  last_activity_at?: string | null
+  expires_at?: string | null
+  revoked_at?: string | null
+  created_at: string
+  updated_at: string
+  is_revoked: boolean
+}
+
+export interface PrototypeWorkspaceSnapshotSummary {
+  snapshot_id: string
+  prototype_workspace_id: string
+  parent_snapshot_id?: string | null
+  created_from_session_id?: string | null
+  author_user_id?: number | null
+  author_shared_actor_id?: string | null
+  storage_ref?: string | null
+  diff_summary: Record<string, unknown>
+  prompt_summary?: string | null
+  preview_health: Record<string, unknown>
+  created_at: string
+  is_canonical: boolean
+  is_last_known_good: boolean
+}
+
+export interface PrototypeWorkspaceDetail extends PrototypeWorkspace {
+  viewer_role: PrototypeWorkspaceViewerRole
+  sessions: PrototypeWorkspaceSessionSummary[]
+  snapshots: PrototypeWorkspaceSnapshotSummary[]
+}
+
+export interface PrototypeWorkspaceSessionCreateInput {
+  request_nonce?: string | null
+}
+
+export interface PrototypeCollaboratorSessionCreateInput {
+  session_token: string
+  request_nonce?: string | null
+}
+
+export interface PrototypeSessionJob {
+  job_id: string
+  job_type: "branch_session_bootstrap"
+  status: string
+  message: string
+  prototype_workspace_id: string
+  prototype_session_id: string
+  actor_type: string
+  shared_actor_id?: string | null
+  idempotency_key?: string | null
+}
+
+export interface PrototypePromotionCreateInput {
+  prototype_workspace_id: string
+  prototype_session_id: string
+  candidate_snapshot_id: string
+  session_token: string
+  request_reason?: string | null
+}
+
+export interface PrototypePromotionRequest {
+  id: string
+  prototype_workspace_id: string
+  prototype_session_id: string
+  candidate_snapshot_id: string
+  requested_by_user_id?: number | null
+  requested_by_shared_actor_id?: string | null
+  status: string
+  reviewed_by_user_id?: number | null
+  review_notes?: string | null
+  created_at: string
+  updated_at: string
+}

--- a/apps/packages/ui/src/types/sharing.ts
+++ b/apps/packages/ui/src/types/sharing.ts
@@ -9,7 +9,10 @@
 
 export type ShareScopeType = "team" | "org"
 export type AccessLevel = "view_chat" | "view_chat_add" | "full_edit"
-export type ShareResourceType = "chatbook" | "workspace"
+export type ShareResourceType =
+  | "chatbook"
+  | "workspace"
+  | "prototype_workspace"
 
 export const ACCESS_LEVEL_LABELS: Record<AccessLevel, string> = {
   view_chat: "Read-only",
@@ -115,4 +118,16 @@ export interface PublicSharePreview {
   is_password_protected: boolean
   access_level: AccessLevel
   allow_clone: boolean
+}
+
+export interface PrototypeLinkExchangeRequest {
+  display_name?: string
+  password?: string
+}
+
+export interface PrototypeLinkExchangeResponse {
+  shared_actor_id: string
+  actor_type: "external_collaborator"
+  session_token: string
+  runtime_policy_profile: string
 }

--- a/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
@@ -10,7 +10,6 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from ....core.AuthNZ.User_DB_Handling import User, get_request_user
 from ..schemas.prototype_workspace_schemas import (
     PrototypeCollaboratorSessionCreateRequest,
-    PrototypeWorkspaceDetailResponse,
     PrototypePreviewGrantResponse,
     PrototypePreviewRenewRequest,
     PrototypePromotionCreateRequest,
@@ -19,6 +18,7 @@ from ..schemas.prototype_workspace_schemas import (
     PrototypePromotionReviewResponse,
     PrototypeSessionJobResponse,
     PrototypeWorkspaceCreateRequest,
+    PrototypeWorkspaceDetailResponse,
     PrototypeWorkspaceResponse,
     PrototypeWorkspaceSessionCreateRequest,
 )
@@ -401,9 +401,10 @@ async def review_promotion_request(
 )
 async def renew_preview_grant(
     preview_handle: str,
-    _body: PrototypePreviewRenewRequest,
+    body: PrototypePreviewRenewRequest,
     user: User = Depends(get_request_user),
 ):
+    body.model_dump()
     preview_broker = await _maybe_await(_get_preview_broker())
     record = preview_broker.get_preview_record(preview_handle)
     if not record:
@@ -416,11 +417,15 @@ async def renew_preview_grant(
     if _coerce_user_id(user) != int(workspace["owner_user_id"]):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the owner can renew prototype previews")
 
+    from tldw_Server_API.app.core.Prototype_Workspaces.preview_broker import (
+        PrototypePreviewHandleNotFound,
+    )
+
     try:
         renewed = await preview_broker.renew_preview_grant(preview_handle)
+    except PrototypePreviewHandleNotFound as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except RuntimeError as exc:
         detail = str(exc)
-        if "not found" in detail:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail) from exc
     return PrototypePreviewGrantResponse.model_validate(renewed)

--- a/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
@@ -1,0 +1,375 @@
+"""Prototype workspace collaboration endpoints."""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ....core.AuthNZ.User_DB_Handling import User, get_request_user
+from ..schemas.prototype_workspace_schemas import (
+    PrototypeCollaboratorSessionCreateRequest,
+    PrototypePreviewGrantResponse,
+    PrototypePreviewRenewRequest,
+    PrototypePromotionCreateRequest,
+    PrototypePromotionRequestResponse,
+    PrototypePromotionReviewRequest,
+    PrototypePromotionReviewResponse,
+    PrototypeSessionJobResponse,
+    PrototypeWorkspaceCreateRequest,
+    PrototypeWorkspaceResponse,
+    PrototypeWorkspaceSessionCreateRequest,
+)
+
+router = APIRouter(tags=["prototype-workspaces"])
+
+
+def _get_repo():
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    async def _build():
+        return PrototypeWorkspacesRepo(db_pool=await get_db_pool())
+
+    return _build()
+
+
+def _get_preview_broker():
+    from tldw_Server_API.app.core.Prototype_Workspaces.preview_broker import (
+        PrototypePreviewBroker,
+    )
+
+    async def _build():
+        repo = await _maybe_await(_get_repo())
+        return PrototypePreviewBroker(repo=repo)
+
+    return _build()
+
+
+def _get_service():
+    from tldw_Server_API.app.core.Prototype_Workspaces.service import PrototypeWorkspaceService
+
+    async def _build():
+        repo = await _maybe_await(_get_repo())
+        broker = await _maybe_await(_get_preview_broker())
+        return PrototypeWorkspaceService(repo=repo, preview_broker=broker)
+
+    return _build()
+
+
+def _get_jobs_service():
+    from tldw_Server_API.app.core.Prototype_Workspaces.jobs import PrototypeWorkspaceJobs
+
+    async def _build():
+        repo = await _maybe_await(_get_repo())
+        return PrototypeWorkspaceJobs(repo=repo)
+
+    return _build()
+
+
+def _get_access_service():
+    from tldw_Server_API.app.core.Prototype_Workspaces.access import PrototypeAccessService
+
+    async def _build():
+        repo = await _maybe_await(_get_repo())
+        return PrototypeAccessService(repo)
+
+    return _build()
+
+
+async def _maybe_await(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _request_nonce_or_new(value: str | None) -> str:
+    candidate = str(value or "").strip()
+    return candidate or f"req_{uuid.uuid4().hex}"
+
+
+def _coerce_user_id(user: User) -> int:
+    try:
+        return int(user.id)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Authenticated user id is not compatible with prototype workspaces",
+        ) from exc
+
+
+def _epoch_to_iso8601(epoch: int | None) -> str | None:
+    if epoch is None:
+        return None
+    return datetime.fromtimestamp(int(epoch), timezone.utc).isoformat()
+
+
+@router.post(
+    "/prototype-workspaces",
+    response_model=PrototypeWorkspaceResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a prototype workspace",
+)
+async def create_prototype_workspace(
+    body: PrototypeWorkspaceCreateRequest,
+    user: User = Depends(get_request_user),
+):
+    service = await _maybe_await(_get_service())
+    workspace = await service.create_workspace(
+        owner_user_id=_coerce_user_id(user),
+        title=body.title,
+        creation_source=body.creation_source,
+        description=body.description,
+        prompt=body.prompt,
+        preview_policy=body.preview_policy,
+        share_policy=body.share_policy,
+        runtime_policy=body.runtime_policy,
+        designated_promoter_ids=body.designated_promoter_ids,
+    )
+    return PrototypeWorkspaceResponse.model_validate(workspace)
+
+
+@router.post(
+    "/prototype-workspaces/{prototype_workspace_id}/sessions",
+    response_model=PrototypeSessionJobResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Create or reuse an owner branch session",
+)
+async def create_owner_branch_session(
+    prototype_workspace_id: str,
+    body: PrototypeWorkspaceSessionCreateRequest,
+    user: User = Depends(get_request_user),
+):
+    repo = await _maybe_await(_get_repo())
+    workspace = await repo.get_workspace(prototype_workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
+
+    owner_user_id = int(workspace["owner_user_id"])
+    if _coerce_user_id(user) != owner_user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the owner can create branch sessions")
+
+    service = await _maybe_await(_get_service())
+    request_nonce = _request_nonce_or_new(body.request_nonce)
+    created = await service.create_or_reuse_branch_session(
+        prototype_workspace_id=prototype_workspace_id,
+        actor_type="owner",
+        actor_user_id=owner_user_id,
+        request_nonce=request_nonce,
+    )
+    session = created["session"]
+
+    jobs = await _maybe_await(_get_jobs_service())
+    job = await jobs.enqueue_branch_session_bootstrap(
+        prototype_workspace_id=prototype_workspace_id,
+        actor_type="owner",
+        actor_user_id=owner_user_id,
+        request_nonce=request_nonce,
+    )
+
+    return PrototypeSessionJobResponse(
+        job_id=str(job["id"]),
+        status=str(job.get("status") or "pending"),
+        prototype_workspace_id=prototype_workspace_id,
+        prototype_session_id=str(session["id"]),
+        actor_type="owner",
+        idempotency_key=job.get("idempotency_key"),
+    )
+
+
+@router.post(
+    "/prototype-sessions",
+    response_model=PrototypeSessionJobResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Create or reuse an external collaborator branch session",
+)
+async def create_external_branch_session(
+    body: PrototypeCollaboratorSessionCreateRequest,
+):
+    access_service = await _maybe_await(_get_access_service())
+    token_payload = access_service.decode_session_token(body.session_token)
+    if not token_payload:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid prototype session token")
+
+    prototype_workspace_id = str(token_payload["prototype_workspace_id"])
+    shared_actor_id = str(token_payload["shared_actor_id"])
+    share_link_id = int(token_payload["share_link_id"])
+    request_nonce = _request_nonce_or_new(body.request_nonce)
+
+    service = await _maybe_await(_get_service())
+    created = await service.create_or_reuse_branch_session(
+        prototype_workspace_id=prototype_workspace_id,
+        actor_type="external_collaborator",
+        actor_shared_actor_id=shared_actor_id,
+        request_nonce=request_nonce,
+        share_link_id=share_link_id,
+        expires_at=_epoch_to_iso8601(token_payload.get("exp")),
+    )
+    session = created["session"]
+
+    jobs = await _maybe_await(_get_jobs_service())
+    job = await jobs.enqueue_branch_session_bootstrap(
+        prototype_workspace_id=prototype_workspace_id,
+        actor_type="external_collaborator",
+        actor_shared_actor_id=shared_actor_id,
+        request_nonce=request_nonce,
+        share_link_id=share_link_id,
+        expires_at=_epoch_to_iso8601(token_payload.get("exp")),
+    )
+
+    return PrototypeSessionJobResponse(
+        job_id=str(job["id"]),
+        status=str(job.get("status") or "pending"),
+        prototype_workspace_id=prototype_workspace_id,
+        prototype_session_id=str(session["id"]),
+        actor_type="external_collaborator",
+        shared_actor_id=shared_actor_id,
+        idempotency_key=job.get("idempotency_key"),
+    )
+
+
+@router.post(
+    "/prototype-promotions",
+    response_model=PrototypePromotionRequestResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a prototype promotion request",
+)
+async def create_promotion_request(
+    body: PrototypePromotionCreateRequest,
+):
+    access_service = await _maybe_await(_get_access_service())
+    token_payload = access_service.decode_session_token(body.session_token)
+    if not token_payload:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid prototype session token")
+    if str(token_payload["prototype_workspace_id"]) != body.prototype_workspace_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Session token does not match prototype workspace")
+
+    repo = await _maybe_await(_get_repo())
+    session = await repo.get_session(body.prototype_session_id)
+    if not session:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype session not found")
+    if str(session.get("prototype_workspace_id")) != body.prototype_workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Prototype session does not belong to the requested workspace",
+        )
+    if str(session.get("actor_shared_actor_id") or "") != str(token_payload["shared_actor_id"]):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Session token does not authorize promotion requests for this branch session",
+        )
+
+    candidate_snapshot = await repo.get_snapshot(body.candidate_snapshot_id)
+    if not candidate_snapshot:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype snapshot not found")
+    if str(candidate_snapshot.get("prototype_workspace_id")) != body.prototype_workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Prototype snapshot does not belong to the requested workspace",
+        )
+    if str(candidate_snapshot.get("created_from_session_id") or "") != body.prototype_session_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Prototype snapshot does not belong to the requested branch session",
+        )
+    if str(candidate_snapshot.get("author_shared_actor_id") or "") != str(token_payload["shared_actor_id"]):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Session token does not authorize promotion requests for this snapshot",
+        )
+
+    promotion_request = await repo.create_promotion_request(
+        prototype_workspace_id=body.prototype_workspace_id,
+        prototype_session_id=body.prototype_session_id,
+        candidate_snapshot_id=body.candidate_snapshot_id,
+        requested_by_shared_actor_id=str(token_payload["shared_actor_id"]),
+    )
+    return PrototypePromotionRequestResponse.model_validate(promotion_request)
+
+
+@router.post(
+    "/prototype-promotions/{promotion_request_id}/review",
+    response_model=PrototypePromotionReviewResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Review a prototype promotion request",
+)
+async def review_promotion_request(
+    promotion_request_id: str,
+    body: PrototypePromotionReviewRequest,
+    user: User = Depends(get_request_user),
+):
+    repo = await _maybe_await(_get_repo())
+    promotion_request = await repo.get_promotion_request(promotion_request_id)
+    if not promotion_request:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype promotion request not found")
+
+    workspace = await repo.get_workspace(str(promotion_request["prototype_workspace_id"]))
+    if not workspace:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
+    reviewer_user_id = _coerce_user_id(user)
+    if reviewer_user_id != int(workspace["owner_user_id"]):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the owner can review promotion requests")
+
+    if body.decision == "reject":
+        updated = await repo.update_promotion_request(
+            promotion_request_id,
+            status="rejected",
+            reviewed_by_user_id=reviewer_user_id,
+            review_notes=body.review_notes,
+        )
+        if not updated:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype promotion request not found")
+        return PrototypePromotionReviewResponse(
+            status="rejected",
+            prototype_workspace_id=str(updated["prototype_workspace_id"]),
+            candidate_snapshot_id=str(updated["candidate_snapshot_id"]),
+            canonical_snapshot_id=workspace.get("canonical_snapshot_id"),
+            details={"review_notes": updated.get("review_notes")},
+        )
+
+    service = await _maybe_await(_get_service())
+    result = await service.promote_candidate(
+        prototype_workspace_id=str(promotion_request["prototype_workspace_id"]),
+        candidate_snapshot_id=str(promotion_request["candidate_snapshot_id"]),
+        reviewer_user_id=reviewer_user_id,
+        review_baseline_snapshot_id=body.review_baseline_snapshot_id,
+        promotion_request_id=promotion_request_id,
+        review_notes=body.review_notes,
+    )
+    return PrototypePromotionReviewResponse.model_validate(result)
+
+
+@router.post(
+    "/prototype-previews/{preview_handle}/renew",
+    response_model=PrototypePreviewGrantResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Renew a prototype preview grant",
+)
+async def renew_preview_grant(
+    preview_handle: str,
+    _body: PrototypePreviewRenewRequest,
+    user: User = Depends(get_request_user),
+):
+    preview_broker = await _maybe_await(_get_preview_broker())
+    record = preview_broker.get_preview_record(preview_handle)
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype preview handle not found")
+
+    repo = await _maybe_await(_get_repo())
+    workspace = await repo.get_workspace(str(record["prototype_workspace_id"]))
+    if not workspace:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
+    if _coerce_user_id(user) != int(workspace["owner_user_id"]):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the owner can renew prototype previews")
+
+    try:
+        renewed = await preview_broker.renew_preview_grant(preview_handle)
+    except RuntimeError as exc:
+        detail = str(exc)
+        if "not found" in detail:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail) from exc
+    return PrototypePreviewGrantResponse.model_validate(renewed)

--- a/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
@@ -408,6 +408,8 @@ async def renew_preview_grant(
     preview_broker = await _maybe_await(_get_preview_broker())
     record = preview_broker.get_preview_record(preview_handle)
     if not record:
+        record = await preview_broker.get_preview_record_async(preview_handle)
+    if not record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype preview handle not found")
 
     repo = await _maybe_await(_get_repo())

--- a/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from ....core.AuthNZ.User_DB_Handling import User, get_request_user
 from ..schemas.prototype_workspace_schemas import (
     PrototypeCollaboratorSessionCreateRequest,
+    PrototypeWorkspaceDetailResponse,
     PrototypePreviewGrantResponse,
     PrototypePreviewRenewRequest,
     PrototypePromotionCreateRequest,
@@ -107,6 +108,31 @@ def _epoch_to_iso8601(epoch: int | None) -> str | None:
     return datetime.fromtimestamp(int(epoch), timezone.utc).isoformat()
 
 
+async def _build_workspace_detail_response(repo, workspace: dict) -> PrototypeWorkspaceDetailResponse:
+    sessions = await repo.list_sessions_for_workspace(str(workspace["id"]))
+    snapshots = await repo.list_snapshots_for_workspace(str(workspace["id"]))
+    canonical_snapshot_id = str(workspace.get("canonical_snapshot_id") or "")
+    last_known_good_snapshot_id = str(workspace.get("last_known_good_snapshot_id") or "")
+
+    snapshot_records = [
+        {
+            **snapshot,
+            "is_canonical": str(snapshot.get("snapshot_id") or "") == canonical_snapshot_id,
+            "is_last_known_good": str(snapshot.get("snapshot_id") or "") == last_known_good_snapshot_id,
+        }
+        for snapshot in snapshots
+    ]
+
+    return PrototypeWorkspaceDetailResponse.model_validate(
+        {
+            **workspace,
+            "viewer_role": "owner",
+            "sessions": sessions,
+            "snapshots": snapshot_records,
+        }
+    )
+
+
 @router.post(
     "/prototype-workspaces",
     response_model=PrototypeWorkspaceResponse,
@@ -130,6 +156,28 @@ async def create_prototype_workspace(
         designated_promoter_ids=body.designated_promoter_ids,
     )
     return PrototypeWorkspaceResponse.model_validate(workspace)
+
+
+@router.get(
+    "/prototype-workspaces/{prototype_workspace_id}",
+    response_model=PrototypeWorkspaceDetailResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get prototype workspace detail for the owner workspace view",
+)
+async def get_prototype_workspace(
+    prototype_workspace_id: str,
+    user: User = Depends(get_request_user),
+):
+    repo = await _maybe_await(_get_repo())
+    workspace = await repo.get_workspace(prototype_workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
+
+    owner_user_id = int(workspace["owner_user_id"])
+    if _coerce_user_id(user) != owner_user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the owner can view prototype workspace detail")
+
+    return await _build_workspace_detail_response(repo, workspace)
 
 
 @router.post(

--- a/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
@@ -358,8 +358,12 @@ async def review_promotion_request(
     if not workspace:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
     reviewer_user_id = _coerce_user_id(user)
-    if reviewer_user_id != int(workspace["owner_user_id"]):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the owner can review promotion requests")
+    service = await _maybe_await(_get_service())
+    if not service._is_promoter(workspace, reviewer_user_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Reviewer does not have promotion permissions",
+        )
 
     if body.decision == "reject":
         updated = await repo.update_promotion_request(
@@ -378,7 +382,6 @@ async def review_promotion_request(
             details={"review_notes": updated.get("review_notes")},
         )
 
-    service = await _maybe_await(_get_service())
     result = await service.promote_candidate(
         prototype_workspace_id=str(promotion_request["prototype_workspace_id"]),
         candidate_snapshot_id=str(promotion_request["candidate_snapshot_id"]),

--- a/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import inspect
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
@@ -26,34 +27,37 @@ from ..schemas.prototype_workspace_schemas import (
 router = APIRouter(tags=["prototype-workspaces"])
 
 
-def _get_repo():
+def _get_repo() -> Any:
+    """Build the prototype workspace repository from the AuthNZ database pool."""
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
     from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
         PrototypeWorkspacesRepo,
     )
 
-    async def _build():
+    async def _build() -> Any:
         return PrototypeWorkspacesRepo(db_pool=await get_db_pool())
 
     return _build()
 
 
-def _get_preview_broker():
+def _get_preview_broker() -> Any:
+    """Build the preview broker dependency with the shared prototype repo."""
     from tldw_Server_API.app.core.Prototype_Workspaces.preview_broker import (
         PrototypePreviewBroker,
     )
 
-    async def _build():
+    async def _build() -> Any:
         repo = await _maybe_await(_get_repo())
         return PrototypePreviewBroker(repo=repo)
 
     return _build()
 
 
-def _get_service():
+def _get_service() -> Any:
+    """Build the orchestration service dependency for workspace operations."""
     from tldw_Server_API.app.core.Prototype_Workspaces.service import PrototypeWorkspaceService
 
-    async def _build():
+    async def _build() -> Any:
         repo = await _maybe_await(_get_repo())
         broker = await _maybe_await(_get_preview_broker())
         return PrototypeWorkspaceService(repo=repo, preview_broker=broker)
@@ -61,38 +65,68 @@ def _get_service():
     return _build()
 
 
-def _get_jobs_service():
+def _get_jobs_service() -> Any:
+    """Build the runtime jobs dependency for prototype branch sessions."""
     from tldw_Server_API.app.core.Prototype_Workspaces.jobs import PrototypeWorkspaceJobs
 
-    async def _build():
+    async def _build() -> Any:
         repo = await _maybe_await(_get_repo())
         return PrototypeWorkspaceJobs(repo=repo)
 
     return _build()
 
 
-def _get_access_service():
+def _get_access_service() -> Any:
+    """Build the external collaborator access dependency."""
     from tldw_Server_API.app.core.Prototype_Workspaces.access import PrototypeAccessService
 
-    async def _build():
+    async def _build() -> Any:
         repo = await _maybe_await(_get_repo())
         return PrototypeAccessService(repo)
 
     return _build()
 
 
-async def _maybe_await(value):
+async def _repo_dependency() -> Any:
+    """Resolve the repository factory through FastAPI dependency injection."""
+    return await _maybe_await(_get_repo())
+
+
+async def _preview_broker_dependency() -> Any:
+    """Resolve the preview broker factory through FastAPI dependency injection."""
+    return await _maybe_await(_get_preview_broker())
+
+
+async def _service_dependency() -> Any:
+    """Resolve the orchestration service factory through FastAPI dependency injection."""
+    return await _maybe_await(_get_service())
+
+
+async def _jobs_service_dependency() -> Any:
+    """Resolve the jobs service factory through FastAPI dependency injection."""
+    return await _maybe_await(_get_jobs_service())
+
+
+async def _access_service_dependency() -> Any:
+    """Resolve the access service factory through FastAPI dependency injection."""
+    return await _maybe_await(_get_access_service())
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await factory results that are coroutines while preserving sync test doubles."""
     if inspect.isawaitable(value):
         return await value
     return value
 
 
 def _request_nonce_or_new(value: str | None) -> str:
+    """Return a provided idempotency nonce or generate a request-scoped nonce."""
     candidate = str(value or "").strip()
     return candidate or f"req_{uuid.uuid4().hex}"
 
 
 def _coerce_user_id(user: User) -> int:
+    """Convert the authenticated user id into the integer form used by AuthNZ repos."""
     try:
         return int(user.id)
     except (TypeError, ValueError) as exc:
@@ -103,12 +137,42 @@ def _coerce_user_id(user: User) -> int:
 
 
 def _epoch_to_iso8601(epoch: int | None) -> str | None:
+    """Convert a JWT epoch timestamp into an ISO-8601 string for persisted sessions."""
     if epoch is None:
         return None
     return datetime.fromtimestamp(int(epoch), timezone.utc).isoformat()
 
 
-async def _build_workspace_detail_response(repo, workspace: dict) -> PrototypeWorkspaceDetailResponse:
+def _branch_session_http_error(exc: ValueError | RuntimeError) -> HTTPException:
+    """Map expected branch-session domain failures to stable HTTP responses."""
+    detail = str(exc).lower()
+    if "not found" in detail:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
+    if "archived" in detail:
+        return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Prototype workspace is archived")
+    if "revoked" in detail or "expired" in detail:
+        return HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Prototype session token is no longer active",
+        )
+    if "canonical snapshot" in detail or "base_snapshot_id" in detail:
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Prototype workspace is not ready for branch sessions",
+        )
+    if isinstance(exc, ValueError):
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid prototype branch session request",
+        )
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Prototype branch session could not be created",
+    )
+
+
+async def _build_workspace_detail_response(repo: Any, workspace: dict[str, Any]) -> PrototypeWorkspaceDetailResponse:
+    """Build an owner-facing workspace detail response with sessions and snapshots."""
     sessions = await repo.list_sessions_for_workspace(str(workspace["id"]))
     snapshots = await repo.list_snapshots_for_workspace(str(workspace["id"]))
     canonical_snapshot_id = str(workspace.get("canonical_snapshot_id") or "")
@@ -142,8 +206,9 @@ async def _build_workspace_detail_response(repo, workspace: dict) -> PrototypeWo
 async def create_prototype_workspace(
     body: PrototypeWorkspaceCreateRequest,
     user: User = Depends(get_request_user),
-):
-    service = await _maybe_await(_get_service())
+    service: Any = Depends(_service_dependency),
+) -> PrototypeWorkspaceResponse:
+    """Create a prototype workspace and seed its canonical snapshot for the owner."""
     workspace = await service.create_workspace(
         owner_user_id=_coerce_user_id(user),
         title=body.title,
@@ -167,8 +232,9 @@ async def create_prototype_workspace(
 async def get_prototype_workspace(
     prototype_workspace_id: str,
     user: User = Depends(get_request_user),
-):
-    repo = await _maybe_await(_get_repo())
+    repo: Any = Depends(_repo_dependency),
+) -> PrototypeWorkspaceDetailResponse:
+    """Return owner-visible prototype workspace detail and branch inventory."""
     workspace = await repo.get_workspace(prototype_workspace_id)
     if not workspace:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
@@ -190,8 +256,11 @@ async def create_owner_branch_session(
     prototype_workspace_id: str,
     body: PrototypeWorkspaceSessionCreateRequest,
     user: User = Depends(get_request_user),
-):
-    repo = await _maybe_await(_get_repo())
+    repo: Any = Depends(_repo_dependency),
+    service: Any = Depends(_service_dependency),
+    jobs: Any = Depends(_jobs_service_dependency),
+) -> PrototypeSessionJobResponse:
+    """Create or reuse an owner branch session and enqueue its bootstrap job."""
     workspace = await repo.get_workspace(prototype_workspace_id)
     if not workspace:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
@@ -200,17 +269,18 @@ async def create_owner_branch_session(
     if _coerce_user_id(user) != owner_user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the owner can create branch sessions")
 
-    service = await _maybe_await(_get_service())
     request_nonce = _request_nonce_or_new(body.request_nonce)
-    created = await service.create_or_reuse_branch_session(
-        prototype_workspace_id=prototype_workspace_id,
-        actor_type="owner",
-        actor_user_id=owner_user_id,
-        request_nonce=request_nonce,
-    )
+    try:
+        created = await service.create_or_reuse_branch_session(
+            prototype_workspace_id=prototype_workspace_id,
+            actor_type="owner",
+            actor_user_id=owner_user_id,
+            request_nonce=request_nonce,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise _branch_session_http_error(exc) from exc
     session = created["session"]
 
-    jobs = await _maybe_await(_get_jobs_service())
     job = await jobs.enqueue_branch_session_bootstrap(
         prototype_workspace_id=prototype_workspace_id,
         actor_type="owner",
@@ -236,8 +306,11 @@ async def create_owner_branch_session(
 )
 async def create_external_branch_session(
     body: PrototypeCollaboratorSessionCreateRequest,
-):
-    access_service = await _maybe_await(_get_access_service())
+    access_service: Any = Depends(_access_service_dependency),
+    service: Any = Depends(_service_dependency),
+    jobs: Any = Depends(_jobs_service_dependency),
+) -> PrototypeSessionJobResponse:
+    """Create or reuse an external collaborator branch session from a session token."""
     token_payload = access_service.decode_session_token(body.session_token)
     if not token_payload:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid prototype session token")
@@ -247,18 +320,19 @@ async def create_external_branch_session(
     share_link_id = int(token_payload["share_link_id"])
     request_nonce = _request_nonce_or_new(body.request_nonce)
 
-    service = await _maybe_await(_get_service())
-    created = await service.create_or_reuse_branch_session(
-        prototype_workspace_id=prototype_workspace_id,
-        actor_type="external_collaborator",
-        actor_shared_actor_id=shared_actor_id,
-        request_nonce=request_nonce,
-        share_link_id=share_link_id,
-        expires_at=_epoch_to_iso8601(token_payload.get("exp")),
-    )
+    try:
+        created = await service.create_or_reuse_branch_session(
+            prototype_workspace_id=prototype_workspace_id,
+            actor_type="external_collaborator",
+            actor_shared_actor_id=shared_actor_id,
+            request_nonce=request_nonce,
+            share_link_id=share_link_id,
+            expires_at=_epoch_to_iso8601(token_payload.get("exp")),
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise _branch_session_http_error(exc) from exc
     session = created["session"]
 
-    jobs = await _maybe_await(_get_jobs_service())
     job = await jobs.enqueue_branch_session_bootstrap(
         prototype_workspace_id=prototype_workspace_id,
         actor_type="external_collaborator",
@@ -287,15 +361,16 @@ async def create_external_branch_session(
 )
 async def create_promotion_request(
     body: PrototypePromotionCreateRequest,
-):
-    access_service = await _maybe_await(_get_access_service())
+    access_service: Any = Depends(_access_service_dependency),
+    repo: Any = Depends(_repo_dependency),
+) -> PrototypePromotionRequestResponse:
+    """Create a promotion request for an external collaborator-owned snapshot."""
     token_payload = access_service.decode_session_token(body.session_token)
     if not token_payload:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid prototype session token")
     if str(token_payload["prototype_workspace_id"]) != body.prototype_workspace_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Session token does not match prototype workspace")
 
-    repo = await _maybe_await(_get_repo())
     session = await repo.get_session(body.prototype_session_id)
     if not session:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype session not found")
@@ -348,8 +423,10 @@ async def review_promotion_request(
     promotion_request_id: str,
     body: PrototypePromotionReviewRequest,
     user: User = Depends(get_request_user),
-):
-    repo = await _maybe_await(_get_repo())
+    repo: Any = Depends(_repo_dependency),
+    service: Any = Depends(_service_dependency),
+) -> PrototypePromotionReviewResponse:
+    """Review a promotion request and promote or reject the candidate snapshot."""
     promotion_request = await repo.get_promotion_request(promotion_request_id)
     if not promotion_request:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype promotion request not found")
@@ -358,7 +435,6 @@ async def review_promotion_request(
     if not workspace:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")
     reviewer_user_id = _coerce_user_id(user)
-    service = await _maybe_await(_get_service())
     if not service._is_promoter(workspace, reviewer_user_id):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -403,16 +479,17 @@ async def renew_preview_grant(
     preview_handle: str,
     body: PrototypePreviewRenewRequest,
     user: User = Depends(get_request_user),
-):
+    preview_broker: Any = Depends(_preview_broker_dependency),
+    repo: Any = Depends(_repo_dependency),
+) -> PrototypePreviewGrantResponse:
+    """Renew an owner-authorized prototype preview grant."""
     body.model_dump()
-    preview_broker = await _maybe_await(_get_preview_broker())
     record = preview_broker.get_preview_record(preview_handle)
     if not record:
         record = await preview_broker.get_preview_record_async(preview_handle)
     if not record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype preview handle not found")
 
-    repo = await _maybe_await(_get_repo())
     workspace = await repo.get_workspace(str(record["prototype_workspace_id"]))
     if not workspace:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prototype workspace not found")

--- a/tldw_Server_API/app/api/v1/endpoints/sharing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sharing.py
@@ -9,6 +9,7 @@ creating share links (tokens), and admin management.
 """
 from __future__ import annotations
 
+import inspect
 import threading
 import time
 from collections import defaultdict
@@ -57,13 +58,20 @@ def _get_repo():
     """Lazily construct the SharedWorkspaceRepo from the AuthNZ DB pool."""
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
     from tldw_Server_API.app.core.AuthNZ.repos.shared_workspace_repo import SharedWorkspaceRepo
-    pool = get_db_pool()
-    return SharedWorkspaceRepo(db_pool=pool)
+
+    async def _build():
+        return SharedWorkspaceRepo(db_pool=await get_db_pool())
+
+    return _build()
 
 
 def _get_token_service():
     from tldw_Server_API.app.core.Sharing.share_token_service import ShareTokenService
-    return ShareTokenService(_get_repo())
+
+    async def _build():
+        return ShareTokenService(await _maybe_await(_get_repo()))
+
+    return _build()
 
 
 def _get_prototype_repo():
@@ -72,13 +80,25 @@ def _get_prototype_repo():
         PrototypeWorkspacesRepo,
     )
 
-    return PrototypeWorkspacesRepo(db_pool=get_db_pool())
+    async def _build():
+        return PrototypeWorkspacesRepo(db_pool=await get_db_pool())
+
+    return _build()
 
 
 def _get_prototype_access_service():
     from tldw_Server_API.app.core.Prototype_Workspaces.access import PrototypeAccessService
 
-    return PrototypeAccessService(_get_prototype_repo())
+    async def _build():
+        return PrototypeAccessService(await _maybe_await(_get_prototype_repo()))
+
+    return _build()
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 _cached_audit_service: "ShareAuditService | None" = None  # noqa: F821
@@ -261,7 +281,7 @@ async def share_workspace(
     # [CRITICAL FIX #3] Verify the user owns this workspace
     await _verify_workspace_ownership(workspace_id, user)
 
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     audit = _get_audit_service()
     try:
         share = await repo.create_share(
@@ -309,7 +329,7 @@ async def list_workspace_shares(
     include_revoked: bool = Query(False),
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     shares = await repo.list_shares_for_workspace(
         workspace_id, user.id, include_revoked=include_revoked
     )
@@ -328,7 +348,7 @@ async def update_share(
     request: Request,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     audit = _get_audit_service()
 
     existing = await repo.get_share(share_id)
@@ -367,7 +387,7 @@ async def revoke_share(
     request: Request,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     audit = _get_audit_service()
 
     existing = await repo.get_share(share_id)
@@ -404,7 +424,7 @@ async def revoke_share(
 async def shared_with_me(
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
 
     # Gather shares from all teams/orgs the user belongs to
     items: list[SharedWithMeItem] = []
@@ -475,7 +495,7 @@ async def get_shared_workspace(
     share_id: int,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     share = await repo.get_share(share_id)
     if not share or share.get("is_revoked"):
         raise HTTPException(status_code=404, detail="Share not found or revoked")
@@ -499,7 +519,7 @@ async def clone_shared_workspace(
     background_tasks: BackgroundTasks,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     audit = _get_audit_service()
 
     share = await repo.get_share(share_id)
@@ -599,7 +619,7 @@ async def list_shared_workspace_sources(
     share_id: int,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     share = await repo.get_share(share_id)
     if not share or share.get("is_revoked"):
         raise HTTPException(status_code=404, detail="Share not found or revoked")
@@ -635,7 +655,7 @@ async def get_shared_workspace_media(
     media_id: int,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     share = await repo.get_share(share_id)
     if not share or share.get("is_revoked"):
         raise HTTPException(status_code=404, detail="Share not found or revoked")
@@ -683,7 +703,7 @@ async def chat_with_shared_workspace(
     request: Request,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     audit = _get_audit_service()
 
     share = await repo.get_share(share_id)
@@ -752,7 +772,7 @@ async def create_token(
     request: Request,
     user: User = Depends(get_request_user),
 ):
-    svc = _get_token_service()
+    svc = await _maybe_await(_get_token_service())
     audit = _get_audit_service()
 
     result = await svc.generate_token(
@@ -787,7 +807,7 @@ async def create_token(
 async def list_tokens(
     user: User = Depends(get_request_user),
 ):
-    svc = _get_token_service()
+    svc = await _maybe_await(_get_token_service())
     tokens = await svc.list_tokens(user.id)
     return TokenListResponse(tokens=[TokenResponse(**t) for t in tokens], total=len(tokens))
 
@@ -802,7 +822,7 @@ async def revoke_token(
     request: Request,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     audit = _get_audit_service()
 
     token = await repo.get_token(token_id)
@@ -811,7 +831,7 @@ async def revoke_token(
     if token["owner_user_id"] != user.id:
         raise HTTPException(status_code=403, detail="Not the token owner")
 
-    svc = _get_token_service()
+    svc = await _maybe_await(_get_token_service())
     await svc.revoke_token(token_id)
 
     await audit.log(
@@ -843,7 +863,7 @@ async def public_preview(
     # [CRITICAL FIX #1] Rate limit public endpoints (10 req/min per IP)
     _check_public_rate_limit(request)
 
-    svc = _get_token_service()
+    svc = await _maybe_await(_get_token_service())
     validated = await svc.validate_token(token)
     # Return identical 404 for not-found / expired / revoked to prevent enumeration
     if not validated:
@@ -869,7 +889,7 @@ async def public_verify_password(
     # [CRITICAL FIX #1] Rate limit public endpoints (10 req/min per IP)
     _check_public_rate_limit(request)
 
-    svc = _get_token_service()
+    svc = await _maybe_await(_get_token_service())
     audit = _get_audit_service()
 
     validated = await svc.validate_token(token)
@@ -912,7 +932,7 @@ async def public_prototype_session_exchange(
         PrototypeAccessError,
     )
 
-    svc = _get_token_service()
+    svc = await _maybe_await(_get_token_service())
     audit = _get_audit_service()
     validated = await svc.validate_token(token, allow_exhausted=True)
     if not validated:
@@ -927,7 +947,7 @@ async def public_prototype_session_exchange(
         )
 
     resume_cookie_value = request.cookies.get(PROTOTYPE_SHARED_ACTOR_COOKIE)
-    access_service = _get_prototype_access_service()
+    access_service = await _maybe_await(_get_prototype_access_service())
     can_resume_without_password = await access_service.can_resume_external_collaborator(
         prototype_workspace_id=prototype_workspace_id,
         share_link_id=int(validated["id"]),
@@ -1040,7 +1060,7 @@ async def public_import(
     request: Request,
     user: User = Depends(get_request_user),
 ):
-    svc = _get_token_service()
+    svc = await _maybe_await(_get_token_service())
     audit = _get_audit_service()
 
     validated = await svc.validate_token(token)
@@ -1099,7 +1119,7 @@ async def admin_list_shares(
     include_revoked: bool = Query(False),
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     shares = await repo.list_all_shares(limit=limit, offset=offset, include_revoked=include_revoked)
     total = await repo.count_all_shares(include_revoked=include_revoked)
     pagination = build_offset_pagination_meta(
@@ -1126,7 +1146,7 @@ async def admin_update_config(
     body: UpdateConfigRequest,
     user: User = Depends(get_request_user),
 ):
-    repo = _get_repo()
+    repo = await _maybe_await(_get_repo())
     for key, value in body.config.items():
         await repo.set_config(
             key, value,

--- a/tldw_Server_API/app/api/v1/endpoints/sharing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sharing.py
@@ -17,7 +17,8 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response, status
 from loguru import logger
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user, rbac_rate_limit
 from tldw_Server_API.app.api.v1.utils.pagination import build_offset_pagination_meta
 
 from ..schemas.sharing_schemas import (
@@ -27,9 +28,9 @@ from ..schemas.sharing_schemas import (
     CloneWorkspaceRequest,
     CloneWorkspaceResponse,
     CreateTokenRequest,
-    PublicSharePreview,
     PrototypeLinkExchangeRequest,
     PrototypeLinkExchangeResponse,
+    PublicSharePreview,
     ResourceType,
     SharedChatRequest,
     SharedMediaResponse,
@@ -66,6 +67,7 @@ def _get_repo():
 
 
 def _get_token_service():
+    """Lazily construct the share-token service from the shared workspace repo."""
     from tldw_Server_API.app.core.Sharing.share_token_service import ShareTokenService
 
     async def _build():
@@ -75,6 +77,7 @@ def _get_token_service():
 
 
 def _get_prototype_repo():
+    """Lazily construct the prototype workspace repo for share-token checks."""
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
     from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
         PrototypeWorkspacesRepo,
@@ -87,6 +90,7 @@ def _get_prototype_repo():
 
 
 def _get_prototype_access_service():
+    """Lazily construct the prototype private-link access service."""
     from tldw_Server_API.app.core.Prototype_Workspaces.access import PrototypeAccessService
 
     async def _build():
@@ -101,7 +105,7 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
-_cached_audit_service: "ShareAuditService | None" = None  # noqa: F821
+_cached_audit_service: ShareAuditService | None = None  # noqa: F821
 
 
 def _get_audit_service():
@@ -125,10 +129,33 @@ def _client_ip(request: Request) -> str:
 
 
 def _request_is_secure(request: Request) -> bool:
-    forwarded_proto = request.headers.get("x-forwarded-proto")
-    if forwarded_proto and "https" in forwarded_proto.lower():
-        return True
+    """Mirror SecurityHeadersMiddleware HTTPS detection for cookie security."""
+    forwarded_proto = request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
+    if forwarded_proto:
+        return forwarded_proto == "https"
     return request.url.scheme == "https"
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Return an integer value when possible without raising for malformed inputs."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _get_owned_prototype_workspace(
+    prototype_workspace_id: str,
+    owner_user_id: Any,
+) -> dict[str, Any]:
+    """Return a prototype workspace only when the expected owner matches."""
+    repo = await _maybe_await(_get_prototype_repo())
+    workspace = await repo.get_workspace(prototype_workspace_id)
+    expected_owner_id = _coerce_int(owner_user_id)
+    actual_owner_id = _coerce_int(workspace.get("owner_user_id")) if workspace else None
+    if not workspace or expected_owner_id is None or actual_owner_id != expected_owner_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
+    return workspace
 
 
 def _sanitize_shared_chat_result(value: Any) -> Any:
@@ -774,6 +801,11 @@ async def create_token(
 ):
     svc = await _maybe_await(_get_token_service())
     audit = _get_audit_service()
+    if body.resource_type == ResourceType.PROTOTYPE_WORKSPACE:
+        await _get_owned_prototype_workspace(
+            prototype_workspace_id=body.resource_id,
+            owner_user_id=user.id,
+        )
 
     result = await svc.generate_token(
         resource_type=body.resource_type.value,
@@ -945,6 +977,10 @@ async def public_prototype_session_exchange(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Share token is not a prototype workspace link",
         )
+    await _get_owned_prototype_workspace(
+        prototype_workspace_id=prototype_workspace_id,
+        owner_user_id=validated.get("owner_user_id"),
+    )
 
     resume_cookie_value = request.cookies.get(PROTOTYPE_SHARED_ACTOR_COOKIE)
     access_service = await _maybe_await(_get_prototype_access_service())

--- a/tldw_Server_API/app/api/v1/endpoints/sharing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sharing.py
@@ -14,7 +14,7 @@ import time
 from collections import defaultdict
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response, status
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
 from tldw_Server_API.app.api.v1.utils.pagination import build_offset_pagination_meta
@@ -27,6 +27,9 @@ from ..schemas.sharing_schemas import (
     CloneWorkspaceResponse,
     CreateTokenRequest,
     PublicSharePreview,
+    PrototypeLinkExchangeRequest,
+    PrototypeLinkExchangeResponse,
+    ResourceType,
     SharedChatRequest,
     SharedMediaResponse,
     SharedWithMeItem,
@@ -63,6 +66,21 @@ def _get_token_service():
     return ShareTokenService(_get_repo())
 
 
+def _get_prototype_repo():
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    return PrototypeWorkspacesRepo(db_pool=get_db_pool())
+
+
+def _get_prototype_access_service():
+    from tldw_Server_API.app.core.Prototype_Workspaces.access import PrototypeAccessService
+
+    return PrototypeAccessService(_get_prototype_repo())
+
+
 _cached_audit_service: "ShareAuditService | None" = None  # noqa: F821
 
 
@@ -84,6 +102,13 @@ async def shutdown_sharing_audit_service() -> None:
 
 def _client_ip(request: Request) -> str:
     return request.client.host if request.client else "unknown"
+
+
+def _request_is_secure(request: Request) -> bool:
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    if forwarded_proto and "https" in forwarded_proto.lower():
+        return True
+    return request.url.scheme == "https"
 
 
 def _sanitize_shared_chat_result(value: Any) -> Any:
@@ -870,6 +895,142 @@ async def public_verify_password(
 
 
 @router.post(
+    "/public/{token}/prototype-session",
+    response_model=PrototypeLinkExchangeResponse,
+    summary="Exchange a prototype private link for an external collaborator session",
+)
+async def public_prototype_session_exchange(
+    token: str,
+    body: PrototypeLinkExchangeRequest,
+    request: Request,
+    response: Response,
+):
+    _check_public_rate_limit(request)
+
+    from tldw_Server_API.app.core.Prototype_Workspaces.access import (
+        PROTOTYPE_SHARED_ACTOR_COOKIE,
+        PrototypeAccessError,
+    )
+
+    svc = _get_token_service()
+    audit = _get_audit_service()
+    validated = await svc.validate_token(token, allow_exhausted=True)
+    if not validated:
+        raise HTTPException(status_code=404, detail="Resource not found")
+
+    resource_type = str(validated.get("resource_type") or "").strip().lower()
+    prototype_workspace_id = str(validated.get("resource_id") or "").strip()
+    if resource_type != ResourceType.PROTOTYPE_WORKSPACE.value or not prototype_workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Share token is not a prototype workspace link",
+        )
+
+    resume_cookie_value = request.cookies.get(PROTOTYPE_SHARED_ACTOR_COOKIE)
+    access_service = _get_prototype_access_service()
+    can_resume_without_password = await access_service.can_resume_external_collaborator(
+        prototype_workspace_id=prototype_workspace_id,
+        share_link_id=int(validated["id"]),
+        resume_cookie_value=resume_cookie_value,
+    )
+    if validated.get("is_password_protected"):
+        if body.password:
+            password_ok = await svc.verify_password(validated, body.password)
+            await audit.log(
+                "token.password_verified" if password_ok else "token.password_failed",
+                resource_type=validated["resource_type"],
+                resource_id=validated["resource_id"],
+                owner_user_id=validated["owner_user_id"],
+                token_id=validated["id"],
+                ip_address=_client_ip(request),
+                user_agent=request.headers.get("user-agent"),
+            )
+            if not password_ok:
+                raise HTTPException(status_code=403, detail="Invalid password")
+        else:
+            if not can_resume_without_password:
+                raise HTTPException(status_code=403, detail="Password required")
+
+    if not can_resume_without_password and not str(body.display_name or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="display_name is required for first-time sessions",
+        )
+
+    claimed_new_use = False
+    if not can_resume_without_password:
+        claimed_new_use = await svc.claim_token_use(validated["id"])
+        if not claimed_new_use:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+    claim_released = False
+    try:
+        access_context = await access_service.exchange_external_collaborator(
+            prototype_workspace_id=prototype_workspace_id,
+            share_link_id=int(validated["id"]),
+            display_name=body.display_name,
+            resume_cookie_value=resume_cookie_value,
+            allow_create=claimed_new_use,
+            expires_at=validated.get("expires_at"),
+        )
+    except PrototypeAccessError as exc:
+        if claimed_new_use:
+            await svc.release_token_use(validated["id"])
+        if exc.code == "workspace_not_found":
+            raise HTTPException(status_code=404, detail="Prototype workspace not found") from exc
+        if exc.code == "workspace_archived":
+            raise HTTPException(status_code=403, detail="Prototype workspace is archived") from exc
+        if exc.code == "resume_required":
+            raise HTTPException(status_code=404, detail="Resource not found") from exc
+        raise
+    except Exception:
+        if claimed_new_use and not claim_released:
+            await svc.release_token_use(validated["id"])
+            claim_released = True
+        raise
+    if access_context.is_resume and claimed_new_use:
+        await svc.release_token_use(validated["id"])
+        claim_released = True
+    try:
+        await audit.log(
+            "token.prototype_session_exchanged",
+            resource_type=validated["resource_type"],
+            resource_id=validated["resource_id"],
+            owner_user_id=validated["owner_user_id"],
+            token_id=validated["id"],
+            ip_address=_client_ip(request),
+            user_agent=request.headers.get("user-agent"),
+            metadata={
+                "shared_actor_id": access_context.shared_actor_id,
+                "actor_type": access_context.actor_type,
+                "runtime_policy_profile": access_context.runtime_policy_profile,
+                "is_resume": access_context.is_resume,
+                "resumed_without_password": can_resume_without_password,
+                "claimed_new_use": claimed_new_use,
+            },
+        )
+
+        response.set_cookie(
+            key=PROTOTYPE_SHARED_ACTOR_COOKIE,
+            value=access_context.resume_cookie_value,
+            max_age=7 * 24 * 60 * 60,
+            httponly=True,
+            samesite="lax",
+            secure=_request_is_secure(request),
+        )
+        return PrototypeLinkExchangeResponse(
+            shared_actor_id=access_context.shared_actor_id,
+            actor_type="external_collaborator",
+            session_token=access_context.session_token,
+            runtime_policy_profile=access_context.runtime_policy_profile,
+        )
+    except Exception:
+        if claimed_new_use and not claim_released:
+            await svc.release_token_use(validated["id"])
+        raise
+
+
+@router.post(
     "/public/{token}/import",
     dependencies=[Depends(rbac_rate_limit("sharing.read"))],
     summary="Import resource from share token (requires auth)",
@@ -885,6 +1046,12 @@ async def public_import(
     validated = await svc.validate_token(token)
     if not validated:
         raise HTTPException(status_code=404, detail="Resource not found")
+
+    if validated.get("resource_type") == ResourceType.PROTOTYPE_WORKSPACE.value:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Prototype workspace links must be exchanged via /prototype-session",
+        )
 
     # [CRITICAL FIX #4] Block import on password-protected tokens without verification
     if validated.get("is_password_protected"):

--- a/tldw_Server_API/app/api/v1/endpoints/sharing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sharing.py
@@ -984,6 +984,7 @@ async def public_prototype_session_exchange(
             raise HTTPException(status_code=404, detail="Resource not found")
 
     claim_released = False
+    provisioning_succeeded = False
     try:
         access_context = await access_service.exchange_external_collaborator(
             prototype_workspace_id=prototype_workspace_id,
@@ -993,9 +994,11 @@ async def public_prototype_session_exchange(
             allow_create=claimed_new_use,
             expires_at=validated.get("expires_at"),
         )
+        provisioning_succeeded = bool(access_context.shared_actor_id or access_context.session_token)
     except PrototypeAccessError as exc:
         if claimed_new_use:
             await svc.release_token_use(validated["id"])
+            claim_released = True
         if exc.code == "workspace_not_found":
             raise HTTPException(status_code=404, detail="Prototype workspace not found") from exc
         if exc.code == "workspace_archived":
@@ -1045,7 +1048,7 @@ async def public_prototype_session_exchange(
             runtime_policy_profile=access_context.runtime_policy_profile,
         )
     except Exception:
-        if claimed_new_use and not claim_released:
+        if claimed_new_use and not claim_released and not provisioning_succeeded:
             await svc.release_token_use(validated["id"])
         raise
 

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -599,6 +599,13 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
             tags=("sharing",),
             route_key="sharing",
         ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prototype_workspaces",
+            log_name="prototype_workspaces",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("prototype-workspaces",),
+            route_key="prototype-workspaces",
+        ),
     ):
         append_imported_router_spec(specs, collaboration_spec)
 

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -555,6 +555,13 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
             skip_context=minimal_skip_context,
         ),
         ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prototype_workspaces",
+            log_name="prototype_workspaces",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("prototype-workspaces",),
+            skip_context=minimal_skip_context,
+        ),
+        ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.personalization",
             log_name="personalization",
             prefix=f"{API_V1_PREFIX}/personalization",

--- a/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
@@ -1,0 +1,112 @@
+"""Pydantic schemas for prototype workspace collaboration endpoints."""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class PrototypeWorkspaceCreateRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=255)
+    creation_source: str = Field(..., min_length=1, max_length=64)
+    description: str | None = Field(None, max_length=2000)
+    prompt: str | None = None
+    preview_policy: dict[str, Any] = Field(default_factory=dict)
+    share_policy: dict[str, Any] = Field(default_factory=dict)
+    runtime_policy: dict[str, Any] = Field(default_factory=dict)
+    designated_promoter_ids: list[int] = Field(default_factory=list)
+
+
+class PrototypeWorkspaceResponse(BaseModel):
+    id: str
+    owner_user_id: int
+    title: str
+    description: str | None = None
+    creation_source: str
+    canonical_snapshot_id: str | None = None
+    last_known_good_snapshot_id: str | None = None
+    canonical_preview_status: str | None = None
+    publish_validation_status: str | None = None
+    preview_policy: dict[str, Any] = Field(default_factory=dict)
+    share_policy: dict[str, Any] = Field(default_factory=dict)
+    runtime_policy: dict[str, Any] = Field(default_factory=dict)
+    designated_promoter_ids: list[int] = Field(default_factory=list)
+    created_at: str
+    updated_at: str
+    archived_at: str | None = None
+    is_archived: bool = False
+
+
+class PrototypeWorkspaceSessionCreateRequest(BaseModel):
+    request_nonce: str | None = Field(None, min_length=1, max_length=255)
+
+
+class PrototypeCollaboratorSessionCreateRequest(BaseModel):
+    session_token: str = Field(..., min_length=1)
+    request_nonce: str | None = Field(None, min_length=1, max_length=255)
+
+
+class PrototypeSessionJobResponse(BaseModel):
+    job_id: str
+    job_type: Literal["branch_session_bootstrap"] = "branch_session_bootstrap"
+    status: str = "pending"
+    message: str = "Prototype branch session job created"
+    prototype_workspace_id: str
+    prototype_session_id: str
+    actor_type: str
+    shared_actor_id: str | None = None
+    idempotency_key: str | None = None
+
+
+class PrototypePromotionCreateRequest(BaseModel):
+    prototype_workspace_id: str = Field(..., min_length=1)
+    prototype_session_id: str = Field(..., min_length=1)
+    candidate_snapshot_id: str = Field(..., min_length=1)
+    session_token: str = Field(..., min_length=1)
+    request_reason: str | None = Field(None, max_length=2000)
+
+
+class PrototypePromotionRequestResponse(BaseModel):
+    id: str
+    prototype_workspace_id: str
+    prototype_session_id: str
+    candidate_snapshot_id: str
+    requested_by_user_id: int | None = None
+    requested_by_shared_actor_id: str | None = None
+    status: str
+    reviewed_by_user_id: int | None = None
+    review_notes: str | None = None
+    created_at: str
+    updated_at: str
+
+
+class PrototypePromotionReviewRequest(BaseModel):
+    decision: Literal["approve", "reject"]
+    review_notes: str | None = Field(None, max_length=2000)
+    review_baseline_snapshot_id: str | None = Field(None, min_length=1)
+
+
+class PrototypePromotionReviewResponse(BaseModel):
+    status: str
+    failure_code: str | None = None
+    prototype_workspace_id: str
+    candidate_snapshot_id: str
+    canonical_snapshot_id: str | None = None
+    preview_handle: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class PrototypePreviewRenewRequest(BaseModel):
+    pass
+
+
+class PrototypePreviewGrantResponse(BaseModel):
+    preview_handle: str
+    preview_scope: str
+    prototype_workspace_id: str
+    prototype_session_id: str | None = None
+    snapshot_id: str | None = None
+    preview_url: str
+    expires_at: str
+    token: str
+    runtime_policy_profile: str

--- a/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
@@ -37,6 +37,51 @@ class PrototypeWorkspaceResponse(BaseModel):
     is_archived: bool = False
 
 
+class PrototypeWorkspaceSessionSummaryResponse(BaseModel):
+    id: str
+    prototype_workspace_id: str
+    base_snapshot_id: str
+    actor_user_id: int | None = None
+    actor_shared_actor_id: str | None = None
+    actor_type: str
+    share_link_id: int | None = None
+    acp_session_id: str | None = None
+    sandbox_session_id: str | None = None
+    sandbox_run_id: str | None = None
+    runtime_status: str
+    preview_handle: str | None = None
+    preview_status: str
+    last_saved_snapshot_id: str | None = None
+    last_activity_at: str | None = None
+    expires_at: str | None = None
+    revoked_at: str | None = None
+    created_at: str
+    updated_at: str
+    is_revoked: bool = False
+
+
+class PrototypeWorkspaceSnapshotSummaryResponse(BaseModel):
+    snapshot_id: str
+    prototype_workspace_id: str
+    parent_snapshot_id: str | None = None
+    created_from_session_id: str | None = None
+    author_user_id: int | None = None
+    author_shared_actor_id: str | None = None
+    storage_ref: str | None = None
+    diff_summary: dict[str, Any] = Field(default_factory=dict)
+    prompt_summary: str | None = None
+    preview_health: dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    is_canonical: bool = False
+    is_last_known_good: bool = False
+
+
+class PrototypeWorkspaceDetailResponse(PrototypeWorkspaceResponse):
+    viewer_role: Literal["owner", "internal_collaborator"] = "owner"
+    sessions: list[PrototypeWorkspaceSessionSummaryResponse] = Field(default_factory=list)
+    snapshots: list[PrototypeWorkspaceSnapshotSummaryResponse] = Field(default_factory=list)
+
+
 class PrototypeWorkspaceSessionCreateRequest(BaseModel):
     request_nonce: str | None = Field(None, min_length=1, max_length=255)
 

--- a/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PrototypeWorkspaceCreateRequest(BaseModel):
@@ -142,7 +142,7 @@ class PrototypePromotionReviewResponse(BaseModel):
 
 
 class PrototypePreviewRenewRequest(BaseModel):
-    pass
+    model_config = ConfigDict(extra="forbid")
 
 
 class PrototypePreviewGrantResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/sharing_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sharing_schemas.py
@@ -9,7 +9,7 @@ Pydantic models for workspace sharing CRUD, share tokens, and admin operations.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -30,6 +30,7 @@ class AccessLevel(str, Enum):
 class ResourceType(str, Enum):
     CHATBOOK = "chatbook"
     WORKSPACE = "workspace"
+    PROTOTYPE_WORKSPACE = "prototype_workspace"
 
 
 # ── Workspace Sharing ──
@@ -135,6 +136,18 @@ class VerifyPasswordRequest(BaseModel):
 class VerifyPasswordResponse(BaseModel):
     verified: bool
     session_token: str | None = None
+
+
+class PrototypeLinkExchangeRequest(BaseModel):
+    display_name: str | None = Field(None, min_length=1, max_length=120)
+    password: str | None = Field(None, min_length=1, max_length=128)
+
+
+class PrototypeLinkExchangeResponse(BaseModel):
+    shared_actor_id: str
+    actor_type: Literal["external_collaborator"] = "external_collaborator"
+    session_token: str
+    runtime_policy_profile: str
 
 
 # ── Clone ──

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -818,6 +818,108 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
     logger.info("Migration 086: Created prototype workspace metadata tables")
 
 
+def migration_087_expand_share_tokens_resource_type_for_prototypes(conn: sqlite3.Connection) -> None:
+    """Rebuild share_tokens to support prototype_workspace and backfill legacy encoded rows."""
+    logger.info("Migration 087: START expand share_tokens resource_type for prototypes")
+
+    if not _sqlite_table_exists(conn, "share_tokens"):
+        logger.info("Migration 087: share_tokens table missing; skipping")
+        return
+
+    table_sql_row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'share_tokens'"
+    ).fetchone()
+    table_sql = str(table_sql_row[0] if table_sql_row else "").lower()
+    has_prototype_type = "prototype_workspace" in table_sql
+    legacy_count_row = conn.execute(
+        """
+        SELECT COUNT(*) FROM share_tokens
+        WHERE resource_type = 'workspace'
+          AND resource_id LIKE 'prototype_workspace::%'
+        """
+    ).fetchone()
+    legacy_count = int(legacy_count_row[0]) if legacy_count_row else 0
+
+    if has_prototype_type and legacy_count == 0:
+        logger.info("Migration 087: share_tokens already supports prototype_workspace; skipping")
+        return
+
+    conn.execute("PRAGMA foreign_keys = OFF")
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS share_tokens_new (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                token_hash      TEXT UNIQUE NOT NULL,
+                token_prefix    TEXT NOT NULL,
+                resource_type   TEXT NOT NULL
+                    CHECK (resource_type IN ('chatbook', 'workspace', 'prototype_workspace')),
+                resource_id     TEXT NOT NULL,
+                owner_user_id   INTEGER NOT NULL,
+                access_level    TEXT NOT NULL DEFAULT 'view_chat',
+                allow_clone     INTEGER NOT NULL DEFAULT 1,
+                password_hash   TEXT,
+                max_uses        INTEGER,
+                use_count       INTEGER NOT NULL DEFAULT 0,
+                expires_at      TIMESTAMP,
+                created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                revoked_at      TIMESTAMP,
+                FOREIGN KEY (owner_user_id) REFERENCES users(id)
+            )
+            """
+        )
+
+        conn.execute(
+            """
+            INSERT INTO share_tokens_new (
+                id, token_hash, token_prefix, resource_type, resource_id,
+                owner_user_id, access_level, allow_clone, password_hash,
+                max_uses, use_count, expires_at, created_at, revoked_at
+            )
+            SELECT
+                id,
+                token_hash,
+                token_prefix,
+                CASE
+                    WHEN resource_type = 'workspace'
+                         AND resource_id LIKE 'prototype_workspace::%'
+                    THEN 'prototype_workspace'
+                    ELSE resource_type
+                END AS resource_type,
+                CASE
+                    WHEN resource_type = 'workspace'
+                         AND resource_id LIKE 'prototype_workspace::%'
+                    THEN substr(resource_id, 22)
+                    ELSE resource_id
+                END AS resource_id,
+                owner_user_id,
+                access_level,
+                allow_clone,
+                password_hash,
+                max_uses,
+                use_count,
+                expires_at,
+                created_at,
+                revoked_at
+            FROM share_tokens
+            """
+        )
+
+        conn.execute("DROP TABLE IF EXISTS share_tokens")
+        conn.execute("ALTER TABLE share_tokens_new RENAME TO share_tokens")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_share_tokens_prefix ON share_tokens(token_prefix)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_share_tokens_owner ON share_tokens(owner_user_id)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_share_tokens_resource ON share_tokens(resource_type, resource_id)")
+    finally:
+        conn.execute("PRAGMA foreign_keys = ON")
+
+    conn.commit()
+    logger.info(
+        "Migration 087: Expanded share_tokens resource_type and backfilled {} legacy prototype rows",
+        legacy_count,
+    )
+
+
 def rollback_086_drop_prototype_workspace_tables(conn: sqlite3.Connection) -> None:
     """Rollback migration 086 by dropping prototype workspace metadata tables."""
     conn.execute("DROP TABLE IF EXISTS prototype_promotion_requests")
@@ -4999,6 +5101,11 @@ def get_authnz_migrations() -> list[Migration]:
             "Create prototype workspace metadata tables",
             migration_086_create_prototype_workspace_tables,
             rollback_086_drop_prototype_workspace_tables,
+        ),
+        Migration(
+            87,
+            "Expand share_tokens resource_type for prototype workspace links",
+            migration_087_expand_share_tokens_resource_type_for_prototypes,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -643,6 +643,192 @@ def migration_085_remove_api_keys_scope_default(conn: sqlite3.Connection) -> Non
     logger.info("Migration 085: COMPLETE remove api_keys.scope default")
 
 
+def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) -> None:
+    """Create shared metadata tables for prototype workspaces and collaboration sessions."""
+    logger.info("Migration 086: START prototype workspace metadata tables")
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prototype_workspaces (
+            id TEXT PRIMARY KEY,
+            owner_user_id INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            creation_source TEXT NOT NULL
+                CHECK (creation_source IN ('prompt', 'template', 'existing_workspace')),
+            canonical_snapshot_id TEXT,
+            last_known_good_snapshot_id TEXT,
+            canonical_preview_status TEXT,
+            publish_validation_status TEXT,
+            preview_policy_json TEXT NOT NULL DEFAULT '{}',
+            share_policy_json TEXT NOT NULL DEFAULT '{}',
+            runtime_policy_json TEXT NOT NULL DEFAULT '{}',
+            designated_promoter_ids_json TEXT NOT NULL DEFAULT '[]',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            archived_at TIMESTAMP,
+            FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_workspaces_owner_updated "
+        "ON prototype_workspaces(owner_user_id, updated_at)"
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prototype_snapshots (
+            id TEXT PRIMARY KEY,
+            prototype_workspace_id TEXT NOT NULL,
+            parent_snapshot_id TEXT,
+            created_from_session_id TEXT,
+            author_user_id INTEGER,
+            author_shared_actor_id TEXT,
+            storage_ref TEXT,
+            diff_summary_json TEXT NOT NULL DEFAULT '{}',
+            prompt_summary TEXT,
+            preview_health_json TEXT NOT NULL DEFAULT '{}',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (prototype_workspace_id) REFERENCES prototype_workspaces(id) ON DELETE CASCADE,
+            UNIQUE (id, prototype_workspace_id),
+            CHECK (
+                (author_user_id IS NOT NULL AND author_shared_actor_id IS NULL)
+                OR (author_user_id IS NULL AND author_shared_actor_id IS NOT NULL)
+            )
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_snapshots_workspace_created "
+        "ON prototype_snapshots(prototype_workspace_id, created_at)"
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prototype_shared_actors (
+            id TEXT PRIMARY KEY,
+            prototype_workspace_id TEXT NOT NULL,
+            share_link_id INTEGER NOT NULL,
+            display_name TEXT NOT NULL,
+            session_binding_id TEXT,
+            runtime_policy_profile TEXT NOT NULL,
+            quota_policy_json TEXT NOT NULL DEFAULT '{}',
+            last_activity_at TIMESTAMP,
+            expires_at TIMESTAMP,
+            revoked_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (prototype_workspace_id) REFERENCES prototype_workspaces(id) ON DELETE CASCADE,
+            UNIQUE (id, prototype_workspace_id)
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_shared_actors_workspace "
+        "ON prototype_shared_actors(prototype_workspace_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_shared_actors_share_link_revoked "
+        "ON prototype_shared_actors(share_link_id, revoked_at)"
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prototype_sessions (
+            id TEXT PRIMARY KEY,
+            prototype_workspace_id TEXT NOT NULL,
+            base_snapshot_id TEXT NOT NULL,
+            actor_user_id INTEGER,
+            actor_shared_actor_id TEXT,
+            actor_type TEXT NOT NULL
+                CHECK (actor_type IN ('owner', 'internal_collaborator', 'external_collaborator')),
+            share_link_id INTEGER,
+            acp_session_id TEXT,
+            sandbox_session_id TEXT,
+            sandbox_run_id TEXT,
+            runtime_status TEXT,
+            preview_handle TEXT,
+            preview_status TEXT,
+            last_saved_snapshot_id TEXT,
+            last_activity_at TIMESTAMP,
+            expires_at TIMESTAMP,
+            revoked_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (prototype_workspace_id) REFERENCES prototype_workspaces(id) ON DELETE CASCADE,
+            FOREIGN KEY (actor_user_id) REFERENCES users(id),
+            FOREIGN KEY (base_snapshot_id, prototype_workspace_id)
+                REFERENCES prototype_snapshots(id, prototype_workspace_id),
+            FOREIGN KEY (actor_shared_actor_id, prototype_workspace_id)
+                REFERENCES prototype_shared_actors(id, prototype_workspace_id),
+            UNIQUE (id, prototype_workspace_id),
+            CHECK (
+                (actor_type = 'external_collaborator'
+                    AND actor_user_id IS NULL
+                    AND actor_shared_actor_id IS NOT NULL)
+                OR (
+                    actor_type IN ('owner', 'internal_collaborator')
+                    AND actor_user_id IS NOT NULL
+                    AND actor_shared_actor_id IS NULL
+                )
+            )
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_sessions_workspace_updated "
+        "ON prototype_sessions(prototype_workspace_id, updated_at)"
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prototype_promotion_requests (
+            id TEXT PRIMARY KEY,
+            prototype_workspace_id TEXT NOT NULL,
+            prototype_session_id TEXT NOT NULL,
+            candidate_snapshot_id TEXT NOT NULL,
+            requested_by_user_id INTEGER,
+            requested_by_shared_actor_id TEXT,
+            status TEXT NOT NULL
+                CHECK (status IN ('pending', 'approved', 'rejected', 'promoted', 'stale')),
+            reviewed_by_user_id INTEGER,
+            review_notes TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (prototype_workspace_id) REFERENCES prototype_workspaces(id) ON DELETE CASCADE,
+            FOREIGN KEY (prototype_session_id) REFERENCES prototype_sessions(id) ON DELETE CASCADE,
+            FOREIGN KEY (candidate_snapshot_id, prototype_workspace_id)
+                REFERENCES prototype_snapshots(id, prototype_workspace_id),
+            FOREIGN KEY (prototype_session_id, prototype_workspace_id)
+                REFERENCES prototype_sessions(id, prototype_workspace_id),
+            CHECK (
+                (requested_by_user_id IS NOT NULL AND requested_by_shared_actor_id IS NULL)
+                OR (requested_by_user_id IS NULL AND requested_by_shared_actor_id IS NOT NULL)
+            )
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_promotion_requests_workspace_status "
+        "ON prototype_promotion_requests(prototype_workspace_id, status)"
+    )
+
+    conn.commit()
+    logger.info("Migration 086: Created prototype workspace metadata tables")
+
+
+def rollback_086_drop_prototype_workspace_tables(conn: sqlite3.Connection) -> None:
+    """Rollback migration 086 by dropping prototype workspace metadata tables."""
+    conn.execute("DROP TABLE IF EXISTS prototype_promotion_requests")
+    conn.execute("DROP TABLE IF EXISTS prototype_sessions")
+    conn.execute("DROP TABLE IF EXISTS prototype_shared_actors")
+    conn.execute("DROP TABLE IF EXISTS prototype_snapshots")
+    conn.execute("DROP TABLE IF EXISTS prototype_workspaces")
+    conn.commit()
+    logger.info("Rollback 086: Dropped prototype workspace metadata tables")
+
+
 def migration_012_create_rbac_tables(conn: sqlite3.Connection) -> None:
     """Create core RBAC tables: roles, permissions, mappings, and user overrides."""
     logger.info("Migration 012: START RBAC core tables")
@@ -4807,6 +4993,12 @@ def get_authnz_migrations() -> list[Migration]:
             85,
             "Remove api_keys.scope default",
             migration_085_remove_api_keys_scope_default,
+        ),
+        Migration(
+            86,
+            "Create prototype workspace metadata tables",
+            migration_086_create_prototype_workspace_tables,
+            rollback_086_drop_prototype_workspace_tables,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -840,6 +840,8 @@ def migration_087_expand_share_tokens_resource_type_for_prototypes(conn: sqlite3
     ).fetchone()
     legacy_count = int(legacy_count_row[0]) if legacy_count_row else 0
 
+    conn.execute("DROP TABLE IF EXISTS share_tokens_new")
+
     if has_prototype_type and legacy_count == 0:
         logger.info("Migration 087: share_tokens already supports prototype_workspace; skipping")
         return

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -783,6 +783,45 @@ def migration_086_create_prototype_workspace_tables(conn: sqlite3.Connection) ->
 
     conn.execute(
         """
+        CREATE TABLE IF NOT EXISTS prototype_preview_handles (
+            id TEXT PRIMARY KEY,
+            preview_scope TEXT NOT NULL
+                CHECK (preview_scope IN ('canonical', 'session')),
+            scope_id TEXT NOT NULL,
+            prototype_workspace_id TEXT NOT NULL,
+            prototype_session_id TEXT,
+            actor_key TEXT NOT NULL,
+            target_ref TEXT NOT NULL,
+            runtime_policy_profile TEXT NOT NULL,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            is_active INTEGER NOT NULL DEFAULT 1,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            revoked_at TIMESTAMP,
+            FOREIGN KEY (prototype_workspace_id) REFERENCES prototype_workspaces(id) ON DELETE CASCADE,
+            FOREIGN KEY (prototype_session_id, prototype_workspace_id)
+                REFERENCES prototype_sessions(id, prototype_workspace_id)
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_preview_handles_workspace "
+        "ON prototype_preview_handles(prototype_workspace_id, created_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_preview_handles_session "
+        "ON prototype_preview_handles(prototype_session_id, created_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prototype_preview_handles_scope_active "
+        "ON prototype_preview_handles(scope_id, is_active)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_prototype_preview_handles_active_scope "
+        "ON prototype_preview_handles(scope_id) WHERE is_active = 1"
+    )
+
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS prototype_promotion_requests (
             id TEXT PRIMARY KEY,
             prototype_workspace_id TEXT NOT NULL,
@@ -925,6 +964,7 @@ def migration_087_expand_share_tokens_resource_type_for_prototypes(conn: sqlite3
 def rollback_086_drop_prototype_workspace_tables(conn: sqlite3.Connection) -> None:
     """Rollback migration 086 by dropping prototype workspace metadata tables."""
     conn.execute("DROP TABLE IF EXISTS prototype_promotion_requests")
+    conn.execute("DROP TABLE IF EXISTS prototype_preview_handles")
     conn.execute("DROP TABLE IF EXISTS prototype_sessions")
     conn.execute("DROP TABLE IF EXISTS prototype_shared_actors")
     conn.execute("DROP TABLE IF EXISTS prototype_snapshots")

--- a/tldw_Server_API/app/core/AuthNZ/repos/__init__.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/__init__.py
@@ -9,6 +9,9 @@ services like APIKeyManager can remain backend-agnostic.
 from tldw_Server_API.app.core.AuthNZ.repos.admin_monitoring_repo import AuthnzAdminMonitoringRepo
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 from tldw_Server_API.app.core.AuthNZ.repos.org_stt_settings_repo import AuthnzOrgSttSettingsRepo
+from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+    PrototypeWorkspacesRepo,
+)
 from tldw_Server_API.app.core.AuthNZ.repos.workspace_provider_installations_repo import (
     WorkspaceProviderInstallationsRepo,
     get_workspace_provider_installations_repo,
@@ -18,6 +21,7 @@ __all__ = [
     "AuthnzAdminMonitoringRepo",
     "McpHubRepo",
     "AuthnzOrgSttSettingsRepo",
+    "PrototypeWorkspacesRepo",
     "WorkspaceProviderInstallationsRepo",
     "get_workspace_provider_installations_repo",
 ]

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
 _VALID_CREATION_SOURCES = {"prompt", "template", "existing_workspace"}
 _VALID_ACTOR_TYPES = {"owner", "internal_collaborator", "external_collaborator"}
 _VALID_PROMOTION_STATUSES = {"pending", "approved", "rejected", "promoted", "stale"}
+_VALID_PREVIEW_SCOPES = {"canonical", "session"}
 _ROW_CONVERSION_EXCEPTIONS = (AttributeError, KeyError, TypeError, ValueError)
 
 
@@ -77,6 +78,13 @@ def _normalize_promotion_status(status: str | None) -> str:
     value = (status or "").strip().lower()
     if value not in _VALID_PROMOTION_STATUSES:
         raise ValueError(f"Invalid status: {status}")
+    return value
+
+
+def _normalize_preview_scope(preview_scope: str | None) -> str:
+    value = (preview_scope or "").strip().lower()
+    if value not in _VALID_PREVIEW_SCOPES:
+        raise ValueError(f"Invalid preview_scope: {preview_scope}")
     return value
 
 
@@ -176,6 +184,16 @@ class PrototypeWorkspacesRepo:
             out["reviewed_by_user_id"] = int(out["reviewed_by_user_id"])
         return out
 
+    @staticmethod
+    def _normalize_preview_handle_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        out["preview_handle"] = out.get("id")
+        out["metadata"] = _load_json_dict(out.get("metadata_json"))
+        out["is_active"] = _to_bool(out.get("is_active"))
+        return out
+
     async def ensure_tables(self) -> None:
         required = {
             "prototype_workspaces",
@@ -183,6 +201,7 @@ class PrototypeWorkspacesRepo:
             "prototype_sessions",
             "prototype_shared_actors",
             "prototype_promotion_requests",
+            "prototype_preview_handles",
         }
         if self._is_postgres_backend():
             table_query = """
@@ -711,6 +730,147 @@ class PrototypeWorkspacesRepo:
             ),
         )
         return await self.get_session(prototype_session_id)
+
+    async def replace_active_preview_handle_record(
+        self,
+        *,
+        preview_handle: str,
+        preview_scope: str,
+        scope_id: str,
+        prototype_workspace_id: str,
+        prototype_session_id: str | None,
+        actor_key: str,
+        target_ref: str,
+        runtime_policy_profile: str,
+        metadata: dict[str, Any] | None = None,
+        created_at: str | datetime | None = None,
+    ) -> dict[str, Any]:
+        preview_scope_value = _normalize_preview_scope(preview_scope)
+        ts = self._ts()
+        created_at_value = created_at if created_at is not None else ts
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_preview_handles
+            SET is_active = ?, revoked_at = ?
+            WHERE scope_id = ? AND is_active = ?
+            """,
+            (
+                False,
+                created_at_value,
+                scope_id,
+                True,
+            ),
+        )
+        await self.db_pool.execute(
+            """
+            INSERT INTO prototype_preview_handles (
+                id, preview_scope, scope_id, prototype_workspace_id, prototype_session_id,
+                actor_key, target_ref, runtime_policy_profile, metadata_json,
+                is_active, created_at, revoked_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                preview_handle,
+                preview_scope_value,
+                scope_id,
+                prototype_workspace_id,
+                prototype_session_id,
+                actor_key,
+                target_ref,
+                runtime_policy_profile,
+                json.dumps(metadata or {}),
+                True,
+                created_at_value,
+                None,
+            ),
+        )
+        created = await self.get_preview_handle_record(preview_handle)
+        return created or {}
+
+    async def get_preview_handle_record(self, preview_handle: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, preview_scope, scope_id, prototype_workspace_id, prototype_session_id,
+                   actor_key, target_ref, runtime_policy_profile, metadata_json,
+                   is_active, created_at, revoked_at
+            FROM prototype_preview_handles
+            WHERE id = ?
+            """,
+            (preview_handle,),
+        )
+        return self._normalize_preview_handle_row(self._row_to_dict(row) if row else None)
+
+    async def get_active_preview_handle_for_scope(self, scope_id: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, preview_scope, scope_id, prototype_workspace_id, prototype_session_id,
+                   actor_key, target_ref, runtime_policy_profile, metadata_json,
+                   is_active, created_at, revoked_at
+            FROM prototype_preview_handles
+            WHERE scope_id = ? AND is_active = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (scope_id, True),
+        )
+        return self._normalize_preview_handle_row(self._row_to_dict(row) if row else None)
+
+    async def revoke_preview_handle_record(
+        self,
+        preview_handle: str,
+        *,
+        revoked_at: str | datetime | None = None,
+    ) -> bool:
+        existing = await self.get_preview_handle_record(preview_handle)
+        if not existing or not existing.get("is_active"):
+            return False
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_preview_handles
+            SET is_active = ?, revoked_at = ?
+            WHERE id = ?
+            """,
+            (
+                False,
+                revoked_at if revoked_at is not None else self._ts(),
+                preview_handle,
+            ),
+        )
+        return True
+
+    async def restore_preview_handle_record_if_scope_unclaimed(
+        self,
+        preview_handle: str,
+    ) -> dict[str, Any] | None:
+        existing = await self.get_preview_handle_record(preview_handle)
+        if not existing:
+            return None
+        scope_id = str(existing.get("scope_id") or "")
+        if not scope_id:
+            return None
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_preview_handles
+            SET is_active = ?, revoked_at = NULL
+            WHERE id = ?
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM prototype_preview_handles
+                  WHERE scope_id = ? AND is_active = ? AND id <> ?
+              )
+            """,
+            (
+                True,
+                preview_handle,
+                scope_id,
+                True,
+                preview_handle,
+            ),
+        )
+        restored = await self.get_preview_handle_record(preview_handle)
+        if restored and restored.get("is_active"):
+            return restored
+        return None
 
     async def create_promotion_request(
         self,

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -6,11 +6,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from loguru import logger
+
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
 
 _VALID_CREATION_SOURCES = {"prompt", "template", "existing_workspace"}
 _VALID_ACTOR_TYPES = {"owner", "internal_collaborator", "external_collaborator"}
 _VALID_PROMOTION_STATUSES = {"pending", "approved", "rejected", "promoted", "stale"}
+_ROW_CONVERSION_EXCEPTIONS = (AttributeError, KeyError, TypeError, ValueError)
 
 
 def _to_bool(value: Any) -> bool:
@@ -100,11 +103,13 @@ class PrototypeWorkspacesRepo:
             try:
                 keys = row.keys()
                 return {key: row[key] for key in keys}
-            except Exception:
+            except _ROW_CONVERSION_EXCEPTIONS as exc:
+                logger.debug("Failed to convert prototype workspace row by keys: {}", exc)
                 return {}
         try:
             return dict(row)
-        except Exception:
+        except _ROW_CONVERSION_EXCEPTIONS as exc:
+            logger.debug("Failed to convert prototype workspace row with dict(): {}", exc)
             return {}
 
     @staticmethod

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -307,6 +307,7 @@ class PrototypeWorkspacesRepo:
         prototype_workspace_id: str,
         share_link_id: int,
         display_name: str,
+        session_binding_id: str | None = None,
         runtime_policy_profile: str,
         quota_policy: dict[str, Any] | None = None,
         expires_at: str | None = None,
@@ -317,15 +318,16 @@ class PrototypeWorkspacesRepo:
             """
             INSERT INTO prototype_shared_actors (
                 id, prototype_workspace_id, share_link_id, display_name,
-                runtime_policy_profile, quota_policy_json, last_activity_at,
-                expires_at, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                session_binding_id, runtime_policy_profile, quota_policy_json,
+                last_activity_at, expires_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 actor_id,
                 prototype_workspace_id,
                 int(share_link_id),
                 display_name,
+                session_binding_id,
                 runtime_policy_profile,
                 json.dumps(quota_policy or {}),
                 ts,
@@ -336,6 +338,35 @@ class PrototypeWorkspacesRepo:
         )
         created = await self.get_shared_actor(actor_id)
         return created or {}
+
+    async def touch_shared_actor(self, shared_actor_id: str) -> dict[str, Any] | None:
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_shared_actors
+            SET last_activity_at = ?, updated_at = ?
+            WHERE id = ? AND revoked_at IS NULL
+            """,
+            (ts, ts, shared_actor_id),
+        )
+        return await self.get_shared_actor(shared_actor_id)
+
+    async def rotate_shared_actor_binding(
+        self,
+        shared_actor_id: str,
+        *,
+        new_session_binding_id: str,
+    ) -> dict[str, Any] | None:
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_shared_actors
+            SET session_binding_id = ?, last_activity_at = ?, updated_at = ?
+            WHERE id = ? AND revoked_at IS NULL
+            """,
+            (new_session_binding_id, ts, ts, shared_actor_id),
+        )
+        return await self.get_shared_actor(shared_actor_id)
 
     async def get_shared_actor(self, shared_actor_id: str) -> dict[str, Any] | None:
         row = await self.db_pool.fetchone(

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+
+_VALID_CREATION_SOURCES = {"prompt", "template", "existing_workspace"}
+_VALID_ACTOR_TYPES = {"owner", "internal_collaborator", "external_collaborator"}
+_VALID_PROMOTION_STATUSES = {"pending", "approved", "rejected", "promoted", "stale"}
+
+
+def _to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    return text in {"1", "true", "t", "yes", "y"}
+
+
+def _load_json_dict(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return dict(raw)
+    if not raw:
+        return {}
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return {}
+        return dict(parsed) if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _load_json_list(raw: Any) -> list[Any]:
+    if isinstance(raw, list):
+        return list(raw)
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return []
+        return list(parsed) if isinstance(parsed, list) else []
+    return []
+
+
+def _normalize_creation_source(creation_source: str | None) -> str:
+    value = (creation_source or "").strip().lower()
+    if value not in _VALID_CREATION_SOURCES:
+        raise ValueError(f"Invalid creation_source: {creation_source}")
+    return value
+
+
+def _normalize_actor_type(actor_type: str | None) -> str:
+    value = (actor_type or "").strip().lower()
+    if value not in _VALID_ACTOR_TYPES:
+        raise ValueError(f"Invalid actor_type: {actor_type}")
+    return value
+
+
+def _is_blank(value: str | None) -> bool:
+    return value is None or not str(value).strip()
+
+
+def _normalize_promotion_status(status: str | None) -> str:
+    value = (status or "").strip().lower()
+    if value not in _VALID_PROMOTION_STATUSES:
+        raise ValueError(f"Invalid status: {status}")
+    return value
+
+
+@dataclass
+class PrototypeWorkspacesRepo:
+    """Data access for prototype workspace metadata in the AuthNZ DB."""
+
+    db_pool: DatabasePool
+
+    def _ts(self) -> datetime | str:
+        now = datetime.now(timezone.utc)
+        return now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        if row is None:
+            return {}
+        if isinstance(row, dict):
+            return dict(row)
+        if hasattr(row, "keys"):
+            try:
+                keys = row.keys()
+                return {key: row[key] for key in keys}
+            except Exception:
+                return {}
+        try:
+            return dict(row)
+        except Exception:
+            return {}
+
+    @staticmethod
+    def _new_id(prefix: str) -> str:
+        return f"{prefix}_{uuid.uuid4().hex}"
+
+    @staticmethod
+    def _normalize_workspace_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        if out.get("owner_user_id") is not None:
+            out["owner_user_id"] = int(out["owner_user_id"])
+        out["preview_policy"] = _load_json_dict(out.get("preview_policy_json"))
+        out["share_policy"] = _load_json_dict(out.get("share_policy_json"))
+        out["runtime_policy"] = _load_json_dict(out.get("runtime_policy_json"))
+        out["designated_promoter_ids"] = _load_json_list(out.get("designated_promoter_ids_json"))
+        out["is_archived"] = out.get("archived_at") is not None
+        return out
+
+    @staticmethod
+    def _normalize_snapshot_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        if out.get("author_user_id") is not None:
+            out["author_user_id"] = int(out["author_user_id"])
+        out["snapshot_id"] = out.get("id")
+        out["diff_summary"] = _load_json_dict(out.get("diff_summary_json"))
+        out["preview_health"] = _load_json_dict(out.get("preview_health_json"))
+        return out
+
+    @staticmethod
+    def _normalize_shared_actor_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        if out.get("share_link_id") is not None:
+            out["share_link_id"] = int(out["share_link_id"])
+        out["quota_policy"] = _load_json_dict(out.get("quota_policy_json"))
+        out["is_revoked"] = out.get("revoked_at") is not None
+        return out
+
+    @staticmethod
+    def _normalize_session_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        if out.get("actor_user_id") is not None:
+            out["actor_user_id"] = int(out["actor_user_id"])
+        if out.get("share_link_id") is not None:
+            out["share_link_id"] = int(out["share_link_id"])
+        out["is_revoked"] = out.get("revoked_at") is not None
+        return out
+
+    @staticmethod
+    def _normalize_promotion_request_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        if out.get("requested_by_user_id") is not None:
+            out["requested_by_user_id"] = int(out["requested_by_user_id"])
+        if out.get("reviewed_by_user_id") is not None:
+            out["reviewed_by_user_id"] = int(out["reviewed_by_user_id"])
+        return out
+
+    async def ensure_tables(self) -> None:
+        required = {
+            "prototype_workspaces",
+            "prototype_snapshots",
+            "prototype_sessions",
+            "prototype_shared_actors",
+            "prototype_promotion_requests",
+        }
+        rows = await self.db_pool.fetchall(
+            "SELECT name FROM sqlite_master WHERE type='table'",
+            (),
+        )
+        existing = {
+            str(name)
+            for row in rows
+            if (name := self._row_to_dict(row).get("name")) and str(name) in required
+        }
+        missing = required - existing
+        if missing:
+            raise RuntimeError(
+                "Prototype workspace tables are missing. Run AuthNZ migrations. "
+                f"Missing: {sorted(missing)}"
+            )
+
+    async def create_workspace(
+        self,
+        *,
+        owner_user_id: int,
+        title: str,
+        creation_source: str,
+        description: str | None = None,
+        preview_policy: dict[str, Any] | None = None,
+        share_policy: dict[str, Any] | None = None,
+        runtime_policy: dict[str, Any] | None = None,
+        designated_promoter_ids: list[int] | None = None,
+    ) -> dict[str, Any]:
+        creation_source_value = _normalize_creation_source(creation_source)
+        workspace_id = self._new_id("pws")
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            INSERT INTO prototype_workspaces (
+                id, owner_user_id, title, description, creation_source,
+                preview_policy_json, share_policy_json, runtime_policy_json,
+                designated_promoter_ids_json, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                workspace_id,
+                int(owner_user_id),
+                title,
+                description,
+                creation_source_value,
+                json.dumps(preview_policy or {}),
+                json.dumps(share_policy or {}),
+                json.dumps(runtime_policy or {}),
+                json.dumps(designated_promoter_ids or []),
+                ts,
+                ts,
+            ),
+        )
+        created = await self.get_workspace(workspace_id)
+        return created or {}
+
+    async def get_workspace(self, prototype_workspace_id: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, owner_user_id, title, description, creation_source,
+                   canonical_snapshot_id, last_known_good_snapshot_id,
+                   canonical_preview_status, publish_validation_status,
+                   preview_policy_json, share_policy_json, runtime_policy_json,
+                   designated_promoter_ids_json, created_at, updated_at, archived_at
+            FROM prototype_workspaces
+            WHERE id = ?
+            """,
+            (prototype_workspace_id,),
+        )
+        return self._normalize_workspace_row(self._row_to_dict(row) if row else None)
+
+    async def create_snapshot(
+        self,
+        *,
+        prototype_workspace_id: str,
+        snapshot_id: str,
+        created_by_user_id: int | None = None,
+        created_by_shared_actor_id: str | None = None,
+        parent_snapshot_id: str | None = None,
+        created_from_session_id: str | None = None,
+        storage_ref: str | None = None,
+        diff_summary: dict[str, Any] | None = None,
+        prompt_summary: str | None = None,
+        preview_health: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if (created_by_user_id is None) == (created_by_shared_actor_id is None):
+            raise ValueError("exactly one actor identity must be set")
+
+        await self.db_pool.execute(
+            """
+            INSERT INTO prototype_snapshots (
+                id, prototype_workspace_id, parent_snapshot_id, created_from_session_id,
+                author_user_id, author_shared_actor_id, storage_ref, diff_summary_json,
+                prompt_summary, preview_health_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                snapshot_id,
+                prototype_workspace_id,
+                parent_snapshot_id,
+                created_from_session_id,
+                int(created_by_user_id) if created_by_user_id is not None else None,
+                created_by_shared_actor_id,
+                storage_ref,
+                json.dumps(diff_summary or {}),
+                prompt_summary,
+                json.dumps(preview_health or {}),
+            ),
+        )
+        created = await self.get_snapshot(snapshot_id)
+        return created or {}
+
+    async def get_snapshot(self, snapshot_id: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, prototype_workspace_id, parent_snapshot_id, created_from_session_id,
+                   author_user_id, author_shared_actor_id, storage_ref, diff_summary_json,
+                   prompt_summary, preview_health_json, created_at
+            FROM prototype_snapshots
+            WHERE id = ?
+            """,
+            (snapshot_id,),
+        )
+        return self._normalize_snapshot_row(self._row_to_dict(row) if row else None)
+
+    async def create_shared_actor(
+        self,
+        *,
+        prototype_workspace_id: str,
+        share_link_id: int,
+        display_name: str,
+        runtime_policy_profile: str,
+        quota_policy: dict[str, Any] | None = None,
+        expires_at: str | None = None,
+    ) -> dict[str, Any]:
+        actor_id = self._new_id("psa")
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            INSERT INTO prototype_shared_actors (
+                id, prototype_workspace_id, share_link_id, display_name,
+                runtime_policy_profile, quota_policy_json, last_activity_at,
+                expires_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                actor_id,
+                prototype_workspace_id,
+                int(share_link_id),
+                display_name,
+                runtime_policy_profile,
+                json.dumps(quota_policy or {}),
+                ts,
+                expires_at,
+                ts,
+                ts,
+            ),
+        )
+        created = await self.get_shared_actor(actor_id)
+        return created or {}
+
+    async def get_shared_actor(self, shared_actor_id: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, prototype_workspace_id, share_link_id, display_name,
+                   session_binding_id, runtime_policy_profile, quota_policy_json,
+                   last_activity_at, expires_at, revoked_at, created_at, updated_at
+            FROM prototype_shared_actors
+            WHERE id = ?
+            """,
+            (shared_actor_id,),
+        )
+        return self._normalize_shared_actor_row(self._row_to_dict(row) if row else None)
+
+    async def create_session(
+        self,
+        *,
+        prototype_workspace_id: str,
+        base_snapshot_id: str,
+        actor_type: str,
+        actor_user_id: int | None = None,
+        actor_shared_actor_id: str | None = None,
+        share_link_id: int | None = None,
+        expires_at: str | None = None,
+    ) -> dict[str, Any]:
+        actor_type_value = _normalize_actor_type(actor_type)
+        if _is_blank(base_snapshot_id):
+            raise ValueError("base_snapshot_id is required")
+
+        workspace = await self.get_workspace(prototype_workspace_id)
+        if workspace is None:
+            raise ValueError("prototype_workspace_id does not exist")
+
+        if actor_type_value == "external_collaborator":
+            if actor_shared_actor_id is None or actor_user_id is not None:
+                raise ValueError(
+                    "external_collaborator requires actor_shared_actor_id and forbids actor_user_id"
+                )
+        else:
+            if actor_user_id is None or actor_shared_actor_id is not None:
+                raise ValueError(
+                    "owner/internal_collaborator requires actor_user_id and forbids actor_shared_actor_id"
+                )
+            user_row = await self.db_pool.fetchone(
+                "SELECT id FROM users WHERE id = ?",
+                (int(actor_user_id),),
+            )
+            if not user_row:
+                raise ValueError("actor_user_id must reference an existing user")
+
+        snapshot_row = await self.db_pool.fetchone(
+            """
+            SELECT id
+            FROM prototype_snapshots
+            WHERE id = ? AND prototype_workspace_id = ?
+            """,
+            (base_snapshot_id, prototype_workspace_id),
+        )
+        if not snapshot_row:
+            raise ValueError("base_snapshot_id must reference a snapshot in the same workspace")
+
+        if actor_shared_actor_id is not None:
+            shared_actor_row = await self.db_pool.fetchone(
+                """
+                SELECT id
+                FROM prototype_shared_actors
+                WHERE id = ? AND prototype_workspace_id = ? AND revoked_at IS NULL
+                """,
+                (actor_shared_actor_id, prototype_workspace_id),
+            )
+            if not shared_actor_row:
+                raise ValueError(
+                    "actor_shared_actor_id must reference an active shared actor in the same workspace"
+                )
+
+        if actor_type_value == "owner" and int(actor_user_id) != int(workspace["owner_user_id"]):
+            raise ValueError("owner actor must match workspace owner")
+
+        session_id = self._new_id("pss")
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            INSERT INTO prototype_sessions (
+                id, prototype_workspace_id, base_snapshot_id, actor_user_id,
+                actor_shared_actor_id, actor_type, share_link_id, runtime_status,
+                preview_status, last_activity_at, expires_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                prototype_workspace_id,
+                base_snapshot_id,
+                int(actor_user_id) if actor_user_id is not None else None,
+                actor_shared_actor_id,
+                actor_type_value,
+                int(share_link_id) if share_link_id is not None else None,
+                "pending",
+                "uninitialized",
+                ts,
+                expires_at,
+                ts,
+                ts,
+            ),
+        )
+        created = await self.get_session(session_id)
+        return created or {}
+
+    async def get_session(self, prototype_session_id: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, prototype_workspace_id, base_snapshot_id, actor_user_id,
+                   actor_shared_actor_id, actor_type, share_link_id, acp_session_id,
+                   sandbox_session_id, sandbox_run_id, runtime_status, preview_handle,
+                   preview_status, last_saved_snapshot_id, last_activity_at, expires_at,
+                   revoked_at, created_at, updated_at
+            FROM prototype_sessions
+            WHERE id = ?
+            """,
+            (prototype_session_id,),
+        )
+        return self._normalize_session_row(self._row_to_dict(row) if row else None)
+
+    async def create_promotion_request(
+        self,
+        *,
+        prototype_workspace_id: str,
+        prototype_session_id: str,
+        candidate_snapshot_id: str,
+        requested_by_user_id: int | None = None,
+        requested_by_shared_actor_id: str | None = None,
+        status: str = "pending",
+    ) -> dict[str, Any]:
+        if (requested_by_user_id is None) == (requested_by_shared_actor_id is None):
+            raise ValueError("exactly one actor identity must be set")
+
+        workspace = await self.get_workspace(prototype_workspace_id)
+        if workspace is None:
+            raise ValueError("prototype_workspace_id does not exist")
+
+        session_row = await self.db_pool.fetchone(
+            """
+            SELECT id
+            FROM prototype_sessions
+            WHERE id = ? AND prototype_workspace_id = ?
+            """,
+            (prototype_session_id, prototype_workspace_id),
+        )
+        if not session_row:
+            raise ValueError("prototype_session_id must reference a session in the same workspace")
+
+        snapshot_row = await self.db_pool.fetchone(
+            """
+            SELECT id
+            FROM prototype_snapshots
+            WHERE id = ? AND prototype_workspace_id = ?
+            """,
+            (candidate_snapshot_id, prototype_workspace_id),
+        )
+        if not snapshot_row:
+            raise ValueError("candidate_snapshot_id must reference a snapshot in the same workspace")
+
+        if requested_by_shared_actor_id is not None:
+            shared_actor_row = await self.db_pool.fetchone(
+                """
+                SELECT id
+                FROM prototype_shared_actors
+                WHERE id = ? AND prototype_workspace_id = ? AND revoked_at IS NULL
+                """,
+                (requested_by_shared_actor_id, prototype_workspace_id),
+            )
+            if not shared_actor_row:
+                raise ValueError(
+                    "requested_by_shared_actor_id must reference an active shared actor in the same workspace"
+                )
+
+        request_id = self._new_id("ppr")
+        status_value = _normalize_promotion_status(status)
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            INSERT INTO prototype_promotion_requests (
+                id, prototype_workspace_id, prototype_session_id, candidate_snapshot_id,
+                requested_by_user_id, requested_by_shared_actor_id, status, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                request_id,
+                prototype_workspace_id,
+                prototype_session_id,
+                candidate_snapshot_id,
+                int(requested_by_user_id) if requested_by_user_id is not None else None,
+                requested_by_shared_actor_id,
+                status_value,
+                ts,
+                ts,
+            ),
+        )
+        created = await self.get_promotion_request(request_id)
+        return created or {}
+
+    async def get_promotion_request(self, promotion_request_id: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, prototype_workspace_id, prototype_session_id, candidate_snapshot_id,
+                   requested_by_user_id, requested_by_shared_actor_id, status,
+                   reviewed_by_user_id, review_notes, created_at, updated_at
+            FROM prototype_promotion_requests
+            WHERE id = ?
+            """,
+            (promotion_request_id,),
+        )
+        return self._normalize_promotion_request_row(self._row_to_dict(row) if row else None)

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -295,6 +295,27 @@ class PrototypeWorkspacesRepo:
         )
         return await self.get_workspace(prototype_workspace_id)
 
+    async def archive_workspace(
+        self,
+        prototype_workspace_id: str,
+        *,
+        archived_at: str | datetime | None = None,
+    ) -> dict[str, Any] | None:
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_workspaces
+            SET archived_at = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                archived_at if archived_at is not None else ts,
+                ts,
+                prototype_workspace_id,
+            ),
+        )
+        return await self.get_workspace(prototype_workspace_id)
+
     async def create_snapshot(
         self,
         *,
@@ -335,6 +356,15 @@ class PrototypeWorkspacesRepo:
         )
         created = await self.get_snapshot(snapshot_id)
         return created or {}
+
+    async def delete_snapshot(self, snapshot_id: str) -> None:
+        await self.db_pool.execute(
+            """
+            DELETE FROM prototype_snapshots
+            WHERE id = ?
+            """,
+            (snapshot_id,),
+        )
 
     async def get_snapshot(self, snapshot_id: str) -> dict[str, Any] | None:
         row = await self.db_pool.fetchone(

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -77,27 +77,18 @@ def _normalize_promotion_status(status: str | None) -> str:
     return value
 
 
-def _normalize_datetime(value: Any) -> datetime | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
-    try:
-        parsed = datetime.fromisoformat(str(value))
-    except (TypeError, ValueError):
-        return None
-    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
-
-
 @dataclass
 class PrototypeWorkspacesRepo:
     """Data access for prototype workspace metadata in the AuthNZ DB."""
 
     db_pool: DatabasePool
 
+    def _is_postgres_backend(self) -> bool:
+        return bool(getattr(self.db_pool, "pool", None))
+
     def _ts(self) -> datetime | str:
         now = datetime.now(timezone.utc)
-        return now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        return now if self._is_postgres_backend() else now.isoformat()
 
     @staticmethod
     def _row_to_dict(row: Any) -> dict[str, Any]:
@@ -188,8 +179,17 @@ class PrototypeWorkspacesRepo:
             "prototype_shared_actors",
             "prototype_promotion_requests",
         }
+        if self._is_postgres_backend():
+            table_query = """
+            SELECT table_name AS name
+            FROM information_schema.tables
+            WHERE table_schema = current_schema()
+              AND table_type = 'BASE TABLE'
+            """
+        else:
+            table_query = "SELECT name FROM sqlite_master WHERE type='table'"
         rows = await self.db_pool.fetchall(
-            "SELECT name FROM sqlite_master WHERE type='table'",
+            table_query,
             (),
         )
         existing = {
@@ -268,32 +268,22 @@ class PrototypeWorkspacesRepo:
         canonical_preview_status: str | None = None,
         publish_validation_status: str | None = None,
     ) -> dict[str, Any] | None:
-        existing = await self.get_workspace(prototype_workspace_id)
-        if not existing:
-            return None
-
         ts = self._ts()
         await self.db_pool.execute(
             """
             UPDATE prototype_workspaces
-            SET canonical_snapshot_id = ?,
-                last_known_good_snapshot_id = ?,
-                canonical_preview_status = ?,
-                publish_validation_status = ?,
+            SET canonical_snapshot_id = COALESCE(?, canonical_snapshot_id),
+                last_known_good_snapshot_id = COALESCE(?, last_known_good_snapshot_id),
+                canonical_preview_status = COALESCE(?, canonical_preview_status),
+                publish_validation_status = COALESCE(?, publish_validation_status),
                 updated_at = ?
             WHERE id = ?
             """,
             (
-                canonical_snapshot_id if canonical_snapshot_id is not None else existing.get("canonical_snapshot_id"),
-                last_known_good_snapshot_id
-                if last_known_good_snapshot_id is not None
-                else existing.get("last_known_good_snapshot_id"),
-                canonical_preview_status
-                if canonical_preview_status is not None
-                else existing.get("canonical_preview_status"),
-                publish_validation_status
-                if publish_validation_status is not None
-                else existing.get("publish_validation_status"),
+                canonical_snapshot_id,
+                last_known_good_snapshot_id,
+                canonical_preview_status,
+                publish_validation_status,
                 ts,
                 prototype_workspace_id,
             ),
@@ -602,27 +592,38 @@ class PrototypeWorkspacesRepo:
         actor_shared_actor_id: str | None = None,
     ) -> dict[str, Any] | None:
         actor_type_value = _normalize_actor_type(actor_type)
-        rows = await self.list_sessions_for_workspace(
-            prototype_workspace_id,
-            include_revoked=False,
+        actor_user_param = int(actor_user_id) if actor_user_id is not None else None
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, prototype_workspace_id, base_snapshot_id, actor_user_id,
+                   actor_shared_actor_id, actor_type, share_link_id, acp_session_id,
+                   sandbox_session_id, sandbox_run_id, runtime_status, preview_handle,
+                   preview_status, last_saved_snapshot_id, last_activity_at, expires_at,
+                   revoked_at, created_at, updated_at
+            FROM prototype_sessions
+            WHERE prototype_workspace_id = ?
+              AND base_snapshot_id = ?
+              AND actor_type = ?
+              AND (? IS NULL OR actor_user_id = ?)
+              AND (? IS NULL OR actor_shared_actor_id = ?)
+              AND revoked_at IS NULL
+              AND (runtime_status IS NULL OR LOWER(runtime_status) NOT IN ('failed', 'revoked', 'closed'))
+              AND (expires_at IS NULL OR expires_at > ?)
+            ORDER BY updated_at DESC, created_at DESC
+            LIMIT 1
+            """,
+            (
+                prototype_workspace_id,
+                base_snapshot_id,
+                actor_type_value,
+                actor_user_param,
+                actor_user_param,
+                actor_shared_actor_id,
+                actor_shared_actor_id,
+                self._ts(),
+            ),
         )
-        for session in rows:
-            if session.get("base_snapshot_id") != base_snapshot_id:
-                continue
-            if session.get("actor_type") != actor_type_value:
-                continue
-            if actor_user_id is not None and session.get("actor_user_id") != int(actor_user_id):
-                continue
-            if actor_shared_actor_id is not None and session.get("actor_shared_actor_id") != actor_shared_actor_id:
-                continue
-            runtime_status = str(session.get("runtime_status") or "").strip().lower()
-            if runtime_status in {"failed", "revoked", "closed"}:
-                continue
-            expires_at = _normalize_datetime(session.get("expires_at"))
-            if expires_at is not None and expires_at <= datetime.now(timezone.utc):
-                continue
-            return session
-        return None
+        return self._normalize_session_row(self._row_to_dict(row) if row else None)
 
     async def update_session_state(
         self,

--- a/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/prototype_workspaces_repo.py
@@ -77,6 +77,18 @@ def _normalize_promotion_status(status: str | None) -> str:
     return value
 
 
+def _normalize_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
 @dataclass
 class PrototypeWorkspacesRepo:
     """Data access for prototype workspace metadata in the AuthNZ DB."""
@@ -247,6 +259,47 @@ class PrototypeWorkspacesRepo:
         )
         return self._normalize_workspace_row(self._row_to_dict(row) if row else None)
 
+    async def update_workspace_state(
+        self,
+        prototype_workspace_id: str,
+        *,
+        canonical_snapshot_id: str | None = None,
+        last_known_good_snapshot_id: str | None = None,
+        canonical_preview_status: str | None = None,
+        publish_validation_status: str | None = None,
+    ) -> dict[str, Any] | None:
+        existing = await self.get_workspace(prototype_workspace_id)
+        if not existing:
+            return None
+
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_workspaces
+            SET canonical_snapshot_id = ?,
+                last_known_good_snapshot_id = ?,
+                canonical_preview_status = ?,
+                publish_validation_status = ?,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                canonical_snapshot_id if canonical_snapshot_id is not None else existing.get("canonical_snapshot_id"),
+                last_known_good_snapshot_id
+                if last_known_good_snapshot_id is not None
+                else existing.get("last_known_good_snapshot_id"),
+                canonical_preview_status
+                if canonical_preview_status is not None
+                else existing.get("canonical_preview_status"),
+                publish_validation_status
+                if publish_validation_status is not None
+                else existing.get("publish_validation_status"),
+                ts,
+                prototype_workspace_id,
+            ),
+        )
+        return await self.get_workspace(prototype_workspace_id)
+
     async def create_snapshot(
         self,
         *,
@@ -300,6 +353,20 @@ class PrototypeWorkspacesRepo:
             (snapshot_id,),
         )
         return self._normalize_snapshot_row(self._row_to_dict(row) if row else None)
+
+    async def list_snapshots_for_workspace(self, prototype_workspace_id: str) -> list[dict[str, Any]]:
+        rows = await self.db_pool.fetchall(
+            """
+            SELECT id, prototype_workspace_id, parent_snapshot_id, created_from_session_id,
+                   author_user_id, author_shared_actor_id, storage_ref, diff_summary_json,
+                   prompt_summary, preview_health_json, created_at
+            FROM prototype_snapshots
+            WHERE prototype_workspace_id = ?
+            ORDER BY created_at DESC
+            """,
+            (prototype_workspace_id,),
+        )
+        return [self._normalize_snapshot_row(self._row_to_dict(r)) or {} for r in rows]
 
     async def create_shared_actor(
         self,
@@ -489,6 +556,126 @@ class PrototypeWorkspacesRepo:
         )
         return self._normalize_session_row(self._row_to_dict(row) if row else None)
 
+    async def list_sessions_for_workspace(
+        self,
+        prototype_workspace_id: str,
+        *,
+        include_revoked: bool = False,
+    ) -> list[dict[str, Any]]:
+        if include_revoked:
+            rows = await self.db_pool.fetchall(
+                """
+                SELECT id, prototype_workspace_id, base_snapshot_id, actor_user_id,
+                       actor_shared_actor_id, actor_type, share_link_id, acp_session_id,
+                       sandbox_session_id, sandbox_run_id, runtime_status, preview_handle,
+                       preview_status, last_saved_snapshot_id, last_activity_at, expires_at,
+                       revoked_at, created_at, updated_at
+                FROM prototype_sessions
+                WHERE prototype_workspace_id = ?
+                ORDER BY updated_at DESC, created_at DESC
+                """,
+                (prototype_workspace_id,),
+            )
+        else:
+            rows = await self.db_pool.fetchall(
+                """
+                SELECT id, prototype_workspace_id, base_snapshot_id, actor_user_id,
+                       actor_shared_actor_id, actor_type, share_link_id, acp_session_id,
+                       sandbox_session_id, sandbox_run_id, runtime_status, preview_handle,
+                       preview_status, last_saved_snapshot_id, last_activity_at, expires_at,
+                       revoked_at, created_at, updated_at
+                FROM prototype_sessions
+                WHERE prototype_workspace_id = ? AND revoked_at IS NULL
+                ORDER BY updated_at DESC, created_at DESC
+                """,
+                (prototype_workspace_id,),
+            )
+        return [self._normalize_session_row(self._row_to_dict(r)) or {} for r in rows]
+
+    async def find_active_session(
+        self,
+        *,
+        prototype_workspace_id: str,
+        base_snapshot_id: str,
+        actor_type: str,
+        actor_user_id: int | None = None,
+        actor_shared_actor_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        actor_type_value = _normalize_actor_type(actor_type)
+        rows = await self.list_sessions_for_workspace(
+            prototype_workspace_id,
+            include_revoked=False,
+        )
+        for session in rows:
+            if session.get("base_snapshot_id") != base_snapshot_id:
+                continue
+            if session.get("actor_type") != actor_type_value:
+                continue
+            if actor_user_id is not None and session.get("actor_user_id") != int(actor_user_id):
+                continue
+            if actor_shared_actor_id is not None and session.get("actor_shared_actor_id") != actor_shared_actor_id:
+                continue
+            runtime_status = str(session.get("runtime_status") or "").strip().lower()
+            if runtime_status in {"failed", "revoked", "closed"}:
+                continue
+            expires_at = _normalize_datetime(session.get("expires_at"))
+            if expires_at is not None and expires_at <= datetime.now(timezone.utc):
+                continue
+            return session
+        return None
+
+    async def update_session_state(
+        self,
+        prototype_session_id: str,
+        *,
+        acp_session_id: str | None = None,
+        sandbox_session_id: str | None = None,
+        sandbox_run_id: str | None = None,
+        runtime_status: str | None = None,
+        preview_handle: str | None = None,
+        preview_status: str | None = None,
+        last_saved_snapshot_id: str | None = None,
+        last_activity_at: str | datetime | None = None,
+        revoked_at: str | datetime | None = None,
+    ) -> dict[str, Any] | None:
+        existing = await self.get_session(prototype_session_id)
+        if not existing:
+            return None
+
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_sessions
+            SET acp_session_id = ?,
+                sandbox_session_id = ?,
+                sandbox_run_id = ?,
+                runtime_status = ?,
+                preview_handle = ?,
+                preview_status = ?,
+                last_saved_snapshot_id = ?,
+                last_activity_at = ?,
+                revoked_at = ?,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                acp_session_id if acp_session_id is not None else existing.get("acp_session_id"),
+                sandbox_session_id if sandbox_session_id is not None else existing.get("sandbox_session_id"),
+                sandbox_run_id if sandbox_run_id is not None else existing.get("sandbox_run_id"),
+                runtime_status if runtime_status is not None else existing.get("runtime_status"),
+                preview_handle if preview_handle is not None else existing.get("preview_handle"),
+                preview_status if preview_status is not None else existing.get("preview_status"),
+                last_saved_snapshot_id
+                if last_saved_snapshot_id is not None
+                else existing.get("last_saved_snapshot_id"),
+                last_activity_at if last_activity_at is not None else ts,
+                revoked_at if revoked_at is not None else existing.get("revoked_at"),
+                ts,
+                prototype_session_id,
+            ),
+        )
+        return await self.get_session(prototype_session_id)
+
     async def create_promotion_request(
         self,
         *,
@@ -579,3 +766,40 @@ class PrototypeWorkspacesRepo:
             (promotion_request_id,),
         )
         return self._normalize_promotion_request_row(self._row_to_dict(row) if row else None)
+
+    async def update_promotion_request(
+        self,
+        promotion_request_id: str,
+        *,
+        status: str | None = None,
+        reviewed_by_user_id: int | None = None,
+        review_notes: str | None = None,
+    ) -> dict[str, Any] | None:
+        existing = await self.get_promotion_request(promotion_request_id)
+        if not existing:
+            return None
+
+        status_value = (
+            _normalize_promotion_status(status)
+            if status is not None
+            else str(existing.get("status") or "pending")
+        )
+        ts = self._ts()
+        await self.db_pool.execute(
+            """
+            UPDATE prototype_promotion_requests
+            SET status = ?,
+                reviewed_by_user_id = ?,
+                review_notes = ?,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                status_value,
+                int(reviewed_by_user_id) if reviewed_by_user_id is not None else existing.get("reviewed_by_user_id"),
+                review_notes if review_notes is not None else existing.get("review_notes"),
+                ts,
+                promotion_request_id,
+            ),
+        )
+        return await self.get_promotion_request(promotion_request_id)

--- a/tldw_Server_API/app/core/AuthNZ/repos/shared_workspace_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/shared_workspace_repo.py
@@ -60,14 +60,17 @@ class SharedWorkspaceRepo:
 
     db_pool: DatabasePool
 
+    def _is_postgres_backend(self) -> bool:
+        return bool(getattr(self.db_pool, "pool", None))
+
     def _ts(self) -> datetime | str:
         """Return a timestamp suitable for the current backend (native datetime for PG, ISO string for SQLite)."""
         now = datetime.now(timezone.utc)
-        return now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        return now if self._is_postgres_backend() else now.isoformat()
 
     def _bool(self, val: bool) -> bool | int:
         """Return a boolean suitable for the current backend (native bool for PG, int for SQLite)."""
-        return val if getattr(self.db_pool, "pool", None) is not None else int(val)
+        return val if self._is_postgres_backend() else int(val)
 
     async def ensure_tables(self) -> None:
         required = {"shared_workspaces", "share_tokens", "share_audit_log", "sharing_config"}
@@ -98,9 +101,9 @@ class SharedWorkspaceRepo:
         except Exception:
             try:
                 keys = row.keys()
-                return {key: row[key] for key in keys}
             except Exception:
                 return {}
+            return {key: row[key] for key in keys}
 
     @staticmethod
     def _normalize_share_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -365,6 +368,63 @@ class SharedWorkspaceRepo:
     async def increment_token_use_count(self, token_id: int) -> None:
         await self.db_pool.execute(
             "UPDATE share_tokens SET use_count = use_count + 1 WHERE id = ?",
+            (token_id,),
+        )
+
+    async def claim_token_use(self, token_id: int) -> bool:
+        if not hasattr(self.db_pool, "transaction"):
+            await self.db_pool.execute(
+                """
+                UPDATE share_tokens
+                SET use_count = use_count + 1
+                WHERE id = ?
+                  AND revoked_at IS NULL
+                  AND (max_uses IS NULL OR use_count < max_uses)
+                """,
+                (token_id,),
+            )
+            row = await self.db_pool.fetchone("SELECT changes() AS change_count", ())
+            return int(self._row_to_dict(row).get("change_count", 0)) > 0 if row else False
+
+        async with self.db_pool.transaction() as conn:
+            if self._is_postgres_backend():
+                row = await conn.fetchrow(
+                    """
+                    UPDATE share_tokens
+                    SET use_count = use_count + 1
+                    WHERE id = $1
+                      AND revoked_at IS NULL
+                      AND (max_uses IS NULL OR use_count < max_uses)
+                    RETURNING id
+                    """,
+                    token_id,
+                )
+                return row is not None
+
+            await conn.execute(
+                """
+                UPDATE share_tokens
+                SET use_count = use_count + 1
+                WHERE id = ?
+                  AND revoked_at IS NULL
+                  AND (max_uses IS NULL OR use_count < max_uses)
+                """,
+                (token_id,),
+            )
+            cursor = await conn.execute("SELECT changes() AS change_count")
+            row = await cursor.fetchone()
+            return int(self._row_to_dict(row).get("change_count", 0)) > 0 if row else False
+
+    async def release_token_use(self, token_id: int) -> None:
+        await self.db_pool.execute(
+            """
+            UPDATE share_tokens
+            SET use_count = CASE
+                WHEN use_count > 0 THEN use_count - 1
+                ELSE 0
+            END
+            WHERE id = ?
+            """,
             (token_id,),
         )
 

--- a/tldw_Server_API/app/core/Prototype_Workspaces/access.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/access.py
@@ -219,6 +219,53 @@ class PrototypeAccessService:
             return None
         return {"shared_actor_id": shared_actor_id, "binding_secret": binding_secret}
 
+    def decode_session_token(self, value: str | None) -> dict[str, Any] | None:
+        if not value:
+            return None
+        parts = str(value).split(".")
+        if len(parts) != 3 or parts[0] != "ptc":
+            return None
+        payload_b64, signature_b64 = parts[1], parts[2]
+        expected_sig = hmac.new(
+            self._signing_secret.encode("utf-8"),
+            payload_b64.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+        expected_sig_b64 = _b64url(expected_sig)
+        if not hmac.compare_digest(expected_sig_b64, signature_b64):
+            return None
+        try:
+            payload_raw = _b64url_decode(payload_b64)
+            payload = json.loads(payload_raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+
+        shared_actor_id = str(payload.get("sub") or "").strip()
+        prototype_workspace_id = str(payload.get("workspace_id") or "").strip()
+        actor_type = str(payload.get("actor_type") or "").strip()
+        runtime_policy_profile = str(payload.get("runtime_policy_profile") or "").strip()
+        try:
+            share_link_id = int(payload.get("share_link_id"))
+            exp = int(payload.get("exp"))
+            iat = int(payload.get("iat"))
+        except (TypeError, ValueError):
+            return None
+        if not shared_actor_id or not prototype_workspace_id:
+            return None
+        if actor_type != "external_collaborator":
+            return None
+        if exp <= int(time.time()):
+            return None
+        return {
+            "shared_actor_id": shared_actor_id,
+            "prototype_workspace_id": prototype_workspace_id,
+            "share_link_id": share_link_id,
+            "actor_type": actor_type,
+            "runtime_policy_profile": runtime_policy_profile,
+            "iat": iat,
+            "exp": exp,
+        }
+
     async def _resolve_resume_candidate(
         self,
         *,

--- a/tldw_Server_API/app/core/Prototype_Workspaces/access.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/access.py
@@ -20,7 +20,6 @@ from tldw_Server_API.app.core.AuthNZ.settings import get_settings
 PROTOTYPE_SHARED_ACTOR_COOKIE = "prototype_shared_actor"
 DEFAULT_EXTERNAL_RUNTIME_POLICY_PROFILE = "locked_collab"
 DEFAULT_EXTERNAL_DISPLAY_NAME = "External Collaborator"
-_FALLBACK_SIGNING_SECRET = secrets.token_urlsafe(32)
 
 
 class PrototypeAccessError(RuntimeError):
@@ -41,6 +40,25 @@ class PrototypeExternalAccessContext:
     is_resume: bool
 
 
+def _resolve_stable_signing_secret(signing_secret: str | None) -> str:
+    settings = get_settings()
+    candidates = (
+        signing_secret,
+        getattr(settings, "JWT_SECRET_KEY", None),
+        getattr(settings, "SINGLE_USER_API_KEY", None),
+        os.getenv("JWT_SECRET_KEY"),
+        os.getenv("SINGLE_USER_API_KEY"),
+    )
+    for candidate in candidates:
+        value = str(candidate or "").strip()
+        if value:
+            return value
+    raise RuntimeError(
+        "Prototype access tokens require a stable signing secret; set "
+        "JWT_SECRET_KEY or SINGLE_USER_API_KEY"
+    )
+
+
 class PrototypeAccessService:
     """Create or resume external prototype collaborators for private-link exchange."""
 
@@ -53,18 +71,7 @@ class PrototypeAccessService:
     ) -> None:
         self._repo = repo
         self._session_ttl_seconds = max(int(session_ttl_seconds), 60)
-        settings = get_settings()
-        configured_signing_secret = (
-            getattr(settings, "JWT_SECRET_KEY", None)
-            or getattr(settings, "SINGLE_USER_API_KEY", None)
-        )
-        self._signing_secret = (
-            signing_secret
-            or configured_signing_secret
-            or os.getenv("JWT_SECRET_KEY")
-            or os.getenv("SINGLE_USER_API_KEY")
-            or _FALLBACK_SIGNING_SECRET
-        )
+        self._signing_secret = _resolve_stable_signing_secret(signing_secret)
 
     async def exchange_external_collaborator(
         self,
@@ -377,9 +384,7 @@ def _is_active_resume_candidate(
     if actor.get("is_revoked") or actor.get("revoked_at"):
         return False
     expires_at = _parse_optional_ts(actor.get("expires_at"))
-    if expires_at is not None and expires_at <= datetime.now(timezone.utc):
-        return False
-    return True
+    return expires_at is None or expires_at > datetime.now(timezone.utc)
 
 
 def _b64url(raw: bytes) -> str:

--- a/tldw_Server_API/app/core/Prototype_Workspaces/access.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/access.py
@@ -1,0 +1,344 @@
+"""Prototype workspace access helpers for external private-link collaborators."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+    PrototypeWorkspacesRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+
+PROTOTYPE_SHARED_ACTOR_COOKIE = "prototype_shared_actor"
+DEFAULT_EXTERNAL_RUNTIME_POLICY_PROFILE = "locked_collab"
+DEFAULT_EXTERNAL_DISPLAY_NAME = "External Collaborator"
+_FALLBACK_SIGNING_SECRET = secrets.token_urlsafe(32)
+
+
+class PrototypeAccessError(RuntimeError):
+    """Raised when a prototype private-link exchange cannot be completed."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass
+class PrototypeExternalAccessContext:
+    shared_actor_id: str
+    actor_type: str
+    session_token: str
+    runtime_policy_profile: str
+    resume_cookie_value: str
+    is_resume: bool
+
+
+class PrototypeAccessService:
+    """Create or resume external prototype collaborators for private-link exchange."""
+
+    def __init__(
+        self,
+        repo: PrototypeWorkspacesRepo,
+        *,
+        session_ttl_seconds: int = 30 * 60,
+        signing_secret: str | None = None,
+    ) -> None:
+        self._repo = repo
+        self._session_ttl_seconds = max(int(session_ttl_seconds), 60)
+        settings = get_settings()
+        configured_signing_secret = (
+            getattr(settings, "JWT_SECRET_KEY", None)
+            or getattr(settings, "SINGLE_USER_API_KEY", None)
+        )
+        self._signing_secret = (
+            signing_secret
+            or configured_signing_secret
+            or os.getenv("JWT_SECRET_KEY")
+            or os.getenv("SINGLE_USER_API_KEY")
+            or _FALLBACK_SIGNING_SECRET
+        )
+
+    async def exchange_external_collaborator(
+        self,
+        *,
+        prototype_workspace_id: str,
+        share_link_id: int,
+        display_name: str | None,
+        resume_cookie_value: str | None,
+        allow_create: bool = True,
+        expires_at: str | None = None,
+    ) -> PrototypeExternalAccessContext:
+        workspace = await self._repo.get_workspace(prototype_workspace_id)
+        if not workspace:
+            raise PrototypeAccessError("workspace_not_found", "Prototype workspace not found")
+        if workspace.get("is_archived"):
+            raise PrototypeAccessError("workspace_archived", "Prototype workspace is archived")
+
+        runtime_policy = workspace.get("runtime_policy") or {}
+        share_policy = workspace.get("share_policy") or {}
+        runtime_policy_profile = str(
+            runtime_policy.get("external_collaborator_profile")
+            or runtime_policy.get("external_runtime_policy_profile")
+            or DEFAULT_EXTERNAL_RUNTIME_POLICY_PROFILE
+        )
+        quota_policy = runtime_policy.get("external_quota_policy")
+        if not isinstance(quota_policy, dict):
+            quota_policy = {}
+
+        allow_resume = _to_bool(share_policy.get("allow_browser_session_resume", True))
+
+        actor: dict[str, Any] | None = None
+        binding_secret: str | None = None
+        is_resume = False
+        candidate = await self._resolve_resume_candidate(
+            prototype_workspace_id=prototype_workspace_id,
+            share_link_id=share_link_id,
+            allow_resume=allow_resume,
+            resume_cookie_value=resume_cookie_value,
+        )
+        if candidate:
+            next_binding_secret = secrets.token_urlsafe(24)
+            rotated = await self._repo.rotate_shared_actor_binding(
+                candidate["id"],
+                new_session_binding_id=next_binding_secret,
+            )
+            if rotated and _is_active_resume_candidate(
+                rotated,
+                prototype_workspace_id=prototype_workspace_id,
+                share_link_id=share_link_id,
+            ):
+                actor = rotated
+                is_resume = True
+                binding_secret = str(rotated.get("session_binding_id") or next_binding_secret)
+
+        if actor is None:
+            if not allow_create:
+                raise PrototypeAccessError(
+                    "resume_required",
+                    "Prototype share link has exhausted new-collaborator uses",
+                )
+            binding_secret = secrets.token_urlsafe(24)
+            actor = await self._repo.create_shared_actor(
+                prototype_workspace_id=prototype_workspace_id,
+                share_link_id=share_link_id,
+                display_name=_normalize_display_name(display_name),
+                session_binding_id=binding_secret,
+                runtime_policy_profile=runtime_policy_profile,
+                quota_policy=quota_policy,
+                expires_at=expires_at,
+            )
+        if not binding_secret:
+            binding_secret = str(actor.get("session_binding_id") or "")
+
+        session_token = self._mint_session_token(
+            shared_actor_id=actor["id"],
+            prototype_workspace_id=prototype_workspace_id,
+            share_link_id=share_link_id,
+            runtime_policy_profile=runtime_policy_profile,
+        )
+        resume_cookie = self.encode_resume_cookie(
+            shared_actor_id=actor["id"],
+            binding_secret=binding_secret,
+        )
+        return PrototypeExternalAccessContext(
+            shared_actor_id=actor["id"],
+            actor_type="external_collaborator",
+            session_token=session_token,
+            runtime_policy_profile=runtime_policy_profile,
+            resume_cookie_value=resume_cookie,
+            is_resume=is_resume,
+        )
+
+    async def can_resume_external_collaborator(
+        self,
+        *,
+        prototype_workspace_id: str,
+        share_link_id: int,
+        resume_cookie_value: str | None,
+    ) -> bool:
+        workspace = await self._repo.get_workspace(prototype_workspace_id)
+        if not workspace or workspace.get("is_archived"):
+            return False
+        share_policy = workspace.get("share_policy") or {}
+        allow_resume = _to_bool(share_policy.get("allow_browser_session_resume", True))
+        candidate = await self._resolve_resume_candidate(
+            prototype_workspace_id=prototype_workspace_id,
+            share_link_id=share_link_id,
+            allow_resume=allow_resume,
+            resume_cookie_value=resume_cookie_value,
+        )
+        return candidate is not None
+
+    def encode_resume_cookie(self, *, shared_actor_id: str, binding_secret: str) -> str:
+        payload = {
+            "shared_actor_id": shared_actor_id,
+            "binding_secret": binding_secret,
+            "nonce": secrets.token_urlsafe(8),
+        }
+        payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        payload_b64 = _b64url(payload_json)
+        signature = hmac.new(
+            self._signing_secret.encode("utf-8"),
+            payload_b64.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+        signature_b64 = _b64url(signature)
+        return f"ptca.{payload_b64}.{signature_b64}"
+
+    def decode_resume_cookie(self, value: str | None) -> dict[str, str] | None:
+        if not value:
+            return None
+        parts = str(value).split(".")
+        if len(parts) != 3 or parts[0] != "ptca":
+            return None
+        payload_b64, signature_b64 = parts[1], parts[2]
+        expected_sig = hmac.new(
+            self._signing_secret.encode("utf-8"),
+            payload_b64.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+        expected_sig_b64 = _b64url(expected_sig)
+        if not hmac.compare_digest(expected_sig_b64, signature_b64):
+            return None
+        try:
+            payload_raw = _b64url_decode(payload_b64)
+            payload = json.loads(payload_raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        shared_actor_id = str(payload.get("shared_actor_id") or "").strip()
+        binding_secret = str(payload.get("binding_secret") or "").strip()
+        if not shared_actor_id or not binding_secret:
+            return None
+        return {"shared_actor_id": shared_actor_id, "binding_secret": binding_secret}
+
+    async def _resolve_resume_candidate(
+        self,
+        *,
+        prototype_workspace_id: str,
+        share_link_id: int,
+        allow_resume: bool,
+        resume_cookie_value: str | None,
+    ) -> dict[str, Any] | None:
+        if not allow_resume or not resume_cookie_value:
+            return None
+        resume_binding = self.decode_resume_cookie(resume_cookie_value)
+        if not resume_binding:
+            return None
+        candidate = await self._repo.get_shared_actor(resume_binding["shared_actor_id"])
+        if not (
+            _is_active_resume_candidate(
+                candidate,
+                prototype_workspace_id=prototype_workspace_id,
+                share_link_id=share_link_id,
+            )
+            and candidate
+            and candidate.get("session_binding_id")
+            and hmac.compare_digest(
+                str(candidate.get("session_binding_id")),
+                resume_binding["binding_secret"],
+            )
+        ):
+            return None
+        return candidate
+
+    def _mint_session_token(
+        self,
+        *,
+        shared_actor_id: str,
+        prototype_workspace_id: str,
+        share_link_id: int,
+        runtime_policy_profile: str,
+    ) -> str:
+        issued_at = int(time.time())
+        expires_at = issued_at + self._session_ttl_seconds
+        payload = {
+            "sub": shared_actor_id,
+            "workspace_id": prototype_workspace_id,
+            "share_link_id": int(share_link_id),
+            "actor_type": "external_collaborator",
+            "runtime_policy_profile": runtime_policy_profile,
+            "iat": issued_at,
+            "exp": expires_at,
+            "nonce": secrets.token_urlsafe(12),
+        }
+        payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        payload_b64 = _b64url(payload_json)
+        signature = hmac.new(
+            self._signing_secret.encode("utf-8"),
+            payload_b64.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+        signature_b64 = _b64url(signature)
+        return f"ptc.{payload_b64}.{signature_b64}"
+
+
+def _normalize_display_name(display_name: str | None) -> str:
+    value = str(display_name or "").strip()
+    if not value:
+        return DEFAULT_EXTERNAL_DISPLAY_NAME
+    return value[:120]
+
+
+def _to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    return text in {"1", "true", "t", "yes", "y"}
+
+
+def _parse_optional_ts(value: Any) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _is_active_resume_candidate(
+    actor: dict[str, Any] | None,
+    *,
+    prototype_workspace_id: str,
+    share_link_id: int,
+) -> bool:
+    if not actor:
+        return False
+    if actor.get("prototype_workspace_id") != prototype_workspace_id:
+        return False
+    if int(actor.get("share_link_id") or 0) != int(share_link_id):
+        return False
+    if actor.get("is_revoked") or actor.get("revoked_at"):
+        return False
+    expires_at = _parse_optional_ts(actor.get("expires_at"))
+    if expires_at is not None and expires_at <= datetime.now(timezone.utc):
+        return False
+    return True
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(raw: str) -> bytes:
+    padded = raw + ("=" * ((4 - len(raw) % 4) % 4))
+    return base64.urlsafe_b64decode(padded.encode("ascii"))

--- a/tldw_Server_API/app/core/Prototype_Workspaces/jobs.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/jobs.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from typing import Any
 
 from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
     PrototypeWorkspacesRepo,
 )
 from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env
 
 from .models import PrototypeJobType, actor_key_for_session
 
@@ -20,6 +22,26 @@ PROTOTYPE_JOB_TYPES = {
     PrototypeJobType.SNAPSHOT_SAVE.value,
     PrototypeJobType.PUBLISH_VALIDATE_AND_PROMOTE.value,
 }
+_DEFAULT_JOBS_MANAGER: JobManager | None = None
+_DEFAULT_JOBS_MANAGER_KEY: tuple[str, str] | None = None
+
+
+def _jobs_manager_environment_key() -> tuple[str, str]:
+    return (
+        str(os.getenv("JOBS_DB_URL") or ""),
+        str(os.getenv("JOBS_DB_PATH") or ""),
+    )
+
+
+def _get_default_jobs_manager() -> JobManager:
+    global _DEFAULT_JOBS_MANAGER
+    global _DEFAULT_JOBS_MANAGER_KEY
+
+    key = _jobs_manager_environment_key()
+    if _DEFAULT_JOBS_MANAGER is None or key != _DEFAULT_JOBS_MANAGER_KEY:
+        _DEFAULT_JOBS_MANAGER = jobs_manager_from_env()
+        _DEFAULT_JOBS_MANAGER_KEY = key
+    return _DEFAULT_JOBS_MANAGER
 
 
 def build_branch_session_bootstrap_idempotency_key(
@@ -95,7 +117,7 @@ class PrototypeWorkspaceJobs:
         queue: str = PROTOTYPE_QUEUE,
     ) -> None:
         self._repo = repo
-        self._jobs_manager = jobs_manager or JobManager()
+        self._jobs_manager = jobs_manager if jobs_manager is not None else _get_default_jobs_manager()
         self._queue = str(queue or PROTOTYPE_QUEUE)
 
     @staticmethod

--- a/tldw_Server_API/app/core/Prototype_Workspaces/jobs.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/jobs.py
@@ -1,0 +1,282 @@
+"""Jobs helpers for prototype workspace runtime orchestration."""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+    PrototypeWorkspacesRepo,
+)
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+from .models import PrototypeJobType, actor_key_for_session
+
+PROTOTYPE_DOMAIN = "prototype_workspaces"
+PROTOTYPE_QUEUE = "default"
+PROTOTYPE_JOB_TYPES = {
+    PrototypeJobType.BRANCH_SESSION_BOOTSTRAP.value,
+    PrototypeJobType.PREVIEW_BOOT.value,
+    PrototypeJobType.SNAPSHOT_SAVE.value,
+    PrototypeJobType.PUBLISH_VALIDATE_AND_PROMOTE.value,
+}
+
+
+def build_branch_session_bootstrap_idempotency_key(
+    *,
+    prototype_workspace_id: str,
+    base_snapshot_id: str,
+    actor_type: str,
+    actor_user_id: int | None = None,
+    actor_shared_actor_id: str | None = None,
+    request_nonce: str,
+) -> str:
+    actor_key = actor_key_for_session(
+        actor_type=actor_type,
+        actor_user_id=actor_user_id,
+        actor_shared_actor_id=actor_shared_actor_id,
+    )
+    nonce = str(request_nonce or "").strip()
+    if not nonce:
+        raise ValueError("request_nonce is required")
+    return (
+        "prototype:branch:"
+        f"{prototype_workspace_id}:{actor_key}:{base_snapshot_id}:{nonce}"
+    )
+
+
+def build_preview_boot_idempotency_key(
+    *,
+    prototype_session_id: str | None,
+    prototype_workspace_id: str,
+    snapshot_id: str,
+    runtime_target_url: str,
+    runtime_profile_version: str | None = None,
+) -> str:
+    scope_token = prototype_session_id or f"canonical:{prototype_workspace_id}"
+    profile_version = str(runtime_profile_version or "v1")
+    target_fingerprint = hashlib.sha256(
+        str(runtime_target_url or "").encode("utf-8")
+    ).hexdigest()[:16]
+    return f"prototype:preview:{scope_token}:{snapshot_id}:{profile_version}:{target_fingerprint}"
+
+
+def build_snapshot_save_idempotency_key(
+    *,
+    prototype_session_id: str,
+    save_request_id: str,
+) -> str:
+    request_id = str(save_request_id or "").strip()
+    if not request_id:
+        raise ValueError("save_request_id is required")
+    return f"prototype:snapshot-save:{prototype_session_id}:{request_id}"
+
+
+def build_promote_idempotency_key(
+    *,
+    prototype_workspace_id: str,
+    candidate_snapshot_id: str,
+    canonical_snapshot_id: str,
+) -> str:
+    return (
+        "prototype:promote:"
+        f"{prototype_workspace_id}:{candidate_snapshot_id}:{canonical_snapshot_id}"
+    )
+
+
+class PrototypeWorkspaceJobs:
+    """Create stable Jobs entries for prototype runtime operations."""
+
+    def __init__(
+        self,
+        *,
+        repo: PrototypeWorkspacesRepo,
+        jobs_manager: JobManager | None = None,
+        queue: str = PROTOTYPE_QUEUE,
+    ) -> None:
+        self._repo = repo
+        self._jobs_manager = jobs_manager or JobManager()
+        self._queue = str(queue or PROTOTYPE_QUEUE)
+
+    @staticmethod
+    def _normalize_job_row(job: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(job)
+        payload = normalized.get("payload")
+        if isinstance(payload, str):
+            try:
+                decoded = json.loads(payload)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                decoded = payload
+            normalized["payload"] = decoded
+        return normalized
+
+    async def enqueue_branch_session_bootstrap(
+        self,
+        *,
+        prototype_workspace_id: str,
+        actor_type: str,
+        actor_user_id: int | None = None,
+        actor_shared_actor_id: str | None = None,
+        request_nonce: str,
+        share_link_id: int | None = None,
+        expires_at: str | None = None,
+    ) -> dict[str, Any]:
+        workspace = await self._repo.get_workspace(prototype_workspace_id)
+        if not workspace:
+            raise ValueError("prototype workspace not found")
+
+        base_snapshot_id = str(
+            workspace.get("canonical_snapshot_id")
+            or workspace.get("last_known_good_snapshot_id")
+            or ""
+        ).strip()
+        if not base_snapshot_id:
+            raise ValueError("prototype workspace does not have a canonical snapshot")
+
+        payload = {
+            "prototype_workspace_id": prototype_workspace_id,
+            "base_snapshot_id": base_snapshot_id,
+            "actor_type": actor_type,
+            "actor_user_id": actor_user_id,
+            "actor_shared_actor_id": actor_shared_actor_id,
+            "share_link_id": share_link_id,
+            "expires_at": expires_at,
+            "request_nonce": request_nonce,
+        }
+        return self._normalize_job_row(self._jobs_manager.create_job(
+            domain=PROTOTYPE_DOMAIN,
+            queue=self._queue,
+            job_type=PrototypeJobType.BRANCH_SESSION_BOOTSTRAP.value,
+            payload=payload,
+            owner_user_id=str(workspace["owner_user_id"]),
+            idempotency_key=build_branch_session_bootstrap_idempotency_key(
+                prototype_workspace_id=prototype_workspace_id,
+                base_snapshot_id=base_snapshot_id,
+                actor_type=actor_type,
+                actor_user_id=actor_user_id,
+                actor_shared_actor_id=actor_shared_actor_id,
+                request_nonce=request_nonce,
+            ),
+        ))
+
+    async def enqueue_preview_boot(
+        self,
+        *,
+        prototype_workspace_id: str,
+        snapshot_id: str,
+        runtime_target_url: str,
+        prototype_session_id: str | None = None,
+        runtime_profile_version: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        workspace = await self._repo.get_workspace(prototype_workspace_id)
+        if not workspace:
+            raise ValueError("prototype workspace not found")
+
+        return self._normalize_job_row(self._jobs_manager.create_job(
+            domain=PROTOTYPE_DOMAIN,
+            queue=self._queue,
+            job_type=PrototypeJobType.PREVIEW_BOOT.value,
+            payload={
+                "prototype_workspace_id": prototype_workspace_id,
+                "prototype_session_id": prototype_session_id,
+                "snapshot_id": snapshot_id,
+                "runtime_target_url": runtime_target_url,
+                "metadata": metadata or {},
+                "runtime_profile_version": runtime_profile_version or "v1",
+            },
+            owner_user_id=str(workspace["owner_user_id"]),
+            idempotency_key=build_preview_boot_idempotency_key(
+                prototype_workspace_id=prototype_workspace_id,
+                prototype_session_id=prototype_session_id,
+                snapshot_id=snapshot_id,
+                runtime_target_url=runtime_target_url,
+                runtime_profile_version=runtime_profile_version,
+            ),
+        ))
+
+    async def enqueue_snapshot_save(
+        self,
+        *,
+        prototype_session_id: str,
+        save_request_id: str,
+        snapshot_id: str | None = None,
+        storage_ref: str | None = None,
+        diff_summary: dict[str, Any] | None = None,
+        prompt_summary: str | None = None,
+        preview_health: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        session = await self._repo.get_session(prototype_session_id)
+        if not session:
+            raise ValueError("prototype session not found")
+        workspace = await self._repo.get_workspace(str(session["prototype_workspace_id"]))
+        if not workspace:
+            raise ValueError("prototype workspace not found")
+
+        return self._normalize_job_row(self._jobs_manager.create_job(
+            domain=PROTOTYPE_DOMAIN,
+            queue=self._queue,
+            job_type=PrototypeJobType.SNAPSHOT_SAVE.value,
+            payload={
+                "prototype_session_id": prototype_session_id,
+                "snapshot_id": snapshot_id,
+                "save_request_id": save_request_id,
+                "storage_ref": storage_ref,
+                "diff_summary": diff_summary or {},
+                "prompt_summary": prompt_summary,
+                "preview_health": preview_health or {},
+            },
+            owner_user_id=str(workspace["owner_user_id"]),
+            idempotency_key=build_snapshot_save_idempotency_key(
+                prototype_session_id=prototype_session_id,
+                save_request_id=save_request_id,
+            ),
+        ))
+
+    async def enqueue_publish_validate_and_promote(
+        self,
+        *,
+        prototype_workspace_id: str,
+        candidate_snapshot_id: str,
+        reviewer_user_id: int,
+        review_baseline_snapshot_id: str | None = None,
+        promotion_request_id: str | None = None,
+        review_notes: str | None = None,
+    ) -> dict[str, Any]:
+        workspace = await self._repo.get_workspace(prototype_workspace_id)
+        if not workspace:
+            raise ValueError("prototype workspace not found")
+
+        review_baseline = str(
+            review_baseline_snapshot_id
+            or workspace.get("last_known_good_snapshot_id")
+            or workspace.get("canonical_snapshot_id")
+            or ""
+        ).strip()
+        if not review_baseline:
+            raise ValueError("prototype workspace does not have a canonical snapshot")
+
+        return self._normalize_job_row(self._jobs_manager.create_job(
+            domain=PROTOTYPE_DOMAIN,
+            queue=self._queue,
+            job_type=PrototypeJobType.PUBLISH_VALIDATE_AND_PROMOTE.value,
+            payload={
+                "prototype_workspace_id": prototype_workspace_id,
+                "candidate_snapshot_id": candidate_snapshot_id,
+                "reviewer_user_id": int(reviewer_user_id),
+                "review_baseline_snapshot_id": review_baseline,
+                "promotion_request_id": promotion_request_id,
+                "review_notes": review_notes,
+                "canonical_snapshot_id": review_baseline,
+            },
+            owner_user_id=str(workspace["owner_user_id"]),
+            idempotency_key=build_promote_idempotency_key(
+                prototype_workspace_id=prototype_workspace_id,
+                candidate_snapshot_id=candidate_snapshot_id,
+                canonical_snapshot_id=review_baseline,
+            ),
+        ))
+
+
+class PrototypeRuntimeJobs(PrototypeWorkspaceJobs):
+    """Compatibility alias for tests and future callers."""

--- a/tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py
@@ -17,6 +17,16 @@ from .models import PrototypeJobType
 from .service import PrototypeWorkspaceService
 
 
+def _required_int_payload(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if value is None or str(value).strip() == "":
+        raise ValueError(f"{key} is required")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{key} must be an integer") from exc
+
+
 async def handle_prototype_job(
     job: dict[str, Any],
     *,
@@ -79,7 +89,7 @@ async def handle_prototype_job(
         result = await service.promote_candidate(
             prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
             candidate_snapshot_id=str(payload.get("candidate_snapshot_id") or ""),
-            reviewer_user_id=int(payload.get("reviewer_user_id")),
+            reviewer_user_id=_required_int_payload(payload, "reviewer_user_id"),
             review_baseline_snapshot_id=payload.get("review_baseline_snapshot_id"),
             promotion_request_id=payload.get("promotion_request_id"),
             review_notes=payload.get("review_notes"),

--- a/tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/jobs_worker.py
@@ -1,0 +1,146 @@
+"""Jobs worker for prototype workspace runtime orchestration."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
+from tldw_Server_API.app.core.Jobs.worker_utils import coerce_int as _coerce_int
+from tldw_Server_API.app.core.Jobs.worker_utils import jobs_manager_from_env as _jobs_manager
+
+from .jobs import PROTOTYPE_DOMAIN, PROTOTYPE_QUEUE
+from .models import PrototypeJobType
+from .service import PrototypeWorkspaceService
+
+
+async def handle_prototype_job(
+    job: dict[str, Any],
+    *,
+    service: PrototypeWorkspaceService,
+) -> dict[str, Any]:
+    """Dispatch a single prototype runtime job through the service layer."""
+    payload = job.get("payload") or {}
+    job_type = str(job.get("job_type") or payload.get("job_type") or "").strip().lower()
+    if not job_type:
+        raise ValueError("missing prototype job_type")
+
+    if job_type == PrototypeJobType.BRANCH_SESSION_BOOTSTRAP.value:
+        result = await service.create_or_reuse_branch_session(
+            prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
+            base_snapshot_id=payload.get("base_snapshot_id"),
+            actor_type=str(payload.get("actor_type") or ""),
+            actor_user_id=payload.get("actor_user_id"),
+            actor_shared_actor_id=payload.get("actor_shared_actor_id"),
+            request_nonce=payload.get("request_nonce"),
+            share_link_id=payload.get("share_link_id"),
+            expires_at=payload.get("expires_at"),
+        )
+        session = result.get("session") or {}
+        return {
+            "status": "ok",
+            "session_id": session.get("id"),
+            "created": bool(result.get("created")),
+        }
+
+    if job_type == PrototypeJobType.PREVIEW_BOOT.value:
+        grant = await service.boot_preview(
+            prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
+            prototype_session_id=payload.get("prototype_session_id"),
+            snapshot_id=str(payload.get("snapshot_id") or ""),
+            runtime_target_url=str(payload.get("runtime_target_url") or ""),
+            metadata=payload.get("metadata") or {},
+            runtime_policy_profile=payload.get("runtime_policy_profile"),
+        )
+        return {
+            "status": "ok",
+            "preview_handle": grant.get("preview_handle"),
+            "preview_url": grant.get("preview_url"),
+        }
+
+    if job_type == PrototypeJobType.SNAPSHOT_SAVE.value:
+        snapshot = await service.save_session_snapshot(
+            prototype_session_id=str(payload.get("prototype_session_id") or ""),
+            snapshot_id=payload.get("snapshot_id"),
+            storage_ref=payload.get("storage_ref"),
+            diff_summary=payload.get("diff_summary") or {},
+            prompt_summary=payload.get("prompt_summary"),
+            preview_health=payload.get("preview_health") or {},
+        )
+        return {
+            "status": "ok",
+            "snapshot_id": snapshot.get("snapshot_id"),
+        }
+
+    if job_type == PrototypeJobType.PUBLISH_VALIDATE_AND_PROMOTE.value:
+        result = await service.promote_candidate(
+            prototype_workspace_id=str(payload.get("prototype_workspace_id") or ""),
+            candidate_snapshot_id=str(payload.get("candidate_snapshot_id") or ""),
+            reviewer_user_id=int(payload.get("reviewer_user_id")),
+            review_baseline_snapshot_id=payload.get("review_baseline_snapshot_id"),
+            promotion_request_id=payload.get("promotion_request_id"),
+            review_notes=payload.get("review_notes"),
+        )
+        return result
+
+    raise ValueError(f"unsupported prototype job_type: {job_type}")
+
+
+async def run_prototype_jobs_worker(
+    *,
+    service: PrototypeWorkspaceService,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run the prototype workspace jobs worker until stopped."""
+    worker_id = (os.getenv("PROTOTYPE_WORKSPACE_WORKER_ID") or f"prototype-jobs-{os.getpid()}").strip()
+    queue = (os.getenv("PROTOTYPE_WORKSPACE_JOBS_QUEUE") or PROTOTYPE_QUEUE).strip() or PROTOTYPE_QUEUE
+    lease_seconds = _coerce_int(
+        os.getenv("PROTOTYPE_WORKSPACE_JOBS_LEASE_SECONDS") or os.getenv("JOBS_LEASE_SECONDS"),
+        60,
+    )
+    renew_jitter = _coerce_int(
+        os.getenv("PROTOTYPE_WORKSPACE_JOBS_RENEW_JITTER_SECONDS")
+        or os.getenv("JOBS_LEASE_RENEW_JITTER_SECONDS"),
+        5,
+    )
+    renew_threshold = _coerce_int(
+        os.getenv("PROTOTYPE_WORKSPACE_JOBS_RENEW_THRESHOLD_SECONDS")
+        or os.getenv("JOBS_LEASE_RENEW_THRESHOLD_SECONDS"),
+        10,
+    )
+    cfg = WorkerConfig(
+        domain=PROTOTYPE_DOMAIN,
+        queue=queue,
+        worker_id=worker_id,
+        lease_seconds=lease_seconds,
+        renew_jitter_seconds=renew_jitter,
+        renew_threshold_seconds=renew_threshold,
+    )
+    sdk = WorkerSDK(_jobs_manager(), cfg)
+    _stop_watcher_task: asyncio.Task[None] | None = None
+
+    if stop_event is not None:
+        async def _watch_stop() -> None:
+            await stop_event.wait()
+            sdk.stop()
+
+        _stop_watcher_task = asyncio.create_task(_watch_stop())
+
+    logger.info("Prototype workspace jobs worker starting (queue={}, worker_id={})", queue, worker_id)
+    try:
+        await sdk.run(handler=lambda job: handle_prototype_job(job, service=service))
+    finally:
+        if _stop_watcher_task is not None and not _stop_watcher_task.done():
+            _stop_watcher_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await _stop_watcher_task
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        "Prototype workspace jobs worker requires an injected PrototypeWorkspaceService. "
+        "Import run_prototype_jobs_worker() from the application bootstrap."
+    )

--- a/tldw_Server_API/app/core/Prototype_Workspaces/models.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/models.py
@@ -1,0 +1,126 @@
+"""Typed models and shared constants for prototype workspace runtime orchestration."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class PrototypeActorType(str, Enum):
+    OWNER = "owner"
+    INTERNAL_COLLABORATOR = "internal_collaborator"
+    EXTERNAL_COLLABORATOR = "external_collaborator"
+
+
+class PrototypeJobType(str, Enum):
+    BRANCH_SESSION_BOOTSTRAP = "branch_session_bootstrap"
+    PREVIEW_BOOT = "preview_boot"
+    SNAPSHOT_SAVE = "snapshot_save"
+    PUBLISH_VALIDATE_AND_PROMOTE = "publish_validate_and_promote"
+
+
+class PrototypePreviewScope(str, Enum):
+    CANONICAL = "canonical"
+    SESSION = "session"
+
+
+class PrototypePreviewStatus(str, Enum):
+    UNINITIALIZED = "uninitialized"
+    STARTING = "starting"
+    READY = "ready"
+    FAILED = "failed"
+    REVOKED = "revoked"
+
+
+class PrototypeRuntimeStatus(str, Enum):
+    PENDING = "pending"
+    QUEUED = "queued"
+    STARTING = "starting"
+    READY = "ready"
+    FAILED = "failed"
+    CLOSED = "closed"
+    REVOKED = "revoked"
+
+
+@dataclass(slots=True)
+class PrototypePreviewHandleRecord:
+    handle_id: str
+    preview_scope: PrototypePreviewScope
+    scope_id: str
+    prototype_workspace_id: str
+    prototype_session_id: str | None
+    actor_key: str
+    target_ref: str
+    runtime_policy_profile: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    is_active: bool = True
+    created_at: str | None = None
+    revoked_at: str | None = None
+
+
+@dataclass(slots=True)
+class PrototypePreviewGrant:
+    preview_handle: str
+    preview_url: str
+    expires_at: str
+    token: str
+
+
+@dataclass(slots=True)
+class PrototypeJobRequest:
+    job_type: PrototypeJobType
+    idempotency_key: str
+    payload: dict[str, Any]
+    owner_user_id: str | None
+
+
+@dataclass(slots=True)
+class PrototypePromotionResult:
+    status: str
+    failure_code: str | None = None
+    prototype_workspace_id: str | None = None
+    candidate_snapshot_id: str | None = None
+    canonical_snapshot_id: str | None = None
+    preview_handle: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "failure_code": self.failure_code,
+            "prototype_workspace_id": self.prototype_workspace_id,
+            "candidate_snapshot_id": self.candidate_snapshot_id,
+            "canonical_snapshot_id": self.canonical_snapshot_id,
+            "preview_handle": self.preview_handle,
+            "details": dict(self.details),
+        }
+
+
+def actor_key_for_session(
+    *,
+    actor_type: str,
+    actor_user_id: int | None = None,
+    actor_shared_actor_id: str | None = None,
+) -> str:
+    normalized = PrototypeActorType(str(actor_type).strip().lower())
+    if normalized == PrototypeActorType.EXTERNAL_COLLABORATOR:
+        if not actor_shared_actor_id:
+            raise ValueError("external collaborator actor key requires actor_shared_actor_id")
+        return f"shared_actor:{actor_shared_actor_id}"
+    if actor_user_id is None:
+        raise ValueError("internal actor key requires actor_user_id")
+    return f"user:{int(actor_user_id)}"
+
+
+def preview_scope_id(
+    *,
+    preview_scope: str,
+    prototype_workspace_id: str,
+    prototype_session_id: str | None = None,
+) -> str:
+    normalized = PrototypePreviewScope(str(preview_scope).strip().lower())
+    if normalized == PrototypePreviewScope.CANONICAL:
+        return f"canonical:{prototype_workspace_id}"
+    if not prototype_session_id:
+        raise ValueError("session preview scope requires prototype_session_id")
+    return f"session:{prototype_session_id}"

--- a/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
@@ -10,6 +10,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 
+from loguru import logger
+
 from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
     PrototypeWorkspacesRepo,
 )
@@ -38,6 +40,16 @@ def _normalize_iso8601(value: Any) -> datetime | None:
     except (TypeError, ValueError):
         return None
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
 
 
 def _resolve_stable_signing_secret(signing_secret: str | None) -> str:
@@ -154,6 +166,7 @@ class PrototypePreviewBroker:
             created_at=now.isoformat(),
         )
         previous_handle_id: str | None = None
+        previous_persisted_record = await self._repo.get_active_preview_handle_for_scope(scope_id)
 
         with self._lock:
             previous_handle_id = self._active_scope_handles.get(scope_id)
@@ -162,6 +175,18 @@ class PrototypePreviewBroker:
             self._active_scope_handles[scope_id] = handle_id
 
         try:
+            await self._repo.replace_active_preview_handle_record(
+                preview_handle=handle_id,
+                preview_scope=preview_scope.value,
+                scope_id=scope_id,
+                prototype_workspace_id=prototype_workspace_id,
+                prototype_session_id=prototype_session_id,
+                actor_key=actor_key,
+                target_ref=str(runtime_target_url),
+                runtime_policy_profile=resolved_runtime_policy,
+                metadata=dict(record.metadata),
+                created_at=record.created_at,
+            )
             if prototype_session_id:
                 updated = await self._repo.update_session_state(
                     prototype_session_id,
@@ -179,16 +204,44 @@ class PrototypePreviewBroker:
                 if not updated_workspace:
                     raise RuntimeError("failed to persist canonical preview state")
         except Exception:
+            should_restore_previous = False
+            revoked_at = _utc_now().isoformat()
+            try:
+                await self._repo.revoke_preview_handle_record(handle_id, revoked_at=revoked_at)
+            except Exception as cleanup_exc:
+                logger.debug(
+                    "Failed to revoke preview handle {} during rollback: {}",
+                    handle_id,
+                    cleanup_exc,
+                )
             with self._lock:
                 failed_record = self._records.get(handle_id)
                 if failed_record is not None:
                     failed_record.is_active = False
-                    failed_record.revoked_at = _utc_now().isoformat()
+                    failed_record.revoked_at = revoked_at
                 if self._active_scope_handles.get(scope_id) == handle_id:
                     self._active_scope_handles.pop(scope_id, None)
-                if previous_handle_id:
+                    should_restore_previous = True
+                elif self._active_scope_handles.get(scope_id) is None:
+                    should_restore_previous = True
+            if should_restore_previous and previous_persisted_record:
+                try:
+                    restored = await self._repo.restore_preview_handle_record_if_scope_unclaimed(
+                        str(previous_persisted_record["preview_handle"])
+                    )
+                except Exception as cleanup_exc:
+                    logger.debug(
+                        "Failed to restore previous preview handle {} during rollback: {}",
+                        previous_persisted_record.get("preview_handle"),
+                        cleanup_exc,
+                    )
+                else:
+                    if restored:
+                        self._sync_record_cache(self._record_from_dict(restored))
+            elif should_restore_previous and previous_handle_id:
+                with self._lock:
                     previous_record = self._records.get(previous_handle_id)
-                    if previous_record is not None:
+                    if previous_record is not None and self._active_scope_handles.get(scope_id) is None:
                         previous_record.is_active = True
                         previous_record.revoked_at = None
                         self._active_scope_handles[scope_id] = previous_handle_id
@@ -214,15 +267,19 @@ class PrototypePreviewBroker:
         handle_id = str(preview_handle or "").strip()
         if not handle_id:
             return False
+        record = await self._load_record(handle_id, require_active=True)
+        if not record:
+            return False
+        revoked_at = _utc_now().isoformat()
+        revoked = await self._repo.revoke_preview_handle_record(handle_id, revoked_at=revoked_at)
         with self._lock:
             record = self._records.get(handle_id)
-            if not record or not record.is_active:
-                return False
-            record.is_active = False
-            record.revoked_at = _utc_now().isoformat()
-            if self._active_scope_handles.get(record.scope_id) == handle_id:
+            if record is not None:
+                record.is_active = False
+                record.revoked_at = revoked_at
+            if record is not None and self._active_scope_handles.get(record.scope_id) == handle_id:
                 self._active_scope_handles.pop(record.scope_id, None)
-        return True
+        return revoked
 
     def get_preview_record(self, preview_handle: str) -> dict[str, Any] | None:
         handle_id = str(preview_handle or "").strip()
@@ -234,16 +291,24 @@ class PrototypePreviewBroker:
                 return None
             return self._record_to_dict(record)
 
+    async def get_preview_record_async(self, preview_handle: str) -> dict[str, Any] | None:
+        handle_id = str(preview_handle or "").strip()
+        if not handle_id:
+            return None
+        record = await self._load_record(handle_id, require_active=False)
+        if not record:
+            return None
+        return self._record_to_dict(record)
+
     async def renew_preview_grant(self, preview_handle: str) -> dict[str, Any]:
         handle_id = str(preview_handle or "").strip()
         if not handle_id:
             raise PrototypePreviewHandleNotFound("preview handle is required")
 
-        with self._lock:
-            record = self._records.get(handle_id)
-            if not record or not record.is_active:
-                raise PrototypePreviewHandleNotFound("preview handle not found")
-            record_dict = self._record_to_dict(record)
+        record = await self._load_record(handle_id, require_active=True)
+        if not record:
+            raise PrototypePreviewHandleNotFound("preview handle not found")
+        record_dict = self._record_to_dict(record)
 
         if not await self._is_grant_still_authorized(record):
             raise RuntimeError("preview handle is no longer authorized")
@@ -278,20 +343,17 @@ class PrototypePreviewBroker:
         if not handle_id or not token or exp <= now or not expected_actor_key:
             return None
 
-        with self._lock:
-            record = self._records.get(handle_id)
-            if not record or not record.is_active:
-                return None
-            if record.actor_key != expected_actor_key:
-                return None
-            expected_sig = self._build_signature(
-                preview_handle=handle_id,
-                actor_key=expected_actor_key,
-                exp=exp,
-            )
-            if not hmac.compare_digest(token, expected_sig):
-                return None
-            record_dict = self._record_to_dict(record)
+        record = await self._load_record(handle_id, require_active=True)
+        if not record or record.actor_key != expected_actor_key:
+            return None
+        expected_sig = self._build_signature(
+            preview_handle=handle_id,
+            actor_key=expected_actor_key,
+            exp=exp,
+        )
+        if not hmac.compare_digest(token, expected_sig):
+            return None
+        record_dict = self._record_to_dict(record)
         if not await self._is_grant_still_authorized(record):
             return None
         return record_dict
@@ -393,6 +455,30 @@ class PrototypePreviewBroker:
             hashlib.sha256,
         ).hexdigest()
 
+    async def _load_record(
+        self,
+        handle_id: str,
+        *,
+        require_active: bool,
+    ) -> PrototypePreviewHandleRecord | None:
+        persisted = await self._repo.get_preview_handle_record(handle_id)
+        if not persisted:
+            return None
+        record = self._record_from_dict(persisted)
+        self._sync_record_cache(record)
+        if require_active and not record.is_active:
+            return None
+        return record
+
+    @classmethod
+    def _sync_record_cache(cls, record: PrototypePreviewHandleRecord) -> None:
+        with cls._lock:
+            cls._records[record.handle_id] = record
+            if record.is_active:
+                cls._active_scope_handles[record.scope_id] = record.handle_id
+            elif cls._active_scope_handles.get(record.scope_id) == record.handle_id:
+                cls._active_scope_handles.pop(record.scope_id, None)
+
     @classmethod
     def _revoke_scope_locked(cls, *, scope_id: str, revoked_at: str) -> None:
         existing_handle = cls._active_scope_handles.get(scope_id)
@@ -405,6 +491,25 @@ class PrototypePreviewBroker:
         record.is_active = False
         record.revoked_at = revoked_at
         cls._active_scope_handles.pop(scope_id, None)
+
+    @staticmethod
+    def _record_from_dict(row: dict[str, Any]) -> PrototypePreviewHandleRecord:
+        return PrototypePreviewHandleRecord(
+            handle_id=str(row.get("preview_handle") or row.get("id") or ""),
+            preview_scope=PrototypePreviewScope(str(row["preview_scope"])),
+            scope_id=str(row["scope_id"]),
+            prototype_workspace_id=str(row["prototype_workspace_id"]),
+            prototype_session_id=(
+                str(row["prototype_session_id"]) if row.get("prototype_session_id") is not None else None
+            ),
+            actor_key=str(row["actor_key"]),
+            target_ref=str(row["target_ref"]),
+            runtime_policy_profile=str(row["runtime_policy_profile"]),
+            metadata=dict(row.get("metadata") or {}),
+            is_active=_coerce_bool(row.get("is_active")),
+            created_at=str(row["created_at"]) if row.get("created_at") is not None else None,
+            revoked_at=str(row["revoked_at"]) if row.get("revoked_at") is not None else None,
+        )
 
     @staticmethod
     def _record_to_dict(record: PrototypePreviewHandleRecord) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
@@ -60,6 +60,10 @@ def _resolve_stable_signing_secret(signing_secret: str | None) -> str:
     )
 
 
+class PrototypePreviewHandleNotFound(RuntimeError):
+    """Raised when a preview handle cannot be found or renewed."""
+
+
 class PrototypePreviewBroker:
     """Issue opaque preview handles and short-lived signed grants."""
 
@@ -233,12 +237,12 @@ class PrototypePreviewBroker:
     async def renew_preview_grant(self, preview_handle: str) -> dict[str, Any]:
         handle_id = str(preview_handle or "").strip()
         if not handle_id:
-            raise RuntimeError("preview handle is required")
+            raise PrototypePreviewHandleNotFound("preview handle is required")
 
         with self._lock:
             record = self._records.get(handle_id)
             if not record or not record.is_active:
-                raise RuntimeError("preview handle not found")
+                raise PrototypePreviewHandleNotFound("preview handle not found")
             record_dict = self._record_to_dict(record)
 
         if not await self._is_grant_still_authorized(record):

--- a/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
@@ -1,0 +1,380 @@
+"""Brokered preview handles for prototype workspaces and sessions."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, ClassVar
+
+from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+    PrototypeWorkspacesRepo,
+)
+
+from .models import (
+    PrototypePreviewHandleRecord,
+    PrototypePreviewScope,
+    PrototypePreviewStatus,
+    actor_key_for_session,
+    preview_scope_id,
+)
+
+_FALLBACK_SIGNING_SECRET = secrets.token_urlsafe(32)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_iso8601(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+class PrototypePreviewBroker:
+    """Issue opaque preview handles and short-lived signed grants."""
+
+    _records: ClassVar[dict[str, PrototypePreviewHandleRecord]] = {}
+    _active_scope_handles: ClassVar[dict[str, str]] = {}
+    _lock: ClassVar[threading.RLock] = threading.RLock()
+
+    def __init__(
+        self,
+        *,
+        repo: PrototypeWorkspacesRepo,
+        base_preview_path: str = "/api/v1/prototype-previews",
+        grant_ttl_seconds: int = 5 * 60,
+        signing_secret: str | None = None,
+    ) -> None:
+        self._repo = repo
+        self._base_preview_path = str(base_preview_path or "/api/v1/prototype-previews").rstrip("/")
+        self._grant_ttl_seconds = max(int(grant_ttl_seconds), 30)
+        self._signing_secret = (
+            signing_secret
+            or os.getenv("PROTOTYPE_PREVIEW_SIGNING_SECRET")
+            or os.getenv("JWT_SECRET_KEY")
+            or os.getenv("SINGLE_USER_API_KEY")
+            or _FALLBACK_SIGNING_SECRET
+        )
+
+    async def issue_preview_grant(
+        self,
+        *,
+        prototype_workspace_id: str,
+        snapshot_id: str,
+        runtime_target_url: str,
+        prototype_session_id: str | None = None,
+        runtime_policy_profile: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        workspace = await self._repo.get_workspace(prototype_workspace_id)
+        if not workspace:
+            raise RuntimeError("prototype workspace not found")
+        if workspace.get("is_archived"):
+            raise RuntimeError("prototype workspace is archived")
+        if not str(snapshot_id or "").strip():
+            raise ValueError("snapshot_id is required")
+        if not str(runtime_target_url or "").strip():
+            raise ValueError("runtime_target_url is required")
+
+        session: dict[str, Any] | None = None
+        preview_scope = PrototypePreviewScope.CANONICAL
+        actor_key = f"workspace:{prototype_workspace_id}"
+        resolved_runtime_policy = runtime_policy_profile or "canonical_preview"
+
+        if prototype_session_id:
+            preview_scope = PrototypePreviewScope.SESSION
+            session = await self._repo.get_session(prototype_session_id)
+            if not session or session.get("prototype_workspace_id") != prototype_workspace_id:
+                raise RuntimeError("prototype session not found in workspace")
+            if session.get("is_revoked"):
+                raise RuntimeError("revoked session cannot receive preview grants")
+            expires_at = _normalize_iso8601(session.get("expires_at"))
+            if expires_at and expires_at <= _utc_now():
+                raise RuntimeError("expired session cannot receive preview grants")
+            await self._assert_session_actor_active(session)
+            actor_key = actor_key_for_session(
+                actor_type=str(session.get("actor_type") or ""),
+                actor_user_id=session.get("actor_user_id"),
+                actor_shared_actor_id=session.get("actor_shared_actor_id"),
+            )
+            resolved_runtime_policy = await self._resolve_runtime_policy_profile(
+                workspace=workspace,
+                session=session,
+                explicit_profile=runtime_policy_profile,
+            )
+
+        scope_id = preview_scope_id(
+            preview_scope=preview_scope.value,
+            prototype_workspace_id=prototype_workspace_id,
+            prototype_session_id=prototype_session_id,
+        )
+        handle_id = f"pph_{uuid.uuid4().hex}"
+        now = _utc_now()
+        record = PrototypePreviewHandleRecord(
+            handle_id=handle_id,
+            preview_scope=preview_scope,
+            scope_id=scope_id,
+            prototype_workspace_id=prototype_workspace_id,
+            prototype_session_id=prototype_session_id,
+            actor_key=actor_key,
+            target_ref=str(runtime_target_url),
+            runtime_policy_profile=resolved_runtime_policy,
+            metadata={
+                "snapshot_id": str(snapshot_id),
+                **(metadata or {}),
+            },
+            created_at=now.isoformat(),
+        )
+        previous_handle_id: str | None = None
+
+        with self._lock:
+            previous_handle_id = self._active_scope_handles.get(scope_id)
+            self._revoke_scope_locked(scope_id=scope_id, revoked_at=now.isoformat())
+            self._records[handle_id] = record
+            self._active_scope_handles[scope_id] = handle_id
+
+        try:
+            if prototype_session_id:
+                updated = await self._repo.update_session_state(
+                    prototype_session_id,
+                    preview_handle=handle_id,
+                    preview_status=PrototypePreviewStatus.READY.value,
+                    last_activity_at=now.isoformat(),
+                )
+                if not updated:
+                    raise RuntimeError("failed to persist preview handle")
+            else:
+                updated_workspace = await self._repo.update_workspace_state(
+                    prototype_workspace_id,
+                    canonical_preview_status=PrototypePreviewStatus.READY.value,
+                )
+                if not updated_workspace:
+                    raise RuntimeError("failed to persist canonical preview state")
+        except Exception:
+            with self._lock:
+                failed_record = self._records.get(handle_id)
+                if failed_record is not None:
+                    failed_record.is_active = False
+                    failed_record.revoked_at = _utc_now().isoformat()
+                if self._active_scope_handles.get(scope_id) == handle_id:
+                    self._active_scope_handles.pop(scope_id, None)
+                if previous_handle_id:
+                    previous_record = self._records.get(previous_handle_id)
+                    if previous_record is not None:
+                        previous_record.is_active = True
+                        previous_record.revoked_at = None
+                        self._active_scope_handles[scope_id] = previous_handle_id
+            raise
+
+        token, expires_at = self._mint_grant_token(
+            preview_handle=handle_id,
+            actor_key=actor_key,
+        )
+        return {
+            "preview_handle": handle_id,
+            "preview_scope": preview_scope.value,
+            "prototype_workspace_id": prototype_workspace_id,
+            "prototype_session_id": prototype_session_id,
+            "snapshot_id": str(snapshot_id),
+            "preview_url": f"{self._base_preview_path}/{handle_id}?exp={expires_at}&token={token}",
+            "expires_at": datetime.fromtimestamp(expires_at, timezone.utc).isoformat(),
+            "token": token,
+            "runtime_policy_profile": resolved_runtime_policy,
+        }
+
+    async def revoke_preview_handle(self, preview_handle: str) -> bool:
+        handle_id = str(preview_handle or "").strip()
+        if not handle_id:
+            return False
+        with self._lock:
+            record = self._records.get(handle_id)
+            if not record or not record.is_active:
+                return False
+            record.is_active = False
+            record.revoked_at = _utc_now().isoformat()
+            if self._active_scope_handles.get(record.scope_id) == handle_id:
+                self._active_scope_handles.pop(record.scope_id, None)
+        return True
+
+    def get_preview_record(self, preview_handle: str) -> dict[str, Any] | None:
+        handle_id = str(preview_handle or "").strip()
+        if not handle_id:
+            return None
+        with self._lock:
+            record = self._records.get(handle_id)
+            if not record:
+                return None
+            return self._record_to_dict(record)
+
+    async def validate_preview_grant(
+        self,
+        *,
+        preview_handle: str,
+        token: str,
+        exp: int,
+        actor_key: str,
+    ) -> dict[str, Any] | None:
+        handle_id = str(preview_handle or "").strip()
+        expected_actor_key = str(actor_key or "").strip()
+        now = int(time.time())
+        if not handle_id or not token or exp <= now or not expected_actor_key:
+            return None
+
+        with self._lock:
+            record = self._records.get(handle_id)
+            if not record or not record.is_active:
+                return None
+            if record.actor_key != expected_actor_key:
+                return None
+            expected_sig = self._build_signature(
+                preview_handle=handle_id,
+                actor_key=expected_actor_key,
+                exp=exp,
+            )
+            if not hmac.compare_digest(token, expected_sig):
+                return None
+            record_dict = self._record_to_dict(record)
+        if not await self._is_grant_still_authorized(record):
+            return None
+        return record_dict
+
+    async def resolve_preview_target(
+        self,
+        *,
+        preview_handle: str,
+        token: str,
+        exp: int,
+        actor_key: str,
+    ) -> dict[str, Any] | None:
+        record = await self.validate_preview_grant(
+            preview_handle=preview_handle,
+            token=token,
+            exp=exp,
+            actor_key=actor_key,
+        )
+        if not record:
+            return None
+        return {
+            **record,
+            "runtime_target_url": record.get("target_ref"),
+        }
+
+    async def _is_grant_still_authorized(self, record: PrototypePreviewHandleRecord) -> bool:
+        if record.preview_scope == PrototypePreviewScope.CANONICAL:
+            workspace = await self._repo.get_workspace(record.prototype_workspace_id)
+            return bool(workspace) and not bool(workspace.get("is_archived"))
+
+        if not record.prototype_session_id:
+            return False
+        session = await self._repo.get_session(record.prototype_session_id)
+        if not session or session.get("is_revoked"):
+            return False
+        session_expires_at = _normalize_iso8601(session.get("expires_at"))
+        if session_expires_at and session_expires_at <= _utc_now():
+            return False
+        return await self._session_actor_is_active(session)
+
+    async def _assert_session_actor_active(self, session: dict[str, Any]) -> None:
+        if not await self._session_actor_is_active(session):
+            actor_type = str(session.get("actor_type") or "").strip().lower()
+            if actor_type == "external_collaborator":
+                raise RuntimeError("revoked shared actor cannot receive preview grants")
+            raise RuntimeError("inactive session actor cannot receive preview grants")
+
+    async def _session_actor_is_active(self, session: dict[str, Any]) -> bool:
+        actor_type = str(session.get("actor_type") or "").strip().lower()
+        if actor_type != "external_collaborator":
+            return True
+
+        shared_actor_id = session.get("actor_shared_actor_id")
+        actor = await self._repo.get_shared_actor(str(shared_actor_id or ""))
+        if not actor:
+            return False
+        if actor.get("is_revoked"):
+            return False
+        expires_at = _normalize_iso8601(actor.get("expires_at"))
+        if expires_at and expires_at <= _utc_now():
+            return False
+        return True
+
+    async def _resolve_runtime_policy_profile(
+        self,
+        *,
+        workspace: dict[str, Any],
+        session: dict[str, Any],
+        explicit_profile: str | None,
+    ) -> str:
+        if explicit_profile:
+            return str(explicit_profile)
+
+        actor_type = str(session.get("actor_type") or "").strip().lower()
+        if actor_type == "external_collaborator":
+            actor = await self._repo.get_shared_actor(str(session.get("actor_shared_actor_id") or ""))
+            if actor and actor.get("runtime_policy_profile"):
+                return str(actor["runtime_policy_profile"])
+
+        runtime_policy = workspace.get("runtime_policy") or {}
+        if actor_type == "owner":
+            return str(runtime_policy.get("owner_profile") or "owner_collab")
+        if actor_type == "internal_collaborator":
+            return str(runtime_policy.get("internal_collaborator_profile") or "internal_collab")
+        return str(runtime_policy.get("external_collaborator_profile") or "locked_collab")
+
+    def _mint_grant_token(self, *, preview_handle: str, actor_key: str) -> tuple[str, int]:
+        exp = int(time.time()) + self._grant_ttl_seconds
+        token = self._build_signature(
+            preview_handle=preview_handle,
+            actor_key=actor_key,
+            exp=exp,
+        )
+        return token, exp
+
+    def _build_signature(self, *, preview_handle: str, actor_key: str, exp: int) -> str:
+        msg = f"{preview_handle}:{actor_key}:{int(exp)}".encode("utf-8")
+        return hmac.new(
+            self._signing_secret.encode("utf-8"),
+            msg,
+            hashlib.sha256,
+        ).hexdigest()
+
+    @classmethod
+    def _revoke_scope_locked(cls, *, scope_id: str, revoked_at: str) -> None:
+        existing_handle = cls._active_scope_handles.get(scope_id)
+        if not existing_handle:
+            return
+        record = cls._records.get(existing_handle)
+        if not record:
+            cls._active_scope_handles.pop(scope_id, None)
+            return
+        record.is_active = False
+        record.revoked_at = revoked_at
+        cls._active_scope_handles.pop(scope_id, None)
+
+    @staticmethod
+    def _record_to_dict(record: PrototypePreviewHandleRecord) -> dict[str, Any]:
+        return {
+            "preview_handle": record.handle_id,
+            "preview_scope": record.preview_scope.value,
+            "scope_id": record.scope_id,
+            "prototype_workspace_id": record.prototype_workspace_id,
+            "prototype_session_id": record.prototype_session_id,
+            "actor_key": record.actor_key,
+            "target_ref": record.target_ref,
+            "runtime_policy_profile": record.runtime_policy_profile,
+            "metadata": dict(record.metadata),
+            "is_active": bool(record.is_active),
+            "created_at": record.created_at,
+            "revoked_at": record.revoked_at,
+        }

--- a/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
-import secrets
 import threading
 import time
 import uuid
@@ -14,6 +13,7 @@ from typing import Any, ClassVar
 from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
     PrototypeWorkspacesRepo,
 )
+from tldw_Server_API.app.core.AuthNZ.settings import get_settings
 
 from .models import (
     PrototypePreviewHandleRecord,
@@ -22,8 +22,6 @@ from .models import (
     actor_key_for_session,
     preview_scope_id,
 )
-
-_FALLBACK_SIGNING_SECRET = secrets.token_urlsafe(32)
 
 
 def _utc_now() -> datetime:
@@ -40,6 +38,26 @@ def _normalize_iso8601(value: Any) -> datetime | None:
     except (TypeError, ValueError):
         return None
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _resolve_stable_signing_secret(signing_secret: str | None) -> str:
+    settings = get_settings()
+    candidates = (
+        signing_secret,
+        os.getenv("PROTOTYPE_PREVIEW_SIGNING_SECRET"),
+        getattr(settings, "JWT_SECRET_KEY", None),
+        getattr(settings, "SINGLE_USER_API_KEY", None),
+        os.getenv("JWT_SECRET_KEY"),
+        os.getenv("SINGLE_USER_API_KEY"),
+    )
+    for candidate in candidates:
+        value = str(candidate or "").strip()
+        if value:
+            return value
+    raise RuntimeError(
+        "Prototype preview grants require a stable signing secret; set "
+        "PROTOTYPE_PREVIEW_SIGNING_SECRET, JWT_SECRET_KEY, or SINGLE_USER_API_KEY"
+    )
 
 
 class PrototypePreviewBroker:
@@ -60,13 +78,7 @@ class PrototypePreviewBroker:
         self._repo = repo
         self._base_preview_path = str(base_preview_path or "/api/v1/prototype-previews").rstrip("/")
         self._grant_ttl_seconds = max(int(grant_ttl_seconds), 30)
-        self._signing_secret = (
-            signing_secret
-            or os.getenv("PROTOTYPE_PREVIEW_SIGNING_SECRET")
-            or os.getenv("JWT_SECRET_KEY")
-            or os.getenv("SINGLE_USER_API_KEY")
-            or _FALLBACK_SIGNING_SECRET
-        )
+        self._signing_secret = _resolve_stable_signing_secret(signing_secret)
 
     async def issue_preview_grant(
         self,
@@ -335,9 +347,7 @@ class PrototypePreviewBroker:
         if actor.get("is_revoked"):
             return False
         expires_at = _normalize_iso8601(actor.get("expires_at"))
-        if expires_at and expires_at <= _utc_now():
-            return False
-        return True
+        return not (expires_at and expires_at <= _utc_now())
 
     async def _resolve_runtime_policy_profile(
         self,
@@ -372,9 +382,9 @@ class PrototypePreviewBroker:
         return token, exp
 
     def _build_signature(self, *, preview_handle: str, actor_key: str, exp: int) -> str:
-        msg = f"{preview_handle}:{actor_key}:{int(exp)}".encode("utf-8")
+        msg = f"{preview_handle}:{actor_key}:{int(exp)}".encode()
         return hmac.new(
-            self._signing_secret.encode("utf-8"),
+            self._signing_secret.encode(),
             msg,
             hashlib.sha256,
         ).hexdigest()

--- a/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/preview_broker.py
@@ -218,6 +218,36 @@ class PrototypePreviewBroker:
                 return None
             return self._record_to_dict(record)
 
+    async def renew_preview_grant(self, preview_handle: str) -> dict[str, Any]:
+        handle_id = str(preview_handle or "").strip()
+        if not handle_id:
+            raise RuntimeError("preview handle is required")
+
+        with self._lock:
+            record = self._records.get(handle_id)
+            if not record or not record.is_active:
+                raise RuntimeError("preview handle not found")
+            record_dict = self._record_to_dict(record)
+
+        if not await self._is_grant_still_authorized(record):
+            raise RuntimeError("preview handle is no longer authorized")
+
+        token, expires_at = self._mint_grant_token(
+            preview_handle=handle_id,
+            actor_key=str(record_dict["actor_key"]),
+        )
+        return {
+            "preview_handle": handle_id,
+            "preview_scope": record_dict["preview_scope"],
+            "prototype_workspace_id": record_dict["prototype_workspace_id"],
+            "prototype_session_id": record_dict["prototype_session_id"],
+            "snapshot_id": (record_dict.get("metadata") or {}).get("snapshot_id"),
+            "preview_url": f"{self._base_preview_path}/{handle_id}?exp={expires_at}&token={token}",
+            "expires_at": datetime.fromtimestamp(expires_at, timezone.utc).isoformat(),
+            "token": token,
+            "runtime_policy_profile": str(record_dict["runtime_policy_profile"]),
+        }
+
     async def validate_preview_grant(
         self,
         *,

--- a/tldw_Server_API/app/core/Prototype_Workspaces/service.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/service.py
@@ -59,6 +59,46 @@ class PrototypeWorkspaceService:
         self._preview_broker = preview_broker or PrototypePreviewBroker(repo=repo)
         self._publish_validator = publish_validator
 
+    async def create_workspace(
+        self,
+        *,
+        owner_user_id: int,
+        title: str,
+        creation_source: str,
+        description: str | None = None,
+        prompt: str | None = None,
+        preview_policy: dict[str, Any] | None = None,
+        share_policy: dict[str, Any] | None = None,
+        runtime_policy: dict[str, Any] | None = None,
+        designated_promoter_ids: list[int] | None = None,
+    ) -> dict[str, Any]:
+        workspace = await self._repo.create_workspace(
+            owner_user_id=int(owner_user_id),
+            title=title,
+            description=description,
+            creation_source=creation_source,
+            preview_policy=preview_policy,
+            share_policy=share_policy,
+            runtime_policy=runtime_policy,
+            designated_promoter_ids=designated_promoter_ids,
+        )
+        seed_snapshot = await self._repo.create_snapshot(
+            prototype_workspace_id=workspace["id"],
+            snapshot_id=f"psnap_{uuid.uuid4().hex}",
+            created_by_user_id=int(owner_user_id),
+            storage_ref="prototype://seed",
+            prompt_summary=prompt,
+            diff_summary={"creation_source": creation_source},
+        )
+        updated = await self._repo.update_workspace_state(
+            workspace["id"],
+            canonical_snapshot_id=seed_snapshot["snapshot_id"],
+            last_known_good_snapshot_id=seed_snapshot["snapshot_id"],
+            canonical_preview_status="uninitialized",
+            publish_validation_status="pending",
+        )
+        return updated or workspace
+
     async def create_or_reuse_branch_session(
         self,
         *,
@@ -142,6 +182,9 @@ class PrototypeWorkspaceService:
             runtime_policy_profile=runtime_policy_profile,
             metadata=metadata,
         )
+
+    async def renew_preview_grant(self, *, preview_handle: str) -> dict[str, Any]:
+        return await self._preview_broker.renew_preview_grant(preview_handle)
 
     async def save_session_snapshot(
         self,

--- a/tldw_Server_API/app/core/Prototype_Workspaces/service.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/service.py
@@ -1,0 +1,403 @@
+"""Orchestration service for prototype workspace runtime and promotion flows."""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+    PrototypeWorkspacesRepo,
+)
+
+from .models import (
+    PrototypePromotionResult,
+    PrototypeRuntimeStatus,
+)
+from .preview_broker import PrototypePreviewBroker
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _normalize_promoter_ids(raw: Any) -> set[int]:
+    if not isinstance(raw, list):
+        return set()
+    out: set[int] = set()
+    for item in raw:
+        try:
+            out.add(int(item))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+class PrototypeWorkspaceService:
+    """Coordinate branch sessions, snapshots, previews, and promotions."""
+
+    def __init__(
+        self,
+        *,
+        repo: PrototypeWorkspacesRepo,
+        preview_broker: PrototypePreviewBroker | None = None,
+        publish_validator: Any | None = None,
+    ) -> None:
+        self._repo = repo
+        self._preview_broker = preview_broker or PrototypePreviewBroker(repo=repo)
+        self._publish_validator = publish_validator
+
+    async def create_or_reuse_branch_session(
+        self,
+        *,
+        prototype_workspace_id: str,
+        actor_type: str,
+        actor_user_id: int | None = None,
+        actor_shared_actor_id: str | None = None,
+        request_nonce: str | None = None,
+        share_link_id: int | None = None,
+        expires_at: str | None = None,
+        base_snapshot_id: str | None = None,
+    ) -> dict[str, Any]:
+        workspace = await self._repo.get_workspace(prototype_workspace_id)
+        if not workspace:
+            raise ValueError("prototype workspace not found")
+
+        resolved_base_snapshot_id = str(
+            base_snapshot_id
+            or workspace.get("canonical_snapshot_id")
+            or workspace.get("last_known_good_snapshot_id")
+            or ""
+        ).strip()
+        if not resolved_base_snapshot_id:
+            raise ValueError("prototype workspace does not have a canonical snapshot")
+        await self._assert_branch_actor_active(
+            actor_type=actor_type,
+            actor_shared_actor_id=actor_shared_actor_id,
+        )
+
+        existing = await self._repo.find_active_session(
+            prototype_workspace_id=prototype_workspace_id,
+            base_snapshot_id=resolved_base_snapshot_id,
+            actor_type=actor_type,
+            actor_user_id=actor_user_id,
+            actor_shared_actor_id=actor_shared_actor_id,
+        )
+        if existing:
+            return {
+                "created": False,
+                "request_nonce": request_nonce,
+                "session": existing,
+            }
+
+        session = await self._repo.create_session(
+            prototype_workspace_id=prototype_workspace_id,
+            base_snapshot_id=resolved_base_snapshot_id,
+            actor_type=actor_type,
+            actor_user_id=actor_user_id,
+            actor_shared_actor_id=actor_shared_actor_id,
+            share_link_id=share_link_id,
+            expires_at=expires_at,
+        )
+        updated = await self._repo.update_session_state(
+            session["id"],
+            runtime_status=PrototypeRuntimeStatus.QUEUED.value,
+            last_activity_at=_utc_now(),
+        )
+        return {
+            "created": True,
+            "request_nonce": request_nonce,
+            "session": updated or session,
+        }
+
+    async def boot_preview(
+        self,
+        *,
+        prototype_workspace_id: str,
+        snapshot_id: str,
+        runtime_target_url: str,
+        prototype_session_id: str | None = None,
+        runtime_policy_profile: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await self._preview_broker.issue_preview_grant(
+            prototype_workspace_id=prototype_workspace_id,
+            prototype_session_id=prototype_session_id,
+            snapshot_id=snapshot_id,
+            runtime_target_url=runtime_target_url,
+            runtime_policy_profile=runtime_policy_profile,
+            metadata=metadata,
+        )
+
+    async def save_session_snapshot(
+        self,
+        *,
+        prototype_session_id: str,
+        snapshot_id: str | None = None,
+        storage_ref: str | None = None,
+        diff_summary: dict[str, Any] | None = None,
+        prompt_summary: str | None = None,
+        preview_health: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        session = await self._repo.get_session(prototype_session_id)
+        if not session:
+            raise ValueError("prototype session not found")
+        await self._assert_session_is_active(session)
+
+        new_snapshot_id = str(snapshot_id or f"psnap_{uuid.uuid4().hex}")
+        snapshot = await self._repo.create_snapshot(
+            prototype_workspace_id=str(session["prototype_workspace_id"]),
+            snapshot_id=new_snapshot_id,
+            created_by_user_id=session.get("actor_user_id"),
+            created_by_shared_actor_id=session.get("actor_shared_actor_id"),
+            parent_snapshot_id=str(
+                session.get("last_saved_snapshot_id")
+                or session.get("base_snapshot_id")
+                or ""
+            ).strip()
+            or None,
+            created_from_session_id=prototype_session_id,
+            storage_ref=storage_ref,
+            diff_summary=diff_summary,
+            prompt_summary=prompt_summary,
+            preview_health=preview_health,
+        )
+        await self._repo.update_session_state(
+            prototype_session_id,
+            last_saved_snapshot_id=snapshot["snapshot_id"],
+            last_activity_at=_utc_now(),
+        )
+        return snapshot
+
+    async def promote_candidate(
+        self,
+        *,
+        prototype_workspace_id: str,
+        candidate_snapshot_id: str,
+        reviewer_user_id: int,
+        review_baseline_snapshot_id: str | None = None,
+        promotion_request_id: str | None = None,
+        review_notes: str | None = None,
+    ) -> dict[str, Any]:
+        workspace = await self._repo.get_workspace(prototype_workspace_id)
+        if not workspace:
+            raise ValueError("prototype workspace not found")
+
+        reviewer_id = int(reviewer_user_id)
+        if not self._is_promoter(workspace, reviewer_id):
+            raise PermissionError("reviewer does not have prototype.promote permission")
+
+        candidate = await self._repo.get_snapshot(candidate_snapshot_id)
+        if not candidate or candidate.get("prototype_workspace_id") != prototype_workspace_id:
+            raise ValueError("candidate snapshot not found in prototype workspace")
+
+        promotion_request = None
+        if promotion_request_id:
+            promotion_request = await self._repo.get_promotion_request(promotion_request_id)
+            if not promotion_request:
+                raise ValueError("promotion request not found")
+            if promotion_request.get("prototype_workspace_id") != prototype_workspace_id:
+                raise ValueError("promotion request does not belong to prototype workspace")
+            if promotion_request.get("candidate_snapshot_id") != candidate_snapshot_id:
+                raise ValueError("promotion request candidate does not match requested candidate")
+
+        canonical_snapshot_id = str(workspace.get("canonical_snapshot_id") or "").strip()
+        resolved_review_baseline_snapshot_id = str(
+            review_baseline_snapshot_id
+            or workspace.get("last_known_good_snapshot_id")
+            or canonical_snapshot_id
+            or ""
+        ).strip()
+
+        stale_result = await self._detect_stale_candidate(
+            candidate=candidate,
+            review_baseline_snapshot_id=resolved_review_baseline_snapshot_id,
+        )
+        if stale_result:
+            if promotion_request:
+                await self._repo.update_promotion_request(
+                    promotion_request["id"],
+                    status="stale",
+                    reviewed_by_user_id=reviewer_id,
+                    review_notes=review_notes or "Candidate is stale against the canonical snapshot",
+                )
+            return PrototypePromotionResult(
+                status="stale",
+                failure_code="stale_candidate",
+                prototype_workspace_id=prototype_workspace_id,
+                candidate_snapshot_id=candidate_snapshot_id,
+                canonical_snapshot_id=canonical_snapshot_id or None,
+            ).to_dict()
+
+        validation = await self._run_publish_validator(
+            workspace=workspace,
+            candidate=candidate,
+            reviewer_user_id=reviewer_id,
+            canonical_snapshot_id=canonical_snapshot_id or None,
+            review_baseline_snapshot_id=resolved_review_baseline_snapshot_id or None,
+            promotion_request=promotion_request,
+        )
+        validation_ok = bool(validation.get("ok"))
+        if not validation_ok:
+            failure_reason = str(
+                validation.get("reason")
+                or validation.get("failure_code")
+                or "publish validation failed"
+            )
+            await self._repo.update_workspace_state(
+                prototype_workspace_id,
+                publish_validation_status="failed",
+            )
+            if promotion_request:
+                await self._repo.update_promotion_request(
+                    promotion_request["id"],
+                    status="rejected",
+                    reviewed_by_user_id=reviewer_id,
+                    review_notes=review_notes or failure_reason,
+                )
+            return PrototypePromotionResult(
+                status="failed",
+                failure_code="publish_validation_failed",
+                prototype_workspace_id=prototype_workspace_id,
+                candidate_snapshot_id=candidate_snapshot_id,
+                canonical_snapshot_id=canonical_snapshot_id or None,
+                details={"reason": failure_reason},
+            ).to_dict()
+
+        preview_grant = await self._preview_broker.issue_preview_grant(
+            prototype_workspace_id=prototype_workspace_id,
+            snapshot_id=candidate_snapshot_id,
+            runtime_target_url=str(
+                validation.get("runtime_target_url")
+                or f"runtime://canonical/{prototype_workspace_id}/{candidate_snapshot_id}"
+            ),
+            metadata={
+                "candidate_snapshot_id": candidate_snapshot_id,
+                "validation_mode": "publish",
+            },
+        )
+        updated_workspace = await self._repo.update_workspace_state(
+            prototype_workspace_id,
+            canonical_snapshot_id=candidate_snapshot_id,
+            last_known_good_snapshot_id=candidate_snapshot_id,
+            canonical_preview_status="ready",
+            publish_validation_status="validated",
+        )
+        if not updated_workspace or updated_workspace.get("canonical_snapshot_id") != candidate_snapshot_id:
+            await self._preview_broker.revoke_preview_handle(preview_grant["preview_handle"])
+            raise RuntimeError("failed to persist canonical workspace update")
+        if promotion_request:
+            await self._repo.update_promotion_request(
+                promotion_request["id"],
+                status="promoted",
+                reviewed_by_user_id=reviewer_id,
+                review_notes=review_notes,
+            )
+
+        return PrototypePromotionResult(
+            status="promoted",
+            prototype_workspace_id=prototype_workspace_id,
+            candidate_snapshot_id=candidate_snapshot_id,
+            canonical_snapshot_id=candidate_snapshot_id,
+            preview_handle=preview_grant["preview_handle"],
+            details={"preview_url": preview_grant["preview_url"]},
+        ).to_dict()
+
+    async def _detect_stale_candidate(
+        self,
+        *,
+        candidate: dict[str, Any],
+        review_baseline_snapshot_id: str,
+    ) -> bool:
+        if not review_baseline_snapshot_id:
+            return False
+
+        session_id = str(candidate.get("created_from_session_id") or "").strip()
+        if session_id:
+            session = await self._repo.get_session(session_id)
+            if not session:
+                return True
+            return str(session.get("base_snapshot_id") or "").strip() != review_baseline_snapshot_id
+
+        parent_snapshot_id = str(candidate.get("parent_snapshot_id") or "").strip()
+        if parent_snapshot_id:
+            return parent_snapshot_id != review_baseline_snapshot_id
+        return False
+
+    async def _run_publish_validator(self, **kwargs: Any) -> dict[str, Any]:
+        validator = self._publish_validator
+        if validator is None:
+            return {"ok": True}
+
+        candidate = None
+        if hasattr(validator, "validate_publish_candidate"):
+            candidate = validator.validate_publish_candidate(**kwargs)
+        elif hasattr(validator, "validate"):
+            candidate = validator.validate(**kwargs)
+        elif callable(validator):
+            candidate = validator(**kwargs)
+        else:
+            return {"ok": False, "reason": "publish validator is not callable"}
+
+        if inspect.isawaitable(candidate):
+            candidate = await candidate
+
+        if isinstance(candidate, bool):
+            return {"ok": bool(candidate)}
+        if isinstance(candidate, dict):
+            return dict(candidate)
+        return {"ok": bool(candidate)}
+
+    @staticmethod
+    def _is_promoter(workspace: dict[str, Any], reviewer_user_id: int) -> bool:
+        owner_user_id = int(workspace.get("owner_user_id"))
+        if reviewer_user_id == owner_user_id:
+            return True
+        return reviewer_user_id in _normalize_promoter_ids(workspace.get("designated_promoter_ids"))
+
+    async def _assert_branch_actor_active(
+        self,
+        *,
+        actor_type: str,
+        actor_shared_actor_id: str | None,
+    ) -> None:
+        if str(actor_type or "").strip().lower() != "external_collaborator":
+            return
+        actor = await self._repo.get_shared_actor(str(actor_shared_actor_id or ""))
+        if not actor or actor.get("is_revoked"):
+            raise RuntimeError("revoked shared actor cannot create or reuse branch sessions")
+        expires_at = _normalize_datetime(actor.get("expires_at"))
+        if expires_at and expires_at <= datetime.now(timezone.utc):
+            raise RuntimeError("expired shared actor cannot create or reuse branch sessions")
+
+    async def _assert_session_is_active(self, session: dict[str, Any]) -> None:
+        if session.get("is_revoked"):
+            raise RuntimeError("revoked session cannot save snapshots")
+        expires_at = _normalize_datetime(session.get("expires_at"))
+        if expires_at and expires_at <= datetime.now(timezone.utc):
+            raise RuntimeError("expired session cannot save snapshots")
+        actor_type = str(session.get("actor_type") or "").strip().lower()
+        if actor_type != "external_collaborator":
+            return
+        actor = await self._repo.get_shared_actor(str(session.get("actor_shared_actor_id") or ""))
+        if not actor or actor.get("is_revoked"):
+            raise RuntimeError("revoked shared actor cannot save snapshots")
+        actor_expires_at = _normalize_datetime(actor.get("expires_at"))
+        if actor_expires_at and actor_expires_at <= datetime.now(timezone.utc):
+            raise RuntimeError("expired shared actor cannot save snapshots")
+
+
+class PrototypePromotionService(PrototypeWorkspaceService):
+    """Compatibility alias for tests and future focused promotion entrypoints."""

--- a/tldw_Server_API/app/core/Prototype_Workspaces/service.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/service.py
@@ -74,6 +74,8 @@ class PrototypeWorkspaceService:
         workspace = await self._repo.get_workspace(prototype_workspace_id)
         if not workspace:
             raise ValueError("prototype workspace not found")
+        if workspace.get("is_archived"):
+            raise RuntimeError("archived workspaces cannot create branch sessions")
 
         resolved_base_snapshot_id = str(
             base_snapshot_id
@@ -154,6 +156,11 @@ class PrototypeWorkspaceService:
         session = await self._repo.get_session(prototype_session_id)
         if not session:
             raise ValueError("prototype session not found")
+        workspace = await self._repo.get_workspace(str(session["prototype_workspace_id"]))
+        if not workspace:
+            raise ValueError("prototype workspace not found")
+        if workspace.get("is_archived"):
+            raise RuntimeError("archived workspaces cannot save snapshots")
         await self._assert_session_is_active(session)
 
         new_snapshot_id = str(snapshot_id or f"psnap_{uuid.uuid4().hex}")

--- a/tldw_Server_API/app/core/Prototype_Workspaces/service.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/service.py
@@ -82,22 +82,28 @@ class PrototypeWorkspaceService:
             runtime_policy=runtime_policy,
             designated_promoter_ids=designated_promoter_ids,
         )
-        seed_snapshot = await self._repo.create_snapshot(
-            prototype_workspace_id=workspace["id"],
-            snapshot_id=f"psnap_{uuid.uuid4().hex}",
-            created_by_user_id=int(owner_user_id),
-            storage_ref="prototype://seed",
-            prompt_summary=prompt,
-            diff_summary={"creation_source": creation_source},
-        )
-        updated = await self._repo.update_workspace_state(
-            workspace["id"],
-            canonical_snapshot_id=seed_snapshot["snapshot_id"],
-            last_known_good_snapshot_id=seed_snapshot["snapshot_id"],
-            canonical_preview_status="uninitialized",
-            publish_validation_status="pending",
-        )
-        return updated or workspace
+        try:
+            seed_snapshot = await self._repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id=f"psnap_{uuid.uuid4().hex}",
+                created_by_user_id=int(owner_user_id),
+                storage_ref="prototype://seed",
+                prompt_summary=prompt,
+                diff_summary={"creation_source": creation_source},
+            )
+            updated = await self._repo.update_workspace_state(
+                workspace["id"],
+                canonical_snapshot_id=seed_snapshot["snapshot_id"],
+                last_known_good_snapshot_id=seed_snapshot["snapshot_id"],
+                canonical_preview_status="uninitialized",
+                publish_validation_status="pending",
+            )
+            if not updated or updated.get("canonical_snapshot_id") != seed_snapshot["snapshot_id"]:
+                raise RuntimeError("failed to persist prototype workspace seed snapshot")
+            return updated
+        except Exception:
+            await self._repo.archive_workspace(workspace["id"])
+            raise
 
     async def create_or_reuse_branch_session(
         self,
@@ -224,11 +230,17 @@ class PrototypeWorkspaceService:
             prompt_summary=prompt_summary,
             preview_health=preview_health,
         )
-        await self._repo.update_session_state(
-            prototype_session_id,
-            last_saved_snapshot_id=snapshot["snapshot_id"],
-            last_activity_at=_utc_now(),
-        )
+        try:
+            updated_session = await self._repo.update_session_state(
+                prototype_session_id,
+                last_saved_snapshot_id=snapshot["snapshot_id"],
+                last_activity_at=_utc_now(),
+            )
+            if not updated_session or updated_session.get("last_saved_snapshot_id") != snapshot["snapshot_id"]:
+                raise RuntimeError("failed to persist session snapshot state")
+        except Exception:
+            await self._repo.delete_snapshot(snapshot["snapshot_id"])
+            raise
         return snapshot
 
     async def promote_candidate(
@@ -326,6 +338,12 @@ class PrototypeWorkspaceService:
                 details={"reason": failure_reason},
             ).to_dict()
 
+        previous_workspace_state = {
+            "canonical_snapshot_id": workspace.get("canonical_snapshot_id"),
+            "last_known_good_snapshot_id": workspace.get("last_known_good_snapshot_id"),
+            "canonical_preview_status": workspace.get("canonical_preview_status"),
+            "publish_validation_status": workspace.get("publish_validation_status"),
+        }
         preview_grant = await self._preview_broker.issue_preview_grant(
             prototype_workspace_id=prototype_workspace_id,
             snapshot_id=candidate_snapshot_id,
@@ -338,23 +356,35 @@ class PrototypeWorkspaceService:
                 "validation_mode": "publish",
             },
         )
-        updated_workspace = await self._repo.update_workspace_state(
-            prototype_workspace_id,
-            canonical_snapshot_id=candidate_snapshot_id,
-            last_known_good_snapshot_id=candidate_snapshot_id,
-            canonical_preview_status="ready",
-            publish_validation_status="validated",
-        )
-        if not updated_workspace or updated_workspace.get("canonical_snapshot_id") != candidate_snapshot_id:
-            await self._preview_broker.revoke_preview_handle(preview_grant["preview_handle"])
-            raise RuntimeError("failed to persist canonical workspace update")
-        if promotion_request:
-            await self._repo.update_promotion_request(
-                promotion_request["id"],
-                status="promoted",
-                reviewed_by_user_id=reviewer_id,
-                review_notes=review_notes,
+        try:
+            updated_workspace = await self._repo.update_workspace_state(
+                prototype_workspace_id,
+                canonical_snapshot_id=candidate_snapshot_id,
+                last_known_good_snapshot_id=candidate_snapshot_id,
+                canonical_preview_status="ready",
+                publish_validation_status="validated",
             )
+            if not updated_workspace or updated_workspace.get("canonical_snapshot_id") != candidate_snapshot_id:
+                raise RuntimeError("failed to persist canonical workspace update")
+            if promotion_request:
+                updated_request = await self._repo.update_promotion_request(
+                    promotion_request["id"],
+                    status="promoted",
+                    reviewed_by_user_id=reviewer_id,
+                    review_notes=review_notes,
+                )
+                if not updated_request or updated_request.get("status") != "promoted":
+                    raise RuntimeError("failed to persist promotion request update")
+        except Exception:
+            await self._preview_broker.revoke_preview_handle(preview_grant["preview_handle"])
+            await self._repo.update_workspace_state(
+                prototype_workspace_id,
+                canonical_snapshot_id=previous_workspace_state["canonical_snapshot_id"],
+                last_known_good_snapshot_id=previous_workspace_state["last_known_good_snapshot_id"],
+                canonical_preview_status=previous_workspace_state["canonical_preview_status"],
+                publish_validation_status=previous_workspace_state["publish_validation_status"],
+            )
+            raise
 
         return PrototypePromotionResult(
             status="promoted",

--- a/tldw_Server_API/app/core/Prototype_Workspaces/service.py
+++ b/tldw_Server_API/app/core/Prototype_Workspaces/service.py
@@ -426,14 +426,14 @@ class PrototypeWorkspaceService:
         if str(actor_type or "").strip().lower() != "external_collaborator":
             return
         actor = await self._repo.get_shared_actor(str(actor_shared_actor_id or ""))
-        if not actor or actor.get("is_revoked"):
+        if not actor or actor.get("is_revoked") or actor.get("revoked_at"):
             raise RuntimeError("revoked shared actor cannot create or reuse branch sessions")
         expires_at = _normalize_datetime(actor.get("expires_at"))
         if expires_at and expires_at <= datetime.now(timezone.utc):
             raise RuntimeError("expired shared actor cannot create or reuse branch sessions")
 
     async def _assert_session_is_active(self, session: dict[str, Any]) -> None:
-        if session.get("is_revoked"):
+        if session.get("is_revoked") or session.get("revoked_at"):
             raise RuntimeError("revoked session cannot save snapshots")
         expires_at = _normalize_datetime(session.get("expires_at"))
         if expires_at and expires_at <= datetime.now(timezone.utc):
@@ -442,7 +442,7 @@ class PrototypeWorkspaceService:
         if actor_type != "external_collaborator":
             return
         actor = await self._repo.get_shared_actor(str(session.get("actor_shared_actor_id") or ""))
-        if not actor or actor.get("is_revoked"):
+        if not actor or actor.get("is_revoked") or actor.get("revoked_at"):
             raise RuntimeError("revoked shared actor cannot save snapshots")
         actor_expires_at = _normalize_datetime(actor.get("expires_at"))
         if actor_expires_at and actor_expires_at <= datetime.now(timezone.utc):

--- a/tldw_Server_API/app/core/Sharing/share_token_service.py
+++ b/tldw_Server_API/app/core/Sharing/share_token_service.py
@@ -15,6 +15,11 @@ from tldw_Server_API.app.core.AuthNZ.repos.shared_workspace_repo import SharedWo
 class ShareTokenService:
     """Manages token-based sharing links with expiry, password, and use limits."""
 
+    _PROTOTYPE_RESOURCE_TYPE = "prototype_workspace"
+    _PROTOTYPE_RESOURCE_ALIASES = {"prototype_workspace", "prototype"}
+    _PROTOTYPE_STORAGE_PREFIX = "prototype_workspace::"
+    _SUPPORTED_RESOURCE_TYPES = {"chatbook", "workspace", "prototype_workspace"}
+
     def __init__(self, repo: SharedWorkspaceRepo) -> None:
         self._repo = repo
 
@@ -30,6 +35,10 @@ class ShareTokenService:
         max_uses: int | None = None,
         expires_at: str | None = None,
     ) -> dict[str, Any]:
+        normalized_resource_type, normalized_resource_id = self._normalize_resource_identity_for_write(
+            resource_type=resource_type,
+            resource_id=resource_id,
+        )
         raw_token = secrets.token_urlsafe(32)
         token_hash = hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
         token_prefix = raw_token[:8]
@@ -44,8 +53,8 @@ class ShareTokenService:
         record = await self._repo.create_token(
             token_hash=token_hash,
             token_prefix=token_prefix,
-            resource_type=resource_type,
-            resource_id=resource_id,
+            resource_type=normalized_resource_type,
+            resource_id=normalized_resource_id,
             owner_user_id=owner_user_id,
             access_level=access_level,
             allow_clone=allow_clone,
@@ -55,10 +64,43 @@ class ShareTokenService:
         )
 
         # Return raw token only once — never stored server-side
+        record = self._hydrate_legacy_resource_identity(record)
         record["raw_token"] = raw_token
         return record
 
-    async def validate_token(self, raw_token: str) -> dict[str, Any] | None:
+    def _normalize_resource_identity_for_write(self, *, resource_type: str, resource_id: str) -> tuple[str, str]:
+        normalized_type = str(resource_type or "").strip().lower()
+        normalized_id = str(resource_id or "").strip()
+        if not normalized_type or not normalized_id:
+            raise ValueError("resource_type and resource_id are required")
+        if normalized_type in self._PROTOTYPE_RESOURCE_ALIASES:
+            normalized_type = self._PROTOTYPE_RESOURCE_TYPE
+        if normalized_type not in self._SUPPORTED_RESOURCE_TYPES:
+            raise ValueError(f"Unsupported resource_type: {resource_type}")
+        if (
+            normalized_type == self._PROTOTYPE_RESOURCE_TYPE
+            and normalized_id.startswith(self._PROTOTYPE_STORAGE_PREFIX)
+        ):
+            normalized_id = normalized_id[len(self._PROTOTYPE_STORAGE_PREFIX):]
+        if not normalized_id:
+            raise ValueError("resource_id is required")
+        return normalized_type, normalized_id
+
+    def _hydrate_legacy_resource_identity(self, record: dict[str, Any]) -> dict[str, Any]:
+        hydrated = dict(record)
+        stored_type = str(hydrated.get("resource_type") or "").strip().lower()
+        stored_id = str(hydrated.get("resource_id") or "").strip()
+        if stored_type == "workspace" and stored_id.startswith(self._PROTOTYPE_STORAGE_PREFIX):
+            hydrated["resource_type"] = self._PROTOTYPE_RESOURCE_TYPE
+            hydrated["resource_id"] = stored_id[len(self._PROTOTYPE_STORAGE_PREFIX):]
+        return hydrated
+
+    async def validate_token(
+        self,
+        raw_token: str,
+        *,
+        allow_exhausted: bool = False,
+    ) -> dict[str, Any] | None:
         prefix = raw_token[:8]
         token_hash = hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
 
@@ -92,10 +134,15 @@ class ShareTokenService:
 
             # Check use count
             max_uses = candidate.get("max_uses")
+            candidate_with_state = dict(candidate)
             if max_uses is not None and candidate.get("use_count", 0) >= max_uses:
-                return None
+                if not allow_exhausted:
+                    return None
+                candidate_with_state["is_use_exhausted"] = True
+            else:
+                candidate_with_state["is_use_exhausted"] = False
 
-            return candidate
+            return self._hydrate_legacy_resource_identity(candidate_with_state)
 
         return None
 
@@ -111,20 +158,48 @@ class ShareTokenService:
     async def use_token(self, token_id: int) -> None:
         await self._repo.increment_token_use_count(token_id)
 
+    async def claim_token_use(self, token_id: int) -> bool:
+        return await self._repo.claim_token_use(token_id)
+
+    async def release_token_use(self, token_id: int) -> None:
+        await self._repo.release_token_use(token_id)
+
     async def revoke_token(self, token_id: int) -> bool:
         return await self._repo.revoke_token(token_id)
 
     async def list_tokens(self, owner_user_id: int) -> list[dict[str, Any]]:
         tokens = await self._repo.list_tokens_for_user(owner_user_id)
         # Strip sensitive fields
-        for t in tokens:
+        for idx, t in enumerate(tokens):
             t.pop("token_hash", None)
             t.pop("password_hash", None)
+            tokens[idx] = self._hydrate_legacy_resource_identity(t)
         return tokens
 
     async def revoke_tokens_for_resource(
         self, resource_type: str, resource_id: str, owner_user_id: int
     ) -> int:
-        return await self._repo.revoke_tokens_for_resource(
-            resource_type, resource_id, owner_user_id
+        normalized_resource_type, normalized_resource_id = self._normalize_resource_identity_for_write(
+            resource_type=resource_type,
+            resource_id=resource_id,
         )
+        revoked = await self._repo.revoke_tokens_for_resource(
+            normalized_resource_type,
+            normalized_resource_id,
+            owner_user_id,
+        )
+        if normalized_resource_type == self._PROTOTYPE_RESOURCE_TYPE:
+            revoked += await self._repo.revoke_tokens_for_resource(
+                "workspace",
+                f"{self._PROTOTYPE_STORAGE_PREFIX}{normalized_resource_id}",
+                owner_user_id,
+            )
+        return revoked
+
+    def get_prototype_workspace_id(self, token_record: dict[str, Any]) -> str | None:
+        normalized = self._hydrate_legacy_resource_identity(token_record)
+        resource_type = str(normalized.get("resource_type") or "").strip().lower()
+        resource_id = str(normalized.get("resource_id") or "").strip()
+        if resource_type == self._PROTOTYPE_RESOURCE_TYPE and resource_id:
+            return resource_id
+        return None

--- a/tldw_Server_API/tests/PrototypeWorkspaces/conftest.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/conftest.py
@@ -1,0 +1,71 @@
+"""Shared fixtures for PrototypeWorkspaces repository tests."""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.migrations import (
+    migration_001_create_users_table,
+    migration_086_create_prototype_workspace_tables,
+)
+
+
+class _FakePool:
+    """Minimal DatabasePool stand-in backed by an in-memory SQLite connection."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    async def execute(self, sql: str, params: tuple = ()) -> None:
+        self._conn.execute(sql, params)
+        self._conn.commit()
+
+    async def fetchone(self, sql: str, params: tuple = ()) -> dict | None:
+        cur = self._conn.execute(sql, params)
+        row = cur.fetchone()
+        if row is None:
+            return None
+        cols = [d[0] for d in cur.description]
+        return dict(zip(cols, row, strict=True))
+
+    async def fetchall(self, sql: str, params: tuple = ()) -> list[dict]:
+        cur = self._conn.execute(sql, params)
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, row, strict=True)) for row in rows]
+
+
+@pytest.fixture
+def prototype_db():
+    """In-memory SQLite database with users + prototype metadata tables."""
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    migration_001_create_users_table(conn)
+    conn.execute(
+        "INSERT INTO users (id, username, email, password_hash) VALUES (1, 'owner', 'owner@test.com', 'hash')"
+    )
+    conn.execute(
+        "INSERT INTO users (id, username, email, password_hash) VALUES (2, 'collab', 'collab@test.com', 'hash')"
+    )
+    conn.commit()
+    migration_086_create_prototype_workspace_tables(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def fake_pool(prototype_db):
+    """FakePool wrapping the in-memory prototype DB."""
+    return _FakePool(prototype_db)
+
+
+@pytest.fixture
+def repo(fake_pool):
+    """PrototypeWorkspacesRepo using the fake pool."""
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    return PrototypeWorkspacesRepo(db_pool=fake_pool)

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
@@ -107,6 +107,38 @@ async def test_preview_broker_keeps_one_active_target_per_scope(repo, prototype_
 
 
 @pytest.mark.asyncio
+async def test_preview_broker_recovers_preview_record_after_memory_clear(repo, prototype_db, preview_broker):
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.preview_broker")
+    broker_cls = _load_attr(module, "PrototypePreviewBroker", "PrototypeWorkspacePreviewBroker")
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+    grant = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9018",
+    )
+    parsed = urlparse(grant["preview_url"])
+    query = parse_qs(parsed.query)
+    exp = int(query["exp"][0])
+
+    broker_cls._records.clear()
+    broker_cls._active_scope_handles.clear()
+    recovered_broker = broker_cls(repo=repo)
+
+    renewed = await recovered_broker.renew_preview_grant(grant["preview_handle"])
+    validated = await recovered_broker.validate_preview_grant(
+        preview_handle=grant["preview_handle"],
+        token=grant["token"],
+        exp=exp,
+        actor_key=f"shared_actor:{session['actor_shared_actor_id']}",
+    )
+
+    assert renewed["preview_handle"] == grant["preview_handle"]
+    assert validated is not None
+    assert validated["preview_handle"] == grant["preview_handle"]
+
+
+@pytest.mark.asyncio
 async def test_revoked_shared_actor_blocks_future_preview_grants(repo, prototype_db, preview_broker):
     workspace, actor, session = await _seed_preview_scope(repo, prototype_db)
 
@@ -221,3 +253,64 @@ async def test_failed_preview_persistence_restores_previous_active_handle(
 
     assert restored is not None
     assert refreshed_session["preview_handle"] == first["preview_handle"]
+
+
+@pytest.mark.asyncio
+async def test_failed_preview_persistence_does_not_restore_previous_after_concurrent_active_change(
+    repo,
+    prototype_db,
+    preview_broker,
+    monkeypatch,
+):
+    models_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.models")
+    record_cls = _load_attr(models_module, "PrototypePreviewHandleRecord")
+    preview_scope = _load_attr(models_module, "PrototypePreviewScope")
+    preview_scope_id = _load_attr(models_module, "preview_scope_id")
+    broker_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.preview_broker")
+    broker_cls = _load_attr(broker_module, "PrototypePreviewBroker", "PrototypeWorkspacePreviewBroker")
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+    first = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9019",
+    )
+    scope_id = preview_scope_id(
+        preview_scope="session",
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+    )
+
+    async def fail_update(*_args: Any, **_kwargs: Any) -> None:
+        replacement = record_cls(
+            handle_id="pph_concurrent_active",
+            preview_scope=preview_scope.SESSION,
+            scope_id=scope_id,
+            prototype_workspace_id=workspace["id"],
+            prototype_session_id=session["id"],
+            actor_key=f"shared_actor:{session['actor_shared_actor_id']}",
+            target_ref="http://127.0.0.1:9020",
+            runtime_policy_profile="locked_collab",
+            metadata={"snapshot_id": "snap_preview_base"},
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        with broker_cls._lock:
+            previous = broker_cls._records[first["preview_handle"]]
+            previous.is_active = False
+            previous.revoked_at = "concurrent-revocation"
+            broker_cls._records[replacement.handle_id] = replacement
+            broker_cls._active_scope_handles[scope_id] = replacement.handle_id
+        return None
+
+    monkeypatch.setattr(repo, "update_session_state", fail_update)
+
+    with pytest.raises(RuntimeError, match="failed to persist preview handle"):
+        await preview_broker.issue_preview_grant(
+            prototype_workspace_id=workspace["id"],
+            prototype_session_id=session["id"],
+            snapshot_id="snap_preview_base",
+            runtime_target_url="http://127.0.0.1:9021",
+        )
+
+    assert broker_cls._active_scope_handles[scope_id] == "pph_concurrent_active"
+    assert broker_cls._records[first["preview_handle"]].is_active is False

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
@@ -1,0 +1,205 @@
+"""Task 4 coverage for brokered preview handles and revocation."""
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_attr(module: Any, *names: str) -> Any:
+    for name in names:
+        if hasattr(module, name):
+            return getattr(module, name)
+    raise AttributeError(f"Module {module.__name__} does not define any of: {', '.join(names)}")
+
+
+@pytest.fixture
+def preview_broker(repo):
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.preview_broker")
+    broker_cls = _load_attr(module, "PrototypePreviewBroker", "PrototypeWorkspacePreviewBroker")
+    return broker_cls(repo=repo)
+
+
+async def _seed_preview_scope(repo, prototype_db):
+    workspace = await repo.create_workspace(
+        owner_user_id=1,
+        title="Task 4 Preview",
+        creation_source="prompt",
+        runtime_policy={"external_collaborator_profile": "locked_collab"},
+        share_policy={"allow_browser_session_resume": True},
+    )
+    await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_preview_base",
+        created_by_user_id=1,
+    )
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=11,
+        display_name="Stakeholder A",
+        runtime_policy_profile="locked_collab",
+    )
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id="snap_preview_base",
+        actor_type="external_collaborator",
+        actor_shared_actor_id=actor["id"],
+    )
+    prototype_db.execute(
+        """
+        UPDATE prototype_workspaces
+        SET canonical_snapshot_id = ?, last_known_good_snapshot_id = ?, canonical_preview_status = ?, publish_validation_status = ?
+        WHERE id = ?
+        """,
+        ("snap_preview_base", "snap_preview_base", "ready", "validated", workspace["id"]),
+    )
+    prototype_db.commit()
+    return workspace, actor, session
+
+
+@pytest.mark.asyncio
+async def test_preview_broker_keeps_one_active_target_per_scope(repo, prototype_db, preview_broker):
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+
+    first = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+    )
+    second = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9012",
+    )
+
+    refreshed_session = await repo.get_session(session["id"])
+
+    assert first["preview_handle"] != second["preview_handle"]
+    assert not first["preview_handle"].startswith("http")
+    assert not second["preview_handle"].startswith("http")
+    assert refreshed_session["preview_handle"] == second["preview_handle"]
+    assert refreshed_session["preview_status"] != "uninitialized"
+
+
+@pytest.mark.asyncio
+async def test_revoked_shared_actor_blocks_future_preview_grants(repo, prototype_db, preview_broker):
+    workspace, actor, session = await _seed_preview_scope(repo, prototype_db)
+
+    await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9011",
+    )
+    prototype_db.execute(
+        "UPDATE prototype_shared_actors SET revoked_at = ? WHERE id = ?",
+        (datetime.now(timezone.utc).isoformat(), actor["id"]),
+    )
+    prototype_db.commit()
+
+    with pytest.raises(RuntimeError, match="revoked"):
+        await preview_broker.issue_preview_grant(
+            prototype_workspace_id=workspace["id"],
+            prototype_session_id=session["id"],
+            snapshot_id="snap_preview_base",
+            runtime_target_url="http://127.0.0.1:9013",
+        )
+
+
+@pytest.mark.asyncio
+async def test_expired_session_blocks_preview_grants(repo, prototype_db, preview_broker):
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+    prototype_db.execute(
+        "UPDATE prototype_sessions SET expires_at = ? WHERE id = ?",
+        ((datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(), session["id"]),
+    )
+    prototype_db.commit()
+
+    with pytest.raises(RuntimeError, match="expired"):
+        await preview_broker.issue_preview_grant(
+            prototype_workspace_id=workspace["id"],
+            prototype_session_id=session["id"],
+            snapshot_id="snap_preview_base",
+            runtime_target_url="http://127.0.0.1:9014",
+        )
+
+
+@pytest.mark.asyncio
+async def test_revoked_actor_invalidates_existing_preview_grant(repo, prototype_db, preview_broker):
+    workspace, actor, session = await _seed_preview_scope(repo, prototype_db)
+    grant = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9015",
+    )
+    parsed = urlparse(grant["preview_url"])
+    query = parse_qs(parsed.query)
+    exp = int(query["exp"][0])
+
+    prototype_db.execute(
+        "UPDATE prototype_shared_actors SET revoked_at = ? WHERE id = ?",
+        (datetime.now(timezone.utc).isoformat(), actor["id"]),
+    )
+    prototype_db.commit()
+
+    record = await preview_broker.validate_preview_grant(
+        preview_handle=grant["preview_handle"],
+        token=grant["token"],
+        exp=exp,
+        actor_key=f"shared_actor:{actor['id']}",
+    )
+
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_failed_preview_persistence_restores_previous_active_handle(
+    repo,
+    prototype_db,
+    preview_broker,
+    monkeypatch,
+):
+    workspace, _actor, session = await _seed_preview_scope(repo, prototype_db)
+    first = await preview_broker.issue_preview_grant(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id="snap_preview_base",
+        runtime_target_url="http://127.0.0.1:9016",
+    )
+    parsed = urlparse(first["preview_url"])
+    query = parse_qs(parsed.query)
+    exp = int(query["exp"][0])
+    original_update = repo.update_session_state
+
+    async def fail_update(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(repo, "update_session_state", fail_update)
+
+    with pytest.raises(RuntimeError, match="failed to persist preview handle"):
+        await preview_broker.issue_preview_grant(
+            prototype_workspace_id=workspace["id"],
+            prototype_session_id=session["id"],
+            snapshot_id="snap_preview_base",
+            runtime_target_url="http://127.0.0.1:9017",
+        )
+
+    restored = await preview_broker.validate_preview_grant(
+        preview_handle=first["preview_handle"],
+        token=first["token"],
+        exp=exp,
+        actor_key=f"shared_actor:{session['actor_shared_actor_id']}",
+    )
+    refreshed_session = await repo.get_session(session["id"])
+    monkeypatch.setattr(repo, "update_session_state", original_update)
+
+    assert restored is not None
+    assert refreshed_session["preview_handle"] == first["preview_handle"]

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_preview_broker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -23,6 +24,23 @@ def preview_broker(repo):
     module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.preview_broker")
     broker_cls = _load_attr(module, "PrototypePreviewBroker", "PrototypeWorkspacePreviewBroker")
     return broker_cls(repo=repo)
+
+
+def test_preview_broker_requires_configured_stable_signing_secret(repo, monkeypatch):
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.preview_broker")
+    broker_cls = _load_attr(module, "PrototypePreviewBroker", "PrototypeWorkspacePreviewBroker")
+    monkeypatch.delenv("PROTOTYPE_PREVIEW_SIGNING_SECRET", raising=False)
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    monkeypatch.delenv("SINGLE_USER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        module,
+        "get_settings",
+        lambda: SimpleNamespace(JWT_SECRET_KEY=None, SINGLE_USER_API_KEY=None),
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError, match="stable signing secret"):
+        broker_cls(repo=repo)
 
 
 async def _seed_preview_scope(repo, prototype_db):

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py
@@ -99,6 +99,64 @@ def test_build_promote_idempotency_key_uses_workspace_candidate_and_canonical_sn
 
 
 @pytest.mark.asyncio
+async def test_create_workspace_archives_partial_workspace_when_seed_snapshot_fails(
+    repo,
+    prototype_db,
+    monkeypatch,
+):
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(module, "PrototypeWorkspaceService")
+    service = service_cls(repo=repo)
+
+    async def fail_create_snapshot(**_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("seed snapshot failed")
+
+    monkeypatch.setattr(repo, "create_snapshot", fail_create_snapshot)
+
+    with pytest.raises(RuntimeError, match="seed snapshot failed"):
+        await service.create_workspace(
+            owner_user_id=1,
+            title="Partial seed failure",
+            creation_source="prompt",
+        )
+
+    row = prototype_db.execute(
+        "SELECT archived_at FROM prototype_workspaces WHERE title = ?",
+        ("Partial seed failure",),
+    ).fetchone()
+    assert row is not None
+    assert row[0] is not None
+
+
+@pytest.mark.asyncio
+async def test_save_session_snapshot_deletes_snapshot_when_session_state_update_fails(
+    repo,
+    prototype_db,
+    monkeypatch,
+):
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(module, "PrototypeWorkspaceService")
+    service = service_cls(repo=repo)
+    workspace, base_snapshot, session, _candidate = await _seed_promotable_workspace(repo, prototype_db)
+
+    async def fail_update_session_state(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("session state update failed")
+
+    monkeypatch.setattr(repo, "update_session_state", fail_update_session_state)
+
+    with pytest.raises(RuntimeError, match="session state update failed"):
+        await service.save_session_snapshot(
+            prototype_session_id=session["id"],
+            snapshot_id="snap_orphaned_save",
+            storage_ref="prototype://failed-save",
+        )
+
+    assert await repo.get_snapshot("snap_orphaned_save") is None
+    updated_workspace = await repo.get_workspace(workspace["id"])
+    assert updated_workspace["canonical_snapshot_id"] == base_snapshot["snapshot_id"]
+
+
+@pytest.mark.asyncio
 async def test_promote_candidate_requires_validation(repo, prototype_db, promotion_service):
     workspace, base_snapshot, _session, candidate = await _seed_promotable_workspace(repo, prototype_db)
 
@@ -211,3 +269,48 @@ async def test_promote_candidate_fails_closed_when_workspace_update_does_not_per
 
     updated_workspace = await repo.get_workspace(workspace["id"])
     assert updated_workspace["canonical_snapshot_id"] == base_snapshot["snapshot_id"]
+
+
+@pytest.mark.asyncio
+async def test_promote_candidate_revokes_preview_and_reverts_workspace_when_request_update_fails(
+    repo,
+    prototype_db,
+    passing_promotion_service,
+    monkeypatch,
+):
+    workspace, base_snapshot, session, candidate = await _seed_promotable_workspace(repo, prototype_db)
+    promotion_request = await repo.create_promotion_request(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        candidate_snapshot_id=candidate["snapshot_id"],
+        requested_by_user_id=2,
+    )
+    revoked_handles: list[str] = []
+    original_revoke = passing_promotion_service._preview_broker.revoke_preview_handle
+
+    async def recording_revoke(preview_handle: str) -> bool:
+        revoked_handles.append(preview_handle)
+        return await original_revoke(preview_handle)
+
+    async def fail_update_promotion_request(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("promotion request update failed")
+
+    monkeypatch.setattr(
+        passing_promotion_service._preview_broker,
+        "revoke_preview_handle",
+        recording_revoke,
+    )
+    monkeypatch.setattr(repo, "update_promotion_request", fail_update_promotion_request)
+
+    with pytest.raises(RuntimeError, match="promotion request update failed"):
+        await passing_promotion_service.promote_candidate(
+            prototype_workspace_id=workspace["id"],
+            candidate_snapshot_id=candidate["snapshot_id"],
+            reviewer_user_id=1,
+            promotion_request_id=promotion_request["id"],
+        )
+
+    updated_workspace = await repo.get_workspace(workspace["id"])
+    assert updated_workspace["canonical_snapshot_id"] == base_snapshot["snapshot_id"]
+    assert updated_workspace["last_known_good_snapshot_id"] == base_snapshot["snapshot_id"]
+    assert revoked_handles

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_promotion_service.py
@@ -1,0 +1,213 @@
+"""Task 4 coverage for candidate promotion and publish validation."""
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_attr(module: Any, *names: str) -> Any:
+    for name in names:
+        if hasattr(module, name):
+            return getattr(module, name)
+    raise AttributeError(f"Module {module.__name__} does not define any of: {', '.join(names)}")
+
+
+class _AlwaysFailingPublishValidator:
+    async def validate(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": False, "reason": "synthetic publish validation failure"}
+
+    async def validate_publish_candidate(self, **kwargs: Any) -> dict[str, Any]:
+        return await self.validate(**kwargs)
+
+    async def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        return await self.validate(**kwargs)
+
+
+class _AlwaysPassingPublishValidator:
+    async def validate(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": True}
+
+    async def validate_publish_candidate(self, **kwargs: Any) -> dict[str, Any]:
+        return await self.validate(**kwargs)
+
+    async def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        return await self.validate(**kwargs)
+
+
+@pytest.fixture
+def promotion_service(repo):
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(module, "PrototypePromotionService", "PrototypeWorkspaceService")
+    return service_cls(repo=repo, publish_validator=_AlwaysFailingPublishValidator())
+
+
+@pytest.fixture
+def passing_promotion_service(repo):
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(module, "PrototypePromotionService", "PrototypeWorkspaceService")
+    return service_cls(repo=repo, publish_validator=_AlwaysPassingPublishValidator())
+
+
+async def _seed_promotable_workspace(repo, prototype_db):
+    workspace = await repo.create_workspace(
+        owner_user_id=1,
+        title="Task 4 Promotion",
+        creation_source="prompt",
+        runtime_policy={"external_collaborator_profile": "locked_collab"},
+    )
+    base_snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_base",
+        created_by_user_id=1,
+    )
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=base_snapshot["snapshot_id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+    )
+    candidate = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_candidate",
+        parent_snapshot_id=base_snapshot["snapshot_id"],
+        created_from_session_id=session["id"],
+        created_by_user_id=2,
+    )
+    prototype_db.execute(
+        """
+        UPDATE prototype_workspaces
+        SET canonical_snapshot_id = ?, last_known_good_snapshot_id = ?, canonical_preview_status = ?, publish_validation_status = ?
+        WHERE id = ?
+        """,
+        (base_snapshot["snapshot_id"], base_snapshot["snapshot_id"], "ready", "validated", workspace["id"]),
+    )
+    prototype_db.commit()
+    return workspace, base_snapshot, session, candidate
+
+
+def test_build_promote_idempotency_key_uses_workspace_candidate_and_canonical_snapshot_ids() -> None:
+    jobs_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.jobs")
+    assert jobs_module.build_promote_idempotency_key(
+        prototype_workspace_id="pw_1",
+        candidate_snapshot_id="snap_candidate",
+        canonical_snapshot_id="snap_canonical",
+    ) == "prototype:promote:pw_1:snap_candidate:snap_canonical"
+
+
+@pytest.mark.asyncio
+async def test_promote_candidate_requires_validation(repo, prototype_db, promotion_service):
+    workspace, base_snapshot, _session, candidate = await _seed_promotable_workspace(repo, prototype_db)
+
+    result = await promotion_service.promote_candidate(
+        prototype_workspace_id=workspace["id"],
+        candidate_snapshot_id=candidate["snapshot_id"],
+        reviewer_user_id=1,
+    )
+
+    updated_workspace = await repo.get_workspace(workspace["id"])
+
+    assert result["status"] == "failed"
+    assert result["failure_code"] == "publish_validation_failed"
+    assert updated_workspace["canonical_snapshot_id"] == base_snapshot["snapshot_id"]
+    assert updated_workspace["last_known_good_snapshot_id"] == base_snapshot["snapshot_id"]
+
+
+@pytest.mark.asyncio
+async def test_stale_candidate_blocks_canonical_advance(repo, prototype_db, passing_promotion_service):
+    workspace, base_snapshot, _session, candidate = await _seed_promotable_workspace(repo, prototype_db)
+    newer_canonical = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_newer_canonical",
+        created_by_user_id=1,
+    )
+    prototype_db.execute(
+        """
+        UPDATE prototype_workspaces
+        SET canonical_snapshot_id = ?, last_known_good_snapshot_id = ?, publish_validation_status = ?
+        WHERE id = ?
+        """,
+        (newer_canonical["snapshot_id"], newer_canonical["snapshot_id"], "validated", workspace["id"]),
+    )
+    prototype_db.commit()
+
+    result = await passing_promotion_service.promote_candidate(
+        prototype_workspace_id=workspace["id"],
+        candidate_snapshot_id=candidate["snapshot_id"],
+        reviewer_user_id=1,
+    )
+
+    updated_workspace = await repo.get_workspace(workspace["id"])
+
+    assert result["status"] == "stale"
+    assert result["failure_code"] == "stale_candidate"
+    assert updated_workspace["canonical_snapshot_id"] == newer_canonical["snapshot_id"]
+    assert updated_workspace["last_known_good_snapshot_id"] == newer_canonical["snapshot_id"]
+
+
+@pytest.mark.asyncio
+async def test_failed_publish_validation_preserves_last_known_good_snapshot_id(
+    repo,
+    prototype_db,
+    promotion_service,
+):
+    workspace, base_snapshot, _session, candidate = await _seed_promotable_workspace(repo, prototype_db)
+    current_canonical = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_current_canonical",
+        created_by_user_id=1,
+    )
+    prototype_db.execute(
+        """
+        UPDATE prototype_workspaces
+        SET canonical_snapshot_id = ?, last_known_good_snapshot_id = ?, publish_validation_status = ?
+        WHERE id = ?
+        """,
+        (current_canonical["snapshot_id"], base_snapshot["snapshot_id"], "validated", workspace["id"]),
+    )
+    prototype_db.commit()
+
+    result = await promotion_service.promote_candidate(
+        prototype_workspace_id=workspace["id"],
+        candidate_snapshot_id=candidate["snapshot_id"],
+        reviewer_user_id=1,
+    )
+
+    updated_workspace = await repo.get_workspace(workspace["id"])
+
+    assert result["status"] == "failed"
+    assert result["failure_code"] == "publish_validation_failed"
+    assert updated_workspace["last_known_good_snapshot_id"] == base_snapshot["snapshot_id"]
+
+
+@pytest.mark.asyncio
+async def test_promote_candidate_fails_closed_when_workspace_update_does_not_persist(
+    repo,
+    prototype_db,
+    passing_promotion_service,
+    monkeypatch,
+):
+    workspace, base_snapshot, _session, candidate = await _seed_promotable_workspace(repo, prototype_db)
+    original_update = repo.update_workspace_state
+    call_count = {"value": 0}
+
+    async def flaky_update(prototype_workspace_id: str, **kwargs: Any):
+        call_count["value"] += 1
+        if call_count["value"] == 1:
+            return await original_update(prototype_workspace_id, **kwargs)
+        return None
+
+    monkeypatch.setattr(repo, "update_workspace_state", flaky_update)
+
+    with pytest.raises(RuntimeError, match="failed to persist canonical"):
+        await passing_promotion_service.promote_candidate(
+            prototype_workspace_id=workspace["id"],
+            candidate_snapshot_id=candidate["snapshot_id"],
+            reviewer_user_id=1,
+        )
+
+    updated_workspace = await repo.get_workspace(workspace["id"])
+    assert updated_workspace["canonical_snapshot_id"] == base_snapshot["snapshot_id"]

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
@@ -506,6 +506,31 @@ class TestPrototypeWorkspaceEndpoints:
         )
         assert body["token"]
 
+    def test_preview_grant_renewal_recovers_after_broker_memory_clear(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, seed_snapshot = _seed_workspace(test_services, title="Preview renewal recovered")
+        preview_grant = _run(
+            test_services.preview_broker.issue_preview_grant(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id=seed_snapshot["snapshot_id"],
+                runtime_target_url="runtime://canonical/preview-renewal-recovered",
+            )
+        )
+        broker_cls = type(test_services.preview_broker)
+        broker_cls._records.clear()
+        broker_cls._active_scope_handles.clear()
+
+        renewed = client.post(
+            f"/api/v1/prototype-previews/{preview_grant['preview_handle']}/renew",
+            json={},
+        )
+
+        assert renewed.status_code == 200
+        assert renewed.json()["preview_handle"] == preview_grant["preview_handle"]
+
     def test_preview_grant_renewal_rejects_unknown_body_fields(
         self,
         client: TestClient,

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
@@ -147,6 +147,48 @@ def client(test_app: FastAPI) -> TestClient:
 
 
 class TestPrototypeWorkspaceEndpoints:
+    def test_owner_can_fetch_workspace_detail_with_snapshot_and_session_inventory(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, seed_snapshot = _seed_workspace(test_services, title="Detail prototype")
+        owner_session_result = _run(
+            test_services.service.create_or_reuse_branch_session(
+                prototype_workspace_id=workspace["id"],
+                actor_type="owner",
+                actor_user_id=1,
+                request_nonce="req_owner_detail_view",
+            )
+        )
+        owner_session = owner_session_result["session"]
+        candidate_snapshot = _run(
+            test_services.repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id="psnap_candidate_detail_1",
+                created_by_user_id=1,
+                parent_snapshot_id=seed_snapshot["snapshot_id"],
+                created_from_session_id=owner_session["id"],
+                storage_ref="prototype://candidate-detail",
+                prompt_summary="Candidate snapshot for detail view",
+            )
+        )
+
+        resp = client.get(f"/api/v1/prototype-workspaces/{workspace['id']}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == workspace["id"]
+        assert body["viewer_role"] == "owner"
+        assert body["canonical_snapshot_id"] == seed_snapshot["snapshot_id"]
+        assert len(body["sessions"]) == 1
+        assert body["sessions"][0]["id"] == owner_session["id"]
+        assert len(body["snapshots"]) == 2
+        assert body["snapshots"][0]["snapshot_id"] == candidate_snapshot["snapshot_id"]
+        assert body["snapshots"][0]["is_canonical"] is False
+        assert body["snapshots"][1]["snapshot_id"] == seed_snapshot["snapshot_id"]
+        assert body["snapshots"][1]["is_canonical"] is True
+
     def test_owner_can_create_workspace_and_request_branch_session(self, client: TestClient) -> None:
         created = client.post(
             "/api/v1/prototype-workspaces",

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -248,6 +249,34 @@ class TestPrototypeWorkspaceEndpoints:
         assert body["prototype_workspace_id"] == workspace["id"]
         assert body["job_type"] == "branch_session_bootstrap"
         assert body["prototype_session_id"].startswith("pss_")
+
+    def test_revoked_collaborator_session_token_returns_403(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, _ = _seed_workspace(test_services, title="Revoked collaborator prototype")
+        access_context = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+        )
+        _run(
+            test_services.repo.db_pool.execute(
+                "UPDATE prototype_shared_actors SET revoked_at = ? WHERE id = ?",
+                (datetime.now(timezone.utc).isoformat(), access_context.shared_actor_id),
+            )
+        )
+
+        resp = client.post(
+            "/api/v1/prototype-sessions",
+            json={
+                "session_token": access_context.session_token,
+                "request_nonce": "req_revoked_collab_token_1",
+            },
+        )
+
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Prototype session token is no longer active"
 
     def test_collaborator_can_submit_promotion_request(
         self,

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
@@ -1,0 +1,482 @@
+"""Integration tests for the prototype workspace API surface."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def owner_user() -> User:
+    return User(
+        id=1,
+        username="owner",
+        email="owner@test.com",
+        roles=["admin"],
+        permissions=["prototype.promote"],
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _seed_workspace(services: SimpleNamespace, *, title: str = "Sales dashboard") -> tuple[dict, dict]:
+    workspace = _run(
+        services.repo.create_workspace(
+            owner_user_id=1,
+            title=title,
+            creation_source="prompt",
+            share_policy={"allow_browser_session_resume": True},
+            runtime_policy={
+                "owner_profile": "owner_collab",
+                "external_collaborator_profile": "locked_collab",
+            },
+        )
+    )
+    seed_snapshot = _run(
+        services.repo.create_snapshot(
+            prototype_workspace_id=workspace["id"],
+            snapshot_id=f"psnap_seed_{workspace['id']}",
+            created_by_user_id=1,
+            storage_ref="prototype://seed",
+            prompt_summary=f"Seed prompt for {title}",
+        )
+    )
+    workspace = _run(
+        services.repo.update_workspace_state(
+            workspace["id"],
+            canonical_snapshot_id=seed_snapshot["snapshot_id"],
+            last_known_good_snapshot_id=seed_snapshot["snapshot_id"],
+            canonical_preview_status="uninitialized",
+            publish_validation_status="pending",
+        )
+    )
+    return workspace, seed_snapshot
+
+
+def _seed_external_access(
+    services: SimpleNamespace,
+    *,
+    prototype_workspace_id: str,
+    share_link_id: int = 41,
+):
+    return _run(
+        services.access_service.exchange_external_collaborator(
+            prototype_workspace_id=prototype_workspace_id,
+            share_link_id=share_link_id,
+            display_name="Acme PM",
+            resume_cookie_value=None,
+        )
+    )
+
+
+@pytest.fixture
+def test_services(monkeypatch, repo, tmp_path):
+    from tldw_Server_API.app.api.v1.endpoints import prototype_workspaces as prototype_endpoints
+    from tldw_Server_API.app.core.Jobs.manager import JobManager
+    from tldw_Server_API.app.core.Prototype_Workspaces.access import PrototypeAccessService
+    from tldw_Server_API.app.core.Prototype_Workspaces.jobs import PrototypeWorkspaceJobs
+    from tldw_Server_API.app.core.Prototype_Workspaces.preview_broker import (
+        PrototypePreviewBroker,
+    )
+    from tldw_Server_API.app.core.Prototype_Workspaces.service import PrototypeWorkspaceService
+
+    PrototypePreviewBroker._records.clear()
+    PrototypePreviewBroker._active_scope_handles.clear()
+
+    preview_broker = PrototypePreviewBroker(
+        repo=repo,
+        base_preview_path="/api/v1/prototype-previews",
+        signing_secret="preview-test-secret",
+    )
+    access_service = PrototypeAccessService(
+        repo,
+        signing_secret="session-test-secret",
+    )
+    service = PrototypeWorkspaceService(
+        repo=repo,
+        preview_broker=preview_broker,
+    )
+    jobs_service = PrototypeWorkspaceJobs(
+        repo=repo,
+        jobs_manager=JobManager(db_path=tmp_path / "prototype_jobs.db"),
+    )
+
+    monkeypatch.setattr(prototype_endpoints, "_get_repo", lambda: repo)
+    monkeypatch.setattr(prototype_endpoints, "_get_service", lambda: service)
+    monkeypatch.setattr(prototype_endpoints, "_get_jobs_service", lambda: jobs_service)
+    monkeypatch.setattr(prototype_endpoints, "_get_access_service", lambda: access_service)
+    monkeypatch.setattr(prototype_endpoints, "_get_preview_broker", lambda: preview_broker)
+
+    return SimpleNamespace(
+        repo=repo,
+        service=service,
+        access_service=access_service,
+        preview_broker=preview_broker,
+        jobs_service=jobs_service,
+    )
+
+
+@pytest.fixture
+def test_app(owner_user: User, test_services: SimpleNamespace) -> FastAPI:
+    from tldw_Server_API.app.api.v1.endpoints.prototype_workspaces import router
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+
+    async def _fake_user() -> User:
+        return owner_user
+
+    app.dependency_overrides[get_request_user] = _fake_user
+    app.state.prototype_test_services = test_services
+    return app
+
+
+@pytest.fixture
+def client(test_app: FastAPI) -> TestClient:
+    return TestClient(test_app)
+
+
+class TestPrototypeWorkspaceEndpoints:
+    def test_owner_can_create_workspace_and_request_branch_session(self, client: TestClient) -> None:
+        created = client.post(
+            "/api/v1/prototype-workspaces",
+            json={
+                "title": "Sales dashboard",
+                "creation_source": "prompt",
+                "prompt": "Build a B2B dashboard",
+            },
+        )
+
+        assert created.status_code == 201
+        created_body = created.json()
+        assert created_body["title"] == "Sales dashboard"
+        assert created_body["id"]
+
+        session = client.post(
+            f"/api/v1/prototype-workspaces/{created_body['id']}/sessions",
+            json={},
+        )
+        assert session.status_code == 202
+        session_body = session.json()
+        assert session_body["job_type"] == "branch_session_bootstrap"
+        assert session_body["prototype_workspace_id"] == created_body["id"]
+        assert session_body["prototype_session_id"].startswith("pss_")
+        assert session_body["actor_type"] == "owner"
+
+    def test_collaborator_can_create_session_with_prototype_session_token(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, _ = _seed_workspace(test_services, title="Collaborator prototype")
+        access_context = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+        )
+
+        resp = client.post(
+            "/api/v1/prototype-sessions",
+            json={
+                "session_token": access_context.session_token,
+                "request_nonce": "req_collab_token_1",
+            },
+        )
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["actor_type"] == "external_collaborator"
+        assert body["shared_actor_id"] == access_context.shared_actor_id
+        assert body["prototype_workspace_id"] == workspace["id"]
+        assert body["job_type"] == "branch_session_bootstrap"
+        assert body["prototype_session_id"].startswith("pss_")
+
+    def test_collaborator_can_submit_promotion_request(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, _ = _seed_workspace(test_services, title="Promotion request prototype")
+        access_context = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+            share_link_id=52,
+        )
+        session_result = _run(
+            test_services.service.create_or_reuse_branch_session(
+                prototype_workspace_id=workspace["id"],
+                actor_type="external_collaborator",
+                actor_shared_actor_id=access_context.shared_actor_id,
+                request_nonce="req_promotion_submission",
+                share_link_id=52,
+            )
+        )
+        session = session_result["session"]
+        candidate_snapshot = _run(
+            test_services.repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id="psnap_demo_1",
+                created_by_shared_actor_id=access_context.shared_actor_id,
+                parent_snapshot_id=session["base_snapshot_id"],
+                created_from_session_id=session["id"],
+                storage_ref="prototype://candidate",
+                prompt_summary="Ready for owner review",
+            )
+        )
+
+        resp = client.post(
+            "/api/v1/prototype-promotions",
+            json={
+                "prototype_workspace_id": workspace["id"],
+                "prototype_session_id": session["id"],
+                "candidate_snapshot_id": candidate_snapshot["snapshot_id"],
+                "session_token": access_context.session_token,
+                "request_reason": "Ready for owner review",
+            },
+        )
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["prototype_workspace_id"] == workspace["id"]
+        assert body["prototype_session_id"] == session["id"]
+        assert body["candidate_snapshot_id"] == candidate_snapshot["snapshot_id"]
+        assert body["status"] == "pending"
+        assert body["requested_by_shared_actor_id"] == access_context.shared_actor_id
+
+    def test_collaborator_cannot_submit_promotion_request_for_another_branch(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, _ = _seed_workspace(test_services, title="Promotion auth prototype")
+        first_actor = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+            share_link_id=81,
+        )
+        second_actor = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+            share_link_id=82,
+        )
+        first_session_result = _run(
+            test_services.service.create_or_reuse_branch_session(
+                prototype_workspace_id=workspace["id"],
+                actor_type="external_collaborator",
+                actor_shared_actor_id=first_actor.shared_actor_id,
+                request_nonce="req_first_branch",
+                share_link_id=81,
+            )
+        )
+        first_session = first_session_result["session"]
+        candidate_snapshot = _run(
+            test_services.repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id="psnap_other_actor_candidate",
+                created_by_shared_actor_id=first_actor.shared_actor_id,
+                parent_snapshot_id=first_session["base_snapshot_id"],
+                created_from_session_id=first_session["id"],
+                storage_ref="prototype://other-actor-candidate",
+                prompt_summary="Another actor's candidate",
+            )
+        )
+
+        resp = client.post(
+            "/api/v1/prototype-promotions",
+            json={
+                "prototype_workspace_id": workspace["id"],
+                "prototype_session_id": first_session["id"],
+                "candidate_snapshot_id": candidate_snapshot["snapshot_id"],
+                "session_token": second_actor.session_token,
+            },
+        )
+
+        assert resp.status_code == 403
+
+    def test_owner_can_review_promotion_request(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, _ = _seed_workspace(test_services, title="Promotion review prototype")
+        access_context = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+            share_link_id=61,
+        )
+        session_result = _run(
+            test_services.service.create_or_reuse_branch_session(
+                prototype_workspace_id=workspace["id"],
+                actor_type="external_collaborator",
+                actor_shared_actor_id=access_context.shared_actor_id,
+                request_nonce="req_review",
+                share_link_id=61,
+            )
+        )
+        session = session_result["session"]
+        candidate_snapshot = _run(
+            test_services.repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id="psnap_review_candidate",
+                created_by_shared_actor_id=access_context.shared_actor_id,
+                parent_snapshot_id=session["base_snapshot_id"],
+                created_from_session_id=session["id"],
+                storage_ref="prototype://review-candidate",
+                prompt_summary="Looks good",
+            )
+        )
+        promotion_request = _run(
+            test_services.repo.create_promotion_request(
+                prototype_workspace_id=workspace["id"],
+                prototype_session_id=session["id"],
+                candidate_snapshot_id=candidate_snapshot["snapshot_id"],
+                requested_by_shared_actor_id=access_context.shared_actor_id,
+            )
+        )
+
+        review = client.post(
+            f"/api/v1/prototype-promotions/{promotion_request['id']}/review",
+            json={
+                "decision": "approve",
+                "review_notes": "Looks good",
+            },
+        )
+
+        assert review.status_code == 200
+        body = review.json()
+        assert body["status"] == "promoted"
+        assert body["preview_handle"]
+        assert body["canonical_snapshot_id"] == candidate_snapshot["snapshot_id"]
+
+    def test_preview_grant_renewal_returns_updated_expiry(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, seed_snapshot = _seed_workspace(test_services, title="Preview renewal prototype")
+        preview_grant = _run(
+            test_services.preview_broker.issue_preview_grant(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id=seed_snapshot["snapshot_id"],
+                runtime_target_url="runtime://canonical/preview-renewal",
+            )
+        )
+
+        renewed = client.post(
+            f"/api/v1/prototype-previews/{preview_grant['preview_handle']}/renew",
+            json={},
+        )
+
+        assert renewed.status_code == 200
+        body = renewed.json()
+        assert body["preview_handle"] == preview_grant["preview_handle"]
+        assert body["expires_at"]
+        assert body["preview_url"].startswith(
+            f"/api/v1/prototype-previews/{preview_grant['preview_handle']}?"
+        )
+        assert body["token"]
+
+    def test_revoked_preview_grant_renewal_returns_404(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, seed_snapshot = _seed_workspace(test_services, title="Preview revoke prototype")
+        preview_grant = _run(
+            test_services.preview_broker.issue_preview_grant(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id=seed_snapshot["snapshot_id"],
+                runtime_target_url="runtime://canonical/preview-revoked",
+            )
+        )
+        _run(test_services.preview_broker.revoke_preview_handle(preview_grant["preview_handle"]))
+
+        renewed = client.post(
+            f"/api/v1/prototype-previews/{preview_grant['preview_handle']}/renew",
+            json={},
+        )
+
+        assert renewed.status_code == 404
+
+    def test_stale_promotion_response_shape(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, seed_snapshot = _seed_workspace(test_services, title="Stale review prototype")
+        access_context = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+            share_link_id=73,
+        )
+        session_result = _run(
+            test_services.service.create_or_reuse_branch_session(
+                prototype_workspace_id=workspace["id"],
+                actor_type="external_collaborator",
+                actor_shared_actor_id=access_context.shared_actor_id,
+                request_nonce="req_stale_review",
+                share_link_id=73,
+            )
+        )
+        session = session_result["session"]
+        fresh_canonical = _run(
+            test_services.repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id="psnap_canonical_fresh",
+                created_by_user_id=1,
+                parent_snapshot_id=seed_snapshot["snapshot_id"],
+                storage_ref="prototype://fresh-canonical",
+                prompt_summary="Fresh canonical state",
+            )
+        )
+        _run(
+            test_services.repo.update_workspace_state(
+                workspace["id"],
+                canonical_snapshot_id=fresh_canonical["snapshot_id"],
+                last_known_good_snapshot_id=fresh_canonical["snapshot_id"],
+            )
+        )
+        candidate_snapshot = _run(
+            test_services.repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id="psnap_candidate_stale",
+                created_by_shared_actor_id=access_context.shared_actor_id,
+                parent_snapshot_id=seed_snapshot["snapshot_id"],
+                created_from_session_id=session["id"],
+                storage_ref="prototype://candidate-stale",
+                prompt_summary="Stale candidate",
+            )
+        )
+        promotion_request = _run(
+            test_services.repo.create_promotion_request(
+                prototype_workspace_id=workspace["id"],
+                prototype_session_id=session["id"],
+                candidate_snapshot_id=candidate_snapshot["snapshot_id"],
+                requested_by_shared_actor_id=access_context.shared_actor_id,
+            )
+        )
+
+        resp = client.post(
+            f"/api/v1/prototype-promotions/{promotion_request['id']}/review",
+            json={
+                "decision": "approve",
+                "review_baseline_snapshot_id": fresh_canonical["snapshot_id"],
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "stale"
+        assert body["failure_code"] == "stale_candidate"
+        assert body["prototype_workspace_id"] == workspace["id"]
+        assert body["candidate_snapshot_id"] == candidate_snapshot["snapshot_id"]
+        assert body["canonical_snapshot_id"] == fresh_canonical["snapshot_id"]

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 from types import SimpleNamespace
 
 import pytest
@@ -504,6 +505,55 @@ class TestPrototypeWorkspaceEndpoints:
             f"/api/v1/prototype-previews/{preview_grant['preview_handle']}?"
         )
         assert body["token"]
+
+    def test_preview_grant_renewal_rejects_unknown_body_fields(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+    ) -> None:
+        workspace, seed_snapshot = _seed_workspace(test_services, title="Preview renewal strict body")
+        preview_grant = _run(
+            test_services.preview_broker.issue_preview_grant(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id=seed_snapshot["snapshot_id"],
+                runtime_target_url="runtime://canonical/preview-renewal-strict",
+            )
+        )
+
+        renewed = client.post(
+            f"/api/v1/prototype-previews/{preview_grant['preview_handle']}/renew",
+            json={"extend_seconds": 600},
+        )
+
+        assert renewed.status_code == 422
+
+    def test_preview_grant_renewal_maps_typed_missing_handle_to_404(
+        self,
+        client: TestClient,
+        test_services: SimpleNamespace,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace, _seed_snapshot = _seed_workspace(test_services, title="Preview renewal typed error")
+        broker_module = importlib.import_module(
+            "tldw_Server_API.app.core.Prototype_Workspaces.preview_broker"
+        )
+        missing_handle_error = getattr(broker_module, "PrototypePreviewHandleNotFound", RuntimeError)
+
+        def fake_record(_preview_handle: str) -> dict[str, str]:
+            return {"prototype_workspace_id": workspace["id"]}
+
+        async def fake_renew(_preview_handle: str) -> dict[str, str]:
+            raise missing_handle_error("preview handle disappeared")
+
+        monkeypatch.setattr(test_services.preview_broker, "get_preview_record", fake_record)
+        monkeypatch.setattr(test_services.preview_broker, "renew_preview_grant", fake_renew)
+
+        renewed = client.post(
+            "/api/v1/prototype-previews/ph_raced_away/renew",
+            json={},
+        )
+
+        assert renewed.status_code == 404
 
     def test_revoked_preview_grant_renewal_returns_404(
         self,

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_endpoints.py
@@ -28,7 +28,12 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-def _seed_workspace(services: SimpleNamespace, *, title: str = "Sales dashboard") -> tuple[dict, dict]:
+def _seed_workspace(
+    services: SimpleNamespace,
+    *,
+    title: str = "Sales dashboard",
+    designated_promoter_ids: list[int] | None = None,
+) -> tuple[dict, dict]:
     workspace = _run(
         services.repo.create_workspace(
             owner_user_id=1,
@@ -39,6 +44,7 @@ def _seed_workspace(services: SimpleNamespace, *, title: str = "Sales dashboard"
                 "owner_profile": "owner_collab",
                 "external_collaborator_profile": "locked_collab",
             },
+            designated_promoter_ids=designated_promoter_ids,
         )
     )
     seed_snapshot = _run(
@@ -397,6 +403,78 @@ class TestPrototypeWorkspaceEndpoints:
         body = review.json()
         assert body["status"] == "promoted"
         assert body["preview_handle"]
+        assert body["canonical_snapshot_id"] == candidate_snapshot["snapshot_id"]
+
+    def test_designated_promoter_can_review_promotion_request(
+        self,
+        test_app: FastAPI,
+        test_services: SimpleNamespace,
+    ) -> None:
+        from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
+
+        async def _fake_promoter() -> User:
+            return User(
+                id=2,
+                username="promoter",
+                email="promoter@test.com",
+                roles=[],
+                permissions=["prototype.promote"],
+            )
+
+        test_app.dependency_overrides[get_request_user] = _fake_promoter
+        client = TestClient(test_app)
+
+        workspace, _ = _seed_workspace(
+            test_services,
+            title="Designated promotion review prototype",
+            designated_promoter_ids=[2],
+        )
+        access_context = _seed_external_access(
+            test_services,
+            prototype_workspace_id=workspace["id"],
+            share_link_id=62,
+        )
+        session_result = _run(
+            test_services.service.create_or_reuse_branch_session(
+                prototype_workspace_id=workspace["id"],
+                actor_type="external_collaborator",
+                actor_shared_actor_id=access_context.shared_actor_id,
+                request_nonce="req_designated_review",
+                share_link_id=62,
+            )
+        )
+        session = session_result["session"]
+        candidate_snapshot = _run(
+            test_services.repo.create_snapshot(
+                prototype_workspace_id=workspace["id"],
+                snapshot_id="psnap_designated_review_candidate",
+                created_by_shared_actor_id=access_context.shared_actor_id,
+                parent_snapshot_id=session["base_snapshot_id"],
+                created_from_session_id=session["id"],
+                storage_ref="prototype://designated-review-candidate",
+                prompt_summary="Looks good to designated promoter",
+            )
+        )
+        promotion_request = _run(
+            test_services.repo.create_promotion_request(
+                prototype_workspace_id=workspace["id"],
+                prototype_session_id=session["id"],
+                candidate_snapshot_id=candidate_snapshot["snapshot_id"],
+                requested_by_shared_actor_id=access_context.shared_actor_id,
+            )
+        )
+
+        review = client.post(
+            f"/api/v1/prototype-promotions/{promotion_request['id']}/review",
+            json={
+                "decision": "approve",
+                "review_notes": "Looks good from designated promoter",
+            },
+        )
+
+        assert review.status_code == 200
+        body = review.json()
+        assert body["status"] == "promoted"
         assert body["canonical_snapshot_id"] == candidate_snapshot["snapshot_id"]
 
     def test_preview_grant_renewal_returns_updated_expiry(

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 import time
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -14,8 +15,8 @@ from tldw_Server_API.app.api.v1.endpoints.sharing import router
 from tldw_Server_API.app.core.AuthNZ.migrations import (
     migration_001_create_users_table,
     migration_077_create_sharing_tables,
-    migration_087_expand_share_tokens_resource_type_for_prototypes,
     migration_086_create_prototype_workspace_tables,
+    migration_087_expand_share_tokens_resource_type_for_prototypes,
 )
 from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
     PrototypeWorkspacesRepo,
@@ -297,6 +298,24 @@ def test_app(monkeypatch, sharing_repo, prototype_repo, token_service):
 @pytest.fixture
 def client(test_app):
     return TestClient(test_app)
+
+
+def test_access_service_requires_configured_stable_signing_secret(
+    prototype_repo,
+    monkeypatch,
+):
+    from tldw_Server_API.app.core.Prototype_Workspaces import access
+
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    monkeypatch.delenv("SINGLE_USER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        access,
+        "get_settings",
+        lambda: SimpleNamespace(JWT_SECRET_KEY=None, SINGLE_USER_API_KEY=None),
+    )
+
+    with pytest.raises(RuntimeError, match="stable signing secret"):
+        access.PrototypeAccessService(prototype_repo)
 
 
 def test_public_prototype_exchange_creates_shared_actor(client, prototype_share_token):

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py
@@ -1,0 +1,688 @@
+"""Integration tests for public prototype private-link exchange."""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints import sharing as sharing_endpoints
+from tldw_Server_API.app.api.v1.endpoints.sharing import router
+from tldw_Server_API.app.core.AuthNZ.migrations import (
+    migration_001_create_users_table,
+    migration_077_create_sharing_tables,
+    migration_087_expand_share_tokens_resource_type_for_prototypes,
+    migration_086_create_prototype_workspace_tables,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+    PrototypeWorkspacesRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.shared_workspace_repo import SharedWorkspaceRepo
+from tldw_Server_API.app.core.Prototype_Workspaces.access import PROTOTYPE_SHARED_ACTOR_COOKIE
+from tldw_Server_API.app.core.Sharing.share_token_service import ShareTokenService
+
+pytestmark = pytest.mark.integration
+
+
+class _FakePool:
+    """Minimal DatabasePool stand-in backed by an in-memory SQLite connection."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    async def execute(self, sql: str, params: tuple = ()) -> None:
+        self._conn.execute(sql, params)
+        self._conn.commit()
+
+    async def fetchone(self, sql: str, params: tuple = ()) -> dict | None:
+        cur = self._conn.execute(sql, params)
+        row = cur.fetchone()
+        if row is None:
+            return None
+        cols = [d[0] for d in cur.description]
+        return dict(zip(cols, row, strict=True))
+
+    async def fetchall(self, sql: str, params: tuple = ()) -> list[dict]:
+        cur = self._conn.execute(sql, params)
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, row, strict=True)) for row in rows]
+
+
+class _NoOpAuditService:
+    async def log(self, *args, **kwargs) -> None:
+        return None
+
+
+@pytest.fixture
+def exchange_db():
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    migration_001_create_users_table(conn)
+    migration_077_create_sharing_tables(conn)
+    migration_087_expand_share_tokens_resource_type_for_prototypes(conn)
+    migration_086_create_prototype_workspace_tables(conn)
+    conn.execute(
+        "INSERT INTO users (id, username, email, password_hash) VALUES (1, 'owner', 'owner@test.com', 'hash')"
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def fake_pool(exchange_db):
+    return _FakePool(exchange_db)
+
+
+@pytest.fixture
+def sharing_repo(fake_pool):
+    return SharedWorkspaceRepo(db_pool=fake_pool)
+
+
+@pytest.fixture
+def prototype_repo(fake_pool):
+    return PrototypeWorkspacesRepo(db_pool=fake_pool)
+
+
+@pytest.fixture
+def token_service(sharing_repo):
+    return ShareTokenService(sharing_repo)
+
+
+@pytest.fixture
+def prototype_workspace(prototype_repo):
+    workspace = asyncio.run(
+        prototype_repo.create_workspace(
+            owner_user_id=1,
+            title="Prototype Demo",
+            creation_source="prompt",
+            share_policy={"allow_browser_session_resume": True},
+            runtime_policy={"external_collaborator_profile": "locked_collab"},
+        )
+    )
+    return workspace
+
+
+@pytest.fixture
+def prototype_share_token(token_service, prototype_workspace):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=prototype_workspace["id"],
+            owner_user_id=1,
+            password="demo-pass",
+        )
+    )
+    return token["raw_token"]
+
+
+@pytest.fixture
+def protected_single_use_prototype_share(token_service, prototype_workspace):
+    return asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=prototype_workspace["id"],
+            owner_user_id=1,
+            password="demo-pass",
+            max_uses=1,
+        )
+    )
+
+
+@pytest.fixture
+def unprotected_prototype_share_token(token_service, prototype_workspace):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=prototype_workspace["id"],
+            owner_user_id=1,
+        )
+    )
+    return token["raw_token"]
+
+
+@pytest.fixture
+def revoked_prototype_share_token(token_service, prototype_workspace):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=prototype_workspace["id"],
+            owner_user_id=1,
+        )
+    )
+    asyncio.run(token_service.revoke_token(token["id"]))
+    return token["raw_token"]
+
+
+@pytest.fixture
+def non_prototype_share_token(token_service):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="workspace",
+            resource_id="ws_regular_workspace",
+            owner_user_id=1,
+        )
+    )
+    return token["raw_token"]
+
+
+@pytest.fixture
+def second_link_same_workspace_token(token_service, prototype_workspace):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=prototype_workspace["id"],
+            owner_user_id=1,
+        )
+    )
+    return token["raw_token"]
+
+
+@pytest.fixture
+def second_prototype_workspace(prototype_repo):
+    workspace = asyncio.run(
+        prototype_repo.create_workspace(
+            owner_user_id=1,
+            title="Prototype Demo 2",
+            creation_source="prompt",
+            share_policy={"allow_browser_session_resume": True},
+            runtime_policy={"external_collaborator_profile": "locked_collab"},
+        )
+    )
+    return workspace
+
+
+@pytest.fixture
+def second_workspace_prototype_share_token(token_service, second_prototype_workspace):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=second_prototype_workspace["id"],
+            owner_user_id=1,
+        )
+    )
+    return token["raw_token"]
+
+
+@pytest.fixture
+def single_use_prototype_share(token_service, prototype_workspace):
+    return asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=prototype_workspace["id"],
+            owner_user_id=1,
+            max_uses=1,
+        )
+    )
+
+
+@pytest.fixture
+def resume_disabled_workspace(prototype_repo):
+    workspace = asyncio.run(
+        prototype_repo.create_workspace(
+            owner_user_id=1,
+            title="No Resume Prototype",
+            creation_source="prompt",
+            share_policy={"allow_browser_session_resume": False},
+            runtime_policy={"external_collaborator_profile": "locked_collab"},
+        )
+    )
+    return workspace
+
+
+@pytest.fixture
+def resume_disabled_prototype_share_token(token_service, resume_disabled_workspace):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=resume_disabled_workspace["id"],
+            owner_user_id=1,
+        )
+    )
+    return token["raw_token"]
+
+
+@pytest.fixture
+def archived_prototype_share_token(exchange_db, token_service, prototype_workspace):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=prototype_workspace["id"],
+            owner_user_id=1,
+        )
+    )
+    exchange_db.execute(
+        "UPDATE prototype_workspaces SET archived_at = CURRENT_TIMESTAMP WHERE id = ?",
+        (prototype_workspace["id"],),
+    )
+    exchange_db.commit()
+    return token["raw_token"]
+
+
+@pytest.fixture
+def missing_workspace_prototype_share_token(token_service):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id="pws_missing_workspace",
+            owner_user_id=1,
+        )
+    )
+    return token["raw_token"]
+
+
+@pytest.fixture
+def test_app(monkeypatch, sharing_repo, prototype_repo, token_service):
+    monkeypatch.setattr(sharing_endpoints, "_get_repo", lambda: sharing_repo)
+    monkeypatch.setattr(sharing_endpoints, "_get_token_service", lambda: token_service)
+    monkeypatch.setattr(
+        sharing_endpoints,
+        "_get_prototype_repo",
+        lambda: prototype_repo,
+        raising=False,
+    )
+    monkeypatch.setattr(sharing_endpoints, "_get_audit_service", lambda: _NoOpAuditService())
+    monkeypatch.setattr(sharing_endpoints, "_check_public_rate_limit", lambda _request: None)
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture
+def client(test_app):
+    return TestClient(test_app)
+
+
+def test_public_prototype_exchange_creates_shared_actor(client, prototype_share_token):
+    resp = client.post(
+        f"/api/v1/sharing/public/{prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM", "password": "demo-pass"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["actor_type"] == "external_collaborator"
+    assert body["shared_actor_id"].startswith("psa_")
+    assert body["session_token"]
+
+
+def test_public_prototype_exchange_revoked_link_returns_404(client, revoked_prototype_share_token):
+    resp = client.post(
+        f"/api/v1/sharing/public/{revoked_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+
+    assert resp.status_code == 404
+
+
+def test_public_prototype_exchange_bad_password_returns_403(client, prototype_share_token):
+    resp = client.post(
+        f"/api/v1/sharing/public/{prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM", "password": "wrong-pass"},
+    )
+
+    assert resp.status_code == 403
+
+
+def test_public_prototype_exchange_missing_password_returns_403(client, prototype_share_token):
+    resp = client.post(
+        f"/api/v1/sharing/public/{prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+
+    assert resp.status_code == 403
+
+
+def test_public_prototype_exchange_missing_display_name_returns_422(
+    client,
+    unprotected_prototype_share_token,
+):
+    resp = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={},
+    )
+
+    assert resp.status_code == 422
+
+
+def test_public_prototype_exchange_releases_claim_on_unexpected_error(
+    client,
+    monkeypatch,
+    sharing_repo,
+    single_use_prototype_share,
+):
+    class _ExplodingAccessService:
+        async def can_resume_external_collaborator(self, **kwargs):
+            return False
+
+        async def exchange_external_collaborator(self, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        sharing_endpoints,
+        "_get_prototype_access_service",
+        lambda: _ExplodingAccessService(),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        client.post(
+            f"/api/v1/sharing/public/{single_use_prototype_share['raw_token']}/prototype-session",
+            json={"display_name": "Acme PM"},
+        )
+
+    token_row = asyncio.run(sharing_repo.get_token(single_use_prototype_share["id"]))
+    assert token_row is not None
+    assert token_row["use_count"] == 0
+
+
+def test_public_prototype_exchange_releases_claim_on_post_exchange_failure(
+    client,
+    monkeypatch,
+    sharing_repo,
+    single_use_prototype_share,
+):
+    class _ExplodingAuditService:
+        async def log(self, *args, **kwargs):
+            raise RuntimeError("audit boom")
+
+    monkeypatch.setattr(
+        sharing_endpoints,
+        "_get_audit_service",
+        lambda: _ExplodingAuditService(),
+    )
+
+    with pytest.raises(RuntimeError, match="audit boom"):
+        client.post(
+            f"/api/v1/sharing/public/{single_use_prototype_share['raw_token']}/prototype-session",
+            json={"display_name": "Acme PM"},
+        )
+
+    token_row = asyncio.run(sharing_repo.get_token(single_use_prototype_share["id"]))
+    assert token_row is not None
+    assert token_row["use_count"] == 0
+
+
+def test_public_prototype_exchange_non_prototype_token_returns_422(client, non_prototype_share_token):
+    resp = client.post(
+        f"/api/v1/sharing/public/{non_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+
+    assert resp.status_code == 422
+
+
+def test_public_preview_reports_prototype_resource_type(
+    client,
+    unprotected_prototype_share_token,
+):
+    resp = client.get(f"/api/v1/sharing/public/{unprotected_prototype_share_token}")
+
+    assert resp.status_code == 200
+    assert resp.json()["resource_type"] == "prototype_workspace"
+
+
+def test_public_prototype_exchange_reuses_same_actor_for_same_browser_session(
+    client,
+    unprotected_prototype_share_token,
+):
+    first = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+
+    second = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM (renamed)"},
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+
+    assert second_body["shared_actor_id"] == first_body["shared_actor_id"]
+
+
+def test_public_prototype_exchange_updates_activity_timestamp_on_resume(
+    client,
+    prototype_repo,
+    unprotected_prototype_share_token,
+):
+    first = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert first.status_code == 200
+    actor_id = first.json()["shared_actor_id"]
+
+    before = asyncio.run(prototype_repo.get_shared_actor(actor_id))
+    time.sleep(0.02)
+    second = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert second.status_code == 200
+    after = asyncio.run(prototype_repo.get_shared_actor(actor_id))
+
+    assert after is not None
+    assert before is not None
+    assert after["last_activity_at"] != before["last_activity_at"]
+
+
+def test_public_prototype_exchange_rotates_resume_cookie_on_reuse(
+    client,
+    prototype_repo,
+    unprotected_prototype_share_token,
+):
+    first = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert first.status_code == 200
+    actor_id = first.json()["shared_actor_id"]
+    first_cookie = first.cookies.get(PROTOTYPE_SHARED_ACTOR_COOKIE)
+    assert first_cookie
+    before = asyncio.run(prototype_repo.get_shared_actor(actor_id))
+
+    second = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert second.status_code == 200
+    second_cookie = second.cookies.get(PROTOTYPE_SHARED_ACTOR_COOKIE)
+    after = asyncio.run(prototype_repo.get_shared_actor(actor_id))
+
+    assert second_cookie
+    assert second_cookie != first_cookie
+    assert before is not None
+    assert after is not None
+    assert after["session_binding_id"] != before["session_binding_id"]
+
+
+def test_public_prototype_exchange_allows_same_browser_resume_after_max_uses(
+    client,
+    test_app,
+    sharing_repo,
+    single_use_prototype_share,
+):
+    raw_token = single_use_prototype_share["raw_token"]
+
+    first = client.post(
+        f"/api/v1/sharing/public/{raw_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert first.status_code == 200
+    first_actor_id = first.json()["shared_actor_id"]
+
+    second = client.post(
+        f"/api/v1/sharing/public/{raw_token}/prototype-session",
+        json={},
+    )
+    assert second.status_code == 200
+    assert second.json()["shared_actor_id"] == first_actor_id
+
+    token_row = asyncio.run(sharing_repo.get_token(single_use_prototype_share["id"]))
+    assert token_row is not None
+    assert token_row["use_count"] == 1
+
+    fresh_client = TestClient(test_app)
+    third = fresh_client.post(
+        f"/api/v1/sharing/public/{raw_token}/prototype-session",
+        json={"display_name": "Another PM"},
+    )
+    assert third.status_code == 404
+
+
+def test_public_prototype_exchange_password_link_resumes_without_replaying_password(
+    client,
+    test_app,
+    sharing_repo,
+    protected_single_use_prototype_share,
+):
+    raw_token = protected_single_use_prototype_share["raw_token"]
+
+    first = client.post(
+        f"/api/v1/sharing/public/{raw_token}/prototype-session",
+        json={"display_name": "Acme PM", "password": "demo-pass"},
+    )
+    assert first.status_code == 200
+    first_actor_id = first.json()["shared_actor_id"]
+
+    second = client.post(
+        f"/api/v1/sharing/public/{raw_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert second.status_code == 200
+    assert second.json()["shared_actor_id"] == first_actor_id
+
+    token_row = asyncio.run(sharing_repo.get_token(protected_single_use_prototype_share["id"]))
+    assert token_row is not None
+    assert token_row["use_count"] == 1
+
+    fresh_client = TestClient(test_app)
+    third = fresh_client.post(
+        f"/api/v1/sharing/public/{raw_token}/prototype-session",
+        json={"display_name": "Another PM"},
+    )
+    assert third.status_code == 403
+
+
+def test_public_prototype_exchange_rejects_forged_resume_cookie(
+    client,
+    test_app,
+    unprotected_prototype_share_token,
+):
+    first = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert first.status_code == 200
+    first_actor_id = first.json()["shared_actor_id"]
+    valid_cookie = first.cookies.get(PROTOTYPE_SHARED_ACTOR_COOKIE)
+    assert valid_cookie
+
+    forged_client = TestClient(test_app)
+    forged_cookie = f"{valid_cookie}tampered"
+    forged_client.cookies.set(PROTOTYPE_SHARED_ACTOR_COOKIE, forged_cookie)
+    second = forged_client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert second.status_code == 200
+    second_actor_id = second.json()["shared_actor_id"]
+
+    assert second_actor_id != first_actor_id
+
+
+def test_public_prototype_exchange_does_not_resume_across_share_links(
+    client,
+    unprotected_prototype_share_token,
+    second_link_same_workspace_token,
+):
+    first = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert first.status_code == 200
+    first_actor_id = first.json()["shared_actor_id"]
+
+    second = client.post(
+        f"/api/v1/sharing/public/{second_link_same_workspace_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert second.status_code == 200
+    second_actor_id = second.json()["shared_actor_id"]
+
+    assert second_actor_id != first_actor_id
+
+
+def test_public_prototype_exchange_does_not_resume_across_workspaces(
+    client,
+    unprotected_prototype_share_token,
+    second_workspace_prototype_share_token,
+):
+    first = client.post(
+        f"/api/v1/sharing/public/{unprotected_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert first.status_code == 200
+    first_actor_id = first.json()["shared_actor_id"]
+
+    second = client.post(
+        f"/api/v1/sharing/public/{second_workspace_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert second.status_code == 200
+    second_actor_id = second.json()["shared_actor_id"]
+
+    assert second_actor_id != first_actor_id
+
+
+def test_public_prototype_exchange_does_not_resume_when_policy_disabled(
+    client,
+    resume_disabled_prototype_share_token,
+):
+    first = client.post(
+        f"/api/v1/sharing/public/{resume_disabled_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert first.status_code == 200
+    first_actor_id = first.json()["shared_actor_id"]
+
+    second = client.post(
+        f"/api/v1/sharing/public/{resume_disabled_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+    assert second.status_code == 200
+    second_actor_id = second.json()["shared_actor_id"]
+
+    assert second_actor_id != first_actor_id
+
+
+def test_public_prototype_exchange_archived_workspace_returns_403(
+    client,
+    archived_prototype_share_token,
+):
+    resp = client.post(
+        f"/api/v1/sharing/public/{archived_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+
+    assert resp.status_code == 403
+
+
+def test_public_prototype_exchange_missing_workspace_returns_404(
+    client,
+    missing_workspace_prototype_share_token,
+):
+    resp = client.post(
+        f"/api/v1/sharing/public/{missing_workspace_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+
+    assert resp.status_code == 404

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py
@@ -381,7 +381,7 @@ def test_public_prototype_exchange_releases_claim_on_unexpected_error(
     assert token_row["use_count"] == 0
 
 
-def test_public_prototype_exchange_releases_claim_on_post_exchange_failure(
+def test_public_prototype_exchange_retains_claim_on_post_exchange_failure(
     client,
     monkeypatch,
     sharing_repo,
@@ -405,7 +405,7 @@ def test_public_prototype_exchange_releases_claim_on_post_exchange_failure(
 
     token_row = asyncio.run(sharing_repo.get_token(single_use_prototype_share["id"]))
     assert token_row is not None
-    assert token_row["use_count"] == 0
+    assert token_row["use_count"] == 1
 
 
 def test_public_prototype_exchange_non_prototype_token_returns_422(client, non_prototype_share_token):

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_link_exchange.py
@@ -70,6 +70,9 @@ def exchange_db():
     conn.execute(
         "INSERT INTO users (id, username, email, password_hash) VALUES (1, 'owner', 'owner@test.com', 'hash')"
     )
+    conn.execute(
+        "INSERT INTO users (id, username, email, password_hash) VALUES (2, 'other', 'other@test.com', 'hash')"
+    )
     conn.commit()
     yield conn
     conn.close()
@@ -272,6 +275,18 @@ def missing_workspace_prototype_share_token(token_service):
             resource_type="prototype_workspace",
             resource_id="pws_missing_workspace",
             owner_user_id=1,
+        )
+    )
+    return token["raw_token"]
+
+
+@pytest.fixture
+def mismatched_owner_prototype_share_token(token_service, prototype_workspace):
+    token = asyncio.run(
+        token_service.generate_token(
+            resource_type="prototype_workspace",
+            resource_id=prototype_workspace["id"],
+            owner_user_id=2,
         )
     )
     return token["raw_token"]
@@ -701,6 +716,18 @@ def test_public_prototype_exchange_missing_workspace_returns_404(
 ):
     resp = client.post(
         f"/api/v1/sharing/public/{missing_workspace_prototype_share_token}/prototype-session",
+        json={"display_name": "Acme PM"},
+    )
+
+    assert resp.status_code == 404
+
+
+def test_public_prototype_exchange_rejects_token_owner_mismatch(
+    client,
+    mismatched_owner_prototype_share_token,
+):
+    resp = client.post(
+        f"/api/v1/sharing/public/{mismatched_owner_prototype_share_token}/prototype-session",
         json={"display_name": "Acme PM"},
     )
 

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -2,10 +2,60 @@
 from __future__ import annotations
 
 import sqlite3
+from typing import Any
 
 import pytest
 
 pytestmark = pytest.mark.unit
+
+
+def _workspace_row(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "id": "pws_sql_review",
+        "owner_user_id": 1,
+        "title": "SQL review",
+        "description": None,
+        "creation_source": "prompt",
+        "canonical_snapshot_id": "snap_existing",
+        "last_known_good_snapshot_id": "snap_existing",
+        "canonical_preview_status": "pending",
+        "publish_validation_status": "unknown",
+        "preview_policy_json": "{}",
+        "share_policy_json": "{}",
+        "runtime_policy_json": "{}",
+        "designated_promoter_ids_json": "[]",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        "archived_at": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _session_row(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "id": "pss_sql_review",
+        "prototype_workspace_id": "pws_sql_review",
+        "base_snapshot_id": "snap_existing",
+        "actor_user_id": None,
+        "actor_shared_actor_id": "psa_sql_review",
+        "actor_type": "external_collaborator",
+        "share_link_id": 101,
+        "acp_session_id": None,
+        "sandbox_session_id": None,
+        "sandbox_run_id": None,
+        "runtime_status": "running",
+        "preview_handle": None,
+        "preview_status": "ready",
+        "last_saved_snapshot_id": None,
+        "last_activity_at": "2026-01-01T00:00:00+00:00",
+        "expires_at": "2999-01-01T00:00:00+00:00",
+        "revoked_at": None,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    row.update(overrides)
+    return row
 
 
 def test_migration_086_creates_prototype_workspace_tables() -> None:
@@ -203,6 +253,119 @@ async def test_create_session_rejects_cross_workspace_shared_actor(repo):
             actor_type="external_collaborator",
             actor_shared_actor_id=actor_two["id"],
         )
+
+
+@pytest.mark.asyncio
+async def test_ensure_tables_uses_information_schema_for_postgres() -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    class RecordingPool:
+        pool = object()
+
+        def __init__(self) -> None:
+            self.fetchall_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+        async def fetchall(self, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, str]]:
+            self.fetchall_calls.append((sql, params))
+            return [
+                {"name": "prototype_workspaces"},
+                {"name": "prototype_snapshots"},
+                {"name": "prototype_sessions"},
+                {"name": "prototype_shared_actors"},
+                {"name": "prototype_promotion_requests"},
+            ]
+
+    pool = RecordingPool()
+    repo = PrototypeWorkspacesRepo(db_pool=pool)  # type: ignore[arg-type]
+
+    await repo.ensure_tables()
+
+    table_query = pool.fetchall_calls[0][0]
+    assert "information_schema.tables" in table_query
+    assert "sqlite_master" not in table_query
+
+
+@pytest.mark.asyncio
+async def test_update_workspace_state_preserves_columns_in_sql_without_pre_read() -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    class RecordingPool:
+        pool = None
+
+        def __init__(self) -> None:
+            self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+            self.fetchone_calls = 0
+
+        async def execute(self, sql: str, params: tuple[Any, ...] = ()) -> None:
+            self.execute_calls.append((sql, params))
+
+        async def fetchone(self, sql: str, params: tuple[Any, ...] = ()) -> dict[str, Any] | None:
+            self.fetchone_calls += 1
+            if not self.execute_calls:
+                pytest.fail("update_workspace_state should not fetch existing state before updating")
+            return _workspace_row(id=params[0])
+
+    pool = RecordingPool()
+    repo = PrototypeWorkspacesRepo(db_pool=pool)  # type: ignore[arg-type]
+
+    updated = await repo.update_workspace_state(
+        "pws_sql_review",
+        canonical_snapshot_id="snap_new",
+    )
+
+    assert updated is not None
+    update_sql, update_params = pool.execute_calls[0]
+    assert "COALESCE(?, canonical_snapshot_id)" in update_sql
+    assert "COALESCE(?, last_known_good_snapshot_id)" in update_sql
+    assert "COALESCE(?, canonical_preview_status)" in update_sql
+    assert "COALESCE(?, publish_validation_status)" in update_sql
+    assert update_params[0] == "snap_new"
+
+
+@pytest.mark.asyncio
+async def test_find_active_session_filters_candidate_in_sql() -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos.prototype_workspaces_repo import (
+        PrototypeWorkspacesRepo,
+    )
+
+    class RecordingPool:
+        pool = None
+
+        def __init__(self) -> None:
+            self.fetchone_calls: list[tuple[str, tuple[Any, ...]]] = []
+            self.fetchall_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+        async def fetchone(self, sql: str, params: tuple[Any, ...] = ()) -> dict[str, Any]:
+            self.fetchone_calls.append((sql, params))
+            return _session_row()
+
+        async def fetchall(self, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+            self.fetchall_calls.append((sql, params))
+            return [_session_row()]
+
+    pool = RecordingPool()
+    repo = PrototypeWorkspacesRepo(db_pool=pool)  # type: ignore[arg-type]
+
+    session = await repo.find_active_session(
+        prototype_workspace_id="pws_sql_review",
+        base_snapshot_id="snap_existing",
+        actor_type="external_collaborator",
+        actor_shared_actor_id="psa_sql_review",
+    )
+
+    assert session is not None
+    query, params = (pool.fetchone_calls or pool.fetchall_calls)[0]
+    assert "base_snapshot_id = ?" in query
+    assert "actor_type = ?" in query
+    assert "actor_shared_actor_id = ?" in query
+    assert "runtime_status" in query
+    assert "expires_at" in query
+    assert "LIMIT 1" in query
+    assert params[:3] == ("pws_sql_review", "snap_existing", "external_collaborator")
 
 
 def test_apply_authnz_migrations_from_v85_includes_prototype_tables(tmp_path) -> None:

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -1,0 +1,236 @@
+"""Unit tests for PrototypeWorkspacesRepo and AuthNZ prototype migration."""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_migration_086_creates_prototype_workspace_tables() -> None:
+    from tldw_Server_API.app.core.AuthNZ.migrations import (
+        migration_001_create_users_table,
+        migration_086_create_prototype_workspace_tables,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        migration_001_create_users_table(conn)
+        migration_086_create_prototype_workspace_tables(conn)
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+        table_names = {str(row[0]) for row in rows}
+        assert {
+            "prototype_workspaces",
+            "prototype_snapshots",
+            "prototype_sessions",
+            "prototype_shared_actors",
+            "prototype_promotion_requests",
+        }.issubset(table_names)
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_snapshot_and_session_enforce_single_actor_identity(repo):
+    workspace = await repo.create_workspace(owner_user_id=1, title="demo", creation_source="prompt")
+    snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_1",
+        created_by_user_id=1,
+    )
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=11,
+        display_name="Stakeholder A",
+        runtime_policy_profile="locked_collab",
+    )
+
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=snapshot["snapshot_id"],
+        actor_shared_actor_id=actor["id"],
+        actor_type="external_collaborator",
+    )
+
+    assert session["actor_shared_actor_id"] == actor["id"]
+    assert session["actor_user_id"] is None
+
+    with pytest.raises(
+        ValueError, match="owner/internal_collaborator requires actor_user_id and forbids actor_shared_actor_id"
+    ):
+        await repo.create_session(
+            prototype_workspace_id=workspace["id"],
+            base_snapshot_id=snapshot["snapshot_id"],
+            actor_type="internal_collaborator",
+            actor_user_id=2,
+            actor_shared_actor_id=actor["id"],
+        )
+
+    with pytest.raises(
+        ValueError, match="owner/internal_collaborator requires actor_user_id and forbids actor_shared_actor_id"
+    ):
+        await repo.create_session(
+            prototype_workspace_id=workspace["id"],
+            base_snapshot_id=snapshot["snapshot_id"],
+            actor_type="internal_collaborator",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_external_collaborator_with_actor_user_id(repo):
+    workspace = await repo.create_workspace(owner_user_id=1, title="demo", creation_source="prompt")
+    snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_user_invalid",
+        created_by_user_id=1,
+    )
+    with pytest.raises(
+        ValueError, match="external_collaborator requires actor_shared_actor_id and forbids actor_user_id"
+    ):
+        await repo.create_session(
+            prototype_workspace_id=workspace["id"],
+            base_snapshot_id=snapshot["snapshot_id"],
+            actor_type="external_collaborator",
+            actor_user_id=2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_internal_collaborator_with_actor_shared_actor_id(repo):
+    workspace = await repo.create_workspace(owner_user_id=1, title="demo", creation_source="prompt")
+    snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_internal_invalid",
+        created_by_user_id=1,
+    )
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=22,
+        display_name="Stakeholder B",
+        runtime_policy_profile="locked_collab",
+    )
+    with pytest.raises(
+        ValueError, match="owner/internal_collaborator requires actor_user_id and forbids actor_shared_actor_id"
+    ):
+        await repo.create_session(
+            prototype_workspace_id=workspace["id"],
+            base_snapshot_id=snapshot["snapshot_id"],
+            actor_type="internal_collaborator",
+            actor_shared_actor_id=actor["id"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_internal_collaborator_with_nonexistent_user(repo):
+    workspace = await repo.create_workspace(owner_user_id=1, title="demo", creation_source="prompt")
+    snapshot = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_missing_user",
+        created_by_user_id=1,
+    )
+    with pytest.raises(ValueError, match="actor_user_id must reference an existing user"):
+        await repo.create_session(
+            prototype_workspace_id=workspace["id"],
+            base_snapshot_id=snapshot["snapshot_id"],
+            actor_type="internal_collaborator",
+            actor_user_id=999,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_missing_base_snapshot_id(repo):
+    workspace = await repo.create_workspace(owner_user_id=1, title="demo", creation_source="prompt")
+    with pytest.raises(ValueError, match="base_snapshot_id is required"):
+        await repo.create_session(
+            prototype_workspace_id=workspace["id"],
+            base_snapshot_id="",
+            actor_type="internal_collaborator",
+            actor_user_id=2,
+        )
+
+    with pytest.raises(ValueError, match="base_snapshot_id must reference a snapshot in the same workspace"):
+        await repo.create_session(
+            prototype_workspace_id=workspace["id"],
+            base_snapshot_id="missing_snapshot",
+            actor_type="internal_collaborator",
+            actor_user_id=2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_cross_workspace_snapshot(repo):
+    workspace_one = await repo.create_workspace(owner_user_id=1, title="w1", creation_source="prompt")
+    workspace_two = await repo.create_workspace(owner_user_id=1, title="w2", creation_source="prompt")
+    await repo.create_snapshot(
+        prototype_workspace_id=workspace_two["id"],
+        snapshot_id="snap_other_workspace",
+        created_by_user_id=1,
+    )
+
+    with pytest.raises(ValueError, match="base_snapshot_id must reference a snapshot in the same workspace"):
+        await repo.create_session(
+            prototype_workspace_id=workspace_one["id"],
+            base_snapshot_id="snap_other_workspace",
+            actor_type="internal_collaborator",
+            actor_user_id=2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_cross_workspace_shared_actor(repo):
+    workspace_one = await repo.create_workspace(owner_user_id=1, title="w1", creation_source="prompt")
+    workspace_two = await repo.create_workspace(owner_user_id=1, title="w2", creation_source="prompt")
+
+    snapshot_one = await repo.create_snapshot(
+        prototype_workspace_id=workspace_one["id"],
+        snapshot_id="snap_workspace_one",
+        created_by_user_id=1,
+    )
+    actor_two = await repo.create_shared_actor(
+        prototype_workspace_id=workspace_two["id"],
+        share_link_id=31,
+        display_name="Stakeholder Other Workspace",
+        runtime_policy_profile="locked_collab",
+    )
+
+    with pytest.raises(
+        ValueError, match="actor_shared_actor_id must reference an active shared actor in the same workspace"
+    ):
+        await repo.create_session(
+            prototype_workspace_id=workspace_one["id"],
+            base_snapshot_id=snapshot_one["snapshot_id"],
+            actor_type="external_collaborator",
+            actor_shared_actor_id=actor_two["id"],
+        )
+
+
+def test_apply_authnz_migrations_from_v85_includes_prototype_tables(tmp_path) -> None:
+    from tldw_Server_API.app.core.AuthNZ.migrations import apply_authnz_migrations
+
+    db_path = tmp_path / "authnz_upgrade_path.db"
+    apply_authnz_migrations(db_path, target_version=85)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+        table_names = {str(row[0]) for row in rows}
+        assert "prototype_workspaces" not in table_names
+    finally:
+        conn.close()
+
+    apply_authnz_migrations(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+        table_names = {str(row[0]) for row in rows}
+        assert {
+            "prototype_workspaces",
+            "prototype_snapshots",
+            "prototype_sessions",
+            "prototype_shared_actors",
+            "prototype_promotion_requests",
+        }.issubset(table_names)
+    finally:
+        conn.close()

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sqlite3
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -285,6 +286,31 @@ async def test_ensure_tables_uses_information_schema_for_postgres() -> None:
     table_query = pool.fetchall_calls[0][0]
     assert "information_schema.tables" in table_query
     assert "sqlite_master" not in table_query
+
+
+def test_row_to_dict_logs_conversion_failures(monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos import prototype_workspaces_repo as repo_module
+
+    class BrokenRow:
+        def keys(self) -> list[str]:
+            return ["id"]
+
+        def __getitem__(self, _key: str) -> str:
+            raise TypeError("broken row access")
+
+    warnings: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        repo_module,
+        "logger",
+        SimpleNamespace(debug=lambda *args: warnings.append(args)),
+        raising=False,
+    )
+
+    result = repo_module.PrototypeWorkspacesRepo._row_to_dict(BrokenRow())
+
+    assert result == {}
+    assert warnings
+    assert "Failed to convert prototype workspace row" in warnings[0][0]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_prototype_repo.py
@@ -276,6 +276,7 @@ async def test_ensure_tables_uses_information_schema_for_postgres() -> None:
                 {"name": "prototype_sessions"},
                 {"name": "prototype_shared_actors"},
                 {"name": "prototype_promotion_requests"},
+                {"name": "prototype_preview_handles"},
             ]
 
     pool = RecordingPool()

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
@@ -1,0 +1,211 @@
+"""Task 4 coverage for prototype runtime job orchestration."""
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_attr(module: Any, *names: str) -> Any:
+    for name in names:
+        if hasattr(module, name):
+            return getattr(module, name)
+    raise AttributeError(f"Module {module.__name__} does not define any of: {', '.join(names)}")
+
+
+@pytest.fixture
+def prototype_jobs(repo):
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.jobs")
+    jobs_cls = _load_attr(module, "PrototypeWorkspaceJobs", "PrototypeRuntimeJobs")
+    return jobs_cls(repo=repo)
+
+
+async def _seed_branch_workspace(repo, prototype_db):
+    workspace = await repo.create_workspace(
+        owner_user_id=1,
+        title="Task 4 Runtime",
+        creation_source="prompt",
+        runtime_policy={"external_collaborator_profile": "locked_collab"},
+        share_policy={"allow_browser_session_resume": True},
+    )
+    canonical = await repo.create_snapshot(
+        prototype_workspace_id=workspace["id"],
+        snapshot_id="snap_canonical",
+        created_by_user_id=1,
+    )
+    prototype_db.execute(
+        """
+        UPDATE prototype_workspaces
+        SET canonical_snapshot_id = ?, last_known_good_snapshot_id = ?, canonical_preview_status = ?, publish_validation_status = ?
+        WHERE id = ?
+        """,
+        ("snap_canonical", "snap_canonical", "ready", "validated", workspace["id"]),
+    )
+    prototype_db.commit()
+    return workspace, canonical
+
+
+def test_jobs_module_exports_expected_task_types() -> None:
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.jobs")
+    assert {
+        "branch_session_bootstrap",
+        "preview_boot",
+        "snapshot_save",
+        "publish_validate_and_promote",
+    }.issubset(set(getattr(module, "PROTOTYPE_JOB_TYPES", set())))
+
+
+@pytest.mark.asyncio
+async def test_branch_session_bootstrap_is_idempotent_for_same_request_nonce(
+    repo,
+    prototype_db,
+    prototype_jobs,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+
+    first = await prototype_jobs.enqueue_branch_session_bootstrap(
+        prototype_workspace_id=workspace["id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+        request_nonce="retry-token",
+    )
+    second = await prototype_jobs.enqueue_branch_session_bootstrap(
+        prototype_workspace_id=workspace["id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+        request_nonce="retry-token",
+    )
+
+    assert first["id"] == second["id"]
+    assert first["job_type"] == "branch_session_bootstrap"
+    assert first["idempotency_key"] == second["idempotency_key"]
+    assert first["payload"]["prototype_workspace_id"] == workspace["id"]
+    assert first["payload"]["base_snapshot_id"] == canonical["snapshot_id"]
+    assert first["payload"]["request_nonce"] == "retry-token"
+
+
+@pytest.mark.asyncio
+async def test_branch_session_bootstrap_does_not_reuse_expired_session(
+    repo,
+    prototype_db,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+    expired = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+    existing = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=canonical["snapshot_id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+        expires_at=expired,
+    )
+
+    service_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(service_module, "PrototypeWorkspaceService", "PrototypePromotionService")
+    service = service_cls(repo=repo)
+
+    result = await service.create_or_reuse_branch_session(
+        prototype_workspace_id=workspace["id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+        request_nonce="fresh-after-expiry",
+    )
+
+    assert result["created"] is True
+    assert result["session"]["id"] != existing["id"]
+
+
+@pytest.mark.asyncio
+async def test_preview_boot_idempotency_distinguishes_runtime_target_url(
+    repo,
+    prototype_db,
+    prototype_jobs,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=canonical["snapshot_id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+    )
+
+    first = await prototype_jobs.enqueue_preview_boot(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id=canonical["snapshot_id"],
+        runtime_target_url="http://127.0.0.1:9101",
+    )
+    second = await prototype_jobs.enqueue_preview_boot(
+        prototype_workspace_id=workspace["id"],
+        prototype_session_id=session["id"],
+        snapshot_id=canonical["snapshot_id"],
+        runtime_target_url="http://127.0.0.1:9102",
+    )
+
+    assert first["id"] != second["id"]
+    assert first["idempotency_key"] != second["idempotency_key"]
+
+
+@pytest.mark.asyncio
+async def test_revoked_external_collaborator_cannot_reuse_branch_session(
+    repo,
+    prototype_db,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+    actor = await repo.create_shared_actor(
+        prototype_workspace_id=workspace["id"],
+        share_link_id=51,
+        display_name="Revoked Stakeholder",
+        runtime_policy_profile="locked_collab",
+    )
+    await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=canonical["snapshot_id"],
+        actor_type="external_collaborator",
+        actor_shared_actor_id=actor["id"],
+    )
+    prototype_db.execute(
+        "UPDATE prototype_shared_actors SET revoked_at = ? WHERE id = ?",
+        (datetime.now(timezone.utc).isoformat(), actor["id"]),
+    )
+    prototype_db.commit()
+
+    service_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(service_module, "PrototypeWorkspaceService", "PrototypePromotionService")
+    service = service_cls(repo=repo)
+
+    with pytest.raises(RuntimeError, match="revoked"):
+        await service.create_or_reuse_branch_session(
+            prototype_workspace_id=workspace["id"],
+            actor_type="external_collaborator",
+            actor_shared_actor_id=actor["id"],
+            request_nonce="after-revoke",
+        )
+
+
+@pytest.mark.asyncio
+async def test_expired_session_cannot_save_snapshot(
+    repo,
+    prototype_db,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=canonical["snapshot_id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+        expires_at=(datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+    )
+
+    service_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(service_module, "PrototypeWorkspaceService", "PrototypePromotionService")
+    service = service_cls(repo=repo)
+
+    with pytest.raises(RuntimeError, match="expired"):
+        await service.save_session_snapshot(
+            prototype_session_id=session["id"],
+            snapshot_id="snap_should_not_save",
+        )

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
@@ -209,3 +209,57 @@ async def test_expired_session_cannot_save_snapshot(
             prototype_session_id=session["id"],
             snapshot_id="snap_should_not_save",
         )
+
+
+@pytest.mark.asyncio
+async def test_archived_workspace_blocks_branch_session_creation(
+    repo,
+    prototype_db,
+):
+    workspace, _canonical = await _seed_branch_workspace(repo, prototype_db)
+    prototype_db.execute(
+        "UPDATE prototype_workspaces SET archived_at = ? WHERE id = ?",
+        (datetime.now(timezone.utc).isoformat(), workspace["id"]),
+    )
+    prototype_db.commit()
+
+    service_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(service_module, "PrototypeWorkspaceService", "PrototypePromotionService")
+    service = service_cls(repo=repo)
+
+    with pytest.raises(RuntimeError, match="archived"):
+        await service.create_or_reuse_branch_session(
+            prototype_workspace_id=workspace["id"],
+            actor_type="internal_collaborator",
+            actor_user_id=2,
+            request_nonce="archived-block",
+        )
+
+
+@pytest.mark.asyncio
+async def test_archived_workspace_blocks_snapshot_save(
+    repo,
+    prototype_db,
+):
+    workspace, canonical = await _seed_branch_workspace(repo, prototype_db)
+    session = await repo.create_session(
+        prototype_workspace_id=workspace["id"],
+        base_snapshot_id=canonical["snapshot_id"],
+        actor_type="internal_collaborator",
+        actor_user_id=2,
+    )
+    prototype_db.execute(
+        "UPDATE prototype_workspaces SET archived_at = ? WHERE id = ?",
+        (datetime.now(timezone.utc).isoformat(), workspace["id"]),
+    )
+    prototype_db.commit()
+
+    service_module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.service")
+    service_cls = _load_attr(service_module, "PrototypeWorkspaceService", "PrototypePromotionService")
+    service = service_cls(repo=repo)
+
+    with pytest.raises(RuntimeError, match="archived"):
+        await service.save_session_snapshot(
+            prototype_session_id=session["id"],
+            snapshot_id="snap_archived_block",
+        )

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_runtime_jobs.py
@@ -24,6 +24,15 @@ def prototype_jobs(repo):
     return jobs_cls(repo=repo)
 
 
+class _PromoteService:
+    def __init__(self) -> None:
+        self.called = False
+
+    async def promote_candidate(self, **_kwargs: Any) -> dict[str, Any]:
+        self.called = True
+        return {"status": "promoted"}
+
+
 async def _seed_branch_workspace(repo, prototype_db):
     workspace = await repo.create_workspace(
         owner_user_id=1,
@@ -57,6 +66,42 @@ def test_jobs_module_exports_expected_task_types() -> None:
         "snapshot_save",
         "publish_validate_and_promote",
     }.issubset(set(getattr(module, "PROTOTYPE_JOB_TYPES", set())))
+
+
+def test_default_jobs_manager_is_shared_for_same_environment(repo, tmp_path, monkeypatch) -> None:
+    module = importlib.import_module("tldw_Server_API.app.core.Prototype_Workspaces.jobs")
+    jobs_cls = _load_attr(module, "PrototypeWorkspaceJobs", "PrototypeRuntimeJobs")
+    monkeypatch.delenv("JOBS_DB_URL", raising=False)
+    monkeypatch.setenv("JOBS_DB_PATH", str(tmp_path / "prototype_jobs.db"))
+    monkeypatch.setattr(module, "_DEFAULT_JOBS_MANAGER", None, raising=False)
+    monkeypatch.setattr(module, "_DEFAULT_JOBS_MANAGER_KEY", None, raising=False)
+
+    first = jobs_cls(repo=repo)
+    second = jobs_cls(repo=repo)
+
+    assert first._jobs_manager is second._jobs_manager
+
+
+@pytest.mark.asyncio
+async def test_publish_job_requires_reviewer_user_id_before_service_call() -> None:
+    worker_module = importlib.import_module(
+        "tldw_Server_API.app.core.Prototype_Workspaces.jobs_worker"
+    )
+    service = _PromoteService()
+
+    with pytest.raises(ValueError, match="reviewer_user_id is required"):
+        await worker_module.handle_prototype_job(
+            {
+                "job_type": "publish_validate_and_promote",
+                "payload": {
+                    "prototype_workspace_id": "pw_1",
+                    "candidate_snapshot_id": "snap_candidate",
+                },
+            },
+            service=service,
+        )
+
+    assert service.called is False
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/PrototypeWorkspaces/test_service_authorization.py
+++ b/tldw_Server_API/tests/PrototypeWorkspaces/test_service_authorization.py
@@ -1,0 +1,112 @@
+"""Authorization regressions for prototype workspace branch sessions."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.Prototype_Workspaces.service import PrototypeWorkspaceService
+
+pytestmark = pytest.mark.unit
+
+
+async def _seed_workspace(service: PrototypeWorkspaceService) -> dict[str, Any]:
+    return await service.create_workspace(
+        owner_user_id=1,
+        title="Revocation Auth",
+        creation_source="prompt",
+    )
+
+
+def _revoked_at() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_create_or_reuse_branch_session_rejects_revoked_at_only_shared_actor(repo, monkeypatch):
+    service = PrototypeWorkspaceService(repo=repo)
+    workspace = await _seed_workspace(service)
+
+    async def revoked_actor(_shared_actor_id: str) -> dict[str, Any]:
+        return {"id": "pactor_revoked", "revoked_at": _revoked_at()}
+
+    async def existing_session(**_kwargs: Any) -> dict[str, Any]:
+        return {"id": "pss_existing"}
+
+    monkeypatch.setattr(repo, "get_shared_actor", revoked_actor)
+    monkeypatch.setattr(repo, "find_active_session", existing_session)
+
+    with pytest.raises(RuntimeError, match="revoked shared actor"):
+        await service.create_or_reuse_branch_session(
+            prototype_workspace_id=workspace["id"],
+            actor_type="external_collaborator",
+            actor_shared_actor_id="pactor_revoked",
+        )
+
+
+@pytest.mark.asyncio
+async def test_save_session_snapshot_rejects_revoked_at_only_session(repo, monkeypatch):
+    service = PrototypeWorkspaceService(repo=repo)
+    workspace = await _seed_workspace(service)
+
+    async def revoked_session(_prototype_session_id: str) -> dict[str, Any]:
+        return {
+            "id": "pss_revoked",
+            "prototype_workspace_id": workspace["id"],
+            "base_snapshot_id": workspace["canonical_snapshot_id"],
+            "actor_type": "internal_collaborator",
+            "actor_user_id": 2,
+            "revoked_at": _revoked_at(),
+        }
+
+    async def create_snapshot(**_kwargs: Any) -> dict[str, Any]:
+        return {"snapshot_id": "psnap_should_not_be_created"}
+
+    async def update_session_state(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(repo, "get_session", revoked_session)
+    monkeypatch.setattr(repo, "create_snapshot", create_snapshot)
+    monkeypatch.setattr(repo, "update_session_state", update_session_state)
+
+    with pytest.raises(RuntimeError, match="revoked session"):
+        await service.save_session_snapshot(
+            prototype_session_id="pss_revoked",
+            snapshot_id="psnap_blocked",
+        )
+
+
+@pytest.mark.asyncio
+async def test_save_session_snapshot_rejects_revoked_at_only_shared_actor(repo, monkeypatch):
+    service = PrototypeWorkspaceService(repo=repo)
+    workspace = await _seed_workspace(service)
+
+    async def external_session(_prototype_session_id: str) -> dict[str, Any]:
+        return {
+            "id": "pss_external",
+            "prototype_workspace_id": workspace["id"],
+            "base_snapshot_id": workspace["canonical_snapshot_id"],
+            "actor_type": "external_collaborator",
+            "actor_shared_actor_id": "pactor_revoked",
+        }
+
+    async def revoked_actor(_shared_actor_id: str) -> dict[str, Any]:
+        return {"id": "pactor_revoked", "revoked_at": _revoked_at()}
+
+    async def create_snapshot(**_kwargs: Any) -> dict[str, Any]:
+        return {"snapshot_id": "psnap_should_not_be_created"}
+
+    async def update_session_state(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(repo, "get_session", external_session)
+    monkeypatch.setattr(repo, "get_shared_actor", revoked_actor)
+    monkeypatch.setattr(repo, "create_snapshot", create_snapshot)
+    monkeypatch.setattr(repo, "update_session_state", update_session_state)
+
+    with pytest.raises(RuntimeError, match="revoked shared actor"):
+        await service.save_session_snapshot(
+            prototype_session_id="pss_external",
+            snapshot_id="psnap_blocked",
+        )

--- a/tldw_Server_API/tests/Sharing/conftest.py
+++ b/tldw_Server_API/tests/Sharing/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from tldw_Server_API.app.core.AuthNZ.migrations import (
     migration_001_create_users_table,
     migration_077_create_sharing_tables,
+    migration_087_expand_share_tokens_resource_type_for_prototypes,
 )
 
 
@@ -52,6 +53,7 @@ def sharing_db():
     )
     conn.commit()
     migration_077_create_sharing_tables(conn)
+    migration_087_expand_share_tokens_resource_type_for_prototypes(conn)
     yield conn
     conn.close()
 

--- a/tldw_Server_API/tests/Sharing/test_share_token_migrations.py
+++ b/tldw_Server_API/tests/Sharing/test_share_token_migrations.py
@@ -1,0 +1,98 @@
+"""SQLite migration coverage for workspace share tokens."""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.migrations import (
+    migration_001_create_users_table,
+    migration_077_create_sharing_tables,
+    migration_087_expand_share_tokens_resource_type_for_prototypes,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_migration_087_retries_from_clean_rebuild_table() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        migration_001_create_users_table(conn)
+        migration_077_create_sharing_tables(conn)
+        conn.execute(
+            "INSERT INTO users (id, username, email, password_hash) VALUES (1, 'owner', 'owner@test.com', 'hash')"
+        )
+        conn.execute(
+            """
+            INSERT INTO share_tokens (
+                id, token_hash, token_prefix, resource_type, resource_id,
+                owner_user_id, access_level, allow_clone
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                1,
+                "hash_retry",
+                "pref",
+                "workspace",
+                "prototype_workspace::pws_retry",
+                1,
+                "view_chat",
+                1,
+            ),
+        )
+        conn.execute(
+            """
+            CREATE TABLE share_tokens_new (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                token_hash      TEXT UNIQUE NOT NULL,
+                token_prefix    TEXT NOT NULL,
+                resource_type   TEXT NOT NULL
+                    CHECK (resource_type IN ('chatbook', 'workspace', 'prototype_workspace')),
+                resource_id     TEXT NOT NULL,
+                owner_user_id   INTEGER NOT NULL,
+                access_level    TEXT NOT NULL DEFAULT 'view_chat',
+                allow_clone     INTEGER NOT NULL DEFAULT 1,
+                password_hash   TEXT,
+                max_uses        INTEGER,
+                use_count       INTEGER NOT NULL DEFAULT 0,
+                expires_at      TIMESTAMP,
+                created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                revoked_at      TIMESTAMP,
+                FOREIGN KEY (owner_user_id) REFERENCES users(id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO share_tokens_new (
+                id, token_hash, token_prefix, resource_type, resource_id,
+                owner_user_id, access_level, allow_clone
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                1,
+                "hash_retry",
+                "pref",
+                "prototype_workspace",
+                "pws_retry",
+                1,
+                "view_chat",
+                1,
+            ),
+        )
+        conn.commit()
+
+        migration_087_expand_share_tokens_resource_type_for_prototypes(conn)
+
+        row = conn.execute(
+            "SELECT resource_type, resource_id FROM share_tokens WHERE token_hash = ?",
+            ("hash_retry",),
+        ).fetchone()
+        scratch = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'share_tokens_new'"
+        ).fetchone()
+
+        assert row == ("prototype_workspace", "pws_retry")
+        assert scratch is None
+    finally:
+        conn.close()

--- a/tldw_Server_API/tests/Sharing/test_share_token_service.py
+++ b/tldw_Server_API/tests/Sharing/test_share_token_service.py
@@ -117,6 +117,21 @@ async def test_use_token_increments(token_service, repo):
 
 
 @pytest.mark.asyncio
+async def test_claim_token_use_honors_max_uses(token_service, repo):
+    result = await token_service.generate_token(
+        resource_type="workspace",
+        resource_id="ws-1",
+        owner_user_id=1,
+        max_uses=1,
+    )
+    assert await token_service.claim_token_use(result["id"]) is True
+    assert await token_service.claim_token_use(result["id"]) is False
+
+    fetched = await repo.get_token(result["id"])
+    assert fetched["use_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_revoke_token(token_service):
     result = await token_service.generate_token(
         resource_type="workspace",

--- a/tldw_Server_API/tests/Sharing/test_sharing_endpoints.py
+++ b/tldw_Server_API/tests/Sharing/test_sharing_endpoints.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import builtins
+import asyncio
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -558,6 +559,17 @@ class TestShareTokens:
         assert "raw_token" in data
         assert data["resource_type"] == "workspace"
 
+    def test_create_prototype_workspace_token(self, client, mock_repo):
+        resp = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "prototype_workspace",
+            "resource_id": "pws-1",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "raw_token" in data
+        assert data["resource_type"] == "prototype_workspace"
+        assert data["resource_id"] == "pws-1"
+
     def test_list_tokens(self, client, mock_repo):
         client.post("/api/v1/sharing/tokens", json={
             "resource_type": "workspace",
@@ -587,6 +599,16 @@ class TestPublicEndpoints:
         resp = client.get(f"/api/v1/sharing/public/{raw_token}")
         assert resp.status_code == 200
         assert resp.json()["resource_type"] == "workspace"
+
+    def test_public_preview_prototype_workspace_token(self, client, mock_repo):
+        create = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "prototype_workspace",
+            "resource_id": "pws-1",
+        })
+        raw_token = create.json()["raw_token"]
+        resp = client.get(f"/api/v1/sharing/public/{raw_token}")
+        assert resp.status_code == 200
+        assert resp.json()["resource_type"] == "prototype_workspace"
 
     def test_public_preview_invalid(self, client, mock_repo):
         resp = client.get("/api/v1/sharing/public/not-a-valid-token-here-12345678")
@@ -638,6 +660,22 @@ class TestPublicEndpoints:
         resp = client.post(f"/api/v1/sharing/public/{raw_token}/import")
         assert resp.status_code == 403
         assert "Password verification required" in resp.json()["detail"]
+
+    def test_public_import_rejects_prototype_workspace_token(self, client, mock_repo):
+        create = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "prototype_workspace",
+            "resource_id": "pws-import",
+        })
+        token_id = create.json()["id"]
+        raw_token = create.json()["raw_token"]
+
+        resp = client.post(f"/api/v1/sharing/public/{raw_token}/import")
+        assert resp.status_code == 422
+        assert "prototype-session" in resp.json()["detail"]
+
+        token_row = asyncio.run(mock_repo.get_token(token_id))
+        assert token_row is not None
+        assert token_row["use_count"] == 0
 
 
 class TestAdmin:

--- a/tldw_Server_API/tests/Sharing/test_sharing_endpoints.py
+++ b/tldw_Server_API/tests/Sharing/test_sharing_endpoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import builtins
 import asyncio
+import inspect
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -12,10 +13,17 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from pydantic import Field
 
+from tldw_Server_API.app.api.v1.endpoints import sharing as sharing_endpoints
 from tldw_Server_API.app.api.v1.endpoints.sharing import router
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 
 pytestmark = pytest.mark.integration
+
+
+async def _resolve_factory(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 class _TestUser(User):
@@ -317,6 +325,44 @@ async def test_admin_audit_log_includes_canonical_offset_pagination(monkeypatch)
     assert response.pagination.total == 3
     assert response.pagination.has_more is True
     assert response.pagination.next_offset == 2
+
+
+@pytest.mark.asyncio
+async def test_lazy_shared_repo_awaits_db_pool(monkeypatch):
+    fake_pool = object()
+
+    async def fake_get_db_pool():
+        return fake_pool
+
+    from tldw_Server_API.app.core.AuthNZ import database
+
+    monkeypatch.setattr(database, "get_db_pool", fake_get_db_pool)
+
+    repo = await _resolve_factory(sharing_endpoints._get_repo())
+    db_pool = repo.db_pool
+    if inspect.isawaitable(db_pool):
+        await db_pool
+
+    assert db_pool is fake_pool
+
+
+@pytest.mark.asyncio
+async def test_lazy_prototype_repo_awaits_db_pool(monkeypatch):
+    fake_pool = object()
+
+    async def fake_get_db_pool():
+        return fake_pool
+
+    from tldw_Server_API.app.core.AuthNZ import database
+
+    monkeypatch.setattr(database, "get_db_pool", fake_get_db_pool)
+
+    repo = await _resolve_factory(sharing_endpoints._get_prototype_repo())
+    db_pool = repo.db_pool
+    if inspect.isawaitable(db_pool):
+        await db_pool
+
+    assert db_pool is fake_pool
 
 
 @pytest.fixture

--- a/tldw_Server_API/tests/Sharing/test_sharing_endpoints.py
+++ b/tldw_Server_API/tests/Sharing/test_sharing_endpoints.py
@@ -1,15 +1,15 @@
 """Integration tests for the sharing API endpoints."""
 from __future__ import annotations
 
-import builtins
 import asyncio
+import builtins
 import inspect
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 from pydantic import Field
 
@@ -368,6 +368,10 @@ async def test_lazy_prototype_repo_awaits_db_pool(monkeypatch):
 @pytest.fixture
 def mock_repo(repo, tmp_path):
     """Patch repo and security helpers while keeping the real audit service wiring."""
+    class _PrototypeRepoStub:
+        async def get_workspace(self, prototype_workspace_id: str):
+            return {"id": prototype_workspace_id, "owner_user_id": 1}
+
     async def _noop_verify(*args, **kwargs):
         pass
 
@@ -383,6 +387,7 @@ def mock_repo(repo, tmp_path):
          patch("tldw_Server_API.app.api.v1.endpoints.sharing._verify_workspace_ownership", _noop_verify), \
          patch("tldw_Server_API.app.api.v1.endpoints.sharing._validate_user_has_share_access", _noop_verify), \
          patch("tldw_Server_API.app.api.v1.endpoints.sharing._get_token_service") as mock_ts, \
+         patch("tldw_Server_API.app.api.v1.endpoints.sharing._get_prototype_repo", return_value=_PrototypeRepoStub()), \
          patch("tldw_Server_API.app.core.DB_Management.db_path_utils.DatabasePaths.get_shared_audit_db_path", return_value=shared_audit_path):
         from tldw_Server_API.app.core.Sharing.share_token_service import ShareTokenService
         mock_ts.return_value = ShareTokenService(repo)
@@ -616,6 +621,20 @@ class TestShareTokens:
         assert data["resource_type"] == "prototype_workspace"
         assert data["resource_id"] == "pws-1"
 
+    def test_create_prototype_workspace_token_requires_owner(self, client, mock_repo, monkeypatch):
+        class _ForeignPrototypeRepo:
+            async def get_workspace(self, prototype_workspace_id: str):
+                return {"id": prototype_workspace_id, "owner_user_id": 2}
+
+        monkeypatch.setattr(sharing_endpoints, "_get_prototype_repo", lambda: _ForeignPrototypeRepo())
+
+        resp = client.post("/api/v1/sharing/tokens", json={
+            "resource_type": "prototype_workspace",
+            "resource_id": "pws-foreign",
+        })
+
+        assert resp.status_code == 404
+
     def test_list_tokens(self, client, mock_repo):
         client.post("/api/v1/sharing/tokens", json={
             "resource_type": "workspace",
@@ -633,6 +652,22 @@ class TestShareTokens:
         token_id = create.json()["id"]
         resp = client.delete(f"/api/v1/sharing/tokens/{token_id}")
         assert resp.status_code == 200
+
+
+def test_request_is_secure_uses_first_forwarded_proto_value():
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "headers": [(b"x-forwarded-proto", b"http,https")],
+        }
+    )
+
+    assert sharing_endpoints._request_is_secure(request) is False
 
 
 class TestPublicEndpoints:


### PR DESCRIPTION
https://www.anthropic.com/news/claude-design-anthropic-labs

## Summary
- add the prototype workspace domain slice across metadata, runtime jobs, previews, sharing, promotion, and owner/collaborator APIs
- add the `/prototype-workspaces` frontend route, owner/collaborator screens, prototype share-link flow, and regression coverage for the public share handoff
- add operator/API documentation plus verification notes for the full prototype workspace vertical slice

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/PrototypeWorkspaces tldw_Server_API/tests/Sharing/test_sharing_endpoints.py -q`
- [x] `cd apps/packages/ui && bunx vitest run src/hooks/__tests__/usePrototypeWorkspaces.test.tsx src/hooks/__tests__/useSharing.auth.test.tsx src/routes/__tests__/option-prototype-workspaces.route.test.tsx src/components/Option/PrototypeWorkspace/__tests__/PrototypeWorkspacePage.test.tsx src/components/Option/__tests__/PublicShare.test.tsx`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -f json -o /tmp/bandit_prototype_task6.json tldw_Server_API/app/api/v1/endpoints/prototype_workspaces.py tldw_Server_API/app/api/v1/schemas/prototype_workspace_schemas.py`

## Change summary
Human requester must replace this section before merge.
Per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`, this PR is not merge-ready until you add your own summary explaining what changed and why these implementation choices were made.