### PR TITLE
feat: consolidate terminal stack and release automation

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,8 +1,6 @@
 name: Publish PyPI Package
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       target:
@@ -71,7 +69,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: build
-    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -57,6 +57,10 @@ jobs:
               if (cd "$req_dir" && cyclonedx-py requirements "$req_file" "${pyproject_args[@]}" -o "$out_file"); then
                 return 0
               fi
+              echo "cyclonedx-py positional requirements failed; trying -i form"
+              if (cd "$req_dir" && cyclonedx-py requirements -i "$req_file" "${pyproject_args[@]}" -o "$out_file"); then
+                return 0
+              fi
               echo "cyclonedx-py failed; will try fallbacks"
             fi
 
@@ -64,6 +68,10 @@ jobs:
             if python -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('cyclonedx_py') else 1)" >/dev/null 2>&1; then
               echo "Using python -m cyclonedx_py"
               if (cd "$req_dir" && python -m cyclonedx_py requirements "$req_file" "${pyproject_args[@]}" -o "$out_file"); then
+                return 0
+              fi
+              echo "python -m cyclonedx_py positional requirements failed; trying -i form"
+              if (cd "$req_dir" && python -m cyclonedx_py requirements -i "$req_file" "${pyproject_args[@]}" -o "$out_file"); then
                 return 0
               fi
               echo "python -m cyclonedx_py failed; trying legacy CLI"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -90,33 +90,31 @@ jobs:
             return 1
           }
 
-          gen_from_pyproject() {
-            local project_file="$1"
-            local tmp_req
-            tmp_req="$(mktemp)"
-            python - "$project_file" "$tmp_req" <<'PY'
+          gen_requirements_from_pyproject() {
+            local pyproject="$1"
+            local generated_req
+            generated_req="$(mktemp)"
+            python - "$pyproject" "$generated_req" <<'PY'
           import sys
           import tomllib
           from pathlib import Path
 
-          project_file = Path(sys.argv[1])
-          out_file = Path(sys.argv[2])
-          data = tomllib.loads(project_file.read_text(encoding="utf-8"))
-          dependencies = data.get("project", {}).get("dependencies", [])
-          out_file.write_text("\n".join(dependencies) + "\n", encoding="utf-8")
+          pyproject = Path(sys.argv[1])
+          generated_req = Path(sys.argv[2])
+          data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+          dependencies = data.get("project", {}).get("dependencies") or []
+          dependencies = [str(dependency).strip() for dependency in dependencies if str(dependency).strip()]
+          if not dependencies:
+              raise SystemExit(f"No [project].dependencies entries found in {pyproject}")
+
+          generated_req.write_text("\n".join(dependencies) + "\n", encoding="utf-8")
+          print(f"Wrote {len(dependencies)} requirements from {pyproject} to {generated_req}")
           PY
-
-            if [ ! -s "$tmp_req" ]; then
-              echo "No project dependencies found in ${project_file}" >&2
-              rm -f "$tmp_req"
-              return 1
-            fi
-
-            if gen_from_requirements "$tmp_req"; then
-              rm -f "$tmp_req"
+            if gen_from_requirements "$generated_req"; then
+              rm -f "$generated_req"
               return 0
             fi
-            rm -f "$tmp_req"
+            rm -f "$generated_req"
             return 1
           }
 
@@ -125,9 +123,9 @@ jobs:
           elif [ -f "$repo_root/requirements.txt" ]; then
             gen_from_requirements "$repo_root/requirements.txt"
           elif [ -f "$repo_root/pyproject.toml" ]; then
-            gen_from_pyproject "$repo_root/pyproject.toml"
+            gen_requirements_from_pyproject "$repo_root/pyproject.toml"
           else
-            echo "No requirements file or pyproject.toml found; cannot generate SBOM" >&2
+            echo "No Python dependency source found; cannot generate SBOM" >&2
             exit 1
           fi
 

--- a/Docs/Development/Container_Image_Lifecycle.md
+++ b/Docs/Development/Container_Image_Lifecycle.md
@@ -59,7 +59,7 @@ Three GitHub Actions workflows manage the lifecycle:
 
 **Trigger:** Push to `main` (fires on every merge).
 
-**What it does:** Builds and pushes snapshot images for `app`, `webui`, and `admin-ui` to GHCR. These snapshots let operators and CI test the latest `main` without waiting for a release.
+**What it does:** Builds and pushes snapshot images for `app`, `webui`, and `admin-ui` to GHCR. These snapshots let operators and CI test the latest `main` without waiting for a release, and they continue to republish on every `main` push independently of GitHub Release publication.
 
 **Key details:**
 - Registry: GHCR only (not Docker Hub).
@@ -78,9 +78,9 @@ Three GitHub Actions workflows manage the lifecycle:
 
 **File:** `.github/workflows/publish-docker.yml`
 
-**Trigger:** Release (published event), plus `workflow_dispatch` with an optional `manual_tag` input for ad-hoc builds.
+**Trigger:** GitHub Release publication (`release.published`), plus `workflow_dispatch` with an optional `manual_tag` input for ad-hoc builds.
 
-**What it does:** Builds and pushes release images for `app`, `worker`, and `audio-worker` to both Docker Hub and GHCR.
+**What it does:** Builds and pushes release images for `app`, `worker`, and `audio-worker` to both Docker Hub and GHCR. GitHub Release publication is the release-driving event for this workflow in v1.
 
 **Key details:**
 - Registries: both Docker Hub and GHCR.

--- a/Docs/Development/PyPI_Publishing.md
+++ b/Docs/Development/PyPI_Publishing.md
@@ -9,7 +9,7 @@ This guide sets up and uses the repository's PyPI release flow for the `tldw-ser
   - `make pypi-check`
 - CI packaging validation:
   - `.github/workflows/pypi-package.yml`
-- Release publishing workflow (Trusted Publishing):
+- Manual PyPI publishing workflow (Trusted Publishing):
   - `.github/workflows/publish-pypi.yml`
 
 ## One-Time Setup (PyPI)
@@ -50,11 +50,16 @@ python -c "import tldw_Server_API; print('ok')"
 1. Bump version in `pyproject.toml`.
 2. Create and push a Git tag (for example `v0.1.22`).
 3. Publish a GitHub Release from that tag.
-4. GitHub Actions runs `publish-pypi.yml` and uploads to PyPI using OIDC.
+4. GitHub Actions runs `publish-docker.yml` for Docker release publication.
 
-For preflight/testing, run `publish-pypi.yml` manually from Actions and choose `testpypi`.
+For PyPI publishing in this rollout, run `publish-pypi.yml` manually from Actions, select the release tag/ref that matches the GitHub Release and Docker release publish, and choose:
+
+- `testpypi` for TestPyPI
+- `pypi` for the real PyPI publish
 
 ## Notes
 
+- `publish-pypi.yml` is manual-dispatch-only in this rollout; GitHub Release publication no longer triggers PyPI uploads.
+- Pushing to `main` continues to republish rolling GHCR snapshots through `publish-ghcr-main.yml` before and independently of GitHub Release publication.
 - The default dependency set is intentionally broad and may be heavy for minimal installs.
 - If you want a lighter default install later, move optional feature stacks (for example some STT/TTS stacks) into extras and keep base runtime lean.

--- a/Docs/Development/Release_Process.md
+++ b/Docs/Development/Release_Process.md
@@ -1,0 +1,43 @@
+# Release Process
+
+This is the authoritative local operator path for cutting a release. Use [Docs/Release_Checklist.md](../Release_Checklist.md) for the broad readiness checklist before you start, but run the release from this document.
+
+## Supported Commands
+
+- `make release` runs the default patch flow.
+- `make release-patch` cuts the next patch release.
+- `make release-minor` cuts the next minor release.
+
+All three commands call `Helper_Scripts/release.py`, which:
+
+1. fetches `origin/main`
+2. requires the local branch to be `main` and exactly aligned with pre-bump `origin/main`
+3. reads required checks from `Docs/Development/CI_REQUIRED_GATES.md`
+4. verifies those required checks are green on the pre-bump `origin/main` commit
+5. updates release metadata and source docs, creates the release commit, tags it, pushes `main`, then creates the GitHub Release
+
+## Branch Rule
+
+`main` is the only supported source branch for this rollout. The helper aborts on any other branch because the required-check gate is defined against `origin/main`, the release commit is meant to land directly on `main`, and pushing that release commit republishes `main` snapshots before the GitHub Release drives formal publication.
+
+## Artifact Boundary
+
+Treat main snapshots republish as a first-class side effect of the release command.
+
+- Formal release artifacts are the `app`, `worker`, and `audio-worker` images published by the GitHub Release workflow with versioned release tags.
+- `main` snapshots are the rolling GHCR `app`, `webui`, and `admin-ui` images republished by pushes to `main`.
+- Pushing the release commit republishes `main` snapshots before GitHub Release publication triggers the formal Docker release artifacts.
+- `Docs/site/` is generated documentation-site output, not release source material. It remains ignored and is not staged by the release helper.
+
+## Retry And Recovery
+
+The helper is intentionally resumable for narrow failure states.
+
+- If the push to `origin/main` fails with non-fast-forward, stop and rerun from a fresh fetch; do not force-push around it.
+- If the release commit exists locally or the tag already exists locally, rerun the same command after confirming the worktree is clean.
+- If the remote tag exists but the GitHub Release does not, rerunning recovers by creating the missing GitHub Release instead of cutting a second release.
+- If the GitHub Release already exists, treat the release as already published and verify artifacts rather than retrying the cut.
+
+## PyPI Boundary
+
+PyPI is outside the automatic GitHub Release path in this rollout. The release command only handles the local release commit, tag push, snapshot republish, and GitHub Release publication that drives Docker release images. PyPI remains a narrow manual boundary: run `publish-pypi.yml` manually only after the release is published and you are ready to upload the matching package.

--- a/Docs/Published/RELEASE_NOTES.md
+++ b/Docs/Published/RELEASE_NOTES.md
@@ -2,4 +2,5 @@
 
 Published release notes entry point.
 
-For release process details, see `Docs/Release_Checklist.md`.
+For release process details, see `Docs/Development/Release_Process.md`.
+Use [Release Process](../Development/Release_Process.md) as the authoritative operator path and [Release Checklist](../Release_Checklist.md) as the broad readiness checklist.

--- a/Docs/Release_Checklist.md
+++ b/Docs/Release_Checklist.md
@@ -1,6 +1,6 @@
 ## tldw_server Release Checklist
 
-This document provides a practical checklist for preparing a full tldw_server release. It is meant to be a living document: keep it up to date as the project evolves and adapt the scope (for example, use a subset for small bugfix releases).
+This document is the broad readiness checklist for preparing a full tldw_server release. The authoritative operator path lives in [Docs/Development/Release_Process.md](Development/Release_Process.md); use that document for the actual release command flow, then use this checklist to confirm scope, readiness, and follow-through. Keep this checklist up to date as the project evolves and adapt the scope (for example, use a subset for small bugfix releases).
 
 ---
 

--- a/Docs/mkdocs.yml
+++ b/Docs/mkdocs.yml
@@ -59,13 +59,13 @@ markdown_extensions:
 
 extra:
   generator: false
-  version: v0.1.19
+  version: v0.1.30
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/rmusser01/tldw_server
       name: GitHub
 copyright: |
-  © 2024-2025 tldw_Server - v0.1.19 - <a href="https://github.com/rmusser01/tldw_server">GitHub</a>
+  © 2024-2025 tldw_Server - v0.1.30 - <a href="https://github.com/rmusser01/tldw_server">GitHub</a>
 
 nav:
   - Home: Getting_Started/README.md

--- a/Docs/mkdocs.yml
+++ b/Docs/mkdocs.yml
@@ -59,13 +59,13 @@ markdown_extensions:
 
 extra:
   generator: false
-  version: v0.1.30
+  version: v0.1.31
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/rmusser01/tldw_server
       name: GitHub
 copyright: |
-  © 2024-2025 tldw_Server - v0.1.30 - <a href="https://github.com/rmusser01/tldw_server">GitHub</a>
+  © 2024-2025 tldw_Server - v0.1.31 - <a href="https://github.com/rmusser01/tldw_server">GitHub</a>
 
 nav:
   - Home: Getting_Started/README.md

--- a/Docs/superpowers/plans/2026-04-22-release-process-automation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-22-release-process-automation-implementation-plan.md
@@ -1,0 +1,413 @@
+# Release Process Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a repo-owned local release command that cuts releases from `main`, gates on the documented required checks for the pre-bump `origin/main` commit, updates release metadata/docs consistently, and publishes a GitHub Release that triggers the existing Docker release workflow.
+
+**Architecture:** Keep the rollout narrow and explicit. Introduce a focused Python helper under `Helper_Scripts/` for release orchestration, wire Makefile entrypoints to that helper, narrow the PyPI workflow trigger so GitHub Release publication does not auto-publish PyPI, and update the maintainer docs to describe the real release contract. Validate behavior with utility-script tests, workflow contract tests, and docs contract tests instead of relying on manual inspection.
+
+**Tech Stack:** Python 3, Makefile, GitHub Actions YAML, pytest, Markdown docs
+
+---
+
+### Task 1: Lock The Release Boundary And Workflow Contracts
+
+**Files:**
+- Modify: `.github/workflows/publish-pypi.yml`
+- Modify: `Docs/Development/PyPI_Publishing.md`
+- Modify: `Docs/Development/Container_Image_Lifecycle.md`
+- Test: `tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py`
+- Create: `tldw_Server_API/tests/CI/test_release_workflow_contracts.py`
+
+- [ ] **Step 1: Write the failing workflow-contract tests**
+
+Add a new CI contract test file that asserts:
+
+- `publish-pypi.yml` no longer has a `release` trigger
+- `publish-pypi.yml` still supports `workflow_dispatch`
+- `publish-docker.yml` remains release-driven
+- the documented release image set stays `app`, `worker`, `audio-worker`
+
+Also extend `tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py` with a failing assertion that `publish-pypi.yml` is manual-dispatch-only.
+
+- [ ] **Step 2: Run the workflow-contract tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py tldw_Server_API/tests/CI/test_release_workflow_contracts.py -v`
+Expected: FAIL because `publish-pypi.yml` still triggers on `release.published` and the new release workflow contract test file does not exist yet.
+
+- [ ] **Step 3: Narrow the PyPI publish trigger**
+
+Edit `.github/workflows/publish-pypi.yml` so:
+
+- `workflow_dispatch` remains
+- `release.published` is removed
+- the existing `publish-pypi` job still works for manual `target == pypi`
+
+Keep the existing build job and trusted publishing configuration unchanged.
+
+- [ ] **Step 4: Update the maintainer publishing docs**
+
+Revise:
+
+- `Docs/Development/PyPI_Publishing.md`
+- `Docs/Development/Container_Image_Lifecycle.md`
+
+So they state clearly:
+
+- GitHub Release publication drives Docker release publishing
+- PyPI publishing is manual-dispatch-only in this rollout
+- `main` pushes continue to republish rolling GHCR snapshots
+
+- [ ] **Step 5: Re-run the workflow-contract tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py tldw_Server_API/tests/CI/test_release_workflow_contracts.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit the workflow-boundary change**
+
+```bash
+git add .github/workflows/publish-pypi.yml \
+  Docs/Development/PyPI_Publishing.md \
+  Docs/Development/Container_Image_Lifecycle.md \
+  tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py \
+  tldw_Server_API/tests/CI/test_release_workflow_contracts.py
+git commit -m "build: narrow PyPI release trigger"
+```
+
+### Task 2: Add The Release Helper Core With Check-Gate Parsing
+
+**Files:**
+- Create: `Helper_Scripts/release.py`
+- Test: `tldw_Server_API/tests/Utils/test_release_helper.py`
+- Read for reference: `Docs/Development/CI_REQUIRED_GATES.md`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+Create `tldw_Server_API/tests/Utils/test_release_helper.py` with focused unit tests for:
+
+- parsing the current version from `pyproject.toml`
+- computing patch and minor bumps
+- extracting stable required gate names from `Docs/Development/CI_REQUIRED_GATES.md`
+- rejecting unsupported release branches
+- detecting exact duplicate bullets within the same changelog subsection after simple normalization
+- classifying resumable states:
+  - local release commit only
+  - local tag only
+  - remote tag without GitHub Release
+  - existing GitHub Release
+
+- [ ] **Step 2: Run the helper tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_release_helper.py -v`
+Expected: FAIL because `Helper_Scripts/release.py` does not exist yet.
+
+- [ ] **Step 3: Write the minimal helper skeleton**
+
+Implement `Helper_Scripts/release.py` with pure functions first:
+
+- `read_current_version(...)`
+- `bump_version(...)`
+- `extract_required_check_names(...)`
+- `normalize_bullet_text(...)`
+- `find_exact_duplicate_bullets(...)`
+- `classify_release_state(...)`
+
+Keep shell/`gh` execution out of these functions so the logic stays easy to test.
+
+- [ ] **Step 4: Re-run the helper tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_release_helper.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit the helper core**
+
+```bash
+git add Helper_Scripts/release.py tldw_Server_API/tests/Utils/test_release_helper.py
+git commit -m "feat: add release helper core"
+```
+
+### Task 3: Add Changelog Promotion And Docs Metadata Updates
+
+**Files:**
+- Modify: `Helper_Scripts/release.py`
+- Modify: `README.md`
+- Modify: `Docs/mkdocs.yml`
+- Modify: `Docs/Published/RELEASE_NOTES.md`
+- Test: `tldw_Server_API/tests/Utils/test_release_helper.py`
+- Create: `tldw_Server_API/tests/Docs/test_release_docs_contract.py`
+
+- [ ] **Step 1: Add failing tests for changelog promotion and docs metadata**
+
+Extend `tldw_Server_API/tests/Utils/test_release_helper.py` with failing tests for:
+
+- promoting `CHANGELOG.md` `Unreleased` into a dated `X.Y.Z` section
+- leaving the `Unreleased` headings reset but empty
+- reporting cross-section near-duplicates as warnings instead of hard failures
+
+Create `tldw_Server_API/tests/Docs/test_release_docs_contract.py` with failing assertions that:
+
+- `README.md` release line matches the package version source under the release helper’s update path
+- `Docs/mkdocs.yml` version/copyright strings can be updated coherently
+- `Docs/Published/RELEASE_NOTES.md` points to the authoritative release-process doc path once that doc exists
+
+- [ ] **Step 2: Run the changelog/docs tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_release_helper.py tldw_Server_API/tests/Docs/test_release_docs_contract.py -v`
+Expected: FAIL because changelog promotion and release-doc update helpers are not implemented yet.
+
+- [ ] **Step 3: Implement changelog and docs metadata helpers**
+
+Extend `Helper_Scripts/release.py` with functions to:
+
+- parse and promote the `Unreleased` section
+- reject exact duplicate bullets within one subsection
+- update `README.md`’s release line text
+- update version-bearing metadata in `Docs/mkdocs.yml`
+- update the release-notes entry point text in `Docs/Published/RELEASE_NOTES.md`
+
+Do not attempt `Docs/site` rewriting here. Keep this step focused on deterministic source-file updates; generated docs are built separately and remain out of release commits.
+
+- [ ] **Step 4: Re-run the changelog/docs tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_release_helper.py tldw_Server_API/tests/Docs/test_release_docs_contract.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit the changelog/docs metadata layer**
+
+```bash
+git add Helper_Scripts/release.py README.md Docs/mkdocs.yml Docs/Published/RELEASE_NOTES.md \
+  tldw_Server_API/tests/Utils/test_release_helper.py \
+  tldw_Server_API/tests/Docs/test_release_docs_contract.py
+git commit -m "feat: add release metadata promotion"
+```
+
+### Task 4: Keep Generated Docs Site Out Of Release Commits
+
+**Files:**
+- Modify: `Helper_Scripts/release.py`
+- Modify: `.gitignore`
+- Test: `tldw_Server_API/tests/Docs/test_release_docs_contract.py`
+- Read for reference: `Docs/mkdocs.yml`, `.github/workflows/mkdocs.yml`
+
+- [ ] **Step 1: Add a failing generated-docs policy test**
+
+Extend `tldw_Server_API/tests/Docs/test_release_docs_contract.py` with a focused assertion that `Docs/site/` is ignored generated output, has no tracked files, and is not managed by the release helper.
+
+Use a narrow repo-policy assertion rather than checking every generated page.
+
+- [ ] **Step 2: Run the docs contract test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Docs/test_release_docs_contract.py -v`
+Expected: FAIL if `Docs/site` is staged, tracked, or still treated as release-managed output.
+
+- [ ] **Step 3: Implement generated-doc exclusion**
+
+Update the release path so that:
+
+- `Docs/site/` remains ignored in `.gitignore`
+- no `Docs/site` files are staged or committed
+- `Helper_Scripts/release.py` updates source docs metadata only
+- generated docs can be built separately by docs publishing workflows
+
+Do not redesign the docs pipeline.
+
+- [ ] **Step 4: Re-run the docs contract test**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Docs/test_release_docs_contract.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit the deterministic docs handling**
+
+```bash
+git add Helper_Scripts/release.py .gitignore \
+  tldw_Server_API/tests/Docs/test_release_docs_contract.py
+git commit -m "docs: keep generated docs site out of releases"
+```
+
+### Task 5: Add Orchestration, Push Abort Semantics, And Make Targets
+
+**Files:**
+- Modify: `Helper_Scripts/release.py`
+- Modify: `Makefile`
+- Test: `tldw_Server_API/tests/Utils/test_release_helper.py`
+- Create: `tldw_Server_API/tests/Utils/test_makefile_release_targets.py`
+
+- [ ] **Step 1: Add failing orchestration and Makefile tests**
+
+Extend `tldw_Server_API/tests/Utils/test_release_helper.py` with orchestration-level tests for:
+
+- requiring branch `main`
+- requiring a clean worktree
+- hard-aborting on non-fast-forward push failure when `main` has moved
+- resuming from “remote tag exists, GitHub Release missing”
+- treating the release commit as not requiring a second green CI cycle
+
+Create `tldw_Server_API/tests/Utils/test_makefile_release_targets.py` with failing assertions that:
+
+- `release-patch` target exists
+- `release-minor` target exists
+- `release` target exists
+- the targets delegate to `Helper_Scripts/release.py`
+
+- [ ] **Step 2: Run the orchestration/Makefile tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_release_helper.py tldw_Server_API/tests/Utils/test_makefile_release_targets.py -v`
+Expected: FAIL because orchestration functions and Make targets are incomplete.
+
+- [ ] **Step 3: Implement the orchestration layer**
+
+Finish `Helper_Scripts/release.py` so it:
+
+- fetches `origin/main`
+- validates green required checks for the documented gate names on the pre-bump `origin/main` SHA
+- prepares metadata edits
+- creates the release commit and tag
+- pushes `main` and the tag
+- hard-aborts on non-fast-forward push failure without rebasing or retrying
+- creates/publishes the GitHub Release
+- resumes cleanly from partially completed states
+
+Keep network and shell calls behind small wrapper functions so they can be stubbed in tests.
+
+- [ ] **Step 4: Add the Make targets**
+
+Update `Makefile` help text and targets to add:
+
+- `release-patch`
+- `release-minor`
+- `release`
+- optional `release-dry-run` or `DRY_RUN=1` wiring
+
+Use the existing Makefile style: thin wrapper targets that delegate to Python helpers.
+
+- [ ] **Step 5: Re-run the orchestration/Makefile tests**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_release_helper.py tldw_Server_API/tests/Utils/test_makefile_release_targets.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit the release command wiring**
+
+```bash
+git add Helper_Scripts/release.py Makefile \
+  tldw_Server_API/tests/Utils/test_release_helper.py \
+  tldw_Server_API/tests/Utils/test_makefile_release_targets.py
+git commit -m "feat: add local release command"
+```
+
+### Task 6: Add The Maintainer Release Process Document
+
+**Files:**
+- Create: `Docs/Development/Release_Process.md`
+- Modify: `Docs/Published/RELEASE_NOTES.md`
+- Modify: `Docs/Release_Checklist.md`
+- Test: `tldw_Server_API/tests/Docs/test_release_docs_contract.py`
+
+- [ ] **Step 1: Add a failing docs contract assertion**
+
+Extend `tldw_Server_API/tests/Docs/test_release_docs_contract.py` so it fails until:
+
+- `Docs/Development/Release_Process.md` exists
+- it names the authoritative local release commands
+- it distinguishes release artifacts from `main` snapshot artifacts
+- it states that pushing the release commit republishes `main` snapshots
+- it points to `Docs/Release_Checklist.md` as the broad readiness checklist
+
+- [ ] **Step 2: Run the docs contract test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Docs/test_release_docs_contract.py -v`
+Expected: FAIL because the release-process doc does not exist yet.
+
+- [ ] **Step 3: Write the maintainer release-process doc**
+
+Create `Docs/Development/Release_Process.md` as the short authoritative operator path. It should cover:
+
+- what the local release command does
+- why `main` is the only supported source branch
+- the required-check gate source (`Docs/Development/CI_REQUIRED_GATES.md`)
+- snapshot republish as a first-class side effect
+- which images are formal release artifacts vs `main` snapshots
+- retry/recovery behavior
+- the narrow PyPI boundary for this rollout
+
+Update the release-notes entry point and checklist cross-links if needed so the new document is the authoritative process reference.
+
+- [ ] **Step 4: Re-run the docs contract test**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Docs/test_release_docs_contract.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit the release-process docs**
+
+```bash
+git add Docs/Development/Release_Process.md Docs/Published/RELEASE_NOTES.md Docs/Release_Checklist.md \
+  tldw_Server_API/tests/Docs/test_release_docs_contract.py
+git commit -m "docs: add authoritative release process"
+```
+
+### Task 7: Verify The Full Release-Automation Change Set
+
+**Files:**
+- Modify: `Docs/superpowers/plans/2026-04-22-release-process-automation-implementation-plan.md`
+
+- [ ] **Step 1: Run the focused Python test suite**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py \
+  tldw_Server_API/tests/CI/test_release_workflow_contracts.py \
+  tldw_Server_API/tests/Utils/test_release_helper.py \
+  tldw_Server_API/tests/Utils/test_makefile_release_targets.py \
+  tldw_Server_API/tests/Docs/test_release_docs_contract.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run docs build verification**
+
+Run: `source .venv/bin/activate && python -m mkdocs build --strict -f Docs/mkdocs.yml`
+Expected: PASS
+
+- [ ] **Step 3: Run Bandit on the touched scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  Helper_Scripts/release.py \
+  tldw_Server_API/tests/CI \
+  tldw_Server_API/tests/Utils \
+  tldw_Server_API/tests/Docs \
+  Docs/Development \
+  Docs/Published \
+  .github/workflows \
+  -f json -o /tmp/bandit_release_process_automation.json
+```
+
+Expected: command completes without new actionable findings in the touched executable paths. Markdown AST parse errors are acceptable if Bandit reports them only for documentation files.
+
+- [ ] **Step 4: Run a dry-run release invocation**
+
+Run one of:
+
+```bash
+source .venv/bin/activate && python Helper_Scripts/release.py --dry-run --bump patch
+```
+
+or
+
+```bash
+make release-patch DRY_RUN=1
+```
+
+Expected:
+
+- no files are committed or pushed
+- the helper prints the pre-bump `origin/main` SHA it validated
+- the helper prints the required gate names it expects
+- the helper prints the planned metadata edits, tag name, GitHub Release title/body, and snapshot republish warning
+
+- [ ] **Step 5: Mark plan progress**
+
+Update this plan so completed steps are checked off before handoff.

--- a/Docs/superpowers/specs/2026-04-22-persona-dialtree-defensive-design.md
+++ b/Docs/superpowers/specs/2026-04-22-persona-dialtree-defensive-design.md
@@ -1,0 +1,360 @@
+# Defensive Persona Dialogue Trees Design
+
+**Date:** 2026-04-22
+
+## Goal
+
+Adapt the useful ideas from DialTree for the tldw_server persona and character systems as a defensive robustness and candidate-selection layer.
+
+The system should improve persona/character behavior by exploring multiple safe dialogue or plan candidates, pruning unsafe or low-quality branches, and scoring complete trajectories for persona consistency, policy adherence, grounding, and usefulness.
+
+This design covers both:
+
+- Offline defensive evals for personas and characters.
+- Runtime bounded exploration for live persona behavior.
+
+## Source Paper
+
+Paper reviewed:
+
+- [Tree-based Dialogue Reinforced Policy Optimization for Red-Teaming Attacks](https://arxiv.org/html/2510.02286v2)
+- [OpenReview entry](https://openreview.net/forum?id=El37o7iBjX)
+
+The paper introduces DialTree, a tree-search reinforcement-learning framework for multi-turn red-teaming. The relevant transferable ideas are:
+
+- Dialogue tree rollout instead of single linear rollouts.
+- Branch pruning for malformed, off-topic, or low-quality branches.
+- Trajectory-level scoring rather than isolated turn scoring.
+- Stable structure preservation during optimization.
+
+The offensive RL and jailbreak-training parts of the paper are not part of this design.
+
+## Current Project Context
+
+The repo already has adjacent but not equivalent systems:
+
+- `tldw_Server_API/app/core/Persona/` persists persona profiles, sessions, policy rules, state docs, memories, exemplars, and websocket interactions.
+- `tldw_Server_API/app/core/Persona/exemplar_retrieval.py` performs deterministic persona exemplar selection.
+- `tldw_Server_API/app/core/Character_Chat/modules/persona_exemplar_selector.py` performs character-scoped exemplar selection with scoring, MMR diversification, safety gating, and token-budget packing.
+- `tldw_Server_API/app/core/Persona/policy_evaluator.py` enforces persona/session/tool policy.
+- `tldw_Server_API/app/api/v1/endpoints/persona.py` has the live persona websocket plan-confirm-act loop.
+- `Docs/Product/Completed/Persona_Roleplay_PRD.md` defines persona roleplay exemplars, policy-first boundaries, and IOO/IOR/LCS diagnostics.
+
+What is missing:
+
+- No tree rollout over alternate multi-turn persona trajectories.
+- No branch-level pruning for persona drift, prompt injection progression, or unsafe tool-plan evolution.
+- No trajectory-level robustness score across several turns.
+- No shared offline/runtime tree engine.
+- No runtime candidate explorer that ranks multiple safe plans or responses before showing one.
+
+## Recommended Approach
+
+Build a shared defensive dialogue-tree core, then use it in both offline evals and runtime exploration.
+
+Implementation should proceed in one design family:
+
+1. Shared tree engine and pruner/scorer contracts.
+2. Offline robustness eval harness.
+3. Runtime shallow explorer behind feature flags.
+
+This avoids duplicate systems and gives the runtime path a safer validation base.
+
+## Non-Goals
+
+- Do not implement offensive jailbreak training.
+- Do not implement GRPO, DAPO, or model fine-tuning.
+- Do not optimize for eliciting harmful content.
+- Do not store a jailbreak strategy library in normal runtime data.
+- Do not let tree scoring override existing persona policy enforcement.
+- Do not auto-mutate persona prompts, memories, state docs, or exemplars based on eval failures.
+
+## Architecture
+
+Add a new defensive tree layer beside the existing persona/character systems.
+
+### Core Modules
+
+Proposed backend modules:
+
+- `tldw_Server_API/app/core/Persona/dialogue_tree.py`
+- `tldw_Server_API/app/core/Persona/dialogue_tree_pruners.py`
+- `tldw_Server_API/app/core/Persona/dialogue_tree_scorers.py`
+- `tldw_Server_API/app/core/Persona/dialogue_tree_traces.py`
+- `tldw_Server_API/app/core/Persona/robustness_eval.py`
+- `tldw_Server_API/app/core/Persona/runtime_explorer.py`
+
+Names can be adjusted during planning, but the boundaries should remain clear.
+
+### PersonaDialogueTree
+
+Shared engine for:
+
+- Root state creation.
+- Candidate branch expansion.
+- Branch pruning.
+- Trajectory assembly.
+- Scoring.
+- Best-candidate selection.
+- Trace serialization.
+
+The engine should be model/provider agnostic. It accepts candidate generators and scorer/pruner callables.
+
+### PersonaTreePruners
+
+Pruners return structured decisions with:
+
+- `pruned: bool`
+- `severity: soft | hard`
+- `reason_code`
+- `reason`
+- optional diagnostics
+
+Initial pruners:
+
+- Malformed candidate output.
+- Off-topic or task-drift detection.
+- Prompt-injection pressure.
+- Persona-boundary violation.
+- Unsafe or unauthorized tool plan.
+- Duplicate or low-diversity branch.
+- Token, depth, branch, and latency budget limits.
+- Exemplar over-copying risk.
+
+Hard prunes should block fallback when the candidate itself would violate policy or safety.
+
+### PersonaTrajectoryScorers
+
+Scorers return independent structured scores so the aggregate remains debuggable.
+
+Initial scorers:
+
+- Persona consistency.
+- Character voice/style adherence.
+- Policy adherence.
+- Tool-plan safety.
+- Memory/state grounding.
+- Exemplar use quality.
+- Refusal quality.
+- User-goal usefulness.
+- Drift resistance over multiple turns.
+
+Scores should be numeric where useful but keep explanations and skipped reasons. Deterministic scorers should be the default baseline. LLM-judge scorers may be optional and explicitly marked as skipped when unavailable.
+
+### PersonaRobustnessEval
+
+Offline harness that runs tree evals against persona and character profiles.
+
+It should support:
+
+- Benign interaction scenarios.
+- Persona-drift scenarios.
+- Prompt-injection scenarios.
+- Tool misuse scenarios.
+- Boundary-pressure scenarios.
+- Exemplar over-copying scenarios.
+- Multi-turn escalation scenarios.
+
+The eval harness should produce structured trace artifacts and summary reports, not automatic profile rewrites.
+
+### PersonaRuntimeExplorer
+
+Runtime adapter for live persona behavior.
+
+It should:
+
+- Run only behind feature flags.
+- Use shallow trees and strict budgets.
+- Generate candidate plans or responses.
+- Apply the same pruners and scorers as offline evals.
+- Select the highest-scoring safe candidate.
+- Fall back to existing behavior when exploration is unavailable, times out, or all candidates are soft-pruned.
+- Emit a safe denial when all candidates are hard-policy violations.
+
+The initial runtime integration should target persona websocket plan proposal near the existing `_propose_plan(...)` path. Character chat runtime response exploration can follow after the persona path is stable.
+
+## Data Flow
+
+### Offline Eval Flow
+
+1. Select a persona or character plus an eval suite.
+2. Build a root state with profile metadata, policy snapshot, state docs, relevant memory/exemplar context, and scenario goal.
+3. Expand candidate user/assistant/tool-plan branches using configured generators.
+4. Apply pruners at each node.
+5. Assemble surviving root-to-leaf trajectories.
+6. Score trajectories.
+7. Persist trace artifact and report summary metrics.
+8. Surface failing trajectories and scorer breakdowns for human review.
+
+### Runtime Flow
+
+1. Persona websocket receives `user_message`.
+2. Existing context resolution runs: session policy, memory, companion context, persona state docs, and exemplar prompt sections.
+3. If runtime exploration is disabled, existing behavior continues unchanged.
+4. If enabled, a shallow tree generates candidate plans or candidate assistant answers.
+5. Candidates are pruned and scored.
+6. The best safe candidate is emitted.
+7. If exploration fails or exceeds budget, fallback behavior depends on failure type:
+   - soft failure: existing `_propose_plan(...)`
+   - hard policy/safety violation: safe denial or denied tool-plan event
+
+### Trace Shape
+
+Trace records should be portable JSON-like objects.
+
+Required fields:
+
+- `root`: persona/character ids, session mode, scenario, policy snapshot id, model/provider metadata, feature flags.
+- `nodes`: node id, parent id, turn index, candidate source, visible dialogue summary, hidden scoring metadata, prune status.
+- `edges`: action type, candidate text or summarized tool plan, generator metadata.
+- `trajectory_scores`: per-scorer output and aggregate score.
+- `decision`: selected node, fallback reason, or failure class.
+
+Privacy constraints:
+
+- Do not store API keys, secrets, auth headers, or raw credentials.
+- Do not persist full external tool responses unless explicitly requested for a test fixture.
+- Summarize tool results using existing retention-summary patterns.
+- Keep adversarial eval traces separate from normal persona memory, exemplars, and chat history.
+
+## Error Handling
+
+Runtime handling must be conservative:
+
+- Candidate generation failure falls back to existing single-path behavior.
+- Scoring failure discards the affected candidate and records a skipped scorer reason.
+- LLM judge unavailability falls back to deterministic scorers.
+- Budget exhaustion stops exploration and falls back if no hard violation occurred.
+- Hard policy/safety violation emits safe denial rather than fallback to a potentially unsafe path.
+- Trace persistence failure should not break live chat; emit diagnostics and continue.
+
+Offline handling:
+
+- Eval failures should be reported as failed test cases, not thrown away.
+- Judge/scorer errors should be represented as skipped or errored scorer entries.
+- Missing optional model providers should skip provider-dependent evals.
+
+## Safety Boundaries
+
+- Runtime exploration never executes tools during candidate generation.
+- Existing persona policy remains final authority before any tool call.
+- Runtime exploration may reject, rank, or choose candidates; it may not grant capabilities.
+- External LLM judges classify candidates but cannot authorize actions.
+- Red-team fixtures remain isolated from user-facing memory, exemplars, and state docs.
+- Harmful request text in fixtures should be minimized, category-labeled, and avoid procedural harmful details.
+
+## Configuration
+
+Initial feature flags and settings should be additive.
+
+Candidate config keys:
+
+- `PERSONA_DIALOGUE_TREE_EVAL_ENABLED`
+- `PERSONA_RUNTIME_EXPLORER_ENABLED`
+- `PERSONA_RUNTIME_EXPLORER_MAX_DEPTH`
+- `PERSONA_RUNTIME_EXPLORER_MAX_BRANCHING`
+- `PERSONA_RUNTIME_EXPLORER_TIMEOUT_MS`
+- `PERSONA_RUNTIME_EXPLORER_MAX_TOKENS`
+- `PERSONA_DIALOGUE_TREE_TRACE_RETENTION_DAYS`
+
+Defaults:
+
+- Offline eval flag may default off unless explicitly invoked.
+- Runtime explorer must default off.
+- Runtime depth should initially be `1`.
+- Runtime branching should initially be small, for example `2`.
+- Runtime timeout should be short enough to preserve websocket responsiveness.
+
+## API And UI Surface
+
+Initial implementation can be backend-first.
+
+Optional follow-on API endpoints:
+
+- `POST /api/v1/persona/evals/dialogue-tree/run`
+- `GET /api/v1/persona/evals/dialogue-tree/runs/{run_id}`
+- `GET /api/v1/persona/evals/dialogue-tree/runs/{run_id}/trace`
+
+Runtime websocket additions:
+
+- Optional diagnostic `notice` when runtime exploration is enabled, skipped, timed out, or falls back.
+- Optional debug metadata for selected candidate id and scorer summary when requested by an authenticated developer/debug flag.
+
+No UI is required for the first implementation beyond existing logs/API results. A later UI can show trace trees and scorer breakdowns.
+
+## Testing Strategy
+
+### Core Unit Tests
+
+- Tree expansion respects max depth, max branching, candidate caps, and deterministic ordering.
+- Pruners classify malformed candidates, off-topic drift, prompt injection pressure, unsafe tool plans, duplicate branches, and over-budget branches.
+- Scorers return stable structured outputs for normal and malformed inputs.
+- Aggregate scoring handles skipped/failed scorer results.
+- Trace serialization redacts or summarizes sensitive fields.
+
+### Offline Eval Tests
+
+- Benign scenario produces at least one passing trajectory.
+- Persona-drift scenario fails persona-consistency scoring.
+- Prompt-injection scenario is pruned or scored below threshold.
+- Risky tool-plan scenario is denied by policy scoring.
+- Reports include failing trajectories, scorer breakdowns, and skipped scorer reasons.
+
+### Runtime Tests
+
+- Feature flag off preserves persona websocket behavior.
+- Feature flag on emits the highest-scoring safe plan when candidates are available.
+- Candidate generation timeout falls back to existing `_propose_plan(...)`.
+- All hard-policy candidates produce safe denial rather than fallback.
+- Existing confirmation semantics are unchanged for write/export/delete tools.
+
+### Verification
+
+Use targeted pytest suites:
+
+- `tldw_Server_API/tests/Persona/`
+- relevant `tldw_Server_API/tests/Character_Chat/` tests when character integration is touched
+
+Run Bandit on touched backend code before implementation completion.
+
+## Rollout
+
+Stage 1: Shared Core And Offline Harness
+
+- Add tree, pruner, scorer, and trace contracts.
+- Add deterministic initial pruners/scorers.
+- Add offline robustness eval harness.
+- Add tests for benign, drift, injection, and unsafe-tool scenarios.
+
+Stage 2: Runtime Persona Explorer
+
+- Add shallow runtime adapter behind `PERSONA_RUNTIME_EXPLORER_ENABLED`.
+- Integrate around persona websocket planning.
+- Preserve fallback to existing behavior.
+- Add telemetry/diagnostic notices.
+
+Stage 3: Character Chat Integration
+
+- Use the offline evaluator for character/persona prompt robustness checks.
+- Optionally apply runtime response exploration to character chat after persona runtime proves stable.
+
+Stage 4: Trace Review UI
+
+- Add optional UI to inspect tree traces, pruned branches, and scorer breakdowns.
+
+## Acceptance Criteria
+
+- Offline eval can run multi-turn defensive tree scenarios for at least one persona and one character.
+- Eval traces include branch/prune/score decisions and redact sensitive data.
+- Runtime explorer can be enabled without changing behavior when disabled.
+- Runtime explorer falls back safely on timeout or soft failure.
+- Hard policy/safety violations are not routed through unsafe fallback.
+- Existing persona policy confirmation behavior remains unchanged.
+- Tests cover core tree behavior, eval reports, and websocket runtime fallback.
+
+## Open Questions
+
+- Should trace artifacts live in ChaChaNotes DB, the existing eval DB, or filesystem-backed run artifacts?
+- Which deterministic scorer thresholds should block runtime candidates versus only lowering score?
+- Should LLM judge scorers be allowed in runtime at all, or reserved for offline eval only?
+- What is the preferred first eval suite: persona drift, prompt injection, unsafe tool plans, or all three in a small smoke set?

--- a/Docs/superpowers/specs/2026-04-22-release-process-automation-design.md
+++ b/Docs/superpowers/specs/2026-04-22-release-process-automation-design.md
@@ -1,0 +1,447 @@
+# Release Process Automation Design
+
+Date: 2026-04-22
+Status: Approved for planning
+Owner: Codex brainstorming session
+
+## Summary
+
+Add a repo-owned, local release entrypoint that cuts a release from `main` with a single command and then hands off artifact publication to existing GitHub Actions workflows. The first iteration should automate:
+
+- version bumping from the canonical package version in [`pyproject.toml`](../../../pyproject.toml)
+- changelog promotion from [`CHANGELOG.md`](../../../CHANGELOG.md)
+- release commit creation
+- annotated tag creation
+- push of `main` and the release tag
+- GitHub Release publication via `gh`
+
+Publishing of release artifacts remains GitHub-native. A published GitHub Release should trigger Docker publishing for the release image set already defined in [`.github/workflows/publish-docker.yml`](../../../.github/workflows/publish-docker.yml). Rolling snapshot publishing for `main` remains separate and continues to be handled by [`.github/workflows/publish-ghcr-main.yml`](../../../.github/workflows/publish-ghcr-main.yml).
+
+This design intentionally does not try to automate everything in one pass. The goal is to create one authoritative maintainer path that is accurate, safe, resumable, and aligned with the repository’s current release topology.
+
+## Problem
+
+The repository currently has useful release-related building blocks, but they are not composed into one authoritative release flow.
+
+Today:
+
+- package versioning is defined in [`pyproject.toml`](../../../pyproject.toml), but human-facing version references already drift in places such as [`README.md`](../../../README.md)
+- release notes exist in [`CHANGELOG.md`](../../../CHANGELOG.md), but there is no repo-owned release command that turns changelog state into a published release
+- Docker release publishing already exists in [`.github/workflows/publish-docker.yml`](../../../.github/workflows/publish-docker.yml), but it only runs after a GitHub Release is published
+- `main` snapshot image publishing already exists in [`.github/workflows/publish-ghcr-main.yml`](../../../.github/workflows/publish-ghcr-main.yml), which means the repo already has two distinct publication modes that must remain clearly separated
+- PyPI publishing is also currently tied to `release.published` in [`.github/workflows/publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml), which conflicts with the desired first-iteration scope of “Docker + GitHub Release only”
+- release readiness guidance exists in [`Docs/Release_Checklist.md`](../../../Docs/Release_Checklist.md), but that document is a broad checklist rather than a concise authoritative operator workflow
+
+This leaves maintainers without a safe, consistent, local “cut a release” command and makes it too easy for documentation to describe a release process that the repo does not actually enforce.
+
+## Goals
+
+- Provide one authoritative local maintainer entrypoint for cutting releases
+- Support these user-facing commands in the first iteration:
+  - `make release-patch`
+  - `make release-minor`
+  - `make release VERSION=X.Y.Z`
+- Restrict automated releases to `main`
+- Require the release command to fail closed on unsafe repo state
+- Keep release publication separate from `main` snapshot publication
+- Treat `main` snapshot publication as an explicit release side effect when the release commit is pushed
+- Gate release initiation on green required checks for the pre-bump `origin/main` commit
+- Use [`pyproject.toml`](../../../pyproject.toml) as the canonical release version source
+- Use [`CHANGELOG.md`](../../../CHANGELOG.md) as the canonical GitHub Release notes source
+- Make the release helper resumable across partial-failure states
+- Add a short maintainer-facing release-process document that matches the actual repo behavior
+- Keep the first automated release scope to Docker publishing plus GitHub Release publication
+- Keep source docs and maintainer release/publishing docs aligned with the release workflow
+
+## Non-Goals
+
+- Automate merging or syncing `dev` into `main`
+- Redesign all existing CI workflows into reusable workflow primitives
+- Expand the release image set beyond what [`.github/workflows/publish-docker.yml`](../../../.github/workflows/publish-docker.yml) already publishes
+- Include PyPI in the first automated release path
+- Invent a full semantic-release or release-train system
+- Replace [`Docs/Release_Checklist.md`](../../../Docs/Release_Checklist.md) with a smaller document
+
+## Current State
+
+### Existing release artifact publishing
+
+[`.github/workflows/publish-docker.yml`](../../../.github/workflows/publish-docker.yml):
+
+- triggers on `release.published` and `workflow_dispatch`
+- publishes release images to GHCR and Docker Hub
+- currently publishes exactly these release image variants:
+  - `app`
+  - `worker`
+  - `audio-worker`
+
+This workflow already represents the remote “publish release images” half of the desired system.
+
+### Existing snapshot publishing
+
+[`.github/workflows/publish-ghcr-main.yml`](../../../.github/workflows/publish-ghcr-main.yml):
+
+- triggers on `push` to `main`
+- publishes rolling GHCR snapshots
+- currently covers:
+  - `app`
+  - `webui`
+  - `admin-ui`
+
+This workflow is already the source of truth for `main` snapshots and must remain distinct from formal releases.
+
+### Existing PyPI publish coupling
+
+[`.github/workflows/publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml):
+
+- triggers on `release.published`
+- also supports `workflow_dispatch`
+
+That means any automation that publishes a GitHub Release today will also publish to PyPI. This is incompatible with the desired first release automation boundary unless the workflow trigger is changed.
+
+### Existing version drift
+
+The canonical package version is currently defined in [`pyproject.toml`](../../../pyproject.toml), but not every visible version reference follows it.
+
+Examples:
+
+- [`pyproject.toml`](../../../pyproject.toml) currently reports `0.1.30`
+- [`README.md`](../../../README.md) currently describes the release line as `0.3.1`
+- some CLI modules still contain hard-coded version strings
+
+The release design must treat version drift as a first-class problem, not an incidental cleanup.
+
+Additional tracked documentation drift already exists in the docs toolchain:
+
+- [`Docs/mkdocs.yml`](../../../Docs/mkdocs.yml) still contains an older site version string
+- maintainer publishing docs such as [`Docs/Development/PyPI_Publishing.md`](../../../Docs/Development/PyPI_Publishing.md) still describe release-triggered PyPI publication
+
+Generated documentation output under `Docs/site/` is not release source material and must remain ignored. The release design therefore needs concrete rules for source docs and maintainer docs, not generated-site cleanup.
+
+### Existing release notes source
+
+[`CHANGELOG.md`](../../../CHANGELOG.md) already has an `Unreleased` section and versioned sections, which makes it the best source for GitHub Release notes. However, existing sections already show signs of duplication, so the release helper cannot assume that changelog input is always clean.
+
+## Proposed Design
+
+### 1. Define the release boundary explicitly
+
+The release command will support only one release source branch:
+
+- `main`
+
+This means:
+
+- the helper must fail if the current branch is not `main`
+- the helper must fail if the local branch is behind or diverged from `origin/main`
+- the helper does not perform merges or decide what from `dev` should be released
+
+Maintainer workflow:
+
+1. prepare or merge releasable work onto `main`
+2. run the local release command from `main`
+3. let GitHub Actions publish artifacts after the GitHub Release is published
+
+This keeps release scope crisp and prevents the release command from becoming a policy engine for cross-branch promotion.
+
+### 2. Decouple PyPI from the first automated release path
+
+Before the new release command is documented as authoritative, [`.github/workflows/publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml) should be adjusted so PyPI publication is not triggered by `release.published`.
+
+First-iteration recommendation:
+
+- keep PyPI publish available via `workflow_dispatch`
+- remove `release.published` as an automatic trigger
+
+Reason:
+
+- the user-requested first boundary is “Docker + GitHub Release”
+- leaving PyPI tied to release publication would make the operator doc false on day one
+
+This is a small but required precondition for the automation to match the intended scope.
+
+### 3. Keep published release images and `main` snapshots distinct
+
+The release-process doc must explicitly describe the two different image contracts.
+
+Release artifacts:
+
+- produced by [`.github/workflows/publish-docker.yml`](../../../.github/workflows/publish-docker.yml)
+- image set in v1:
+  - `app`
+  - `worker`
+  - `audio-worker`
+
+Rolling `main` snapshots:
+
+- produced by [`.github/workflows/publish-ghcr-main.yml`](../../../.github/workflows/publish-ghcr-main.yml)
+- image set:
+  - `app`
+  - `webui`
+  - `admin-ui`
+
+This matters because a vague “publishes Docker images” statement would cause maintainers to assume the release path also publishes the UI images, which it does not today.
+
+It also means that pushing the release commit to `main` will intentionally republish the rolling `main` snapshot tags before the GitHub Release is published. That snapshot republish is an expected, first-class side effect of the release flow in v1, not an incidental background event.
+
+### 4. Standardize the release version source
+
+Canonical source of release version:
+
+- [`pyproject.toml`](../../../pyproject.toml)
+
+The release helper must:
+
+- read the current version from [`pyproject.toml`](../../../pyproject.toml)
+- compute the target version from:
+  - patch bump
+  - minor bump
+  - explicit version input
+- write the new version back to [`pyproject.toml`](../../../pyproject.toml)
+
+The release helper should also update known human-facing release-line references that are meant to track the current release version.
+
+First-pass cleanup scope:
+
+- [`README.md`](../../../README.md) current release line
+- [`Docs/mkdocs.yml`](../../../Docs/mkdocs.yml) docs-site version/copyright metadata
+
+For v1, that means:
+
+- `Docs/site/` remains generated output and is excluded from version control
+- the helper must not stage or mutate `Docs/site/`
+- maintainers can build the documentation site separately when publishing docs, but generated-site churn is not part of the release commit
+
+This keeps release diffs bounded and avoids rewriting large portions of the generated site for unrelated reasons such as time-relative rendering or other build-time noise.
+
+Related maintainer docs that describe release and publishing behavior are also in scope for alignment in this project, but they are workflow-alignment tasks rather than per-release version-bump targets. Minimum scope:
+
+- [`Docs/Development/PyPI_Publishing.md`](../../../Docs/Development/PyPI_Publishing.md)
+- [`Docs/Published/RELEASE_NOTES.md`](../../../Docs/Published/RELEASE_NOTES.md)
+
+Hard-coded CLI versions need an explicit policy. The safest first-iteration rule is:
+
+- update human-facing release-line references that claim to reflect the overall project release
+- do not claim universal version unification until module-specific hard-coded CLI versions are either wired to package metadata or deliberately declared independent
+
+This avoids silently overpromising what “version automation” covers.
+
+### 5. Use `CHANGELOG.md` as the canonical release-notes source
+
+The release helper will derive the GitHub Release body from the finalized release section in [`CHANGELOG.md`](../../../CHANGELOG.md).
+
+Expected changelog flow:
+
+1. read the `Unreleased` section
+2. validate that it contains meaningful content
+3. create a new release section for `X.Y.Z` with the current date
+4. move the `Unreleased` contents into that new versioned section
+5. reset `Unreleased` to empty section headings
+
+The helper should fail closed if:
+
+- `Unreleased` is empty
+- the changelog layout is malformed
+- the extracted release slice cannot be unambiguously identified
+- exact duplicate bullets are detected within the same changelog subsection after simple normalization
+
+For v1, simple normalization means:
+
+- trim leading/trailing whitespace
+- collapse internal runs of whitespace to a single space
+- compare bullet text only within the same subsection (`Added`, `Changed`, `Fixed`, `Removed`)
+
+Potential near-duplicates across different subsections should be reported as warnings in the dry-run/release output, not treated as hard failures.
+
+This protects the GitHub Release body from being generated from junk input and acknowledges that the existing changelog already contains duplicate content in at least one versioned section.
+
+### 6. Add a repo-owned local release helper
+
+Add a repo-owned helper script:
+
+- `Helper_Scripts/release.py`
+
+Responsibilities:
+
+- validate local and remote git state
+- validate `gh` authentication
+- compute target version
+- update release metadata
+- run focused preflight checks
+- create the release commit
+- create the annotated tag
+- push `main` and the tag
+- create and publish the GitHub Release
+- print the resulting release URL and expected workflow handoff
+
+Suggested command surface:
+
+- `make release-patch`
+- `make release-minor`
+- `make release VERSION=X.Y.Z`
+
+Optional but strongly recommended:
+
+- `make release-dry-run VERSION=X.Y.Z`
+- or a `DRY_RUN=1` flag on the main entrypoint
+
+The dry-run mode should show:
+
+- current version
+- target version
+- planned file edits
+- derived changelog slice
+- commit message
+- tag name
+- proposed release title/body
+
+### 7. Fail closed on unsafe preconditions
+
+The helper should stop before any irreversible action if any of these checks fail:
+
+- current branch is not `main`
+- working tree is dirty
+- `origin/main` cannot be fetched
+- local branch is behind or diverged from `origin/main`
+- required files are missing
+- `gh auth status` is not healthy
+- the changelog cannot be promoted safely
+
+Recommended first-iteration preflight checks after metadata edits but before commit/tag/push:
+
+- build a candidate release body from the changelog
+- run a focused packaging/doc sanity check appropriate to touched release metadata
+- verify that the current pre-bump `origin/main` commit already has green required checks before proceeding, using the stable gate names documented in [`Docs/Development/CI_REQUIRED_GATES.md`](../../../Docs/Development/CI_REQUIRED_GATES.md) as the authoritative required-check contract for v1
+
+The helper should allow a narrow explicit bypass only where justified, not a broad “ignore everything” mode by default.
+
+The v1 gate is intentionally on the pre-bump `origin/main` commit, not on the generated release commit. The release commit is treated as a derived administrative change on top of already-green code, and the helper does not wait for a second CI cycle before publishing the GitHub Release in the first iteration.
+
+This choice is deliberate:
+
+- the helper validates the exact upstream code revision being released before any local release metadata is committed
+- the generated release commit is not itself required to go green before `gh release create`
+- the helper should query GitHub for the documented stable check names rather than discover branch-protection settings dynamically, which would add permission and configuration coupling
+
+### 8. Make the release helper resumable by state detection
+
+The release command will perform several irreversible steps. It must therefore be resumable by inspecting current state rather than assuming every rerun starts cleanly.
+
+Minimum state cases to support:
+
+- release commit exists locally but tag does not
+- tag exists locally but has not been pushed
+- remote tag exists but GitHub Release does not
+- GitHub Release already exists for the tag
+
+Desired behavior:
+
+- continue from the earliest missing step
+- avoid creating duplicate commits or tags
+- exit cleanly and report success if the release is already fully published
+
+Because the push step republishes `main` snapshots as a first-class side effect, reruns after a successful push but before GitHub Release creation should detect the already-pushed release commit and continue from GitHub Release creation rather than trying to create another commit or re-push new release state.
+
+If `main` advances after the helper validates `origin/main` but before the push succeeds, the helper must hard-abort on non-fast-forward push failure. It must not auto-rebase, auto-merge, or retry against the new head inside the same release attempt. The maintainer must rerun the release command from a freshly fetched checkout so the required-check gate is re-evaluated against the new `origin/main` commit.
+
+This makes the command robust against a failed network call, interrupted shell session, or a partial `gh` failure after push.
+
+### 9. Keep the operator doc concise and authoritative
+
+Add a concise maintainer-facing document:
+
+- `Docs/Development/Release_Process.md`
+
+This document should cover:
+
+- what triggers publishing
+- which artifacts are release artifacts versus `main` snapshots
+- the authoritative local release commands
+- what the command does
+- recovery and retry behavior
+- explicit boundary note that PyPI is outside the first automated release path
+
+[`Docs/Release_Checklist.md`](../../../Docs/Release_Checklist.md) should remain the broad release-readiness checklist and be referenced as supporting material, not replaced.
+
+## Command Flow
+
+Nominal flow:
+
+1. verify branch, cleanliness, and remote state
+2. verify `gh` authentication
+3. compute target version
+4. update [`pyproject.toml`](../../../pyproject.toml)
+5. update human-facing release-line references in scope
+6. promote changelog `Unreleased` into `X.Y.Z`
+7. run focused preflight checks
+8. create release commit with a standard message such as `release: vX.Y.Z`
+9. create annotated tag `vX.Y.Z`
+10. push `main` and `vX.Y.Z`
+11. create and publish the GitHub Release using the promoted changelog section as the body
+12. print the release URL and expected Docker workflow handoff
+
+Remote handoff:
+
+- pushing the release commit to `main` triggers [`.github/workflows/publish-ghcr-main.yml`](../../../.github/workflows/publish-ghcr-main.yml), which republishes the rolling `main` snapshot images
+- GitHub Release publication then triggers [`.github/workflows/publish-docker.yml`](../../../.github/workflows/publish-docker.yml), which publishes the formal release image set
+
+## Verification Strategy
+
+The implementation should be verified at three levels.
+
+### Unit-level
+
+- target-version parsing and bump logic
+- changelog section detection and promotion
+- duplicate-bullet detection for release-body candidates
+- resumable state detection
+
+### Integration-level
+
+- dry-run against a fixture repo state
+- successful release path against a local temporary repo with mocked `gh`
+- partial-state rerun behavior:
+  - tag exists, no release
+  - release exists already
+
+### Manual validation
+
+- verify the new local command from a clean `main` checkout
+- confirm that the helper blocks when required checks on the pre-bump `origin/main` commit are not green
+- confirm that pushing the release commit republishes the expected `main` snapshots before the GitHub Release exists
+- confirm that GitHub Release publication triggers Docker publishing only
+- confirm that PyPI does not publish automatically once its workflow trigger is narrowed
+- confirm that docs source updates stay in sync with the release version and `Docs/site/` remains untracked generated output
+- confirm that the release-process doc matches actual repository behavior after the code lands
+
+## Risks
+
+- Hidden version references may still drift if the first iteration updates too small a set of files
+- Existing changelog quality issues may cause the helper to fail frequently until changelog discipline improves
+- Release automation that commits and pushes automatically can be dangerous if preflight checks are too weak
+- GitHub CLI auth or API behavior may differ between maintainer environments unless preflight is explicit
+
+## Mitigations
+
+- keep the first release scope narrow and explicit
+- fail closed on ambiguity instead of trying to auto-correct everything
+- provide a dry-run mode
+- make the helper resumable
+- document artifact boundaries precisely
+- keep PyPI outside the automated release path until intentionally added
+
+## Open Questions
+
+- Should module-specific CLI version strings be unified now or deferred to a separate cleanup task?
+
+## Recommendation
+
+Proceed in two tightly scoped phases:
+
+1. Align the repo’s release boundaries with the intended workflow:
+   - narrow PyPI publish triggers
+   - define `main` as the only supported release branch
+   - decide the first-pass version-reference scope
+2. Implement the repo-owned release helper and the concise maintainer release-process doc
+
+This yields a release workflow that is materially more automated without pretending the repository already has a unified release-management system.

--- a/Helper_Scripts/release.py
+++ b/Helper_Scripts/release.py
@@ -576,11 +576,8 @@ def orchestrate_release(
         release_commit_sha = runner.create_release_commit(next_version)
         runner.create_or_update_tag(next_version)
     elif state == "local_release_commit_only":
-        release_commit_sha = (
-            _call_runner_if_present(runner, "get_head_sha")
-            if isinstance(_call_runner_if_present(runner, "get_head_sha"), str)
-            else None
-        )
+        head_sha = _call_runner_if_present(runner, "get_head_sha")
+        release_commit_sha = head_sha if isinstance(head_sha, str) else None
         runner.create_or_update_tag(next_version)
     elif state == "local_tag_only":
         head_sha = _call_runner_if_present(runner, "get_head_sha")

--- a/Helper_Scripts/release.py
+++ b/Helper_Scripts/release.py
@@ -666,7 +666,12 @@ class ShellReleaseRunner:
         resolved_executable = executable if Path(executable).is_absolute() else shutil.which(executable)
         if resolved_executable is None:
             raise FileNotFoundError(f"Executable not found: {executable}")
-        command = [resolved_executable, *args[1:]]
+        resolved_path = Path(resolved_executable)
+        if not resolved_path.is_absolute():
+            raise FileNotFoundError(
+                f"Executable did not resolve to an absolute path: {executable}"
+            )
+        command = [str(resolved_path), *args[1:]]
         completed = subprocess.run(
             command,
             cwd=self.repo_root,

--- a/Helper_Scripts/release.py
+++ b/Helper_Scripts/release.py
@@ -309,13 +309,31 @@ def update_readme_release_references(readme_text: str, version: str) -> str:
 def update_mkdocs_version_metadata(mkdocs_text: str, version: str) -> str:
     """Update the MkDocs version and copyright metadata."""
 
-    version_pattern = r"(?m)^(  version: )v?\d+\.\d+\.\d+$"
+    lines = mkdocs_text.splitlines()
+    extra_index = next(
+        (index for index, line in enumerate(lines) if line.strip() == "extra:"),
+        None,
+    )
+    if extra_index is None:
+        raise ValueError("Missing MkDocs extra anchor")
 
-    updated_text, version_count = re.subn(version_pattern, rf"\g<1>v{version}", mkdocs_text)
-    if version_count == 0:
-        raise ValueError("Missing MkDocs version anchor")
+    extra_indent = len(lines[extra_index]) - len(lines[extra_index].lstrip(" "))
+    version_updated = False
+    for index in range(extra_index + 1, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent <= extra_indent:
+            break
+        if stripped.startswith("version:"):
+            lines[index] = f"{line[:indent]}version: v{version}"
+            version_updated = True
+            break
+    if not version_updated:
+        raise ValueError("Missing MkDocs extra.version anchor")
 
-    lines = updated_text.splitlines()
     copyright_index = next(
         (index for index, line in enumerate(lines) if line.strip() == "copyright: |"),
         None,
@@ -323,17 +341,20 @@ def update_mkdocs_version_metadata(mkdocs_text: str, version: str) -> str:
     if copyright_index is None or copyright_index + 1 >= len(lines):
         raise ValueError("Missing MkDocs copyright anchor")
 
-    copyright_line = lines[copyright_index + 1]
-    updated_copyright_line, copyright_count = re.subn(
-        r"v?\d+\.\d+\.\d+",
-        f"v{version}",
-        copyright_line,
-        count=1,
-    )
-    if copyright_count == 0 or updated_copyright_line == copyright_line:
-        raise ValueError("Missing MkDocs copyright anchor")
+    copyright_indent = len(lines[copyright_index]) - len(lines[copyright_index].lstrip(" "))
+    copyright_count = 0
+    for index in range(copyright_index + 1, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if stripped:
+            indent = len(line) - len(line.lstrip(" "))
+            if indent <= copyright_indent:
+                break
+        lines[index], count = re.subn(r"v?\d+\.\d+\.\d+", f"v{version}", line)
+        copyright_count += count
+    if copyright_count == 0:
+        raise ValueError("Missing MkDocs copyright version anchor")
 
-    lines[copyright_index + 1] = updated_copyright_line
     updated_text = "\n".join(lines)
     if mkdocs_text.endswith("\n"):
         updated_text += "\n"

--- a/Helper_Scripts/release.py
+++ b/Helper_Scripts/release.py
@@ -8,6 +8,7 @@ from difflib import SequenceMatcher
 import json
 from pathlib import Path
 import re
+import shutil
 # Bandit B404 is expected here because the helper shells out to fixed git/gh commands.
 import subprocess  # nosec B404
 from typing import Any, Mapping, Protocol, Sequence
@@ -168,6 +169,8 @@ def _parse_unreleased_changelog_subsections(changelog_text: str) -> dict[str, li
 
     if not seen_structural_content:
         raise ValueError("Unreleased changelog section is empty or malformed")
+    if sum(len(bullets) for bullets in subsections.values()) == 0:
+        raise ValueError("Unreleased changelog section has no bullets")
 
     return subsections
 
@@ -321,9 +324,6 @@ def update_mkdocs_version_metadata(mkdocs_text: str, version: str) -> str:
         raise ValueError("Missing MkDocs copyright anchor")
 
     copyright_line = lines[copyright_index + 1]
-    if "https://github.com/rmusser01/tldw_server" not in copyright_line:
-        raise ValueError("Missing MkDocs copyright anchor")
-
     updated_copyright_line, copyright_count = re.subn(
         r"v?\d+\.\d+\.\d+",
         f"v{version}",
@@ -450,7 +450,11 @@ class ReleaseRunner(Protocol):
 
     def push_tag(self, version: str) -> None: ...
 
-    def create_github_release(self, version: str) -> None: ...
+    def prepare_release_notes_from_tag(self, version: str) -> None: ...
+
+    def get_metadata_warnings(self) -> list[str]: ...
+
+    def create_github_release(self, version: str) -> bool: ...
 
 
 def _call_runner_if_present(runner: object, method_name: str, *args: object) -> object | None:
@@ -458,6 +462,51 @@ def _call_runner_if_present(runner: object, method_name: str, *args: object) -> 
     if method is None:
         return None
     return method(*args)
+
+
+def _runner_dry_run(runner: object) -> bool:
+    return bool(getattr(runner, "dry_run", False))
+
+
+def _runner_metadata_warnings(runner: object) -> list[str]:
+    warnings = _call_runner_if_present(runner, "get_metadata_warnings")
+    if isinstance(warnings, list):
+        return [str(warning) for warning in warnings]
+    return []
+
+
+def _create_github_release(runner: ReleaseRunner, version: str) -> bool:
+    created = runner.create_github_release(version)
+    if isinstance(created, bool):
+        return created
+    return not _runner_dry_run(runner)
+
+
+def _release_result(
+    *,
+    branch: str,
+    current_version: str,
+    next_version: str,
+    required_checks: list[str],
+    state: str,
+    validated_sha: str,
+    release_commit_sha: str | None,
+    github_release_created: bool,
+    dry_run: bool,
+    warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "branch": branch,
+        "current_version": current_version,
+        "next_version": next_version,
+        "required_checks": required_checks,
+        "state": state,
+        "validated_sha": validated_sha,
+        "release_commit_sha": release_commit_sha,
+        "github_release_created": github_release_created,
+        "dry_run": dry_run,
+        "warnings": warnings,
+    }
 
 
 def orchestrate_release(
@@ -481,34 +530,40 @@ def orchestrate_release(
 
     _call_runner_if_present(runner, "ensure_github_auth")
 
+    dry_run = _runner_dry_run(runner)
+    warnings: list[str] = []
     github_release_created = False
     release_commit_sha: str | None = None
 
     if state == "existing_github_release":
-        return {
-            "branch": branch,
-            "current_version": current_version,
-            "next_version": next_version,
-            "required_checks": required_checks,
-            "state": state,
-            "validated_sha": validated_sha,
-            "release_commit_sha": None,
-            "github_release_created": False,
-        }
+        return _release_result(
+            branch=branch,
+            current_version=current_version,
+            next_version=next_version,
+            required_checks=required_checks,
+            state=state,
+            validated_sha=validated_sha,
+            release_commit_sha=None,
+            github_release_created=False,
+            dry_run=dry_run,
+            warnings=warnings,
+        )
 
     if state == "remote_tag_without_github_release":
-        runner.create_github_release(next_version)
-        github_release_created = True
-        return {
-            "branch": branch,
-            "current_version": current_version,
-            "next_version": next_version,
-            "required_checks": required_checks,
-            "state": state,
-            "validated_sha": validated_sha,
-            "release_commit_sha": None,
-            "github_release_created": github_release_created,
-        }
+        _call_runner_if_present(runner, "prepare_release_notes_from_tag", next_version)
+        github_release_created = _create_github_release(runner, next_version)
+        return _release_result(
+            branch=branch,
+            current_version=current_version,
+            next_version=next_version,
+            required_checks=required_checks,
+            state=state,
+            validated_sha=validated_sha,
+            release_commit_sha=None,
+            github_release_created=github_release_created,
+            dry_run=dry_run,
+            warnings=warnings,
+        )
 
     if state == "fresh":
         head_sha = _call_runner_if_present(runner, "get_head_sha")
@@ -517,6 +572,7 @@ def orchestrate_release(
 
         runner.ensure_required_checks_green(validated_sha, required_checks)
         runner.prepare_metadata(current_version, next_version)
+        warnings = _runner_metadata_warnings(runner)
         release_commit_sha = runner.create_release_commit(next_version)
         runner.create_or_update_tag(next_version)
     elif state == "local_release_commit_only":
@@ -551,19 +607,20 @@ def orchestrate_release(
         raise
 
     runner.push_tag(next_version)
-    runner.create_github_release(next_version)
-    github_release_created = True
+    github_release_created = _create_github_release(runner, next_version)
 
-    return {
-        "branch": branch,
-        "current_version": current_version,
-        "next_version": next_version,
-        "required_checks": required_checks,
-        "state": state,
-        "validated_sha": validated_sha,
-        "release_commit_sha": release_commit_sha,
-        "github_release_created": github_release_created,
-    }
+    return _release_result(
+        branch=branch,
+        current_version=current_version,
+        next_version=next_version,
+        required_checks=required_checks,
+        state=state,
+        validated_sha=validated_sha,
+        release_commit_sha=release_commit_sha,
+        github_release_created=github_release_created,
+        dry_run=dry_run,
+        warnings=warnings,
+    )
 
 
 class ShellReleaseRunner:
@@ -574,6 +631,7 @@ class ShellReleaseRunner:
         self.dry_run = dry_run
         self._prepared_paths: list[Path] = []
         self._release_notes_body: str | None = None
+        self._metadata_warnings: list[str] = []
         self._release_date = datetime.now(timezone.utc).date().isoformat()
         self._repo_slug: str | None = None
 
@@ -584,8 +642,15 @@ class ShellReleaseRunner:
         check: bool = True,
         capture_output: bool = True,
     ) -> subprocess.CompletedProcess[str]:
+        if not args:
+            raise ValueError("Command arguments must not be empty")
+        executable = args[0]
+        resolved_executable = executable if Path(executable).is_absolute() else shutil.which(executable)
+        if resolved_executable is None:
+            raise FileNotFoundError(f"Executable not found: {executable}")
+        command = [resolved_executable, *args[1:]]
         completed = subprocess.run(
-            list(args),
+            command,
             cwd=self.repo_root,
             text=True,
             capture_output=capture_output,
@@ -725,6 +790,7 @@ class ShellReleaseRunner:
             version=next_version,
             release_date=self._release_date,
         )
+        self._metadata_warnings = list(warnings)
 
         updated_readme = update_readme_release_references(readme_text, next_version)
         updated_mkdocs = update_mkdocs_version_metadata(mkdocs_text, next_version)
@@ -750,6 +816,15 @@ class ShellReleaseRunner:
         readme_path.write_text(updated_readme, encoding="utf-8")
         mkdocs_path.write_text(updated_mkdocs, encoding="utf-8")
         release_notes_path.write_text(updated_release_notes, encoding="utf-8")
+
+    def get_metadata_warnings(self) -> list[str]:
+        return list(self._metadata_warnings)
+
+    def prepare_release_notes_from_tag(self, version: str) -> None:
+        tag_name = release_tag_name(version)
+        self._run_command(["git", "fetch", "origin", "--tags"])
+        changelog_text = self._run_text(["git", "show", f"{tag_name}:CHANGELOG.md"])
+        self._release_notes_body = extract_release_notes_for_version(changelog_text, version)
 
     def create_release_commit(self, next_version: str) -> str:
         if not self._prepared_paths:
@@ -779,7 +854,7 @@ class ShellReleaseRunner:
             return
         self._run_command(["git", "push", "origin", release_tag_name(version)])
 
-    def create_github_release(self, version: str) -> None:
+    def create_github_release(self, version: str) -> bool:
         if self._release_notes_body is None:
             changelog_path = self.repo_root / "CHANGELOG.md"
             self._release_notes_body = extract_release_notes_for_version(
@@ -788,7 +863,7 @@ class ShellReleaseRunner:
             )
 
         if self.dry_run:
-            return
+            return False
 
         tag_name = release_tag_name(version)
         self._run_command(
@@ -804,6 +879,7 @@ class ShellReleaseRunner:
                 self._release_notes_body,
             ]
         )
+        return True
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:

--- a/Helper_Scripts/release.py
+++ b/Helper_Scripts/release.py
@@ -1,0 +1,831 @@
+"""Pure helpers for the release automation flow."""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from datetime import datetime, timezone
+from difflib import SequenceMatcher
+import json
+from pathlib import Path
+import re
+# Bandit B404 is expected here because the helper shells out to fixed git/gh commands.
+import subprocess  # nosec B404
+from typing import Any, Mapping, Protocol, Sequence
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+SUPPORTED_RELEASE_BRANCH = "main"
+ALLOWED_CHANGELOG_SECTIONS = ("Added", "Changed", "Fixed", "Removed")
+_SEMVER_PATTERN = r"v?\d+\.\d+\.\d+"
+
+
+def read_current_version(pyproject_path: str | Path) -> str:
+    """Read the canonical project version from ``pyproject.toml``."""
+
+    path = Path(pyproject_path)
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    version = data["project"]["version"]
+    return str(version)
+
+
+def bump_version(version: str, bump: str) -> str:
+    """Bump a semantic version by patch or minor."""
+
+    normalized = version.lstrip("v")
+    parts = normalized.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"Unsupported semantic version: {version!r}")
+
+    major, minor, patch = (int(part) for part in parts)
+    if bump == "patch":
+        patch += 1
+    elif bump == "minor":
+        minor += 1
+        patch = 0
+    else:
+        raise ValueError(f"Unsupported bump type: {bump!r}")
+
+    return f"{major}.{minor}.{patch}"
+
+
+def extract_required_check_names(doc_path: str | Path) -> list[str]:
+    """Extract the stable required CI gate names from the CI gates doc."""
+
+    path = Path(doc_path)
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    in_section = False
+    required_names: list[str] = []
+    seen: set[str] = set()
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if line == "## Required Check Names":
+            in_section = True
+            continue
+        if in_section and line.startswith("#"):
+            break
+        if not in_section:
+            continue
+
+        match = re.match(r"^\d+\.\s+`([^`]+)`", line)
+        if match is None:
+            continue
+
+        name = match.group(1)
+        if name not in seen:
+            seen.add(name)
+            required_names.append(name)
+
+    if not in_section:
+        raise ValueError("Missing '## Required Check Names' section")
+    if not required_names:
+        raise ValueError("'## Required Check Names' section is empty")
+
+    return required_names
+
+
+def normalize_bullet_text(text: str) -> str:
+    """Trim whitespace and collapse all internal whitespace runs."""
+
+    return " ".join(text.split())
+
+
+def find_exact_duplicate_bullets(
+    subsections: Mapping[str, Sequence[str]],
+) -> list[tuple[str, str]]:
+    """Find exact duplicate bullets within each changelog subsection."""
+
+    duplicates: list[tuple[str, str]] = []
+
+    for subsection in ALLOWED_CHANGELOG_SECTIONS:
+        bullets = subsections.get(subsection, ())
+        counts = Counter(normalize_bullet_text(bullet) for bullet in bullets)
+        duplicates.extend(
+            (subsection, bullet_text)
+            for bullet_text, count in counts.items()
+            if count > 1
+        )
+
+    return duplicates
+
+
+def _parse_unreleased_changelog_subsections(changelog_text: str) -> dict[str, list[str]]:
+    """Extract bullets from the ``Unreleased`` changelog section."""
+
+    lines = changelog_text.splitlines()
+    unreleased_index = next(
+        (index for index, line in enumerate(lines) if line.strip() == "## [Unreleased]"),
+        None,
+    )
+    if unreleased_index is None:
+        raise ValueError("Missing [Unreleased] changelog section")
+
+    section_end = len(lines)
+    for index in range(unreleased_index + 1, len(lines)):
+        if lines[index].startswith("## "):
+            section_end = index
+            break
+
+    subsections: dict[str, list[str]] = {section: [] for section in ALLOWED_CHANGELOG_SECTIONS}
+    current_section: str | None = None
+    seen_structural_content = False
+
+    for raw_line in lines[unreleased_index + 1 : section_end]:
+        stripped_line = raw_line.strip()
+        if not stripped_line:
+            continue
+        if stripped_line.startswith("## "):
+            break
+        if stripped_line.startswith("### "):
+            candidate = stripped_line.removeprefix("### ").strip()
+            if candidate not in ALLOWED_CHANGELOG_SECTIONS:
+                raise ValueError(
+                    f"Unsupported changelog subsection in Unreleased: {candidate!r}"
+                )
+            current_section = candidate
+            seen_structural_content = True
+            continue
+        if stripped_line.startswith("- "):
+            if current_section is None:
+                raise ValueError(
+                    "Changelog bullets in Unreleased must appear under a supported subsection"
+                )
+            subsections[current_section].append(stripped_line[2:])
+            seen_structural_content = True
+            continue
+        if raw_line[:1].isspace():
+            raise ValueError(
+                "Wrapped or indented changelog content is not supported in Unreleased"
+            )
+        raise ValueError("Unsupported content in Unreleased changelog slice")
+
+    if not seen_structural_content:
+        raise ValueError("Unreleased changelog section is empty or malformed")
+
+    return subsections
+
+
+def _find_cross_section_near_duplicates(
+    subsections: Mapping[str, Sequence[str]],
+) -> list[str]:
+    """Report near-duplicates across different changelog subsections."""
+
+    warnings: list[str] = []
+    subsection_names = [section for section in ALLOWED_CHANGELOG_SECTIONS if subsections.get(section)]
+
+    for index, first_section in enumerate(subsection_names):
+        first_bullets = [normalize_bullet_text(bullet) for bullet in subsections.get(first_section, ())]
+        for second_section in subsection_names[index + 1 :]:
+            second_bullets = [normalize_bullet_text(bullet) for bullet in subsections.get(second_section, ())]
+            for first_bullet in first_bullets:
+                for second_bullet in second_bullets:
+                    similarity = SequenceMatcher(None, first_bullet, second_bullet).ratio()
+                    if similarity >= 0.84 or first_bullet in second_bullet or second_bullet in first_bullet:
+                        warnings.append(
+                            "Near-duplicate changelog bullets across "
+                            f"{first_section} and {second_section}: "
+                            f"{first_bullet!r} ~ {second_bullet!r}"
+                        )
+
+    return warnings
+
+
+def _render_changelog_section(title: str, subsections: Mapping[str, Sequence[str]], *, date: str | None = None) -> str:
+    """Render a Keep-a-Changelog section with stable spacing."""
+
+    heading = f"## [{title}]"
+    if date is not None:
+        heading = f"{heading} - {date}"
+
+    lines: list[str] = [heading, ""]
+    for subsection in ALLOWED_CHANGELOG_SECTIONS:
+        lines.append(f"### {subsection}")
+        lines.append("")
+        for bullet in subsections.get(subsection, ()):
+            lines.append(f"- {normalize_bullet_text(bullet)}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def promote_changelog_unreleased_section(
+    changelog_text: str,
+    version: str,
+    release_date: str,
+) -> tuple[str, list[str]]:
+    """Promote ``Unreleased`` into a dated changelog section."""
+
+    subsections = _parse_unreleased_changelog_subsections(changelog_text)
+    duplicate_bullets = find_exact_duplicate_bullets(subsections)
+    if duplicate_bullets:
+        section, bullet_text = duplicate_bullets[0]
+        raise ValueError(
+            f"Duplicate changelog bullet detected in {section!r}: {bullet_text!r}"
+        )
+
+    warnings = _find_cross_section_near_duplicates(subsections)
+
+    lines = changelog_text.splitlines()
+    unreleased_index = next(
+        (index for index, line in enumerate(lines) if line.strip() == "## [Unreleased]"),
+        None,
+    )
+    if unreleased_index is None:
+        raise ValueError("Missing [Unreleased] changelog section")
+
+    section_end = len(lines)
+    for index in range(unreleased_index + 1, len(lines)):
+        if lines[index].startswith("## "):
+            section_end = index
+            break
+
+    prefix = "\n".join(lines[:unreleased_index]).rstrip()
+    if prefix:
+        prefix += "\n\n"
+
+    reset_unreleased = _render_changelog_section("Unreleased", {section: () for section in ALLOWED_CHANGELOG_SECTIONS})
+    promoted_section = _render_changelog_section(version, subsections, date=release_date)
+    suffix = "\n".join(lines[section_end:]).lstrip("\n")
+
+    result = prefix + reset_unreleased + "\n" + promoted_section + suffix
+    return result.rstrip() + "\n", warnings
+
+
+def update_pyproject_version(pyproject_text: str, version: str) -> str:
+    """Update the package version in ``pyproject.toml``."""
+
+    updated_text, count = re.subn(
+        r'(?m)^(version\s*=\s*")\d+\.\d+\.\d+(")$',
+        rf"\g<1>{version}\g<2>",
+        pyproject_text,
+        count=1,
+    )
+    if count == 0:
+        raise ValueError("Missing pyproject version anchor")
+
+    return updated_text
+
+
+def update_readme_release_references(readme_text: str, version: str) -> str:
+    """Update release-line references in the README to ``version``."""
+
+    replacements = [
+        (
+            rf"(?m)^(- `){_SEMVER_PATTERN}(` Beta status\. Expect rough edges and please report issues\.)$",
+            rf"\g<1>{version}\g<2>",
+            "current release line",
+        ),
+        (
+            rf"(?m)^(- The `dev` branch currently contains additional unreleased work beyond `){_SEMVER_PATTERN}(`; see \[CHANGELOG\.md\]\(CHANGELOG\.md\) for branch-level detail and \[Docs/Published/RELEASE_NOTES\.md\]\(Docs/Published/RELEASE_NOTES\.md\) for the published release entry point\.)$",
+            rf"\g<1>{version}\g<2>",
+            "beyond-release reference",
+        ),
+        (
+            rf"(?m)^(Currently landing on `dev` \(post-`){_SEMVER_PATTERN}(` branch work\):)$",
+            rf"\g<1>{version}\g<2>",
+            "post-release reference",
+        ),
+    ]
+
+    updated_text = readme_text
+    for pattern, replacement, anchor_name in replacements:
+        updated_text, count = re.subn(pattern, replacement, updated_text)
+        if count == 0:
+            raise ValueError(f"Missing README anchor for {anchor_name}")
+
+    return updated_text
+
+
+def update_mkdocs_version_metadata(mkdocs_text: str, version: str) -> str:
+    """Update the MkDocs version and copyright metadata."""
+
+    version_pattern = r"(?m)^(  version: )v?\d+\.\d+\.\d+$"
+
+    updated_text, version_count = re.subn(version_pattern, rf"\g<1>v{version}", mkdocs_text)
+    if version_count == 0:
+        raise ValueError("Missing MkDocs version anchor")
+
+    lines = updated_text.splitlines()
+    copyright_index = next(
+        (index for index, line in enumerate(lines) if line.strip() == "copyright: |"),
+        None,
+    )
+    if copyright_index is None or copyright_index + 1 >= len(lines):
+        raise ValueError("Missing MkDocs copyright anchor")
+
+    copyright_line = lines[copyright_index + 1]
+    if "https://github.com/rmusser01/tldw_server" not in copyright_line:
+        raise ValueError("Missing MkDocs copyright anchor")
+
+    updated_copyright_line, copyright_count = re.subn(
+        r"v?\d+\.\d+\.\d+",
+        f"v{version}",
+        copyright_line,
+        count=1,
+    )
+    if copyright_count == 0 or updated_copyright_line == copyright_line:
+        raise ValueError("Missing MkDocs copyright anchor")
+
+    lines[copyright_index + 1] = updated_copyright_line
+    updated_text = "\n".join(lines)
+    if mkdocs_text.endswith("\n"):
+        updated_text += "\n"
+
+    return updated_text
+
+
+def update_release_notes_entry_point(
+    release_notes_text: str,
+    release_process_doc_path: str,
+) -> str:
+    """Point release notes at the authoritative release-process document."""
+
+    updated_text, count = re.subn(
+        r"(?m)^For release process details, see `[^`]+`\.$",
+        f"For release process details, see `{release_process_doc_path}`.",
+        release_notes_text,
+    )
+    if count == 0:
+        raise ValueError("Missing release notes process anchor")
+    return updated_text
+
+
+def validate_release_branch(branch: str) -> str:
+    """Accept only the supported release branch."""
+
+    normalized_branch = branch.strip()
+    if normalized_branch != SUPPORTED_RELEASE_BRANCH:
+        raise ValueError(
+            f"Unsupported release branch: {branch!r}; expected {SUPPORTED_RELEASE_BRANCH!r}"
+        )
+    return normalized_branch
+
+
+def classify_release_state(
+    *,
+    local_release_commit_exists: bool,
+    local_tag_exists: bool,
+    remote_tag_exists: bool,
+    github_release_exists: bool,
+) -> str:
+    """Classify a resumable release state snapshot."""
+
+    if github_release_exists and not remote_tag_exists:
+        raise ValueError("inconsistent release state: GitHub Release exists without remote tag")
+
+    if github_release_exists:
+        return "existing_github_release"
+    if remote_tag_exists:
+        return "remote_tag_without_github_release"
+    if local_tag_exists:
+        return "local_tag_only"
+    if local_release_commit_exists:
+        return "local_release_commit_only"
+    raise ValueError("No resumable release state could be determined")
+
+
+def release_tag_name(version: str) -> str:
+    """Return the canonical tag for ``version``."""
+
+    return f"v{version.lstrip('v')}"
+
+
+def release_commit_message(version: str) -> str:
+    """Return the canonical release commit subject."""
+
+    return f"chore(release): {release_tag_name(version)}"
+
+
+def extract_release_notes_for_version(changelog_text: str, version: str) -> str:
+    """Extract the rendered changelog section for ``version``."""
+
+    tag = version.lstrip("v")
+    lines = changelog_text.splitlines()
+    heading = f"## [{tag}]"
+    start_index = next(
+        (index for index, line in enumerate(lines) if line.startswith(heading)),
+        None,
+    )
+    if start_index is None:
+        raise ValueError(f"Missing release section for {tag}")
+
+    end_index = len(lines)
+    for index in range(start_index + 1, len(lines)):
+        if lines[index].startswith("## "):
+            end_index = index
+            break
+
+    return "\n".join(lines[start_index:end_index]).strip() + "\n"
+
+
+class ReleaseRunner(Protocol):
+    """Runtime contract for release orchestration."""
+
+    def fetch_origin_main(self) -> str: ...
+
+    def get_current_branch(self) -> str: ...
+
+    def is_worktree_clean(self) -> bool: ...
+
+    def get_origin_main_sha(self) -> str: ...
+
+    def get_release_state(self, version: str) -> str: ...
+
+    def ensure_required_checks_green(self, sha: str, required_checks: list[str]) -> None: ...
+
+    def prepare_metadata(self, current_version: str, next_version: str) -> None: ...
+
+    def create_release_commit(self, next_version: str) -> str: ...
+
+    def create_or_update_tag(self, version: str) -> None: ...
+
+    def push_main(self) -> None: ...
+
+    def push_tag(self, version: str) -> None: ...
+
+    def create_github_release(self, version: str) -> None: ...
+
+
+def _call_runner_if_present(runner: object, method_name: str, *args: object) -> object | None:
+    method = getattr(runner, method_name, None)
+    if method is None:
+        return None
+    return method(*args)
+
+
+def orchestrate_release(
+    *,
+    bump: str,
+    runner: ReleaseRunner,
+    pyproject_path: str | Path,
+    ci_gates_doc_path: str | Path,
+) -> dict[str, Any]:
+    """Run the release flow against an injected runner."""
+
+    validated_sha = runner.fetch_origin_main()
+    branch = validate_release_branch(runner.get_current_branch())
+    if not runner.is_worktree_clean():
+        raise RuntimeError("Release automation requires a clean worktree")
+
+    current_version = read_current_version(pyproject_path)
+    next_version = bump_version(current_version, bump)
+    state = runner.get_release_state(next_version)
+    required_checks = extract_required_check_names(ci_gates_doc_path)
+
+    _call_runner_if_present(runner, "ensure_github_auth")
+
+    github_release_created = False
+    release_commit_sha: str | None = None
+
+    if state == "existing_github_release":
+        return {
+            "branch": branch,
+            "current_version": current_version,
+            "next_version": next_version,
+            "required_checks": required_checks,
+            "state": state,
+            "validated_sha": validated_sha,
+            "release_commit_sha": None,
+            "github_release_created": False,
+        }
+
+    if state == "remote_tag_without_github_release":
+        runner.create_github_release(next_version)
+        github_release_created = True
+        return {
+            "branch": branch,
+            "current_version": current_version,
+            "next_version": next_version,
+            "required_checks": required_checks,
+            "state": state,
+            "validated_sha": validated_sha,
+            "release_commit_sha": None,
+            "github_release_created": github_release_created,
+        }
+
+    if state == "fresh":
+        head_sha = _call_runner_if_present(runner, "get_head_sha")
+        if isinstance(head_sha, str) and head_sha != runner.get_origin_main_sha():
+            raise RuntimeError("Release automation requires local main to match origin/main")
+
+        runner.ensure_required_checks_green(validated_sha, required_checks)
+        runner.prepare_metadata(current_version, next_version)
+        release_commit_sha = runner.create_release_commit(next_version)
+        runner.create_or_update_tag(next_version)
+    elif state == "local_release_commit_only":
+        release_commit_sha = (
+            _call_runner_if_present(runner, "get_head_sha")
+            if isinstance(_call_runner_if_present(runner, "get_head_sha"), str)
+            else None
+        )
+        runner.create_or_update_tag(next_version)
+    elif state == "local_tag_only":
+        head_sha = _call_runner_if_present(runner, "get_head_sha")
+        tag_target_sha = _call_runner_if_present(runner, "get_local_tag_target_sha", next_version)
+        release_commit_sha = head_sha if isinstance(head_sha, str) else None
+        if (
+            isinstance(head_sha, str)
+            and isinstance(tag_target_sha, str)
+            and tag_target_sha != head_sha
+        ):
+            raise RuntimeError(
+                "Release aborted: local release tag does not point at current HEAD"
+            )
+    else:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unsupported release state: {state}")
+
+    try:
+        runner.push_main()
+    except RuntimeError as exc:
+        if "non-fast-forward" in str(exc).lower():
+            raise RuntimeError(
+                "Release aborted: non-fast-forward push to origin/main; main moved and the release must be rerun from a fresh fetch"
+            ) from exc
+        raise
+
+    runner.push_tag(next_version)
+    runner.create_github_release(next_version)
+    github_release_created = True
+
+    return {
+        "branch": branch,
+        "current_version": current_version,
+        "next_version": next_version,
+        "required_checks": required_checks,
+        "state": state,
+        "validated_sha": validated_sha,
+        "release_commit_sha": release_commit_sha,
+        "github_release_created": github_release_created,
+    }
+
+
+class ShellReleaseRunner:
+    """Real release runner backed by ``git`` and ``gh``."""
+
+    def __init__(self, repo_root: str | Path, *, dry_run: bool = False):
+        self.repo_root = Path(repo_root)
+        self.dry_run = dry_run
+        self._prepared_paths: list[Path] = []
+        self._release_notes_body: str | None = None
+        self._release_date = datetime.now(timezone.utc).date().isoformat()
+        self._repo_slug: str | None = None
+
+    def _run_command(
+        self,
+        args: Sequence[str],
+        *,
+        check: bool = True,
+        capture_output: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        completed = subprocess.run(
+            list(args),
+            cwd=self.repo_root,
+            text=True,
+            capture_output=capture_output,
+            check=False,
+        )  # nosec B603
+        if check and completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            stdout = (completed.stdout or "").strip()
+            detail = stderr or stdout or f"exit code {completed.returncode}"
+            raise RuntimeError(f"Command failed: {' '.join(args)}: {detail}")
+        return completed
+
+    def _run_text(self, args: Sequence[str]) -> str:
+        return self._run_command(args).stdout.strip()
+
+    def ensure_github_auth(self) -> None:
+        self._run_command(["gh", "auth", "status"])
+
+    def fetch_origin_main(self) -> str:
+        self._run_command(["git", "fetch", "origin", "main"])
+        return self.get_origin_main_sha()
+
+    def get_current_branch(self) -> str:
+        return self._run_text(["git", "branch", "--show-current"])
+
+    def is_worktree_clean(self) -> bool:
+        return self._run_text(["git", "status", "--porcelain"]) == ""
+
+    def get_head_sha(self) -> str:
+        return self._run_text(["git", "rev-parse", "HEAD"])
+
+    def get_origin_main_sha(self) -> str:
+        return self._run_text(["git", "rev-parse", "origin/main"])
+
+    def _get_repo_slug(self) -> str:
+        if self._repo_slug is None:
+            self._repo_slug = self._run_text(
+                ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
+            )
+        return self._repo_slug
+
+    def _local_tag_exists(self, tag_name: str) -> bool:
+        result = self._run_command(
+            ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag_name}"],
+            check=False,
+        )
+        return result.returncode == 0
+
+    def _remote_tag_exists(self, tag_name: str) -> bool:
+        output = self._run_text(["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag_name}"])
+        return output != ""
+
+    def get_local_tag_target_sha(self, version: str) -> str | None:
+        tag_name = release_tag_name(version)
+        result = self._run_command(
+            ["git", "rev-list", "-n", "1", tag_name],
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() or None
+
+    def _github_release_exists(self, tag_name: str) -> bool:
+        result = self._run_command(["gh", "release", "view", tag_name], check=False)
+        if result.returncode == 0:
+            return True
+
+        error_text = f"{result.stderr}\n{result.stdout}".lower()
+        if "not found" in error_text or "404" in error_text:
+            return False
+
+        raise RuntimeError(f"GitHub release lookup failed for {tag_name}: {error_text.strip()}")
+
+    def get_release_state(self, version: str) -> str:
+        tag_name = release_tag_name(version)
+        local_release_commit_exists = self._run_text(["git", "log", "-1", "--format=%s"]) == release_commit_message(version)
+        local_tag_exists = self._local_tag_exists(tag_name)
+        remote_tag_exists = self._remote_tag_exists(tag_name)
+        github_release_exists = self._github_release_exists(tag_name)
+
+        if not local_release_commit_exists and not local_tag_exists and not remote_tag_exists and not github_release_exists:
+            return "fresh"
+
+        return classify_release_state(
+            local_release_commit_exists=local_release_commit_exists,
+            local_tag_exists=local_tag_exists,
+            remote_tag_exists=remote_tag_exists,
+            github_release_exists=github_release_exists,
+        )
+
+    def ensure_required_checks_green(self, sha: str, required_checks: list[str]) -> None:
+        repo_slug = self._get_repo_slug()
+        payload = self._run_text(["gh", "api", f"repos/{repo_slug}/commits/{sha}/check-runs?per_page=100"])
+        data = json.loads(payload)
+        check_runs = data.get("check_runs", [])
+        status_by_name = {
+            str(check_run.get("name")): (
+                str(check_run.get("status")),
+                str(check_run.get("conclusion")),
+            )
+            for check_run in check_runs
+        }
+
+        missing = [name for name in required_checks if name not in status_by_name]
+        failing = [
+            name
+            for name in required_checks
+            if name in status_by_name and status_by_name[name] != ("completed", "success")
+        ]
+        if missing or failing:
+            details = []
+            if missing:
+                details.append(f"missing={missing}")
+            if failing:
+                details.append(f"non_green={failing}")
+            raise RuntimeError(
+                f"Required CI gates are not green on {sha}: " + ", ".join(details)
+            )
+
+    def prepare_metadata(self, current_version: str, next_version: str) -> None:
+        pyproject_path = self.repo_root / "pyproject.toml"
+        changelog_path = self.repo_root / "CHANGELOG.md"
+        readme_path = self.repo_root / "README.md"
+        mkdocs_path = self.repo_root / "Docs" / "mkdocs.yml"
+        release_notes_path = self.repo_root / "Docs" / "Published" / "RELEASE_NOTES.md"
+        release_process_doc = "Docs/Development/Release_Process.md"
+
+        pyproject_text = pyproject_path.read_text(encoding="utf-8")
+        changelog_text = changelog_path.read_text(encoding="utf-8")
+        readme_text = readme_path.read_text(encoding="utf-8")
+        mkdocs_text = mkdocs_path.read_text(encoding="utf-8")
+        release_notes_text = release_notes_path.read_text(encoding="utf-8")
+
+        updated_pyproject = update_pyproject_version(pyproject_text, next_version)
+        updated_changelog, warnings = promote_changelog_unreleased_section(
+            changelog_text=changelog_text,
+            version=next_version,
+            release_date=self._release_date,
+        )
+
+        updated_readme = update_readme_release_references(readme_text, next_version)
+        updated_mkdocs = update_mkdocs_version_metadata(mkdocs_text, next_version)
+        updated_release_notes = update_release_notes_entry_point(
+            release_notes_text,
+            release_process_doc,
+        )
+
+        self._release_notes_body = extract_release_notes_for_version(updated_changelog, next_version)
+        self._prepared_paths = [
+            pyproject_path,
+            changelog_path,
+            readme_path,
+            mkdocs_path,
+            release_notes_path,
+        ]
+
+        if self.dry_run:
+            return
+
+        pyproject_path.write_text(updated_pyproject, encoding="utf-8")
+        changelog_path.write_text(updated_changelog, encoding="utf-8")
+        readme_path.write_text(updated_readme, encoding="utf-8")
+        mkdocs_path.write_text(updated_mkdocs, encoding="utf-8")
+        release_notes_path.write_text(updated_release_notes, encoding="utf-8")
+
+    def create_release_commit(self, next_version: str) -> str:
+        if not self._prepared_paths:
+            raise RuntimeError("Release metadata has not been prepared")
+
+        rel_paths = [str(path.relative_to(self.repo_root)) for path in self._prepared_paths]
+        if self.dry_run:
+            return f"dry-run-release-{next_version}"
+
+        self._run_command(["git", "add", *rel_paths])
+        self._run_command(["git", "commit", "-m", release_commit_message(next_version)])
+        return self.get_head_sha()
+
+    def create_or_update_tag(self, version: str) -> None:
+        tag_name = release_tag_name(version)
+        if self.dry_run:
+            return
+        self._run_command(["git", "tag", "-a", tag_name, "-m", tag_name])
+
+    def push_main(self) -> None:
+        if self.dry_run:
+            return
+        self._run_command(["git", "push", "origin", "main"])
+
+    def push_tag(self, version: str) -> None:
+        if self.dry_run:
+            return
+        self._run_command(["git", "push", "origin", release_tag_name(version)])
+
+    def create_github_release(self, version: str) -> None:
+        if self._release_notes_body is None:
+            changelog_path = self.repo_root / "CHANGELOG.md"
+            self._release_notes_body = extract_release_notes_for_version(
+                changelog_path.read_text(encoding="utf-8"),
+                version,
+            )
+
+        if self.dry_run:
+            return
+
+        tag_name = release_tag_name(version)
+        self._run_command(
+            [
+                "gh",
+                "release",
+                "create",
+                tag_name,
+                "--verify-tag",
+                "--title",
+                tag_name,
+                "--notes",
+                self._release_notes_body,
+            ]
+        )
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Cut a local release from main.")
+    parser.add_argument("--bump", choices=("patch", "minor"), required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_argument_parser().parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+    runner = ShellReleaseRunner(repo_root=repo_root, dry_run=args.dry_run)
+    result = orchestrate_release(
+        bump=args.bump,
+        runner=runner,
+        pyproject_path=repo_root / "pyproject.toml",
+        ci_gates_doc_path=repo_root / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ help:
 	@echo "  make tooling-install         Install test/smoke extras"
 	@echo "  make tooling-smoke           Run unified smoke checks"
 	@echo "  make lint-changed            Lint only changed files"
+	@echo "  make release                 Cut a patch release from main"
+	@echo "  make release-patch           Cut a patch release from main"
+	@echo "  make release-minor           Cut a minor release from main"
 	@echo ""
 	@echo "Docker:"
 	@echo "  make quickstart-docker-webui Docker API + WebUI"
@@ -48,7 +51,7 @@ help:
 # -----------------------------------------------------------------------------
 # Quickstart targets (first-time setup)
 # -----------------------------------------------------------------------------
-.PHONY: setup-wizard-tools setup-docker-single start-docker-single verify-docker-single setup-docker-multi start-docker-multi verify-docker-multi install-local setup-local-single start-local-single verify-local-single quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check tooling-install tooling-smoke show-api-key
+.PHONY: setup-wizard-tools setup-docker-single start-docker-single verify-docker-single setup-docker-multi start-docker-multi verify-docker-multi install-local setup-local-single start-local-single verify-local-single quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check tooling-install tooling-smoke show-api-key release release-patch release-minor
 
 PYTHON ?= python3
 VENV_DIR ?= .venv
@@ -77,6 +80,7 @@ MODEL_CYCLE_EXCLUDED ?=postgres,redis
 MODEL_CYCLE_FIRST_BOOT_WAIT ?=0
 MODEL_CYCLE_SECOND_BOOT_WAIT ?=0
 MODEL_CYCLE_DRY_RUN ?=false
+RELEASE_DRY_RUN ?=false
 
 quickstart-prereqs:
 	@command -v $(PYTHON) >/dev/null 2>&1 || (echo "[quickstart] $(PYTHON) not found. Install Python 3.10+ and retry." && exit 1)
@@ -188,6 +192,15 @@ tooling-install:
 	@echo "[tooling-install] Installing tooling extras into $(VENV_DIR)..."
 	@$(VENV_PYTHON) -m pip install --upgrade pip setuptools wheel
 	@$(VENV_PYTHON) -m pip install -e ".[tooling]"
+
+release:
+	@$(MAKE) release-patch RELEASE_DRY_RUN=$(RELEASE_DRY_RUN)
+
+release-patch:
+	@$(PYTHON) Helper_Scripts/release.py --bump patch $(if $(filter true TRUE 1 yes YES,$(RELEASE_DRY_RUN)),--dry-run,)
+
+release-minor:
+	@$(PYTHON) Helper_Scripts/release.py --bump minor $(if $(filter true TRUE 1 yes YES,$(RELEASE_DRY_RUN)),--dry-run,)
 
 quickstart-docker-bootstrap:
 	@echo "[quickstart-docker-bootstrap] Ensuring $(TLDW_ENV_FILE) has safe first-use auth defaults..."

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Optional add-ons (apply AFTER your base profile is healthy):
 ## Current Status
 
 Current release line:
-- `0.1.30` Beta status. Expect rough edges and please report issues.
+- `0.1.31` Beta status. Expect rough edges and please report issues.
 - Primary client surfaces are the Next.js WebUI, Admin UI, and browser extension.
-- The `dev` branch currently contains additional unreleased work beyond `0.1.30`; see [CHANGELOG.md](CHANGELOG.md) for branch-level detail and [Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for the published release entry point.
+- The `dev` branch currently contains additional unreleased work beyond `0.1.31`; see [CHANGELOG.md](CHANGELOG.md) for branch-level detail and [Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for the published release entry point.
 
 <details>
 <summary>Current focus and migration notes from the old Gradio version</summary>

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Optional add-ons (apply AFTER your base profile is healthy):
 ## Current Status
 
 Current release line:
-- `0.1.31` Beta status. Expect rough edges and please report issues.
+- `0.1.30` Beta status. Expect rough edges and please report issues.
 - Primary client surfaces are the Next.js WebUI, Admin UI, and browser extension.
-- The `dev` branch currently contains additional unreleased work beyond `0.1.31`; see [CHANGELOG.md](CHANGELOG.md) for branch-level detail and [Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for the published release entry point.
+- The `dev` branch currently contains additional unreleased work beyond `0.1.30`; see [CHANGELOG.md](CHANGELOG.md) for branch-level detail and [Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for the published release entry point.
 
 <details>
 <summary>Current focus and migration notes from the old Gradio version</summary>
@@ -154,7 +154,7 @@ Recently shipped:
 - MCP Hub governance pack management and broader ACP workspace discovery/health support.
 - Audio installer and bundle follow-through, including curated `kitten_tts` and `pocket_tts_cpp` paths.
 
-Currently landing on `dev` (post-`0.1.31` branch work):
+Currently landing on `dev` (post-`0.1.30` branch work):
 - Writing Suite Phases 2-4 with characters, world info, plot/research tools, AI analysis, agent chat, and live writing feedback.
 - Persona-routed onboarding, Mission Control home flows, and storage quota warnings.
 - Browser web clipper support for capturing pages into the research workflow.
@@ -892,7 +892,8 @@ Examples
 │   ├── cli/                      # CLI entry points
 │   ├── Config_Files/             # config.txt, example YAMLs, migration helpers
 │   ├── Databases/                # Default DBs (runtime data; some are gitignored)
-│   └── tests/                    # Pytest suite
+│   ├── tests/                    # Pytest suite
+│   └── requirements.txt          # Legacy pin set (prefer pyproject extras)
 ├── admin-ui/                     # Admin dashboard
 ├── apps/tldw-frontend/                # Next.js WebUI (primary web client)
 ├── Docs/                         # Documentation (API, Development, RAG, AuthNZ, TTS, etc.)

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Recently shipped:
 - MCP Hub governance pack management and broader ACP workspace discovery/health support.
 - Audio installer and bundle follow-through, including curated `kitten_tts` and `pocket_tts_cpp` paths.
 
-Currently landing on `dev` (post-`0.1.30` branch work):
+Currently landing on `dev` (post-`0.1.31` branch work):
 - Writing Suite Phases 2-4 with characters, world info, plot/research tools, AI analysis, agent chat, and live writing feedback.
 - Persona-routed onboarding, Mission Control home flows, and storage quota warnings.
 - Browser web clipper support for capturing pages into the research workflow.

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -13600,6 +13600,395 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         message = str(error).lower()
         return "unique constraint" in message or "duplicate key" in message
 
+    # ----------------------
+    # Skill registry
+    # ----------------------
+    def _ensure_skill_registry_table(self) -> None:
+        """Ensure the skill_registry table exists for the active backend."""
+        if self.backend_type == BackendType.SQLITE:
+            self.execute_query(
+                """
+                CREATE TABLE IF NOT EXISTS skill_registry (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    description TEXT,
+                    argument_hint TEXT,
+                    disable_model_invocation BOOLEAN DEFAULT 0,
+                    user_invocable BOOLEAN DEFAULT 1,
+                    allowed_tools TEXT,
+                    model TEXT,
+                    context TEXT DEFAULT 'inline',
+                    directory_path TEXT NOT NULL,
+                    last_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    file_hash TEXT,
+                    uuid TEXT UNIQUE NOT NULL,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    deleted BOOLEAN DEFAULT 0,
+                    version INTEGER NOT NULL DEFAULT 1
+                )
+                """,
+                script=False,
+                commit=True,
+            )
+            self.execute_query(
+                "CREATE INDEX IF NOT EXISTS idx_skill_name ON skill_registry(name)",
+                script=False,
+                commit=True,
+            )
+            self.execute_query(
+                "CREATE INDEX IF NOT EXISTS idx_skill_user_invocable ON skill_registry(user_invocable)",
+                script=False,
+                commit=True,
+            )
+            self.execute_query(
+                "CREATE INDEX IF NOT EXISTS idx_skill_deleted ON skill_registry(deleted)",
+                script=False,
+                commit=True,
+            )
+            return
+
+        if self.backend_type == BackendType.POSTGRESQL:
+            self.backend.execute(
+                """
+                CREATE TABLE IF NOT EXISTS skill_registry (
+                    id SERIAL PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    description TEXT,
+                    argument_hint TEXT,
+                    disable_model_invocation BOOLEAN DEFAULT FALSE,
+                    user_invocable BOOLEAN DEFAULT TRUE,
+                    allowed_tools TEXT,
+                    model TEXT,
+                    context TEXT DEFAULT 'inline',
+                    directory_path TEXT NOT NULL,
+                    last_modified TIMESTAMP NOT NULL DEFAULT NOW(),
+                    file_hash TEXT,
+                    uuid TEXT UNIQUE NOT NULL,
+                    created_at TIMESTAMP DEFAULT NOW(),
+                    deleted BOOLEAN DEFAULT FALSE,
+                    version INTEGER NOT NULL DEFAULT 1
+                )
+                """
+            )
+            self.backend.execute("CREATE INDEX IF NOT EXISTS idx_skill_name ON skill_registry(name)")
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_skill_user_invocable ON skill_registry(user_invocable)"
+            )
+            self.backend.execute("CREATE INDEX IF NOT EXISTS idx_skill_deleted ON skill_registry(deleted)")
+            return
+
+        raise NotImplementedError(
+            f"skill_registry table creation not supported for backend {self.backend_type.value}"
+        )
+
+    def _coerce_skill_datetime(self, value: Any) -> datetime | None:
+        """Best-effort conversion of database timestamps to datetime."""
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        return None
+
+    def _skill_row_to_dict(self, row: Any) -> dict[str, Any] | None:
+        """Convert a skill_registry row to a dict with JSON fields decoded."""
+        if not row:
+            return None
+        item = dict(row)
+        allowed_tools = item.get("allowed_tools")
+        if isinstance(allowed_tools, str):
+            try:
+                item["allowed_tools"] = json.loads(allowed_tools)
+            except json.JSONDecodeError:
+                item["allowed_tools"] = [tool.strip() for tool in allowed_tools.split(",") if tool.strip()]
+        elif allowed_tools is None:
+            item["allowed_tools"] = None
+        else:
+            item["allowed_tools"] = allowed_tools
+
+        item["disable_model_invocation"] = bool(item.get("disable_model_invocation", False))
+        item["user_invocable"] = bool(item.get("user_invocable", True))
+        item["deleted"] = bool(item.get("deleted", False))
+        item["created_at"] = self._coerce_skill_datetime(item.get("created_at"))
+        item["last_modified"] = self._coerce_skill_datetime(item.get("last_modified"))
+        return item
+
+    def _skill_bool_value(self, value: bool) -> bool | int:
+        return value if self.backend_type == BackendType.POSTGRESQL else int(value)
+
+    def list_skill_registry(
+        self,
+        *,
+        include_hidden: bool = False,
+        include_deleted: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List skill registry entries with optional filters."""
+        self._ensure_skill_registry_table()
+        clauses = []
+        params: list[Any] = []
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(self._skill_bool_value(False))
+        if not include_hidden:
+            clauses.append("user_invocable = ?")
+            params.append(self._skill_bool_value(True))
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        query = (
+            "SELECT * FROM skill_registry "  # nosec B608
+            f"{where_sql} "
+            "ORDER BY name ASC LIMIT ? OFFSET ?"
+        )
+        params.extend([limit, offset])
+        try:
+            cursor = self.execute_query(query, tuple(params))
+            return [item for row in cursor.fetchall() if (item := self._skill_row_to_dict(row))]
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error listing skills: {exc}")
+            raise
+
+    def count_skill_registry(
+        self,
+        *,
+        include_hidden: bool = False,
+        include_deleted: bool = False,
+    ) -> int:
+        """Return count of skills in registry."""
+        self._ensure_skill_registry_table()
+        clauses = []
+        params: list[Any] = []
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(self._skill_bool_value(False))
+        if not include_hidden:
+            clauses.append("user_invocable = ?")
+            params.append(self._skill_bool_value(True))
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        query = f"SELECT COUNT(*) AS cnt FROM skill_registry {where_sql}"  # nosec B608
+        try:
+            cursor = self.execute_query(query, tuple(params))
+            row = cursor.fetchone()
+            return int(row["cnt"]) if row else 0
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error counting skills: {exc}")
+            raise
+
+    def get_skill_registry(self, name: str, *, include_deleted: bool = False) -> dict[str, Any] | None:
+        """Fetch a skill registry entry by name."""
+        self._ensure_skill_registry_table()
+        query = "SELECT * FROM skill_registry WHERE name = ?"
+        params: list[Any] = [name]
+        if not include_deleted:
+            query += " AND deleted = ?"
+            params.append(self._skill_bool_value(False))
+        try:
+            cursor = self.execute_query(query, tuple(params))
+            return self._skill_row_to_dict(cursor.fetchone())
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error fetching skill '{name}': {exc}")
+            raise
+
+    def insert_skill_registry(self, skill_data: dict[str, Any]) -> str:
+        """Insert a new skill registry row and return its UUID."""
+        self._ensure_skill_registry_table()
+        name = str(skill_data.get("name") or "").strip().lower()
+        if not name:
+            raise InputError("Skill name is required.")  # noqa: TRY003
+        directory_path = str(skill_data.get("directory_path") or "")
+        if not directory_path:
+            raise InputError("directory_path is required for skill registry.")  # noqa: TRY003
+
+        now = self._get_current_utc_timestamp_iso()
+        skill_uuid = str(skill_data.get("uuid") or self._generate_uuid())
+        allowed_tools_json = self._ensure_json_string(skill_data.get("allowed_tools"))
+
+        query = (
+            "INSERT INTO skill_registry ("
+            "name, description, argument_hint, disable_model_invocation, user_invocable, "
+            "allowed_tools, model, context, directory_path, last_modified, file_hash, uuid, "
+            "created_at, deleted, version"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        params = (
+            name,
+            skill_data.get("description"),
+            skill_data.get("argument_hint"),
+            self._skill_bool_value(bool(skill_data.get("disable_model_invocation", False))),
+            self._skill_bool_value(bool(skill_data.get("user_invocable", True))),
+            allowed_tools_json,
+            skill_data.get("model"),
+            skill_data.get("context", "inline"),
+            directory_path,
+            now,
+            skill_data.get("file_hash"),
+            skill_uuid,
+            skill_data.get("created_at") or now,
+            self._skill_bool_value(bool(skill_data.get("deleted", False))),
+            int(skill_data.get("version", 1)),
+        )
+        try:
+            self.execute_query(query, params, commit=True)
+            return skill_uuid
+        except sqlite3.IntegrityError as exc:
+            if "unique constraint failed: skill_registry.name" in str(exc).lower():
+                raise ConflictError(
+                    f"Skill '{name}' already exists.",
+                    entity="skill_registry",
+                    entity_id=name,
+                ) from exc
+            if "unique constraint failed: skill_registry.uuid" in str(exc).lower():
+                raise ConflictError(
+                    "Skill UUID already exists.",
+                    entity="skill_registry",
+                    entity_id=skill_uuid,
+                ) from exc
+            raise CharactersRAGDBError(f"Database integrity error adding skill '{name}': {exc}") from exc
+        except BackendDatabaseError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(
+                    f"Skill '{name}' already exists.",
+                    entity="skill_registry",
+                    entity_id=name,
+                ) from exc
+            raise CharactersRAGDBError(f"Database integrity error adding skill '{name}': {exc}") from exc
+
+    def update_skill_registry(
+        self,
+        name: str,
+        update_data: dict[str, Any],
+        expected_version: int,
+    ) -> bool:
+        """Update a skill registry row using optimistic locking."""
+        if not update_data:
+            raise InputError(f"No data provided for update of skill '{name}'.")  # noqa: TRY003
+
+        self._ensure_skill_registry_table()
+        now = self._get_current_utc_timestamp_iso()
+        allowed_fields = {
+            "description",
+            "argument_hint",
+            "disable_model_invocation",
+            "user_invocable",
+            "allowed_tools",
+            "model",
+            "context",
+            "directory_path",
+            "file_hash",
+            "deleted",
+        }
+
+        set_parts: list[str] = []
+        params: list[Any] = []
+        for key, value in update_data.items():
+            if key not in allowed_fields:
+                continue
+            if key == "allowed_tools":
+                params.append(self._ensure_json_string(value))
+                set_parts.append("allowed_tools = ?")
+            elif key in {"disable_model_invocation", "user_invocable", "deleted"}:
+                params.append(self._skill_bool_value(bool(value)))
+                set_parts.append(f"{key} = ?")
+            else:
+                params.append(value)
+                set_parts.append(f"{key} = ?")
+
+        if not set_parts:
+            raise InputError(f"No supported data provided for update of skill '{name}'.")  # noqa: TRY003
+
+        set_parts.extend(["last_modified = ?", "version = version + 1"])
+        params.append(now)
+        params.extend([name, expected_version])
+        query = (
+            f"UPDATE skill_registry SET {', '.join(set_parts)} "  # nosec B608
+            "WHERE name = ? AND version = ? AND deleted = ?"
+        )
+        params.append(self._skill_bool_value(False))
+
+        try:
+            with self.transaction() as conn:
+                current_db_version = self._get_current_db_version(conn, "skill_registry", "name", name)
+                if current_db_version != expected_version:
+                    raise ConflictError(
+                        f"Skill '{name}' was modified (db has {current_db_version}, expected {expected_version}).",
+                        entity="skill_registry",
+                        entity_id=name,
+                    )
+
+                prepared_query, prepared_params = self._prepare_backend_statement(query, tuple(params))
+                cursor = conn.execute(prepared_query, prepared_params)
+                if cursor.rowcount == 0:
+                    raise ConflictError(
+                        f"Skill '{name}' update affected 0 rows.",
+                        entity="skill_registry",
+                        entity_id=name,
+                    )
+                return True
+        except ConflictError:
+            raise
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error updating skill '{name}': {exc}")
+            raise
+
+    def mark_skill_registry_deleted(self, name: str, expected_version: int) -> bool:
+        """Soft-delete a skill registry row using optimistic locking."""
+        self._ensure_skill_registry_table()
+        now = self._get_current_utc_timestamp_iso()
+        next_version = expected_version + 1
+
+        query = (
+            "UPDATE skill_registry SET deleted = ?, last_modified = ?, version = ? "
+            "WHERE name = ? AND version = ? AND deleted = ?"
+        )
+        params = (
+            self._skill_bool_value(True),
+            now,
+            next_version,
+            name,
+            expected_version,
+            self._skill_bool_value(False),
+        )
+
+        try:
+            with self.transaction() as conn:
+                try:
+                    current_db_version = self._get_current_db_version(conn, "skill_registry", "name", name)
+                except ConflictError:
+                    check_deleted = conn.execute(
+                        "SELECT deleted, version FROM skill_registry WHERE name = ?",
+                        (name,),
+                    ).fetchone()
+                    if check_deleted and check_deleted["deleted"]:
+                        logger.info("Skill '{}' already deleted; soft-delete is idempotent.", name)
+                        return True
+                    raise
+
+                if current_db_version != expected_version:
+                    raise ConflictError(
+                        f"Skill '{name}' version mismatch (db has {current_db_version}, expected {expected_version}).",
+                        entity="skill_registry",
+                        entity_id=name,
+                    )
+
+                prepared_query, prepared_params = self._prepare_backend_statement(query, params)
+                cursor = conn.execute(prepared_query, prepared_params)
+                if cursor.rowcount == 0:
+                    raise ConflictError(
+                        f"Skill '{name}' delete affected 0 rows.",
+                        entity="skill_registry",
+                        entity_id=name,
+                    )
+                return True
+        except ConflictError:
+            raise
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error deleting skill '{name}': {exc}")
+            raise
+
     def _deserialize_row_fields(self, row: sqlite3.Row, json_fields: list[str]) -> dict[str, Any] | None:
         """
         Converts a sqlite3.Row object to a dictionary, deserializing specified JSON fields.

--- a/tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py
@@ -7,6 +7,10 @@ def _load(path: str) -> dict:
     return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
 
 
+def _workflow_on(workflow: dict) -> dict:
+    return workflow[True]
+
+
 def _install_step_run(workflow: dict, job_name: str = "build-and-check") -> str:
     steps = workflow["jobs"][job_name]["steps"]
     install_steps = [step for step in steps if step.get("name") == "Install packaging tools"]
@@ -26,3 +30,22 @@ def test_publish_pypi_workflow_installs_setuptools_backend() -> None:
     run_script = _install_step_run(workflow, job_name="build")
     assert "setuptools" in run_script
     assert "wheel" in run_script
+
+
+def test_publish_pypi_workflow_is_manual_dispatch_only() -> None:
+    workflow = _load(".github/workflows/publish-pypi.yml")
+    on = _workflow_on(workflow)
+    target = on["workflow_dispatch"]["inputs"]["target"]
+
+    assert set(on) == {"workflow_dispatch"}
+    assert "release" not in on
+    assert target["options"] == ["testpypi", "pypi"]
+    assert target["default"] == "testpypi"
+
+    publish_testpypi = workflow["jobs"]["publish-testpypi"]
+    assert publish_testpypi["if"] == (
+        "${{ github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi' }}"
+    )
+
+    publish_pypi = workflow["jobs"]["publish-pypi"]
+    assert publish_pypi["if"] == "${{ github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' }}"

--- a/tldw_Server_API/tests/CI/test_release_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_release_workflow_contracts.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import yaml
+
+
+def _load(path: str) -> dict:
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+
+
+def _workflow_on(workflow: dict) -> dict:
+    return workflow[True]
+
+
+def test_publish_docker_workflow_is_release_driven() -> None:
+    workflow = _load(".github/workflows/publish-docker.yml")
+    on = _workflow_on(workflow)
+
+    assert "release" in on
+    assert on["release"] == {"types": ["published"]}
+    assert "workflow_dispatch" in on
+
+
+def test_publish_docker_matrix_remains_app_worker_audio_worker() -> None:
+    workflow = _load(".github/workflows/publish-docker.yml")
+    matrix = workflow["jobs"]["push_to_registries"]["strategy"]["matrix"]["include"]
+
+    assert [entry["name"] for entry in matrix] == ["app", "worker", "audio-worker"]
+
+
+def test_publish_ghcr_main_workflow_remains_push_to_main_driven() -> None:
+    workflow = _load(".github/workflows/publish-ghcr-main.yml")
+    on = _workflow_on(workflow)
+
+    assert "push" in on
+    assert on["push"] == {"branches": ["main"]}
+    assert "release" not in on
+    assert "workflow_dispatch" not in on
+
+
+def test_publish_ghcr_main_matrix_remains_app_webui_admin_ui() -> None:
+    workflow = _load(".github/workflows/publish-ghcr-main.yml")
+    matrix = workflow["jobs"]["publish-ghcr-main"]["strategy"]["matrix"]["include"]
+
+    assert [entry["name"] for entry in matrix] == ["app", "webui", "admin-ui"]

--- a/tldw_Server_API/tests/CI/test_sbom_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_sbom_workflow_contracts.py
@@ -21,6 +21,8 @@ def test_sbom_workflow_supports_pyproject_dependency_source() -> None:
 
     assert 'gen_from_requirements "$repo_root/tldw_Server_API/requirements.txt"' in run_script
     assert 'gen_from_requirements "$repo_root/requirements.txt"' in run_script
+    assert 'cyclonedx-py requirements "$req_file" -o "$out_file"' in run_script
+    assert 'cyclonedx-py requirements -i "$req_file" -o "$out_file"' in run_script
     assert "gen_requirements_from_pyproject" in run_script
     assert "tomllib" in run_script
     assert '[project].dependencies' in run_script

--- a/tldw_Server_API/tests/CI/test_sbom_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_sbom_workflow_contracts.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import yaml
+
+
+def _load(path: str) -> dict:
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+
+
+def _get_step(steps: list[dict], name: str) -> dict:
+    matching = [step for step in steps if step.get("name") == name]
+    assert matching, f"{name} step missing"
+    return matching[0]
+
+
+def test_sbom_workflow_supports_pyproject_dependency_source() -> None:
+    workflow = _load(".github/workflows/sbom.yml")
+    steps = workflow["jobs"]["build-sbom"]["steps"]
+    python_sbom_step = _get_step(steps, "Generate Python SBOM (CycloneDX)")
+    run_script = python_sbom_step["run"]
+
+    assert 'gen_from_requirements "$repo_root/tldw_Server_API/requirements.txt"' in run_script
+    assert 'gen_from_requirements "$repo_root/requirements.txt"' in run_script
+    assert "gen_requirements_from_pyproject" in run_script
+    assert "tomllib" in run_script
+    assert '[project].dependencies' in run_script
+    assert 'gen_requirements_from_pyproject "$repo_root/pyproject.toml"' in run_script

--- a/tldw_Server_API/tests/CI/test_sbom_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_sbom_workflow_contracts.py
@@ -21,8 +21,8 @@ def test_sbom_workflow_supports_pyproject_dependency_source() -> None:
 
     assert 'gen_from_requirements "$repo_root/tldw_Server_API/requirements.txt"' in run_script
     assert 'gen_from_requirements "$repo_root/requirements.txt"' in run_script
-    assert 'cyclonedx-py requirements "$req_file" -o "$out_file"' in run_script
-    assert 'cyclonedx-py requirements -i "$req_file" -o "$out_file"' in run_script
+    assert 'cyclonedx-py requirements "$req_file" "${pyproject_args[@]}" -o "$out_file"' in run_script
+    assert 'cyclonedx-py requirements -i "$req_file" "${pyproject_args[@]}" -o "$out_file"' in run_script
     assert "gen_requirements_from_pyproject" in run_script
     assert "tomllib" in run_script
     assert '[project].dependencies' in run_script

--- a/tldw_Server_API/tests/Docs/test_release_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_release_docs_contract.py
@@ -82,6 +82,36 @@ def test_mkdocs_version_metadata_does_not_depend_on_copyright_url() -> None:
     assert "v0.1.31 - <a href=\"https://example.com/project\">Project</a>" in updated_text
 
 
+def test_mkdocs_version_metadata_updates_version_inside_multiline_copyright() -> None:
+    mkdocs_text = (
+        "extra:\n"
+        "  generator: false\n"
+        "  version: v0.1.19\n"
+        "copyright: |\n"
+        "  Maintained by tldw_Server contributors.\n"
+        "  Release train: v0.1.19\n"
+        "  <a href=\"https://example.com/project\">Project</a>\n"
+    )
+
+    updated_text = update_mkdocs_version_metadata(mkdocs_text, "0.1.31")
+
+    assert "version: v0.1.31" in updated_text
+    assert "Release train: v0.1.31" in updated_text
+    assert "https://example.com/project" in updated_text
+
+
+def test_repository_release_metadata_matches_pyproject() -> None:
+    current_version = read_current_version(REPO_ROOT / "pyproject.toml")
+    readme_text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    mkdocs_text = (REPO_ROOT / "Docs" / "mkdocs.yml").read_text(encoding="utf-8")
+
+    assert f"`{current_version}` Beta status. Expect rough edges and please report issues." in readme_text
+    assert f"beyond `{current_version}`" in readme_text
+    assert f"post-`{current_version}` branch work" in readme_text
+    assert f"version: v{current_version}" in mkdocs_text
+    assert f"v{current_version}" in mkdocs_text
+
+
 def test_mkdocs_version_metadata_raises_for_missing_anchor() -> None:
     with pytest.raises(ValueError, match="(?i)mkdocs|anchor|version"):
         update_mkdocs_version_metadata("extra:\n  generator: false\n", "0.1.30")

--- a/tldw_Server_API/tests/Docs/test_release_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_release_docs_contract.py
@@ -67,6 +67,21 @@ def test_mkdocs_version_metadata_updates_coherently() -> None:
     assert "© 2024-2025 tldw_Server" in updated_text
 
 
+def test_mkdocs_version_metadata_does_not_depend_on_copyright_url() -> None:
+    mkdocs_text = (
+        "extra:\n"
+        "  generator: false\n"
+        "  version: v0.1.19\n"
+        "copyright: |\n"
+        "  © 2024-2025 tldw_Server - v0.1.19 - <a href=\"https://example.com/project\">Project</a>\n"
+    )
+
+    updated_text = update_mkdocs_version_metadata(mkdocs_text, "0.1.31")
+
+    assert "version: v0.1.31" in updated_text
+    assert "v0.1.31 - <a href=\"https://example.com/project\">Project</a>" in updated_text
+
+
 def test_mkdocs_version_metadata_raises_for_missing_anchor() -> None:
     with pytest.raises(ValueError, match="(?i)mkdocs|anchor|version"):
         update_mkdocs_version_metadata("extra:\n  generator: false\n", "0.1.30")

--- a/tldw_Server_API/tests/Docs/test_release_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_release_docs_contract.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import Helper_Scripts.release as release  # noqa: E402
+from Helper_Scripts.release import (  # noqa: E402
+    read_current_version,
+    update_mkdocs_version_metadata,
+    update_readme_release_references,
+    update_release_notes_entry_point,
+)
+
+
+def test_readme_release_references_update_to_target_version() -> None:
+    target_version = read_current_version(REPO_ROOT / "pyproject.toml")
+    readme_text = (
+        "## Current Status\n\n"
+        "Current release line:\n"
+        "- `0.3.1` Beta status. Expect rough edges and please report issues.\n"
+        "- Primary client surfaces are the Next.js WebUI, Admin UI, and browser extension.\n"
+        "- The `dev` branch currently contains additional unreleased work beyond `0.3.1`; "
+        "see [CHANGELOG.md](CHANGELOG.md) for branch-level detail and "
+        "[Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for the published "
+        "release entry point.\n\n"
+        "Currently landing on `dev` (post-`0.3.1` branch work):\n"
+        "- Placeholder\n"
+    )
+
+    updated_text = update_readme_release_references(readme_text, target_version)
+
+    assert f"`{target_version}` Beta status. Expect rough edges and please report issues." in updated_text
+    assert (
+        f"The `dev` branch currently contains additional unreleased work beyond `{target_version}`;"
+        in updated_text
+    )
+    assert (
+        f"Currently landing on `dev` (post-`{target_version}` branch work):" in updated_text
+    )
+
+
+def test_mkdocs_version_metadata_updates_coherently() -> None:
+    target_version = read_current_version(REPO_ROOT / "pyproject.toml")
+    mkdocs_text = (
+        "extra:\n"
+        "  generator: false\n"
+        "  version: v0.1.19\n"
+        "  social:\n"
+        "    - icon: fontawesome/brands/github\n"
+        "      link: https://github.com/rmusser01/tldw_server\n"
+        "      name: GitHub\n"
+        "copyright: |\n"
+        "  © 2024-2025 tldw_Server - v0.1.19 - <a href=\"https://github.com/rmusser01/tldw_server\">GitHub</a>\n"
+    )
+
+    updated_text = update_mkdocs_version_metadata(mkdocs_text, target_version)
+
+    assert f"version: v{target_version}" in updated_text
+    assert f"v{target_version} - <a href=\"https://github.com/rmusser01/tldw_server\">GitHub</a>" in updated_text
+    assert "© 2024-2025 tldw_Server" in updated_text
+
+
+def test_mkdocs_version_metadata_raises_for_missing_anchor() -> None:
+    with pytest.raises(ValueError, match="(?i)mkdocs|anchor|version"):
+        update_mkdocs_version_metadata("extra:\n  generator: false\n", "0.1.30")
+
+
+def test_release_notes_entry_point_points_to_authoritative_release_process_doc() -> None:
+    release_notes_text = "# Release Notes\n\nPublished release notes entry point.\n\nFor release process details, see `Docs/Release_Checklist.md`.\n"
+
+    updated_text = update_release_notes_entry_point(
+        release_notes_text,
+        "Docs/Development/Release_Process.md",
+    )
+
+    assert "Docs/Development/Release_Process.md" in updated_text
+    assert "Docs/Release_Checklist.md" not in updated_text
+
+
+def test_release_notes_entry_point_raises_for_missing_anchor() -> None:
+    with pytest.raises(ValueError, match="(?i)release notes|anchor"):
+        update_release_notes_entry_point(
+            "# Release Notes\n\nNo process pointer here.\n",
+            "Docs/Development/Release_Process.md",
+        )
+
+
+def test_docs_site_repo_policy_keeps_generated_site_untracked() -> None:
+    gitignore_lines = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+
+    assert "/Docs/site/" in gitignore_lines
+    assert "!Docs/site/**/*.json" not in gitignore_lines
+
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "ls-files", "Docs/site"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_release_helper_does_not_manage_generated_docs_site_outputs() -> None:
+    assert not hasattr(release, "update_docs_site_version_bearing_outputs")
+
+
+def test_release_process_doc_is_authoritative_operator_path() -> None:
+    release_process_path = REPO_ROOT / "Docs/Development/Release_Process.md"
+    release_notes_path = REPO_ROOT / "Docs/Published/RELEASE_NOTES.md"
+    release_checklist_path = REPO_ROOT / "Docs/Release_Checklist.md"
+
+    assert release_process_path.exists(), "expected release process operator doc to exist"
+
+    release_process_text = release_process_path.read_text(encoding="utf-8")
+    release_notes_text = release_notes_path.read_text(encoding="utf-8")
+    release_checklist_text = release_checklist_path.read_text(encoding="utf-8")
+
+    assert all(
+        command in release_process_text
+        for command in ("`make release`", "`make release-patch`", "`make release-minor`")
+    )
+    assert "`main`" in release_process_text
+    assert "Docs/Development/CI_REQUIRED_GATES.md" in release_process_text
+    assert "formal release artifacts" in release_process_text.lower()
+    assert "main snapshots" in release_process_text.lower()
+    assert "release commit" in release_process_text.lower()
+    assert "republishes" in release_process_text.lower()
+    assert "Docs/Release_Checklist.md" in release_process_text
+    assert "retry" in release_process_text.lower() or "rerun" in release_process_text.lower()
+    assert "recover" in release_process_text.lower()
+    assert "PyPI" in release_process_text
+    assert "manual" in release_process_text.lower()
+
+    assert "Docs/Development/Release_Process.md" in release_notes_text
+    assert "](../Development/Release_Process.md)" in release_notes_text
+    assert "](../Release_Checklist.md)" in release_notes_text
+
+    assert "Docs/Development/Release_Process.md" in release_checklist_text
+    assert "broad readiness checklist" in release_checklist_text.lower()

--- a/tldw_Server_API/tests/Utils/test_makefile_release_targets.py
+++ b/tldw_Server_API/tests/Utils/test_makefile_release_targets.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MAKEFILE_PATH = REPO_ROOT / "Makefile"
+
+
+def _read_makefile() -> str:
+    return MAKEFILE_PATH.read_text(encoding="utf-8")
+
+
+def _extract_target_block(makefile_text: str, target_name: str) -> str:
+    lines = makefile_text.splitlines()
+    for index, line in enumerate(lines):
+        if line == f"{target_name}:":
+            block_lines: list[str] = []
+            for candidate in lines[index + 1 :]:
+                if candidate.startswith("\t"):
+                    block_lines.append(candidate)
+                    continue
+                if candidate == "":
+                    if block_lines:
+                        break
+                    continue
+                break
+            if not block_lines:
+                raise AssertionError(f"Missing recipe for Make target: {target_name}")
+            return "\n".join(block_lines) + "\n"
+    raise AssertionError(f"Missing Make target: {target_name}")
+
+
+def test_release_patch_target_exists_and_delegates_to_release_helper() -> None:
+    block = _extract_target_block(_read_makefile(), "release-patch")
+    assert "Helper_Scripts/release.py" in block
+    assert "--bump patch" in block
+    assert "RELEASE_DRY_RUN" in block
+    assert "--dry-run" in block
+
+
+def test_release_minor_target_exists_and_delegates_to_release_helper() -> None:
+    block = _extract_target_block(_read_makefile(), "release-minor")
+    assert "Helper_Scripts/release.py" in block
+    assert "--bump minor" in block
+    assert "RELEASE_DRY_RUN" in block
+    assert "--dry-run" in block
+
+
+def test_release_target_exists_and_delegates_to_release_helper() -> None:
+    makefile_text = _read_makefile()
+    block = _extract_target_block(makefile_text, "release")
+    assert "Helper_Scripts/release.py" in block or "release-patch" in block
+    assert "RELEASE_DRY_RUN=$(RELEASE_DRY_RUN)" in block

--- a/tldw_Server_API/tests/Utils/test_release_helper.py
+++ b/tldw_Server_API/tests/Utils/test_release_helper.py
@@ -721,6 +721,29 @@ def test_shell_release_runner_run_command_uses_absolute_executable_path(
     assert Path(recorded_commands[0][0]).is_absolute()
 
 
+def test_shell_release_runner_run_command_rejects_relative_resolved_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def _fake_which(executable: str) -> str:
+        assert executable == "git"
+        return "relative-bin/git"
+
+    def _fake_run(
+        command_args: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        raise AssertionError(f"subprocess should not run relative command: {command_args}")
+
+    monkeypatch.setattr(release_module.shutil, "which", _fake_which)
+    monkeypatch.setattr(release_module.subprocess, "run", _fake_run)
+
+    runner = ShellReleaseRunner(repo_root=tmp_path, dry_run=False)
+
+    with pytest.raises(FileNotFoundError, match="absolute path"):
+        runner._run_command(["git", "status"])
+
+
 def test_shell_release_runner_create_or_update_tag_uses_annotated_tag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     recorded_commands: list[list[str]] = []
 

--- a/tldw_Server_API/tests/Utils/test_release_helper.py
+++ b/tldw_Server_API/tests/Utils/test_release_helper.py
@@ -558,6 +558,22 @@ def test_orchestrate_release_resumes_from_remote_tag_without_github_release() ->
     )
 
 
+def test_orchestrate_release_local_release_commit_only_reads_head_sha_once() -> None:
+    runner = StubReleaseRunner()
+    runner.release_state = "local_release_commit_only"
+    runner.head_sha = "release-commit-on-head"
+
+    result = orchestrate_release(
+        bump="patch",
+        runner=runner,
+        pyproject_path=REPO_ROOT / "pyproject.toml",
+        ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+    )
+
+    assert result["release_commit_sha"] == "release-commit-on-head"
+    assert runner.operations.count("get_head_sha") == 1
+
+
 def test_orchestrate_release_reports_dry_run_without_created_release() -> None:
     runner = StubReleaseRunner()
     runner.dry_run = True

--- a/tldw_Server_API/tests/Utils/test_release_helper.py
+++ b/tldw_Server_API/tests/Utils/test_release_helper.py
@@ -1,0 +1,631 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import subprocess  # nosec B404
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from Helper_Scripts.release import (  # noqa: E402
+    ShellReleaseRunner,
+    bump_version,
+    classify_release_state,
+    extract_required_check_names,
+    find_exact_duplicate_bullets,
+    normalize_bullet_text,
+    orchestrate_release,
+    read_current_version,
+    promote_changelog_unreleased_section,
+    update_mkdocs_version_metadata,
+    update_readme_release_references,
+    update_release_notes_entry_point,
+    validate_release_branch,
+)
+
+
+def test_read_current_version_from_pyproject(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "example"
+version = "9.8.7"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert read_current_version(pyproject) == "9.8.7"
+
+
+def test_bump_version_patch():
+    assert bump_version("0.1.30", "patch") == "0.1.31"
+
+
+def test_bump_version_minor():
+    assert bump_version("0.1.30", "minor") == "0.2.0"
+
+
+def test_extract_required_check_names():
+    checks = extract_required_check_names(
+        REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md"
+    )
+    assert checks == [
+        "backend-required",
+        "security-required",
+        "coverage-required",
+        "frontend-required",
+        "e2e-required",
+        "container-build-check",
+    ]
+
+
+def test_extract_required_check_names_ignores_nested_subsections(tmp_path: Path):
+    doc = tmp_path / "CI_REQUIRED_GATES.md"
+    doc.write_text(
+        """
+# CI Required Gates
+
+## Required Check Names
+
+1. `backend-required`
+2. `security-required`
+
+### Nested Details
+
+1. `ignored-required`
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert extract_required_check_names(doc) == [
+        "backend-required",
+        "security-required",
+    ]
+
+
+@pytest.mark.parametrize(
+    "doc_text",
+    [
+        (
+            """
+# CI Required Gates
+
+## Something Else
+
+1. `backend-required`
+""".strip()
+            + "\n"
+        ),
+        (
+            """
+# CI Required Gates
+
+## Required Check Names
+
+### Nested Details
+
+No enumerated checks here.
+""".strip()
+            + "\n"
+        ),
+    ],
+)
+def test_extract_required_check_names_fails_closed_when_section_missing_or_empty(
+    tmp_path: Path,
+    doc_text: str,
+):
+    doc = tmp_path / "CI_REQUIRED_GATES.md"
+    doc.write_text(doc_text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="(?i)required check names|missing|empty"):
+        extract_required_check_names(doc)
+
+
+def test_normalize_bullet_text_collapses_internal_whitespace():
+    assert normalize_bullet_text("  Add   release   notes \n with tabs\t") == (
+        "Add release notes with tabs"
+    )
+
+
+def test_validate_release_branch_rejects_unsupported_branch():
+    with pytest.raises(ValueError, match="main"):
+        validate_release_branch("dev")
+
+
+def test_find_exact_duplicate_bullets_only_within_same_section():
+    duplicate_bullets = find_exact_duplicate_bullets(
+        {
+            "Added": [
+                "  Add release helper core  ",
+                "Add   release   helper core",
+                "Keep release body stable",
+            ],
+            "Changed": [
+                "Add release helper core",
+            ],
+            "Fixed": [
+                "Separate fix text",
+                "Separate    fix   text",
+            ],
+        }
+    )
+
+    assert duplicate_bullets == [
+        ("Added", "Add release helper core"),
+        ("Fixed", "Separate fix text"),
+    ]
+
+
+def test_promote_changelog_unreleased_section_moves_content_and_resets_headings():
+    changelog_text = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n\n"
+        "- Add release helper core\n"
+        "- Expand release helper warnings\n\n"
+        "### Changed\n\n"
+        "- Update release metadata coherently\n\n"
+        "### Fixed\n\n"
+        "- Fix release helper output\n\n"
+        "### Removed\n\n"
+        "## [0.1.29] - 2026-03-29\n\n"
+        "### Added\n\n"
+        "- Existing release note\n"
+    )
+
+    promoted_text, warnings = promote_changelog_unreleased_section(
+        changelog_text=changelog_text,
+        version="0.1.30",
+        release_date="2026-04-22",
+    )
+
+    assert warnings == []
+    assert "## [0.1.30] - 2026-04-22" in promoted_text
+    unreleased_block = promoted_text.split("## [Unreleased]", 1)[1].split(
+        "## [0.1.30] - 2026-04-22", 1
+    )[0]
+    assert "### Added" in unreleased_block
+    assert "### Changed" in unreleased_block
+    assert "### Fixed" in unreleased_block
+    assert "### Removed" in unreleased_block
+    assert "- Add release helper core" not in unreleased_block
+    assert "- Add release helper core" in promoted_text
+    assert promoted_text.index("## [Unreleased]") < promoted_text.index("## [0.1.30] - 2026-04-22")
+
+
+def test_promote_changelog_unreleased_section_rejects_exact_duplicates_within_subsection():
+    changelog_text = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n\n"
+        "- Duplicate release helper bullet\n"
+        "- Duplicate   release   helper   bullet\n\n"
+        "### Changed\n\n"
+        "- Update release metadata coherently\n"
+    )
+
+    with pytest.raises(ValueError, match="(?i)duplicate"):
+        promote_changelog_unreleased_section(
+            changelog_text=changelog_text,
+            version="0.1.30",
+            release_date="2026-04-22",
+        )
+
+
+def test_promote_changelog_unreleased_section_reports_cross_section_near_duplicates_as_warnings():
+    changelog_text = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n\n"
+        "- Add release helper core\n\n"
+        "### Changed\n\n"
+        "- Add release helper core docs and metadata\n"
+    )
+
+    promoted_text, warnings = promote_changelog_unreleased_section(
+        changelog_text=changelog_text,
+        version="0.1.30",
+        release_date="2026-04-22",
+    )
+
+    assert "## [0.1.30] - 2026-04-22" in promoted_text
+    assert warnings
+    assert any("Added" in warning and "Changed" in warning for warning in warnings)
+
+
+@pytest.mark.parametrize(
+    "unsupported_slice",
+    [
+        (
+            "# Changelog\n\n"
+            "## [Unreleased]\n\n"
+            "Some prose that should not be silently dropped.\n"
+        ),
+        (
+            "# Changelog\n\n"
+            "## [Unreleased]\n\n"
+            "### Notes\n\n"
+            "- Unsupported subsection content\n"
+        ),
+        (
+            "# Changelog\n\n"
+            "## [Unreleased]\n\n"
+            "### Added\n\n"
+            "- Wrapped bullet text\n"
+            "  continues on the next line\n"
+        ),
+    ],
+)
+def test_promote_changelog_unreleased_section_rejects_unsupported_content(unsupported_slice: str):
+    with pytest.raises(ValueError, match="(?i)unreleased|unsupported|ambiguous"):
+        promote_changelog_unreleased_section(
+            changelog_text=unsupported_slice,
+            version="0.1.30",
+            release_date="2026-04-22",
+        )
+
+
+def test_update_readme_release_references_raises_when_expected_anchors_missing():
+    with pytest.raises(ValueError, match="(?i)readme|release line|anchor"):
+        update_readme_release_references("README without current release anchors", "0.1.30")
+
+
+def test_update_mkdocs_version_metadata_raises_when_expected_anchors_missing():
+    with pytest.raises(ValueError, match="(?i)mkdocs|anchor|version"):
+        update_mkdocs_version_metadata("extra:\n  generator: false\n", "0.1.30")
+
+
+def test_update_release_notes_entry_point_raises_when_anchor_missing():
+    with pytest.raises(ValueError, match="(?i)release notes|anchor"):
+        update_release_notes_entry_point("Published release notes entry point.", "Docs/Development/Release_Process.md")
+
+
+def test_classify_release_state_rejects_inconsistent_snapshot():
+    with pytest.raises(ValueError, match="inconsistent"):
+        classify_release_state(
+            local_release_commit_exists=True,
+            local_tag_exists=False,
+            remote_tag_exists=False,
+            github_release_exists=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        (
+            {
+                "local_release_commit_exists": True,
+                "local_tag_exists": False,
+                "remote_tag_exists": False,
+                "github_release_exists": False,
+            },
+            "local_release_commit_only",
+        ),
+        (
+            {
+                "local_release_commit_exists": False,
+                "local_tag_exists": True,
+                "remote_tag_exists": False,
+                "github_release_exists": False,
+            },
+            "local_tag_only",
+        ),
+        (
+            {
+                "local_release_commit_exists": False,
+                "local_tag_exists": False,
+                "remote_tag_exists": True,
+                "github_release_exists": False,
+            },
+            "remote_tag_without_github_release",
+        ),
+        (
+            {
+                "local_release_commit_exists": True,
+                "local_tag_exists": True,
+                "remote_tag_exists": True,
+                "github_release_exists": True,
+            },
+            "existing_github_release",
+        ),
+    ],
+)
+def test_classify_release_state(kwargs: dict[str, bool], expected: str):
+    assert classify_release_state(**kwargs) == expected
+
+
+class StubReleaseRunner:
+    def __init__(self) -> None:
+        self.branch = "main"
+        self.worktree_clean = True
+        self.origin_main_sha = "abc123prebump"
+        self.head_sha = self.origin_main_sha
+        self.local_tag_target_sha: str | None = self.origin_main_sha
+        self.required_checks = {
+            "backend-required": "success",
+            "security-required": "success",
+            "coverage-required": "success",
+            "frontend-required": "success",
+            "e2e-required": "success",
+            "container-build-check": "success",
+        }
+        self.release_state = "fresh"
+        self.remote_main_sha = self.origin_main_sha
+        self.push_main_error: str | None = None
+        self.recorded_check_sha: list[str] = []
+        self.metadata_prepared = False
+        self.commit_created = False
+        self.tag_created = False
+        self.github_release_created = False
+        self.pushed_main = False
+        self.pushed_tag = False
+        self.operations: list[str] = []
+
+    def fetch_origin_main(self) -> str:
+        self.operations.append("fetch_origin_main")
+        return self.origin_main_sha
+
+    def get_current_branch(self) -> str:
+        self.operations.append("get_current_branch")
+        return self.branch
+
+    def is_worktree_clean(self) -> bool:
+        self.operations.append("is_worktree_clean")
+        return self.worktree_clean
+
+    def get_origin_main_sha(self) -> str:
+        self.operations.append("get_origin_main_sha")
+        return self.origin_main_sha
+
+    def get_head_sha(self) -> str:
+        self.operations.append("get_head_sha")
+        return self.head_sha
+
+    def get_local_tag_target_sha(self, version: str) -> str | None:
+        self.operations.append(f"get_local_tag_target_sha:{version}")
+        return self.local_tag_target_sha
+
+    def get_release_state(self, version: str) -> str:
+        self.operations.append(f"get_release_state:{version}")
+        return self.release_state
+
+    def ensure_required_checks_green(self, sha: str, required_checks: list[str]) -> None:
+        self.operations.append(f"ensure_required_checks_green:{sha}")
+        self.recorded_check_sha.append(sha)
+        failing = [
+            check_name
+            for check_name in required_checks
+            if self.required_checks.get(check_name) != "success"
+        ]
+        if failing:
+            raise RuntimeError(f"Required checks not green for {sha}: {failing}")
+
+    def prepare_metadata(self, current_version: str, next_version: str) -> None:
+        self.operations.append(f"prepare_metadata:{current_version}->{next_version}")
+        self.metadata_prepared = True
+
+    def create_release_commit(self, next_version: str) -> str:
+        self.operations.append(f"create_release_commit:{next_version}")
+        self.commit_created = True
+        return f"release-commit-{next_version}"
+
+    def create_or_update_tag(self, version: str) -> None:
+        self.operations.append(f"create_or_update_tag:{version}")
+        self.tag_created = True
+
+    def get_remote_main_sha(self) -> str:
+        self.operations.append("get_remote_main_sha")
+        return self.remote_main_sha
+
+    def push_main(self) -> None:
+        self.operations.append("push_main")
+        if self.push_main_error is not None:
+            raise RuntimeError(self.push_main_error)
+        self.pushed_main = True
+
+    def push_tag(self, version: str) -> None:
+        self.operations.append(f"push_tag:{version}")
+        self.pushed_tag = True
+
+    def create_github_release(self, version: str) -> None:
+        self.operations.append(f"create_github_release:{version}")
+        self.github_release_created = True
+
+
+def test_orchestrate_release_requires_main_branch():
+    runner = StubReleaseRunner()
+    runner.branch = "dev"
+
+    with pytest.raises(ValueError, match="expected 'main'"):
+        orchestrate_release(
+            bump="patch",
+            runner=runner,
+            pyproject_path=REPO_ROOT / "pyproject.toml",
+            ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+        )
+
+    assert runner.operations[:2] == ["fetch_origin_main", "get_current_branch"]
+    assert "prepare_metadata" not in " ".join(runner.operations)
+
+
+def test_orchestrate_release_requires_clean_worktree():
+    runner = StubReleaseRunner()
+    runner.worktree_clean = False
+
+    with pytest.raises(RuntimeError, match="clean worktree"):
+        orchestrate_release(
+            bump="patch",
+            runner=runner,
+            pyproject_path=REPO_ROOT / "pyproject.toml",
+            ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+        )
+
+    assert runner.operations[:3] == [
+        "fetch_origin_main",
+        "get_current_branch",
+        "is_worktree_clean",
+    ]
+    assert runner.metadata_prepared is False
+
+
+def test_orchestrate_release_hard_aborts_on_non_fast_forward_push_failure():
+    runner = StubReleaseRunner()
+    runner.remote_main_sha = "def456moved"
+    runner.push_main_error = "git push origin main failed: non-fast-forward"
+
+    with pytest.raises(RuntimeError, match="non-fast-forward"):
+        orchestrate_release(
+            bump="patch",
+            runner=runner,
+            pyproject_path=REPO_ROOT / "pyproject.toml",
+            ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+        )
+
+    assert runner.recorded_check_sha == ["abc123prebump"]
+    assert runner.commit_created is True
+    assert runner.tag_created is True
+    assert runner.pushed_main is False
+    assert runner.pushed_tag is False
+    assert runner.github_release_created is False
+    assert runner.operations.count("fetch_origin_main") == 1
+
+
+def test_orchestrate_release_resumes_from_remote_tag_without_github_release():
+    runner = StubReleaseRunner()
+    runner.release_state = "remote_tag_without_github_release"
+
+    result = orchestrate_release(
+        bump="patch",
+        runner=runner,
+        pyproject_path=REPO_ROOT / "pyproject.toml",
+        ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+    )
+
+    assert result["state"] == "remote_tag_without_github_release"
+    assert result["github_release_created"] is True
+    assert runner.github_release_created is True
+    assert runner.commit_created is False
+    assert runner.tag_created is False
+    assert runner.pushed_main is False
+    assert runner.pushed_tag is False
+    assert "prepare_metadata" not in " ".join(runner.operations)
+
+
+def test_orchestrate_release_uses_prebump_origin_main_sha_for_required_checks_only():
+    runner = StubReleaseRunner()
+
+    result = orchestrate_release(
+        bump="patch",
+        runner=runner,
+        pyproject_path=REPO_ROOT / "pyproject.toml",
+        ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+    )
+
+    assert result["validated_sha"] == "abc123prebump"
+    assert runner.recorded_check_sha == ["abc123prebump"]
+    assert all("release-commit-" not in operation for operation in runner.operations if operation.startswith("ensure_required_checks_green:"))
+    assert runner.commit_created is True
+    assert runner.pushed_main is True
+    assert runner.pushed_tag is True
+    assert runner.github_release_created is True
+
+
+def test_orchestrate_release_local_tag_only_fails_closed_when_tag_points_behind_head():
+    runner = StubReleaseRunner()
+    runner.release_state = "local_tag_only"
+    runner.head_sha = "newer-head-commit"
+    runner.local_tag_target_sha = "older-release-commit"
+
+    with pytest.raises(RuntimeError, match="local release tag.*HEAD|tag.*behind"):
+        orchestrate_release(
+            bump="patch",
+            runner=runner,
+            pyproject_path=REPO_ROOT / "pyproject.toml",
+            ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+        )
+
+    assert runner.pushed_main is False
+    assert runner.pushed_tag is False
+    assert runner.github_release_created is False
+
+
+def test_shell_release_runner_prepare_metadata_allows_cross_section_warning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    repo_root = tmp_path
+    (repo_root / "Docs" / "Published").mkdir(parents=True)
+
+    (repo_root / "pyproject.toml").write_text(
+        """
+[project]
+name = "tldw-server"
+version = "0.1.30"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo_root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n\n"
+        "- Add release helper core\n\n"
+        "### Changed\n\n"
+        "- Add release helper core docs and metadata\n\n"
+        "### Fixed\n\n"
+        "- Fix release helper output\n\n"
+        "### Removed\n\n"
+        "## [0.1.30] - 2026-04-20\n\n"
+        "### Added\n\n"
+        "- Existing release entry\n",
+        encoding="utf-8",
+    )
+    (repo_root / "README.md").write_text(
+        "- `0.1.30` Beta status. Expect rough edges and please report issues.\n"
+        "- The `dev` branch currently contains additional unreleased work beyond `0.1.30`; see [CHANGELOG.md](CHANGELOG.md) for branch-level detail and [Docs/Published/RELEASE_NOTES.md](Docs/Published/RELEASE_NOTES.md) for the published release entry point.\n"
+        "Currently landing on `dev` (post-`0.1.30` branch work):\n",
+        encoding="utf-8",
+    )
+    (repo_root / "Docs" / "mkdocs.yml").write_text(
+        'extra:\n  version: v0.1.30\ncopyright: |\n  © 2024-2025 tldw_Server - v0.1.30 - <a href="https://github.com/rmusser01/tldw_server">GitHub</a>\n',
+        encoding="utf-8",
+    )
+    (repo_root / "Docs" / "Published" / "RELEASE_NOTES.md").write_text(
+        "Published release notes entry point.\n\nFor release process details, see `Docs/Development/Release_Process.md`.\n",
+        encoding="utf-8",
+    )
+
+    runner = ShellReleaseRunner(repo_root=repo_root, dry_run=True)
+
+    runner.prepare_metadata("0.1.30", "0.1.31")
+
+    assert runner._release_notes_body is not None
+    assert "## [0.1.31] - " in runner._release_notes_body
+    assert "Add release helper core docs and metadata" in runner._release_notes_body
+    assert all("Docs/site" not in str(path) for path in runner._prepared_paths)
+
+
+def test_shell_release_runner_create_or_update_tag_uses_annotated_tag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    recorded_commands: list[list[str]] = []
+
+    def _fake_run_command(
+        self: ShellReleaseRunner,
+        args: list[str],
+        *,
+        check: bool = True,
+        capture_output: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(list(args))
+        return subprocess.CompletedProcess(list(args), 0, "", "")
+
+    monkeypatch.setattr(ShellReleaseRunner, "_run_command", _fake_run_command)
+
+    runner = ShellReleaseRunner(repo_root=tmp_path, dry_run=False)
+
+    runner.create_or_update_tag("1.2.3")
+
+    assert recorded_commands == [["git", "tag", "-a", "v1.2.3", "-m", "v1.2.3"]]

--- a/tldw_Server_API/tests/Utils/test_release_helper.py
+++ b/tldw_Server_API/tests/Utils/test_release_helper.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+import Helper_Scripts.release as release_module  # noqa: E402
 from Helper_Scripts.release import (  # noqa: E402
     ShellReleaseRunner,
     bump_version,
@@ -27,7 +28,7 @@ from Helper_Scripts.release import (  # noqa: E402
 )
 
 
-def test_read_current_version_from_pyproject(tmp_path: Path):
+def test_read_current_version_from_pyproject(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         """
@@ -42,15 +43,15 @@ version = "9.8.7"
     assert read_current_version(pyproject) == "9.8.7"
 
 
-def test_bump_version_patch():
+def test_bump_version_patch() -> None:
     assert bump_version("0.1.30", "patch") == "0.1.31"
 
 
-def test_bump_version_minor():
+def test_bump_version_minor() -> None:
     assert bump_version("0.1.30", "minor") == "0.2.0"
 
 
-def test_extract_required_check_names():
+def test_extract_required_check_names() -> None:
     checks = extract_required_check_names(
         REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md"
     )
@@ -64,7 +65,7 @@ def test_extract_required_check_names():
     ]
 
 
-def test_extract_required_check_names_ignores_nested_subsections(tmp_path: Path):
+def test_extract_required_check_names_ignores_nested_subsections(tmp_path: Path) -> None:
     doc = tmp_path / "CI_REQUIRED_GATES.md"
     doc.write_text(
         """
@@ -119,7 +120,7 @@ No enumerated checks here.
 def test_extract_required_check_names_fails_closed_when_section_missing_or_empty(
     tmp_path: Path,
     doc_text: str,
-):
+) -> None:
     doc = tmp_path / "CI_REQUIRED_GATES.md"
     doc.write_text(doc_text, encoding="utf-8")
 
@@ -127,18 +128,18 @@ def test_extract_required_check_names_fails_closed_when_section_missing_or_empty
         extract_required_check_names(doc)
 
 
-def test_normalize_bullet_text_collapses_internal_whitespace():
+def test_normalize_bullet_text_collapses_internal_whitespace() -> None:
     assert normalize_bullet_text("  Add   release   notes \n with tabs\t") == (
         "Add release notes with tabs"
     )
 
 
-def test_validate_release_branch_rejects_unsupported_branch():
+def test_validate_release_branch_rejects_unsupported_branch() -> None:
     with pytest.raises(ValueError, match="main"):
         validate_release_branch("dev")
 
 
-def test_find_exact_duplicate_bullets_only_within_same_section():
+def test_find_exact_duplicate_bullets_only_within_same_section() -> None:
     duplicate_bullets = find_exact_duplicate_bullets(
         {
             "Added": [
@@ -162,7 +163,7 @@ def test_find_exact_duplicate_bullets_only_within_same_section():
     ]
 
 
-def test_promote_changelog_unreleased_section_moves_content_and_resets_headings():
+def test_promote_changelog_unreleased_section_moves_content_and_resets_headings() -> None:
     changelog_text = (
         "# Changelog\n\n"
         "## [Unreleased]\n\n"
@@ -199,7 +200,7 @@ def test_promote_changelog_unreleased_section_moves_content_and_resets_headings(
     assert promoted_text.index("## [Unreleased]") < promoted_text.index("## [0.1.30] - 2026-04-22")
 
 
-def test_promote_changelog_unreleased_section_rejects_exact_duplicates_within_subsection():
+def test_promote_changelog_unreleased_section_rejects_exact_duplicates_within_subsection() -> None:
     changelog_text = (
         "# Changelog\n\n"
         "## [Unreleased]\n\n"
@@ -218,7 +219,7 @@ def test_promote_changelog_unreleased_section_rejects_exact_duplicates_within_su
         )
 
 
-def test_promote_changelog_unreleased_section_reports_cross_section_near_duplicates_as_warnings():
+def test_promote_changelog_unreleased_section_reports_cross_section_near_duplicates_as_warnings() -> None:
     changelog_text = (
         "# Changelog\n\n"
         "## [Unreleased]\n\n"
@@ -237,6 +238,27 @@ def test_promote_changelog_unreleased_section_reports_cross_section_near_duplica
     assert "## [0.1.30] - 2026-04-22" in promoted_text
     assert warnings
     assert any("Added" in warning and "Changed" in warning for warning in warnings)
+
+
+def test_promote_changelog_unreleased_section_rejects_headings_without_bullets() -> None:
+    changelog_text = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n\n"
+        "### Changed\n\n"
+        "### Fixed\n\n"
+        "### Removed\n\n"
+        "## [0.1.30] - 2026-04-20\n\n"
+        "### Added\n\n"
+        "- Existing release entry\n"
+    )
+
+    with pytest.raises(ValueError, match="(?i)unreleased.*no bullets|no bullets"):
+        promote_changelog_unreleased_section(
+            changelog_text=changelog_text,
+            version="0.1.31",
+            release_date="2026-04-27",
+        )
 
 
 @pytest.mark.parametrize(
@@ -262,7 +284,7 @@ def test_promote_changelog_unreleased_section_reports_cross_section_near_duplica
         ),
     ],
 )
-def test_promote_changelog_unreleased_section_rejects_unsupported_content(unsupported_slice: str):
+def test_promote_changelog_unreleased_section_rejects_unsupported_content(unsupported_slice: str) -> None:
     with pytest.raises(ValueError, match="(?i)unreleased|unsupported|ambiguous"):
         promote_changelog_unreleased_section(
             changelog_text=unsupported_slice,
@@ -271,22 +293,22 @@ def test_promote_changelog_unreleased_section_rejects_unsupported_content(unsupp
         )
 
 
-def test_update_readme_release_references_raises_when_expected_anchors_missing():
+def test_update_readme_release_references_raises_when_expected_anchors_missing() -> None:
     with pytest.raises(ValueError, match="(?i)readme|release line|anchor"):
         update_readme_release_references("README without current release anchors", "0.1.30")
 
 
-def test_update_mkdocs_version_metadata_raises_when_expected_anchors_missing():
+def test_update_mkdocs_version_metadata_raises_when_expected_anchors_missing() -> None:
     with pytest.raises(ValueError, match="(?i)mkdocs|anchor|version"):
         update_mkdocs_version_metadata("extra:\n  generator: false\n", "0.1.30")
 
 
-def test_update_release_notes_entry_point_raises_when_anchor_missing():
+def test_update_release_notes_entry_point_raises_when_anchor_missing() -> None:
     with pytest.raises(ValueError, match="(?i)release notes|anchor"):
         update_release_notes_entry_point("Published release notes entry point.", "Docs/Development/Release_Process.md")
 
 
-def test_classify_release_state_rejects_inconsistent_snapshot():
+def test_classify_release_state_rejects_inconsistent_snapshot() -> None:
     with pytest.raises(ValueError, match="inconsistent"):
         classify_release_state(
             local_release_commit_exists=True,
@@ -337,13 +359,14 @@ def test_classify_release_state_rejects_inconsistent_snapshot():
         ),
     ],
 )
-def test_classify_release_state(kwargs: dict[str, bool], expected: str):
+def test_classify_release_state(kwargs: dict[str, bool], expected: str) -> None:
     assert classify_release_state(**kwargs) == expected
 
 
 class StubReleaseRunner:
     def __init__(self) -> None:
         self.branch = "main"
+        self.dry_run = False
         self.worktree_clean = True
         self.origin_main_sha = "abc123prebump"
         self.head_sha = self.origin_main_sha
@@ -360,7 +383,9 @@ class StubReleaseRunner:
         self.remote_main_sha = self.origin_main_sha
         self.push_main_error: str | None = None
         self.recorded_check_sha: list[str] = []
+        self.metadata_warnings: list[str] = []
         self.metadata_prepared = False
+        self.release_notes_from_tag_prepared = False
         self.commit_created = False
         self.tag_created = False
         self.github_release_created = False
@@ -411,6 +436,14 @@ class StubReleaseRunner:
         self.operations.append(f"prepare_metadata:{current_version}->{next_version}")
         self.metadata_prepared = True
 
+    def get_metadata_warnings(self) -> list[str]:
+        self.operations.append("get_metadata_warnings")
+        return self.metadata_warnings
+
+    def prepare_release_notes_from_tag(self, version: str) -> None:
+        self.operations.append(f"prepare_release_notes_from_tag:{version}")
+        self.release_notes_from_tag_prepared = True
+
     def create_release_commit(self, next_version: str) -> str:
         self.operations.append(f"create_release_commit:{next_version}")
         self.commit_created = True
@@ -434,12 +467,15 @@ class StubReleaseRunner:
         self.operations.append(f"push_tag:{version}")
         self.pushed_tag = True
 
-    def create_github_release(self, version: str) -> None:
+    def create_github_release(self, version: str) -> bool:
         self.operations.append(f"create_github_release:{version}")
+        if self.dry_run:
+            return False
         self.github_release_created = True
+        return True
 
 
-def test_orchestrate_release_requires_main_branch():
+def test_orchestrate_release_requires_main_branch() -> None:
     runner = StubReleaseRunner()
     runner.branch = "dev"
 
@@ -455,7 +491,7 @@ def test_orchestrate_release_requires_main_branch():
     assert "prepare_metadata" not in " ".join(runner.operations)
 
 
-def test_orchestrate_release_requires_clean_worktree():
+def test_orchestrate_release_requires_clean_worktree() -> None:
     runner = StubReleaseRunner()
     runner.worktree_clean = False
 
@@ -475,7 +511,7 @@ def test_orchestrate_release_requires_clean_worktree():
     assert runner.metadata_prepared is False
 
 
-def test_orchestrate_release_hard_aborts_on_non_fast_forward_push_failure():
+def test_orchestrate_release_hard_aborts_on_non_fast_forward_push_failure() -> None:
     runner = StubReleaseRunner()
     runner.remote_main_sha = "def456moved"
     runner.push_main_error = "git push origin main failed: non-fast-forward"
@@ -497,7 +533,7 @@ def test_orchestrate_release_hard_aborts_on_non_fast_forward_push_failure():
     assert runner.operations.count("fetch_origin_main") == 1
 
 
-def test_orchestrate_release_resumes_from_remote_tag_without_github_release():
+def test_orchestrate_release_resumes_from_remote_tag_without_github_release() -> None:
     runner = StubReleaseRunner()
     runner.release_state = "remote_tag_without_github_release"
 
@@ -510,15 +546,51 @@ def test_orchestrate_release_resumes_from_remote_tag_without_github_release():
 
     assert result["state"] == "remote_tag_without_github_release"
     assert result["github_release_created"] is True
+    assert runner.release_notes_from_tag_prepared is True
     assert runner.github_release_created is True
     assert runner.commit_created is False
     assert runner.tag_created is False
     assert runner.pushed_main is False
     assert runner.pushed_tag is False
     assert "prepare_metadata" not in " ".join(runner.operations)
+    assert runner.operations.index("prepare_release_notes_from_tag:0.1.32") < runner.operations.index(
+        "create_github_release:0.1.32"
+    )
 
 
-def test_orchestrate_release_uses_prebump_origin_main_sha_for_required_checks_only():
+def test_orchestrate_release_reports_dry_run_without_created_release() -> None:
+    runner = StubReleaseRunner()
+    runner.dry_run = True
+
+    result = orchestrate_release(
+        bump="patch",
+        runner=runner,
+        pyproject_path=REPO_ROOT / "pyproject.toml",
+        ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+    )
+
+    assert result["dry_run"] is True
+    assert result["github_release_created"] is False
+    assert runner.github_release_created is False
+
+
+def test_orchestrate_release_includes_metadata_warnings() -> None:
+    runner = StubReleaseRunner()
+    runner.metadata_warnings = [
+        "Near-duplicate changelog bullets across Added and Changed: 'a' ~ 'a docs'"
+    ]
+
+    result = orchestrate_release(
+        bump="patch",
+        runner=runner,
+        pyproject_path=REPO_ROOT / "pyproject.toml",
+        ci_gates_doc_path=REPO_ROOT / "Docs" / "Development" / "CI_REQUIRED_GATES.md",
+    )
+
+    assert result["warnings"] == runner.metadata_warnings
+
+
+def test_orchestrate_release_uses_prebump_origin_main_sha_for_required_checks_only() -> None:
     runner = StubReleaseRunner()
 
     result = orchestrate_release(
@@ -537,7 +609,7 @@ def test_orchestrate_release_uses_prebump_origin_main_sha_for_required_checks_on
     assert runner.github_release_created is True
 
 
-def test_orchestrate_release_local_tag_only_fails_closed_when_tag_points_behind_head():
+def test_orchestrate_release_local_tag_only_fails_closed_when_tag_points_behind_head() -> None:
     runner = StubReleaseRunner()
     runner.release_state = "local_tag_only"
     runner.head_sha = "newer-head-commit"
@@ -556,7 +628,7 @@ def test_orchestrate_release_local_tag_only_fails_closed_when_tag_points_behind_
     assert runner.github_release_created is False
 
 
-def test_shell_release_runner_prepare_metadata_allows_cross_section_warning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+def test_shell_release_runner_prepare_metadata_allows_cross_section_warning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     repo_root = tmp_path
     (repo_root / "Docs" / "Published").mkdir(parents=True)
 
@@ -606,10 +678,34 @@ version = "0.1.30"
     assert runner._release_notes_body is not None
     assert "## [0.1.31] - " in runner._release_notes_body
     assert "Add release helper core docs and metadata" in runner._release_notes_body
+    assert runner.get_metadata_warnings()
     assert all("Docs/site" not in str(path) for path in runner._prepared_paths)
 
 
-def test_shell_release_runner_create_or_update_tag_uses_annotated_tag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+def test_shell_release_runner_run_command_uses_absolute_executable_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    recorded_commands: list[list[str]] = []
+
+    def _fake_run(
+        command_args: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(list(command_args))
+        return subprocess.CompletedProcess(command_args, 0, "ok", "")
+
+    monkeypatch.setattr(release_module.subprocess, "run", _fake_run)
+
+    runner = ShellReleaseRunner(repo_root=tmp_path, dry_run=False)
+
+    runner._run_command(["git", "status"])
+
+    assert recorded_commands
+    assert Path(recorded_commands[0][0]).is_absolute()
+
+
+def test_shell_release_runner_create_or_update_tag_uses_annotated_tag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     recorded_commands: list[list[str]] = []
 
     def _fake_run_command(


### PR DESCRIPTION
## Summary
- Consolidates the terminal stack branch history into the current pushed branch.
- Adds release automation docs, helper orchestration, Make targets, workflow boundary updates, and contract tests.
- Keeps Docs/site as ignored generated documentation output, not release-controlled source material.

## Test Plan
- [x] source .venv/bin/activate && python -m pytest tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py tldw_Server_API/tests/CI/test_release_workflow_contracts.py tldw_Server_API/tests/Utils/test_release_helper.py tldw_Server_API/tests/Utils/test_makefile_release_targets.py tldw_Server_API/tests/Docs/test_release_docs_contract.py -v
- [x] source .venv/bin/activate && python -m bandit Helper_Scripts/release.py tldw_Server_API/tests/CI/test_pypi_workflow_contracts.py tldw_Server_API/tests/CI/test_release_workflow_contracts.py tldw_Server_API/tests/Utils/test_release_helper.py tldw_Server_API/tests/Utils/test_makefile_release_targets.py tldw_Server_API/tests/Docs/test_release_docs_contract.py -f json -o /tmp/bandit_release_process_touched.json
- [x] source .venv/bin/activate && python Helper_Scripts/release.py --dry-run --bump patch

## Change summary
Human-written Change summary required before this PR is merge-ready. Explain what changed and why these implementation choices were made.