### PR TITLE
docs: refresh RAG module README orientation

### DIFF
--- a/Docs/superpowers/plans/2026-04-24-rag-module-readme-orientation-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-24-rag-module-readme-orientation-implementation-plan.md
@@ -1,0 +1,418 @@
+# RAG Module README Orientation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite `tldw_Server_API/app/core/RAG/README.md` into a concise, accurate contributor orientation with a curated advanced appendix.
+
+**Architecture:** This is a docs-only replacement of an overgrown module README. The implementation gathers current facts from active RAG endpoint/schema/pipeline files, rewrites the README around active unified RAG paths, and validates that stale functional-pipeline guidance is no longer presented as active contributor guidance.
+
+**Tech Stack:** Markdown, FastAPI route/source inspection, Pydantic schema inspection, `rg`, project virtualenv for optional Bandit validation.
+
+---
+
+## File Structure
+
+- Modify: `tldw_Server_API/app/core/RAG/README.md`
+  - Responsibility: quick contributor orientation for the active RAG module.
+  - Final shape: start-here section, request flow, module map, common contributor tasks, endpoint summary, configuration/profile notes, testing commands, curated advanced notes, and accurately labeled related docs.
+
+- Reference only: `Docs/superpowers/specs/2026-04-24-rag-module-readme-orientation-design.md`
+  - Responsibility: approved design and accuracy rules.
+
+- Reference only: `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`
+  - Responsibility: active unified RAG API router.
+
+- Reference only: `tldw_Server_API/app/api/v1/endpoints/rag_health.py`
+  - Responsibility: active RAG operational health/cache/metrics router.
+
+- Reference only: `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py`
+  - Responsibility: public unified RAG request/response schemas.
+
+- Reference only: `tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py`
+  - Responsibility: active RAG pipeline entrypoints.
+
+- Reference only: `tldw_Server_API/app/core/RAG/rag_service/profiles.py`
+  - Responsibility: internal profile helper definitions and profile merge semantics.
+
+- Reference only: `tldw_Server_API/app/core/RAG/rag_service/database_retrievers.py`
+  - Responsibility: retrieval source names and retriever classes.
+
+- Reference only: `tldw_Server_API/app/core/RAG/rag_service/vector_stores/`
+  - Responsibility: vector-store adapter names and extension point.
+
+No Python source files should be modified.
+
+---
+
+### Task 1: Gather Current RAG Facts
+
+**Files:**
+- Read: `Docs/superpowers/specs/2026-04-24-rag-module-readme-orientation-design.md`
+- Read: `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`
+- Read: `tldw_Server_API/app/api/v1/endpoints/rag_health.py`
+- Read: `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py`
+- Read: `tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py`
+- Read: `tldw_Server_API/app/core/RAG/rag_service/profiles.py`
+- Read: `tldw_Server_API/app/core/RAG/rag_service/database_retrievers.py`
+- Read: `tldw_Server_API/app/core/RAG/rag_service/vector_stores/`
+- Test: source-inspection commands only
+
+- [ ] **Step 1: Confirm the approved scope**
+
+Run:
+
+```bash
+sed -n '1,240p' Docs/superpowers/specs/2026-04-24-rag-module-readme-orientation-design.md
+```
+
+Expected: spec describes a README-only orientation update, no Python behavior changes, and the link caveat for stale deep docs.
+
+- [ ] **Step 2: Capture active endpoint inventory**
+
+Run:
+
+```bash
+rg -n '@router\.(get|post)\(' -A 8 tldw_Server_API/app/api/v1/endpoints/rag_unified.py tldw_Server_API/app/api/v1/endpoints/rag_health.py
+```
+
+Expected: output includes `/search`, `/search/stream`, `/batch`, `/batch/resume/{checkpoint_id}`, `/feedback/implicit`, `/capabilities`, `/features`, `/simple`, `/advanced`, `/vlm/backends`, `/ablate`, and health/cache/metrics endpoints.
+
+- [ ] **Step 3: Confirm router prefixes**
+
+Run:
+
+```bash
+rg -n 'router = APIRouter|include_router\(.*rag|rag_unified|rag_health' tldw_Server_API/app/api/v1/endpoints/rag_unified.py tldw_Server_API/app/api/v1/endpoints/rag_health.py tldw_Server_API/app/main.py
+```
+
+Expected: both routers use `/api/v1/rag` and are included from `main.py`.
+
+- [ ] **Step 4: Confirm public schema and profile values**
+
+Run:
+
+```bash
+rg -n 'class UnifiedRAGRequest|class UnifiedRAGResponse|class UnifiedBatchRequest|class UnifiedBatchResponse|rag_profile' tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py
+```
+
+Expected: public schema classes exist and `rag_profile` accepts `fast`, `balanced`, and `accuracy`.
+
+- [ ] **Step 5: Confirm internal profile helper names**
+
+Run:
+
+```bash
+sed -n '1,340p' tldw_Server_API/app/core/RAG/rag_service/profiles.py
+```
+
+Expected: internal helpers include additional profile names such as `production`, `research`, and `cheap`; README must distinguish these from public request `rag_profile` values if mentioned.
+
+- [ ] **Step 6: Confirm active pipeline entrypoints**
+
+Run:
+
+```bash
+rg -n 'async def unified_rag_pipeline|async def unified_batch_pipeline|async def simple_search|async def advanced_search' tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py
+```
+
+Expected: active entrypoints are `unified_rag_pipeline`, `unified_batch_pipeline`, `simple_search`, and `advanced_search`.
+
+- [ ] **Step 7: Confirm retrieval and vector-store terminology**
+
+Run:
+
+```bash
+rg -n 'class .*Retriever|DataSource|RetrievalConfig|media_db|notes|characters|chats|kanban|sql' tldw_Server_API/app/core/RAG/rag_service/database_retrievers.py
+find tldw_Server_API/app/core/RAG/rag_service/vector_stores -maxdepth 1 -type f -name '*.py' -print | sort
+```
+
+Expected: current retrieval sources and vector-store adapters are visible; README should use these names rather than older aliases.
+
+- [ ] **Step 8: Confirm current test locations**
+
+Run:
+
+```bash
+rg --files tldw_Server_API/tests/RAG_NEW tldw_Server_API/tests/RAG tldw_Server_API/tests/e2e | rg 'rag|RAG'
+```
+
+Expected: current unit/integration/e2e RAG tests are found; README should list representative folders and targeted commands without inventing missing files.
+
+---
+
+### Task 2: Replace README With Orientation Structure
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/RAG/README.md`
+- Test: stale-term check should fail before the rewrite and pass after the rewrite
+
+- [ ] **Step 1: Run stale active-guide check before editing**
+
+Run:
+
+```bash
+rg -n 'functional_pipeline\.py|rag_api\.py|standard_pipeline|minimal_pipeline|quality_pipeline|IMPLEMENTATION_STATUS\.md|DEPRECATION_NOTICE\.md' tldw_Server_API/app/core/RAG/README.md
+```
+
+Expected: current README reports stale or missing-doc references. This confirms the rewrite is addressing known drift.
+
+- [ ] **Step 2: Replace the top-level README with the approved structure**
+
+Edit `tldw_Server_API/app/core/RAG/README.md` with these sections in this order:
+
+```markdown
+# RAG Module
+
+## Start Here
+
+## Request Flow
+
+## Module Map
+
+## Common Contributor Tasks
+
+## Current Endpoints
+
+## Configuration And Profiles
+
+## Testing
+
+## Advanced Notes
+
+## Related Documentation
+```
+
+Expected: the old long README content is replaced rather than patched in place, with only concise source-verified advanced notes carried forward.
+
+- [ ] **Step 3: Write the opening role statement**
+
+Include text equivalent to:
+
+```markdown
+This README is a contributor orientation for the backend RAG module. It is not the full API reference or a complete implementation guide; use it to find the active code paths and then follow the linked docs or source files for detail.
+```
+
+Expected: readers know the README's scope immediately.
+
+- [ ] **Step 4: Add `Start Here`**
+
+Document active entrypoints:
+
+```markdown
+- API routers: `rag_unified.py`, `rag_health.py`
+- Public schemas: `UnifiedRAGRequest`, `UnifiedRAGResponse`, `UnifiedBatchRequest`, `UnifiedBatchResponse`
+- Core pipeline: `unified_rag_pipeline()`, `unified_batch_pipeline()`
+- Convenience functions: `simple_search()`, `advanced_search()`
+```
+
+Expected: no source line numbers and no archived functional-pipeline names.
+
+- [ ] **Step 5: Add `Request Flow`**
+
+Summarize the active flow:
+
+```markdown
+POST /api/v1/rag/search
+  -> UnifiedRAGRequest validation
+  -> auth/rate-limit/permission dependencies
+  -> profile/default resolution
+  -> per-user DB adapter/path injection
+  -> unified_rag_pipeline(...)
+  -> UnifiedRAGResponse mapping
+```
+
+Expected: the flow mentions adjacent batch, streaming, capability, and health paths but does not over-explain every internal branch.
+
+- [ ] **Step 6: Add `Module Map`**
+
+Group files by responsibility:
+
+```markdown
+- `API_DOCUMENTATION.md`: local endpoint/parameter reference.
+- `CAPABILITIES.md`: feature discovery and capability summary.
+- `UNIFIED_PIPELINE_EXAMPLES.md`: request and pipeline examples to verify against current schema.
+- `exceptions.py`: RAG-specific exception types.
+- `rag_custom_metrics.py`: RAG metrics helpers.
+- `rag_service/`: implementation package for retrieval, generation, guardrails, citations, profiles, vector stores, metrics, and utilities.
+```
+
+Expected: the map is concise and avoids claiming stale docs are authoritative.
+
+---
+
+### Task 3: Fill Contributor Tasks, Endpoints, Profiles, Tests, And Advanced Notes
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/RAG/README.md`
+- Test: source-inspection and stale-term commands
+
+- [ ] **Step 1: Add `Common Contributor Tasks`**
+
+Map common tasks to files:
+
+```markdown
+- Add retrieval behavior: `rag_service/database_retrievers.py`
+- Add vector-store support: `rag_service/vector_stores/`
+- Adjust profiles/defaults: `rag_service/profiles.py` plus endpoint payload handling in `rag_unified.py`
+- Adjust request/response contract: `rag_schemas_unified.py` and endpoint response mapping
+- Adjust reranking: `rag_service/advanced_reranking.py`
+- Adjust generation/streaming: `rag_service/generation.py`, `rag_service/response_writer.py`, and `/search/stream`
+- Adjust guardrails/citations/claims: `guardrails.py`, `citations.py`, `claims.py`, `faithfulness.py`, and related tests
+```
+
+Expected: contributor task mappings are practical and source-verified.
+
+- [ ] **Step 2: Add grouped `Current Endpoints`**
+
+Group endpoints by purpose rather than by source line:
+
+```markdown
+- Primary search: `POST /api/v1/rag/search`
+- Streaming search: `POST /api/v1/rag/search/stream`
+- Convenience search: `GET /api/v1/rag/simple`, `GET /api/v1/rag/advanced`
+- Batch: `POST /api/v1/rag/batch`, `POST /api/v1/rag/batch/resume/{checkpoint_id}`
+- Feedback and experiments: `POST /api/v1/rag/feedback/implicit`, `POST /api/v1/rag/ablate`
+- Discovery: `GET /api/v1/rag/capabilities`, `GET /api/v1/rag/features`, `GET /api/v1/rag/vlm/backends`
+- Operational: `GET /api/v1/rag/health`, `GET /api/v1/rag/health/live`, `GET /api/v1/rag/health/ready`, cache/metrics/cost/batch-job/regression endpoints from `rag_health.py`
+```
+
+Expected: endpoint names match the router decorators inspected in Task 1.
+
+- [ ] **Step 3: Add `Configuration And Profiles`**
+
+Document profile behavior carefully:
+
+```markdown
+- Public request `rag_profile` values are `fast`, `balanced`, and `accuracy`.
+- `profiles.py` also contains internal helper profiles such as `production`, `research`, and `cheap`; do not assume they are accepted directly by `UnifiedRAGRequest`.
+- Explicit request fields override profile defaults.
+- `index_namespace` can be set directly or via `corpus`.
+- Production deployments should prefer injected DB adapters/paths over raw fallback assumptions.
+```
+
+Expected: README avoids confusing public request schema with internal helpers.
+
+- [ ] **Step 4: Add `Testing`**
+
+Include representative focused commands:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_rag_request_schema_profiles.py -v
+python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_rag_profiles.py -v
+python -m pytest tldw_Server_API/tests/RAG_NEW/integration/test_rag_health_endpoints.py -v
+python -m pytest tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py -v
+python -m pytest tldw_Server_API/tests/RAG/test_rag_sources_sql_validation.py -v
+```
+
+Expected: commands reference existing files only and are clearly examples, not mandatory for a docs-only README edit.
+
+- [ ] **Step 5: Add `Advanced Notes`**
+
+Keep short notes only on:
+
+```markdown
+- Streaming requires `enable_generation=true`.
+- Vector search depends on embeddings/vector-store availability; hybrid search can still use FTS.
+- Citations, hard-citation gating, claims, numeric fidelity, and post-verification can abstain or ask for clarification when evidence is weak.
+- Reranking options can carry cost/latency tradeoffs; two-tier reranking is quality-oriented.
+- Multi-tenant or production usage should avoid assumptions about raw SQL fallbacks and should preserve user/tenant scoping.
+```
+
+Expected: appendix is concise and source-verified; long cURL examples and parameter catalogs stay out of the README.
+
+- [ ] **Step 6: Add `Related Documentation` with accurate role labels**
+
+Use labels like:
+
+```markdown
+- `API_DOCUMENTATION.md`: local endpoint/parameter reference.
+- `CAPABILITIES.md`: capability summary.
+- `UNIFIED_PIPELINE_EXAMPLES.md`: examples to verify against the current schema.
+- `rag_service/README.md`: package-level implementation map.
+- `Docs/API-related/RAG_API_Documentation.md`: broader API doc; verify against current schema before treating examples as definitive.
+- `Docs/Code_Documentation/RAG-Developer-Guide.md`: broader guide that may contain legacy context; prefer current source files for active behavior.
+```
+
+Expected: no stale broader guide is called canonical, authoritative, or source of truth.
+
+---
+
+### Task 4: Validate And Commit README Rewrite
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/RAG/README.md`
+- Test: Markdown/source-inspection commands, optional Bandit record
+
+- [ ] **Step 1: Run stale active-guide check after editing**
+
+Run:
+
+```bash
+rg -n 'functional_pipeline\.py|rag_api\.py|standard_pipeline|minimal_pipeline|quality_pipeline|IMPLEMENTATION_STATUS\.md|DEPRECATION_NOTICE\.md' tldw_Server_API/app/core/RAG/README.md
+```
+
+Expected: no output. If output exists, it must be clearly marked legacy context; prefer removing it entirely from this README.
+
+- [ ] **Step 2: Check that stale authority language is absent**
+
+Run:
+
+```bash
+rg -n 'canonical|authoritative|source of truth' tldw_Server_API/app/core/RAG/README.md
+```
+
+Expected: no output, unless the term appears only in a warning not to treat stale docs that way. Prefer no output.
+
+- [ ] **Step 3: Check endpoint and profile terms**
+
+Run:
+
+```bash
+rg -n '/api/v1/rag/(search|search/stream|batch|batch/resume|simple|advanced|capabilities|features|vlm/backends|health)' tldw_Server_API/app/core/RAG/README.md
+rg -n 'fast|balanced|accuracy|production|research|cheap' tldw_Server_API/app/core/RAG/README.md
+```
+
+Expected: active endpoint references are present; public profiles are distinguished from internal helper profiles if both are mentioned.
+
+- [ ] **Step 4: Review final README headings**
+
+Run:
+
+```bash
+rg -n '^#{1,3} ' tldw_Server_API/app/core/RAG/README.md
+```
+
+Expected: headings match the planned structure and the document is much shorter than the previous long README.
+
+- [ ] **Step 5: Optional project security checklist record**
+
+Run only if needed for the final project checklist:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r tldw_Server_API/app/core/RAG -f json -o /tmp/bandit_rag_readme_orientation.json
+```
+
+Expected: any Bandit findings are baseline findings in untouched Python files. A README-only change should not introduce Python findings.
+
+- [ ] **Step 6: Review diff**
+
+Run:
+
+```bash
+git diff -- tldw_Server_API/app/core/RAG/README.md
+```
+
+Expected: diff replaces stale long-form content with a concise orientation and does not touch unrelated files.
+
+- [ ] **Step 7: Commit README update**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/core/RAG/README.md
+git commit -m "docs: refresh rag module readme orientation"
+```
+
+Expected: commit contains only `tldw_Server_API/app/core/RAG/README.md`.

--- a/Docs/superpowers/specs/2026-04-24-rag-module-readme-orientation-design.md
+++ b/Docs/superpowers/specs/2026-04-24-rag-module-readme-orientation-design.md
@@ -37,6 +37,12 @@ Supporting docs may be linked but should not be rewritten as part of this task u
 - `tldw_Server_API/app/core/RAG/UNIFIED_PIPELINE_EXAMPLES.md`
 - `tldw_Server_API/app/core/RAG/rag_service/README.md`
 
+Important link caveat:
+
+- Some deeper RAG docs currently still contain stale functional-pipeline guidance. The README must not describe those docs as authoritative unless their current content is verified during implementation.
+- If a linked doc is useful but stale in places, the README should label it by its actual role, such as "legacy/migration context" or "API examples, verify against current schema", rather than presenting it as the source of truth.
+- When in doubt, prefer linking to current code files, `API_DOCUMENTATION.md`, `CAPABILITIES.md`, and `UNIFIED_PIPELINE_EXAMPLES.md` over stale broad guides.
+
 Out of scope:
 
 - Python behavior changes.
@@ -56,7 +62,7 @@ Why this is preferred:
 - Preserves the README as a fast entrypoint.
 - Avoids carrying forward stale examples and missing-doc links.
 - Keeps advanced RAG concepts discoverable without making the README a full manual.
-- Leaves canonical deep-dive and API details in dedicated docs.
+- Leaves deep-dive and API details in dedicated docs that are verified or clearly labeled by role.
 
 ### Alternative: Short orientation only
 
@@ -120,10 +126,12 @@ The updated README should be concise at the top and explicit about its role. It 
 6. `## Current Endpoints`
    - Summarize active RAG endpoints from `rag_unified.py` and `rag_health.py`.
    - Avoid brittle source line numbers.
+   - Group endpoints by purpose: primary search, convenience/search presets, batch/resume, feedback, capabilities/features, VLM helpers, and operational health/cache/metrics.
    - Point to API docs for full request and response examples.
 
 7. `## Configuration And Profiles`
    - Explain request-level options, `rag_profile`, environment/config defaults, and production adapter expectations at a high level.
+   - Distinguish public API `rag_profile` values from internal profile helper names if both are mentioned.
    - Link deeper config details instead of duplicating every knob.
 
 8. `## Testing`
@@ -136,7 +144,7 @@ The updated README should be concise at the top and explicit about its role. It 
    - Avoid long cURL examples and parameter catalogs that belong in API docs.
 
 10. `## Related Documentation`
-    - Link canonical deeper docs and examples.
+    - Link deeper docs and examples only with accurate role labels.
     - Make ownership clear so future contributors know where to edit.
 
 ## Accuracy Rules
@@ -145,10 +153,12 @@ The updated README should be concise at the top and explicit about its role. It 
 - Verify public request/response names from `rag_schemas_unified.py`.
 - Verify pipeline entrypoints from `unified_pipeline.py`.
 - Verify profile names and precedence behavior from `profiles.py` and endpoint handling.
+- Distinguish public request profiles accepted by `UnifiedRAGRequest` from additional internal profiles exposed by `profiles.py`.
 - Verify retrieval and vector-store terminology from retriever and vector-store modules.
 - Verify current test paths with `rg --files`.
 - Do not preserve source line references in the README; they drift quickly.
 - Do not link missing files such as `IMPLEMENTATION_STATUS.md` or `DEPRECATION_NOTICE.md` unless they exist when implementation happens.
+- Do not call a deeper RAG doc "canonical", "authoritative", or "source of truth" unless its current content is verified as current during the implementation pass.
 - Mention archived functional pipelines only as legacy context, not as active contributor guidance.
 - Omit, shorten, or label uncertain features instead of presenting them as guaranteed behavior.
 
@@ -170,13 +180,20 @@ Validation steps:
   - `DEPRECATION_NOTICE.md`
 - Review Markdown headings and local links for readability.
 
-No Bandit run is required because no Python code changes are planned.
+No Python code changes are planned. If the final project checklist requires a Bandit record anyway, run it from the project virtual environment against the nearest Python scope, for example:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r tldw_Server_API/app/core/RAG -f json -o /tmp/bandit_rag_readme_orientation.json
+```
+
+Treat any findings as baseline unless they are in Python code changed by this task; this README update should not introduce Python security findings.
 
 ## Success Criteria
 
 - The README quickly orients contributors to the active unified RAG path.
 - Stale functional-pipeline guidance is removed or clearly marked as legacy context.
 - Missing-doc links and brittle line-number references are removed.
-- The README points API users and deep implementation readers to the right dedicated docs.
+- The README points API users and deep implementation readers to the right dedicated docs without presenting stale docs as authoritative.
 - The advanced appendix contains only concise, source-verified notes.
 - No unrelated dirty worktree files are modified.

--- a/Docs/superpowers/specs/2026-04-24-rag-module-readme-orientation-design.md
+++ b/Docs/superpowers/specs/2026-04-24-rag-module-readme-orientation-design.md
@@ -1,0 +1,182 @@
+# RAG Module README Orientation Design
+
+Date: 2026-04-24
+Topic: RAG module README accuracy and contributor orientation
+Status: Approved design
+
+## Objective
+
+Update `tldw_Server_API/app/core/RAG/README.md` so it is accurate, current, and useful as a quick contributor orientation for the RAG module.
+
+The README should not be the canonical deep implementation guide or the full API reference. Its job is to help a contributor landing in `app/core/RAG/` quickly understand what is active, where the main request path starts, which files matter, how the pieces fit together, and where to go next for deeper detail.
+
+## Scope
+
+Primary file to update:
+
+- `tldw_Server_API/app/core/RAG/README.md`
+
+Source files to verify against:
+
+- `tldw_Server_API/app/api/v1/endpoints/rag_unified.py`
+- `tldw_Server_API/app/api/v1/endpoints/rag_health.py`
+- `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py`
+- `tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py`
+- `tldw_Server_API/app/core/RAG/rag_service/profiles.py`
+- `tldw_Server_API/app/core/RAG/rag_service/database_retrievers.py`
+- `tldw_Server_API/app/core/RAG/rag_service/vector_stores/`
+- Current RAG tests under `tldw_Server_API/tests/RAG_NEW`, `tldw_Server_API/tests/RAG`, and relevant e2e test files.
+
+Supporting docs may be linked but should not be rewritten as part of this task unless a link target needs a tiny correction:
+
+- `Docs/Code_Documentation/RAG-Developer-Guide.md`
+- `Docs/API-related/RAG_API_Documentation.md`
+- `Docs/API-related/RAG-API-Guide.md`
+- `tldw_Server_API/app/core/RAG/API_DOCUMENTATION.md`
+- `tldw_Server_API/app/core/RAG/CAPABILITIES.md`
+- `tldw_Server_API/app/core/RAG/UNIFIED_PIPELINE_EXAMPLES.md`
+- `tldw_Server_API/app/core/RAG/rag_service/README.md`
+
+Out of scope:
+
+- Python behavior changes.
+- Endpoint/schema changes.
+- Broad RAG documentation consolidation beyond this README.
+- Updating unrelated dirty worktree files.
+- Reworking archived functional-pipeline docs.
+
+## Approaches Considered
+
+### Recommended: Orientation plus curated appendix
+
+Replace the current long README with a concise orientation page, then keep a short advanced appendix with only source-verified notes that are useful to contributors working inside `rag_service/`.
+
+Why this is preferred:
+
+- Preserves the README as a fast entrypoint.
+- Avoids carrying forward stale examples and missing-doc links.
+- Keeps advanced RAG concepts discoverable without making the README a full manual.
+- Leaves canonical deep-dive and API details in dedicated docs.
+
+### Alternative: Short orientation only
+
+Replace the README with a very short module map and links.
+
+Trade-offs:
+
+- Lowest maintenance burden.
+- Risks being too thin for contributors who need immediate context on streaming, guardrails, reranking, citations, and production gotchas.
+
+### Alternative: Correct the current long README in place
+
+Keep most sections and patch stale references.
+
+Trade-offs:
+
+- Least disruptive to existing document shape.
+- Preserves duplication with API and developer docs.
+- Higher risk of future drift because the README remains too broad.
+
+## Chosen Design
+
+Use the recommended orientation plus curated appendix approach.
+
+The updated README should be concise at the top and explicit about its role. It should state that deeper implementation and API references live elsewhere, then focus on active code paths and contributor navigation.
+
+## Proposed README Structure
+
+1. `# RAG Module`
+   - Short description of the active unified RAG module.
+   - One sentence explaining that this README is a contributor orientation, not the complete API reference.
+
+2. `## Start Here`
+   - Active API router files.
+   - Active schema file.
+   - Active pipeline entrypoints.
+   - Link to deeper developer/API docs.
+
+3. `## Request Flow`
+   - `POST /api/v1/rag/search` receives a `UnifiedRAGRequest`.
+   - Endpoint dependencies apply auth/rate limits and resolve profile/default behavior.
+   - User/tenant database adapters are passed into the pipeline where available.
+   - `unified_rag_pipeline()` runs retrieval, optional expansion, reranking, guardrails, generation, citations, and metadata collection.
+   - Endpoint maps pipeline output to `UnifiedRAGResponse`.
+   - Batch, streaming, health, and capability endpoints are called out as adjacent flows.
+
+4. `## Module Map`
+   - `README.md`, `API_DOCUMENTATION.md`, `CAPABILITIES.md`, `UNIFIED_PIPELINE_EXAMPLES.md`.
+   - `exceptions.py`, `rag_custom_metrics.py`.
+   - `rag_service/` with a concise map of the most important implementation files.
+   - `rag_service/vector_stores/` adapters.
+
+5. `## Common Contributor Tasks`
+   - Add or adjust retrieval source.
+   - Add vector-store adapter.
+   - Add reranking strategy.
+   - Add or adjust profile/default behavior.
+   - Adjust guardrails, citations, generation, claims, or streaming behavior.
+   - Add tests and choose the right test location.
+
+6. `## Current Endpoints`
+   - Summarize active RAG endpoints from `rag_unified.py` and `rag_health.py`.
+   - Avoid brittle source line numbers.
+   - Point to API docs for full request and response examples.
+
+7. `## Configuration And Profiles`
+   - Explain request-level options, `rag_profile`, environment/config defaults, and production adapter expectations at a high level.
+   - Link deeper config details instead of duplicating every knob.
+
+8. `## Testing`
+   - List targeted test folders and representative commands.
+   - Keep commands limited to docs-relevant validation and focused RAG checks.
+
+9. `## Advanced Notes`
+   - Curated, source-verified notes only.
+   - Include short notes on streaming, citations, claims/factuality, guardrails, reranking, vector search, and production gotchas.
+   - Avoid long cURL examples and parameter catalogs that belong in API docs.
+
+10. `## Related Documentation`
+    - Link canonical deeper docs and examples.
+    - Make ownership clear so future contributors know where to edit.
+
+## Accuracy Rules
+
+- Verify active endpoints from `rag_unified.py` and `rag_health.py`.
+- Verify public request/response names from `rag_schemas_unified.py`.
+- Verify pipeline entrypoints from `unified_pipeline.py`.
+- Verify profile names and precedence behavior from `profiles.py` and endpoint handling.
+- Verify retrieval and vector-store terminology from retriever and vector-store modules.
+- Verify current test paths with `rg --files`.
+- Do not preserve source line references in the README; they drift quickly.
+- Do not link missing files such as `IMPLEMENTATION_STATUS.md` or `DEPRECATION_NOTICE.md` unless they exist when implementation happens.
+- Mention archived functional pipelines only as legacy context, not as active contributor guidance.
+- Omit, shorten, or label uncertain features instead of presenting them as guaranteed behavior.
+
+## Validation Plan
+
+This is a docs-only change.
+
+Validation steps:
+
+- Inspect active endpoint decorators in `rag_unified.py` and `rag_health.py`.
+- Inspect schema, profile, pipeline, retriever, and vector-store files listed above.
+- Use `rg` against the edited README for stale active-guide terms:
+  - `functional_pipeline.py`
+  - `rag_api.py`
+  - `standard_pipeline`
+  - `minimal_pipeline`
+  - `quality_pipeline`
+  - `IMPLEMENTATION_STATUS.md`
+  - `DEPRECATION_NOTICE.md`
+- Review Markdown headings and local links for readability.
+
+No Bandit run is required because no Python code changes are planned.
+
+## Success Criteria
+
+- The README quickly orients contributors to the active unified RAG path.
+- Stale functional-pipeline guidance is removed or clearly marked as legacy context.
+- Missing-doc links and brittle line-number references are removed.
+- The README points API users and deep implementation readers to the right dedicated docs.
+- The advanced appendix contains only concise, source-verified notes.
+- No unrelated dirty worktree files are modified.

--- a/Helper_Scripts/TTS_Installers/install_tts_omnivoice_sidecar.py
+++ b/Helper_Scripts/TTS_Installers/install_tts_omnivoice_sidecar.py
@@ -418,9 +418,9 @@ def install_sidecar_runtime(
     interpreter_path: Path,
     repo_root: Path,
     source_checkout: Path,
-    install_inference_deps: bool = False,
+    install_inference_deps: bool = True,
 ) -> None:
-    """Install the minimal sidecar runtime into the dedicated environment."""
+    """Install the sidecar runtime and OmniVoice source dependencies."""
 
     _run_checked_command([str(interpreter_path), "-m", "pip", "install", "--upgrade", "pip"])
     _run_checked_command(
@@ -444,7 +444,10 @@ def install_sidecar_runtime(
             "install",
         ]
         if not install_inference_deps:
-            install_command.append("--no-deps")
+            logger.warning(
+                "OmniVoice source dependencies are required in the sidecar venv; "
+                "installing dependencies despite install_inference_deps=False"
+            )
         install_command.extend(["-e", str(source_checkout)])
         _run_checked_command(install_command, cwd=repo_root)
 
@@ -461,7 +464,8 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--install-inference-deps",
         action="store_true",
-        help="Install OmniVoice editable source with its dependency set instead of minimal sidecar-only dependencies.",
+        default=True,
+        help="Retained for compatibility; OmniVoice source dependencies are installed by default.",
     )
     return parser.parse_args(argv)
 

--- a/Helper_Scripts/release.py
+++ b/Helper_Scripts/release.py
@@ -270,8 +270,8 @@ def update_pyproject_version(pyproject_text: str, version: str) -> str:
     """Update the package version in ``pyproject.toml``."""
 
     updated_text, count = re.subn(
-        r'(?m)^(version\s*=\s*")\d+\.\d+\.\d+(")$',
-        rf"\g<1>{version}\g<2>",
+        r'''(?m)^(version\s*=\s*)(["'])(\d+\.\d+\.\d+)(\2)$''',
+        rf"\g<1>\g<2>{version}\g<4>",
         pyproject_text,
         count=1,
     )

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_health.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_health.py
@@ -149,6 +149,8 @@ def _serialize_tts_caps_for_health(tts_service: TTSServiceV2, caps: Any) -> Any:
 
 
 def _sanitize_public_provider_detail(value: Any) -> Any:
+    """Remove sensitive keys and suspicious runtime diagnostics from public TTS health details."""
+
     if isinstance(value, str):
         if _SUSPICIOUS_PUBLIC_HEALTH_RE.search(value):
             return _SANITIZED_PUBLIC_HEALTH_MESSAGE
@@ -167,6 +169,8 @@ def _sanitize_public_provider_detail(value: Any) -> Any:
 
 
 def _normalize_public_health_key(value: Any) -> str:
+    """Normalize a provider-detail key before comparing it with the sensitive-key denylist."""
+
     return re.sub(r"[^a-z0-9]+", "", str(value or "").strip().lower())
 
 
@@ -179,6 +183,8 @@ def _derive_omnivoice_supervisor_health(
     tts_service: Any,
     current_detail: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
+    """Summarize OmniVoice sidecar supervisor state without exposing process internals."""
+
     current_detail = current_detail if isinstance(current_detail, dict) else {}
     availability = str(current_detail.get("availability") or "").strip().lower()
 

--- a/tldw_Server_API/app/core/RAG/README.md
+++ b/tldw_Server_API/app/core/RAG/README.md
@@ -37,7 +37,7 @@ Adjacent paths share the same module boundary. `POST /api/v1/rag/batch` uses `Un
 
 ## Module Map
 
-- `API_DOCUMENTATION.md`: local endpoint/parameter reference.
+- `API_DOCUMENTATION.md`: in-module pointer to the maintained API reference in `Docs/API-related/RAG_API_Documentation.md`.
 - `CAPABILITIES.md`: feature discovery and capability summary.
 - `UNIFIED_PIPELINE_EXAMPLES.md`: request and pipeline examples to verify against current schema.
 - `exceptions.py`: RAG-specific exception types.
@@ -91,7 +91,7 @@ ChromaDB is the default vector store adapter. PGVector is conditional on optiona
 
 ## Testing
 
-For this README, verify the heading structure and rerun the stale-reference check from the task before committing. The heading check should show only the orientation sections in this file.
+For this README, verify the heading structure and confirm no retired RAG guides, old router names, or superseded pipeline names are referenced before committing. The heading check should show only the orientation sections in this file.
 
 For RAG code changes, activate the project virtual environment first:
 

--- a/tldw_Server_API/app/core/RAG/README.md
+++ b/tldw_Server_API/app/core/RAG/README.md
@@ -48,16 +48,18 @@ Inside `rag_service/`, start with `unified_pipeline.py` for orchestration, `data
 
 ## Common Contributor Tasks
 
-- Change public request or response fields in `rag_schemas_unified.py`, then update endpoint tests and API docs.
-- Change route behavior in `rag_unified.py` or `rag_health.py`; keep transport, dependency, and response-mapping logic at the endpoint boundary.
-- Add or change retrieval sources in `rag_service/database_retrievers.py` and the source registry, then update capability/discovery output and tests.
-- Add vector backend support under `rag_service/vector_stores/` by implementing the shared adapter contract and registering the adapter in the factory.
-- Tune built-in presets in `rag_service/profiles.py`; verify endpoint profile application still preserves explicit request fields.
-- Add generation, citation, guardrail, or reranking behavior inside the relevant `rag_service/` module and surface controls through schema fields or profile defaults when they are public.
+- Add retrieval behavior: `rag_service/database_retrievers.py` and the source registry, then update discovery output and tests.
+- Add vector-store support: `rag_service/vector_stores/` by implementing the shared adapter contract and registering the adapter in the factory.
+- Adjust profiles/defaults: `rag_service/profiles.py` plus endpoint payload handling in `rag_unified.py`.
+- Adjust request/response contract: `rag_schemas_unified.py` and endpoint response mapping.
+- Adjust reranking: `rag_service/advanced_reranking.py`.
+- Adjust generation/streaming: `rag_service/generation.py`, `rag_service/response_writer.py`, and `POST /api/v1/rag/search/stream`.
+- Adjust guardrails/citations/claims: `guardrails.py`, `citations.py`, `claims.py`, `faithfulness.py`, and related tests.
+- Adjust route behavior in `rag_unified.py` or `rag_health.py`; keep transport, dependency, and response conversion at the endpoint boundary.
 
 ## Current Endpoints
 
-Unified query routes:
+Search and generation routes:
 
 - `POST /api/v1/rag/search`: primary unified RAG search.
 - `POST /api/v1/rag/search/stream`: NDJSON streaming search for generated answers.
@@ -65,16 +67,25 @@ Unified query routes:
 - `POST /api/v1/rag/batch/resume/{checkpoint_id}`: resume a checkpointed batch run.
 - `GET /api/v1/rag/simple`: lightweight convenience search.
 - `GET /api/v1/rag/advanced`: convenience search with common advanced options enabled.
+
+Discovery routes:
+
 - `GET /api/v1/rag/capabilities`: runtime capability, default, and limit discovery.
 - `GET /api/v1/rag/features`: feature groups and related request parameter names.
 - `GET /api/v1/rag/vlm/backends`: VLM/table-processing backend availability.
+
+Feedback and experimentation routes:
+
 - `POST /api/v1/rag/feedback/implicit`: implicit interaction feedback capture.
 - `POST /api/v1/rag/ablate`: compare retrieval/generation variants for one query.
-- `GET /api/v1/rag/health/simple`: lightweight unified-pipeline health check.
 
-Health and operations routes under the same prefix:
+Health routes:
 
 - `GET /api/v1/rag/health`, `GET /api/v1/rag/health/live`, `GET /api/v1/rag/health/ready`
+- `GET /api/v1/rag/health/simple`: lightweight unified-pipeline health check.
+
+Operations routes:
+
 - `GET /api/v1/rag/cache/stats`, `POST /api/v1/rag/cache/clear`, `GET /api/v1/rag/cache/warm`
 - `GET /api/v1/rag/metrics/summary`, `GET /api/v1/rag/costs/summary`, `GET /api/v1/rag/batch/jobs`
 - `POST /api/v1/rag/quality-gate`, `POST /api/v1/rag/baseline/save`, `GET /api/v1/rag/regression/check`, `POST /api/v1/rag/regression/check`
@@ -85,7 +96,9 @@ Configuration enters through request fields, profile defaults, and application s
 
 Public `search_mode` values are `fts`, `vector`, and `hybrid`. Public request `sources` are `media_db`, `notes`, `characters`, `chats`, `kanban`, and `sql`.
 
-Request-time `rag_profile` currently accepts `fast`, `balanced`, and `accuracy`. Lower-level profile helpers also define `production`, `research`, and `cheap`; exposing those through the public request model is an API compatibility decision, not just a profile-file edit.
+Public request `rag_profile` values are `fast`, `balanced`, and `accuracy`. `rag_service/profiles.py` also contains internal helper profiles such as `production`, `research`, and `cheap`; do not assume they are accepted directly by `UnifiedRAGRequest`.
+
+Explicit request fields override profile defaults. `index_namespace` can be set directly or via `corpus`; endpoint payload handling maps the alias before calling the pipeline. Production deployments should prefer injected DB adapters and resolved per-user paths over raw fallback assumptions.
 
 ChromaDB is the default vector store adapter. PGVector is conditional on optional import and configuration. Treat other declared vector-store types as unavailable until an adapter is implemented, registered, and tested.
 
@@ -102,6 +115,17 @@ source .venv/bin/activate
 Focused RAG test entry points:
 
 ```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_rag_request_schema_profiles.py -v
+python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_rag_profiles.py -v
+python -m pytest tldw_Server_API/tests/RAG_NEW/integration/test_rag_health_endpoints.py -v
+python -m pytest tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py -v
+python -m pytest tldw_Server_API/tests/RAG/test_rag_sources_sql_validation.py -v
+```
+
+Broader RAG suites:
+
+```bash
 python -m pytest tldw_Server_API/tests/RAG_NEW/unit -v
 python -m pytest tldw_Server_API/tests/RAG_NEW/integration -v
 python -m pytest tldw_Server_API/tests/RAG -v
@@ -114,6 +138,12 @@ Use narrower tests while iterating: schema/profile tests for request changes, re
 `strategy` currently selects between `standard` and `agentic` request handling. The agentic branch builds a query-time synthetic chunk path, while the default path builds explicit pipeline kwargs and calls `unified_rag_pipeline()`.
 
 Streaming search requires `enable_generation=true`; the endpoint rejects streaming requests without generation enabled. Batch search and batch resume use the batch schema/checkpoint path rather than requiring clients to loop over single-search calls.
+
+Vector search depends on embeddings and vector-store availability. Hybrid search can still use FTS when vector retrieval is unavailable or disabled.
+
+Citation, hard-citation, claim, numeric fidelity, and post-verification features may abstain or ask for clarification when evidence is weak. Reranking options carry cost and latency tradeoffs; `two_tier` reranking is quality-oriented because it combines a fast pass with LLM scoring.
+
+Multi-tenant or production usage should avoid assumptions about raw SQL fallbacks and should preserve user and tenant scoping through injected adapters, paths, and permissions.
 
 The public source values are normalized before retrieval. `characters` and `chats` are separate public source values but currently share the character-card/ChaChaNotes-backed retrieval path. Do not advertise additional public sources unless normalization, retriever wiring, discovery output, and tests are all updated.
 

--- a/tldw_Server_API/app/core/RAG/README.md
+++ b/tldw_Server_API/app/core/RAG/README.md
@@ -1,58 +1,127 @@
 # RAG Module
 
-This package contains the backend implementation for unified Retrieval-Augmented Generation in `tldw_server`.
+This README is a contributor orientation for the backend RAG module. It is not the full API reference or a complete implementation guide; use it to find the active code paths and then follow the linked docs or source files for detail.
 
-For canonical contributor guidance, see `Docs/Code_Documentation/RAG-Developer-Guide.md`.
+## Start Here
 
-## Active Entrypoints
+Active entrypoints:
 
-Programmatic entrypoints:
+- API routers: `rag_unified.py`, `rag_health.py`
+- Public schemas: `UnifiedRAGRequest`, `UnifiedRAGResponse`, `UnifiedBatchRequest`, `UnifiedBatchResponse`
+- Core pipeline: `unified_rag_pipeline()`, `unified_batch_pipeline()`
+- Convenience functions: `simple_search()`, `advanced_search()`
 
-- `rag_service/unified_pipeline.py` - `unified_rag_pipeline(...)`
-- `rag_service/unified_pipeline.py` - `unified_batch_pipeline(...)`
-- `rag_service/unified_pipeline.py` - `simple_search(...)`
-- `rag_service/unified_pipeline.py` - `advanced_search(...)`
+Primary source paths:
 
-HTTP entrypoints:
+- Routers: `tldw_Server_API/app/api/v1/endpoints/rag_unified.py` and `tldw_Server_API/app/api/v1/endpoints/rag_health.py`
+- Schemas: `tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py`
+- Pipeline: `tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py`
 
-- `app/api/v1/endpoints/rag_unified.py` - active `/api/v1/rag` unified routes
-- `app/api/v1/endpoints/rag_health.py` - active `/api/v1/rag` health and operations routes
-- `app/api/v1/schemas/rag_schemas_unified.py` - request and response schemas
+## Request Flow
+
+Primary search flow:
+
+```text
+POST /api/v1/rag/search
+  -> UnifiedRAGRequest validation
+  -> auth/rate-limit/permission dependencies
+  -> profile/default resolution
+  -> per-user DB adapter/path injection
+  -> unified_rag_pipeline(...)
+  -> UnifiedRAGResponse mapping
+```
+
+The endpoint layer handles FastAPI concerns: auth dependencies, request validation, source normalization, profile/default application, user-scoped database adapters, and response conversion. The pipeline layer receives explicit inputs and returns the search result carrier used to build `UnifiedRAGResponse`.
+
+Adjacent paths share the same module boundary. `POST /api/v1/rag/batch` uses `UnifiedBatchRequest` and `unified_batch_pipeline()`, `POST /api/v1/rag/search/stream` streams generated answer events, `GET /api/v1/rag/capabilities` and `GET /api/v1/rag/features` expose discovery data, and health/operations routes live in `rag_health.py`.
 
 ## Module Map
 
-- `rag_service/unified_pipeline.py` - unified request execution, batch execution, convenience wrappers
-- `rag_service/database_retrievers.py` - datastore retrieval adapters and source fan-out
-- `rag_service/advanced_reranking.py` - reranking strategies
-- `rag_service/query_expansion.py` - query expansion strategies
-- `rag_service/vector_stores/` - vector store factory and adapters
-- `rag_service/citations.py` - citation helpers
-- `rag_service/generation.py` - answer generation helpers
-- `rag_service/health_check.py` - health checks used by operations routes
-- `exceptions.py` - RAG-specific exceptions
+- `API_DOCUMENTATION.md`: local endpoint/parameter reference.
+- `CAPABILITIES.md`: feature discovery and capability summary.
+- `UNIFIED_PIPELINE_EXAMPLES.md`: request and pipeline examples to verify against current schema.
+- `exceptions.py`: RAG-specific exception types.
+- `rag_custom_metrics.py`: RAG metrics helpers.
+- `rag_service/`: implementation package for retrieval, generation, guardrails, citations, profiles, vector stores, metrics, and utilities.
 
-## Public Request Surface
+Inside `rag_service/`, start with `unified_pipeline.py` for orchestration, `database_retrievers.py` for source retrieval, `advanced_reranking.py` for reranking, `query_expansion.py` for expansion, `profiles.py` for presets, and `vector_stores/` for vector adapter contracts and implementations.
 
-Public `search_mode` values:
+## Common Contributor Tasks
 
-- `fts`
-- `vector`
-- `hybrid`
+- Change public request or response fields in `rag_schemas_unified.py`, then update endpoint tests and API docs.
+- Change route behavior in `rag_unified.py` or `rag_health.py`; keep transport, dependency, and response-mapping logic at the endpoint boundary.
+- Add or change retrieval sources in `rag_service/database_retrievers.py` and the source registry, then update capability/discovery output and tests.
+- Add vector backend support under `rag_service/vector_stores/` by implementing the shared adapter contract and registering the adapter in the factory.
+- Tune built-in presets in `rag_service/profiles.py`; verify endpoint profile application still preserves explicit request fields.
+- Add generation, citation, guardrail, or reranking behavior inside the relevant `rag_service/` module and surface controls through schema fields or profile defaults when they are public.
 
-Public request `sources`:
+## Current Endpoints
 
-- `media_db`
-- `notes`
-- `characters`
-- `chats`
-- `kanban`
-- `sql`
+Unified query routes:
 
-ChromaDB is the default vector store adapter. PGVector is available only when its optional import succeeds and the deployment is configured for it.
+- `POST /api/v1/rag/search`: primary unified RAG search.
+- `POST /api/v1/rag/search/stream`: NDJSON streaming search for generated answers.
+- `POST /api/v1/rag/batch`: concurrent multi-query RAG search.
+- `POST /api/v1/rag/batch/resume/{checkpoint_id}`: resume a checkpointed batch run.
+- `GET /api/v1/rag/simple`: lightweight convenience search.
+- `GET /api/v1/rag/advanced`: convenience search with common advanced options enabled.
+- `GET /api/v1/rag/capabilities`: runtime capability, default, and limit discovery.
+- `GET /api/v1/rag/features`: feature groups and related request parameter names.
+- `GET /api/v1/rag/vlm/backends`: VLM/table-processing backend availability.
+- `POST /api/v1/rag/feedback/implicit`: implicit interaction feedback capture.
+- `POST /api/v1/rag/ablate`: compare retrieval/generation variants for one query.
+- `GET /api/v1/rag/health/simple`: lightweight unified-pipeline health check.
+
+Health and operations routes under the same prefix:
+
+- `GET /api/v1/rag/health`, `GET /api/v1/rag/health/live`, `GET /api/v1/rag/health/ready`
+- `GET /api/v1/rag/cache/stats`, `POST /api/v1/rag/cache/clear`, `GET /api/v1/rag/cache/warm`
+- `GET /api/v1/rag/metrics/summary`, `GET /api/v1/rag/costs/summary`, `GET /api/v1/rag/batch/jobs`
+- `POST /api/v1/rag/quality-gate`, `POST /api/v1/rag/baseline/save`, `GET /api/v1/rag/regression/check`, `POST /api/v1/rag/regression/check`
+
+## Configuration And Profiles
+
+Configuration enters through request fields, profile defaults, and application settings. Endpoint resolution follows this precedence: explicit request value, profile default, search/default helper value, then schema default.
+
+Public `search_mode` values are `fts`, `vector`, and `hybrid`. Public request `sources` are `media_db`, `notes`, `characters`, `chats`, `kanban`, and `sql`.
+
+Request-time `rag_profile` currently accepts `fast`, `balanced`, and `accuracy`. Lower-level profile helpers also define `production`, `research`, and `cheap`; exposing those through the public request model is an API compatibility decision, not just a profile-file edit.
+
+ChromaDB is the default vector store adapter. PGVector is conditional on optional import and configuration. Treat other declared vector-store types as unavailable until an adapter is implemented, registered, and tested.
+
+## Testing
+
+For this README, verify the heading structure and rerun the stale-reference check from the task before committing. The heading check should show only the orientation sections in this file.
+
+For RAG code changes, activate the project virtual environment first:
+
+```bash
+source .venv/bin/activate
+```
+
+Focused RAG test entry points:
+
+```bash
+python -m pytest tldw_Server_API/tests/RAG_NEW/unit -v
+python -m pytest tldw_Server_API/tests/RAG_NEW/integration -v
+python -m pytest tldw_Server_API/tests/RAG -v
+```
+
+Use narrower tests while iterating: schema/profile tests for request changes, response-mapping tests for endpoint conversion, pipeline tests for orchestration changes, vector-store tests for adapter work, and AuthNZ permission tests when RAG access control changes.
+
+## Advanced Notes
+
+`strategy` currently selects between `standard` and `agentic` request handling. The agentic branch builds a query-time synthetic chunk path, while the default path builds explicit pipeline kwargs and calls `unified_rag_pipeline()`.
+
+Streaming search requires `enable_generation=true`; the endpoint rejects streaming requests without generation enabled. Batch search and batch resume use the batch schema/checkpoint path rather than requiring clients to loop over single-search calls.
+
+The public source values are normalized before retrieval. `characters` and `chats` are separate public source values but currently share the character-card/ChaChaNotes-backed retrieval path. Do not advertise additional public sources unless normalization, retriever wiring, discovery output, and tests are all updated.
 
 ## Related Documentation
 
-- `Docs/Code_Documentation/RAG-Developer-Guide.md` - canonical developer and contributor guide
-- `Docs/API-related/RAG_API_Documentation.md` - concise endpoint reference
-- `Docs/API-related/RAG-API-Guide.md` - consumer examples
-- `tldw_Server_API/app/core/RAG/CAPABILITIES.md` - runtime capability discovery notes
+- `Docs/Code_Documentation/RAG-Developer-Guide.md`: primary deeper contributor guide for architecture, extension points, profiles, and testing.
+- `Docs/API-related/RAG_API_Documentation.md`: maintained endpoint reference.
+- `Docs/API-related/RAG-API-Guide.md`: consumer examples and client-oriented usage notes.
+- `tldw_Server_API/app/core/RAG/API_DOCUMENTATION.md`: in-module pointer to the maintained API reference.
+- `tldw_Server_API/app/core/RAG/CAPABILITIES.md`: runtime capability interpretation notes.
+- `tldw_Server_API/app/core/RAG/UNIFIED_PIPELINE_EXAMPLES.md`: request and programmatic examples to compare with current schemas.

--- a/tldw_Server_API/app/core/TTS/adapters/omnivoice_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/omnivoice_adapter.py
@@ -1,3 +1,9 @@
+"""OmniVoice TTS adapter backed by the local authenticated sidecar.
+
+The adapter validates public TTS requests, materializes optional clone-mode
+reference audio, delegates synthesis to the sidecar supervisor, and normalizes
+the returned audio format before handing responses back to the TTS service.
+"""
 from __future__ import annotations
 
 import asyncio
@@ -60,7 +66,7 @@ class OmniVoiceAdapter(TTSAdapter):
         }
     )
 
-    def __init__(self, config: dict[str, Any] | None = None):
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
         super().__init__(config)
         cfg = config or {}
         extras = cfg.get("extra_params", {}) or {}

--- a/tldw_Server_API/tests/Setup/test_audio_health_helpers.py
+++ b/tldw_Server_API/tests/Setup/test_audio_health_helpers.py
@@ -7,6 +7,12 @@ from unittest.mock import MagicMock
 from tldw_Server_API.app.api.v1.endpoints.audio import audio_health
 
 
+def test_public_tts_health_helpers_document_sanitization_contracts():
+    assert audio_health._sanitize_public_provider_detail.__doc__
+    assert audio_health._normalize_public_health_key.__doc__
+    assert audio_health._derive_omnivoice_supervisor_health.__doc__
+
+
 @pytest.mark.asyncio
 async def test_collect_setup_stt_health_normalizes_http_exception(mocker):
     mocker.patch.object(

--- a/tldw_Server_API/tests/TTS/adapters/test_omnivoice_adapter_mock.py
+++ b/tldw_Server_API/tests/TTS/adapters/test_omnivoice_adapter_mock.py
@@ -1,12 +1,15 @@
 import asyncio
+import inspect
 import wave
 from io import BytesIO
 from pathlib import Path
+from typing import get_type_hints
 
 import httpx
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, ProviderStatus, TTSRequest
+from tldw_Server_API.app.core.TTS.adapters import omnivoice_adapter as omnivoice_adapter_module
 from tldw_Server_API.app.core.TTS.adapters.omnivoice_adapter import OmniVoiceAdapter
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSGenerationError
 
@@ -61,6 +64,12 @@ class _FakeClient:
         self.recorded["json"] = json
         self.recorded["headers"] = dict(headers or {})
         return self.response
+
+
+def test_omnivoice_adapter_documents_module_and_init_contract() -> None:
+    assert omnivoice_adapter_module.__doc__
+    assert inspect.signature(OmniVoiceAdapter.__init__).return_annotation != inspect.Signature.empty
+    assert get_type_hints(OmniVoiceAdapter.__init__)["return"] is type(None)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_installer.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_omnivoice_installer.py
@@ -179,6 +179,31 @@ def test_omnivoice_installer_installs_source_with_dependencies_when_requested(tm
 
 
 @pytest.mark.unit
+def test_omnivoice_installer_installs_source_dependencies_by_default(tmp_path, monkeypatch):
+    from Helper_Scripts.TTS_Installers import install_tts_omnivoice_sidecar as installer
+
+    commands = []
+    source_checkout = tmp_path / "OmniVoice"
+    source_checkout.mkdir()
+
+    def _fake_run(command, **kwargs):  # noqa: ARG001
+        commands.append(command)
+
+    monkeypatch.setattr(installer.subprocess, "run", _fake_run)
+
+    installer.install_sidecar_runtime(
+        interpreter_path=tmp_path / ".venv" / "bin" / "python",
+        repo_root=tmp_path,
+        source_checkout=source_checkout,
+    )
+
+    editable_install = commands[-1]
+    assert "-e" in editable_install  # nosec B101
+    assert "--no-deps" not in editable_install  # nosec B101
+    assert str(source_checkout) in editable_install  # nosec B101
+
+
+@pytest.mark.unit
 def test_omnivoice_installer_updates_only_provider_block(tmp_path):
     from Helper_Scripts.TTS_Installers.install_tts_omnivoice_sidecar import (
         build_runtime_layout,

--- a/tldw_Server_API/tests/Utils/test_release_helper.py
+++ b/tldw_Server_API/tests/Utils/test_release_helper.py
@@ -22,6 +22,7 @@ from Helper_Scripts.release import (  # noqa: E402
     orchestrate_release,
     read_current_version,
     promote_changelog_unreleased_section,
+    update_pyproject_version,
     update_mkdocs_version_metadata,
     update_readme_release_references,
     update_release_notes_entry_point,
@@ -50,6 +51,14 @@ def test_bump_version_patch() -> None:
 
 def test_bump_version_minor() -> None:
     assert bump_version("0.1.30", "minor") == "0.2.0"
+
+
+def test_update_pyproject_version_supports_single_quoted_toml() -> None:
+    pyproject_text = "[project]\nname = \"example\"\nversion = '0.1.30'\n"
+
+    updated_text = update_pyproject_version(pyproject_text, "0.1.31")
+
+    assert updated_text == "[project]\nname = \"example\"\nversion = '0.1.31'\n"
 
 
 def test_extract_required_check_names() -> None:


### PR DESCRIPTION
## Summary
- Merge the latest RAG developer docs consolidation baseline into this branch.
- Replace the in-module RAG README with a concise contributor orientation covering active entrypoints, request flow, module map, endpoints, profiles, testing, and advanced notes.
- Include the approved design spec and implementation plan for the README orientation work.

## Change summary
Human requester must replace this section before merge per the AI-generated PR policy in Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

## Test Plan
- Stale RAG term scan: no obsolete filenames or deprecated pipeline names found in the README.
- Authority-language scan: no canonical/source-of-truth phrasing found in the README.
- Heading, endpoint, and profile checks confirmed expected README coverage.
- git diff --check b09630c35..HEAD passed.
- Bandit was run on tldw_Server_API/app/core/RAG; it reported existing low-severity findings only in untouched Python files.
- Final subagent review found no issues.

Docs-only change; no Python pytest run.