### PR TITLE
fix(workflows): remediate backend contracts and operations

### DIFF
--- a/Docs/Operations/Workflows_Runbook.md
+++ b/Docs/Operations/Workflows_Runbook.md
@@ -35,7 +35,8 @@ Operational guidance for running, migrating, backing up, and troubleshooting the
 - Artifact GC worker (optional)
   - Enable: `WORKFLOWS_ARTIFACT_GC_ENABLED=true`.
   - Configure: `WORKFLOWS_ARTIFACT_RETENTION_DAYS` (default 30), `WORKFLOWS_ARTIFACT_GC_INTERVAL_SEC`.
-  - Policy: delete file:// artifacts from disk if present and remove DB rows older than cutoff.
+  - Policy: delete `file://` artifacts from disk if present and remove DB rows older than cutoff.
+  - Evidence: each successful deletion appends an `artifact_gc` event to the parent run.
 
 - Run/event retention (manual)
   - Consider periodic deletion by age for `workflow_events` and old `workflow_runs` in high-volume deployments.
@@ -56,18 +57,28 @@ Operational guidance for running, migrating, backing up, and troubleshooting the
    - Check tenant and owner constraints; admins can filter with `owner=`.
    - Confirm DB instance: the API and tests should use the same DB path/URL; check `DATABASE_URL_WORKFLOWS`.
 3) Webhook not firing
-   - Confirm `WORKFLOWS_DISABLE_COMPLETION_WEBHOOKS` is not set.
-   - Check `webhook_delivery` events for `blocked|failed`.
-   - Validate egress policy and allowlists; inspect DLQ with `SELECT * FROM workflow_webhook_dlq`.
-   - If using signatures, ensure receiver computes HMAC over `"{ts}.{body}"` with header `X-Signature-Timestamp`.
+  - Confirm `WORKFLOWS_DISABLE_COMPLETION_WEBHOOKS` is not set.
+  - Check `webhook_delivery` events for `blocked|failed`.
+  - Validate egress policy and allowlists; inspect DLQ with `SELECT * FROM workflow_webhook_dlq`.
+  - DLQ replay appends `webhook_delivery` evidence for both delivered and failed attempts.
+  - Exhausted DLQ rows are parked with a future `next_attempt_at` once `WORKFLOWS_WEBHOOK_DLQ_MAX_ATTEMPTS` is reached.
+  - If using signatures, ensure receiver computes HMAC over `"{ts}.{body}"` with header `X-Signature-Timestamp`.
 4) Event stream out of order / missing
-   - Validate uniqueness of `(run_id, event_seq)` and counters table health.
+  - Validate uniqueness of `(run_id, event_seq)` and counters table health.
+  - If workflow evidence appears sparse, remember the GC and replay paths now record `artifact_gc` and `webhook_delivery` events respectively.
 5) “database is locked” (SQLite)
-   - WAL mode and busy timeout should handle most cases; reduce concurrency or move to Postgres.
+  - WAL mode and busy timeout should handle most cases; reduce concurrency or move to Postgres.
 6) Artifact download 404/403
-   - Verify artifact exists for the run (`GET /runs/{run_id}/artifacts`).
-   - Check path containment vs recorded `workdir` (strict mode may block).
-   - In tests, ensure the route uses the same DB instance as the test fixture.
+  - Verify artifact exists for the run (`GET /runs/{run_id}/artifacts`).
+  - Check path containment vs recorded `workdir` (strict mode may block).
+  - In tests, ensure the route uses the same DB instance as the test fixture.
+
+## Scheduler Notes
+
+- Recurring schedule discovery scans all tenant rows within each per-user scheduler DB; it no longer assumes `tenant_id="default"`.
+- Manual `POST /api/v1/scheduler/workflows/{schedule_id}/run-now` uses the same routing rule as recurring execution.
+- Watchlist-backed schedules must land on `watchlist_run` in the `watchlists` queue; other schedules use `workflow_run` in the `workflows` queue.
+- `run_adhoc` requires the same `workflows` scope as saved-definition runs.
 
 ## Authoring Checks
 

--- a/tldw_Server_API/Config_Files/privilege_catalog.yaml
+++ b/tldw_Server_API/Config_Files/privilege_catalog.yaml
@@ -824,6 +824,20 @@ scopes:
     ownership_predicates:
       - same_org
     doc_url: https://docs.example.com/privileges/workflows-run-saved
+  - id: workflows.run_adhoc
+    description: Trigger an ad-hoc workflow definition manually.
+    resource_tags:
+      - workflows
+      - automation
+    sensitivity_tier: high
+    rate_limit_class: elevated
+    default_roles:
+      - admin
+      - automation_manager
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/workflows-run-adhoc
   - id: evals.create_run
     description: Launch evaluation runs from existing evaluation definitions.
     resource_tags:

--- a/tldw_Server_API/app/api/v1/endpoints/scheduler_workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduler_workflows.py
@@ -16,7 +16,11 @@ from tldw_Server_API.app.core.AuthNZ.permissions import WORKFLOWS_ADMIN
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Scheduler import get_global_scheduler
-from tldw_Server_API.app.services.workflows_scheduler import get_workflows_scheduler
+from tldw_Server_API.app.services.workflows_scheduler import (
+    build_schedule_payload,
+    get_workflows_scheduler,
+    resolve_schedule_submission_target,
+)
 
 router = APIRouter(prefix="/api/v1/scheduler/workflows", tags=["scheduler", "workflows"])
 
@@ -384,17 +388,11 @@ async def run_now(
     if str(current_user.id) != s.user_id and not is_admin:
         raise HTTPException(status_code=403, detail="Forbidden")
     # Submit immediate job to core Scheduler
-    payload = {
-        "workflow_id": s.workflow_id,
-        "inputs": __import__("json").loads(s.inputs_json or "{}"),
-        "user_id": s.user_id,
-        "tenant_id": s.tenant_id,
-        "mode": s.run_mode,
-        "validation_mode": s.validation_mode,
-    }
+    payload = build_schedule_payload(s)
+    handler_name, queue_name = resolve_schedule_submission_target(payload)
     # Use the global scheduler instance to avoid duplicate worker pools
     core = await get_global_scheduler()
-    task_id = await core.submit("workflow_run", payload=payload, queue_name="workflows", metadata={"user_id": s.user_id})
+    task_id = await core.submit(handler_name, payload=payload, queue_name=queue_name, metadata={"user_id": s.user_id})
     return {"task_id": task_id}
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -2258,7 +2258,14 @@ async def run_adhoc(
     current_user: User = Depends(get_request_user),
     db: WorkflowsDatabase = Depends(_get_db),
     audit_service=Depends(get_audit_service_for_user),
-    _token_scope=Depends(auth_deps.require_token_scope("workflows", require_if_present=True, count_as="run")),
+    _token_scope: None = Depends(
+        auth_deps.require_token_scope(
+            "workflows",
+            require_if_present=True,
+            endpoint_id="workflows.run_adhoc",
+            count_as="run",
+        )
+    ),
 ):
     import os
     if os.getenv("WORKFLOWS_DISABLE_ADHOC", "false").lower() in {"1", "true", "yes"}:
@@ -2693,6 +2700,7 @@ async def replay_webhook_dlq(
 
     url = str(target.get("url") or "")
     tenant_id = str(target.get("tenant_id") or "default")
+    run_id_str = str(target.get("run_id") or "")
     try:
         body = json.loads(target.get("body_json") or "{}")
     except (json.JSONDecodeError, TypeError, ValueError) as exc:
@@ -2711,11 +2719,10 @@ async def replay_webhook_dlq(
             record_webhook_delivery_event(
                 db,
                 tenant_id=tenant_id,
-                run_id=str(target.get("run_id") or ""),
+                run_id=run_id_str,
                 url=url,
                 status="delivered",
                 source="dlq_replay",
-                strict=True,
             )
             db.delete_webhook_dlq(dlq_id=dlq_id)
         except sqlite3.Error as exc:
@@ -2784,12 +2791,11 @@ async def replay_webhook_dlq(
                     record_webhook_delivery_event(
                         db,
                         tenant_id=tenant_id,
-                        run_id=str(target.get("run_id") or ""),
+                        run_id=run_id_str,
                         url=url,
                         status="delivered",
                         code=status_code,
                         source="dlq_replay",
-                        strict=True,
                     )
                     db.delete_webhook_dlq(dlq_id=dlq_id)
                 except sqlite3.Error as exc:
@@ -2814,7 +2820,7 @@ async def replay_webhook_dlq(
                     record_webhook_delivery_event(
                         db,
                         tenant_id=tenant_id,
-                        run_id=str(target.get("run_id") or ""),
+                        run_id=run_id_str,
                         url=url,
                         status="failed",
                         code=status_code,
@@ -2869,7 +2875,7 @@ async def replay_webhook_dlq(
             record_webhook_delivery_event(
                 db,
                 tenant_id=tenant_id,
-                run_id=str(target.get("run_id") or ""),
+                run_id=run_id_str,
                 url=url,
                 status="failed",
                 reason=error_detail,

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -90,6 +90,9 @@ from tldw_Server_API.app.core.testing import (
     is_test_mode,
     is_truthy,
 )
+from tldw_Server_API.app.services.workflows_webhook_dlq_service import (
+    record_webhook_delivery_event,
+)
 from tldw_Server_API.app.core.Workflows import RunMode, WorkflowEngine, WorkflowScheduler
 from tldw_Server_API.app.core.Workflows.adapters._common import artifacts_base_dir, is_subpath
 from tldw_Server_API.app.core.Workflows.capabilities import get_step_capability
@@ -2255,6 +2258,7 @@ async def run_adhoc(
     current_user: User = Depends(get_request_user),
     db: WorkflowsDatabase = Depends(_get_db),
     audit_service=Depends(get_audit_service_for_user),
+    _token_scope=Depends(auth_deps.require_token_scope("workflows", require_if_present=True, count_as="run")),
 ):
     import os
     if os.getenv("WORKFLOWS_DISABLE_ADHOC", "false").lower() in {"1", "true", "yes"}:
@@ -2704,6 +2708,15 @@ async def replay_webhook_dlq(
     import os as _os
     if is_test_mode() and is_truthy(_os.getenv("WORKFLOWS_TEST_REPLAY_SUCCESS", "")):
         try:
+            record_webhook_delivery_event(
+                db,
+                tenant_id=tenant_id,
+                run_id=str(target.get("run_id") or ""),
+                url=url,
+                status="delivered",
+                source="dlq_replay",
+                strict=True,
+            )
             db.delete_webhook_dlq(dlq_id=dlq_id)
         except sqlite3.Error as exc:
             logger.debug(
@@ -2768,6 +2781,16 @@ async def replay_webhook_dlq(
             logger.debug("DLQ replay POST to {} -> {}", url, status_code)
             if 200 <= status_code < 400:
                 try:
+                    record_webhook_delivery_event(
+                        db,
+                        tenant_id=tenant_id,
+                        run_id=str(target.get("run_id") or ""),
+                        url=url,
+                        status="delivered",
+                        code=status_code,
+                        source="dlq_replay",
+                        strict=True,
+                    )
                     db.delete_webhook_dlq(dlq_id=dlq_id)
                 except sqlite3.Error as exc:
                     logger.debug(
@@ -2788,6 +2811,16 @@ async def replay_webhook_dlq(
                 # Update attempts/backoff minimally
                 error_category = _classify_webhook_status(status_code)
                 try:
+                    record_webhook_delivery_event(
+                        db,
+                        tenant_id=tenant_id,
+                        run_id=str(target.get("run_id") or ""),
+                        url=url,
+                        status="failed",
+                        code=status_code,
+                        reason=f"status={status_code}",
+                        source="dlq_replay",
+                    )
                     db.update_webhook_dlq_failure(
                         dlq_id=dlq_id,
                         last_error=f"status={status_code}",
@@ -2833,6 +2866,15 @@ async def replay_webhook_dlq(
         )
         try:
             error_detail = f"{type(e).__name__}: {e}"
+            record_webhook_delivery_event(
+                db,
+                tenant_id=tenant_id,
+                run_id=str(target.get("run_id") or ""),
+                url=url,
+                status="failed",
+                reason=error_detail,
+                source="dlq_replay",
+            )
             db.update_webhook_dlq_failure(dlq_id=dlq_id, last_error=error_detail, next_attempt_at_iso=None)
         except sqlite3.Error as exc:
             logger.debug(

--- a/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from loguru import logger
 
@@ -140,6 +141,26 @@ CREATE TABLE IF NOT EXISTS workflow_step_runs (
     FOREIGN KEY (run_id) REFERENCES workflow_runs(run_id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS workflow_step_attempts (
+    attempt_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    step_run_id TEXT NOT NULL,
+    step_id TEXT NOT NULL,
+    attempt_number INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    reason_code_core TEXT,
+    reason_code_detail TEXT,
+    retryable BOOLEAN,
+    error_summary TEXT,
+    metadata_json JSONB,
+    started_at TIMESTAMPTZ NOT NULL,
+    ended_at TIMESTAMPTZ,
+    UNIQUE (step_run_id, attempt_number),
+    FOREIGN KEY (run_id) REFERENCES workflow_runs(run_id) ON DELETE CASCADE,
+    FOREIGN KEY (step_run_id) REFERENCES workflow_step_runs(step_run_id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS workflow_events (
     event_id BIGSERIAL PRIMARY KEY,
     tenant_id TEXT NOT NULL,
@@ -189,6 +210,9 @@ CREATE TABLE IF NOT EXISTS workflow_research_waits (
 CREATE INDEX IF NOT EXISTS idx_workflows_owner ON workflows(owner_id);
 CREATE INDEX IF NOT EXISTS idx_runs_status ON workflow_runs(status);
 CREATE INDEX IF NOT EXISTS idx_runs_idempotency_lookup ON workflow_runs(tenant_id, user_id, idempotency_key, created_at);
+CREATE INDEX IF NOT EXISTS idx_step_attempts_run_attempts ON workflow_step_attempts(run_id, attempt_number, started_at);
+CREATE INDEX IF NOT EXISTS idx_step_attempts_run_step_attempts ON workflow_step_attempts(run_id, step_id, attempt_number, started_at);
+CREATE INDEX IF NOT EXISTS idx_step_attempts_step_run_attempts ON workflow_step_attempts(step_run_id, attempt_number, started_at);
     CREATE INDEX IF NOT EXISTS idx_events_run_seq ON workflow_events(run_id, event_seq);
 CREATE UNIQUE INDEX IF NOT EXISTS ux_workflow_research_wait_run_step ON workflow_research_waits(workflow_run_id, step_id);
 CREATE INDEX IF NOT EXISTS idx_workflow_research_wait_lookup ON workflow_research_waits(research_run_id, checkpoint_id, wait_status);
@@ -480,7 +504,7 @@ class WorkflowRun:
 
 
 class WorkflowsDatabase:
-    _CURRENT_SCHEMA_VERSION = 7
+    _CURRENT_SCHEMA_VERSION = 8
     """Workflow persistence adapter supporting SQLite and DatabaseBackend instances."""
 
     def __init__(
@@ -713,6 +737,50 @@ class WorkflowsDatabase:
 
         return applied_version
 
+    @staticmethod
+    def _step_attempt_migration_score(row: dict[str, Any]) -> tuple[bool, str, str, str]:
+        return (
+            row.get("ended_at") is not None,
+            str(row.get("ended_at") or row.get("started_at") or ""),
+            str(row.get("started_at") or ""),
+            str(row.get("attempt_id") or ""),
+        )
+
+    def _normalize_step_attempt_migration_rows(
+        self,
+        rows: Sequence[Any],
+        *,
+        valid_run_ids: set[str] | None = None,
+        valid_step_run_ids: set[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        canonical_rows: dict[tuple[str, int], dict[str, Any]] = {}
+        for row in rows:
+            data = self._row_to_dict(row)
+            run_id = str(data.get("run_id") or "").strip()
+            if not run_id:
+                continue
+            if valid_run_ids is not None and run_id not in valid_run_ids:
+                continue
+            step_run_id = str(data.get("step_run_id") or "").strip()
+            if not step_run_id:
+                continue
+            if valid_step_run_ids is not None and step_run_id not in valid_step_run_ids:
+                continue
+            try:
+                attempt_number = int(data.get("attempt_number") or 0)
+            except _WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS:
+                continue
+            if attempt_number <= 0:
+                continue
+            logical_key = (step_run_id, attempt_number)
+            existing = canonical_rows.get(logical_key)
+            if existing is None or self._step_attempt_migration_score(data) > self._step_attempt_migration_score(existing):
+                canonical_rows[logical_key] = data
+        return [
+            canonical_rows[key]
+            for key in sorted(canonical_rows.keys(), key=lambda item: (item[0], item[1]))
+        ]
+
     def _get_backend_migrations(self):
         return {
             1: self._backend_migrate_to_v1,
@@ -722,6 +790,7 @@ class WorkflowsDatabase:
             5: self._backend_migrate_to_v5,
             6: self._backend_migrate_to_v6,
             7: self._backend_migrate_to_v7,
+            8: self._backend_migrate_to_v8,
         }
 
     def _backend_migrate_to_v1(self, conn) -> None:
@@ -943,6 +1012,43 @@ class WorkflowsDatabase:
         backend = self.backend
         ident = backend.escape_identifier
         backend.execute(
+            f"CREATE TABLE IF NOT EXISTS {ident('workflow_step_attempts')} ("
+            f"{ident('attempt_id')} TEXT PRIMARY KEY,"
+            f"{ident('tenant_id')} TEXT NOT NULL,"
+            f"{ident('run_id')} TEXT NOT NULL,"
+            f"{ident('step_run_id')} TEXT NOT NULL,"
+            f"{ident('step_id')} TEXT NOT NULL,"
+            f"{ident('attempt_number')} INTEGER NOT NULL,"
+            f"{ident('status')} TEXT NOT NULL,"
+            f"{ident('reason_code_core')} TEXT,"
+            f"{ident('reason_code_detail')} TEXT,"
+            f"{ident('retryable')} BOOLEAN,"
+            f"{ident('error_summary')} TEXT,"
+            f"{ident('metadata_json')} JSONB,"
+            f"{ident('started_at')} TIMESTAMPTZ NOT NULL,"
+            f"{ident('ended_at')} TIMESTAMPTZ,"
+            f"UNIQUE ({ident('step_run_id')}, {ident('attempt_number')}),"
+            f"FOREIGN KEY ({ident('run_id')}) REFERENCES {ident('workflow_runs')}({ident('run_id')}) ON DELETE CASCADE,"
+            f"FOREIGN KEY ({ident('step_run_id')}) REFERENCES {ident('workflow_step_runs')}({ident('step_run_id')}) ON DELETE CASCADE"
+            ")",
+            connection=conn,
+        )
+        backend.execute(
+            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_run_attempts')} "
+            f"ON {ident('workflow_step_attempts')} ({ident('run_id')}, {ident('attempt_number')}, {ident('started_at')})",
+            connection=conn,
+        )
+        backend.execute(
+            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_run_step_attempts')} "
+            f"ON {ident('workflow_step_attempts')} ({ident('run_id')}, {ident('step_id')}, {ident('attempt_number')}, {ident('started_at')})",
+            connection=conn,
+        )
+        backend.execute(
+            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_step_run_attempts')} "
+            f"ON {ident('workflow_step_attempts')} ({ident('step_run_id')}, {ident('attempt_number')}, {ident('started_at')})",
+            connection=conn,
+        )
+        backend.execute(
             f"CREATE TABLE IF NOT EXISTS {ident('workflow_research_waits')} ("
             f"{ident('wait_id')} TEXT PRIMARY KEY,"
             f"{ident('tenant_id')} TEXT NOT NULL,"
@@ -969,6 +1075,127 @@ class WorkflowsDatabase:
         backend.execute(
             f"CREATE INDEX IF NOT EXISTS {ident('idx_workflow_research_wait_lookup')} "
             f"ON {ident('workflow_research_waits')} ({ident('research_run_id')}, {ident('checkpoint_id')}, {ident('wait_status')})",
+            connection=conn,
+        )
+
+    def _backend_migrate_to_v8(self, conn) -> None:
+        if not self.backend:
+            return
+        backend = self.backend
+        ident = backend.escape_identifier
+        legacy_rows: list[Any] = []
+        valid_run_ids: set[str] = set()
+        valid_step_run_ids: set[str] = set()
+
+        run_result = backend.execute(
+            f"SELECT {ident('run_id')} FROM {ident('workflow_runs')}",  # nosec B608
+            connection=conn,
+        )
+        for row in self._rows_from_result(run_result):
+            data = self._row_to_dict(row)
+            run_id = str(data.get("run_id") or "").strip()
+            if run_id:
+                valid_run_ids.add(run_id)
+
+        step_run_result = backend.execute(
+            f"SELECT {ident('step_run_id')} FROM {ident('workflow_step_runs')}",  # nosec B608
+            connection=conn,
+        )
+        for row in self._rows_from_result(step_run_result):
+            data = self._row_to_dict(row)
+            step_run_id = str(data.get("step_run_id") or "").strip()
+            if step_run_id:
+                valid_step_run_ids.add(step_run_id)
+
+        if backend.table_exists("workflow_step_attempts", connection=conn):
+            backend.execute(
+                f"ALTER TABLE {ident('workflow_step_attempts')} RENAME TO {ident('workflow_step_attempts_legacy_v8')}",
+                connection=conn,
+            )
+            result = backend.execute(
+                f"SELECT * FROM {ident('workflow_step_attempts_legacy_v8')}",  # nosec B608
+                connection=conn,
+            )
+            legacy_rows = self._rows_from_result(result)
+
+        backend.execute(
+            f"DROP TABLE IF EXISTS {ident('workflow_step_attempts')}",
+            connection=conn,
+        )
+        backend.execute(
+            f"CREATE TABLE {ident('workflow_step_attempts')} ("
+            f"{ident('attempt_id')} TEXT PRIMARY KEY,"
+            f"{ident('tenant_id')} TEXT NOT NULL,"
+            f"{ident('run_id')} TEXT NOT NULL,"
+            f"{ident('step_run_id')} TEXT NOT NULL,"
+            f"{ident('step_id')} TEXT NOT NULL,"
+            f"{ident('attempt_number')} INTEGER NOT NULL,"
+            f"{ident('status')} TEXT NOT NULL,"
+            f"{ident('reason_code_core')} TEXT,"
+            f"{ident('reason_code_detail')} TEXT,"
+            f"{ident('retryable')} BOOLEAN,"
+            f"{ident('error_summary')} TEXT,"
+            f"{ident('metadata_json')} JSONB,"
+            f"{ident('started_at')} TIMESTAMPTZ NOT NULL,"
+            f"{ident('ended_at')} TIMESTAMPTZ,"
+            f"UNIQUE ({ident('step_run_id')}, {ident('attempt_number')}),"
+            f"FOREIGN KEY ({ident('run_id')}) REFERENCES {ident('workflow_runs')}({ident('run_id')}) ON DELETE CASCADE,"
+            f"FOREIGN KEY ({ident('step_run_id')}) REFERENCES {ident('workflow_step_runs')}({ident('step_run_id')}) ON DELETE CASCADE"
+            ")",
+            connection=conn,
+        )
+        for row in self._normalize_step_attempt_migration_rows(
+            legacy_rows,
+            valid_run_ids=valid_run_ids,
+            valid_step_run_ids=valid_step_run_ids,
+        ):
+            metadata_raw = row.get("metadata_json")
+            if isinstance(metadata_raw, (dict, list)):
+                metadata_value = json.dumps(metadata_raw)
+            else:
+                metadata_value = metadata_raw
+            backend.execute(
+                f"INSERT INTO {ident('workflow_step_attempts')} ("  # nosec B608
+                f"{ident('attempt_id')}, {ident('tenant_id')}, {ident('run_id')}, {ident('step_run_id')}, "
+                f"{ident('step_id')}, {ident('attempt_number')}, {ident('status')}, {ident('reason_code_core')}, "
+                f"{ident('reason_code_detail')}, {ident('retryable')}, {ident('error_summary')}, "
+                f"{ident('metadata_json')}, {ident('started_at')}, {ident('ended_at')}"
+                f") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+                (
+                    str(row.get("attempt_id") or uuid4()),
+                    str(row.get("tenant_id") or ""),
+                    str(row.get("run_id") or ""),
+                    str(row.get("step_run_id") or ""),
+                    str(row.get("step_id") or ""),
+                    int(row.get("attempt_number") or 0),
+                    str(row.get("status") or "running"),
+                    row.get("reason_code_core"),
+                    row.get("reason_code_detail"),
+                    row.get("retryable"),
+                    row.get("error_summary"),
+                    metadata_value,
+                    str(row.get("started_at") or _utcnow_iso()),
+                    row.get("ended_at"),
+                ),
+                connection=conn,
+            )
+        backend.execute(
+            f"DROP TABLE IF EXISTS {ident('workflow_step_attempts_legacy_v8')}",
+            connection=conn,
+        )
+        backend.execute(
+            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_run_attempts')} "
+            f"ON {ident('workflow_step_attempts')} ({ident('run_id')}, {ident('attempt_number')}, {ident('started_at')})",
+            connection=conn,
+        )
+        backend.execute(
+            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_run_step_attempts')} "
+            f"ON {ident('workflow_step_attempts')} ({ident('run_id')}, {ident('step_id')}, {ident('attempt_number')}, {ident('started_at')})",
+            connection=conn,
+        )
+        backend.execute(
+            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_step_run_attempts')} "
+            f"ON {ident('workflow_step_attempts')} ({ident('step_run_id')}, {ident('attempt_number')}, {ident('started_at')})",
             connection=conn,
         )
 
@@ -1005,7 +1232,143 @@ class WorkflowsDatabase:
             logger.error("Unexpected error while initialising workflows schema: {}", exc)
             raise
 
+    def _get_sqlite_schema_version(self) -> int:
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS workflow_schema_version (version INTEGER NOT NULL)"
+        )
+        row = self._conn.execute(
+            "SELECT version FROM workflow_schema_version LIMIT 1"
+        ).fetchone()
+        if not row:
+            self._conn.execute(
+                "INSERT INTO workflow_schema_version (version) VALUES (0)"
+            )
+            self._conn.commit()
+            return 0
+        return int(row[0] or 0)
+
+    def _set_sqlite_schema_version(self, version: int) -> None:
+        cur = self._conn.execute(
+            "UPDATE workflow_schema_version SET version = ?",
+            (int(version),),
+        )
+        if cur.rowcount == 0:
+            self._conn.execute(
+                "INSERT INTO workflow_schema_version (version) VALUES (?)",
+                (int(version),),
+            )
+        self._conn.commit()
+
+    def _sqlite_migrate_to_v8(self) -> None:
+        cur = self._conn.cursor()
+        legacy_rows: list[Any] = []
+        valid_run_ids = {
+            str(row[0]).strip()
+            for row in cur.execute("SELECT run_id FROM workflow_runs").fetchall()
+            if str(row[0]).strip()
+        }
+        valid_step_run_ids = {
+            str(row[0]).strip()
+            for row in cur.execute("SELECT step_run_id FROM workflow_step_runs").fetchall()
+            if str(row[0]).strip()
+        }
+        existing = cur.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workflow_step_attempts'"
+        ).fetchone()
+        if existing:
+            cur.execute("ALTER TABLE workflow_step_attempts RENAME TO workflow_step_attempts_legacy_v8")
+            legacy_rows = cur.execute(
+                "SELECT * FROM workflow_step_attempts_legacy_v8"
+            ).fetchall()
+
+        cur.execute("DROP TABLE IF EXISTS workflow_step_attempts")
+        cur.execute(
+            """
+            CREATE TABLE workflow_step_attempts (
+                attempt_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                step_run_id TEXT NOT NULL,
+                step_id TEXT NOT NULL,
+                attempt_number INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                reason_code_core TEXT,
+                reason_code_detail TEXT,
+                retryable INTEGER,
+                error_summary TEXT,
+                metadata_json TEXT,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                UNIQUE(step_run_id, attempt_number),
+                FOREIGN KEY(run_id) REFERENCES workflow_runs(run_id) ON DELETE CASCADE,
+                FOREIGN KEY(step_run_id) REFERENCES workflow_step_runs(step_run_id) ON DELETE CASCADE
+            );
+            """
+        )
+        for row in self._normalize_step_attempt_migration_rows(
+            legacy_rows,
+            valid_run_ids=valid_run_ids,
+            valid_step_run_ids=valid_step_run_ids,
+        ):
+            metadata_raw = row.get("metadata_json")
+            if isinstance(metadata_raw, (dict, list)):
+                metadata_value = json.dumps(metadata_raw)
+            else:
+                metadata_value = metadata_raw
+            cur.execute(
+                """
+                INSERT INTO workflow_step_attempts(
+                    attempt_id, tenant_id, run_id, step_run_id, step_id, attempt_number, status, reason_code_core,
+                    reason_code_detail, retryable, error_summary, metadata_json, started_at, ended_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(row.get("attempt_id") or uuid4()),
+                    str(row.get("tenant_id") or ""),
+                    str(row.get("run_id") or ""),
+                    str(row.get("step_run_id") or ""),
+                    str(row.get("step_id") or ""),
+                    int(row.get("attempt_number") or 0),
+                    str(row.get("status") or "running"),
+                    row.get("reason_code_core"),
+                    row.get("reason_code_detail"),
+                    row.get("retryable"),
+                    row.get("error_summary"),
+                    metadata_value,
+                    str(row.get("started_at") or _utcnow_iso()),
+                    row.get("ended_at"),
+                ),
+            )
+        cur.execute("DROP TABLE IF EXISTS workflow_step_attempts_legacy_v8")
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_run_attempts "
+            "ON workflow_step_attempts(run_id, attempt_number, started_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_run_step_attempts "
+            "ON workflow_step_attempts(run_id, step_id, attempt_number, started_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_step_run_attempts "
+            "ON workflow_step_attempts(step_run_id, attempt_number, started_at)"
+        )
+        self._conn.commit()
+
+    def _run_sqlite_migrations(self, current_version: int, target_version: int) -> int:
+        applied_version = current_version
+        if applied_version < 8 <= target_version:
+            self._sqlite_migrate_to_v8()
+            self._set_sqlite_schema_version(8)
+            applied_version = 8
+        return applied_version
+
     def _create_schema(self) -> None:
+        current_version = self._get_sqlite_schema_version()
+        if current_version > self._CURRENT_SCHEMA_VERSION:
+            raise WorkflowsSchemaError(
+                "Workflows schema version is newer than supported by this release."
+            )
+
         cur = self._conn.cursor()
         # Definitions
         cur.execute(
@@ -1095,6 +1458,30 @@ class WorkflowsDatabase:
             """
         )
 
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS workflow_step_attempts (
+                attempt_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                step_run_id TEXT NOT NULL,
+                step_id TEXT NOT NULL,
+                attempt_number INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                reason_code_core TEXT,
+                reason_code_detail TEXT,
+                retryable INTEGER,
+                error_summary TEXT,
+                metadata_json TEXT,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                UNIQUE(step_run_id, attempt_number),
+                FOREIGN KEY(run_id) REFERENCES workflow_runs(run_id) ON DELETE CASCADE,
+                FOREIGN KEY(step_run_id) REFERENCES workflow_step_runs(step_run_id) ON DELETE CASCADE
+            );
+            """
+        )
+
         # Events
         cur.execute(
             """
@@ -1117,6 +1504,18 @@ class WorkflowsDatabase:
         cur.execute("CREATE INDEX IF NOT EXISTS idx_runs_status ON workflow_runs(status)")
         cur.execute(
             "CREATE INDEX IF NOT EXISTS idx_runs_idempotency_lookup ON workflow_runs(tenant_id, user_id, idempotency_key, created_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_run_attempts "
+            "ON workflow_step_attempts(run_id, attempt_number, started_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_run_step_attempts "
+            "ON workflow_step_attempts(run_id, step_id, attempt_number, started_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_step_run_attempts "
+            "ON workflow_step_attempts(step_run_id, attempt_number, started_at)"
         )
         # Partial indexes for frequently accessed statuses (supported on modern SQLite)
         try:
@@ -1245,6 +1644,13 @@ class WorkflowsDatabase:
             "ON workflow_research_waits(research_run_id, checkpoint_id, wait_status)"
         )
         self._conn.commit()
+
+        applied_version = self._run_sqlite_migrations(
+            current_version,
+            self._CURRENT_SCHEMA_VERSION,
+        )
+        if applied_version < self._CURRENT_SCHEMA_VERSION:
+            self._set_sqlite_schema_version(self._CURRENT_SCHEMA_VERSION)
 
     # ---------- Definitions ----------
 
@@ -1781,44 +2187,65 @@ class WorkflowsDatabase:
 
         # SQLite path
         conn = self._acquire_sqlite()
-        cur = conn.cursor()
         try:
-            # Try per-run counter with a short critical section
-            row = cur.execute(
-                "SELECT next_seq FROM workflow_event_counters WHERE run_id = ?",
-                (run_id,),
-            ).fetchone()
-            if not row:
-                next_seq = 1
-                cur.execute(
-                    "INSERT OR IGNORE INTO workflow_event_counters(run_id, next_seq) VALUES (?, ?)",
-                    (run_id, next_seq),
-                )
-            else:
-                current = int(row[0] if not isinstance(row, dict) else row.get("next_seq", 0))
-                next_seq = current + 1
-                cur.execute(
-                    "UPDATE workflow_event_counters SET next_seq = ? WHERE run_id = ?",
-                    (next_seq, run_id),
-                )
-        except _WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS:
-            # Fallback to aggregate scan if counters table missing
-            row = cur.execute(
-                "SELECT COALESCE(MAX(event_seq), 0) as max_seq FROM workflow_events WHERE run_id = ?",
-                (run_id,),
-            ).fetchone()
-            next_seq = int(row["max_seq"] if isinstance(row, dict) else row[0]) + 1
+            tries = 0
+            while True:
+                try:
+                    conn.execute("BEGIN IMMEDIATE")
+                    break
+                except sqlite3.OperationalError as e:
+                    if "locked" in str(e).lower() and tries < 4:
+                        import time as _time
 
-        params_insert = (
-            tenant_id,
-            run_id,
-            step_run_id,
-            next_seq,
-            event_type,
-            json.dumps(payload or {}),
-            _utcnow_iso(),
-        )
-        try:
+                        _time.sleep(0.05 * (2 ** tries))
+                        tries += 1
+                        continue
+                    raise
+
+            cur = conn.cursor()
+            try:
+                # Try per-run counter with an explicit write transaction so
+                # the counter increment and event insert share one serialized
+                # critical section on SQLite.
+                row = cur.execute(
+                    """
+                    INSERT INTO workflow_event_counters(run_id, next_seq)
+                    VALUES (?, 1)
+                    ON CONFLICT(run_id) DO UPDATE SET next_seq = workflow_event_counters.next_seq + 1
+                    RETURNING next_seq
+                    """,
+                    (run_id,),
+                ).fetchone()
+                next_seq = int(row["next_seq"] if isinstance(row, dict) else row[0]) if row else 1
+            except _WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS:
+                # Fallback for older SQLite builds or partially migrated tables.
+                row = cur.execute(
+                    "SELECT next_seq FROM workflow_event_counters WHERE run_id = ?",
+                    (run_id,),
+                ).fetchone()
+                if not row:
+                    next_seq = 1
+                    cur.execute(
+                        "INSERT OR IGNORE INTO workflow_event_counters(run_id, next_seq) VALUES (?, ?)",
+                        (run_id, next_seq),
+                    )
+                else:
+                    current = int(row[0] if not isinstance(row, dict) else row.get("next_seq", 0))
+                    next_seq = current + 1
+                    cur.execute(
+                        "UPDATE workflow_event_counters SET next_seq = ? WHERE run_id = ?",
+                        (next_seq, run_id),
+                    )
+
+            params_insert = (
+                tenant_id,
+                run_id,
+                step_run_id,
+                next_seq,
+                event_type,
+                json.dumps(payload or {}),
+                _utcnow_iso(),
+            )
             cur.execute(
                 """
                 INSERT INTO workflow_events(tenant_id, run_id, step_run_id, event_seq, event_type, payload_json, created_at)
@@ -1828,18 +2255,13 @@ class WorkflowsDatabase:
             )
             conn.commit()
         except sqlite3.OperationalError as e:
-            if "locked" in str(e).lower():
-                # Retry on lock contention
-                self._sqlite_retry_execute(
-                    """
-                    INSERT INTO workflow_events(tenant_id, run_id, step_run_id, event_seq, event_type, payload_json, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    params_insert,
-                )
-                self._sqlite_retry_commit()
-            else:
-                raise
+            with contextlib.suppress(sqlite3.Error):
+                conn.rollback()
+            raise
+        except sqlite3.Error:
+            with contextlib.suppress(sqlite3.Error):
+                conn.rollback()
+            raise
         self._release_sqlite(conn)
         return next_seq
 
@@ -1981,6 +2403,22 @@ class WorkflowsDatabase:
         finally:
             self._release_sqlite(conn)
 
+    def list_step_runs(self, *, run_id: str) -> list[dict[str, Any]]:
+        """Return step runs for a workflow run ordered by creation time."""
+        query = """
+            SELECT * FROM workflow_step_runs
+            WHERE run_id = ?
+            ORDER BY started_at ASC, step_run_id ASC
+        """
+        params = (str(run_id),)
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                result = self._execute_backend(query, params, connection=conn)
+            rows = self._rows_from_result(result)
+        else:
+            rows = self._conn.cursor().execute(query, params).fetchall()
+        return [self._row_to_dict(row) for row in rows]
+
     def update_step_attempt(self, *, step_run_id: str, attempt: int) -> None:
         """Persist the current attempt count for a step run."""
         params = (int(attempt), step_run_id)
@@ -2005,6 +2443,136 @@ class WorkflowsDatabase:
                 self._sqlite_retry_commit()
             else:
                 raise
+
+    def create_step_attempt(
+        self,
+        *,
+        tenant_id: str,
+        run_id: str,
+        step_run_id: str,
+        step_id: str,
+        attempt_number: int,
+        status: str = "running",
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        step_run_id_value = str(step_run_id or "").strip()
+        if not step_run_id_value:
+            raise ValueError("step_run_id is required for workflow step attempts")
+        attempt_id = str(uuid4())
+        params = (
+            attempt_id,
+            tenant_id,
+            run_id,
+            step_run_id_value,
+            step_id,
+            int(attempt_number),
+            status,
+            json.dumps(metadata or {}),
+            _utcnow_iso(),
+        )
+        query = """
+            INSERT INTO workflow_step_attempts(
+                attempt_id, tenant_id, run_id, step_run_id, step_id, attempt_number, status, metadata_json, started_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                self._execute_backend(query, params, connection=conn)
+            return attempt_id
+
+        try:
+            self._conn.execute(query, params)
+            self._conn.commit()
+        except sqlite3.OperationalError as e:
+            if "locked" in str(e).lower():
+                self._sqlite_retry_execute(query, params)
+                self._sqlite_retry_commit()
+            else:
+                raise
+        return attempt_id
+
+    def complete_step_attempt(
+        self,
+        *,
+        attempt_id: str,
+        status: str,
+        reason_code_core: str | None = None,
+        reason_code_detail: str | None = None,
+        retryable: bool | None = None,
+        error_summary: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        retryable_value = None if retryable is None else bool(retryable)
+        metadata_json = None if metadata is None else json.dumps(metadata)
+        params = (
+            status,
+            reason_code_core,
+            reason_code_detail,
+            retryable_value,
+            error_summary,
+            metadata_json,
+            _utcnow_iso(),
+            attempt_id,
+        )
+        query = """
+            UPDATE workflow_step_attempts
+            SET status = ?,
+                reason_code_core = ?,
+                reason_code_detail = ?,
+                retryable = ?,
+                error_summary = ?,
+                metadata_json = COALESCE(?, metadata_json),
+                ended_at = ?
+            WHERE attempt_id = ?
+        """
+
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                self._execute_backend(query, params, connection=conn)
+            return
+
+        try:
+            self._conn.execute(query, params)
+            self._conn.commit()
+        except sqlite3.OperationalError as e:
+            if "locked" in str(e).lower():
+                self._sqlite_retry_execute(query, params)
+                self._sqlite_retry_commit()
+            else:
+                raise
+
+    def list_step_attempts(
+        self,
+        *,
+        run_id: str,
+        step_id: str | None = None,
+        step_run_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        sql = "SELECT * FROM workflow_step_attempts WHERE run_id = ?"
+        params: list[Any] = [str(run_id)]
+        if step_id is not None:
+            sql += " AND step_id = ?"
+            params.append(str(step_id))
+        if step_run_id is not None:
+            sql += " AND step_run_id = ?"
+            params.append(str(step_run_id))
+        sql += " ORDER BY attempt_number ASC, started_at ASC, attempt_id ASC"
+
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                result = self._execute_backend(sql, tuple(params), connection=conn)
+            rows = self._rows_from_result(result)
+        else:
+            rows = self._conn.cursor().execute(sql, params).fetchall()
+
+        attempts: list[dict[str, Any]] = []
+        for row in rows:
+            data = self._row_to_dict(row)
+            with contextlib.suppress(_WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS):
+                data["metadata_json"] = json.loads(data.get("metadata_json") or "{}")
+            attempts.append(data)
+        return attempts
 
     def get_last_failed_step_id(self, run_id: str) -> str | None:
         query = (

--- a/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
@@ -2217,16 +2217,13 @@ class WorkflowsDatabase:
                 params_insert,
             )
             conn.commit()
-        except sqlite3.OperationalError as e:
+            return next_seq
+        except (sqlite3.Error, TypeError, ValueError):
             with contextlib.suppress(sqlite3.Error):
                 conn.rollback()
             raise
-        except sqlite3.Error:
-            with contextlib.suppress(sqlite3.Error):
-                conn.rollback()
-            raise
-        self._release_sqlite(conn)
-        return next_seq
+        finally:
+            self._release_sqlite(conn)
 
     def get_events(self, run_id: str, since: int | None = None, limit: int = 500, types: list[str] | None = None) -> list[dict[str, Any]]:
         sql = "SELECT * FROM workflow_events WHERE run_id = ?"

--- a/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
@@ -1012,43 +1012,6 @@ class WorkflowsDatabase:
         backend = self.backend
         ident = backend.escape_identifier
         backend.execute(
-            f"CREATE TABLE IF NOT EXISTS {ident('workflow_step_attempts')} ("
-            f"{ident('attempt_id')} TEXT PRIMARY KEY,"
-            f"{ident('tenant_id')} TEXT NOT NULL,"
-            f"{ident('run_id')} TEXT NOT NULL,"
-            f"{ident('step_run_id')} TEXT NOT NULL,"
-            f"{ident('step_id')} TEXT NOT NULL,"
-            f"{ident('attempt_number')} INTEGER NOT NULL,"
-            f"{ident('status')} TEXT NOT NULL,"
-            f"{ident('reason_code_core')} TEXT,"
-            f"{ident('reason_code_detail')} TEXT,"
-            f"{ident('retryable')} BOOLEAN,"
-            f"{ident('error_summary')} TEXT,"
-            f"{ident('metadata_json')} JSONB,"
-            f"{ident('started_at')} TIMESTAMPTZ NOT NULL,"
-            f"{ident('ended_at')} TIMESTAMPTZ,"
-            f"UNIQUE ({ident('step_run_id')}, {ident('attempt_number')}),"
-            f"FOREIGN KEY ({ident('run_id')}) REFERENCES {ident('workflow_runs')}({ident('run_id')}) ON DELETE CASCADE,"
-            f"FOREIGN KEY ({ident('step_run_id')}) REFERENCES {ident('workflow_step_runs')}({ident('step_run_id')}) ON DELETE CASCADE"
-            ")",
-            connection=conn,
-        )
-        backend.execute(
-            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_run_attempts')} "
-            f"ON {ident('workflow_step_attempts')} ({ident('run_id')}, {ident('attempt_number')}, {ident('started_at')})",
-            connection=conn,
-        )
-        backend.execute(
-            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_run_step_attempts')} "
-            f"ON {ident('workflow_step_attempts')} ({ident('run_id')}, {ident('step_id')}, {ident('attempt_number')}, {ident('started_at')})",
-            connection=conn,
-        )
-        backend.execute(
-            f"CREATE INDEX IF NOT EXISTS {ident('idx_step_attempts_step_run_attempts')} "
-            f"ON {ident('workflow_step_attempts')} ({ident('step_run_id')}, {ident('attempt_number')}, {ident('started_at')})",
-            connection=conn,
-        )
-        backend.execute(
             f"CREATE TABLE IF NOT EXISTS {ident('workflow_research_waits')} ("
             f"{ident('wait_id')} TEXT PRIMARY KEY,"
             f"{ident('tenant_id')} TEXT NOT NULL,"
@@ -2569,8 +2532,22 @@ class WorkflowsDatabase:
         attempts: list[dict[str, Any]] = []
         for row in rows:
             data = self._row_to_dict(row)
-            with contextlib.suppress(_WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS):
-                data["metadata_json"] = json.loads(data.get("metadata_json") or "{}")
+            metadata_raw = data.get("metadata_json")
+            if isinstance(metadata_raw, (dict, list)):
+                data["metadata_json"] = metadata_raw
+            elif not metadata_raw:
+                data["metadata_json"] = {}
+            else:
+                try:
+                    data["metadata_json"] = json.loads(str(metadata_raw))
+                except _WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS as exc:
+                    logger.warning(
+                        "Workflows DB: malformed step attempt metadata_json run_id={} attempt_id={}: {}",
+                        run_id,
+                        data.get("attempt_id"),
+                        exc,
+                    )
+                    data["metadata_json"] = {}
             attempts.append(data)
         return attempts
 

--- a/tldw_Server_API/app/core/DB_Management/Workflows_Scheduler_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_Scheduler_DB.py
@@ -455,7 +455,8 @@ class WorkflowsSchedulerDB:
                     validation_mode=r.get("validation_mode") or "block", enabled=bool(r.get("enabled") in (1, True, "1")),
                     require_online=bool(r.get("require_online") in (1, True, "1")),
                     concurrency_mode=(r.get("concurrency_mode") or "skip"), misfire_grace_sec=int(r.get("misfire_grace_sec") or 300),
-                    coalesce=bool(r.get("coalesce") in (1, True, "1")), jitter_sec=int(r.get("jitter_sec") or 0), last_run_at=r.get("last_run_at"), next_run_at=r.get("next_run_at"),
+                    coalesce=bool(r.get("coalesce") in (1, True, "1")), jitter_sec=int(r.get("jitter_sec") or 0), acp_config_json=r.get("acp_config_json"),
+                    last_run_at=r.get("last_run_at"), next_run_at=r.get("next_run_at"),
                     last_status=r.get("last_status"), created_at=r.get("created_at"), updated_at=r.get("updated_at")
                 )
             )

--- a/tldw_Server_API/app/core/DB_Management/Workflows_Scheduler_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_Scheduler_DB.py
@@ -430,6 +430,37 @@ class WorkflowsSchedulerDB:
             )
         return out
 
+    def list_all_schedules(
+        self,
+        *,
+        user_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[WorkflowSchedule]:
+        params: list[Any] = []
+        sql = "SELECT * FROM workflow_schedules"
+        if user_id:
+            sql += " WHERE user_id = ?"
+            params.append(user_id)
+        sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        with self.backend.transaction() as conn:
+            res = self.backend.execute(sql, tuple(params), connection=conn)
+        out: list[WorkflowSchedule] = []
+        for r in self._rows(res):
+            out.append(
+                WorkflowSchedule(
+                    id=r["id"], tenant_id=r["tenant_id"], user_id=r["user_id"], workflow_id=r.get("workflow_id"), name=r.get("name"),
+                    cron=r["cron"], timezone=r.get("timezone"), inputs_json=r["inputs_json"], run_mode=r.get("run_mode") or "async",
+                    validation_mode=r.get("validation_mode") or "block", enabled=bool(r.get("enabled") in (1, True, "1")),
+                    require_online=bool(r.get("require_online") in (1, True, "1")),
+                    concurrency_mode=(r.get("concurrency_mode") or "skip"), misfire_grace_sec=int(r.get("misfire_grace_sec") or 300),
+                    coalesce=bool(r.get("coalesce") in (1, True, "1")), jitter_sec=int(r.get("jitter_sec") or 0), last_run_at=r.get("last_run_at"), next_run_at=r.get("next_run_at"),
+                    last_status=r.get("last_status"), created_at=r.get("created_at"), updated_at=r.get("updated_at")
+                )
+            )
+        return out
+
     # Convenience helpers to mutate history
     def set_history(self, id: str, *, last_run_at: str | None = None, next_run_at: str | None = None, last_status: str | None = None) -> None:
         update: dict[str, Any] = {}

--- a/tldw_Server_API/app/core/Workflows/README.md
+++ b/tldw_Server_API/app/core/Workflows/README.md
@@ -8,14 +8,18 @@ Define, run, and monitor multi‑step workflows. Includes definition/versioning,
   - Create/list/delete workflow definitions; create new immutable versions under a definition.
 - Runs
   - Start runs from a saved definition (`run_mode` async/sync) or ad‑hoc payload; inject per‑run secrets (never persisted) and idempotency keys.
+  - Ad‑hoc runs require the same `workflows` scope as saved-definition runs.
   - Events and artifacts persisted; step run entries tracked with timestamps and status.
 - Step types (initial set)
   - `media_ingest`, `prompt` (templating), `llm`, `rag_search`, `kanban`, `mcp_tool`, `tts`, `webhook`, `delay`, `log`, `wait_for_human`, `wait_for_approval`, `branch`, `map`, `process_media`, `policy_check`, `rss_fetch`, `atom_fetch`, `embed`, `translate`, `stt_transcribe`, `notify`, `diff_change_detector`.
   - Map sub-steps: `map` supports nested types `prompt`, `log`, `delay`, `rag_search`, `media_ingest`, `mcp_tool`, `webhook`, `kanban` only (others are rejected).
 - Scheduling
   - Recurring schedules via Workflows Scheduler (cron/APS); presence gating, concurrency mode (skip/queue), coalesce/misfire behavior, jitter.
+  - Scheduler bootstrap/rescan scans all tenant rows inside each per-user scheduler DB, rather than assuming `tenant_id="default"`.
+  - Manual `run-now` uses the same target resolver as recurring execution, so watchlist-backed schedules route to `watchlist_run` on the `watchlists` queue.
 - Governance
   - RBAC checks on run listing and control; optional virtual keys for scheduled runs; audit events on key lifecycle operations.
+  - Webhook DLQ replay and artifact GC both append workflow evidence events (`webhook_delivery` and `artifact_gc`).
 
 Related Endpoints (file:line)
 - Router (prefix `/api/v1/workflows`): tldw_Server_API/app/api/v1/endpoints/workflows.py:46

--- a/tldw_Server_API/app/core/Workflows/engine.py
+++ b/tldw_Server_API/app/core/Workflows/engine.py
@@ -945,13 +945,7 @@ class WorkflowEngine:
             duration_ms = None
             try:
                 r = self.db.get_run(run_id)
-                if r and r.started_at:
-                    from datetime import datetime
-                    try:
-                        started = datetime.fromisoformat(r.started_at)
-                    except _WF_NONCRITICAL_EXCEPTIONS:
-                        started = datetime.strptime(r.started_at.split(".")[0], "%Y-%m-%dT%H:%M:%S")
-                    duration_ms = int((datetime.utcnow() - started).total_seconds() * 1000)
+                duration_ms = self._duration_ms_since(r.started_at) if r and r.started_at else None
             except _WF_NONCRITICAL_EXCEPTIONS:
                 duration_ms = None
             tokens_in, tokens_out, cost_usd = self._aggregate_run_token_usage(run_id)
@@ -1420,14 +1414,7 @@ class WorkflowEngine:
         duration_ms = None
         try:
             if run.started_at:
-                from datetime import datetime
-                fmt = "%Y-%m-%dT%H:%M:%S"
-                # allow microseconds if present
-                try:
-                    started = datetime.fromisoformat(run.started_at)
-                except _WF_NONCRITICAL_EXCEPTIONS:
-                    started = datetime.strptime(run.started_at.split(".")[0], fmt)
-                duration_ms = int((datetime.utcnow() - started).total_seconds() * 1000)
+                duration_ms = self._duration_ms_since(run.started_at)
         except _WF_NONCRITICAL_EXCEPTIONS:
             duration_ms = None
         tokens_in, tokens_out, cost_usd = self._aggregate_run_token_usage(run_id)
@@ -1557,7 +1544,29 @@ class WorkflowEngine:
 
     @staticmethod
     def _now_iso() -> str:
-        return __import__("datetime").datetime.utcnow().isoformat()
+        from datetime import datetime, timezone
+
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _duration_ms_since(started_at: str | None) -> int | None:
+        if not started_at:
+            return None
+        from datetime import datetime, timezone
+
+        try:
+            started = datetime.fromisoformat(started_at)
+        except _WF_NONCRITICAL_EXCEPTIONS:
+            try:
+                started = datetime.strptime(started_at.split(".")[0], "%Y-%m-%dT%H:%M:%S")
+            except _WF_NONCRITICAL_EXCEPTIONS:
+                return None
+        if started.tzinfo is not None:
+            now = datetime.now(timezone.utc)
+            started = started.astimezone(timezone.utc)
+        else:
+            now = datetime.now()
+        return int((now - started).total_seconds() * 1000)
 
     def _compute_max_retries_for_step(self, step_type: str, step_obj: dict[str, Any]) -> int:
         """Adapter-level retry defaults with per-step override via 'retry'."""
@@ -1809,11 +1818,11 @@ class WorkflowEngine:
                     dt = dt.replace(tzinfo=timezone.utc)
                 return dt
 
-            cutoff = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(seconds=int(self.config.heartbeat_interval_sec * 15))
+            cutoff = datetime.now(timezone.utc) - timedelta(seconds=int(self.config.heartbeat_interval_sec * 15))
             stale = self.db.find_orphan_step_runs(cutoff.isoformat())
             if not stale:
                 return
-            now = datetime.utcnow().replace(tzinfo=timezone.utc)
+            now = datetime.now(timezone.utc)
             grace_ms = 5000
             requeue_targets: dict[str, dict[str, Any]] = {}
 

--- a/tldw_Server_API/app/core/Workflows/engine.py
+++ b/tldw_Server_API/app/core/Workflows/engine.py
@@ -266,6 +266,13 @@ class WorkflowEngine:
         step_type: str,
         failure: Any | None = None,
     ) -> dict[str, Any]:
+        """Build metadata persisted with workflow step-attempt records.
+
+        The base payload records the step type and capability descriptor. When a
+        failure envelope is provided, selected classification fields are copied
+        to top-level metadata and the complete envelope is retained under
+        ``failure_envelope`` for investigation and operator diagnostics.
+        """
         metadata: dict[str, Any] = {
             "step_type": step_type,
             "step_capability": get_step_capability(step_type).to_dict(),
@@ -450,7 +457,7 @@ class WorkflowEngine:
     ) -> tuple[str, str]:
         run = self.db.get_run(run_id)
         if run is None:
-            return ("already_applied", "unknown")
+            return ("not_found", "unknown")
 
         current_status = str(getattr(run, "status", "unknown") or "unknown")
         if current_status == target_status:

--- a/tldw_Server_API/app/core/Workflows/engine.py
+++ b/tldw_Server_API/app/core/Workflows/engine.py
@@ -18,6 +18,8 @@ from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabas
 from tldw_Server_API.app.core.exceptions import AdapterError
 from tldw_Server_API.app.core.testing import is_truthy
 from tldw_Server_API.app.core.Workflows.adapters import get_adapter
+from tldw_Server_API.app.core.Workflows.capabilities import get_step_capability
+from tldw_Server_API.app.core.Workflows.failures import build_failure_envelope
 
 _WF_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     AttributeError,
@@ -66,8 +68,9 @@ except _WF_NONCRITICAL_EXCEPTIONS:  # pragma: no cover - safety
 _TEMPLATE_EXPR_RE = re.compile(r'^\s*\{\{(.+?)\}\}\s*$', re.DOTALL)
 
 _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
-    "queued": {"running", "cancelled", "failed"},
-    "running": {"waiting_human", "waiting_approval", "succeeded", "failed", "cancelled"},
+    "queued": {"paused", "running", "cancelled", "failed"},
+    "paused": {"running", "cancelled", "failed"},
+    "running": {"paused", "waiting_human", "waiting_approval", "succeeded", "failed", "cancelled"},
     "waiting_human": {"running", "failed", "cancelled"},
     "waiting_approval": {"running", "failed", "cancelled"},
 }
@@ -257,6 +260,65 @@ class WorkflowEngine:
         except _WF_NONCRITICAL_EXCEPTIONS:
             return (None, None, None)
 
+    def _attempt_metadata(
+        self,
+        *,
+        step_type: str,
+        failure: Any | None = None,
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "step_type": step_type,
+            "step_capability": get_step_capability(step_type).to_dict(),
+        }
+        if failure is not None:
+            failure_payload = (
+                failure.to_dict()
+                if hasattr(failure, "to_dict") and callable(failure.to_dict)
+                else dict(failure)
+            )
+            metadata.update(
+                {
+                    "category": failure_payload.get("category"),
+                    "blame_scope": failure_payload.get("blame_scope"),
+                    "retry_recommendation": failure_payload.get("retry_recommendation"),
+                    "failure_envelope": failure_payload,
+                }
+            )
+        return metadata
+
+    def _create_step_attempt_record(
+        self,
+        *,
+        run_id: str,
+        step_run_id: str,
+        step_id: str,
+        step_type: str,
+        attempt_number: int,
+        tenant_id: str,
+    ) -> str | None:
+        create_step_attempt = getattr(self.db, "create_step_attempt", None)
+        if not callable(create_step_attempt):
+            return None
+        try:
+            return create_step_attempt(
+                tenant_id=tenant_id,
+                run_id=run_id,
+                step_run_id=step_run_id,
+                step_id=step_id,
+                attempt_number=attempt_number,
+                status="running",
+                metadata=self._attempt_metadata(step_type=step_type),
+            )
+        except _WF_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(
+                "WorkflowEngine: failed to create step attempt run_id={} step_run_id={} attempt={} error={}",
+                run_id,
+                step_run_id,
+                attempt_number,
+                e,
+            )
+            return None
+
     def _complete_step_attempt_record(
         self,
         *,
@@ -272,6 +334,7 @@ class WorkflowEngine:
         if not callable(complete_step_attempt):
             return
         try:
+            metadata = self._attempt_metadata(step_type=step_type, failure=failure)
             complete_step_attempt(
                 attempt_id=attempt_id,
                 status=status,
@@ -279,7 +342,7 @@ class WorkflowEngine:
                 reason_code_detail=getattr(failure, "reason_code_detail", None),
                 retryable=getattr(failure, "retryable", None),
                 error_summary=getattr(failure, "error_summary", None),
-                metadata={"step_type": step_type},
+                metadata=metadata,
             )
         except _WF_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(
@@ -295,7 +358,13 @@ class WorkflowEngine:
             self.db.append_event(tenant, run_id, event_type, payload or {}, step_run_id=step_run_id)
         except _WF_NONCRITICAL_EXCEPTIONS as e:
             with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
-                logger.debug(f"WorkflowEngine: append_event failed run_id={run_id} type={event_type}: {e}")
+                logger.warning(
+                    "WorkflowEngine: append_event failed run_id={} type={} step_run_id={} error={}",
+                    run_id,
+                    event_type,
+                    step_run_id,
+                    e,
+                )
 
     def _append_cancel_acknowledged(
         self,
@@ -329,6 +398,7 @@ class WorkflowEngine:
         tokens_input: int | None = None,
         tokens_output: int | None = None,
         cost_usd: float | None = None,
+        on_reject: str = "fail_run",
     ) -> bool:
         """Update run status while enforcing the lifecycle transition contract."""
         current_status: str | None = None
@@ -341,16 +411,17 @@ class WorkflowEngine:
             self._append_event(
                 run_id,
                 "transition_rejected",
-                {"from": current_status, "to": status},
+                {"from": current_status, "to": status, "on_reject": on_reject},
             )
-            self.db.update_run_status(
-                run_id,
-                status="failed",
-                status_reason="invariant_violation",
-                ended_at=ended_at or self._now_iso(),
-                error="invariant_violation",
-            )
-            self._append_event(run_id, "run_failed", {"error": "invariant_violation"})
+            if on_reject == "fail_run":
+                self.db.update_run_status(
+                    run_id,
+                    status="failed",
+                    status_reason="invariant_violation",
+                    ended_at=ended_at or self._now_iso(),
+                    error="invariant_violation",
+                )
+                self._append_event(run_id, "run_failed", {"error": "invariant_violation"})
             return False
 
         self.db.update_run_status(
@@ -367,6 +438,41 @@ class WorkflowEngine:
             cost_usd=cost_usd,
         )
         return True
+
+    def _control_transition(
+        self,
+        run_id: str,
+        *,
+        target_status: str,
+        status_reason: str | None = None,
+        ended_at: str | None = None,
+        op_key: str,
+    ) -> tuple[str, str]:
+        run = self.db.get_run(run_id)
+        if run is None:
+            return ("already_applied", "unknown")
+
+        current_status = str(getattr(run, "status", "unknown") or "unknown")
+        if current_status == target_status:
+            return ("already_applied", current_status)
+        if not _is_allowed_transition(current_status, target_status):
+            self._append_event(
+                run_id,
+                "transition_rejected",
+                {"from": current_status, "to": target_status, "on_reject": "reject"},
+            )
+            return ("invalid_state", current_status)
+        if not self._apply_once(op_key):
+            return ("already_applied", current_status)
+        if not self._update_run_status_guarded(
+            run_id,
+            status=target_status,
+            status_reason=status_reason,
+            ended_at=ended_at,
+            on_reject="reject",
+        ):
+            return ("invalid_state", current_status)
+        return ("applied", current_status)
 
     @staticmethod
     def _resolve_database(db: WorkflowsDatabase | None) -> WorkflowsDatabase:
@@ -414,6 +520,17 @@ class WorkflowEngine:
 
         keep_secrets = False
         finalized = False
+
+        await self._wait_if_paused(run_id)
+        preflight_run = self.db.get_run(run_id)
+        if preflight_run is None:
+            _finalize(False)
+            finalized = True
+            return
+        if str(getattr(preflight_run, "status", "") or "") == "cancelled":
+            _finalize(False)
+            finalized = True
+            return
 
         if not self._update_run_status_guarded(run_id, status="running", started_at=self._now_iso()):
             _finalize(False)
@@ -548,7 +665,13 @@ class WorkflowEngine:
                             phase="before_step",
                             source="start_run",
                         )
-                        self.db.update_run_status(run_id, status="cancelled", status_reason="cancelled_by_user", ended_at=self._now_iso())
+                        if not self._update_run_status_guarded(
+                            run_id,
+                            status="cancelled",
+                            status_reason="cancelled_by_user",
+                            ended_at=self._now_iso(),
+                        ):
+                            return
                         self._append_event(run_id, "run_cancelled", {"by": "user", "before_step": step_id})
                         # Standardize webhook behavior on cancellation pre-execution
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
@@ -577,6 +700,14 @@ class WorkflowEngine:
                         # Persist attempt
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                             self.db.update_step_attempt(step_run_id=step_run_id, attempt=attempt)
+                        attempt_id = self._create_step_attempt_record(
+                            run_id=run_id,
+                            step_run_id=step_run_id,
+                            step_id=str(step_id),
+                            step_type=step_type,
+                            attempt_number=attempt,
+                            tenant_id=str(context.get("tenant_id") or self.config.tenant_id),
+                        )
                         # Honor pause before attempting execution
                         await self._wait_if_paused(run_id, step_run_id)
                         try:
@@ -631,6 +762,15 @@ class WorkflowEngine:
                             with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                                 record_span_exception(e)
 
+                        if err is not None:
+                            failure = build_failure_envelope(err, step_type=step_type)
+                            self._complete_step_attempt_record(
+                                attempt_id=attempt_id,
+                                step_type=step_type,
+                                status="failed",
+                                failure=failure,
+                            )
+
                         if attempt <= max_retries:
                             if not _is_retriable_error(error_reason_code):
                                 self._append_event(
@@ -675,7 +815,7 @@ class WorkflowEngine:
                             continue  # proceed to next selected step
                         # Otherwise, fail the run
                         tokens_in, tokens_out, cost_usd = self._aggregate_run_token_usage(run_id)
-                        self.db.update_run_status(
+                        if not self._update_run_status_guarded(
                             run_id,
                             status="failed",
                             status_reason=str(err),
@@ -684,7 +824,8 @@ class WorkflowEngine:
                             tokens_input=tokens_in,
                             tokens_output=tokens_out,
                             cost_usd=cost_usd,
-                        )
+                        ):
+                            return
                         self._append_event(run_id, "run_failed", {"error": str(err)})
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                             increment_counter("workflows_runs_failed", labels={"tenant": self._tenant_for_run(run_id)})
@@ -717,19 +858,25 @@ class WorkflowEngine:
                         except _WF_NONCRITICAL_EXCEPTIONS:
                             on_timeout = None
                             timeout_cfg = None
-                        self._handle_adapter_wait_state(
+                        if not self._handle_adapter_wait_state(
                             run_id=run_id,
                             step_id=step_id,
                             step_run_id=step_run_id,
                             wait_payload=last_outputs,
                             timeout_seconds=timeout_cfg,
                             on_timeout=on_timeout,
-                        )
+                        ):
+                            return
                         keep_secrets = True
                         _finalize(True)
                         finalized = True
                         return
                     if status_flag == "cancelled":
+                        self._complete_step_attempt_record(
+                            attempt_id=attempt_id,
+                            step_type=step_type,
+                            status="cancelled",
+                        )
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                             self.db.complete_step_run(step_run_id=step_run_id, status="cancelled", outputs=last_outputs)
                         # Emit a step_cancelled event for observability
@@ -740,10 +887,21 @@ class WorkflowEngine:
                             phase="during_step",
                             source="start_run",
                         )
-                        self.db.update_run_status(run_id, status="cancelled", status_reason="cancelled_by_user", ended_at=self._now_iso())
+                        if not self._update_run_status_guarded(
+                            run_id,
+                            status="cancelled",
+                            status_reason="cancelled_by_user",
+                            ended_at=self._now_iso(),
+                        ):
+                            return
                         self._append_event(run_id, "run_cancelled", {"by": "user", "during_step": step_id})
                         return
 
+                    self._complete_step_attempt_record(
+                        attempt_id=attempt_id,
+                        step_type=step_type,
+                        status="succeeded",
+                    )
                     self._append_event(run_id, "step_completed", {"step_id": step_id, "type": step_type})
                     with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                         increment_counter("workflows_steps_succeeded", labels={"type": step_type})
@@ -790,7 +948,7 @@ class WorkflowEngine:
             except _WF_NONCRITICAL_EXCEPTIONS:
                 duration_ms = None
             tokens_in, tokens_out, cost_usd = self._aggregate_run_token_usage(run_id)
-            self.db.update_run_status(
+            if not self._update_run_status_guarded(
                 run_id,
                 status="succeeded",
                 ended_at=self._now_iso(),
@@ -799,7 +957,8 @@ class WorkflowEngine:
                 tokens_input=tokens_in,
                 tokens_output=tokens_out,
                 cost_usd=cost_usd,
-            )
+            ):
+                return
             self._append_event(run_id, "run_completed", {"success": True})
             try:
                 tenant_label = self._tenant_for_run(run_id)
@@ -814,7 +973,7 @@ class WorkflowEngine:
                 await self._maybe_send_completion_webhook(definition, run_id, status="succeeded")
         except _WF_NONCRITICAL_EXCEPTIONS as e:
             tokens_in, tokens_out, cost_usd = self._aggregate_run_token_usage(run_id)
-            self.db.update_run_status(
+            if not self._update_run_status_guarded(
                 run_id,
                 status="failed",
                 status_reason=str(e),
@@ -823,7 +982,8 @@ class WorkflowEngine:
                 tokens_input=tokens_in,
                 tokens_output=tokens_out,
                 cost_usd=cost_usd,
-            )
+            ):
+                return
             self._append_event(run_id, "run_failed", {"error": str(e)})
             logger.error(f"WorkflowEngine: run {run_id} failed: {e}")
             # Completion webhook on failure
@@ -843,19 +1003,31 @@ class WorkflowEngine:
         wait_payload: dict[str, Any],
         timeout_seconds: int | float | None,
         on_timeout: str | None,
-    ) -> None:
+    ) -> bool:
         wait_status = "waiting_human" if wait_payload.get("__status__") == "waiting_human" else "waiting_approval"
         reason = str(wait_payload.get("reason") or "").strip() or None
 
         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
             self.db.complete_step_run(step_run_id=step_run_id, status=wait_status, outputs=wait_payload)
-        with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
-            self.db.update_run_status(
-                run_id,
-                status=wait_status,
-                status_reason=reason or "awaiting_review",
-                outputs=wait_payload,
-            )
+        if not self._update_run_status_guarded(
+            run_id,
+            status=wait_status,
+            status_reason=reason or "awaiting_review",
+            outputs=wait_payload,
+        ):
+            return False
+
+        event_payload: dict[str, Any] = {"step_id": step_id}
+        if reason:
+            event_payload["reason"] = reason
+        if wait_payload.get("assigned_to") is not None:
+            event_payload["assigned_to"] = wait_payload.get("assigned_to")
+        if wait_payload.get("run_id") is not None:
+            event_payload["research_run_id"] = wait_payload.get("run_id")
+        if wait_payload.get("research_checkpoint_id") is not None:
+            event_payload["research_checkpoint_id"] = wait_payload.get("research_checkpoint_id")
+        if wait_payload.get("research_checkpoint_type") is not None:
+            event_payload["research_checkpoint_type"] = wait_payload.get("research_checkpoint_type")
 
         if reason == "research_checkpoint":
             with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
@@ -872,25 +1044,18 @@ class WorkflowEngine:
                     active_poll_seconds=float(wait_payload.get("active_poll_seconds") or 0.0),
                 )
             with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
-                self._append_event(
-                    run_id,
-                    wait_status,
-                    {
-                        "step_id": step_id,
-                        "reason": reason,
-                        "research_run_id": wait_payload.get("run_id"),
-                        "research_checkpoint_id": wait_payload.get("research_checkpoint_id"),
-                        "research_checkpoint_type": wait_payload.get("research_checkpoint_type"),
-                    },
-                    step_run_id=step_run_id,
-                )
-            return
+                self._append_event(run_id, wait_status, event_payload, step_run_id=step_run_id)
+            return True
+
+        with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
+            self._append_event(run_id, wait_status, event_payload, step_run_id=step_run_id)
 
         try:
             if timeout_seconds is not None:
                 self._schedule_human_timeout(run_id, step_id, timeout_seconds, on_timeout)
         except _WF_NONCRITICAL_EXCEPTIONS:
             pass
+        return True
 
     async def continue_run(
         self,
@@ -925,7 +1090,13 @@ class WorkflowEngine:
         keep_secrets = False
         finalized = False
 
+        await self._wait_if_paused(run_id)
+        run = self.db.get_run(run_id)
         if not run:
+            _finalize(False)
+            finalized = True
+            return
+        if str(getattr(run, "status", "") or "") == "cancelled":
             _finalize(False)
             finalized = True
             return
@@ -1036,7 +1207,15 @@ class WorkflowEngine:
                     phase="before_step",
                     source="continue_run",
                 )
-                self.db.update_run_status(run_id, status="cancelled", status_reason="cancelled_by_user", ended_at=self._now_iso())
+                if not self._update_run_status_guarded(
+                    run_id,
+                    status="cancelled",
+                    status_reason="cancelled_by_user",
+                    ended_at=self._now_iso(),
+                ):
+                    _finalize(False)
+                    finalized = True
+                    return
                 self._append_event(run_id, "run_cancelled", {"by": "user", "before_step": sid})
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     await self._maybe_send_completion_webhook(definition, run_id, status="cancelled")
@@ -1057,6 +1236,14 @@ class WorkflowEngine:
                 attempt += 1
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     self.db.update_step_attempt(step_run_id=step_run_id, attempt=attempt)
+                attempt_id = self._create_step_attempt_record(
+                    run_id=run_id,
+                    step_run_id=step_run_id,
+                    step_id=str(sid),
+                    step_type=stype,
+                    attempt_number=attempt,
+                    tenant_id=str(context.get("tenant_id") or self.config.tenant_id),
+                )
                 await self._wait_if_paused(run_id, step_run_id)
                 try:
                     outputs = await asyncio.wait_for(
@@ -1072,6 +1259,14 @@ class WorkflowEngine:
                 except _WF_NONCRITICAL_EXCEPTIONS as e:
                     err = e
                     error_reason_code = _reason_code_from_error(e)
+                if err is not None:
+                    failure = build_failure_envelope(err, step_type=stype)
+                    self._complete_step_attempt_record(
+                        attempt_id=attempt_id,
+                        step_type=stype,
+                        status="failed",
+                        failure=failure,
+                    )
                 if attempt <= max_retries:
                     if not _is_retriable_error(error_reason_code):
                         self._append_event(
@@ -1103,7 +1298,7 @@ class WorkflowEngine:
                     idx = id_to_idx[failure_next]
                     continue
                 tokens_in, tokens_out, cost_usd = self._aggregate_run_token_usage(run_id)
-                self.db.update_run_status(
+                if not self._update_run_status_guarded(
                     run_id,
                     status="failed",
                     status_reason=str(err),
@@ -1112,7 +1307,10 @@ class WorkflowEngine:
                     tokens_input=tokens_in,
                     tokens_output=tokens_out,
                     cost_usd=cost_usd,
-                )
+                ):
+                    _finalize(False)
+                    finalized = True
+                    return
                 self._append_event(run_id, "run_failed", {"error": str(err)})
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     await self._maybe_send_completion_webhook(definition, run_id, status="failed")
@@ -1139,19 +1337,27 @@ class WorkflowEngine:
                 except _WF_NONCRITICAL_EXCEPTIONS:
                     on_timeout = None
                     timeout_cfg = None
-                self._handle_adapter_wait_state(
+                if not self._handle_adapter_wait_state(
                     run_id=run_id,
                     step_id=sid,
                     step_run_id=step_run_id,
                     wait_payload=last,
                     timeout_seconds=timeout_cfg,
                     on_timeout=on_timeout,
-                )
+                ):
+                    _finalize(False)
+                    finalized = True
+                    return
                 keep_secrets = True
                 _finalize(True)
                 finalized = True
                 return
             if last.get("__status__") == "cancelled":
+                self._complete_step_attempt_record(
+                    attempt_id=attempt_id,
+                    step_type=stype,
+                    status="cancelled",
+                )
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     self.db.complete_step_run(step_run_id=step_run_id, status="cancelled", outputs=last)
                 self._append_event(run_id, "step_cancelled", {"step_id": sid})
@@ -1161,7 +1367,15 @@ class WorkflowEngine:
                     phase="during_step",
                     source="continue_run",
                 )
-                self.db.update_run_status(run_id, status="cancelled", status_reason="cancelled_by_user", ended_at=self._now_iso())
+                if not self._update_run_status_guarded(
+                    run_id,
+                    status="cancelled",
+                    status_reason="cancelled_by_user",
+                    ended_at=self._now_iso(),
+                ):
+                    _finalize(False)
+                    finalized = True
+                    return
                 self._append_event(run_id, "run_cancelled", {"by": "user", "during_step": sid})
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     await self._maybe_send_completion_webhook(definition, run_id, status="cancelled")
@@ -1169,6 +1383,11 @@ class WorkflowEngine:
                 finalized = True
                 return
 
+            self._complete_step_attempt_record(
+                attempt_id=attempt_id,
+                step_type=stype,
+                status="succeeded",
+            )
             self._append_event(run_id, "step_completed", {"step_id": sid, "type": stype})
             with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                 self.db.complete_step_run(step_run_id=step_run_id, status="succeeded", outputs=last)
@@ -1205,7 +1424,7 @@ class WorkflowEngine:
         except _WF_NONCRITICAL_EXCEPTIONS:
             duration_ms = None
         tokens_in, tokens_out, cost_usd = self._aggregate_run_token_usage(run_id)
-        self.db.update_run_status(
+        if not self._update_run_status_guarded(
             run_id,
             status="succeeded",
             ended_at=self._now_iso(),
@@ -1214,7 +1433,10 @@ class WorkflowEngine:
             tokens_input=tokens_in,
             tokens_output=tokens_out,
             cost_usd=cost_usd,
-        )
+        ):
+            _finalize(False)
+            finalized = True
+            return
         self._append_event(run_id, "run_completed", {"success": True})
         # Parity with start_run: record completion metrics for continue_run path
         try:
@@ -1244,9 +1466,14 @@ class WorkflowEngine:
         current_status = str(getattr(run, "status", "unknown"))
         if current_status == "paused":
             return "already_applied"
-        if not self._apply_once(f"{run_id}:pause:{current_status}"):
-            return "already_applied"
-        self.db.update_run_status(run_id, status="paused", status_reason="paused_by_user")
+        result, _ = self._control_transition(
+            run_id,
+            target_status="paused",
+            status_reason="paused_by_user",
+            op_key=f"{run_id}:pause:{current_status}",
+        )
+        if result != "applied":
+            return result
         self._append_event(run_id, "run_paused", {"by": "user"})
         return "applied"
 
@@ -1255,9 +1482,21 @@ class WorkflowEngine:
         current_status = str(getattr(run, "status", "unknown"))
         if current_status == "running":
             return "already_applied"
-        if not self._apply_once(f"{run_id}:resume:{current_status}"):
-            return "already_applied"
-        self.db.update_run_status(run_id, status="running", status_reason=None)
+        if current_status != "paused":
+            self._append_event(
+                run_id,
+                "transition_rejected",
+                {"from": current_status, "to": "running", "on_reject": "reject", "source": "control_resume"},
+            )
+            return "invalid_state"
+        result, _ = self._control_transition(
+            run_id,
+            target_status="running",
+            status_reason=None,
+            op_key=f"{run_id}:resume:{current_status}",
+        )
+        if result != "applied":
+            return result
         self._append_event(run_id, "run_resumed", {"by": "user"})
         return "applied"
 
@@ -1271,8 +1510,15 @@ class WorkflowEngine:
             cancel_requested = bool(self.db.is_cancel_requested(run_id))
         if current_status == "cancelled" or cancel_requested:
             return "already_applied"
-        if not self._apply_once(f"{run_id}:cancel:{current_status}:{int(cancel_requested)}"):
-            return "already_applied"
+        result, _ = self._control_transition(
+            run_id,
+            target_status="cancelled",
+            status_reason="cancelled_by_user",
+            ended_at=self._now_iso(),
+            op_key=f"{run_id}:cancel:{current_status}:{int(cancel_requested)}",
+        )
+        if result != "applied":
+            return result
 
         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
             self.db.set_cancel_requested(run_id, True)
@@ -1298,7 +1544,6 @@ class WorkflowEngine:
                 logger.debug(f"WorkflowEngine: cancel subprocess cleanup failed for run_id={run_id}: {e}")
         # Ensure ended_at is set on cancel for lifecycle completeness
         self._append_cancel_acknowledged(run_id, source="control_run")
-        self.db.update_run_status(run_id, status="cancelled", status_reason="cancelled_by_user", ended_at=self._now_iso())
         self._append_event(run_id, "run_cancelled", {"by": "user"})
         self._clear_tenant_cache(run_id)
         return "applied"
@@ -1442,7 +1687,7 @@ class WorkflowEngine:
                     )
                     return
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
-                    self.db.update_run_status(
+                    self._update_run_status_guarded(
                         run_id,
                         status="failed",
                         status_reason="human_timeout",
@@ -1528,8 +1773,6 @@ class WorkflowEngine:
                 raise RuntimeError("assigned_to_required")
             # Mark run waiting, signal caller via special status
             wait_status = "waiting_human" if step_type == "wait_for_human" else "waiting_approval"
-            self.db.update_run_status(run_id, status=wait_status, status_reason="awaiting_review")
-            self._append_event(run_id, wait_status, {"assigned_to": assigned_to})
             return {"__status__": wait_status, "assigned_to": assigned_to}
 
         # Lookup adapter from registry
@@ -1632,7 +1875,14 @@ class WorkflowEngine:
                 if self.db.is_cancel_requested(rid):
                     try:
                         self._append_cancel_acknowledged(rid, source="orphan_reaper")
-                        self.db.update_run_status(rid, status="cancelled", status_reason="cancelled_by_user", ended_at=self._now_iso())
+                        if not self._update_run_status_guarded(
+                            rid,
+                            status="cancelled",
+                            status_reason="cancelled_by_user",
+                            ended_at=self._now_iso(),
+                            on_reject="reject",
+                        ):
+                            continue
                         self._append_event(rid, "run_cancelled", {"by": "user", "reason": "cancel_requested"})
                     except _WF_NONCRITICAL_EXCEPTIONS:
                         pass
@@ -1659,8 +1909,13 @@ class WorkflowEngine:
                 except _WF_NONCRITICAL_EXCEPTIONS:
                     last_outputs = None
 
-                with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
-                    self.db.update_run_status(rid, status="running", status_reason="orphan_requeued")
+                if not self._update_run_status_guarded(
+                    rid,
+                    status="running",
+                    status_reason="orphan_requeued",
+                    on_reject="reject",
+                ):
+                    continue
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     self._append_event(rid, "run_requeued", {"step_id": step_id, "step_run_id": target.get("step_run_id")})
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):

--- a/tldw_Server_API/app/core/Workflows/investigation.py
+++ b/tldw_Server_API/app/core/Workflows/investigation.py
@@ -219,7 +219,7 @@ def _serialize_step(
         "name": step_run.get("name"),
         "type": step_run.get("type"),
         "status": step_run.get("status"),
-        "attempt_count": int(step_run.get("attempt") or len(attempts) or 0),
+        "attempt_count": len(attempts),
         "started_at": step_run.get("started_at"),
         "ended_at": step_run.get("ended_at"),
         "error": step_run.get("error"),

--- a/tldw_Server_API/app/core/Workflows/investigation.py
+++ b/tldw_Server_API/app/core/Workflows/investigation.py
@@ -202,6 +202,11 @@ def _serialize_step(
     attempts: list[dict[str, Any]],
     include_operator_detail: bool,
 ) -> dict[str, Any]:
+    try:
+        legacy_attempt_count = int(step_run.get("attempt") or 0)
+    except (TypeError, ValueError):
+        legacy_attempt_count = 0
+    attempt_count = max(legacy_attempt_count, len(attempts))
     latest_failed_attempt = None
     for attempt in reversed(attempts):
         if str(attempt.get("status") or "") == "failed":
@@ -219,7 +224,7 @@ def _serialize_step(
         "name": step_run.get("name"),
         "type": step_run.get("type"),
         "status": step_run.get("status"),
-        "attempt_count": len(attempts),
+        "attempt_count": attempt_count,
         "started_at": step_run.get("started_at"),
         "ended_at": step_run.get("ended_at"),
         "error": step_run.get("error"),

--- a/tldw_Server_API/app/core/Workflows/investigation.py
+++ b/tldw_Server_API/app/core/Workflows/investigation.py
@@ -206,7 +206,16 @@ def _serialize_step(
         legacy_attempt_count = int(step_run.get("attempt") or 0)
     except (TypeError, ValueError):
         legacy_attempt_count = 0
-    attempt_count = max(legacy_attempt_count, len(attempts))
+    highest_attempt_number = 0
+    for attempt in attempts:
+        try:
+            highest_attempt_number = max(
+                highest_attempt_number,
+                int(attempt.get("attempt_number") or 0),
+            )
+        except (TypeError, ValueError):
+            continue
+    attempt_count = max(legacy_attempt_count, len(attempts), highest_attempt_number)
     latest_failed_attempt = None
     for attempt in reversed(attempts):
         if str(attempt.get("status") or "") == "failed":

--- a/tldw_Server_API/app/services/workflows_artifact_gc_service.py
+++ b/tldw_Server_API/app/services/workflows_artifact_gc_service.py
@@ -26,6 +26,39 @@ def _now_utc() -> datetime:
     return datetime.utcnow().replace(tzinfo=timezone.utc)
 
 
+def _record_artifact_gc_event(
+    db: WorkflowsDatabase,
+    *,
+    tenant_id: str,
+    run_id: str,
+    artifact_id: str,
+    uri: str,
+    artifact_type: str | None,
+    file_deleted: bool,
+    retention_days: int,
+) -> None:
+    payload: dict[str, object] = {
+        "artifact_id": artifact_id,
+        "uri": uri,
+        "status": "deleted",
+        "file_deleted": bool(file_deleted),
+        "row_deleted": True,
+        "retention_days": int(retention_days),
+        "source": "artifact_gc",
+    }
+    if artifact_type:
+        payload["artifact_type"] = artifact_type
+    try:
+        db.append_event(tenant_id, run_id, "artifact_gc", payload)
+    except _GC_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(
+            "Artifact GC: failed to append workflow evidence for artifact_id={} run_id={}: {}",
+            artifact_id,
+            run_id,
+            exc,
+        )
+
+
 async def run_workflows_artifact_gc_worker(stop_event: asyncio.Event) -> None:
     """Background loop to enforce artifact retention by deleting old files and DB rows.
 
@@ -52,15 +85,30 @@ async def run_workflows_artifact_gc_worker(stop_event: asyncio.Event) -> None:
             deleted = 0
             for r in rows:
                 try:
+                    artifact_id = str(r.get("artifact_id") or "")
+                    run_id = str(r.get("run_id") or "")
+                    artifact_type = r.get("type")
                     uri = str(r.get("uri") or "")
+                    file_deleted = False
                     if uri.startswith("file://"):
                         fp = Path(uri[7:])
                         try:
                             if fp.exists() and fp.is_file():
                                 fp.unlink()
+                                file_deleted = True
                         except OSError as fe:
                             logger.warning(f"Artifact GC: failed to delete file {fp}: {fe}")
-                    db.delete_artifact(str(r.get("artifact_id")))
+                    db.delete_artifact(artifact_id)
+                    _record_artifact_gc_event(
+                        db,
+                        tenant_id=str(r.get("tenant_id") or "default"),
+                        run_id=run_id,
+                        artifact_id=artifact_id,
+                        uri=uri,
+                        artifact_type=str(artifact_type) if artifact_type is not None else None,
+                        file_deleted=file_deleted,
+                        retention_days=retention_days,
+                    )
                     deleted += 1
                 except _GC_NONCRITICAL_EXCEPTIONS as e:
                     logger.warning(f"Artifact GC: error deleting artifact {r.get('artifact_id')}: {e}")

--- a/tldw_Server_API/app/services/workflows_db_maintenance.py
+++ b/tldw_Server_API/app/services/workflows_db_maintenance.py
@@ -32,11 +32,44 @@ _WORKFLOWS_DB_MAINTENANCE_NONCRITICAL_EXCEPTIONS = (
 )
 
 
+_POSTGRES_WORKFLOW_VACUUM_TABLES = (
+    "workflows",
+    "workflow_runs",
+    "workflow_events",
+    "workflow_event_counters",
+    "workflow_step_runs",
+    "workflow_step_attempts",
+    "workflow_artifacts",
+    "workflow_research_waits",
+    "workflow_webhook_dlq",
+)
+
+
 def _env_bool(name: str, default: bool = False) -> bool:
     v = os.getenv(name, "")
     if not v:
         return default
     return is_truthy(v.lower())
+
+
+def _vacuum_postgres_workflow_tables(db: WorkflowsDatabase) -> None:
+    """Run VACUUM ANALYZE only for tables owned by the Workflows module."""
+    backend = db.backend
+    if backend is None:
+        return
+    conn = backend.connect()
+    old_autocommit = getattr(conn, "autocommit", False)
+    try:
+        with contextlib.suppress(_WORKFLOWS_DB_MAINTENANCE_NONCRITICAL_EXCEPTIONS):
+            conn.autocommit = True
+        cursor = conn.cursor()
+        ident = backend.escape_identifier
+        for table_name in _POSTGRES_WORKFLOW_VACUUM_TABLES:
+            cursor.execute(f"VACUUM ANALYZE {ident(table_name)}")
+    finally:
+        with contextlib.suppress(_WORKFLOWS_DB_MAINTENANCE_NONCRITICAL_EXCEPTIONS):
+            conn.autocommit = old_autocommit
+        backend.disconnect(conn)
 
 
 async def run_workflows_db_maintenance(stop_event: asyncio.Event) -> None:
@@ -67,8 +100,8 @@ async def run_workflows_db_maintenance(stop_event: asyncio.Event) -> None:
                 # Optional manual VACUUM ANALYZE - autovacuum normally covers this
                 if _env_bool("WORKFLOWS_POSTGRES_VACUUM", False):
                     try:
-                        db.backend.vacuum()  # type: ignore[union-attr]
-                        logger.info("Workflows DB maintenance: VACUUM ANALYZE completed for Postgres backend")
+                        _vacuum_postgres_workflow_tables(db)
+                        logger.info("Workflows DB maintenance: VACUUM ANALYZE completed for workflow Postgres tables")
                     except _WORKFLOWS_DB_MAINTENANCE_NONCRITICAL_EXCEPTIONS as e:
                         logger.warning(f"Workflows DB maintenance: Postgres VACUUM failed: {e}")
             else:

--- a/tldw_Server_API/app/services/workflows_db_maintenance.py
+++ b/tldw_Server_API/app/services/workflows_db_maintenance.py
@@ -67,17 +67,8 @@ async def run_workflows_db_maintenance(stop_event: asyncio.Event) -> None:
                 # Optional manual VACUUM ANALYZE - autovacuum normally covers this
                 if _env_bool("WORKFLOWS_POSTGRES_VACUUM", False):
                     try:
-                        with db.backend.transaction() as conn:  # type: ignore[union-attr]
-                            for table in (
-                                "workflows",
-                                "workflow_runs",
-                                "workflow_events",
-                                "workflow_step_runs",
-                                "workflow_artifacts",
-                                "workflow_webhook_dlq",
-                            ):
-                                db._execute_backend(f"VACUUM (ANALYZE) {db.backend.escape_identifier(table)}", connection=conn)
-                        logger.info("Workflows DB maintenance: VACUUM (ANALYZE) completed for Postgres tables")
+                        db.backend.vacuum()  # type: ignore[union-attr]
+                        logger.info("Workflows DB maintenance: VACUUM ANALYZE completed for Postgres backend")
                     except _WORKFLOWS_DB_MAINTENANCE_NONCRITICAL_EXCEPTIONS as e:
                         logger.warning(f"Workflows DB maintenance: Postgres VACUUM failed: {e}")
             else:

--- a/tldw_Server_API/app/services/workflows_scheduler.py
+++ b/tldw_Server_API/app/services/workflows_scheduler.py
@@ -226,11 +226,18 @@ class _WFRecurringScheduler:
             logger.info(f"Workflows scheduler: registered {loaded} schedule(s)")
 
     def _get_db(self, user_id: int) -> WorkflowsSchedulerDB:
+        """Return a cached scheduler DB handle for a user-specific database."""
         if user_id not in self._db_cache:
             self._db_cache[user_id] = WorkflowsSchedulerDB(user_id=user_id)
         return self._db_cache[user_id]
 
     def _list_registered_schedules(self, user_id: int) -> list[WorkflowSchedule]:
+        """Return every persisted schedule visible in a user's scheduler DB.
+
+        Shared backends can expose schedules for more than one owner through a
+        single DB handle, so this intentionally uses ``user_id=None`` and pages
+        until the DB returns a short page.
+        """
         db = self._get_db(user_id)
         page_size = 1000
         offset = 0
@@ -244,6 +251,11 @@ class _WFRecurringScheduler:
 
     @staticmethod
     def _resolve_schedule_owner_id(schedule: WorkflowSchedule, *, fallback_user_id: int) -> int:
+        """Resolve the owner user id stored on a schedule.
+
+        Older rows can contain malformed owner values; in that case the caller's
+        enumerated user id is used so scheduling can continue.
+        """
         try:
             return int(schedule.user_id)
         except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS:
@@ -299,6 +311,7 @@ class _WFRecurringScheduler:
             logger.debug(f"Workflows scheduler: failed to reconcile jobs: {e}")
 
     def _add_job(self, schedule: WorkflowSchedule, user_id: int | None = None) -> None:
+        """Register an APScheduler job for a recurring workflow schedule."""
         if not self._aps:
             return
         try:
@@ -461,7 +474,12 @@ class _WFRecurringScheduler:
         # Parse ACP config
         try:
             acp_config = _json.loads(s.acp_config_json) if isinstance(s.acp_config_json, str) else (s.acp_config_json or {})
-        except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS:
+        except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(
+                "Workflows scheduler: malformed acp_config_json for ACP schedule {}: {}",
+                s.id,
+                exc,
+            )
             acp_config = {}
 
         payload = {

--- a/tldw_Server_API/app/services/workflows_scheduler.py
+++ b/tldw_Server_API/app/services/workflows_scheduler.py
@@ -16,7 +16,7 @@ import asyncio
 import builtins
 import contextlib
 import os
-import random
+import secrets
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -67,6 +67,24 @@ _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS = (
     UnicodeDecodeError,
     BackendDatabaseError,
 )
+
+
+def build_schedule_payload(schedule: WorkflowSchedule) -> dict[str, Any]:
+    return {
+        "workflow_id": schedule.workflow_id,
+        "inputs": __import__("json").loads(schedule.inputs_json or "{}"),
+        "user_id": schedule.user_id,
+        "tenant_id": schedule.tenant_id,
+        "mode": schedule.run_mode,
+        "validation_mode": schedule.validation_mode,
+    }
+
+
+def resolve_schedule_submission_target(payload: dict[str, Any]) -> tuple[str, str]:
+    inputs = payload.get("inputs")
+    if isinstance(inputs, dict) and inputs.get("watchlist_job_id"):
+        return "watchlist_run", "watchlists"
+    return "workflow_run", "workflows"
 
 
 class _WFRecurringScheduler:
@@ -144,6 +162,7 @@ class _WFRecurringScheduler:
         """Scan all user directories and register their schedules."""
         loaded = 0
         try:
+            seen_schedule_ids: set[str] = set()
             user_ids: set[int] = set()
             try:
                 base = DatabasePaths.get_user_db_base_dir()
@@ -163,20 +182,21 @@ class _WFRecurringScheduler:
 
             for uid in sorted(user_ids):
                 try:
-                    db = self._get_db(uid)
-                    items = db.list_schedules(tenant_id="default", user_id=None, limit=1000, offset=0)
+                    items = self._list_registered_schedules(uid)
                 except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
                     logger.debug(f"Workflows scheduler: list_schedules failed for user {uid}: {e}")
                     items = []
                 for s in items:
-                    if s.enabled:
-                        # Route ACP schedules to _add_acp_job, workflow schedules to _add_job
-                        acp_cfg = getattr(s, "acp_config_json", None)
-                        if acp_cfg:
-                            self._add_acp_job(s, uid)
-                        else:
-                            self._add_job(s, uid)
-                        loaded += 1
+                    if not s.enabled or s.id in seen_schedule_ids:
+                        continue
+                    seen_schedule_ids.add(s.id)
+                    effective_uid = self._resolve_schedule_owner_id(s, fallback_user_id=uid)
+                    acp_cfg = getattr(s, "acp_config_json", None)
+                    if acp_cfg:
+                        self._add_acp_job(s, effective_uid)
+                    else:
+                        self._add_job(s, effective_uid)
+                    loaded += 1
         except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"Workflows scheduler load_all failed: {e}")
         if loaded:
@@ -187,11 +207,23 @@ class _WFRecurringScheduler:
             self._db_cache[user_id] = WorkflowsSchedulerDB(user_id=user_id)
         return self._db_cache[user_id]
 
+    def _list_registered_schedules(self, user_id: int) -> list[WorkflowSchedule]:
+        db = self._get_db(user_id)
+        return db.list_all_schedules(user_id=None, limit=1000, offset=0)
+
+    @staticmethod
+    def _resolve_schedule_owner_id(schedule: WorkflowSchedule, *, fallback_user_id: int) -> int:
+        try:
+            return int(schedule.user_id)
+        except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS:
+            return fallback_user_id
+
     async def _rescan_once(self) -> None:
         if not self._aps:
             return
         # Collect desired enabled schedule IDs from all users
         desired: set[str] = set()
+        seen_schedule_ids: set[str] = set()
         user_ids: set[int] = set()
         try:
             base = DatabasePaths.get_user_db_base_dir()
@@ -209,20 +241,21 @@ class _WFRecurringScheduler:
             logger.debug(f"Workflows scheduler: invalid SINGLE_USER_FIXED_ID: {e}")
         for uid in sorted(user_ids):
             try:
-                db = self._get_db(uid)
-                items = db.list_schedules(tenant_id="default", user_id=None, limit=1000, offset=0)
+                items = self._list_registered_schedules(uid)
             except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"Workflows scheduler: list_schedules failed for user {uid}: {e}")
                 items = []
             for s in items:
-                if s.enabled:
-                    desired.add(s.id)
-                    # Route ACP schedules to _add_acp_job, workflow schedules to _add_job
-                    acp_cfg = getattr(s, "acp_config_json", None)
-                    if acp_cfg:
-                        self._add_acp_job(s, uid)
-                    else:
-                        self._add_job(s, uid)
+                if not s.enabled or s.id in seen_schedule_ids:
+                    continue
+                seen_schedule_ids.add(s.id)
+                desired.add(s.id)
+                effective_uid = self._resolve_schedule_owner_id(s, fallback_user_id=uid)
+                acp_cfg = getattr(s, "acp_config_json", None)
+                if acp_cfg:
+                    self._add_acp_job(s, effective_uid)
+                else:
+                    self._add_job(s, effective_uid)
         # Remove jobs that no longer exist or are disabled
         try:
             current_ids = {j.id for j in (self._aps.get_jobs() or [])}
@@ -310,7 +343,7 @@ class _WFRecurringScheduler:
                     if jitter_sec > 0:
                         ui_jitter = int(os.getenv("WATCHLISTS_NEXT_RUN_UI_JITTER_SEC", "60") or 60)
                         if ui_jitter > 0 and next_dt is not None:
-                            delta = random.randint(-ui_jitter, ui_jitter)
+                            delta = secrets.randbelow(ui_jitter * 2 + 1) - ui_jitter
                             next_dt = next_dt + timedelta(seconds=delta)
                 except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
                     logger.debug(f"Workflows scheduler: UI jitter calc failed for {schedule.id}: {e}")
@@ -459,14 +492,7 @@ class _WFRecurringScheduler:
             db.set_history(schedule_id, last_run_at=datetime.now(timezone.utc).isoformat(), last_status="pending")
         except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"Workflows scheduler: failed to set pending status for {schedule_id}: {e}")
-        payload = {
-            "workflow_id": s.workflow_id,
-            "inputs": __import__("json").loads(s.inputs_json or "{}"),
-            "user_id": s.user_id,
-            "tenant_id": s.tenant_id,
-            "mode": s.run_mode,
-            "validation_mode": s.validation_mode,
-        }
+        payload = build_schedule_payload(s)
         # Presence gating: optionally skip when user is offline
         try:
             if getattr(s, "require_online", False):
@@ -509,25 +535,20 @@ class _WFRecurringScheduler:
             if self._core_scheduler is None:
                 logger.warning("Core Scheduler not initialized; skipping schedule run")
                 return
-            handler_name = "workflow_run"
-            try:
-                if isinstance(payload.get("inputs"), dict) and payload["inputs"].get("watchlist_job_id"):
-                    handler_name = "watchlist_run"
-            except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
-                logger.debug(f"Workflows scheduler: handler selection failed for {schedule_id}: {e}")
+            handler_name, queue_name = resolve_schedule_submission_target(payload)
             task_id = await self._core_scheduler.submit(
                 handler=handler_name,
                 payload=payload,
-                queue_name="workflows" if handler_name == "workflow_run" else "watchlists",
+                queue_name=queue_name,
                 metadata={"user_id": s.user_id},
             )
-            logger.info(f"Scheduled workflow_run submitted: task_id={task_id} schedule_id={s.id}")
+            logger.info(f"Scheduled {handler_name} submitted: task_id={task_id} schedule_id={s.id}")
             try:
                 db.set_history(schedule_id, last_status="queued")
             except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"Workflows scheduler: failed to set queued status for {schedule_id}: {e}")
         except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
-            logger.warning(f"Failed to submit scheduled workflow_run: {e}")
+            logger.warning(f"Failed to submit scheduled workflow: {e}")
             try:
                 db.set_history(schedule_id, last_status="error")
             except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:

--- a/tldw_Server_API/app/services/workflows_scheduler.py
+++ b/tldw_Server_API/app/services/workflows_scheduler.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import builtins
 import contextlib
+import json
 import os
 import secrets
 from datetime import datetime, timedelta
@@ -70,9 +71,25 @@ _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS = (
 
 
 def build_schedule_payload(schedule: WorkflowSchedule) -> dict[str, Any]:
+    """Build the Scheduler payload for a recurring workflow schedule.
+
+    The returned payload preserves the workflow id, user/tenant routing fields,
+    execution mode, validation mode, and decoded inputs. Malformed persisted
+    ``inputs_json`` is treated as an empty dict so one corrupt schedule row does
+    not abort a scheduler fire.
+    """
+    try:
+        inputs = json.loads(schedule.inputs_json or "{}")
+    except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(
+            "Workflows scheduler: malformed inputs_json for schedule {}: {}",
+            schedule.id,
+            exc,
+        )
+        inputs = {}
     return {
         "workflow_id": schedule.workflow_id,
-        "inputs": __import__("json").loads(schedule.inputs_json or "{}"),
+        "inputs": inputs,
         "user_id": schedule.user_id,
         "tenant_id": schedule.tenant_id,
         "mode": schedule.run_mode,
@@ -81,6 +98,12 @@ def build_schedule_payload(schedule: WorkflowSchedule) -> dict[str, Any]:
 
 
 def resolve_schedule_submission_target(payload: dict[str, Any]) -> tuple[str, str]:
+    """Return the Scheduler handler and queue for a schedule payload.
+
+    Watchlist-backed schedules are identified by ``inputs.watchlist_job_id`` and
+    route to the watchlists queue; all other schedules route to the workflows
+    queue as standard workflow runs.
+    """
     inputs = payload.get("inputs")
     if isinstance(inputs, dict) and inputs.get("watchlist_job_id"):
         return "watchlist_run", "watchlists"
@@ -209,7 +232,15 @@ class _WFRecurringScheduler:
 
     def _list_registered_schedules(self, user_id: int) -> list[WorkflowSchedule]:
         db = self._get_db(user_id)
-        return db.list_all_schedules(user_id=None, limit=1000, offset=0)
+        page_size = 1000
+        offset = 0
+        schedules: list[WorkflowSchedule] = []
+        while True:
+            page = db.list_all_schedules(user_id=None, limit=page_size, offset=offset)
+            schedules.extend(page)
+            if len(page) < page_size:
+                return schedules
+            offset += len(page)
 
     @staticmethod
     def _resolve_schedule_owner_id(schedule: WorkflowSchedule, *, fallback_user_id: int) -> int:

--- a/tldw_Server_API/app/services/workflows_scheduler.py
+++ b/tldw_Server_API/app/services/workflows_scheduler.py
@@ -517,6 +517,15 @@ class _WFRecurringScheduler:
                 s = db.get_schedule(schedule_id)
         if not s or not s.enabled:
             return
+        try:
+            fallback_owner_id = (
+                int(user_id)
+                if user_id is not None
+                else int(core_settings.get("SINGLE_USER_FIXED_ID", 1))
+            )
+        except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS:
+            fallback_owner_id = 1
+        owner_user_id = self._resolve_schedule_owner_id(s, fallback_user_id=fallback_owner_id)
         # Record last_run_at and pending status
         try:
             from datetime import timezone
@@ -524,11 +533,12 @@ class _WFRecurringScheduler:
         except _WORKFLOWS_SCHED_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"Workflows scheduler: failed to set pending status for {schedule_id}: {e}")
         payload = build_schedule_payload(s)
+        payload["user_id"] = str(owner_user_id)
         # Presence gating: optionally skip when user is offline
         try:
             if getattr(s, "require_online", False):
                 sm = await get_session_manager()
-                sessions = await sm.get_active_sessions(int(s.user_id))
+                sessions = await sm.get_active_sessions(owner_user_id)
                 if not sessions:
                     # mark skipped and compute next run time
                     try:
@@ -552,8 +562,8 @@ class _WFRecurringScheduler:
                 jwt_svc = JWTService(settings)
                 ttl = int(os.getenv("WORKFLOWS_VIRTUAL_KEY_TTL_MIN", "15") or 15)
                 token = jwt_svc.create_virtual_access_token(
-                    user_id=int(s.user_id),
-                    username=str(s.user_id),
+                    user_id=owner_user_id,
+                    username=str(owner_user_id),
                     role="user",
                     scope="workflows",
                     ttl_minutes=ttl,
@@ -571,7 +581,7 @@ class _WFRecurringScheduler:
                 handler=handler_name,
                 payload=payload,
                 queue_name=queue_name,
-                metadata={"user_id": s.user_id},
+                metadata={"user_id": str(owner_user_id)},
             )
             logger.info(f"Scheduled {handler_name} submitted: task_id={task_id} schedule_id={s.id}")
             try:

--- a/tldw_Server_API/app/services/workflows_webhook_dlq_service.py
+++ b/tldw_Server_API/app/services/workflows_webhook_dlq_service.py
@@ -171,7 +171,16 @@ def record_webhook_delivery_event(
     step_run_id: str | None = None,
     strict: bool = False,
 ) -> None:
-    host = urlparse(url).hostname or ""
+    """Append webhook delivery evidence for a workflow run.
+
+    The persisted payload stores the destination host, delivery status, optional
+    HTTP code/reason/source fields, and never stores the full webhook URL. When
+    ``strict`` is true, append failures are re-raised after logging; otherwise
+    evidence remains best-effort so retry bookkeeping can continue.
+    """
+    parsed_url = urlparse(url)
+    host = parsed_url.hostname or ""
+    redacted_url = f"{parsed_url.scheme}://{parsed_url.netloc}/..." if parsed_url.netloc else "<invalid-url>"
     payload: dict[str, Any] = {"host": host, "status": status}
     if code is not None:
         payload["code"] = int(code)
@@ -185,7 +194,7 @@ def record_webhook_delivery_event(
         logger.warning(
             "Failed to append webhook_delivery evidence for run_id={} url={} status={}: {}",
             run_id,
-            url,
+            redacted_url,
             status,
             exc,
         )

--- a/tldw_Server_API/app/services/workflows_webhook_dlq_service.py
+++ b/tldw_Server_API/app/services/workflows_webhook_dlq_service.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import json
 import os
-import random
+import secrets
 import sqlite3
 from typing import Any
 from urllib.parse import urlparse
@@ -154,8 +154,43 @@ def _compute_next_backoff(attempts: int) -> int:
     cap = int(os.getenv("WORKFLOWS_WEBHOOK_DLQ_MAX_BACKOFF_SEC", "3600"))
     # Exponential with jitter: min(cap, base * 2^attempts) +/- 20%
     raw = min(cap, int(base * (2 ** max(0, attempts))))
-    jitter = raw * random.uniform(0.8, 1.2)
-    return max(1, int(jitter))
+    jitter_pct = 80 + secrets.randbelow(41)
+    return max(1, int(raw * jitter_pct / 100))
+
+
+def record_webhook_delivery_event(
+    db: WorkflowsDatabase,
+    *,
+    tenant_id: str,
+    run_id: str,
+    url: str,
+    status: str,
+    code: int | None = None,
+    reason: str | None = None,
+    source: str | None = None,
+    step_run_id: str | None = None,
+    strict: bool = False,
+) -> None:
+    host = urlparse(url).hostname or ""
+    payload: dict[str, Any] = {"host": host, "status": status}
+    if code is not None:
+        payload["code"] = int(code)
+    if reason:
+        payload["reason"] = reason
+    if source:
+        payload["source"] = source
+    try:
+        db.append_event(tenant_id, run_id, "webhook_delivery", payload, step_run_id=step_run_id)
+    except _WORKFLOWS_DLQ_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(
+            "Failed to append webhook_delivery evidence for run_id={} url={} status={}: {}",
+            run_id,
+            url,
+            status,
+            exc,
+        )
+        if strict:
+            raise
 
 
 async def _attempt_delivery(url: str, payload: dict[str, Any], timeout: float) -> tuple[bool, str | None]:
@@ -245,6 +280,27 @@ async def run_workflows_webhook_dlq_worker(stop_event: asyncio.Event) -> None:
                 )
             except _WORKFLOWS_DLQ_NONCRITICAL_EXCEPTIONS:
                 current_attempt = attempts + 1
+            if current_attempt > max_attempts:
+                exhausted_error = f"max_attempts_exceeded:{max_attempts}"
+                record_webhook_delivery_event(
+                    db,
+                    tenant_id=tenant_id,
+                    run_id=str(r.get("run_id") or ""),
+                    url=url,
+                    status="failed",
+                    reason="max_attempts_exceeded",
+                    source="dlq_worker",
+                )
+                try:
+                    db.update_webhook_dlq_failure(
+                        dlq_id=dlq_id,
+                        last_error=exhausted_error,
+                        next_attempt_at_iso="9999-12-31T23:59:59+00:00",
+                        attempts=current_attempt,
+                    )
+                except _WORKFLOWS_DLQ_NONCRITICAL_EXCEPTIONS as exc:
+                    logger.warning(f"DLQ max-attempts exhaustion update failed for id={dlq_id}: {exc}")
+                continue
             try:
                 body = json.loads(r.get("body_json") or "{}")
             except _WORKFLOWS_DLQ_NONCRITICAL_EXCEPTIONS as e:
@@ -260,6 +316,15 @@ async def run_workflows_webhook_dlq_worker(stop_event: asyncio.Event) -> None:
 
             if not _host_allowed(url, tenant_id):
                 logger.warning(f"DLQ drop (denied host): id={dlq_id} tenant={tenant_id} url={url}")
+                record_webhook_delivery_event(
+                    db,
+                    tenant_id=tenant_id,
+                    run_id=str(r.get("run_id") or ""),
+                    url=url,
+                    status="blocked",
+                    reason="denied_by_policy",
+                    source="dlq_worker",
+                )
                 db.update_webhook_dlq_failure(
                     dlq_id=dlq_id,
                     last_error="denied_by_policy",
@@ -273,6 +338,14 @@ async def run_workflows_webhook_dlq_worker(stop_event: asyncio.Event) -> None:
             except _WORKFLOWS_DLQ_NONCRITICAL_EXCEPTIONS as e:
                 ok, err = False, str(e)
             if ok:
+                record_webhook_delivery_event(
+                    db,
+                    tenant_id=tenant_id,
+                    run_id=str(r.get("run_id") or ""),
+                    url=url,
+                    status="delivered",
+                    source="dlq_worker",
+                )
                 try:
                     db.delete_webhook_dlq(dlq_id=dlq_id)
                 except _WORKFLOWS_DLQ_NONCRITICAL_EXCEPTIONS as _e:
@@ -307,6 +380,15 @@ async def run_workflows_webhook_dlq_worker(stop_event: asyncio.Event) -> None:
                 last_error=err or "unknown_error",
                 next_attempt_at_iso=next_at,
                 attempts=attempts + 1,
+            )
+            record_webhook_delivery_event(
+                db,
+                tenant_id=tenant_id,
+                run_id=str(r.get("run_id") or ""),
+                url=url,
+                status="failed",
+                reason=err or "unknown_error",
+                source="dlq_worker",
             )
             logger.debug(f"DLQ retry scheduled in {next_delay}s (id={dlq_id} attempts={attempts+1}): {err}")
 

--- a/tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py
+++ b/tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py
@@ -139,6 +139,10 @@ def test_workflow_definition_and_run_roundtrip(workflows_dual_backend_db):
         status="succeeded",
         outputs={"response": "Hello"},
     )
+    step_runs = db.list_step_runs(run_id=run_id)
+    assert len(step_runs) == 1
+    assert step_runs[0]["step_run_id"] == step_run_id
+    assert step_runs[0]["status"] == "succeeded"
     attempt_id = db.create_step_attempt(
         tenant_id="tenant-1",
         run_id=run_id,
@@ -185,3 +189,12 @@ def test_workflow_definition_and_run_roundtrip(workflows_dual_backend_db):
 
     # Cleanup flag should succeed without raising
     assert db.soft_delete_definition(workflow_id) is True
+
+
+def test_step_attempt_contract_exists_on_both_backends(workflows_dual_backend_db):
+    _backend_label, db = workflows_dual_backend_db
+
+    assert callable(getattr(db, "create_step_attempt", None))
+    assert callable(getattr(db, "complete_step_attempt", None))
+    assert callable(getattr(db, "list_step_attempts", None))
+    assert callable(getattr(db, "list_step_runs", None))

--- a/tldw_Server_API/tests/Workflows/test_engine_idempotent_lifecycle.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_idempotent_lifecycle.py
@@ -68,6 +68,54 @@ def test_duplicate_pause_resume_requests_are_already_applied(tmp_path):
     assert second_resume == "already_applied"
 
 
+def test_pause_rejects_terminal_run_without_mutating_status(tmp_path):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = "run-pause-terminal"
+    _create_run(db, run_id)
+    db.update_run_status(run_id, status="succeeded")
+
+    engine = WorkflowEngine(db)
+    result = engine.pause(run_id)
+
+    run = db.get_run(run_id)
+    assert result == "invalid_state"
+    assert run is not None
+    assert run.status == "succeeded"
+    assert db.get_events(run_id, types=["run_paused"]) == []
+
+
+def test_resume_requires_paused_status_without_mutating_run(tmp_path):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = "run-resume-invalid"
+    _create_run(db, run_id)
+    db.update_run_status(run_id, status="waiting_human", status_reason="awaiting_review")
+
+    engine = WorkflowEngine(db)
+    result = engine.resume(run_id)
+
+    run = db.get_run(run_id)
+    assert result == "invalid_state"
+    assert run is not None
+    assert run.status == "waiting_human"
+    assert db.get_events(run_id, types=["run_resumed"]) == []
+
+
+def test_cancel_rejects_terminal_run_without_mutating_status(tmp_path):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = "run-cancel-terminal"
+    _create_run(db, run_id)
+    db.update_run_status(run_id, status="succeeded")
+
+    engine = WorkflowEngine(db)
+    result = engine.cancel(run_id)
+
+    run = db.get_run(run_id)
+    assert result == "invalid_state"
+    assert run is not None
+    assert run.status == "succeeded"
+    assert db.get_events(run_id, types=["run_cancelled"]) == []
+
+
 @pytest.mark.asyncio
 async def test_control_run_cancel_duplicate_returns_already_applied(tmp_path):
     db = WorkflowsDatabase(str(tmp_path / "wf.db"))

--- a/tldw_Server_API/tests/Workflows/test_engine_retry_cancel_delay.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_retry_cancel_delay.py
@@ -21,7 +21,15 @@ def client_with_wf(tmp_path, auth_headers):
     db = WorkflowsDatabase(str(tmp_path / "wf.db"))
 
     async def override_user():
-        return User(id=1, username="tester", email="t@e.com", is_active=True, is_admin=True)
+        return User(
+            id=1,
+            username="tester",
+            email="t@e.com",
+            is_active=True,
+            is_admin=True,
+            tenant_id="default",
+            roles=["admin"],
+        )
 
     def override_db():
 

--- a/tldw_Server_API/tests/Workflows/test_engine_state_contracts.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_state_contracts.py
@@ -11,6 +11,44 @@ def test_state_contract_rejects_invalid_transition() -> None:
     assert _is_allowed_transition("running", "queued") is False
 
 
+def test_state_contract_allows_pause_transitions() -> None:
+    assert _is_allowed_transition("queued", "paused") is True
+    assert _is_allowed_transition("running", "paused") is True
+    assert _is_allowed_transition("paused", "running") is True
+
+
+def test_append_event_warns_on_persistence_failure(tmp_path, monkeypatch) -> None:
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = f"run-{uuid.uuid4().hex}"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "append-warning", "version": 1, "steps": []},
+    )
+
+    def _raise_append_event(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError("event-store-down")
+
+    warnings: list[tuple[object, ...]] = []
+
+    monkeypatch.setattr(db, "append_event", _raise_append_event)
+    monkeypatch.setattr(
+        engine_mod.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+
+    engine = engine_mod.WorkflowEngine(db)
+    engine._append_event(run_id, "run_started", {"mode": "async"})
+
+    assert warnings
+    assert "append_event failed" in str(warnings[0][0])
+
+
 @pytest.mark.asyncio
 async def test_invalid_transition_sets_invariant_violation(tmp_path, monkeypatch) -> None:
     db = WorkflowsDatabase(str(tmp_path / "wf.db"))
@@ -38,3 +76,83 @@ async def test_invalid_transition_sets_invariant_violation(tmp_path, monkeypatch
     events = db.get_events(run_id)
     rejected = [event for event in events if event["event_type"] == "transition_rejected"]
     assert rejected
+
+
+@pytest.mark.asyncio
+async def test_success_transition_is_guarded(tmp_path, monkeypatch) -> None:
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = f"run-{uuid.uuid4().hex}"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={
+            "name": "guarded-success",
+            "version": 1,
+            "steps": [
+                {"id": "s1", "type": "log", "config": {"message": "hello"}},
+            ],
+        },
+    )
+
+    monkeypatch.setattr(
+        engine_mod,
+        "_is_allowed_transition",
+        lambda current, target: (current, target) == ("queued", "running"),
+    )
+
+    engine = engine_mod.WorkflowEngine(db)
+    await engine.start_run(run_id)
+
+    run = db.get_run(run_id)
+    assert run is not None
+    assert run.status == "failed"
+    assert run.status_reason == "invariant_violation"
+
+    rejected = [event for event in db.get_events(run_id) if event["event_type"] == "transition_rejected"]
+    assert any(event["payload_json"].get("to") == "succeeded" for event in rejected)
+
+
+@pytest.mark.asyncio
+async def test_wait_transition_is_guarded(tmp_path, monkeypatch) -> None:
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = f"run-{uuid.uuid4().hex}"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={
+            "name": "guarded-wait",
+            "version": 1,
+            "steps": [
+                {
+                    "id": "review",
+                    "type": "wait_for_human",
+                    "config": {"assigned_to_user_id": "7"},
+                },
+            ],
+        },
+    )
+
+    monkeypatch.setattr(
+        engine_mod,
+        "_is_allowed_transition",
+        lambda current, target: (current, target) == ("queued", "running"),
+    )
+
+    engine = engine_mod.WorkflowEngine(db)
+    await engine.start_run(run_id)
+
+    run = db.get_run(run_id)
+    assert run is not None
+    assert run.status == "failed"
+    assert run.status_reason == "invariant_violation"
+
+    rejected = [event for event in db.get_events(run_id) if event["event_type"] == "transition_rejected"]
+    assert any(event["payload_json"].get("to") == "waiting_human" for event in rejected)

--- a/tldw_Server_API/tests/Workflows/test_engine_state_contracts.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_state_contracts.py
@@ -49,6 +49,17 @@ def test_append_event_warns_on_persistence_failure(tmp_path, monkeypatch) -> Non
     assert "append_event failed" in str(warnings[0][0])
 
 
+def test_control_transition_reports_missing_run(tmp_path) -> None:
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    engine = engine_mod.WorkflowEngine(db)
+
+    assert engine._control_transition(
+        "missing-run",
+        target_status="cancelled",
+        op_key="missing-run:cancel",
+    ) == ("not_found", "unknown")
+
+
 @pytest.mark.asyncio
 async def test_invalid_transition_sets_invariant_violation(tmp_path, monkeypatch) -> None:
     db = WorkflowsDatabase(str(tmp_path / "wf.db"))

--- a/tldw_Server_API/tests/Workflows/test_engine_state_contracts.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_state_contracts.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -58,6 +59,21 @@ def test_control_transition_reports_missing_run(tmp_path) -> None:
         target_status="cancelled",
         op_key="missing-run:cancel",
     ) == ("not_found", "unknown")
+
+
+def test_engine_now_iso_is_timezone_aware() -> None:
+    parsed = datetime.fromisoformat(engine_mod.WorkflowEngine._now_iso())
+
+    assert parsed.tzinfo is not None
+
+
+def test_engine_duration_ms_since_accepts_timezone_aware_started_at() -> None:
+    started_at = (datetime.now(timezone.utc) - timedelta(seconds=2)).isoformat()
+
+    duration_ms = engine_mod.WorkflowEngine._duration_ms_since(started_at)
+
+    assert duration_ms is not None
+    assert duration_ms >= 0
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Workflows/test_engine_step_types.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_step_types.py
@@ -16,7 +16,15 @@ def client_with_wf(tmp_path, auth_headers):
     db = WorkflowsDatabase(str(tmp_path / "wf.db"))
 
     async def override_user():
-        return User(id=1, username="tester", email="t@e.com", is_active=True, is_admin=True)
+        return User(
+            id=1,
+            username="tester",
+            email="t@e.com",
+            is_active=True,
+            is_admin=True,
+            tenant_id="default",
+            roles=["admin"],
+        )
 
     def override_db():
 
@@ -114,6 +122,28 @@ def test_log_only_outputs_shape(client_with_wf: TestClient):
     assert out.get("logged") is True
     assert out.get("level") == "debug"
     assert out.get("message", "").endswith("Bob")
+
+
+def test_log_only_run_persists_canonical_attempt_row(client_with_wf: TestClient):
+    client = client_with_wf
+    definition = {
+        "name": "log-only-attempt-row",
+        "version": 1,
+        "steps": [
+            {"id": "l1", "type": "log", "config": {"message": "Hello {{ inputs.name }}", "level": "info"}},
+        ],
+    }
+    wid = client.post("/api/v1/workflows", json=definition).json()["id"]
+    run_id = client.post(f"/api/v1/workflows/{wid}/run", json={"inputs": {"name": "Ivy"}}).json()["run_id"]
+    data = _wait_for_terminal(client, run_id)
+    assert data["status"] == "succeeded"
+
+    db = app.dependency_overrides[wf_mod._get_db]()
+    attempts = db.list_step_attempts(run_id=run_id, step_id="l1")
+    assert len(attempts) == 1
+    assert attempts[0]["attempt_number"] == 1
+    assert attempts[0]["status"] == "succeeded"
+    assert attempts[0]["ended_at"] is not None
 
 
 def test_step_types_include_deep_research(client_with_wf: TestClient):

--- a/tldw_Server_API/tests/Workflows/test_webhook_admin_endpoints.py
+++ b/tldw_Server_API/tests/Workflows/test_webhook_admin_endpoints.py
@@ -1,4 +1,5 @@
 import json
+import sqlite3
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app
@@ -51,7 +52,8 @@ def test_dlq_list_and_replay_simulated(monkeypatch, auth_headers):
     app.dependency_overrides[get_auth_principal] = override_principal
     app.dependency_overrides[wf_mod._get_db] = override_db
 
-    with TestClient(app, headers=auth_headers) as client:
+    client = TestClient(app, headers=auth_headers)
+    try:
         # Seed a DLQ row into the same DB the app uses
         db_for_app.enqueue_webhook_dlq(tenant_id="default", run_id="r1", url="https://example.com/hook", body={"ok": True}, last_error="init")
         # List DLQ
@@ -64,7 +66,9 @@ def test_dlq_list_and_replay_simulated(monkeypatch, auth_headers):
         r2 = client.post(f"/api/v1/workflows/webhooks/dlq/{dlq_id}/replay")
         assert r2.status_code == 200
         assert r2.json().get("ok") is True
-    app.dependency_overrides.clear()
+    finally:
+        client.close()
+        app.dependency_overrides.clear()
 
 
 def test_dlq_replay_appends_delivery_event(monkeypatch, auth_headers, tmp_path):
@@ -149,13 +153,17 @@ def test_dlq_replay_appends_delivery_event(monkeypatch, auth_headers, tmp_path):
         raising=True,
     )
 
-    with TestClient(app, headers=auth_headers) as client:
+    client = TestClient(app, headers=auth_headers)
+    try:
         resp = client.get("/api/v1/workflows/webhooks/dlq?limit=10")
         assert resp.status_code == 200
         dlq_id = resp.json()["items"][0]["id"]
         replay_resp = client.post(f"/api/v1/workflows/webhooks/dlq/{dlq_id}/replay")
         assert replay_resp.status_code == 200, replay_resp.text
         assert replay_resp.json()["ok"] is True
+    finally:
+        client.close()
+        app.dependency_overrides.clear()
 
     events = db_for_app.get_events(run_id)
     delivery_events = [e for e in events if e.get("event_type") == "webhook_delivery"]
@@ -164,4 +172,88 @@ def test_dlq_replay_appends_delivery_event(monkeypatch, auth_headers, tmp_path):
     assert payload.get("status") == "delivered"
     assert payload.get("source") == "dlq_replay"
 
-    app.dependency_overrides.clear()
+
+
+def test_dlq_replay_deletes_successful_delivery_when_evidence_append_fails(monkeypatch, auth_headers, tmp_path):
+    db_for_app = WorkflowsDatabase(str(tmp_path / "wf.db"))
+
+    async def override_user():
+        return User(id=1, username="tester", email="t@e.com", is_active=True, is_admin=True)
+
+    async def override_principal(request: Request):  # type: ignore[override]
+        principal = AuthPrincipal(
+            kind="user",
+            user_id=1,
+            api_key_id=None,
+            subject="tester",
+            token_type="access",
+            jti=None,
+            roles=["admin"],
+            permissions=["workflows.runs.control"],
+            is_admin=True,
+            org_ids=[],
+            team_ids=[],
+        )
+        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        return principal
+
+    def override_db():
+        return db_for_app
+
+    app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[get_auth_principal] = override_principal
+    app.dependency_overrides[wf_mod._get_db] = override_db
+
+    run_id = "wf-dlq-evidence-fails"
+    db_for_app.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "replay", "version": 1, "steps": []},
+    )
+    db_for_app.enqueue_webhook_dlq(
+        tenant_id="default",
+        run_id=run_id,
+        url="https://example.com/hook?sig=secret",
+        body={"ok": True},
+        last_error="init",
+    )
+
+    class _DummyResp:
+        status_code = 200
+
+        async def aclose(self):
+            return None
+
+    async def _fake_http_afetch(**kwargs):  # noqa: ANN003
+        return _DummyResp()
+
+    def _failing_append_event(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise sqlite3.OperationalError("event store unavailable")
+
+    monkeypatch.setattr(wf_mod, "_http_afetch", _fake_http_afetch)
+    monkeypatch.setattr(db_for_app, "append_event", _failing_append_event)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Security.egress.is_webhook_url_allowed_for_tenant",
+        lambda url, tenant_id: True,
+        raising=True,
+    )
+
+    client = TestClient(app, headers=auth_headers)
+    try:
+        resp = client.get("/api/v1/workflows/webhooks/dlq?limit=10")
+        assert resp.status_code == 200
+        dlq_id = resp.json()["items"][0]["id"]
+        replay_resp = client.post(f"/api/v1/workflows/webhooks/dlq/{dlq_id}/replay")
+        assert replay_resp.status_code == 200, replay_resp.text
+        assert replay_resp.json()["ok"] is True
+
+        after = client.get("/api/v1/workflows/webhooks/dlq?limit=10")
+        assert after.status_code == 200
+        assert after.json()["items"] == []
+    finally:
+        client.close()
+        app.dependency_overrides.clear()

--- a/tldw_Server_API/tests/Workflows/test_webhook_admin_endpoints.py
+++ b/tldw_Server_API/tests/Workflows/test_webhook_admin_endpoints.py
@@ -65,3 +65,103 @@ def test_dlq_list_and_replay_simulated(monkeypatch, auth_headers):
         assert r2.status_code == 200
         assert r2.json().get("ok") is True
     app.dependency_overrides.clear()
+
+
+def test_dlq_replay_appends_delivery_event(monkeypatch, auth_headers, tmp_path):
+    db_for_app = WorkflowsDatabase(str(tmp_path / "wf.db"))
+
+    async def override_user():
+        return User(id=1, username="tester", email="t@e.com", is_active=True, is_admin=True)
+
+    async def override_principal(request: Request):  # type: ignore[override]
+        principal = AuthPrincipal(
+            kind="user",
+            user_id=1,
+            api_key_id=None,
+            subject="tester",
+            token_type="access",
+            jti=None,
+            roles=["admin"],
+            permissions=["workflows.runs.control"],
+            is_admin=True,
+            org_ids=[],
+            team_ids=[],
+        )
+        try:
+            request.state.auth = AuthContext(
+                principal=principal,
+                ip=None,
+                user_agent=None,
+                request_id=None,
+            )
+        except Exception:
+            _ = None
+        return principal
+
+    def override_db():
+        return db_for_app
+
+    app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[get_auth_principal] = override_principal
+    app.dependency_overrides[wf_mod._get_db] = override_db
+
+    workflow_id = db_for_app.create_definition(
+        tenant_id="default",
+        name="replay-workflow",
+        version=1,
+        owner_id="1",
+        visibility="private",
+        description=None,
+        tags=[],
+        definition={"name": "replay", "version": 1, "steps": []},
+    )
+    run_id = "wf-dlq-event-run"
+    db_for_app.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={},
+        workflow_id=workflow_id,
+        definition_version=1,
+        definition_snapshot={"name": "replay", "version": 1, "steps": []},
+    )
+    db_for_app.enqueue_webhook_dlq(
+        tenant_id="default",
+        run_id=run_id,
+        url="https://example.com/hook",
+        body={"ok": True},
+        last_error="init",
+    )
+
+    class _DummyResp:
+        status_code = 200
+
+        async def aclose(self):
+            return None
+
+    async def _fake_http_afetch(**kwargs):  # noqa: ANN003
+        return _DummyResp()
+
+    monkeypatch.setattr(wf_mod, "_http_afetch", _fake_http_afetch)
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Security.egress.is_webhook_url_allowed_for_tenant",
+        lambda url, tenant_id: True,
+        raising=True,
+    )
+
+    with TestClient(app, headers=auth_headers) as client:
+        resp = client.get("/api/v1/workflows/webhooks/dlq?limit=10")
+        assert resp.status_code == 200
+        dlq_id = resp.json()["items"][0]["id"]
+        replay_resp = client.post(f"/api/v1/workflows/webhooks/dlq/{dlq_id}/replay")
+        assert replay_resp.status_code == 200, replay_resp.text
+        assert replay_resp.json()["ok"] is True
+
+    events = db_for_app.get_events(run_id)
+    delivery_events = [e for e in events if e.get("event_type") == "webhook_delivery"]
+    assert delivery_events, "Expected replay to append a webhook_delivery event"
+    payload = delivery_events[-1].get("payload_json") or {}
+    assert payload.get("status") == "delivered"
+    assert payload.get("source") == "dlq_replay"
+
+    app.dependency_overrides.clear()

--- a/tldw_Server_API/tests/Workflows/test_webhook_dlq_worker.py
+++ b/tldw_Server_API/tests/Workflows/test_webhook_dlq_worker.py
@@ -101,3 +101,57 @@ async def test_dlq_worker_backoff_and_delivery(monkeypatch, tmp_path):
     # Ensure DLQ is drained after successful retry
     rows2 = db.list_webhook_dlq_due(limit=10)
     assert not rows2, f"Expected DLQ to be empty, found: {rows2}"
+
+
+@pytest.mark.asyncio
+async def test_dlq_worker_stops_retrying_after_max_attempts(monkeypatch, tmp_path):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    db.enqueue_webhook_dlq(
+        tenant_id="default",
+        run_id="run-max-attempts",
+        url="https://post.test/hook",
+        body={"ok": True},
+        last_error="init",
+    )
+    rows = db.list_webhook_dlq_all(limit=10)
+    assert rows, "expected DLQ seed row"
+    dlq_id = rows[0]["id"]
+    db.update_webhook_dlq_failure(
+        dlq_id=dlq_id,
+        last_error="retryable",
+        next_attempt_at_iso=None,
+        attempts=1,
+    )
+
+    monkeypatch.setenv("WORKFLOWS_WEBHOOK_ALLOWLIST", "post.test")
+    monkeypatch.setenv("WORKFLOWS_WEBHOOK_DLQ_INTERVAL_SEC", "1")
+    monkeypatch.setenv("WORKFLOWS_WEBHOOK_DLQ_BATCH", "10")
+    monkeypatch.setenv("WORKFLOWS_WEBHOOK_DLQ_TIMEOUT_SEC", "1")
+    monkeypatch.setenv("WORKFLOWS_WEBHOOK_DLQ_MAX_ATTEMPTS", "1")
+
+    monkeypatch.setattr(dlq_mod, "create_workflows_database", lambda backend=None: db)
+    monkeypatch.setattr(dlq_mod, "get_content_backend_instance", lambda: None)
+
+    calls = {"count": 0}
+
+    async def _fake_afetch(*args, **kwargs):  # noqa: ANN003
+        calls["count"] += 1
+        raise AssertionError("delivery should not be attempted after max attempts")
+
+    monkeypatch.setattr(dlq_mod, "afetch", _fake_afetch)
+
+    stop = asyncio.Event()
+    task = asyncio.create_task(dlq_mod.run_workflows_webhook_dlq_worker(stop))
+    await asyncio.sleep(0.2)
+    stop.set()
+    try:
+        await asyncio.wait_for(task, timeout=2)
+    except asyncio.TimeoutError:
+        task.cancel()
+
+    assert calls["count"] == 0
+    due_rows = db.list_webhook_dlq_due(limit=10)
+    assert not due_rows
+    all_rows = db.list_webhook_dlq_all(limit=10)
+    assert all_rows
+    assert "max_attempts" in str(all_rows[0].get("last_error", "")).lower()

--- a/tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py
@@ -61,12 +61,17 @@ async def test_retrying_step_records_multiple_attempt_rows(tmp_path, monkeypatch
 
     attempts = db.list_step_attempts(run_id=run_id, step_id="s1")
     assert len(attempts) == 2
+    assert [attempt["attempt_number"] for attempt in attempts] == [1, 2]
+    assert attempts[0]["attempt_id"] != attempts[1]["attempt_id"]
     assert attempts[0]["status"] == "failed"
+    assert attempts[0]["ended_at"] is not None
     assert attempts[0]["reason_code_core"] == "transient_network_error"
     assert bool(attempts[0]["retryable"]) is True
     assert attempts[0]["metadata_json"]["retry_recommendation"] == "safe"
     assert attempts[0]["metadata_json"]["blame_scope"] == "step"
+    assert attempts[0]["metadata_json"]["failure_envelope"]["reason_code_core"] == "transient_network_error"
     assert attempts[1]["status"] == "succeeded"
+    assert attempts[1]["ended_at"] is not None
     assert attempts[1]["reason_code_core"] is None
 
 
@@ -95,4 +100,5 @@ async def test_unsafe_step_types_do_not_report_safe_replay(tmp_path, monkeypatch
     assert attempts[0]["reason_code_core"] == "transient_network_error"
     assert bool(attempts[0]["retryable"]) is True
     assert attempts[0]["metadata_json"]["retry_recommendation"] == "conditional"
+    assert attempts[0]["metadata_json"]["failure_envelope"]["reason_code_core"] == "transient_network_error"
     assert attempts[0]["metadata_json"]["step_capability"]["replay_safe"] is False

--- a/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
@@ -47,6 +47,7 @@ if "transformers" not in sys.modules:
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.api.v1.endpoints import workflows as wf_mod
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.AuthNZ.permissions import WORKFLOWS_RUNS_READ
 from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
 
 
@@ -119,7 +120,7 @@ def _seed_failed_run(db: WorkflowsDatabase) -> str:
         status="running",
         inputs={"config": {"url": "https://example.invalid/hook"}},
     )
-    db.update_step_attempt(step_run_id=step_run_id, attempt=2)
+    db.update_step_attempt(step_run_id=step_run_id, attempt=7)
     attempt1 = db.create_step_attempt(
         tenant_id="default",
         run_id=run_id,
@@ -363,6 +364,7 @@ def test_investigation_endpoint_returns_primary_failure(client_with_investigatio
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["primary_failure"]["reason_code_core"] == "transient_network_error"
+    assert data["failed_step"]["attempt_count"] == 2
     assert data["failed_step"]["step_id"] == "s1"
     assert data["recommended_actions"]
     assert data["primary_failure"]["internal_detail"]["event_count"] >= 3
@@ -436,6 +438,7 @@ def test_investigation_redacts_operator_detail_for_non_admin(client_with_investi
         is_admin=False,
         tenant_id="default",
         roles=["user"],
+        permissions=[WORKFLOWS_RUNS_READ],
     )
 
     resp = client.get(f"/api/v1/workflows/runs/{run_id}/investigation")

--- a/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
@@ -78,10 +78,12 @@ def client_with_investigation_db(tmp_path, auth_headers):
     app.dependency_overrides[get_request_user] = override_user
     app.dependency_overrides[wf_mod._get_db] = override_db
 
-    with TestClient(app, headers=auth_headers) as client:
+    client = TestClient(app, headers=auth_headers)
+    try:
         yield client, db, state
-
-    app.dependency_overrides.clear()
+    finally:
+        client.close()
+        app.dependency_overrides.clear()
 
 
 def _seed_failed_run(db: WorkflowsDatabase) -> str:
@@ -364,7 +366,7 @@ def test_investigation_endpoint_returns_primary_failure(client_with_investigatio
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["primary_failure"]["reason_code_core"] == "transient_network_error"
-    assert data["failed_step"]["attempt_count"] == 2
+    assert data["failed_step"]["attempt_count"] == 7
     assert data["failed_step"]["step_id"] == "s1"
     assert data["recommended_actions"]
     assert data["primary_failure"]["internal_detail"]["event_count"] >= 3
@@ -409,7 +411,7 @@ def test_steps_endpoint_returns_step_history(client_with_investigation_db: tuple
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["steps"][0]["step_id"] == "s1"
-    assert data["steps"][0]["attempt_count"] == 2
+    assert data["steps"][0]["attempt_count"] == 7
     assert data["steps"][0]["latest_failure"]["reason_code_core"] == "transient_network_error"
 
 

--- a/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
@@ -415,6 +415,53 @@ def test_steps_endpoint_returns_step_history(client_with_investigation_db: tuple
     assert data["steps"][0]["latest_failure"]["reason_code_core"] == "transient_network_error"
 
 
+def test_steps_endpoint_counts_sparse_attempt_numbers(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
+    client, db, _state = client_with_investigation_db
+    run_id = f"run-sparse-attempts-{uuid4().hex[:8]}"
+    step_run_id = f"{run_id}:s1:1"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "sparse-attempts", "version": 1, "steps": []},
+    )
+    db.create_step_run(
+        step_run_id=step_run_id,
+        tenant_id="default",
+        run_id=run_id,
+        step_id="s1",
+        name="Sparse attempts",
+        step_type="prompt",
+        status="failed",
+        inputs={},
+    )
+    for attempt_number in (1, 3):
+        attempt_id = db.create_step_attempt(
+            tenant_id="default",
+            run_id=run_id,
+            step_run_id=step_run_id,
+            step_id="s1",
+            attempt_number=attempt_number,
+            status="running",
+            metadata={"step_type": "prompt"},
+        )
+        db.complete_step_attempt(
+            attempt_id=attempt_id,
+            status="failed",
+            reason_code_core="runtime_error",
+            metadata={"step_type": "prompt"},
+        )
+
+    resp = client.get(f"/api/v1/workflows/runs/{run_id}/steps")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["steps"][0]["attempt_count"] == 3
+
+
 def test_step_attempts_endpoint_returns_attempt_timeline(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
     client, db, _state = client_with_investigation_db
     run_id = _seed_failed_run(db)

--- a/tldw_Server_API/tests/Workflows/test_workflows_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_api.py
@@ -167,7 +167,8 @@ def test_run_adhoc_requires_workflows_scope_like_saved_run(tmp_path):
     )
 
     headers = {"Authorization": f"Bearer {token}"}
-    with TestClient(app, headers=headers) as client:
+    client = TestClient(app, headers=headers)
+    try:
         saved_resp = client.post(f"/api/v1/workflows/{workflow_id}/run", json={"inputs": {}})
         adhoc_resp = client.post(
             "/api/v1/workflows/run",
@@ -180,10 +181,62 @@ def test_run_adhoc_requires_workflows_scope_like_saved_run(tmp_path):
                 "inputs": {},
             },
         )
-
-    app.dependency_overrides.clear()
+    finally:
+        client.close()
+        app.dependency_overrides.clear()
 
     assert saved_resp.status_code == 403
+    assert adhoc_resp.status_code == 403
+
+
+def test_run_adhoc_rejects_virtual_key_excluded_by_endpoint_allowlist(tmp_path):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+
+    async def override_user():
+        return User(
+            id=1,
+            username="tester",
+            email="t@e.com",
+            is_active=True,
+            is_admin=False,
+            roles=["user"],
+            tenant_id="default",
+        )
+
+    def override_db():
+        return db
+
+    app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[wf_mod._get_db] = override_db
+
+    jwt_service = JWTService(get_auth_settings())
+    token = jwt_service.create_virtual_access_token(
+        user_id=1,
+        username="tester",
+        role="user",
+        scope="workflows",
+        ttl_minutes=5,
+        additional_claims={"allowed_endpoints": ["workflows.run_saved"]},
+    )
+
+    headers = {"Authorization": f"Bearer {token}"}
+    client = TestClient(app, headers=headers)
+    try:
+        adhoc_resp = client.post(
+            "/api/v1/workflows/run",
+            json={
+                "definition": {
+                    "name": "adhoc",
+                    "version": 1,
+                    "steps": [{"id": "s1", "type": "prompt", "config": {"template": "hi"}}],
+                },
+                "inputs": {},
+            },
+        )
+    finally:
+        client.close()
+        app.dependency_overrides.clear()
+
     assert adhoc_resp.status_code == 403
 
 

--- a/tldw_Server_API/tests/Workflows/test_workflows_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_api.py
@@ -48,6 +48,8 @@ if "transformers" not in sys.modules:
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
 from tldw_Server_API.app.core.MCP_unified.auth.jwt_manager import get_jwt_manager
+from tldw_Server_API.app.core.AuthNZ.jwt_service import JWTService
+from tldw_Server_API.app.core.AuthNZ.settings import get_settings as get_auth_settings
 from tldw_Server_API.app.api.v1.endpoints import workflows as wf_mod
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 
@@ -119,6 +121,70 @@ def test_create_and_run_saved_workflow(client_with_workflows_db: TestClient):
     assert ev.status_code == 200
     types = [e["event_type"] for e in ev.json()]
     assert "run_completed" in types
+
+
+def test_run_adhoc_requires_workflows_scope_like_saved_run(tmp_path):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    workflow_id = db.create_definition(
+        tenant_id="default",
+        name="scope-check",
+        version=1,
+        owner_id="1",
+        visibility="private",
+        description=None,
+        tags=[],
+        definition={
+            "name": "scope-check",
+            "version": 1,
+            "steps": [{"id": "s1", "type": "prompt", "config": {"template": "hi"}}],
+        },
+    )
+
+    async def override_user():
+        return User(
+            id=1,
+            username="tester",
+            email="t@e.com",
+            is_active=True,
+            is_admin=False,
+            roles=["user"],
+            tenant_id="default",
+        )
+
+    def override_db():
+        return db
+
+    app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[wf_mod._get_db] = override_db
+
+    jwt_service = JWTService(get_auth_settings())
+    token = jwt_service.create_virtual_access_token(
+        user_id=1,
+        username="tester",
+        role="user",
+        scope="not-workflows",
+        ttl_minutes=5,
+    )
+
+    headers = {"Authorization": f"Bearer {token}"}
+    with TestClient(app, headers=headers) as client:
+        saved_resp = client.post(f"/api/v1/workflows/{workflow_id}/run", json={"inputs": {}})
+        adhoc_resp = client.post(
+            "/api/v1/workflows/run",
+            json={
+                "definition": {
+                    "name": "adhoc",
+                    "version": 1,
+                    "steps": [{"id": "s1", "type": "prompt", "config": {"template": "hi"}}],
+                },
+                "inputs": {},
+            },
+        )
+
+    app.dependency_overrides.clear()
+
+    assert saved_resp.status_code == 403
+    assert adhoc_resp.status_code == 403
 
 
 def test_adhoc_limits_and_validation(client_with_workflows_db: TestClient):

--- a/tldw_Server_API/tests/Workflows/test_workflows_artifact_gc_service.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_artifact_gc_service.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
+from tldw_Server_API.app.services import workflows_artifact_gc_service as gc_mod
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_artifact_gc_appends_deletion_evidence(monkeypatch, tmp_path):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = "run-artifact-gc"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "artifact-gc", "version": 1, "steps": []},
+    )
+
+    artifact_path = tmp_path / "artifact.txt"
+    artifact_path.write_text("artifact payload", encoding="utf-8")
+    artifact_id = "artifact-gc-1"
+    db.add_artifact(
+        artifact_id=artifact_id,
+        tenant_id="default",
+        run_id=run_id,
+        step_run_id=None,
+        type="text",
+        uri=f"file://{artifact_path}",
+        metadata={"purpose": "retention-test"},
+    )
+
+    monkeypatch.setattr(
+        gc_mod,
+        "create_workflows_database",
+        lambda backend=None: db,
+    )
+    monkeypatch.setattr(
+        gc_mod,
+        "get_content_backend_instance",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        gc_mod,
+        "_now_utc",
+        lambda: gc_mod.datetime(2030, 1, 1, tzinfo=gc_mod.timezone.utc),
+    )
+    monkeypatch.setenv("WORKFLOWS_ARTIFACT_RETENTION_DAYS", "30")
+    monkeypatch.setenv("WORKFLOWS_ARTIFACT_GC_INTERVAL_SEC", "1")
+
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(gc_mod.run_workflows_artifact_gc_worker(stop_event))
+    await asyncio.sleep(0.2)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=3)
+
+    assert not artifact_path.exists()
+    assert db.get_artifact(artifact_id) is None
+
+    events = db.get_events(run_id, types=["artifact_gc"])
+    assert events, "Expected artifact GC to append workflow evidence"
+    payload = events[-1]["payload_json"]
+    assert payload["artifact_id"] == artifact_id
+    assert payload["status"] == "deleted"
+    assert payload["file_deleted"] is True
+    assert payload["row_deleted"] is True
+    assert payload["source"] == "artifact_gc"

--- a/tldw_Server_API/tests/Workflows/test_workflows_artifact_gc_service.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_artifact_gc_service.py
@@ -59,9 +59,16 @@ async def test_artifact_gc_appends_deletion_evidence(monkeypatch, tmp_path):
 
     stop_event = asyncio.Event()
     task = asyncio.create_task(gc_mod.run_workflows_artifact_gc_worker(stop_event))
-    await asyncio.sleep(0.2)
-    stop_event.set()
-    await asyncio.wait_for(task, timeout=3)
+
+    async def _wait_for_gc() -> None:
+        while artifact_path.exists() or db.get_artifact(artifact_id) is not None:
+            await asyncio.sleep(0.01)
+
+    try:
+        await asyncio.wait_for(_wait_for_gc(), timeout=3)
+    finally:
+        stop_event.set()
+        await asyncio.wait_for(task, timeout=3)
 
     assert not artifact_path.exists()
     assert db.get_artifact(artifact_id) is None

--- a/tldw_Server_API/tests/Workflows/test_workflows_db.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_db.py
@@ -1,5 +1,8 @@
 import json
+import sqlite3
 from pathlib import Path
+
+import pytest
 
 from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
 
@@ -60,6 +63,32 @@ def test_workflows_db_crud(tmp_path):
     assert [e["event_type"] for e in events] == ["run_started", "step_completed"]
     events_since = db.get_events(run_id, since=1)
     assert len(events_since) == 1 and events_since[0]["event_seq"] == 2
+
+
+def test_sqlite_append_event_uses_begin_immediate(tmp_path):
+    db_path = tmp_path / "workflows.db"
+    db = WorkflowsDatabase(str(db_path))
+
+    run_id = "run-immediate"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="t1",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "immediate", "version": 1, "steps": []},
+    )
+
+    statements: list[str] = []
+    db._conn.set_trace_callback(statements.append)  # type: ignore[attr-defined]
+    try:
+        seq = db.append_event("t1", run_id, "run_started", {"mode": "async"})
+    finally:
+        db._conn.set_trace_callback(None)  # type: ignore[attr-defined]
+
+    assert seq == 1
+    assert any("BEGIN IMMEDIATE" in statement.upper() for statement in statements)
 
 
 def test_workflow_research_wait_db_tracks_links(tmp_path):
@@ -145,3 +174,512 @@ def test_workflow_research_wait_db_claims_links_for_resume_once(tmp_path):
         checkpoint_id="checkpoint-5",
     )
     assert claimed_again == []
+
+
+def test_workflow_step_attempt_round_trip(tmp_path):
+    db_path = tmp_path / "workflows.db"
+    db = WorkflowsDatabase(str(db_path))
+
+    db.create_run(
+        run_id="wf-run-attempt-1",
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "step-attempt-round-trip", "steps": []},
+    )
+    db.create_step_run(
+        step_run_id="wf-run-attempt-1:s1:1",
+        tenant_id="tenant",
+        run_id="wf-run-attempt-1",
+        step_id="s1",
+        name="Prompt step",
+        step_type="prompt",
+        status="running",
+        inputs={"config": {"template": "Hello"}},
+    )
+
+    attempt_id = db.create_step_attempt(
+        tenant_id="tenant",
+        run_id="wf-run-attempt-1",
+        step_run_id="wf-run-attempt-1:s1:1",
+        step_id="s1",
+        attempt_number=1,
+        status="running",
+        metadata={"step_type": "prompt", "retry_recommendation": "safe"},
+    )
+
+    db.complete_step_attempt(
+        attempt_id=attempt_id,
+        status="failed",
+        reason_code_core="transient_network_error",
+        reason_code_detail="RuntimeError",
+        retryable=True,
+        error_summary="upstream reset",
+        metadata={
+            "step_type": "prompt",
+            "retry_recommendation": "safe",
+            "failure_envelope": {"reason_code_core": "transient_network_error"},
+        },
+    )
+
+    attempts = db.list_step_attempts(run_id="wf-run-attempt-1", step_id="s1")
+    assert len(attempts) == 1
+    assert attempts[0]["attempt_id"] == attempt_id
+    assert attempts[0]["step_run_id"] == "wf-run-attempt-1:s1:1"
+    assert attempts[0]["attempt_number"] == 1
+    assert attempts[0]["status"] == "failed"
+    assert attempts[0]["reason_code_core"] == "transient_network_error"
+    assert attempts[0]["reason_code_detail"] == "RuntimeError"
+    assert bool(attempts[0]["retryable"]) is True
+    assert attempts[0]["error_summary"] == "upstream reset"
+    assert attempts[0]["started_at"] is not None
+    assert attempts[0]["ended_at"] is not None
+    assert attempts[0]["metadata_json"]["retry_recommendation"] == "safe"
+    assert attempts[0]["metadata_json"]["failure_envelope"]["reason_code_core"] == "transient_network_error"
+
+
+def test_workflow_step_run_listing_round_trip(tmp_path):
+    db_path = tmp_path / "workflows.db"
+    db = WorkflowsDatabase(str(db_path))
+
+    db.create_run(
+        run_id="wf-run-step-runs-1",
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "step-runs", "steps": []},
+    )
+    db.create_step_run(
+        step_run_id="wf-run-step-runs-1:s2:1",
+        tenant_id="tenant",
+        run_id="wf-run-step-runs-1",
+        step_id="s2",
+        name="Second step",
+        step_type="log",
+        status="running",
+        inputs={"config": {"message": "later"}},
+    )
+    db.create_step_run(
+        step_run_id="wf-run-step-runs-1:s1:1",
+        tenant_id="tenant",
+        run_id="wf-run-step-runs-1",
+        step_id="s1",
+        name="First step",
+        step_type="prompt",
+        status="succeeded",
+        inputs={"config": {"template": "Hello"}},
+    )
+
+    step_runs = db.list_step_runs(run_id="wf-run-step-runs-1")
+    assert [step_run["step_run_id"] for step_run in step_runs] == [
+        "wf-run-step-runs-1:s2:1",
+        "wf-run-step-runs-1:s1:1",
+    ]
+    assert step_runs[0]["step_id"] == "s2"
+    assert step_runs[1]["step_id"] == "s1"
+
+
+def test_workflow_step_attempt_requires_parent_step_run(tmp_path):
+    db_path = tmp_path / "workflows.db"
+    db = WorkflowsDatabase(str(db_path))
+
+    db.create_run(
+        run_id="wf-run-attempt-parent",
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "step-attempt-parent", "steps": []},
+    )
+
+    with pytest.raises(ValueError, match="step_run_id is required"):
+        db.create_step_attempt(
+            tenant_id="tenant",
+            run_id="wf-run-attempt-parent",
+            step_run_id="",
+            step_id="s1",
+            attempt_number=1,
+            status="running",
+            metadata={"step_type": "prompt"},
+        )
+
+
+def test_workflow_step_attempt_rejects_duplicate_logical_attempt(tmp_path):
+    db_path = tmp_path / "workflows.db"
+    db = WorkflowsDatabase(str(db_path))
+
+    db.create_run(
+        run_id="wf-run-attempt-duplicate",
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "step-attempt-duplicate", "steps": []},
+    )
+    db.create_step_run(
+        step_run_id="wf-run-attempt-duplicate:s1:1",
+        tenant_id="tenant",
+        run_id="wf-run-attempt-duplicate",
+        step_id="s1",
+        name="Prompt step",
+        step_type="prompt",
+        status="running",
+        inputs={"config": {"template": "Hello"}},
+    )
+
+    db.create_step_attempt(
+        tenant_id="tenant",
+        run_id="wf-run-attempt-duplicate",
+        step_run_id="wf-run-attempt-duplicate:s1:1",
+        step_id="s1",
+        attempt_number=1,
+        status="running",
+        metadata={"step_type": "prompt"},
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.create_step_attempt(
+            tenant_id="tenant",
+            run_id="wf-run-attempt-duplicate",
+            step_run_id="wf-run-attempt-duplicate:s1:1",
+            step_id="s1",
+            attempt_number=1,
+            status="running",
+            metadata={"step_type": "prompt"},
+        )
+
+
+def test_workflow_step_attempt_migration_rebuilds_legacy_contract(tmp_path):
+    db_path = tmp_path / "workflows_legacy.db"
+    legacy_conn = sqlite3.connect(db_path)
+    legacy_conn.executescript(
+        """
+        CREATE TABLE workflow_schema_version (version INTEGER NOT NULL);
+        INSERT INTO workflow_schema_version(version) VALUES (7);
+
+        CREATE TABLE workflow_runs (
+            run_id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            workflow_id INTEGER,
+            status TEXT NOT NULL,
+            status_reason TEXT,
+            user_id TEXT NOT NULL,
+            inputs_json TEXT NOT NULL,
+            outputs_json TEXT,
+            error TEXT,
+            duration_ms INTEGER,
+            created_at TEXT NOT NULL,
+            started_at TEXT,
+            ended_at TEXT,
+            definition_version INTEGER,
+            definition_snapshot_json TEXT,
+            idempotency_key TEXT,
+            session_id TEXT,
+            validation_mode TEXT DEFAULT 'block',
+            tokens_input INTEGER,
+            tokens_output INTEGER,
+            cost_usd REAL,
+            cancel_requested INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE TABLE workflow_step_runs (
+            step_run_id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            step_id TEXT NOT NULL,
+            name TEXT,
+            type TEXT,
+            status TEXT,
+            attempt INTEGER DEFAULT 0,
+            started_at TEXT,
+            ended_at TEXT,
+            inputs_json TEXT,
+            outputs_json TEXT,
+            error TEXT,
+            decision TEXT,
+            assigned_to TEXT,
+            approved_by TEXT,
+            approved_at TEXT,
+            review_comment TEXT,
+            locked_by TEXT,
+            locked_at TEXT,
+            lock_expires_at TEXT,
+            heartbeat_at TEXT,
+            pid INTEGER,
+            pgid INTEGER,
+            workdir TEXT,
+            stdout_path TEXT,
+            stderr_path TEXT
+        );
+
+        INSERT INTO workflow_runs(
+            run_id, tenant_id, workflow_id, status, status_reason, user_id, inputs_json, outputs_json, error,
+            duration_ms, created_at, started_at, ended_at, definition_version, definition_snapshot_json,
+            idempotency_key, session_id, validation_mode, tokens_input, tokens_output, cost_usd, cancel_requested
+        ) VALUES (
+            'run-legacy',
+            'tenant',
+            NULL,
+            'running',
+            NULL,
+            'user',
+            '{}',
+            NULL,
+            NULL,
+            NULL,
+            '2026-01-01T00:00:00+00:00',
+            NULL,
+            NULL,
+            1,
+            '{}',
+            NULL,
+            NULL,
+            'block',
+            NULL,
+            NULL,
+            NULL,
+            0
+        );
+
+        INSERT INTO workflow_step_runs(
+            step_run_id, tenant_id, run_id, step_id, name, type, status, attempt, started_at, ended_at, inputs_json,
+            outputs_json, error, decision, assigned_to, approved_by, approved_at, review_comment, locked_by,
+            locked_at, lock_expires_at, heartbeat_at, pid, pgid, workdir, stdout_path, stderr_path
+        ) VALUES (
+            'run-legacy:s1:1',
+            'tenant',
+            'run-legacy',
+            's1',
+            'Legacy Step',
+            'prompt',
+            'running',
+            1,
+            '2026-01-01T00:00:00+00:00',
+            NULL,
+            '{}',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL
+        );
+
+        INSERT INTO workflow_step_runs(
+            step_run_id, tenant_id, run_id, step_id, name, type, status, attempt, started_at, ended_at, inputs_json,
+            outputs_json, error, decision, assigned_to, approved_by, approved_at, review_comment, locked_by,
+            locked_at, lock_expires_at, heartbeat_at, pid, pgid, workdir, stdout_path, stderr_path
+        ) VALUES (
+            'run-legacy:s2:1',
+            'tenant',
+            'run-legacy',
+            's2',
+            'Legacy Step 2',
+            'prompt',
+            'running',
+            1,
+            '2026-01-01T00:00:00+00:00',
+            NULL,
+            '{}',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL
+        );
+
+        CREATE TABLE workflow_step_attempts (
+            attempt_id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            step_run_id TEXT,
+            step_id TEXT NOT NULL,
+            attempt_number INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            metadata_json TEXT,
+            started_at TEXT NOT NULL,
+            ended_at TEXT
+        );
+
+        INSERT INTO workflow_step_attempts(
+            attempt_id, tenant_id, run_id, step_run_id, step_id, attempt_number, status, metadata_json, started_at
+        ) VALUES (
+            'legacy-orphan',
+            'tenant',
+            'run-legacy',
+            NULL,
+            's1',
+            1,
+            'running',
+            '{}',
+            '2026-01-01T00:00:00+00:00'
+        );
+
+        INSERT INTO workflow_step_attempts(
+            attempt_id, tenant_id, run_id, step_run_id, step_id, attempt_number, status, metadata_json, started_at, ended_at
+        ) VALUES (
+            'legacy-duplicate-older',
+            'tenant',
+            'run-legacy',
+            'run-legacy:s1:1',
+            's1',
+            1,
+            'running',
+            '{"source":"older"}',
+            '2026-01-01T00:00:00+00:00',
+            NULL
+        );
+
+        INSERT INTO workflow_step_attempts(
+            attempt_id, tenant_id, run_id, step_run_id, step_id, attempt_number, status, metadata_json, started_at, ended_at
+        ) VALUES (
+            'legacy-duplicate-newer',
+            'tenant',
+            'run-legacy',
+            'run-legacy:s1:1',
+            's1',
+            1,
+            'failed',
+            '{"source":"newer"}',
+            '2026-01-01T00:00:10+00:00',
+            '2026-01-01T00:00:20+00:00'
+        );
+
+        INSERT INTO workflow_step_attempts(
+            attempt_id, tenant_id, run_id, step_run_id, step_id, attempt_number, status, metadata_json, started_at, ended_at
+        ) VALUES (
+            'legacy-valid-survivor',
+            'tenant',
+            'run-legacy',
+            'run-legacy:s2:1',
+            's2',
+            1,
+            'succeeded',
+            '{"source":"survivor"}',
+            '2026-01-01T00:01:00+00:00',
+            '2026-01-01T00:01:05+00:00'
+        );
+
+        INSERT INTO workflow_step_attempts(
+            attempt_id, tenant_id, run_id, step_run_id, step_id, attempt_number, status, metadata_json, started_at, ended_at
+        ) VALUES (
+            'legacy-bad-parent',
+            'tenant',
+            'run-legacy',
+            'missing-step-run',
+            's9',
+            1,
+            'failed',
+            '{"source":"bad-parent"}',
+            '2026-01-01T00:02:00+00:00',
+            '2026-01-01T00:02:01+00:00'
+        );
+        """
+    )
+    legacy_conn.commit()
+    legacy_conn.close()
+
+    db = WorkflowsDatabase(str(db_path))
+
+    migrated_conn = sqlite3.connect(db_path)
+    try:
+        columns = {
+            row[1]: row for row in migrated_conn.execute("PRAGMA table_info(workflow_step_attempts)").fetchall()
+        }
+        assert columns["step_run_id"][3] == 1
+
+        indexes = migrated_conn.execute("PRAGMA index_list(workflow_step_attempts)").fetchall()
+        unique_indexes = [row for row in indexes if row[2] == 1]
+        assert unique_indexes
+        index_names = {row[1] for row in indexes}
+        assert "idx_step_attempts_run_attempts" in index_names
+        assert "idx_step_attempts_run_step_attempts" in index_names
+        assert "idx_step_attempts_step_run_attempts" in index_names
+
+        version_row = migrated_conn.execute(
+            "SELECT version FROM workflow_schema_version LIMIT 1"
+        ).fetchone()
+        assert version_row is not None
+        assert int(version_row[0]) == WorkflowsDatabase._CURRENT_SCHEMA_VERSION
+
+        rows = migrated_conn.execute(
+            "SELECT attempt_id, step_run_id, attempt_number, status, metadata_json "
+            "FROM workflow_step_attempts ORDER BY step_run_id ASC"
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0][0] == "legacy-duplicate-newer"
+        assert rows[0][1] == "run-legacy:s1:1"
+        assert rows[0][2] == 1
+        assert rows[0][3] == "failed"
+        assert rows[1][0] == "legacy-valid-survivor"
+        assert rows[1][1] == "run-legacy:s2:1"
+        assert all(row[0] != "legacy-bad-parent" for row in rows)
+    finally:
+        migrated_conn.close()
+
+    db.create_run(
+        run_id="wf-run-attempt-migrated",
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "step-attempt-migrated", "steps": []},
+    )
+    db.create_step_run(
+        step_run_id="wf-run-attempt-migrated:s1:1",
+        tenant_id="tenant",
+        run_id="wf-run-attempt-migrated",
+        step_id="s1",
+        name="Prompt step",
+        step_type="prompt",
+        status="running",
+        inputs={"config": {"template": "Hello"}},
+    )
+    db.create_step_attempt(
+        tenant_id="tenant",
+        run_id="wf-run-attempt-migrated",
+        step_run_id="wf-run-attempt-migrated:s1:1",
+        step_id="s1",
+        attempt_number=1,
+        status="running",
+        metadata={"step_type": "prompt"},
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.create_step_attempt(
+            tenant_id="tenant",
+            run_id="wf-run-attempt-migrated",
+            step_run_id="wf-run-attempt-migrated:s1:1",
+            step_id="s1",
+            attempt_number=1,
+            status="running",
+            metadata={"step_type": "prompt"},
+        )

--- a/tldw_Server_API/tests/Workflows/test_workflows_db.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_db.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.app.core.DB_Management import Workflows_DB as workflows_db_mod
 from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
 
 
@@ -353,6 +354,74 @@ def test_workflow_step_attempt_rejects_duplicate_logical_attempt(tmp_path):
             status="running",
             metadata={"step_type": "prompt"},
         )
+
+
+def test_backend_v7_migration_does_not_create_step_attempts_table() -> None:
+    db = WorkflowsDatabase.__new__(WorkflowsDatabase)
+    queries: list[str] = []
+
+    class _Backend:
+        @staticmethod
+        def escape_identifier(identifier: str) -> str:
+            return f'"{identifier}"'
+
+        def execute(self, query: str, params=None, connection=None):  # noqa: ANN001
+            queries.append(query)
+
+    db.backend = _Backend()
+
+    db._backend_migrate_to_v7(object())
+
+    assert not any("workflow_step_attempts" in query for query in queries)
+    assert any("workflow_research_waits" in query for query in queries)
+
+
+def test_list_step_attempts_logs_malformed_metadata_json(tmp_path, monkeypatch):
+    db_path = tmp_path / "workflows.db"
+    db = WorkflowsDatabase(str(db_path))
+
+    db.create_run(
+        run_id="wf-run-bad-metadata",
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "bad-metadata", "steps": []},
+    )
+    db.create_step_run(
+        step_run_id="wf-run-bad-metadata:s1:1",
+        tenant_id="tenant",
+        run_id="wf-run-bad-metadata",
+        step_id="s1",
+        name="Prompt step",
+        step_type="prompt",
+        status="running",
+        inputs={},
+    )
+    attempt_id = db.create_step_attempt(
+        tenant_id="tenant",
+        run_id="wf-run-bad-metadata",
+        step_run_id="wf-run-bad-metadata:s1:1",
+        step_id="s1",
+        attempt_number=1,
+        status="running",
+        metadata={"step_type": "prompt"},
+    )
+    db._conn.execute(
+        "UPDATE workflow_step_attempts SET metadata_json = ? WHERE attempt_id = ?",
+        ("{not-json", attempt_id),
+    )
+    db._conn.commit()
+
+    warnings: list[tuple[object, ...]] = []
+    monkeypatch.setattr(workflows_db_mod.logger, "warning", lambda *args, **kwargs: warnings.append(args))
+
+    attempts = db.list_step_attempts(run_id="wf-run-bad-metadata", step_id="s1")
+
+    assert attempts[0]["metadata_json"] == {}
+    assert warnings
+    assert "metadata_json" in str(warnings[0][0])
 
 
 def test_workflow_step_attempt_migration_rebuilds_legacy_contract(tmp_path):

--- a/tldw_Server_API/tests/Workflows/test_workflows_db.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_db.py
@@ -92,6 +92,37 @@ def test_sqlite_append_event_uses_begin_immediate(tmp_path):
     assert any("BEGIN IMMEDIATE" in statement.upper() for statement in statements)
 
 
+def test_sqlite_append_event_releases_connection_on_serialization_error(monkeypatch, tmp_path):
+    db_path = tmp_path / "workflows.db"
+    db = WorkflowsDatabase(str(db_path))
+
+    run_id = "run-release-on-error"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="t1",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={"name": "release-on-error", "version": 1, "steps": []},
+    )
+
+    released: list[sqlite3.Connection] = []
+    original_release = db._release_sqlite
+
+    def _record_release(conn: sqlite3.Connection) -> None:
+        released.append(conn)
+        original_release(conn)
+
+    monkeypatch.setattr(db, "_release_sqlite", _record_release)
+
+    with pytest.raises(TypeError):
+        db.append_event("t1", run_id, "bad_payload", {"not_json": object()})
+
+    assert released == [db._conn]
+    assert db._conn.in_transaction is False
+
+
 def test_workflow_research_wait_db_tracks_links(tmp_path):
     db_path = tmp_path / "workflows.db"
     db = WorkflowsDatabase(str(db_path))

--- a/tldw_Server_API/tests/Workflows/test_workflows_db_maintenance.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_db_maintenance.py
@@ -9,13 +9,34 @@ from tldw_Server_API.app.services import workflows_db_maintenance as maintenance
 
 
 @pytest.mark.asyncio
-async def test_postgres_maintenance_uses_backend_vacuum_without_transaction(monkeypatch):
-    calls = {"vacuum": 0, "transaction": 0}
+async def test_postgres_maintenance_vacuums_only_workflow_tables_without_transaction(monkeypatch):
+    calls = {"broad_vacuum": 0, "transaction": 0}
+    queries: list[str] = []
+
+    class _Cursor:
+        def execute(self, query: str) -> None:
+            queries.append(query)
+
+    class _Connection:
+        autocommit = False
+        closed = False
+
+        def cursor(self) -> _Cursor:
+            return _Cursor()
 
     class _StubBackend:
         def vacuum(self, connection=None):  # noqa: ANN001
-            assert connection is None
-            calls["vacuum"] += 1
+            calls["broad_vacuum"] += 1
+
+        def connect(self):
+            return _Connection()
+
+        def disconnect(self, connection):  # noqa: ANN001
+            connection.closed = True
+
+        @staticmethod
+        def escape_identifier(identifier: str) -> str:
+            return f'"{identifier}"'
 
         def transaction(self):  # noqa: ANN201
             calls["transaction"] += 1
@@ -36,5 +57,8 @@ async def test_postgres_maintenance_uses_backend_vacuum_without_transaction(monk
     stop_event.set()
     await asyncio.wait_for(task, timeout=2)
 
-    assert calls["vacuum"] >= 1
+    assert calls["broad_vacuum"] == 0
     assert calls["transaction"] == 0
+    assert queries
+    assert all(query.startswith("VACUUM ANALYZE") for query in queries)
+    assert all("workflow_" in query or '"workflows"' in query for query in queries)

--- a/tldw_Server_API/tests/Workflows/test_workflows_db_maintenance.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_db_maintenance.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.backends.base import BackendType
+from tldw_Server_API.app.services import workflows_db_maintenance as maintenance_mod
+
+
+@pytest.mark.asyncio
+async def test_postgres_maintenance_uses_backend_vacuum_without_transaction(monkeypatch):
+    calls = {"vacuum": 0, "transaction": 0}
+
+    class _StubBackend:
+        def vacuum(self, connection=None):  # noqa: ANN001
+            assert connection is None
+            calls["vacuum"] += 1
+
+        def transaction(self):  # noqa: ANN201
+            calls["transaction"] += 1
+            raise AssertionError("maintenance should not open a transaction for VACUUM")
+
+    class _StubDB:
+        backend = _StubBackend()
+        backend_type = BackendType.POSTGRESQL
+
+    monkeypatch.setenv("WORKFLOWS_DB_MAINTENANCE_INTERVAL_SEC", "1")
+    monkeypatch.setenv("WORKFLOWS_POSTGRES_VACUUM", "true")
+    monkeypatch.setattr(maintenance_mod, "get_content_backend_instance", lambda: object())
+    monkeypatch.setattr(maintenance_mod, "create_workflows_database", lambda backend=None: _StubDB())
+
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(maintenance_mod.run_workflows_db_maintenance(stop_event))
+    await asyncio.sleep(0.1)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=2)
+
+    assert calls["vacuum"] >= 1
+    assert calls["transaction"] == 0

--- a/tldw_Server_API/tests/Workflows/test_workflows_scheduler.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_scheduler.py
@@ -9,6 +9,9 @@ from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app as fastapi_app
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.Workflows_Scheduler_DB import (
+    WorkflowSchedule,
+)
 from tldw_Server_API.app.core.DB_Management.backends.base import (
     DatabaseError as BackendDatabaseError,
 )
@@ -172,6 +175,104 @@ def test_get_tolerates_default_and_user_db_lookup_errors(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_load_all_discovers_non_default_tenant_schedules(monkeypatch, tmp_path):
+    svc = workflows_scheduler_mod._WFRecurringScheduler()
+    loaded: list[tuple[str, int | None]] = []
+    schedule = WorkflowSchedule(
+        id="sched-tenant-a",
+        tenant_id="tenant-a",
+        user_id="1",
+        workflow_id=None,
+        name="Tenant A schedule",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs_json="{}",
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        require_online=False,
+        concurrency_mode="skip",
+        misfire_grace_sec=60,
+        coalesce=True,
+        jitter_sec=0,
+        acp_config_json=None,
+        last_run_at=None,
+        next_run_at=None,
+        last_status=None,
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+
+    class _StubDB:
+        def list_schedules(self, **kwargs):
+            raise AssertionError(f"tenant-filtered schedule lookup should not be used during scheduler bootstrap: {kwargs}")
+
+        def list_all_schedules(self, **kwargs):
+            return [schedule]
+
+    (tmp_path / "1").mkdir()
+    monkeypatch.setattr(
+        workflows_scheduler_mod.DatabasePaths,
+        "get_user_db_base_dir",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(svc, "_get_db", lambda uid: _StubDB())
+    monkeypatch.setattr(svc, "_add_job", lambda schedule_obj, user_id=None: loaded.append((schedule_obj.id, user_id)))
+
+    await svc._load_all()  # type: ignore[attr-defined]
+
+    assert loaded == [("sched-tenant-a", 1)]
+
+
+@pytest.mark.asyncio
+async def test_load_all_uses_schedule_owner_when_shared_backend_returns_duplicates(monkeypatch, tmp_path):
+    svc = workflows_scheduler_mod._WFRecurringScheduler()
+    loaded: list[tuple[str, int | None]] = []
+    schedule = WorkflowSchedule(
+        id="sched-shared",
+        tenant_id="default",
+        user_id="77",
+        workflow_id=None,
+        name="Shared schedule",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs_json="{}",
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        require_online=False,
+        concurrency_mode="skip",
+        misfire_grace_sec=60,
+        coalesce=True,
+        jitter_sec=0,
+        acp_config_json=None,
+        last_run_at=None,
+        next_run_at=None,
+        last_status=None,
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+
+    class _SharedDB:
+        def list_all_schedules(self, **kwargs):
+            return [schedule]
+
+    (tmp_path / "1").mkdir()
+    (tmp_path / "77").mkdir()
+    monkeypatch.setattr(
+        workflows_scheduler_mod.DatabasePaths,
+        "get_user_db_base_dir",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(svc, "_get_db", lambda uid: _SharedDB())
+    monkeypatch.setattr(svc, "_add_job", lambda schedule_obj, user_id=None: loaded.append((schedule_obj.id, user_id)))
+
+    await svc._load_all()  # type: ignore[attr-defined]
+
+    assert loaded == [("sched-shared", 77)]
+
+
+@pytest.mark.asyncio
 async def test_history_updates_on_fire(monkeypatch):
     # Start service directly without TestClient overhead for this unit test
     svc = get_workflows_scheduler()
@@ -210,6 +311,92 @@ async def test_history_updates_on_fire(monkeypatch):
     assert s.last_status in ("pending", "queued", "error", "running")
 
     await svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_run_schedule_routes_watchlist_backed_schedules_to_watchlists_queue(monkeypatch):
+    svc = get_workflows_scheduler()
+    await svc.start()
+    sid = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="watchlist-fire",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs={"watchlist_job_id": 7},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        concurrency_mode="skip",
+        misfire_grace_sec=60,
+        coalesce=True,
+    )
+
+    captured: dict[str, Any] = {}
+
+    class _StubScheduler:
+        async def submit(self, *args: Any, **kwargs: Any) -> str:
+            captured["handler"] = kwargs.get("handler")
+            captured["queue_name"] = kwargs.get("queue_name")
+            captured["payload"] = kwargs.get("payload")
+            return "task-watchlist-fire"
+
+    svc._core_scheduler = _StubScheduler()  # type: ignore[attr-defined]
+
+    await svc._run_schedule(sid)  # type: ignore[attr-defined]
+
+    assert captured["handler"] == "watchlist_run"
+    assert captured["queue_name"] == "watchlists"
+    assert captured["payload"]["inputs"]["watchlist_job_id"] == 7
+
+    await svc.stop()
+
+
+def test_run_now_routes_watchlist_backed_schedules_to_watchlists_queue(client_admin, monkeypatch):
+    client, svc = client_admin
+    sid = svc.create(
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="watchlist-now",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs={"watchlist_job_id": 42},
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        concurrency_mode="skip",
+        misfire_grace_sec=60,
+        coalesce=True,
+    )
+
+    captured: dict[str, Any] = {}
+
+    class _StubScheduler:
+        async def submit(self, handler: str, *args: Any, **kwargs: Any) -> str:
+            captured["handler"] = handler
+            captured["payload"] = kwargs.get("payload")
+            captured["queue_name"] = kwargs.get("queue_name")
+            captured["metadata"] = kwargs.get("metadata")
+            return "task-watchlist-now"
+
+    async def _get_global_scheduler_stub():
+        return _StubScheduler()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.endpoints.scheduler_workflows.get_global_scheduler",
+        _get_global_scheduler_stub,
+    )
+
+    response = client.post(f"/api/v1/scheduler/workflows/{sid}/run-now")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"task_id": "task-watchlist-now"}
+    assert captured["handler"] == "watchlist_run"
+    assert captured["queue_name"] == "watchlists"
+    assert captured["payload"]["inputs"]["watchlist_job_id"] == 42
+    assert captured["metadata"] == {"user_id": "1"}
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Workflows/test_workflows_scheduler.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_scheduler.py
@@ -11,6 +11,7 @@ from tldw_Server_API.app.main import app as fastapi_app
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.Workflows_Scheduler_DB import (
     WorkflowSchedule,
+    WorkflowsSchedulerDB,
 )
 from tldw_Server_API.app.core.DB_Management.backends.base import (
     DatabaseError as BackendDatabaseError,
@@ -20,6 +21,33 @@ from tldw_Server_API.app.services.workflows_scheduler import get_workflows_sched
 
 
 pytestmark = pytest.mark.unit
+
+
+def _schedule(schedule_id: str, *, inputs_json: str = "{}", user_id: str = "1") -> WorkflowSchedule:
+    return WorkflowSchedule(
+        id=schedule_id,
+        tenant_id="default",
+        user_id=user_id,
+        workflow_id=None,
+        name=schedule_id,
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs_json=inputs_json,
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        require_online=False,
+        concurrency_mode="skip",
+        misfire_grace_sec=60,
+        coalesce=True,
+        jitter_sec=0,
+        acp_config_json=None,
+        last_run_at=None,
+        next_run_at=None,
+        last_status=None,
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
 
 
 @pytest.fixture()
@@ -133,6 +161,59 @@ def test_next_run_persisted_after_create(client_admin):
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert isinstance(data.get("next_run_at"), str) and len(data["next_run_at"]) > 0
+
+
+def test_list_all_schedules_preserves_acp_config_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("WORKFLOWS_SCHEDULER_SQLITE_PATH", str(tmp_path / "scheduler.db"))
+    db = WorkflowsSchedulerDB()
+    acp_config = '{"prompt":"summarize"}'
+
+    db.create_schedule(
+        id="acp-schedule",
+        tenant_id="default",
+        user_id="1",
+        workflow_id=None,
+        name="ACP schedule",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs={},
+        acp_config_json=acp_config,
+    )
+
+    schedules = db.list_all_schedules(limit=10)
+
+    assert len(schedules) == 1
+    assert schedules[0].acp_config_json == acp_config
+
+
+def test_build_schedule_payload_defaults_malformed_inputs_to_empty_dict():
+    payload = workflows_scheduler_mod.build_schedule_payload(_schedule("bad-json", inputs_json="{not-json"))
+
+    assert payload["inputs"] == {}
+    assert payload["workflow_id"] is None
+
+
+def test_list_registered_schedules_pages_until_short_page(monkeypatch):
+    svc = workflows_scheduler_mod._WFRecurringScheduler()
+    first_page = [_schedule(f"sched-{idx}") for idx in range(1000)]
+    second_page = [_schedule("sched-1000")]
+    calls: list[tuple[int, int]] = []
+
+    class _PagedDB:
+        def list_all_schedules(self, **kwargs):
+            calls.append((kwargs["limit"], kwargs["offset"]))
+            if kwargs["offset"] == 0:
+                return first_page
+            if kwargs["offset"] == 1000:
+                return second_page
+            return []
+
+    monkeypatch.setattr(svc, "_get_db", lambda uid: _PagedDB())
+
+    schedules = svc._list_registered_schedules(1)
+
+    assert len(schedules) == 1001
+    assert calls == [(1000, 0), (1000, 1000)]
 
 
 def test_get_tolerates_default_and_user_db_lookup_errors(monkeypatch, tmp_path):

--- a/tldw_Server_API/tests/Workflows/test_workflows_scheduler.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_scheduler.py
@@ -434,6 +434,35 @@ async def test_run_schedule_routes_watchlist_backed_schedules_to_watchlists_queu
     await svc.stop()
 
 
+@pytest.mark.asyncio
+async def test_run_schedule_submits_with_resolved_owner_user_id(monkeypatch):
+    monkeypatch.delenv("WORKFLOWS_MINT_VIRTUAL_KEYS", raising=False)
+    svc = workflows_scheduler_mod._WFRecurringScheduler()
+    schedule = _schedule("owner-fallback", user_id="legacy-owner")
+    captured: dict[str, Any] = {}
+
+    class _StubDB:
+        def get_schedule(self, schedule_id: str) -> WorkflowSchedule | None:
+            return schedule if schedule_id == "owner-fallback" else None
+
+        def set_history(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    class _StubScheduler:
+        async def submit(self, *args: Any, **kwargs: Any) -> str:
+            captured["payload"] = kwargs.get("payload")
+            captured["metadata"] = kwargs.get("metadata")
+            return "task-owner-fallback"
+
+    monkeypatch.setattr(svc, "_get_db", lambda uid: _StubDB())
+    svc._core_scheduler = _StubScheduler()  # type: ignore[attr-defined]
+
+    await svc._run_schedule("owner-fallback", user_id=42)  # type: ignore[attr-defined]
+
+    assert captured["payload"]["user_id"] == "42"
+    assert captured["metadata"] == {"user_id": "42"}
+
+
 def test_run_now_routes_watchlist_backed_schedules_to_watchlists_queue(client_admin, monkeypatch):
     client, svc = client_admin
     sid = svc.create(

--- a/tldw_Server_API/tests/Workflows/test_workflows_scheduler.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_scheduler.py
@@ -586,3 +586,59 @@ async def test_run_schedule_mints_virtual_key_when_enabled_with_y(monkeypatch):
     assert payload.get("secrets", {}).get("jwt") == "vk-token-y"
 
     await svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_run_acp_schedule_logs_malformed_acp_config_json(monkeypatch):
+    svc = workflows_scheduler_mod._WFRecurringScheduler()
+    schedule = WorkflowSchedule(
+        id="bad-acp-json",
+        tenant_id="default",
+        user_id="5",
+        workflow_id=None,
+        name="Bad ACP JSON",
+        cron="*/5 * * * *",
+        timezone="UTC",
+        inputs_json="{}",
+        run_mode="async",
+        validation_mode="block",
+        enabled=True,
+        require_online=False,
+        concurrency_mode="skip",
+        misfire_grace_sec=60,
+        coalesce=True,
+        jitter_sec=0,
+        acp_config_json="{not-json",
+        last_run_at=None,
+        next_run_at=None,
+        last_status=None,
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+    warnings: list[tuple[object, ...]] = []
+    captured: dict[str, Any] = {}
+
+    class _StubDB:
+        def get_schedule(self, schedule_id: str) -> WorkflowSchedule | None:
+            return schedule if schedule_id == "bad-acp-json" else None
+
+        def set_history(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    class _StubScheduler:
+        async def submit(self, *args: Any, **kwargs: Any) -> str:
+            captured["payload"] = kwargs.get("payload")
+            return "task-bad-acp-json"
+
+    monkeypatch.setattr(svc, "_get_db", lambda uid: _StubDB())
+    monkeypatch.setattr(
+        workflows_scheduler_mod.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+    svc._core_scheduler = _StubScheduler()  # type: ignore[attr-defined]
+
+    await svc._run_acp_schedule("bad-acp-json", 5)  # type: ignore[attr-defined]
+
+    assert captured["payload"]["prompt"] == ""
+    assert any("malformed acp_config_json" in str(args[0]) for args in warnings)

--- a/tldw_Server_API/tests/fixtures/privilege_route_registry_snapshot.json
+++ b/tldw_Server_API/tests/fixtures/privilege_route_registry_snapshot.json
@@ -171,6 +171,64 @@
       ]
     }
   ],
+  "acp.runs.aggregate": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Aggregate token usage and costs across ACP runs.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.aggregate_acp_runs",
+      "methods": [
+        "GET"
+      ],
+      "name": "aggregate_acp_runs",
+      "path": "/api/v1/acp/runs/aggregate",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    }
+  ],
+  "acp.runs.list": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Query ACP run history with optional filters.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.list_acp_runs",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_acp_runs",
+      "path": "/api/v1/acp/runs",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    }
+  ],
   "acp.sessions.manage": [
     {
       "dependencies": [
@@ -293,6 +351,33 @@
           "type": "dependency"
         }
       ],
+      "description": "List available checkpoints for a sandbox-backed session.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_checkpoints",
+      "methods": [
+        "GET"
+      ],
+      "name": "acp_session_checkpoints",
+      "path": "/api/v1/acp/sessions/{session_id}/checkpoints",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
       "description": "Fork an ACP session from a specific message index.",
       "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_fork",
       "methods": [
@@ -347,6 +432,33 @@
           "type": "dependency"
         }
       ],
+      "description": "Rollback sandbox state to a checkpoint.\n\nProvide either ``to_sequence`` (finds nearest checkpoint at or before\nthat sequence) or ``to_snapshot_id`` (restores directly).  Only works\nfor sandbox-backed sessions with an active CheckpointConsumer.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_rollback",
+      "methods": [
+        "POST"
+      ],
+      "name": "acp_session_rollback",
+      "path": "/api/v1/acp/sessions/{session_id}/rollback",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
       "description": "",
       "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_teardown",
       "methods": [
@@ -354,6 +466,35 @@
       ],
       "name": "acp_session_teardown",
       "path": "/api/v1/acp/sessions/{session_id}/teardown",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    }
+  ],
+  "acp.sessions.prompt_async": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Submit an ACP prompt for asynchronous execution.\n\nReturns a ``task_id`` that can be polled via\n``GET /api/v1/acp/tasks/{task_id}`` for status and results.\n\nTasks are submitted to the global Scheduler and persisted in the\ndatabase, so they survive process restarts and are visible from\nany worker.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_prompt_async",
+      "methods": [
+        "POST"
+      ],
+      "name": "acp_prompt_async",
+      "path": "/api/v1/acp/sessions/prompt-async",
       "rate_limit_resources": [],
       "summary": null,
       "tags": [
@@ -538,6 +679,33 @@
           "type": "dependency"
         }
       ],
+      "description": "Stream ACP session events as Server-Sent Events.\n\nEvents are formatted as typed SSE frames with ``event: {kind}`` and\n``data: {json}`` fields.  A heartbeat comment is sent every 15 seconds\nto keep the connection alive through proxies and load balancers.\n\nUse the *last_event_id* query parameter to replay buffered events from\na given sequence number (e.g. for reconnection catch-up).",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_events_stream",
+      "methods": [
+        "GET"
+      ],
+      "name": "acp_session_events_stream",
+      "path": "/api/v1/acp/sessions/{session_id}/events/stream",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
       "description": "",
       "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_reconciliation",
       "methods": [
@@ -628,6 +796,35 @@
       ],
       "name": "acp_setup_guide",
       "path": "/api/v1/acp/setup-guide",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    }
+  ],
+  "acp.tasks.status": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Poll for the status and result of an async ACP task.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_task_status",
+      "methods": [
+        "GET"
+      ],
+      "name": "acp_task_status",
+      "path": "/api/v1/acp/tasks/{task_id}",
       "rate_limit_resources": [],
       "summary": null,
       "tags": [
@@ -1364,6 +1561,60 @@
           "type": "dependency"
         }
       ],
+      "description": "Query ACP run history with optional filters.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.list_acp_runs",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_acp_runs",
+      "path": "/api/v1/acp/runs",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Aggregate token usage and costs across ACP runs.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.aggregate_acp_runs",
+      "methods": [
+        "GET"
+      ],
+      "name": "aggregate_acp_runs",
+      "path": "/api/v1/acp/runs/aggregate",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
       "description": "List ACP sessions for the authenticated user.",
       "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_list_sessions",
       "methods": [
@@ -1499,6 +1750,33 @@
           "type": "dependency"
         }
       ],
+      "description": "Submit an ACP prompt for asynchronous execution.\n\nReturns a ``task_id`` that can be polled via\n``GET /api/v1/acp/tasks/{task_id}`` for status and results.\n\nTasks are submitted to the global Scheduler and persisted in the\ndatabase, so they survive process restarts and are visible from\nany worker.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_prompt_async",
+      "methods": [
+        "POST"
+      ],
+      "name": "acp_prompt_async",
+      "path": "/api/v1/acp/sessions/prompt-async",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
       "description": "Query artifacts emitted in ACP session messages.",
       "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_artifacts",
       "methods": [
@@ -1533,6 +1811,33 @@
       ],
       "name": "acp_session_audit",
       "path": "/api/v1/acp/sessions/{session_id}/audit",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "List available checkpoints for a sandbox-backed session.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_checkpoints",
+      "methods": [
+        "GET"
+      ],
+      "name": "acp_session_checkpoints",
+      "path": "/api/v1/acp/sessions/{session_id}/checkpoints",
       "rate_limit_resources": [],
       "summary": null,
       "tags": [
@@ -1634,6 +1939,33 @@
           "type": "dependency"
         }
       ],
+      "description": "Stream ACP session events as Server-Sent Events.\n\nEvents are formatted as typed SSE frames with ``event: {kind}`` and\n``data: {json}`` fields.  A heartbeat comment is sent every 15 seconds\nto keep the connection alive through proxies and load balancers.\n\nUse the *last_event_id* query parameter to replay buffered events from\na given sequence number (e.g. for reconnection catch-up).",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_events_stream",
+      "methods": [
+        "GET"
+      ],
+      "name": "acp_session_events_stream",
+      "path": "/api/v1/acp/sessions/{session_id}/events/stream",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
       "description": "Fork an ACP session from a specific message index.",
       "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_fork",
       "methods": [
@@ -1695,6 +2027,33 @@
       ],
       "name": "acp_session_reconciliation",
       "path": "/api/v1/acp/sessions/{session_id}/reconciliation",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Rollback sandbox state to a checkpoint.\n\nProvide either ``to_sequence`` (finds nearest checkpoint at or before\nthat sequence) or ``to_snapshot_id`` (restores directly).  Only works\nfor sandbox-backed sessions with an active CheckpointConsumer.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_session_rollback",
+      "methods": [
+        "POST"
+      ],
+      "name": "acp_session_rollback",
+      "path": "/api/v1/acp/sessions/{session_id}/rollback",
       "rate_limit_resources": [],
       "summary": null,
       "tags": [
@@ -1803,6 +2162,33 @@
       ],
       "name": "acp_setup_guide",
       "path": "/api/v1/acp/setup-guide",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "acp",
+        "acp"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Poll for the status and result of an async ACP task.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.agent_client_protocol.acp_task_status",
+      "methods": [
+        "GET"
+      ],
+      "name": "acp_task_status",
+      "path": "/api/v1/acp/tasks/{task_id}",
       "rate_limit_resources": [],
       "summary": null,
       "tags": [
@@ -2363,6 +2749,677 @@
           "type": "dependency"
         },
         {
+          "id": "audio_tts.get_tts_service",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "personalization_deps.get_usage_event_logger",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.personalization_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Execute a single non-streaming speech chat turn:\n\n  - Accept base64-encoded user audio.\n  - Run STT to obtain a transcript.\n  - Call the LLM with recent conversation history.\n  - Persist user/assistant messages into ChaChaNotes.\n  - Run TTS on the assistant reply and return base64-encoded audio.\n\nThis endpoint focuses on the v1 non-streaming path; streaming speech chat\nis handled by a separate WebSocket endpoint in v2.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_streaming.audio_chat_turn",
+      "methods": [
+        "POST"
+      ],
+      "name": "audio_chat_turn",
+      "path": "/api/v1/audio/chat",
+      "rate_limit_resources": [],
+      "summary": "Non-streaming Speech-to-Speech chat (STT \u2192 LLM \u2192 TTS)",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_history.list_tts_history",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_tts_history",
+      "path": "/api/v1/audio/history",
+      "rate_limit_resources": [],
+      "summary": "List TTS history entries.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_history.delete_tts_history_entry",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_tts_history_entry",
+      "path": "/api/v1/audio/history/{history_id}",
+      "rate_limit_resources": [],
+      "summary": "Delete a TTS history entry (soft delete).",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_history.get_tts_history_entry",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_tts_history_entry",
+      "path": "/api/v1/audio/history/{history_id}",
+      "rate_limit_resources": [],
+      "summary": "Get TTS history entry details.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_history.update_tts_history_entry",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "update_tts_history_entry",
+      "path": "/api/v1/audio/history/{history_id}",
+      "rate_limit_resources": [],
+      "summary": "Update TTS history entry fields.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.try_get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_tts_service",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "personalization_deps.get_usage_event_logger",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.personalization_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Generates audio from the input text.\n\nRequires authentication via Bearer token in Authorization header.\nRate limited to 10 requests per minute per IP address.\n\nInput is sanitized by `TTSInputValidator`, which normalizes Unicode,\nstrips HTML, and removes or rejects potentially dangerous patterns\n(e.g., obvious SQL/command/FS injection attempts). In strict mode\n(the default), such patterns result in HTTP 400 errors; in relaxed\nmode (`strict_validation` set to false via TTS config), dangerous\nsubstrings are stripped and the request is processed if non-empty.\n\nDocs: `Docs/Code_Documentation/Ingestion_Pipeline_Audio.md`,\n`Docs/STT-TTS/TTS-SETUP-GUIDE.md` (sanitization and error semantics).",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts.create_speech",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_speech",
+      "path": "/api/v1/audio/speech",
+      "rate_limit_resources": [],
+      "summary": "Generates audio from text input.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_job_manager",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Submit a long-form TTS job and return job id.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts.create_speech_job",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_speech_job",
+      "path": "/api/v1/audio/speech/jobs",
+      "rate_limit_resources": [],
+      "summary": "Submit a long-form TTS job",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts.get_speech_job_artifacts",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_speech_job_artifacts",
+      "path": "/api/v1/audio/speech/jobs/{job_id}/artifacts",
+      "rate_limit_resources": [],
+      "summary": "List artifacts for a TTS job",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_tts_service",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "personalization_deps.get_usage_event_logger",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.personalization_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts.create_speech_metadata",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_speech_metadata",
+      "path": "/api/v1/audio/speech/metadata",
+      "rate_limit_resources": [],
+      "summary": "Returns alignment metadata for a TTS request.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.get_auth_principal",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.get_db_transaction",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps._check_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps.get_billing_org_id",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Transcribes audio into the input language.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_transcriptions.create_transcription",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_transcription",
+      "path": "/api/v1/audio/transcriptions",
+      "rate_limit_resources": [],
+      "summary": "Transcribes audio into text (OpenAI Compatible)",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.get_auth_principal",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.get_db_transaction",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps._check_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps.get_billing_org_id",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "personalization_deps.get_usage_event_logger",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.personalization_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Translates audio into English.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_transcriptions.create_translation",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_translation",
+      "path": "/api/v1/audio/translations",
+      "rate_limit_resources": [],
+      "summary": "Translates audio into English (OpenAI Compatible)",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "List all custom voice samples uploaded by the user.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.list_voices",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_voices",
+      "path": "/api/v1/audio/voices",
+      "rate_limit_resources": [],
+      "summary": "List user's custom voices",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Encode provider-specific artifacts for a stored voice reference.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.encode_voice_reference",
+      "methods": [
+        "POST"
+      ],
+      "name": "encode_voice_reference",
+      "path": "/api/v1/audio/voices/encode",
+      "rate_limit_resources": [],
+      "summary": "Encode stored voice reference for a provider",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Upload a custom voice sample for use with TTS.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.upload_voice",
+      "methods": [
+        "POST"
+      ],
+      "name": "upload_voice",
+      "path": "/api/v1/audio/voices/upload",
+      "rate_limit_resources": [],
+      "summary": "Upload a custom voice sample",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Delete a custom voice sample.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.delete_voice",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_voice",
+      "path": "/api/v1/audio/voices/{voice_id}",
+      "rate_limit_resources": [],
+      "summary": "Delete a custom voice",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Get detailed information about a specific voice.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.get_voice_details",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_voice_details",
+      "path": "/api/v1/audio/voices/{voice_id}",
+      "rate_limit_resources": [],
+      "summary": "Get voice details",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_tts_service",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Generate a short preview of a custom voice.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.preview_voice",
+      "methods": [
+        "POST"
+      ],
+      "name": "preview_voice",
+      "path": "/api/v1/audio/voices/{voice_id}/preview",
+      "rate_limit_resources": [],
+      "summary": "Generate voice preview",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "ChaCha_Notes_DB_Deps.get_chacha_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
           "id": "auth_deps._checker",
           "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
           "type": "dependency"
@@ -2451,6 +3508,16 @@
         {
           "id": "auth_deps.get_auth_principal",
           "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps._check_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps.get_billing_org_id",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
           "type": "dependency"
         },
         {
@@ -3390,6 +4457,837 @@
       ]
     }
   ],
+  "audio.chat": [
+    {
+      "dependencies": [
+        {
+          "id": "ChaCha_Notes_DB_Deps.get_chacha_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_tts_service",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "personalization_deps.get_usage_event_logger",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.personalization_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Execute a single non-streaming speech chat turn:\n\n  - Accept base64-encoded user audio.\n  - Run STT to obtain a transcript.\n  - Call the LLM with recent conversation history.\n  - Persist user/assistant messages into ChaChaNotes.\n  - Run TTS on the assistant reply and return base64-encoded audio.\n\nThis endpoint focuses on the v1 non-streaming path; streaming speech chat\nis handled by a separate WebSocket endpoint in v2.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_streaming.audio_chat_turn",
+      "methods": [
+        "POST"
+      ],
+      "name": "audio_chat_turn",
+      "path": "/api/v1/audio/chat",
+      "rate_limit_resources": [],
+      "summary": "Non-streaming Speech-to-Speech chat (STT \u2192 LLM \u2192 TTS)",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.history": [
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_history.list_tts_history",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_tts_history",
+      "path": "/api/v1/audio/history",
+      "rate_limit_resources": [],
+      "summary": "List TTS history entries.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_history.delete_tts_history_entry",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_tts_history_entry",
+      "path": "/api/v1/audio/history/{history_id}",
+      "rate_limit_resources": [],
+      "summary": "Delete a TTS history entry (soft delete).",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_history.get_tts_history_entry",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_tts_history_entry",
+      "path": "/api/v1/audio/history/{history_id}",
+      "rate_limit_resources": [],
+      "summary": "Get TTS history entry details.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_history.update_tts_history_entry",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "update_tts_history_entry",
+      "path": "/api/v1/audio/history/{history_id}",
+      "rate_limit_resources": [],
+      "summary": "Update TTS history entry fields.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.speech": [
+    {
+      "dependencies": [
+        {
+          "id": "DB_Deps.try_get_media_db_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_tts_service",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "personalization_deps.get_usage_event_logger",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.personalization_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Generates audio from the input text.\n\nRequires authentication via Bearer token in Authorization header.\nRate limited to 10 requests per minute per IP address.\n\nInput is sanitized by `TTSInputValidator`, which normalizes Unicode,\nstrips HTML, and removes or rejects potentially dangerous patterns\n(e.g., obvious SQL/command/FS injection attempts). In strict mode\n(the default), such patterns result in HTTP 400 errors; in relaxed\nmode (`strict_validation` set to false via TTS config), dangerous\nsubstrings are stripped and the request is processed if non-empty.\n\nDocs: `Docs/Code_Documentation/Ingestion_Pipeline_Audio.md`,\n`Docs/STT-TTS/TTS-SETUP-GUIDE.md` (sanitization and error semantics).",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts.create_speech",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_speech",
+      "path": "/api/v1/audio/speech",
+      "rate_limit_resources": [],
+      "summary": "Generates audio from text input.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_job_manager",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Submit a long-form TTS job and return job id.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts.create_speech_job",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_speech_job",
+      "path": "/api/v1/audio/speech/jobs",
+      "rate_limit_resources": [],
+      "summary": "Submit a long-form TTS job",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts.get_speech_job_artifacts",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_speech_job_artifacts",
+      "path": "/api/v1/audio/speech/jobs/{job_id}/artifacts",
+      "rate_limit_resources": [],
+      "summary": "List artifacts for a TTS job",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_tts_service",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "personalization_deps.get_usage_event_logger",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.personalization_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts.create_speech_metadata",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_speech_metadata",
+      "path": "/api/v1/audio/speech/metadata",
+      "rate_limit_resources": [],
+      "summary": "Returns alignment metadata for a TTS request.",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.tokenizer": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tokenizer.decode_audio_tokenizer",
+      "methods": [
+        "POST"
+      ],
+      "name": "decode_audio_tokenizer",
+      "path": "/api/v1/audio/tokenizer/decode",
+      "rate_limit_resources": [],
+      "summary": "Decode Qwen3-TTS tokens into audio",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tokenizer.encode_audio_tokenizer",
+      "methods": [
+        "POST"
+      ],
+      "name": "encode_audio_tokenizer",
+      "path": "/api/v1/audio/tokenizer/encode",
+      "rate_limit_resources": [],
+      "summary": "Encode audio into Qwen3-TTS tokens",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.tokenizer.decode": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tokenizer.decode_audio_tokenizer",
+      "methods": [
+        "POST"
+      ],
+      "name": "decode_audio_tokenizer",
+      "path": "/api/v1/audio/tokenizer/decode",
+      "rate_limit_resources": [],
+      "summary": "Decode Qwen3-TTS tokens into audio",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.tokenizer.encode": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tokenizer.encode_audio_tokenizer",
+      "methods": [
+        "POST"
+      ],
+      "name": "encode_audio_tokenizer",
+      "path": "/api/v1/audio/tokenizer/encode",
+      "rate_limit_resources": [],
+      "summary": "Encode audio into Qwen3-TTS tokens",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.transcriptions": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.get_auth_principal",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.get_db_transaction",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps._check_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps.get_billing_org_id",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Transcribes audio into the input language.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_transcriptions.create_transcription",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_transcription",
+      "path": "/api/v1/audio/transcriptions",
+      "rate_limit_resources": [],
+      "summary": "Transcribes audio into text (OpenAI Compatible)",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.translations": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.get_auth_principal",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.get_db_transaction",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps._check_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps.get_billing_org_id",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "personalization_deps.get_usage_event_logger",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.personalization_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Translates audio into English.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_transcriptions.create_translation",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_translation",
+      "path": "/api/v1/audio/translations",
+      "rate_limit_resources": [],
+      "summary": "Translates audio into English (OpenAI Compatible)",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.voices.delete": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Delete a custom voice sample.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.delete_voice",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_voice",
+      "path": "/api/v1/audio/voices/{voice_id}",
+      "rate_limit_resources": [],
+      "summary": "Delete a custom voice",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.voices.encode": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Encode provider-specific artifacts for a stored voice reference.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.encode_voice_reference",
+      "methods": [
+        "POST"
+      ],
+      "name": "encode_voice_reference",
+      "path": "/api/v1/audio/voices/encode",
+      "rate_limit_resources": [],
+      "summary": "Encode stored voice reference for a provider",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.voices.get": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Get detailed information about a specific voice.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.get_voice_details",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_voice_details",
+      "path": "/api/v1/audio/voices/{voice_id}",
+      "rate_limit_resources": [],
+      "summary": "Get voice details",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.voices.list": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "List all custom voice samples uploaded by the user.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.list_voices",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_voices",
+      "path": "/api/v1/audio/voices",
+      "rate_limit_resources": [],
+      "summary": "List user's custom voices",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.voices.preview": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "audio_tts.get_tts_service",
+          "module": "tldw_Server_API.app.api.v1.endpoints.audio.audio_tts",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Generate a short preview of a custom voice.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.preview_voice",
+      "methods": [
+        "POST"
+      ],
+      "name": "preview_voice",
+      "path": "/api/v1/audio/voices/{voice_id}/preview",
+      "rate_limit_resources": [],
+      "summary": "Generate voice preview",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
+  "audio.voices.upload": [
+    {
+      "dependencies": [
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps.check_rate_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        }
+      ],
+      "description": "Upload a custom voice sample for use with TTS.",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.audio.audio_voices.upload_voice",
+      "methods": [
+        "POST"
+      ],
+      "name": "upload_voice",
+      "path": "/api/v1/audio/voices/upload",
+      "rate_limit_resources": [],
+      "summary": "Upload a custom voice sample",
+      "tags": [
+        "audio",
+        "Audio",
+        "Audio"
+      ]
+    }
+  ],
   "chat.analytics": [
     {
       "dependencies": [
@@ -3496,6 +5394,16 @@
         {
           "id": "auth_deps.get_auth_principal",
           "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps._check_limit",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "billing_deps.get_billing_org_id",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.billing_deps",
           "type": "dependency"
         },
         {
@@ -5486,12 +7394,88 @@
         }
       ],
       "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.workflows.run_adhoc",
+      "methods": [
+        "POST"
+      ],
+      "name": "run_adhoc",
+      "path": "/api/v1/workflows/run",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "workflows",
+        "workflows"
+      ]
+    },
+    {
+      "dependencies": [
+        {
+          "id": "Audit_DB_Deps.get_audit_service_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "workflows._get_db",
+          "module": "tldw_Server_API.app.api.v1.endpoints.workflows",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
       "endpoint": "tldw_Server_API.app.api.v1.endpoints.workflows.run_saved",
       "methods": [
         "POST"
       ],
       "name": "run_saved",
       "path": "/api/v1/workflows/{workflow_id}/run",
+      "rate_limit_resources": [],
+      "summary": null,
+      "tags": [
+        "workflows",
+        "workflows"
+      ]
+    }
+  ],
+  "workflows.run_adhoc": [
+    {
+      "dependencies": [
+        {
+          "id": "Audit_DB_Deps.get_audit_service_for_user",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps",
+          "type": "dependency"
+        },
+        {
+          "id": "User_DB_Handling.get_request_user",
+          "module": "tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+          "type": "dependency"
+        },
+        {
+          "id": "auth_deps._checker",
+          "module": "tldw_Server_API.app.api.v1.API_Deps.auth_deps",
+          "type": "dependency"
+        },
+        {
+          "id": "workflows._get_db",
+          "module": "tldw_Server_API.app.api.v1.endpoints.workflows",
+          "type": "dependency"
+        }
+      ],
+      "description": "",
+      "endpoint": "tldw_Server_API.app.api.v1.endpoints.workflows.run_adhoc",
+      "methods": [
+        "POST"
+      ],
+      "name": "run_adhoc",
+      "path": "/api/v1/workflows/run",
       "rate_limit_resources": [],
       "summary": null,
       "tags": [


### PR DESCRIPTION
## Summary
- persist step attempts and investigation support, and enforce guarded workflow state transitions
- align recurring scheduler discovery and routing, ad-hoc auth scope, and webhook DLQ evidence behavior
- harden workflow DB maintenance, artifact GC evidence, and backend docs/tests

## Test Plan
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m pytest tldw_Server_API/tests/CI/test_required_workflow_contracts.py tldw_Server_API/tests/Workflows/test_engine_state_contracts.py tldw_Server_API/tests/Workflows/test_workflows_db.py tldw_Server_API/tests/Workflows/test_workflows_db_maintenance.py tldw_Server_API/tests/Workflows/test_workflows_artifact_gc_service.py tldw_Server_API/tests/Workflows/test_workflows_scheduler.py tldw_Server_API/tests/Workflows/test_workflows_api.py::test_run_adhoc_requires_workflows_scope_like_saved_run tldw_Server_API/tests/Workflows/test_webhook_admin_endpoints.py::test_dlq_replay_appends_delivery_event tldw_Server_API/tests/Workflows/test_webhook_dlq_worker.py::test_dlq_worker_stops_retrying_after_max_attempts
- source /Users/appledev/Documents/GitHub/tldw_server/.venv/bin/activate && python -m bandit -f json -o /tmp/bandit_workflows_pr.json tldw_Server_API/app/api/v1/endpoints/workflows.py tldw_Server_API/app/core/DB_Management/Workflows_DB.py tldw_Server_API/app/core/DB_Management/Workflows_Scheduler_DB.py tldw_Server_API/app/core/Workflows/engine.py tldw_Server_API/app/core/Workflows/investigation.py tldw_Server_API/app/services/workflows_scheduler.py tldw_Server_API/app/services/workflows_artifact_gc_service.py tldw_Server_API/app/services/workflows_db_maintenance.py tldw_Server_API/app/services/workflows_webhook_dlq_service.py