### PR TITLE
Phase 2.4 redux: add typed database, server, logging, and embeddings config sections

### DIFF
--- a/tldw_Server_API/app/core/config_sections/__init__.py
+++ b/tldw_Server_API/app/core/config_sections/__init__.py
@@ -5,8 +5,12 @@ from typing import Any
 
 from .audio import AudioConfig, load_audio_config
 from .auth import AuthConfig, load_auth_config
+from .database import DatabaseConfig, load_database_config
+from .embeddings import EmbeddingsConfig, load_embeddings_config
+from .logging import LoggingConfig, load_logging_config
 from .providers import ProvidersConfig, load_providers_config
 from .rag import RAGConfig, load_rag_config
+from .server import ServerConfig, load_server_config
 from .stt import STTConfig, load_stt_config
 from .types import ConfigParserLike
 
@@ -14,9 +18,13 @@ from .types import ConfigParserLike
 @dataclass(frozen=True)
 class ConfigSections:
     auth: AuthConfig
+    database: DatabaseConfig
+    embeddings: EmbeddingsConfig
+    logging: LoggingConfig
     rag: RAGConfig
     audio: AudioConfig
     providers: ProvidersConfig
+    server: ServerConfig
     stt: STTConfig
 
 
@@ -28,9 +36,13 @@ def load_config_sections(config_parser: ConfigParserLike | None = None) -> Confi
 
     return ConfigSections(
         auth=load_auth_config(config_parser),
+        database=load_database_config(config_parser),
+        embeddings=load_embeddings_config(config_parser),
+        logging=load_logging_config(config_parser),
         rag=load_rag_config(config_parser),
         audio=load_audio_config(config_parser),
         providers=load_providers_config(config_parser),
+        server=load_server_config(config_parser),
         stt=load_stt_config(config_parser),
     )
 
@@ -39,13 +51,21 @@ __all__ = [
     "AudioConfig",
     "AuthConfig",
     "ConfigSections",
+    "DatabaseConfig",
+    "EmbeddingsConfig",
+    "LoggingConfig",
     "ProvidersConfig",
     "RAGConfig",
     "STTConfig",
+    "ServerConfig",
     "load_audio_config",
     "load_auth_config",
     "load_config_sections",
+    "load_database_config",
+    "load_embeddings_config",
+    "load_logging_config",
     "load_providers_config",
     "load_rag_config",
+    "load_server_config",
     "load_stt_config",
 ]

--- a/tldw_Server_API/app/core/config_sections/__init__.py
+++ b/tldw_Server_API/app/core/config_sections/__init__.py
@@ -5,9 +5,13 @@ from typing import Any
 
 from .audio import AudioConfig, load_audio_config
 from .auth import AuthConfig, load_auth_config
+from .chat import ChatConfig, load_chat_config
+from .chunking import ChunkingConfig, load_chunking_config
 from .database import DatabaseConfig, load_database_config
 from .embeddings import EmbeddingsConfig, load_embeddings_config
+from .jobs import JobsConfig, load_jobs_config
 from .logging import LoggingConfig, load_logging_config
+from .moderation import ModerationConfig, load_moderation_config
 from .providers import ProvidersConfig, load_providers_config
 from .rag import RAGConfig, load_rag_config
 from .server import ServerConfig, load_server_config
@@ -18,9 +22,13 @@ from .types import ConfigParserLike
 @dataclass(frozen=True)
 class ConfigSections:
     auth: AuthConfig
+    chat: ChatConfig
+    chunking: ChunkingConfig
     database: DatabaseConfig
     embeddings: EmbeddingsConfig
+    jobs: JobsConfig
     logging: LoggingConfig
+    moderation: ModerationConfig
     rag: RAGConfig
     audio: AudioConfig
     providers: ProvidersConfig
@@ -36,9 +44,13 @@ def load_config_sections(config_parser: ConfigParserLike | None = None) -> Confi
 
     return ConfigSections(
         auth=load_auth_config(config_parser),
+        chat=load_chat_config(config_parser),
+        chunking=load_chunking_config(config_parser),
         database=load_database_config(config_parser),
         embeddings=load_embeddings_config(config_parser),
+        jobs=load_jobs_config(config_parser),
         logging=load_logging_config(config_parser),
+        moderation=load_moderation_config(config_parser),
         rag=load_rag_config(config_parser),
         audio=load_audio_config(config_parser),
         providers=load_providers_config(config_parser),
@@ -50,20 +62,28 @@ def load_config_sections(config_parser: ConfigParserLike | None = None) -> Confi
 __all__ = [
     "AudioConfig",
     "AuthConfig",
+    "ChatConfig",
+    "ChunkingConfig",
     "ConfigSections",
     "DatabaseConfig",
     "EmbeddingsConfig",
+    "JobsConfig",
     "LoggingConfig",
+    "ModerationConfig",
     "ProvidersConfig",
     "RAGConfig",
     "STTConfig",
     "ServerConfig",
     "load_audio_config",
     "load_auth_config",
+    "load_chat_config",
+    "load_chunking_config",
     "load_config_sections",
     "load_database_config",
     "load_embeddings_config",
+    "load_jobs_config",
     "load_logging_config",
+    "load_moderation_config",
     "load_providers_config",
     "load_rag_config",
     "load_server_config",

--- a/tldw_Server_API/app/core/config_sections/chat.py
+++ b/tldw_Server_API/app/core/config_sections/chat.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+_TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "no", "n", "off"}
+
+
+@dataclass(frozen=True)
+class ChatConfig:
+    enable_provider_fallback: bool
+    max_base64_image_size_mb: int
+    max_text_length_per_message: int
+    max_messages_per_request: int
+    max_images_per_request: int
+    chat_stream_channel_maxsize: int
+    chat_stream_include_metadata: bool
+    chat_save_default: bool
+    allow_autoswitch_to_openai: bool
+    rate_limit_per_minute: int
+    rate_limit_per_conversation_per_minute: int
+    rate_limit_tokens_per_minute: int
+    run_first_rollout_mode: str
+    run_first_provider_allowlist: list[str]
+    run_first_presentation_variant: str
+
+
+def _get_raw(
+    config_parser: ConfigParserLike,
+    env_map: Mapping[str, str],
+    *,
+    env_keys: tuple[str, ...] = (),
+    option: str,
+    fallback_option: str | None = None,
+    default: str,
+) -> str:
+    for env_key in env_keys:
+        env_value = env_map.get(env_key)
+        if env_value is not None and str(env_value).strip() != "":
+            return str(env_value)
+
+    raw = config_parser.get("Chat-Module", option, fallback=None)
+    text = str(raw).strip() if raw is not None else ""
+    if text:
+        return text
+
+    if fallback_option is not None:
+        fallback_raw = config_parser.get("Chat-Module", fallback_option, fallback=None)
+        fallback_text = str(fallback_raw).strip() if fallback_raw is not None else ""
+        if fallback_text:
+            return fallback_text
+
+    return default
+
+
+def _parse_bool(raw: object, default: bool) -> bool:
+    text = str(raw).strip().lower()
+    if not text:
+        return default
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return default
+
+
+def _parse_int(raw: object, default: int, *, minimum: int | None = None) -> int:
+    text = str(raw).strip()
+    if not text:
+        return default
+    try:
+        value = int(text)
+    except (TypeError, ValueError):
+        return default
+    if minimum is not None and value < minimum:
+        return minimum
+    return value
+
+
+def _parse_csv(raw: object) -> list[str]:
+    text = str(raw).strip()
+    if not text:
+        return []
+    return [item.strip() for item in text.split(",") if item.strip()]
+
+
+def load_chat_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> ChatConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+
+    enable_provider_fallback = _parse_bool(
+        _get_raw(
+            config_parser,
+            env_map,
+            option="enable_provider_fallback",
+            default="false",
+        ),
+        False,
+    )
+    max_base64_image_size_mb = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_keys=("CHAT_IMAGE_MAX_MB",),
+            option="max_base64_image_size_mb",
+            default="3",
+        ),
+        3,
+        minimum=1,
+    )
+    max_text_length_per_message = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            option="max_text_length_per_message",
+            default="400000",
+        ),
+        400000,
+        minimum=1,
+    )
+    max_messages_per_request = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            option="max_messages_per_request",
+            default="1000",
+        ),
+        1000,
+        minimum=1,
+    )
+    max_images_per_request = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            option="max_images_per_request",
+            default="10",
+        ),
+        10,
+        minimum=0,
+    )
+    chat_stream_channel_maxsize = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_keys=("CHAT_STREAM_CHANNEL_MAXSIZE",),
+            option="chat_stream_channel_maxsize",
+            default="100",
+        ),
+        100,
+        minimum=1,
+    )
+    chat_stream_include_metadata = _parse_bool(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_keys=("CHAT_STREAM_INCLUDE_METADATA",),
+            option="chat_stream_include_metadata",
+            default="true",
+        ),
+        True,
+    )
+    chat_save_default = _parse_bool(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_keys=("CHAT_SAVE_DEFAULT", "DEFAULT_CHAT_SAVE"),
+            option="chat_save_default",
+            fallback_option="default_save_to_db",
+            default="false",
+        ),
+        False,
+    )
+    allow_autoswitch_to_openai = _parse_bool(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_keys=("ALLOW_AUTOSWITCH_TO_OPENAI",),
+            option="allow_autoswitch_to_openai",
+            default="false",
+        ),
+        False,
+    )
+    rate_limit_per_minute = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            option="rate_limit_per_minute",
+            default="60",
+        ),
+        60,
+        minimum=1,
+    )
+    rate_limit_per_conversation_per_minute = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            option="rate_limit_per_conversation_per_minute",
+            default="20",
+        ),
+        20,
+        minimum=1,
+    )
+    rate_limit_tokens_per_minute = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            option="rate_limit_tokens_per_minute",
+            default="100000",
+        ),
+        100000,
+        minimum=1,
+    )
+    run_first_rollout_mode = str(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_keys=("CHAT_RUN_FIRST_ROLLOUT_MODE",),
+            option="run_first_rollout_mode",
+            default="default_on",
+        )
+    ).strip() or "default_on"
+    run_first_provider_allowlist = _parse_csv(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_keys=("CHAT_RUN_FIRST_PROVIDER_ALLOWLIST",),
+            option="run_first_provider_allowlist",
+            default="",
+        )
+    )
+    run_first_presentation_variant = str(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_keys=("CHAT_RUN_FIRST_PRESENTATION_VARIANT",),
+            option="run_first_presentation_variant",
+            default="chat_phase2b_v1",
+        )
+    ).strip() or "chat_phase2b_v1"
+
+    return ChatConfig(
+        enable_provider_fallback=enable_provider_fallback,
+        max_base64_image_size_mb=max_base64_image_size_mb,
+        max_text_length_per_message=max_text_length_per_message,
+        max_messages_per_request=max_messages_per_request,
+        max_images_per_request=max_images_per_request,
+        chat_stream_channel_maxsize=chat_stream_channel_maxsize,
+        chat_stream_include_metadata=chat_stream_include_metadata,
+        chat_save_default=chat_save_default,
+        allow_autoswitch_to_openai=allow_autoswitch_to_openai,
+        rate_limit_per_minute=rate_limit_per_minute,
+        rate_limit_per_conversation_per_minute=rate_limit_per_conversation_per_minute,
+        rate_limit_tokens_per_minute=rate_limit_tokens_per_minute,
+        run_first_rollout_mode=run_first_rollout_mode,
+        run_first_provider_allowlist=run_first_provider_allowlist,
+        run_first_presentation_variant=run_first_presentation_variant,
+    )

--- a/tldw_Server_API/app/core/config_sections/chunking.py
+++ b/tldw_Server_API/app/core/config_sections/chunking.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+_TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+
+
+@dataclass(frozen=True)
+class ChunkingConfig:
+    method: str
+    max_size: int
+    overlap: int
+    adaptive: bool
+    multi_level: bool
+    language: str
+
+
+def _parse_int(raw: object, default: int) -> int:
+    text = str(raw).strip()
+    if not text:
+        return default
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_bool(raw: object, default: bool) -> bool:
+    text = str(raw).strip().lower()
+    if not text:
+        return default
+    if text in _TRUE_VALUES:
+        return True
+    return False if text else default
+
+
+def load_chunking_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> ChunkingConfig:
+    del env  # Reserved for future overrides; current runtime reads config defaults directly.
+
+    return ChunkingConfig(
+        method=str(config_parser.get("Chunking", "chunking_method", fallback="words")).strip() or "words",
+        max_size=_parse_int(config_parser.get("Chunking", "chunk_max_size", fallback="400"), 400),
+        overlap=_parse_int(config_parser.get("Chunking", "chunk_overlap", fallback="200"), 200),
+        adaptive=_parse_bool(config_parser.get("Chunking", "adaptive_chunking", fallback="false"), False),
+        multi_level=_parse_bool(
+            config_parser.get("Chunking", "chunking_multi_level", fallback="false"),
+            False,
+        ),
+        language=str(config_parser.get("Chunking", "chunk_language", fallback="en")).strip() or "en",
+    )

--- a/tldw_Server_API/app/core/config_sections/chunking.py
+++ b/tldw_Server_API/app/core/config_sections/chunking.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from .types import ConfigParserLike
 
 _TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+
+_ENV_KEYS = {
+    "chunking_method": ("CHUNKING_METHOD", "CHUNKING_CHUNKING_METHOD"),
+    "chunk_max_size": ("CHUNKING_MAX_SIZE", "CHUNK_MAX_SIZE", "CHUNKING_CHUNK_MAX_SIZE"),
+    "chunk_overlap": ("CHUNKING_OVERLAP", "CHUNK_OVERLAP", "CHUNKING_CHUNK_OVERLAP"),
+    "adaptive_chunking": ("CHUNKING_ADAPTIVE", "ADAPTIVE_CHUNKING", "CHUNKING_ADAPTIVE_CHUNKING"),
+    "chunking_multi_level": ("CHUNKING_MULTI_LEVEL", "CHUNKING_CHUNKING_MULTI_LEVEL"),
+    "chunk_language": ("CHUNKING_LANGUAGE", "CHUNK_LANGUAGE"),
+}
 
 
 @dataclass(frozen=True)
@@ -37,20 +47,37 @@ def _parse_bool(raw: object, default: bool) -> bool:
     return False if text else default
 
 
+def _get_raw(
+    config_parser: ConfigParserLike,
+    env_map: Mapping[str, str],
+    option: str,
+    default: str,
+) -> str:
+    """Return a chunking value with env -> parser -> default precedence."""
+    for env_key in _ENV_KEYS.get(option, (option.upper(),)):
+        env_value = env_map.get(env_key)
+        if env_value is not None and str(env_value).strip() != "":
+            return str(env_value).strip()
+
+    raw = config_parser.get("Chunking", option, fallback=default)
+    text = str(raw).strip()
+    return text or default
+
+
 def load_chunking_config(
     config_parser: ConfigParserLike,
     env: Mapping[str, str] | None = None,
 ) -> ChunkingConfig:
-    del env  # Reserved for future overrides; current runtime reads config defaults directly.
+    env_map: Mapping[str, str] = env if env is not None else os.environ
 
     return ChunkingConfig(
-        method=str(config_parser.get("Chunking", "chunking_method", fallback="words")).strip() or "words",
-        max_size=_parse_int(config_parser.get("Chunking", "chunk_max_size", fallback="400"), 400),
-        overlap=_parse_int(config_parser.get("Chunking", "chunk_overlap", fallback="200"), 200),
-        adaptive=_parse_bool(config_parser.get("Chunking", "adaptive_chunking", fallback="false"), False),
+        method=_get_raw(config_parser, env_map, "chunking_method", "words"),
+        max_size=_parse_int(_get_raw(config_parser, env_map, "chunk_max_size", "400"), 400),
+        overlap=_parse_int(_get_raw(config_parser, env_map, "chunk_overlap", "200"), 200),
+        adaptive=_parse_bool(_get_raw(config_parser, env_map, "adaptive_chunking", "false"), False),
         multi_level=_parse_bool(
-            config_parser.get("Chunking", "chunking_multi_level", fallback="false"),
+            _get_raw(config_parser, env_map, "chunking_multi_level", "false"),
             False,
         ),
-        language=str(config_parser.get("Chunking", "chunk_language", fallback="en")).strip() or "en",
+        language=_get_raw(config_parser, env_map, "chunk_language", "en"),
     )

--- a/tldw_Server_API/app/core/config_sections/database.py
+++ b/tldw_Server_API/app/core/config_sections/database.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    type: str
+    sqlite_path: str
+    sqlite_wal_mode: bool
+    sqlite_foreign_keys: bool
+    backup_path: str
+    pg_host: str
+    pg_port: int
+    pg_database: str
+    pg_user: str
+    pg_sslmode: str
+    pg_pool_size: int
+    pg_max_overflow: int
+    pg_pool_timeout: float
+    chroma_db_path: str
+    prompts_db_path: str
+
+
+def load_database_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> DatabaseConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+    g = lambda key, default: str(
+        env_map.get(f"DB_{key.upper()}", "")
+        or config_parser.get("Database", key, fallback=default)
+    ).strip() or default
+
+    return DatabaseConfig(
+        type=g("type", "sqlite"),
+        sqlite_path=g("sqlite_path", "Databases/server_media_summary.db"),
+        sqlite_wal_mode=g("sqlite_wal_mode", "true").lower() in ("true", "1", "yes"),
+        sqlite_foreign_keys=g("sqlite_foreign_keys", "true").lower() in ("true", "1", "yes"),
+        backup_path=g("backup_path", "./tldw_DB_Backups/"),
+        pg_host=g("pg_host", "localhost"),
+        pg_port=int(g("pg_port", "5432")),
+        pg_database=g("pg_database", "tldw_content"),
+        pg_user=g("pg_user", "tldw_user"),
+        pg_sslmode=g("pg_sslmode", "prefer"),
+        pg_pool_size=int(g("pg_pool_size", "20")),
+        pg_max_overflow=int(g("pg_max_overflow", "40")),
+        pg_pool_timeout=float(g("pg_pool_timeout", "30.0")),
+        chroma_db_path=g("chroma_db_path", "Databases/chroma_db"),
+        prompts_db_path=g("prompts_db_path", "Databases/prompts.db"),
+    )

--- a/tldw_Server_API/app/core/config_sections/database.py
+++ b/tldw_Server_API/app/core/config_sections/database.py
@@ -1,14 +1,20 @@
+"""Typed loader for database-related configuration settings."""
+
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
+
+from tldw_Server_API.app.core.testing import is_truthy
 
 from .types import ConfigParserLike
 
 
 @dataclass(frozen=True)
 class DatabaseConfig:
+    """Database, PostgreSQL pool, Chroma, and prompts database settings."""
+
     type: str
     sqlite_path: str
     sqlite_wal_mode: bool
@@ -26,30 +32,75 @@ class DatabaseConfig:
     prompts_db_path: str
 
 
+def _get_raw(
+    config_parser: ConfigParserLike,
+    env_map: Mapping[str, str],
+    option: str,
+    default: str,
+) -> str:
+    """Return an environment override, parser value, or default for a database option."""
+    raw = env_map.get(f"DB_{option.upper()}")
+    if raw is None or str(raw).strip() == "":
+        raw = config_parser.get("Database", option, fallback=default)
+    text = str(raw).strip()
+    return text or default
+
+
+def _parse_bool(raw: object, default: bool) -> bool:
+    """Parse a boolean value using the project truthy set and conservative fallback."""
+    text = str(raw).strip().lower()
+    if not text:
+        return default
+    if is_truthy(text):
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def _parse_int(raw: object, default: int) -> int:
+    """Parse an integer value, returning the default for malformed input."""
+    text = str(raw).strip()
+    if not text:
+        return default
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_float(raw: object, default: float) -> float:
+    """Parse a float value, returning the default for malformed input."""
+    text = str(raw).strip()
+    if not text:
+        return default
+    try:
+        return float(text)
+    except (TypeError, ValueError):
+        return default
+
+
 def load_database_config(
     config_parser: ConfigParserLike,
     env: Mapping[str, str] | None = None,
 ) -> DatabaseConfig:
+    """Load typed database settings with environment variables taking precedence."""
     env_map: Mapping[str, str] = env if env is not None else os.environ
-    g = lambda key, default: str(
-        env_map.get(f"DB_{key.upper()}", "")
-        or config_parser.get("Database", key, fallback=default)
-    ).strip() or default
 
     return DatabaseConfig(
-        type=g("type", "sqlite"),
-        sqlite_path=g("sqlite_path", "Databases/server_media_summary.db"),
-        sqlite_wal_mode=g("sqlite_wal_mode", "true").lower() in ("true", "1", "yes"),
-        sqlite_foreign_keys=g("sqlite_foreign_keys", "true").lower() in ("true", "1", "yes"),
-        backup_path=g("backup_path", "./tldw_DB_Backups/"),
-        pg_host=g("pg_host", "localhost"),
-        pg_port=int(g("pg_port", "5432")),
-        pg_database=g("pg_database", "tldw_content"),
-        pg_user=g("pg_user", "tldw_user"),
-        pg_sslmode=g("pg_sslmode", "prefer"),
-        pg_pool_size=int(g("pg_pool_size", "20")),
-        pg_max_overflow=int(g("pg_max_overflow", "40")),
-        pg_pool_timeout=float(g("pg_pool_timeout", "30.0")),
-        chroma_db_path=g("chroma_db_path", "Databases/chroma_db"),
-        prompts_db_path=g("prompts_db_path", "Databases/prompts.db"),
+        type=_get_raw(config_parser, env_map, "type", "sqlite"),
+        sqlite_path=_get_raw(config_parser, env_map, "sqlite_path", "Databases/server_media_summary.db"),
+        sqlite_wal_mode=_parse_bool(_get_raw(config_parser, env_map, "sqlite_wal_mode", "true"), True),
+        sqlite_foreign_keys=_parse_bool(_get_raw(config_parser, env_map, "sqlite_foreign_keys", "true"), True),
+        backup_path=_get_raw(config_parser, env_map, "backup_path", "./tldw_DB_Backups/"),
+        pg_host=_get_raw(config_parser, env_map, "pg_host", "localhost"),
+        pg_port=_parse_int(_get_raw(config_parser, env_map, "pg_port", "5432"), 5432),
+        pg_database=_get_raw(config_parser, env_map, "pg_database", "tldw_content"),
+        pg_user=_get_raw(config_parser, env_map, "pg_user", "tldw_user"),
+        pg_sslmode=_get_raw(config_parser, env_map, "pg_sslmode", "prefer"),
+        pg_pool_size=_parse_int(_get_raw(config_parser, env_map, "pg_pool_size", "20"), 20),
+        pg_max_overflow=_parse_int(_get_raw(config_parser, env_map, "pg_max_overflow", "40"), 40),
+        pg_pool_timeout=_parse_float(_get_raw(config_parser, env_map, "pg_pool_timeout", "30.0"), 30.0),
+        chroma_db_path=_get_raw(config_parser, env_map, "chroma_db_path", "Databases/chroma_db"),
+        prompts_db_path=_get_raw(config_parser, env_map, "prompts_db_path", "Databases/prompts.db"),
     )

--- a/tldw_Server_API/app/core/config_sections/embeddings.py
+++ b/tldw_Server_API/app/core/config_sections/embeddings.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
+
+from tldw_Server_API.app.core.testing import is_truthy
 
 from .types import ConfigParserLike
+
+_FALSE_VALUES = {"0", "false", "no", "n", "off"}
 
 
 @dataclass(frozen=True)
@@ -20,24 +24,81 @@ class EmbeddingsConfig:
     contextual_llm_model: str
 
 
+def _env_keys_for(option: str) -> tuple[str, ...]:
+    """Return canonical and legacy environment keys for an embeddings option."""
+    env_key = option.upper()
+    if env_key.startswith("EMBEDDING_"):
+        return (env_key, f"EMBEDDING_{env_key}")
+    return (f"EMBEDDING_{env_key}",)
+
+
+def _get_raw(
+    config_parser: ConfigParserLike,
+    env_map: Mapping[str, str],
+    option: str,
+    default: str,
+) -> str:
+    """Return the first non-empty env override, parser value, or default."""
+    for env_key in _env_keys_for(option):
+        raw = env_map.get(env_key)
+        if raw is not None and str(raw).strip() != "":
+            return str(raw).strip()
+
+    raw = config_parser.get("Embeddings", option, fallback=default)
+    text = str(raw).strip()
+    return text or default
+
+
+def _parse_int(raw: object, default: int) -> int:
+    """Parse an integer value, returning the default for malformed input."""
+    text = str(raw).strip()
+    if not text:
+        return default
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_bool(raw: object, default: bool) -> bool:
+    """Parse a boolean value with project-standard truthy tokens."""
+    text = str(raw).strip().lower()
+    if not text:
+        return default
+    if is_truthy(text):
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return default
+
+
 def load_embeddings_config(
     config_parser: ConfigParserLike,
     env: Mapping[str, str] | None = None,
 ) -> EmbeddingsConfig:
     env_map: Mapping[str, str] = env if env is not None else os.environ
-    g = lambda key, default: str(
-        env_map.get(f"EMBEDDING_{key.upper()}", "")
-        or config_parser.get("Embeddings", key, fallback=default)
-    ).strip() or default
 
     return EmbeddingsConfig(
-        embedding_provider=env_map.get("EMBEDDING_PROVIDER", "") or g("embedding_provider", "huggingface"),
-        embedding_model=env_map.get("EMBEDDING_MODEL", "") or g("embedding_model", "Qwen/Qwen3-Embedding-0.6B"),
-        onnx_model_path=g("onnx_model_path", "./App_Function_Libraries/models/onnx_models/"),
-        model_dir=g("model_dir", "./App_Function_Libraries/models/embedding_models"),
-        embedding_api_url=g("embedding_api_url", "http://localhost:8080/v1/embeddings"),
-        chunk_size=int(g("chunk_size", "400")),
-        overlap=int(g("overlap", "200")),
-        enable_contextual_chunking=g("enable_contextual_chunking", "false").lower() in ("true", "1", "yes"),
-        contextual_llm_model=g("contextual_llm_model", "gpt-3.5-turbo"),
+        embedding_provider=_get_raw(config_parser, env_map, "embedding_provider", "huggingface"),
+        embedding_model=_get_raw(config_parser, env_map, "embedding_model", "Qwen/Qwen3-Embedding-0.6B"),
+        onnx_model_path=_get_raw(
+            config_parser,
+            env_map,
+            "onnx_model_path",
+            "./App_Function_Libraries/models/onnx_models/",
+        ),
+        model_dir=_get_raw(config_parser, env_map, "model_dir", "./App_Function_Libraries/models/embedding_models"),
+        embedding_api_url=_get_raw(
+            config_parser,
+            env_map,
+            "embedding_api_url",
+            "http://localhost:8080/v1/embeddings",
+        ),
+        chunk_size=_parse_int(_get_raw(config_parser, env_map, "chunk_size", "400"), 400),
+        overlap=_parse_int(_get_raw(config_parser, env_map, "overlap", "200"), 200),
+        enable_contextual_chunking=_parse_bool(
+            _get_raw(config_parser, env_map, "enable_contextual_chunking", "false"),
+            False,
+        ),
+        contextual_llm_model=_get_raw(config_parser, env_map, "contextual_llm_model", "gpt-3.5-turbo"),
     )

--- a/tldw_Server_API/app/core/config_sections/embeddings.py
+++ b/tldw_Server_API/app/core/config_sections/embeddings.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+
+@dataclass(frozen=True)
+class EmbeddingsConfig:
+    embedding_provider: str
+    embedding_model: str
+    onnx_model_path: str
+    model_dir: str
+    embedding_api_url: str
+    chunk_size: int
+    overlap: int
+    enable_contextual_chunking: bool
+    contextual_llm_model: str
+
+
+def load_embeddings_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> EmbeddingsConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+    g = lambda key, default: str(
+        env_map.get(f"EMBEDDING_{key.upper()}", "")
+        or config_parser.get("Embeddings", key, fallback=default)
+    ).strip() or default
+
+    return EmbeddingsConfig(
+        embedding_provider=env_map.get("EMBEDDING_PROVIDER", "") or g("embedding_provider", "huggingface"),
+        embedding_model=env_map.get("EMBEDDING_MODEL", "") or g("embedding_model", "Qwen/Qwen3-Embedding-0.6B"),
+        onnx_model_path=g("onnx_model_path", "./App_Function_Libraries/models/onnx_models/"),
+        model_dir=g("model_dir", "./App_Function_Libraries/models/embedding_models"),
+        embedding_api_url=g("embedding_api_url", "http://localhost:8080/v1/embeddings"),
+        chunk_size=int(g("chunk_size", "400")),
+        overlap=int(g("overlap", "200")),
+        enable_contextual_chunking=g("enable_contextual_chunking", "false").lower() in ("true", "1", "yes"),
+        contextual_llm_model=g("contextual_llm_model", "gpt-3.5-turbo"),
+    )

--- a/tldw_Server_API/app/core/config_sections/jobs.py
+++ b/tldw_Server_API/app/core/config_sections/jobs.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+_TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "no", "n", "off"}
+
+
+@dataclass(frozen=True)
+class JobsConfig:
+    prune_enforce: bool
+    prune_interval_sec: int
+    prune_dry_run: bool
+    prune_domain: list[str]
+    prune_queue: list[str]
+    prune_job_type: list[str]
+    retention_days_terminal: int | None
+    retention_days_nonterminal: int
+    retention_days_completed: int
+    retention_days_failed: int
+    retention_days_cancelled: int
+    retention_days_quarantined: int
+
+
+def _get_raw(
+    config_parser: ConfigParserLike,
+    env_map: Mapping[str, str],
+    *,
+    env_key: str,
+    option: str,
+    default: str,
+) -> str:
+    env_value = env_map.get(env_key)
+    if env_value is not None and str(env_value).strip() != "":
+        return str(env_value)
+
+    raw = config_parser.get("Jobs", option, fallback=default)
+    text = str(raw).strip()
+    return text or default
+
+
+def _parse_bool(raw: object, default: bool) -> bool:
+    text = str(raw).strip().lower()
+    if not text:
+        return default
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return default
+
+
+def _parse_int(raw: object, default: int) -> int:
+    text = str(raw).strip()
+    if not text:
+        return default
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_int_optional(raw: object) -> int | None:
+    text = str(raw).strip()
+    if not text:
+        return None
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_csv(raw: object) -> list[str]:
+    text = str(raw).strip()
+    if not text:
+        return []
+    return [item.strip() for item in text.split(",") if item.strip()]
+
+
+def load_jobs_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> JobsConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+
+    prune_enforce = _parse_bool(
+        _get_raw(config_parser, env_map, env_key="JOBS_PRUNE_ENFORCE", option="prune_enforce", default="false"),
+        False,
+    )
+    prune_interval_sec = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="JOBS_PRUNE_INTERVAL_SEC",
+            option="prune_interval_sec",
+            default="86400",
+        ),
+        86400,
+    )
+    prune_dry_run = _parse_bool(
+        _get_raw(config_parser, env_map, env_key="JOBS_PRUNE_DRY_RUN", option="prune_dry_run", default="false"),
+        False,
+    )
+    prune_domain = _parse_csv(
+        _get_raw(config_parser, env_map, env_key="JOBS_PRUNE_DOMAIN", option="prune_domain", default="")
+    )
+    prune_queue = _parse_csv(
+        _get_raw(config_parser, env_map, env_key="JOBS_PRUNE_QUEUE", option="prune_queue", default="")
+    )
+    prune_job_type = _parse_csv(
+        _get_raw(config_parser, env_map, env_key="JOBS_PRUNE_JOB_TYPE", option="prune_job_type", default="")
+    )
+    retention_days_terminal = _parse_int_optional(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="JOBS_RETENTION_DAYS_TERMINAL",
+            option="retention_days_terminal",
+            default="",
+        )
+    )
+    retention_days_nonterminal = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="JOBS_RETENTION_DAYS_NONTERMINAL",
+            option="retention_days_nonterminal",
+            default="0",
+        ),
+        0,
+    )
+    retention_days_completed = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="JOBS_RETENTION_DAYS_COMPLETED",
+            option="retention_days_completed",
+            default="30",
+        ),
+        30,
+    )
+    retention_days_failed = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="JOBS_RETENTION_DAYS_FAILED",
+            option="retention_days_failed",
+            default="60",
+        ),
+        60,
+    )
+    retention_days_cancelled = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="JOBS_RETENTION_DAYS_CANCELLED",
+            option="retention_days_cancelled",
+            default="60",
+        ),
+        60,
+    )
+    retention_days_quarantined = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="JOBS_RETENTION_DAYS_QUARANTINED",
+            option="retention_days_quarantined",
+            default="90",
+        ),
+        90,
+    )
+
+    return JobsConfig(
+        prune_enforce=prune_enforce,
+        prune_interval_sec=prune_interval_sec,
+        prune_dry_run=prune_dry_run,
+        prune_domain=prune_domain,
+        prune_queue=prune_queue,
+        prune_job_type=prune_job_type,
+        retention_days_terminal=retention_days_terminal,
+        retention_days_nonterminal=retention_days_nonterminal,
+        retention_days_completed=retention_days_completed,
+        retention_days_failed=retention_days_failed,
+        retention_days_cancelled=retention_days_cancelled,
+        retention_days_quarantined=retention_days_quarantined,
+    )

--- a/tldw_Server_API/app/core/config_sections/logging.py
+++ b/tldw_Server_API/app/core/config_sections/logging.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from .types import ConfigParserLike
+
+_SYSTEM_LOG_ENV_KEYS = {
+    "system_log_file_path": ("SYSTEM_LOG_FILE_PATH", "LOG_SYSTEM_LOG_FILE_PATH"),
+    "system_log_file_max_entries": ("SYSTEM_LOG_FILE_MAX_ENTRIES", "LOG_SYSTEM_LOG_FILE_MAX_ENTRIES"),
+}
 
 
 @dataclass(frozen=True)
@@ -17,21 +22,59 @@ class LoggingConfig:
     system_log_file_max_entries: int
 
 
+def _env_keys_for(option: str) -> tuple[str, ...]:
+    """Return canonical and legacy environment keys for a logging option."""
+    if option in _SYSTEM_LOG_ENV_KEYS:
+        return _SYSTEM_LOG_ENV_KEYS[option]
+
+    env_key = option.upper()
+    if env_key.startswith("LOG_"):
+        return (env_key, f"LOG_{env_key}")
+    return (f"LOG_{env_key}",)
+
+
+def _get_raw(
+    config_parser: ConfigParserLike,
+    env_map: Mapping[str, str],
+    option: str,
+    default: str,
+) -> str:
+    """Return the first non-empty env override, parser value, or default."""
+    for env_key in _env_keys_for(option):
+        raw = env_map.get(env_key)
+        if raw is not None and str(raw).strip() != "":
+            return str(raw).strip()
+
+    raw = config_parser.get("Logging", option, fallback=default)
+    text = str(raw).strip()
+    return text or default
+
+
+def _parse_int(raw: object, default: int) -> int:
+    """Parse an integer value, returning the default for malformed input."""
+    text = str(raw).strip()
+    if not text:
+        return default
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return default
+
+
 def load_logging_config(
     config_parser: ConfigParserLike,
     env: Mapping[str, str] | None = None,
 ) -> LoggingConfig:
     env_map: Mapping[str, str] = env if env is not None else os.environ
-    g = lambda key, default: str(
-        env_map.get(f"LOG_{key.upper()}", "")
-        or config_parser.get("Logging", key, fallback=default)
-    ).strip() or default
 
     return LoggingConfig(
-        log_level=env_map.get("LOG_LEVEL", "") or g("log_level", "INFO"),
-        log_file=g("log_file", "./Logs/tldw_app_logs.json"),
-        log_metrics_file=g("log_metrics_file", "./Logs/tldw_metrics_logs.json"),
-        backup_count=int(g("backup_count", "5")),
-        system_log_file_path=g("system_log_file_path", "Databases/system_logs.jsonl"),
-        system_log_file_max_entries=int(g("system_log_file_max_entries", "5000")),
+        log_level=_get_raw(config_parser, env_map, "log_level", "INFO"),
+        log_file=_get_raw(config_parser, env_map, "log_file", "./Logs/tldw_app_logs.json"),
+        log_metrics_file=_get_raw(config_parser, env_map, "log_metrics_file", "./Logs/tldw_metrics_logs.json"),
+        backup_count=_parse_int(_get_raw(config_parser, env_map, "backup_count", "5"), 5),
+        system_log_file_path=_get_raw(config_parser, env_map, "system_log_file_path", "Databases/system_logs.jsonl"),
+        system_log_file_max_entries=_parse_int(
+            _get_raw(config_parser, env_map, "system_log_file_max_entries", "5000"),
+            5000,
+        ),
     )

--- a/tldw_Server_API/app/core/config_sections/logging.py
+++ b/tldw_Server_API/app/core/config_sections/logging.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+
+@dataclass(frozen=True)
+class LoggingConfig:
+    log_level: str
+    log_file: str
+    log_metrics_file: str
+    backup_count: int
+    system_log_file_path: str
+    system_log_file_max_entries: int
+
+
+def load_logging_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> LoggingConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+    g = lambda key, default: str(
+        env_map.get(f"LOG_{key.upper()}", "")
+        or config_parser.get("Logging", key, fallback=default)
+    ).strip() or default
+
+    return LoggingConfig(
+        log_level=env_map.get("LOG_LEVEL", "") or g("log_level", "INFO"),
+        log_file=g("log_file", "./Logs/tldw_app_logs.json"),
+        log_metrics_file=g("log_metrics_file", "./Logs/tldw_metrics_logs.json"),
+        backup_count=int(g("backup_count", "5")),
+        system_log_file_path=g("system_log_file_path", "Databases/system_logs.jsonl"),
+        system_log_file_max_entries=int(g("system_log_file_max_entries", "5000")),
+    )

--- a/tldw_Server_API/app/core/config_sections/moderation.py
+++ b/tldw_Server_API/app/core/config_sections/moderation.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+_TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "no", "n", "off"}
+
+
+@dataclass(frozen=True)
+class ModerationConfig:
+    enabled: bool
+    input_enabled: bool
+    output_enabled: bool
+    input_action: str
+    output_action: str
+    redact_replacement: str
+    per_user_overrides: bool
+    blocklist_file: str
+    user_overrides_file: str
+    runtime_overrides_file: str
+    max_scan_chars: int
+    max_replacements_per_pattern: int
+    match_window_chars: int
+    max_fallback_scan_chars: int
+    blocklist_write_debounce_ms: int
+    categories_enabled: list[str]
+    pii_enabled: bool
+
+
+def _get_raw(
+    config_parser: ConfigParserLike,
+    env_map: Mapping[str, str],
+    *,
+    env_key: str | None,
+    option: str,
+    default: str,
+) -> str:
+    if env_key is not None:
+        env_value = env_map.get(env_key)
+        if env_value is not None and str(env_value).strip() != "":
+            return str(env_value)
+
+    raw = config_parser.get("Moderation", option, fallback=default)
+    text = str(raw).strip()
+    return text or default
+
+
+def _parse_bool(raw: object, default: bool) -> bool:
+    text = str(raw).strip().lower()
+    if not text:
+        return default
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return default
+
+
+def _parse_int(raw: object, default: int) -> int:
+    text = str(raw).strip()
+    if not text:
+        return default
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_string_list(raw: object) -> list[str]:
+    if raw is None:
+        return []
+
+    items: list[str]
+    if isinstance(raw, (list, tuple, set)):
+        items = [str(item) for item in raw]
+    else:
+        text = str(raw).strip()
+        if not text:
+            return []
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                parsed = None
+            if isinstance(parsed, list):
+                items = [str(item) for item in parsed]
+            else:
+                items = text.split(",")
+        else:
+            items = text.split(",")
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        value = str(item).strip().lower()
+        if not value or value in seen:
+            continue
+        normalized.append(value)
+        seen.add(value)
+    return normalized
+
+
+def load_moderation_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> ModerationConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+
+    enabled = _parse_bool(
+        _get_raw(config_parser, env_map, env_key=None, option="enabled", default="false"),
+        False,
+    )
+    input_enabled = _parse_bool(
+        _get_raw(config_parser, env_map, env_key=None, option="input_enabled", default="true"),
+        True,
+    )
+    output_enabled = _parse_bool(
+        _get_raw(config_parser, env_map, env_key=None, option="output_enabled", default="true"),
+        True,
+    )
+    input_action = _get_raw(
+        config_parser,
+        env_map,
+        env_key=None,
+        option="input_action",
+        default="block",
+    ).lower()
+    output_action = _get_raw(
+        config_parser,
+        env_map,
+        env_key=None,
+        option="output_action",
+        default="redact",
+    ).lower()
+    redact_replacement = _get_raw(
+        config_parser,
+        env_map,
+        env_key=None,
+        option="redact_replacement",
+        default="[REDACTED]",
+    )
+    per_user_overrides = _parse_bool(
+        _get_raw(config_parser, env_map, env_key=None, option="per_user_overrides", default="true"),
+        True,
+    )
+    blocklist_file = _get_raw(
+        config_parser,
+        env_map,
+        env_key="MODERATION_BLOCKLIST_FILE",
+        option="blocklist_file",
+        default="tldw_Server_API/Config_Files/moderation_blocklist.txt",
+    )
+    user_overrides_file = _get_raw(
+        config_parser,
+        env_map,
+        env_key="MODERATION_USER_OVERRIDES_FILE",
+        option="user_overrides_file",
+        default="tldw_Server_API/Config_Files/moderation_user_overrides.json",
+    )
+    runtime_overrides_file = _get_raw(
+        config_parser,
+        env_map,
+        env_key="MODERATION_RUNTIME_OVERRIDES_FILE",
+        option="runtime_overrides_file",
+        default="tldw_Server_API/Config_Files/moderation_runtime_overrides.json",
+    )
+    max_scan_chars = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="MODERATION_MAX_SCAN_CHARS",
+            option="max_scan_chars",
+            default="200000",
+        ),
+        200000,
+    )
+    max_replacements_per_pattern = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="MODERATION_MAX_REPLACEMENTS_PER_PATTERN",
+            option="max_replacements_per_pattern",
+            default="1000",
+        ),
+        1000,
+    )
+    match_window_chars = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="MODERATION_MATCH_WINDOW_CHARS",
+            option="match_window_chars",
+            default="4096",
+        ),
+        4096,
+    )
+    max_fallback_scan_chars = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="MODERATION_MAX_FALLBACK_SCAN_CHARS",
+            option="max_fallback_scan_chars",
+            default="800000",
+        ),
+        800000,
+    )
+    blocklist_write_debounce_ms = _parse_int(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="MODERATION_BLOCKLIST_WRITE_DEBOUNCE_MS",
+            option="blocklist_write_debounce_ms",
+            default="0",
+        ),
+        0,
+    )
+    categories_enabled = _parse_string_list(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="MODERATION_CATEGORIES_ENABLED",
+            option="categories_enabled",
+            default="",
+        )
+    )
+    pii_enabled = _parse_bool(
+        _get_raw(
+            config_parser,
+            env_map,
+            env_key="MODERATION_PII_ENABLED",
+            option="pii_enabled",
+            default="false",
+        ),
+        False,
+    )
+
+    return ModerationConfig(
+        enabled=enabled,
+        input_enabled=input_enabled,
+        output_enabled=output_enabled,
+        input_action=input_action,
+        output_action=output_action,
+        redact_replacement=redact_replacement,
+        per_user_overrides=per_user_overrides,
+        blocklist_file=blocklist_file,
+        user_overrides_file=user_overrides_file,
+        runtime_overrides_file=runtime_overrides_file,
+        max_scan_chars=max_scan_chars,
+        max_replacements_per_pattern=max_replacements_per_pattern,
+        match_window_chars=match_window_chars,
+        max_fallback_scan_chars=max_fallback_scan_chars,
+        blocklist_write_debounce_ms=blocklist_write_debounce_ms,
+        categories_enabled=categories_enabled,
+        pii_enabled=pii_enabled,
+    )

--- a/tldw_Server_API/app/core/config_sections/moderation.py
+++ b/tldw_Server_API/app/core/config_sections/moderation.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from .types import ConfigParserLike
 
@@ -50,7 +50,7 @@ def _get_raw(
     return text or default
 
 
-def _parse_bool(raw: object, default: bool) -> bool:
+def _parse_bool(raw: object, *, option: str, default: bool) -> bool:
     text = str(raw).strip().lower()
     if not text:
         return default
@@ -58,17 +58,18 @@ def _parse_bool(raw: object, default: bool) -> bool:
         return True
     if text in _FALSE_VALUES:
         return False
-    return default
+    accepted = ", ".join(sorted(_TRUE_VALUES | _FALSE_VALUES))
+    raise ValueError(f"Invalid Moderation.{option} value {raw!r}; expected one of: {accepted}")
 
 
-def _parse_int(raw: object, default: int) -> int:
+def _parse_int(raw: object, *, option: str, default: int) -> int:
     text = str(raw).strip()
     if not text:
         return default
     try:
         return int(text)
-    except (TypeError, ValueError):
-        return default
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid Moderation.{option} integer value {raw!r}") from exc
 
 
 def _parse_string_list(raw: object) -> list[str]:
@@ -113,15 +114,18 @@ def load_moderation_config(
 
     enabled = _parse_bool(
         _get_raw(config_parser, env_map, env_key=None, option="enabled", default="false"),
-        False,
+        option="enabled",
+        default=False,
     )
     input_enabled = _parse_bool(
         _get_raw(config_parser, env_map, env_key=None, option="input_enabled", default="true"),
-        True,
+        option="input_enabled",
+        default=True,
     )
     output_enabled = _parse_bool(
         _get_raw(config_parser, env_map, env_key=None, option="output_enabled", default="true"),
-        True,
+        option="output_enabled",
+        default=True,
     )
     input_action = _get_raw(
         config_parser,
@@ -146,7 +150,8 @@ def load_moderation_config(
     )
     per_user_overrides = _parse_bool(
         _get_raw(config_parser, env_map, env_key=None, option="per_user_overrides", default="true"),
-        True,
+        option="per_user_overrides",
+        default=True,
     )
     blocklist_file = _get_raw(
         config_parser,
@@ -177,7 +182,8 @@ def load_moderation_config(
             option="max_scan_chars",
             default="200000",
         ),
-        200000,
+        option="max_scan_chars",
+        default=200000,
     )
     max_replacements_per_pattern = _parse_int(
         _get_raw(
@@ -187,7 +193,8 @@ def load_moderation_config(
             option="max_replacements_per_pattern",
             default="1000",
         ),
-        1000,
+        option="max_replacements_per_pattern",
+        default=1000,
     )
     match_window_chars = _parse_int(
         _get_raw(
@@ -197,7 +204,8 @@ def load_moderation_config(
             option="match_window_chars",
             default="4096",
         ),
-        4096,
+        option="match_window_chars",
+        default=4096,
     )
     max_fallback_scan_chars = _parse_int(
         _get_raw(
@@ -207,7 +215,8 @@ def load_moderation_config(
             option="max_fallback_scan_chars",
             default="800000",
         ),
-        800000,
+        option="max_fallback_scan_chars",
+        default=800000,
     )
     blocklist_write_debounce_ms = _parse_int(
         _get_raw(
@@ -217,7 +226,8 @@ def load_moderation_config(
             option="blocklist_write_debounce_ms",
             default="0",
         ),
-        0,
+        option="blocklist_write_debounce_ms",
+        default=0,
     )
     categories_enabled = _parse_string_list(
         _get_raw(
@@ -236,7 +246,8 @@ def load_moderation_config(
             option="pii_enabled",
             default="false",
         ),
-        False,
+        option="pii_enabled",
+        default=False,
     )
 
     return ModerationConfig(

--- a/tldw_Server_API/app/core/config_sections/server.py
+++ b/tldw_Server_API/app/core/config_sections/server.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
+
+from tldw_Server_API.app.core.testing import is_truthy
 
 from .types import ConfigParserLike
+
+_FALSE_VALUES = {"0", "false", "no", "n", "off"}
 
 
 @dataclass(frozen=True)
@@ -13,23 +17,52 @@ class ServerConfig:
     cors_allow_credentials: bool
 
 
+def _get_raw(
+    config_parser: ConfigParserLike,
+    env_map: Mapping[str, str],
+    env_key: str,
+    option: str,
+    default: str,
+) -> str:
+    """Return an environment override, parser value, or default for a server option."""
+    raw = env_map.get(env_key)
+    if raw is None or str(raw).strip() == "":
+        raw = config_parser.get("Server", option, fallback=default)
+    text = str(raw).strip()
+    return text or default
+
+
+def _parse_bool(raw: object, default: bool) -> bool:
+    """Parse a boolean value with project-standard truthy tokens."""
+    text = str(raw).strip().lower()
+    if not text:
+        return default
+    if is_truthy(text):
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return default
+
+
 def load_server_config(
     config_parser: ConfigParserLike,
     env: Mapping[str, str] | None = None,
 ) -> ServerConfig:
     env_map: Mapping[str, str] = env if env is not None else os.environ
 
-    disable_cors = str(
-        env_map.get("DISABLE_CORS", "")
-        or config_parser.get("Server", "disable_cors", fallback="false")
-    ).strip().lower() in ("true", "1", "yes")
-
-    cors_allow_credentials = str(
-        env_map.get("CORS_ALLOW_CREDENTIALS", "")
-        or config_parser.get("Server", "cors_allow_credentials", fallback="false")
-    ).strip().lower() in ("true", "1", "yes")
-
     return ServerConfig(
-        disable_cors=disable_cors,
-        cors_allow_credentials=cors_allow_credentials,
+        disable_cors=_parse_bool(
+            _get_raw(config_parser, env_map, "DISABLE_CORS", "disable_cors", "false"),
+            False,
+        ),
+        cors_allow_credentials=_parse_bool(
+            _get_raw(
+                config_parser,
+                env_map,
+                "CORS_ALLOW_CREDENTIALS",
+                "cors_allow_credentials",
+                "false",
+            ),
+            False,
+        ),
     )

--- a/tldw_Server_API/app/core/config_sections/server.py
+++ b/tldw_Server_API/app/core/config_sections/server.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from .types import ConfigParserLike
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    disable_cors: bool
+    cors_allow_credentials: bool
+
+
+def load_server_config(
+    config_parser: ConfigParserLike,
+    env: Mapping[str, str] | None = None,
+) -> ServerConfig:
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+
+    disable_cors = str(
+        env_map.get("DISABLE_CORS", "")
+        or config_parser.get("Server", "disable_cors", fallback="false")
+    ).strip().lower() in ("true", "1", "yes")
+
+    cors_allow_credentials = str(
+        env_map.get("CORS_ALLOW_CREDENTIALS", "")
+        or config_parser.get("Server", "cors_allow_credentials", fallback="false")
+    ).strip().lower() in ("true", "1", "yes")
+
+    return ServerConfig(
+        disable_cors=disable_cors,
+        cors_allow_credentials=cors_allow_credentials,
+    )

--- a/tldw_Server_API/tests/Config/test_config_sections_typed_loaders.py
+++ b/tldw_Server_API/tests/Config/test_config_sections_typed_loaders.py
@@ -19,7 +19,6 @@ from tldw_Server_API.app.core.config_sections.rag import load_rag_config
 from tldw_Server_API.app.core.config_sections.server import load_server_config
 from tldw_Server_API.app.core.config_sections.stt import load_stt_config
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -198,6 +197,46 @@ def test_database_section_loader_prefers_env_and_parses_types() -> None:
     assert cfg.pg_pool_timeout == 45.5
 
 
+def test_numeric_loaders_fall_back_for_invalid_non_security_values() -> None:
+    parser = ConfigParser()
+    parser.add_section("Database")
+    parser.add_section("Embeddings")
+    parser.add_section("Logging")
+
+    database_cfg = load_database_config(
+        parser,
+        env={
+            "DB_PG_PORT": "not-a-port",
+            "DB_PG_POOL_SIZE": "not-a-size",
+            "DB_PG_MAX_OVERFLOW": "not-overflow",
+            "DB_PG_POOL_TIMEOUT": "not-a-timeout",
+        },
+    )
+    embeddings_cfg = load_embeddings_config(
+        parser,
+        env={
+            "EMBEDDING_CHUNK_SIZE": "not-a-size",
+            "EMBEDDING_OVERLAP": "not-overlap",
+        },
+    )
+    logging_cfg = load_logging_config(
+        parser,
+        env={
+            "LOG_BACKUP_COUNT": "not-a-count",
+            "SYSTEM_LOG_FILE_MAX_ENTRIES": "not-a-limit",
+        },
+    )
+
+    assert database_cfg.pg_port == 5432
+    assert database_cfg.pg_pool_size == 20
+    assert database_cfg.pg_max_overflow == 40
+    assert database_cfg.pg_pool_timeout == 30.0
+    assert embeddings_cfg.chunk_size == 400
+    assert embeddings_cfg.overlap == 200
+    assert logging_cfg.backup_count == 5
+    assert logging_cfg.system_log_file_max_entries == 5000
+
+
 def test_chunking_section_loader_parses_global_defaults() -> None:
     parser = ConfigParser()
     parser.add_section("Chunking")
@@ -216,6 +255,36 @@ def test_chunking_section_loader_parses_global_defaults() -> None:
     assert cfg.adaptive is True
     assert cfg.multi_level is True
     assert cfg.language == "fr"
+
+
+def test_chunking_section_loader_env_overrides_parser() -> None:
+    parser = ConfigParser()
+    parser.add_section("Chunking")
+    parser.set("Chunking", "chunking_method", "semantic")
+    parser.set("Chunking", "chunk_max_size", "1024")
+    parser.set("Chunking", "chunk_overlap", "256")
+    parser.set("Chunking", "adaptive_chunking", "false")
+    parser.set("Chunking", "chunking_multi_level", "false")
+    parser.set("Chunking", "chunk_language", "fr")
+
+    cfg = load_chunking_config(
+        parser,
+        env={
+            "CHUNKING_METHOD": "sentences",
+            "CHUNKING_MAX_SIZE": "2048",
+            "CHUNKING_OVERLAP": "512",
+            "CHUNKING_ADAPTIVE": "on",
+            "CHUNKING_MULTI_LEVEL": "yes",
+            "CHUNKING_LANGUAGE": "es",
+        },
+    )
+
+    assert cfg.method == "sentences"
+    assert cfg.max_size == 2048
+    assert cfg.overlap == 512
+    assert cfg.adaptive is True
+    assert cfg.multi_level is True
+    assert cfg.language == "es"
 
 
 def test_chat_section_loader_honors_env_and_parses_scalar_limits() -> None:
@@ -336,6 +405,37 @@ def test_embeddings_section_loader_prefers_env_and_parses_bool() -> None:
     assert cfg.enable_contextual_chunking is True
 
 
+def test_embeddings_section_loader_uses_canonical_api_url_env() -> None:
+    parser = ConfigParser()
+    parser.add_section("Embeddings")
+    parser.set("Embeddings", "embedding_api_url", "http://config.example/v1/embeddings")
+
+    cfg = load_embeddings_config(
+        parser,
+        env={
+            "EMBEDDING_API_URL": " http://env.example/v1/embeddings ",
+            "EMBEDDING_EMBEDDING_API_URL": "http://legacy.example/v1/embeddings",
+            "EMBEDDING_ENABLE_CONTEXTUAL_CHUNKING": "on",
+        },
+    )
+
+    assert cfg.embedding_api_url == "http://env.example/v1/embeddings"
+    assert cfg.enable_contextual_chunking is True
+
+
+def test_embeddings_section_loader_preserves_legacy_double_prefixed_api_url() -> None:
+    parser = ConfigParser()
+    parser.add_section("Embeddings")
+    parser.set("Embeddings", "embedding_api_url", "http://config.example/v1/embeddings")
+
+    cfg = load_embeddings_config(
+        parser,
+        env={"EMBEDDING_EMBEDDING_API_URL": "http://legacy.example/v1/embeddings"},
+    )
+
+    assert cfg.embedding_api_url == "http://legacy.example/v1/embeddings"
+
+
 def test_logging_and_server_section_loaders_honor_env_overrides() -> None:
     parser = ConfigParser()
     parser.add_section("Logging")
@@ -359,6 +459,42 @@ def test_logging_and_server_section_loaders_honor_env_overrides() -> None:
     assert logging_cfg.log_level == "WARNING"
     assert server_cfg.disable_cors is True
     assert server_cfg.cors_allow_credentials is True
+
+
+def test_logging_section_loader_uses_runtime_system_log_env_keys() -> None:
+    parser = ConfigParser()
+    parser.add_section("Logging")
+    parser.set("Logging", "system_log_file_path", "Databases/config-system.jsonl")
+    parser.set("Logging", "system_log_file_max_entries", "100")
+
+    cfg = load_logging_config(
+        parser,
+        env={
+            "SYSTEM_LOG_FILE_PATH": "Databases/env-system.jsonl",
+            "SYSTEM_LOG_FILE_MAX_ENTRIES": "777",
+            "LOG_SYSTEM_LOG_FILE_PATH": "Databases/log-prefixed-system.jsonl",
+            "LOG_SYSTEM_LOG_FILE_MAX_ENTRIES": "333",
+        },
+    )
+
+    assert cfg.system_log_file_path == "Databases/env-system.jsonl"
+    assert cfg.system_log_file_max_entries == 777
+
+
+def test_server_section_loader_accepts_existing_truthy_tokens() -> None:
+    parser = ConfigParser()
+    parser.add_section("Server")
+
+    cfg = load_server_config(
+        parser,
+        env={
+            "DISABLE_CORS": "on",
+            "CORS_ALLOW_CREDENTIALS": "y",
+        },
+    )
+
+    assert cfg.disable_cors is True
+    assert cfg.cors_allow_credentials is True
 
 
 def test_auth_audio_rag_and_provider_loaders_honor_env_and_fallbacks() -> None:
@@ -470,3 +606,16 @@ def test_moderation_section_loader_honors_env_backed_fields_and_normalizes_lists
     assert cfg.blocklist_write_debounce_ms == 25
     assert cfg.categories_enabled == ["safety", "pii"]
     assert cfg.pii_enabled is True
+
+
+def test_moderation_section_loader_rejects_invalid_security_values() -> None:
+    parser = ConfigParser()
+    parser.add_section("Moderation")
+    parser.set("Moderation", "enabled", "maybe")
+
+    with pytest.raises(ValueError, match="enabled.*maybe.*true"):
+        load_moderation_config(parser)
+
+    parser.set("Moderation", "enabled", "true")
+    with pytest.raises(ValueError, match="max_scan_chars.*not-an-int"):
+        load_moderation_config(parser, env={"MODERATION_MAX_SCAN_CHARS": "not-an-int"})

--- a/tldw_Server_API/tests/Config/test_config_sections_typed_loaders.py
+++ b/tldw_Server_API/tests/Config/test_config_sections_typed_loaders.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from configparser import ConfigParser
+
+import pytest
+
+from tldw_Server_API.app.core.config_sections import load_config_sections
+from tldw_Server_API.app.core.config_sections.database import load_database_config
+from tldw_Server_API.app.core.config_sections.embeddings import load_embeddings_config
+from tldw_Server_API.app.core.config_sections.logging import load_logging_config
+from tldw_Server_API.app.core.config_sections.server import load_server_config
+
+
+pytestmark = pytest.mark.unit
+
+
+def _build_parser_with_required_sections() -> ConfigParser:
+    parser = ConfigParser()
+    parser.add_section("AuthNZ")
+    parser.add_section("RAG")
+    parser.add_section("TTS-Settings")
+    parser.add_section("API")
+    parser.add_section("STT-Settings")
+    parser.add_section("Database")
+    parser.add_section("Embeddings")
+    parser.add_section("Logging")
+    parser.add_section("Server")
+    return parser
+
+
+def test_load_config_sections_exposes_new_typed_sections() -> None:
+    parser = _build_parser_with_required_sections()
+    parser.set("Database", "sqlite_path", "Databases/custom.db")
+    parser.set("Embeddings", "embedding_model", "test-embedding-model")
+    parser.set("Logging", "log_level", "DEBUG")
+    parser.set("Server", "disable_cors", "true")
+
+    sections = load_config_sections(parser)
+
+    assert sections.database.sqlite_path == "Databases/custom.db"
+    assert sections.embeddings.embedding_model == "test-embedding-model"
+    assert sections.logging.log_level == "DEBUG"
+    assert sections.server.disable_cors is True
+
+
+def test_database_section_loader_prefers_env_and_parses_types() -> None:
+    parser = ConfigParser()
+    parser.add_section("Database")
+    parser.set("Database", "type", "sqlite")
+    parser.set("Database", "sqlite_wal_mode", "false")
+    parser.set("Database", "pg_port", "5432")
+    parser.set("Database", "pg_pool_timeout", "30.0")
+
+    cfg = load_database_config(
+        parser,
+        env={
+            "DB_TYPE": "postgresql",
+            "DB_SQLITE_WAL_MODE": "yes",
+            "DB_PG_PORT": "6543",
+            "DB_PG_POOL_TIMEOUT": "45.5",
+        },
+    )
+
+    assert cfg.type == "postgresql"
+    assert cfg.sqlite_wal_mode is True
+    assert cfg.pg_port == 6543
+    assert cfg.pg_pool_timeout == 45.5
+
+
+def test_embeddings_section_loader_prefers_env_and_parses_bool() -> None:
+    parser = ConfigParser()
+    parser.add_section("Embeddings")
+    parser.set("Embeddings", "embedding_provider", "config-provider")
+    parser.set("Embeddings", "enable_contextual_chunking", "false")
+
+    cfg = load_embeddings_config(
+        parser,
+        env={
+            "EMBEDDING_PROVIDER": "env-provider",
+            "EMBEDDING_MODEL": "env-model",
+            "EMBEDDING_ENABLE_CONTEXTUAL_CHUNKING": "true",
+        },
+    )
+
+    assert cfg.embedding_provider == "env-provider"
+    assert cfg.embedding_model == "env-model"
+    assert cfg.enable_contextual_chunking is True
+
+
+def test_logging_and_server_section_loaders_honor_env_overrides() -> None:
+    parser = ConfigParser()
+    parser.add_section("Logging")
+    parser.add_section("Server")
+    parser.set("Logging", "log_level", "INFO")
+    parser.set("Server", "disable_cors", "false")
+    parser.set("Server", "cors_allow_credentials", "false")
+
+    logging_cfg = load_logging_config(
+        parser,
+        env={"LOG_LEVEL": "WARNING"},
+    )
+    server_cfg = load_server_config(
+        parser,
+        env={
+            "DISABLE_CORS": "1",
+            "CORS_ALLOW_CREDENTIALS": "true",
+        },
+    )
+
+    assert logging_cfg.log_level == "WARNING"
+    assert server_cfg.disable_cors is True
+    assert server_cfg.cors_allow_credentials is True

--- a/tldw_Server_API/tests/Config/test_config_sections_typed_loaders.py
+++ b/tldw_Server_API/tests/Config/test_config_sections_typed_loaders.py
@@ -4,11 +4,20 @@ from configparser import ConfigParser
 
 import pytest
 
+import tldw_Server_API.app.core.config_sections as config_sections_mod
 from tldw_Server_API.app.core.config_sections import load_config_sections
+from tldw_Server_API.app.core.config_sections.audio import load_audio_config
+from tldw_Server_API.app.core.config_sections.auth import load_auth_config
+from tldw_Server_API.app.core.config_sections.chunking import load_chunking_config
 from tldw_Server_API.app.core.config_sections.database import load_database_config
 from tldw_Server_API.app.core.config_sections.embeddings import load_embeddings_config
+from tldw_Server_API.app.core.config_sections.jobs import load_jobs_config
 from tldw_Server_API.app.core.config_sections.logging import load_logging_config
+from tldw_Server_API.app.core.config_sections.moderation import load_moderation_config
+from tldw_Server_API.app.core.config_sections.providers import load_providers_config
+from tldw_Server_API.app.core.config_sections.rag import load_rag_config
 from tldw_Server_API.app.core.config_sections.server import load_server_config
+from tldw_Server_API.app.core.config_sections.stt import load_stt_config
 
 
 pytestmark = pytest.mark.unit
@@ -21,26 +30,148 @@ def _build_parser_with_required_sections() -> ConfigParser:
     parser.add_section("TTS-Settings")
     parser.add_section("API")
     parser.add_section("STT-Settings")
+    parser.add_section("Chunking")
+    parser.add_section("Chat-Module")
     parser.add_section("Database")
     parser.add_section("Embeddings")
+    parser.add_section("Jobs")
     parser.add_section("Logging")
+    parser.add_section("Moderation")
     parser.add_section("Server")
     return parser
 
 
-def test_load_config_sections_exposes_new_typed_sections() -> None:
+def test_load_config_sections_exposes_new_typed_sections(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_key in (
+        "AUTH_MODE",
+        "APP_MODE",
+        "SINGLE_USER_FIXED_ID",
+        "RAG_VECTOR_STORE_TYPE",
+        "RAG_DEFAULT_LLM_PROVIDER",
+        "RAG_DEFAULT_LLM_MODEL",
+        "TTS_DEFAULT_PROVIDER",
+        "TTS_DEFAULT_VOICE",
+        "LOCAL_TTS_DEVICE",
+        "DEFAULT_API",
+        "DEFAULT_PROVIDER",
+        "CHAT_IMAGE_MAX_MB",
+        "CHAT_STREAM_CHANNEL_MAXSIZE",
+        "CHAT_STREAM_INCLUDE_METADATA",
+        "CHAT_SAVE_DEFAULT",
+        "DEFAULT_CHAT_SAVE",
+        "ALLOW_AUTOSWITCH_TO_OPENAI",
+        "CHAT_RUN_FIRST_ROLLOUT_MODE",
+        "CHAT_RUN_FIRST_PROVIDER_ALLOWLIST",
+        "CHAT_RUN_FIRST_PRESENTATION_VARIANT",
+        "DB_SQLITE_PATH",
+        "EMBEDDING_MODEL",
+        "LOG_LEVEL",
+        "MODERATION_USER_OVERRIDES_FILE",
+        "MODERATION_CATEGORIES_ENABLED",
+        "MODERATION_PII_ENABLED",
+        "DISABLE_CORS",
+        "STT_WS_CONTROL_V2_ENABLED",
+        "STT_REDACT_CATEGORIES",
+    ):
+        monkeypatch.delenv(env_key, raising=False)
+
     parser = _build_parser_with_required_sections()
+    parser.set("AuthNZ", "auth_mode", "multi_user")
+    parser.set("AuthNZ", "single_user_fixed_id", "7")
+    parser.set("RAG", "vector_store_type", "faiss")
+    parser.set("RAG", "rag_default_llm_provider", "anthropic")
+    parser.set("RAG", "rag_default_llm_model", "claude-3-5-sonnet")
+    parser.set("TTS-Settings", "default_tts_provider", "kokoro")
+    parser.set("TTS-Settings", "default_tts_voice", "alloy")
+    parser.set("TTS-Settings", "local_tts_device", "cuda")
+    parser.set("API", "default_api", "openai")
+    parser.set("API", "default_provider", "openrouter")
+    parser.set("Chat-Module", "enable_provider_fallback", "true")
+    parser.set("Chat-Module", "max_base64_image_size_mb", "4")
+    parser.set("Chat-Module", "max_text_length_per_message", "222222")
+    parser.set("Chat-Module", "max_messages_per_request", "25")
+    parser.set("Chat-Module", "max_images_per_request", "4")
+    parser.set("Chat-Module", "chat_stream_channel_maxsize", "24")
+    parser.set("Chat-Module", "chat_stream_include_metadata", "false")
+    parser.set("Chat-Module", "chat_save_default", "true")
+    parser.set("Chat-Module", "allow_autoswitch_to_openai", "true")
+    parser.set("Chat-Module", "rate_limit_per_minute", "120")
+    parser.set("Chat-Module", "rate_limit_per_conversation_per_minute", "30")
+    parser.set("Chat-Module", "rate_limit_tokens_per_minute", "120000")
+    parser.set("Chat-Module", "run_first_rollout_mode", "gated")
+    parser.set(
+        "Chat-Module",
+        "run_first_provider_allowlist",
+        "openai:gpt-4o-mini, anthropic:claude-3-7-sonnet",
+    )
+    parser.set("Chat-Module", "run_first_presentation_variant", "chat_phase2c_v1")
+    parser.set("Chunking", "chunking_method", "sentences")
+    parser.set("Chunking", "chunk_max_size", "512")
+    parser.set("Chunking", "chunk_overlap", "128")
+    parser.set("Chunking", "adaptive_chunking", "true")
     parser.set("Database", "sqlite_path", "Databases/custom.db")
     parser.set("Embeddings", "embedding_model", "test-embedding-model")
+    parser.set("Jobs", "prune_enforce", "true")
+    parser.set("Jobs", "prune_interval_sec", "7200")
+    parser.set("Jobs", "prune_domain", "chatbooks, embeddings")
+    parser.set("Jobs", "retention_days_completed", "14")
     parser.set("Logging", "log_level", "DEBUG")
+    parser.set("Moderation", "enabled", "true")
+    parser.set("Moderation", "output_action", "warn")
+    parser.set("Moderation", "user_overrides_file", "Config_Files/mod-user-overrides.json")
+    parser.set("Moderation", "categories_enabled", "pii, safety")
+    parser.set("Moderation", "pii_enabled", "true")
     parser.set("Server", "disable_cors", "true")
+    parser.set("STT-Settings", "ws_control_v2_enabled", "true")
+    parser.set("STT-Settings", "redact_categories", '["email", "phone"]')
 
     sections = load_config_sections(parser)
 
+    assert sections.auth.mode == "multi_user"
+    assert sections.auth.single_user_fixed_id == 7
+    assert sections.rag.vector_store_type == "faiss"
+    assert sections.rag.default_llm_provider == "anthropic"
+    assert sections.audio.default_tts_provider == "kokoro"
+    assert sections.audio.local_tts_device == "cuda"
+    assert sections.providers.default_api == "openai"
+    assert sections.providers.default_provider == "openrouter"
+    assert sections.chat.enable_provider_fallback is True
+    assert sections.chat.max_base64_image_size_mb == 4
+    assert sections.chat.max_text_length_per_message == 222222
+    assert sections.chat.max_messages_per_request == 25
+    assert sections.chat.max_images_per_request == 4
+    assert sections.chat.chat_stream_channel_maxsize == 24
+    assert sections.chat.chat_stream_include_metadata is False
+    assert sections.chat.chat_save_default is True
+    assert sections.chat.allow_autoswitch_to_openai is True
+    assert sections.chat.rate_limit_per_minute == 120
+    assert sections.chat.rate_limit_per_conversation_per_minute == 30
+    assert sections.chat.rate_limit_tokens_per_minute == 120000
+    assert sections.chat.run_first_rollout_mode == "gated"
+    assert sections.chat.run_first_provider_allowlist == [
+        "openai:gpt-4o-mini",
+        "anthropic:claude-3-7-sonnet",
+    ]
+    assert sections.chat.run_first_presentation_variant == "chat_phase2c_v1"
+    assert sections.chunking.method == "sentences"
+    assert sections.chunking.max_size == 512
+    assert sections.chunking.overlap == 128
+    assert sections.chunking.adaptive is True
     assert sections.database.sqlite_path == "Databases/custom.db"
     assert sections.embeddings.embedding_model == "test-embedding-model"
+    assert sections.jobs.prune_enforce is True
+    assert sections.jobs.prune_interval_sec == 7200
+    assert sections.jobs.prune_domain == ["chatbooks", "embeddings"]
+    assert sections.jobs.retention_days_completed == 14
     assert sections.logging.log_level == "DEBUG"
+    assert sections.moderation.enabled is True
+    assert sections.moderation.output_action == "warn"
+    assert sections.moderation.user_overrides_file == "Config_Files/mod-user-overrides.json"
+    assert sections.moderation.categories_enabled == ["pii", "safety"]
+    assert sections.moderation.pii_enabled is True
     assert sections.server.disable_cors is True
+    assert sections.stt.ws_control_v2_enabled is True
+    assert sections.stt.redact_categories == ["email", "phone"]
 
 
 def test_database_section_loader_prefers_env_and_parses_types() -> None:
@@ -65,6 +196,124 @@ def test_database_section_loader_prefers_env_and_parses_types() -> None:
     assert cfg.sqlite_wal_mode is True
     assert cfg.pg_port == 6543
     assert cfg.pg_pool_timeout == 45.5
+
+
+def test_chunking_section_loader_parses_global_defaults() -> None:
+    parser = ConfigParser()
+    parser.add_section("Chunking")
+    parser.set("Chunking", "chunking_method", "semantic")
+    parser.set("Chunking", "chunk_max_size", "1024")
+    parser.set("Chunking", "chunk_overlap", "256")
+    parser.set("Chunking", "adaptive_chunking", "true")
+    parser.set("Chunking", "chunking_multi_level", "yes")
+    parser.set("Chunking", "chunk_language", "fr")
+
+    cfg = load_chunking_config(parser)
+
+    assert cfg.method == "semantic"
+    assert cfg.max_size == 1024
+    assert cfg.overlap == 256
+    assert cfg.adaptive is True
+    assert cfg.multi_level is True
+    assert cfg.language == "fr"
+
+
+def test_chat_section_loader_honors_env_and_parses_scalar_limits() -> None:
+    parser = ConfigParser()
+    parser.add_section("Chat-Module")
+    parser.set("Chat-Module", "enable_provider_fallback", "false")
+    parser.set("Chat-Module", "max_base64_image_size_mb", "3")
+    parser.set("Chat-Module", "max_text_length_per_message", "500000")
+    parser.set("Chat-Module", "max_messages_per_request", "9")
+    parser.set("Chat-Module", "max_images_per_request", "2")
+    parser.set("Chat-Module", "chat_stream_channel_maxsize", "100")
+    parser.set("Chat-Module", "chat_stream_include_metadata", "true")
+    parser.set("Chat-Module", "default_save_to_db", "true")
+    parser.set("Chat-Module", "allow_autoswitch_to_openai", "false")
+    parser.set("Chat-Module", "rate_limit_per_minute", "60")
+    parser.set("Chat-Module", "rate_limit_per_conversation_per_minute", "20")
+    parser.set("Chat-Module", "rate_limit_tokens_per_minute", "100000")
+    parser.set("Chat-Module", "run_first_rollout_mode", "default_on")
+    parser.set(
+        "Chat-Module",
+        "run_first_provider_allowlist",
+        "openai:gpt-4o-mini,google:gemini-2.5-flash",
+    )
+    parser.set("Chat-Module", "run_first_presentation_variant", "chat_phase2b_v1")
+
+    load_chat_config = getattr(config_sections_mod, "load_chat_config", None)
+    assert callable(load_chat_config)
+
+    cfg = load_chat_config(
+        parser,
+        env={
+            "CHAT_IMAGE_MAX_MB": "8",
+            "CHAT_STREAM_CHANNEL_MAXSIZE": "42",
+            "CHAT_STREAM_INCLUDE_METADATA": "false",
+            "DEFAULT_CHAT_SAVE": "false",
+            "ALLOW_AUTOSWITCH_TO_OPENAI": "true",
+            "CHAT_RUN_FIRST_ROLLOUT_MODE": "gated",
+            "CHAT_RUN_FIRST_PROVIDER_ALLOWLIST": "anthropic:claude-3-7-sonnet, openai:gpt-4o",
+            "CHAT_RUN_FIRST_PRESENTATION_VARIANT": "chat_phase2d_v1",
+        },
+    )
+
+    assert cfg.enable_provider_fallback is False
+    assert cfg.max_base64_image_size_mb == 8
+    assert cfg.max_text_length_per_message == 500000
+    assert cfg.max_messages_per_request == 9
+    assert cfg.max_images_per_request == 2
+    assert cfg.chat_stream_channel_maxsize == 42
+    assert cfg.chat_stream_include_metadata is False
+    assert cfg.chat_save_default is False
+    assert cfg.allow_autoswitch_to_openai is True
+    assert cfg.rate_limit_per_minute == 60
+    assert cfg.rate_limit_per_conversation_per_minute == 20
+    assert cfg.rate_limit_tokens_per_minute == 100000
+    assert cfg.run_first_rollout_mode == "gated"
+    assert cfg.run_first_provider_allowlist == [
+        "anthropic:claude-3-7-sonnet",
+        "openai:gpt-4o",
+    ]
+    assert cfg.run_first_presentation_variant == "chat_phase2d_v1"
+
+
+def test_jobs_section_loader_honors_env_and_parses_retention_windows() -> None:
+    parser = ConfigParser()
+    parser.add_section("Jobs")
+    parser.set("Jobs", "prune_enforce", "false")
+    parser.set("Jobs", "prune_interval_sec", "3600")
+    parser.set("Jobs", "prune_domain", "config-domain")
+    parser.set("Jobs", "prune_queue", "default, low")
+    parser.set("Jobs", "retention_days_terminal", "45")
+    parser.set("Jobs", "retention_days_nonterminal", "5")
+
+    cfg = load_jobs_config(
+        parser,
+        env={
+            "JOBS_PRUNE_ENFORCE": "true",
+            "JOBS_PRUNE_DRY_RUN": "yes",
+            "JOBS_PRUNE_DOMAIN": "chatbooks, embeddings",
+            "JOBS_PRUNE_JOB_TYPE": "export, import",
+            "JOBS_RETENTION_DAYS_COMPLETED": "10",
+            "JOBS_RETENTION_DAYS_FAILED": "20",
+            "JOBS_RETENTION_DAYS_CANCELLED": "30",
+            "JOBS_RETENTION_DAYS_QUARANTINED": "40",
+        },
+    )
+
+    assert cfg.prune_enforce is True
+    assert cfg.prune_interval_sec == 3600
+    assert cfg.prune_dry_run is True
+    assert cfg.prune_domain == ["chatbooks", "embeddings"]
+    assert cfg.prune_queue == ["default", "low"]
+    assert cfg.prune_job_type == ["export", "import"]
+    assert cfg.retention_days_terminal == 45
+    assert cfg.retention_days_nonterminal == 5
+    assert cfg.retention_days_completed == 10
+    assert cfg.retention_days_failed == 20
+    assert cfg.retention_days_cancelled == 30
+    assert cfg.retention_days_quarantined == 40
 
 
 def test_embeddings_section_loader_prefers_env_and_parses_bool() -> None:
@@ -110,3 +359,114 @@ def test_logging_and_server_section_loaders_honor_env_overrides() -> None:
     assert logging_cfg.log_level == "WARNING"
     assert server_cfg.disable_cors is True
     assert server_cfg.cors_allow_credentials is True
+
+
+def test_auth_audio_rag_and_provider_loaders_honor_env_and_fallbacks() -> None:
+    parser = ConfigParser()
+    parser.add_section("AuthNZ")
+    parser.add_section("TTS-Settings")
+    parser.add_section("RAG")
+    parser.add_section("API")
+    parser.set("AuthNZ", "auth_mode", "single_user")
+    parser.set("AuthNZ", "single_user_fixed_id", "44")
+    parser.set("TTS-Settings", "default_tts_provider", "config-tts")
+    parser.set("TTS-Settings", "local_tts_device", "cpu")
+    parser.set("RAG", "vector_store_type", "chromadb")
+    parser.set("RAG", "rag_default_llm_provider", "config-provider")
+    parser.set("API", "default_api", "config-api")
+    parser.set("API", "default_provider", "config-provider")
+
+    auth_cfg = load_auth_config(
+        parser,
+        env={"AUTH_MODE": "multi_user", "SINGLE_USER_FIXED_ID": "99"},
+    )
+    audio_cfg = load_audio_config(
+        parser,
+        env={"TTS_DEFAULT_PROVIDER": "env-tts", "LOCAL_TTS_DEVICE": "mps"},
+    )
+    rag_cfg = load_rag_config(
+        parser,
+        env={"RAG_VECTOR_STORE_TYPE": "faiss", "RAG_DEFAULT_LLM_PROVIDER": "env-provider"},
+    )
+    providers_cfg = load_providers_config(
+        parser,
+        env={"DEFAULT_API": "env-api", "DEFAULT_PROVIDER": "env-provider"},
+    )
+
+    assert auth_cfg.mode == "multi_user"
+    assert auth_cfg.single_user_fixed_id == 99
+    assert audio_cfg.default_tts_provider == "env-tts"
+    assert audio_cfg.local_tts_device == "mps"
+    assert rag_cfg.vector_store_type == "faiss"
+    assert rag_cfg.default_llm_provider == "env-provider"
+    assert providers_cfg.default_api == "env-api"
+    assert providers_cfg.default_provider == "env-provider"
+
+
+def test_stt_section_loader_parses_lists_and_invalid_numbers_conservatively() -> None:
+    parser = ConfigParser()
+    parser.add_section("STT-Settings")
+    parser.set("STT-Settings", "paused_audio_queue_cap_seconds", "2.5")
+    parser.set("STT-Settings", "redact_categories", "email, phone,EMAIL")
+
+    cfg = load_stt_config(
+        parser,
+        env={
+            "STT_WS_CONTROL_V2_ENABLED": "true",
+            "STT_PAUSED_AUDIO_QUEUE_CAP_SECONDS": "-1",
+            "STT_OVERFLOW_WARNING_INTERVAL_SECONDS": "bad-value",
+            "STT_TRANSCRIPT_DIAGNOSTICS_ENABLED": "yes",
+            "STT_DELETE_AUDIO_AFTER_SUCCESS": "0",
+            "STT_AUDIO_RETENTION_HOURS": "6.5",
+            "STT_REDACT_PII": "on",
+            "STT_ALLOW_UNREDACTED_PARTIALS": "off",
+            "STT_REDACT_CATEGORIES": '["EMAIL", "phone", "email"]',
+        },
+    )
+
+    assert cfg.ws_control_v2_enabled is True
+    assert cfg.paused_audio_queue_cap_seconds == 2.0
+    assert cfg.overflow_warning_interval_seconds == 5.0
+    assert cfg.transcript_diagnostics_enabled is True
+    assert cfg.delete_audio_after_success is False
+    assert cfg.audio_retention_hours == 6.5
+    assert cfg.redact_pii is True
+    assert cfg.allow_unredacted_partials is False
+    assert cfg.redact_categories == ["email", "phone"]
+
+
+def test_moderation_section_loader_honors_env_backed_fields_and_normalizes_lists() -> None:
+    parser = ConfigParser()
+    parser.add_section("Moderation")
+    parser.set("Moderation", "enabled", "true")
+    parser.set("Moderation", "input_enabled", "false")
+    parser.set("Moderation", "output_action", "warn")
+    parser.set("Moderation", "categories_enabled", "pii, violence,PII")
+    parser.set("Moderation", "max_scan_chars", "12000")
+    parser.set("Moderation", "blocklist_write_debounce_ms", "15")
+
+    cfg = load_moderation_config(
+        parser,
+        env={
+            "MODERATION_USER_OVERRIDES_FILE": "/tmp/mod-overrides.json",
+            "MODERATION_MAX_SCAN_CHARS": "64000",
+            "MODERATION_MAX_REPLACEMENTS_PER_PATTERN": "250",
+            "MODERATION_MATCH_WINDOW_CHARS": "8192",
+            "MODERATION_MAX_FALLBACK_SCAN_CHARS": "900000",
+            "MODERATION_BLOCKLIST_WRITE_DEBOUNCE_MS": "25",
+            "MODERATION_CATEGORIES_ENABLED": " safety,PII,safety ",
+            "MODERATION_PII_ENABLED": "yes",
+        },
+    )
+
+    assert cfg.enabled is True
+    assert cfg.input_enabled is False
+    assert cfg.output_action == "warn"
+    assert cfg.user_overrides_file == "/tmp/mod-overrides.json"
+    assert cfg.max_scan_chars == 64000
+    assert cfg.max_replacements_per_pattern == 250
+    assert cfg.match_window_chars == 8192
+    assert cfg.max_fallback_scan_chars == 900000
+    assert cfg.blocklist_write_debounce_ms == 25
+    assert cfg.categories_enabled == ["safety", "pii"]
+    assert cfg.pii_enabled is True


### PR DESCRIPTION
Supersedes #1112.

## What changed
- ports the typed `database`, `server`, `logging`, and `embeddings` config-section loaders onto a fresh `origin/dev`-based branch
- wires the new typed sections into `tldw_Server_API.app.core.config_sections.ConfigSections` and `load_config_sections()`
- adds targeted tests for the new section loaders, env precedence, and existing `load_config_sections()` integration slices

## Verification
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Config/test_config_sections_typed_loaders.py -v`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Audio/test_stt_vnext_config_flags.py -v`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Config/test_config_precedence_contract.py -v`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -f json -o /tmp/bandit_phase2_4_redux.json tldw_Server_API/app/core/config_sections/__init__.py tldw_Server_API/app/core/config_sections/database.py tldw_Server_API/app/core/config_sections/embeddings.py tldw_Server_API/app/core/config_sections/logging.py tldw_Server_API/app/core/config_sections/server.py`

## Notes
- old `#1112` was cut from a stale pre-#1072 base; this replacement PR carries forward only the isolated typed-config-section slice
- a human-written `Change summary` is still required before merge per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`