### PR TITLE
Phase 2.4: add 4 typed config sections (database, server, logging, embeddings)

### DIFF
--- a/tldw_Server_API/app/core/config_sections/__init__.py
+++ b/tldw_Server_API/app/core/config_sections/__init__.py
@@ -5,8 +5,12 @@ from typing import Any
 
 from .audio import AudioConfig, load_audio_config
 from .auth import AuthConfig, load_auth_config
+from .database import DatabaseConfig, load_database_config
+from .embeddings import EmbeddingsConfig, load_embeddings_config
+from .logging import LoggingConfig, load_logging_config
 from .providers import ProvidersConfig, load_providers_config
 from .rag import RAGConfig, load_rag_config
+from .server import ServerConfig, load_server_config
 from .stt import STTConfig, load_stt_config
 from .types import ConfigParserLike
 
@@ -14,9 +18,13 @@ from .types import ConfigParserLike
 @dataclass(frozen=True)
 class ConfigSections:
     auth: AuthConfig
+    database: DatabaseConfig
+    embeddings: EmbeddingsConfig
+    logging: LoggingConfig
     rag: RAGConfig
     audio: AudioConfig
     providers: ProvidersConfig
+    server: ServerConfig
     stt: STTConfig
 
 
@@ -28,9 +36,13 @@ def load_config_sections(config_parser: ConfigParserLike | None = None) -> Confi
 
     return ConfigSections(
         auth=load_auth_config(config_parser),
+        database=load_database_config(config_parser),
+        embeddings=load_embeddings_config(config_parser),
+        logging=load_logging_config(config_parser),
         rag=load_rag_config(config_parser),
         audio=load_audio_config(config_parser),
         providers=load_providers_config(config_parser),
+        server=load_server_config(config_parser),
         stt=load_stt_config(config_parser),
     )
 
@@ -39,13 +51,21 @@ __all__ = [
     "AudioConfig",
     "AuthConfig",
     "ConfigSections",
+    "DatabaseConfig",
+    "EmbeddingsConfig",
+    "LoggingConfig",
     "ProvidersConfig",
     "RAGConfig",
     "STTConfig",
+    "ServerConfig",
     "load_audio_config",
     "load_auth_config",
     "load_config_sections",
+    "load_database_config",
+    "load_embeddings_config",
+    "load_logging_config",
     "load_providers_config",
     "load_rag_config",
+    "load_server_config",
     "load_stt_config",
 ]

--- a/tldw_Server_API/app/core/config_sections/database.py
+++ b/tldw_Server_API/app/core/config_sections/database.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    type: str
+    sqlite_path: str
+    sqlite_wal_mode: bool
+    sqlite_foreign_keys: bool
+    backup_path: str
+    pg_host: str
+    pg_port: int
+    pg_database: str
+    pg_user: str
+    pg_sslmode: str
+    pg_pool_size: int
+    pg_max_overflow: int
+    pg_pool_timeout: float
+    chroma_db_path: str
+    prompts_db_path: str
+
+
+def load_database_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> DatabaseConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+    g = lambda key, default: str(
+        env_map.get(f"DB_{key.upper()}", "")
+        or config_parser.get("Database", key, fallback=default)
+    ).strip() or default
+
+    return DatabaseConfig(
+        type=g("type", "sqlite"),
+        sqlite_path=g("sqlite_path", "Databases/server_media_summary.db"),
+        sqlite_wal_mode=g("sqlite_wal_mode", "true").lower() in ("true", "1", "yes"),
+        sqlite_foreign_keys=g("sqlite_foreign_keys", "true").lower() in ("true", "1", "yes"),
+        backup_path=g("backup_path", "./tldw_DB_Backups/"),
+        pg_host=g("pg_host", "localhost"),
+        pg_port=int(g("pg_port", "5432")),
+        pg_database=g("pg_database", "tldw_content"),
+        pg_user=g("pg_user", "tldw_user"),
+        pg_sslmode=g("pg_sslmode", "prefer"),
+        pg_pool_size=int(g("pg_pool_size", "20")),
+        pg_max_overflow=int(g("pg_max_overflow", "40")),
+        pg_pool_timeout=float(g("pg_pool_timeout", "30.0")),
+        chroma_db_path=g("chroma_db_path", "Databases/chroma_db"),
+        prompts_db_path=g("prompts_db_path", "Databases/prompts.db"),
+    )

--- a/tldw_Server_API/app/core/config_sections/embeddings.py
+++ b/tldw_Server_API/app/core/config_sections/embeddings.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+
+@dataclass(frozen=True)
+class EmbeddingsConfig:
+    embedding_provider: str
+    embedding_model: str
+    onnx_model_path: str
+    model_dir: str
+    embedding_api_url: str
+    chunk_size: int
+    overlap: int
+    enable_contextual_chunking: bool
+    contextual_llm_model: str
+
+
+def load_embeddings_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> EmbeddingsConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+    g = lambda key, default: str(
+        env_map.get(f"EMBEDDING_{key.upper()}", "")
+        or config_parser.get("Embeddings", key, fallback=default)
+    ).strip() or default
+
+    return EmbeddingsConfig(
+        embedding_provider=env_map.get("EMBEDDING_PROVIDER", "") or g("embedding_provider", "huggingface"),
+        embedding_model=env_map.get("EMBEDDING_MODEL", "") or g("embedding_model", "Qwen/Qwen3-Embedding-0.6B"),
+        onnx_model_path=g("onnx_model_path", "./App_Function_Libraries/models/onnx_models/"),
+        model_dir=g("model_dir", "./App_Function_Libraries/models/embedding_models"),
+        embedding_api_url=g("embedding_api_url", "http://localhost:8080/v1/embeddings"),
+        chunk_size=int(g("chunk_size", "400")),
+        overlap=int(g("overlap", "200")),
+        enable_contextual_chunking=g("enable_contextual_chunking", "false").lower() in ("true", "1", "yes"),
+        contextual_llm_model=g("contextual_llm_model", "gpt-3.5-turbo"),
+    )

--- a/tldw_Server_API/app/core/config_sections/logging.py
+++ b/tldw_Server_API/app/core/config_sections/logging.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+
+@dataclass(frozen=True)
+class LoggingConfig:
+    log_level: str
+    log_file: str
+    log_metrics_file: str
+    backup_count: int
+    system_log_file_path: str
+    system_log_file_max_entries: int
+
+
+def load_logging_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> LoggingConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+    g = lambda key, default: str(
+        env_map.get(f"LOG_{key.upper()}", "")
+        or config_parser.get("Logging", key, fallback=default)
+    ).strip() or default
+
+    return LoggingConfig(
+        log_level=env_map.get("LOG_LEVEL", "") or g("log_level", "INFO"),
+        log_file=g("log_file", "./Logs/tldw_app_logs.json"),
+        log_metrics_file=g("log_metrics_file", "./Logs/tldw_metrics_logs.json"),
+        backup_count=int(g("backup_count", "5")),
+        system_log_file_path=g("system_log_file_path", "Databases/system_logs.jsonl"),
+        system_log_file_max_entries=int(g("system_log_file_max_entries", "5000")),
+    )

--- a/tldw_Server_API/app/core/config_sections/server.py
+++ b/tldw_Server_API/app/core/config_sections/server.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    disable_cors: bool
+    cors_allow_credentials: bool
+
+
+def load_server_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> ServerConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+
+    disable_cors = str(
+        env_map.get("DISABLE_CORS", "")
+        or config_parser.get("Server", "disable_cors", fallback="false")
+    ).strip().lower() in ("true", "1", "yes")
+
+    cors_allow_credentials = str(
+        env_map.get("CORS_ALLOW_CREDENTIALS", "")
+        or config_parser.get("Server", "cors_allow_credentials", fallback="false")
+    ).strip().lower() in ("true", "1", "yes")
+
+    return ServerConfig(
+        disable_cors=disable_cors,
+        cors_allow_credentials=cors_allow_credentials,
+    )


### PR DESCRIPTION
## Summary

Extend typed config sections from 6 to 10 modules, following the established frozen-dataclass + loader pattern.

**New sections:**
- `DatabaseConfig` — type, sqlite_path, WAL mode, PG pool settings, chroma/prompts paths
- `ServerConfig` — CORS disable, credentials settings
- `LoggingConfig` — log level, file paths, backup count, system log settings
- `EmbeddingsConfig` — provider, model, paths, chunk size, contextual chunking settings

Each supports environment variable overrides (same pattern as existing audio/auth/rag sections).

**Config sections covered: 10 of 52** (audio, auth, database, embeddings, logging, providers, rag, server, stt, types)

## Test plan

- [ ] All 5 modified/created files compile
- [ ] `from tldw_Server_API.app.core.config_sections import load_config_sections` imports cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)