### PR TITLE
feat: dock /chat composer to viewport bottom

### DIFF
--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -1596,6 +1596,7 @@ export const Playground = () => {
           </div>
           <div
             ref={containerRef}
+            data-testid={stickyChatInput ? "playground-chat-transcript" : undefined}
             role="log"
             aria-live="polite"
             aria-relevant="additions"
@@ -1622,6 +1623,7 @@ export const Playground = () => {
             </div>
           </div>
           <div
+            data-testid={stickyChatInput ? "playground-chat-composer-dock" : undefined}
             className={`relative w-full ${
               stickyChatInput
                 ? "sticky bottom-0 z-20 border-t border-border bg-surface/95 backdrop-blur"

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -65,6 +65,10 @@ import {
 } from "@/utils/settings-return"
 import { useChatSurfaceCoordinatorStore } from "@/store/chat-surface-coordinator"
 import { useNavigate } from "react-router-dom"
+import {
+  resolveComposerBottomOffsetPx,
+  type ComposerDockLayoutMetrics
+} from "./mobile-composer-layout"
 
 const toText = (value: unknown): string =>
   typeof value === "string" ? value : String(value)
@@ -93,6 +97,7 @@ export const Playground = () => {
   const threadSearchInputRef = React.useRef<HTMLInputElement>(null)
   const shortcutsTriggerRef = React.useRef<HTMLButtonElement>(null)
   const shortcutsCloseRef = React.useRef<HTMLButtonElement>(null)
+  const composerDockRef = React.useRef<HTMLDivElement>(null)
   const [droppedFiles, setDroppedFiles] = React.useState<File[]>([])
   const [attachedResearchContext, setAttachedResearchContext] =
     React.useState<AttachedResearchContext | null>(null)
@@ -106,6 +111,8 @@ export const Playground = () => {
     React.useState<string | null>(null)
   const [dismissedReturnedResearchRunId, setDismissedReturnedResearchRunId] =
     React.useState<string | null>(null)
+  const [composerDockMetrics, setComposerDockMetrics] =
+    React.useState<ComposerDockLayoutMetrics | null>(null)
   const { t } = useTranslation(["playground", "common"])
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING)
   const [stickyChatInput] = useStorage(
@@ -134,8 +141,30 @@ export const Playground = () => {
     compareFeatureEnabled
   } = useMessageOption()
   const { setSystemPrompt } = useStoreChatModelSettings()
+  const composerBottomOffsetPx = stickyChatInput
+    ? resolveComposerBottomOffsetPx(composerDockMetrics)
+    : 0
+  const handleComposerLayoutChange = React.useCallback(
+    (metrics: ComposerDockLayoutMetrics) => {
+      if (metrics.occupiedHeightPx === 0 && metrics.keyboardInsetPx === 0) {
+        setComposerDockMetrics(null)
+        return
+      }
+
+      const dockEl = composerDockRef.current
+      setComposerDockMetrics({
+        occupiedHeightPx: dockEl
+          ? Math.round(dockEl.getBoundingClientRect().height)
+          : metrics.occupiedHeightPx,
+        keyboardInsetPx: metrics.keyboardInsetPx
+      })
+    },
+    []
+  )
   const { containerRef, isAutoScrollToBottom, autoScrollToBottom } =
-    useSmartScroll(messages, streaming, 120)
+    useSmartScroll(messages, streaming, 120, {
+      bottomOffsetPx: composerBottomOffsetPx
+    })
   const [dropState, setDropState] = React.useState<
     "idle" | "dragging" | "error"
   >("idle")
@@ -1623,6 +1652,7 @@ export const Playground = () => {
             </div>
           </div>
           <div
+            ref={composerDockRef}
             data-testid={stickyChatInput ? "playground-chat-composer-dock" : undefined}
             className={`relative w-full ${
               stickyChatInput
@@ -1648,6 +1678,10 @@ export const Playground = () => {
             )}
             <PlaygroundForm
               droppedFiles={droppedFiles}
+              stickyDockEnabled={stickyChatInput}
+              onComposerLayoutChange={
+                stickyChatInput ? handleComposerLayoutChange : undefined
+              }
               attachedResearchContext={attachedResearchContext}
               attachedResearchContextBaseline={attachedResearchContextBaseline}
               attachedResearchContextPinned={attachedResearchContextPinned}

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -1331,7 +1331,7 @@ export const Playground = () => {
     <div
       ref={drop}
       data-is-dragging={dropState === "dragging"}
-      className="relative flex h-full flex-col items-center bg-bg text-text data-[is-dragging=true]:bg-surface2"
+      className="relative flex h-full min-h-0 flex-col items-center bg-bg text-text data-[is-dragging=true]:bg-surface2"
       style={
         chatBackgroundImage
           ? {
@@ -1380,8 +1380,8 @@ export const Playground = () => {
         </div>
       )}
 
-      <div className="relative z-10 flex h-full w-full">
-        <div className="flex h-full min-w-0 flex-1 flex-col">
+      <div className="relative z-10 flex h-full min-h-0 w-full">
+        <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
           {parentMeta?.parentHistoryId && (
             <div className="flex w-full justify-center px-5 pt-2">
               <div className="inline-flex flex-wrap items-center justify-center gap-2">
@@ -1740,7 +1740,7 @@ export const Playground = () => {
             data-testid={
               stickyChatInput ? "playground-chat-composer-dock" : undefined
             }
-            className={`relative w-full ${
+            className={`relative w-full shrink-0 ${
               stickyChatInput
                 ? "sticky bottom-0 z-20 border-t border-border bg-surface/95 backdrop-blur"
                 : ""

--- a/apps/packages/ui/src/components/Option/Playground/Playground.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/Playground.tsx
@@ -1,45 +1,45 @@
-import React from "react"
-import { PlaygroundForm } from "./PlaygroundForm"
-import { PlaygroundChat } from "./PlaygroundChat"
-import { ChatErrorBoundary } from "@/components/Common/Playground/ChatErrorBoundary"
-import { useMessageOption } from "@/hooks/useMessageOption"
-import { usePlaygroundSessionPersistence } from "@/hooks/usePlaygroundSessionPersistence"
-import { shouldRestorePersistedPlaygroundSession } from "@/hooks/playground-session-restore"
-import { webUIResumeLastChat } from "@/services/app"
+import React from "react";
+import { PlaygroundForm } from "./PlaygroundForm";
+import { PlaygroundChat } from "./PlaygroundChat";
+import { ChatErrorBoundary } from "@/components/Common/Playground/ChatErrorBoundary";
+import { useMessageOption } from "@/hooks/useMessageOption";
+import { usePlaygroundSessionPersistence } from "@/hooks/usePlaygroundSessionPersistence";
+import { shouldRestorePersistedPlaygroundSession } from "@/hooks/playground-session-restore";
+import { webUIResumeLastChat } from "@/services/app";
 import {
   formatToChatHistory,
   formatToMessage,
   getHistoryByServerChatId,
   getPromptById,
-  getRecentChatFromWebUI
-} from "@/db/dexie/helpers"
-import { useStoreChatModelSettings } from "@/store/model"
-import { useSmartScroll } from "@/hooks/useSmartScroll"
-import { ChevronDown, Keyboard, Search, X } from "lucide-react"
-import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings"
-import { otherUnsupportedTypes } from "../Knowledge/utils/unsupported-types"
-import { useTranslation } from "react-i18next"
-import { useStoreMessageOption } from "@/store/option"
-import { useArtifactsStore } from "@/store/artifacts"
-import { useSetting } from "@/hooks/useSetting"
-import { useStorage } from "@plasmohq/storage/hook"
-import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings"
-import { useMobile } from "@/hooks/useMediaQuery"
-import { useLoadLocalConversation } from "@/hooks/useLoadLocalConversation"
-import { tldwClient } from "@/services/tldw/TldwApiClient"
-import { resolvePlaygroundShortcutAction } from "./playground-shortcuts"
+  getRecentChatFromWebUI,
+} from "@/db/dexie/helpers";
+import { useStoreChatModelSettings } from "@/store/model";
+import { useSmartScroll } from "@/hooks/useSmartScroll";
+import { ChevronDown, Keyboard, Search, X } from "lucide-react";
+import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings";
+import { otherUnsupportedTypes } from "../Knowledge/utils/unsupported-types";
+import { useTranslation } from "react-i18next";
+import { useStoreMessageOption } from "@/store/option";
+import { useArtifactsStore } from "@/store/artifacts";
+import { useSetting } from "@/hooks/useSetting";
+import { useStorage } from "@plasmohq/storage/hook";
+import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings";
+import { useMobile } from "@/hooks/useMediaQuery";
+import { useLoadLocalConversation } from "@/hooks/useLoadLocalConversation";
+import { tldwClient } from "@/services/tldw/TldwApiClient";
+import { resolvePlaygroundShortcutAction } from "./playground-shortcuts";
 import {
   EDIT_MESSAGE_EVENT,
   OPEN_HISTORY_EVENT,
   TIMELINE_ACTION_EVENT,
   type OpenHistoryDetail,
-  type TimelineActionDetail
-} from "@/utils/timeline-actions"
-import { useCharacterGreeting } from "@/hooks/useCharacterGreeting"
+  type TimelineActionDetail,
+} from "@/utils/timeline-actions";
+import { useCharacterGreeting } from "@/hooks/useCharacterGreeting";
 import {
   applyChatSettingsPatch,
-  syncChatSettingsForServerChat
-} from "@/services/chat-settings"
+  syncChatSettingsForServerChat,
+} from "@/services/chat-settings";
 import {
   buildResearchFollowUpPrompt,
   clearAttachedResearchContext,
@@ -52,32 +52,32 @@ import {
   toPersistedDeepResearchAttachment,
   unpinAttachedResearchContext,
   type AttachedResearchContext,
-  type ResearchFollowUpTarget
-} from "./research-chat-context"
+  type ResearchFollowUpTarget,
+} from "./research-chat-context";
 import {
   collectThreadSearchMatches,
-  getWrappedMatchIndex
-} from "./playground-thread-search"
+  getWrappedMatchIndex,
+} from "./playground-thread-search";
 import {
   RESEARCH_RETURN_RUN_ID_PARAM,
   SETTINGS_HISTORY_ID_PARAM,
-  SETTINGS_SERVER_CHAT_ID_PARAM
-} from "@/utils/settings-return"
-import { useChatSurfaceCoordinatorStore } from "@/store/chat-surface-coordinator"
-import { useNavigate } from "react-router-dom"
+  SETTINGS_SERVER_CHAT_ID_PARAM,
+} from "@/utils/settings-return";
+import { useChatSurfaceCoordinatorStore } from "@/store/chat-surface-coordinator";
+import { useNavigate } from "react-router-dom";
 import {
   resolveComposerBottomOffsetPx,
-  type ComposerDockLayoutMetrics
-} from "./mobile-composer-layout"
+  type ComposerDockLayoutMetrics,
+} from "./mobile-composer-layout";
 
 const toText = (value: unknown): string =>
-  typeof value === "string" ? value : String(value)
+  typeof value === "string" ? value : String(value);
 
 const LazyArtifactsPanel = React.lazy(() =>
   import("@/components/Sidepanel/Chat/ArtifactsPanel").then((module) => ({
-    default: module.ArtifactsPanel
-  }))
-)
+    default: module.ArtifactsPanel,
+  })),
+);
 
 const renderArtifactsPanel = () => (
   <React.Suspense
@@ -89,37 +89,37 @@ const renderArtifactsPanel = () => (
   >
     <LazyArtifactsPanel />
   </React.Suspense>
-)
+);
 
 export const Playground = () => {
-  const drop = React.useRef<HTMLDivElement>(null)
-  const artifactsTriggerRef = React.useRef<HTMLButtonElement>(null)
-  const threadSearchInputRef = React.useRef<HTMLInputElement>(null)
-  const shortcutsTriggerRef = React.useRef<HTMLButtonElement>(null)
-  const shortcutsCloseRef = React.useRef<HTMLButtonElement>(null)
-  const composerDockRef = React.useRef<HTMLDivElement>(null)
-  const [droppedFiles, setDroppedFiles] = React.useState<File[]>([])
+  const drop = React.useRef<HTMLDivElement>(null);
+  const artifactsTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const threadSearchInputRef = React.useRef<HTMLInputElement>(null);
+  const shortcutsTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const shortcutsCloseRef = React.useRef<HTMLButtonElement>(null);
+  const composerDockRef = React.useRef<HTMLDivElement>(null);
+  const [droppedFiles, setDroppedFiles] = React.useState<File[]>([]);
   const [attachedResearchContext, setAttachedResearchContext] =
-    React.useState<AttachedResearchContext | null>(null)
+    React.useState<AttachedResearchContext | null>(null);
   const [attachedResearchContextBaseline, setAttachedResearchContextBaseline] =
-    React.useState<AttachedResearchContext | null>(null)
+    React.useState<AttachedResearchContext | null>(null);
   const [attachedResearchContextPinned, setAttachedResearchContextPinned] =
-    React.useState<AttachedResearchContext | null>(null)
+    React.useState<AttachedResearchContext | null>(null);
   const [attachedResearchContextHistory, setAttachedResearchContextHistory] =
-    React.useState<AttachedResearchContext[]>([])
+    React.useState<AttachedResearchContext[]>([]);
   const [pendingReturnedResearchRunId, setPendingReturnedResearchRunId] =
-    React.useState<string | null>(null)
+    React.useState<string | null>(null);
   const [dismissedReturnedResearchRunId, setDismissedReturnedResearchRunId] =
-    React.useState<string | null>(null)
+    React.useState<string | null>(null);
   const [composerDockMetrics, setComposerDockMetrics] =
-    React.useState<ComposerDockLayoutMetrics | null>(null)
-  const { t } = useTranslation(["playground", "common"])
-  const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING)
+    React.useState<ComposerDockLayoutMetrics | null>(null);
+  const { t } = useTranslation(["playground", "common"]);
+  const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING);
   const [stickyChatInput] = useStorage(
     "stickyChatInput",
-    DEFAULT_CHAT_SETTINGS.stickyChatInput
-  )
-  const isMobileViewport = useMobile()
+    DEFAULT_CHAT_SETTINGS.stickyChatInput,
+  );
+  const isMobileViewport = useMobile();
   const {
     messages,
     history,
@@ -138,128 +138,132 @@ export const Playground = () => {
     selectedCharacter,
     setSelectedCharacter,
     compareMode,
-    compareFeatureEnabled
-  } = useMessageOption()
-  const { setSystemPrompt } = useStoreChatModelSettings()
+    compareFeatureEnabled,
+  } = useMessageOption();
+  const { setSystemPrompt } = useStoreChatModelSettings();
   const composerBottomOffsetPx = stickyChatInput
     ? resolveComposerBottomOffsetPx(composerDockMetrics)
-    : 0
+    : 0;
   const handleComposerLayoutChange = React.useCallback(
     (metrics: ComposerDockLayoutMetrics) => {
       if (metrics.occupiedHeightPx === 0 && metrics.keyboardInsetPx === 0) {
-        setComposerDockMetrics(null)
-        return
+        setComposerDockMetrics(null);
+        return;
       }
 
-      const dockEl = composerDockRef.current
+      const dockEl = composerDockRef.current;
       setComposerDockMetrics({
         occupiedHeightPx: dockEl
           ? Math.round(dockEl.getBoundingClientRect().height)
           : metrics.occupiedHeightPx,
-        keyboardInsetPx: metrics.keyboardInsetPx
-      })
+        keyboardInsetPx: metrics.keyboardInsetPx,
+      });
     },
-    []
-  )
+    [],
+  );
   const { containerRef, isAutoScrollToBottom, autoScrollToBottom } =
     useSmartScroll(messages, streaming, 120, {
-      bottomOffsetPx: composerBottomOffsetPx
-    })
+      bottomOffsetPx: composerBottomOffsetPx,
+    });
   const [dropState, setDropState] = React.useState<
     "idle" | "dragging" | "error"
-  >("idle")
-  const [threadSearchOpen, setThreadSearchOpen] = React.useState(false)
-  const [threadSearchQuery, setThreadSearchQuery] = React.useState("")
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = React.useState("")
-  const [threadSearchActiveIndex, setThreadSearchActiveIndex] = React.useState(0)
-  const [shortcutsHelpOpen, setShortcutsHelpOpen] = React.useState(false)
-  const [dropFeedback, setDropFeedback] = React.useState<
-    { type: "info" | "error" | "warning"; message: string } | null
-  >(null)
-  const [playgroundReady, setPlaygroundReady] = React.useState(false)
+  >("idle");
+  const [threadSearchOpen, setThreadSearchOpen] = React.useState(false);
+  const [threadSearchQuery, setThreadSearchQuery] = React.useState("");
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = React.useState("");
+  const [threadSearchActiveIndex, setThreadSearchActiveIndex] =
+    React.useState(0);
+  const [shortcutsHelpOpen, setShortcutsHelpOpen] = React.useState(false);
+  const [dropFeedback, setDropFeedback] = React.useState<{
+    type: "info" | "error" | "warning";
+    message: string;
+  } | null>(null);
+  const [playgroundReady, setPlaygroundReady] = React.useState(false);
   const feedbackTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  )
-  const timelineActionRetryTimeoutRef = React.useRef<
-    ReturnType<typeof setTimeout> | null
-  >(null)
-  const initializePlaygroundRef = React.useRef(false)
-  const previousThreadRef = React.useRef<string | null>(null)
-  const stableHistoryId =
-    historyId && historyId !== "temp" ? historyId : null
+    null,
+  );
+  const timelineActionRetryTimeoutRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  const initializePlaygroundRef = React.useRef(false);
+  const previousThreadRef = React.useRef<string | null>(null);
+  const stableHistoryId = historyId && historyId !== "temp" ? historyId : null;
   const setRouteContext = useChatSurfaceCoordinatorStore(
-    (state) => state.setRouteContext
-  )
+    (state) => state.setRouteContext,
+  );
   const setSelectedQuickPrompt = useStoreMessageOption(
-    (state) => state.setSelectedQuickPrompt
-  )
+    (state) => state.setSelectedQuickPrompt,
+  );
 
   React.useEffect(() => {
-    setRouteContext({ routeId: "chat", surface: "webui" })
-  }, [setRouteContext])
+    setRouteContext({ routeId: "chat", surface: "webui" });
+  }, [setRouteContext]);
 
   // Debounce search query to avoid running collectThreadSearchMatches on every keystroke
   React.useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearchQuery(threadSearchQuery), 200)
-    return () => clearTimeout(timer)
-  }, [threadSearchQuery])
+    const timer = setTimeout(
+      () => setDebouncedSearchQuery(threadSearchQuery),
+      200,
+    );
+    return () => clearTimeout(timer);
+  }, [threadSearchQuery]);
 
   const showDropFeedback = React.useCallback(
     (feedback: { type: "info" | "error" | "warning"; message: string }) => {
-      setDropFeedback(feedback)
+      setDropFeedback(feedback);
       if (feedbackTimerRef.current) {
-        clearTimeout(feedbackTimerRef.current)
+        clearTimeout(feedbackTimerRef.current);
       }
       feedbackTimerRef.current = setTimeout(() => {
-        setDropFeedback(null)
-        feedbackTimerRef.current = null
-      }, 6000)
+        setDropFeedback(null);
+        feedbackTimerRef.current = null;
+      }, 6000);
     },
-    []
-  )
+    [],
+  );
 
   React.useEffect(() => {
     if (!drop.current) {
-      return
+      return;
     }
     const handleDragOver = (e: DragEvent) => {
-      e.preventDefault()
-      e.stopPropagation()
-    }
+      e.preventDefault();
+      e.stopPropagation();
+    };
 
     const handleDrop = (e: DragEvent) => {
-      e.preventDefault()
-      e.stopPropagation()
+      e.preventDefault();
+      e.stopPropagation();
 
-      setDropState("idle")
+      setDropState("idle");
 
-      const files = Array.from(e.dataTransfer?.files || [])
+      const files = Array.from(e.dataTransfer?.files || []);
 
       const hasUnsupportedFiles = files.some((file) =>
-        otherUnsupportedTypes.includes(file.type)
-      )
+        otherUnsupportedTypes.includes(file.type),
+      );
 
       if (hasUnsupportedFiles) {
-        setDropState("error")
+        setDropState("error");
         showDropFeedback({
           type: "error",
           message: t(
             "playground:drop.unsupported",
-            "That file type isn’t supported. Try images or text-based files."
-          )
-        })
-        return
+            "That file type isn’t supported. Try images or text-based files.",
+          ),
+        });
+        return;
       }
 
-      const FILE_LIMIT = 5
+      const FILE_LIMIT = 5;
       const allFiles = Array.from(e.dataTransfer?.files || []).filter(
-        (file) => !otherUnsupportedTypes.includes(file.type)
-      )
-      const newFiles = allFiles.slice(0, FILE_LIMIT)
-      const droppedExtra = allFiles.length - newFiles.length
+        (file) => !otherUnsupportedTypes.includes(file.type),
+      );
+      const newFiles = allFiles.slice(0, FILE_LIMIT);
+      const droppedExtra = allFiles.length - newFiles.length;
 
       if (newFiles.length > 0) {
-        setDroppedFiles(newFiles)
+        setDroppedFiles(newFiles);
 
         // Show warning if files were truncated
         if (droppedExtra > 0) {
@@ -269,94 +273,94 @@ export const Playground = () => {
               count: newFiles.length,
               extra: droppedExtra,
               limit: FILE_LIMIT,
-              defaultValue: `Attached first ${newFiles.length} files. ${droppedExtra} additional file(s) were not attached (limit: ${FILE_LIMIT}).`
-            })
-          })
+              defaultValue: `Attached first ${newFiles.length} files. ${droppedExtra} additional file(s) were not attached (limit: ${FILE_LIMIT}).`,
+            }),
+          });
         } else {
           showDropFeedback({
             type: "info",
             message:
               newFiles.length > 1
                 ? t("playground:drop.readyMultiple", {
-                    count: newFiles.length
+                    count: newFiles.length,
                   })
                 : t("playground:drop.readySingle", {
                     name:
                       newFiles[0]?.name ||
-                      t("playground:drop.defaultFileName", "File")
-                  })
-          })
+                      t("playground:drop.defaultFileName", "File"),
+                  }),
+          });
         }
       }
-    }
+    };
     const handleDragEnter = (e: DragEvent) => {
-      e.preventDefault()
-      e.stopPropagation()
-      setDropState("dragging")
+      e.preventDefault();
+      e.stopPropagation();
+      setDropState("dragging");
       showDropFeedback({
         type: "info",
         message: t(
           "playground:drop.hint",
-          "Drop files to attach them to your message"
-        )
-      })
-    }
+          "Drop files to attach them to your message",
+        ),
+      });
+    };
 
     const handleDragLeave = (e: DragEvent) => {
-      e.preventDefault()
-      e.stopPropagation()
-      setDropState("idle")
-    }
+      e.preventDefault();
+      e.stopPropagation();
+      setDropState("idle");
+    };
 
-    drop.current.addEventListener("dragover", handleDragOver)
-    drop.current.addEventListener("drop", handleDrop)
-    drop.current.addEventListener("dragenter", handleDragEnter)
-    drop.current.addEventListener("dragleave", handleDragLeave)
+    drop.current.addEventListener("dragover", handleDragOver);
+    drop.current.addEventListener("drop", handleDrop);
+    drop.current.addEventListener("dragenter", handleDragEnter);
+    drop.current.addEventListener("dragleave", handleDragLeave);
 
     return () => {
       if (drop.current) {
-        drop.current.removeEventListener("dragover", handleDragOver)
-        drop.current.removeEventListener("drop", handleDrop)
-        drop.current.removeEventListener("dragenter", handleDragEnter)
-        drop.current.removeEventListener("dragleave", handleDragLeave)
+        drop.current.removeEventListener("dragover", handleDragOver);
+        drop.current.removeEventListener("drop", handleDrop);
+        drop.current.removeEventListener("dragenter", handleDragEnter);
+        drop.current.removeEventListener("dragleave", handleDragLeave);
       }
-    }
-  }, [showDropFeedback, t])
+    };
+  }, [showDropFeedback, t]);
 
   React.useEffect(() => {
     return () => {
       if (feedbackTimerRef.current) {
-        clearTimeout(feedbackTimerRef.current)
+        clearTimeout(feedbackTimerRef.current);
       }
       if (timelineActionRetryTimeoutRef.current) {
-        clearTimeout(timelineActionRetryTimeoutRef.current)
+        clearTimeout(timelineActionRetryTimeoutRef.current);
       }
-      pendingTimelineActionRef.current = null
-    }
-  }, [])
+      pendingTimelineActionRef.current = null;
+    };
+  }, []);
 
   React.useEffect(() => {
-    const currentThreadKey = `${serverChatId ?? ""}::${historyId ?? ""}`
+    const currentThreadKey = `${serverChatId ?? ""}::${historyId ?? ""}`;
     if (
       previousThreadRef.current !== null &&
       previousThreadRef.current !== currentThreadKey
     ) {
-      setAttachedResearchContext(null)
-      setAttachedResearchContextBaseline(null)
-      setAttachedResearchContextPinned(null)
-      setAttachedResearchContextHistory([])
+      setAttachedResearchContext(null);
+      setAttachedResearchContextBaseline(null);
+      setAttachedResearchContextPinned(null);
+      setAttachedResearchContextHistory([]);
     }
-    previousThreadRef.current = currentThreadKey
-  }, [historyId, serverChatId])
+    previousThreadRef.current = currentThreadKey;
+  }, [historyId, serverChatId]);
 
   const persistAttachedResearchContext = React.useCallback(
     async (
       context: AttachedResearchContext | null,
       pinned: AttachedResearchContext | null,
-      history: AttachedResearchContext[]
+      history: AttachedResearchContext[],
     ) => {
       if (!serverChatId || !stableHistoryId) {
-        return
+        return;
       }
       try {
         await applyChatSettingsPatch({
@@ -370,66 +374,70 @@ export const Playground = () => {
               ? toPersistedDeepResearchAttachment(pinned)
               : null,
             deepResearchAttachmentHistory: history.map((entry) =>
-              toPersistedDeepResearchAttachment(entry, entry.attached_at)
-            )
-          }
-        })
+              toPersistedDeepResearchAttachment(entry, entry.attached_at),
+            ),
+          },
+        });
       } catch {
         // Attachment persistence is best-effort and should never block chat use.
       }
     },
-    [serverChatId, stableHistoryId]
-  )
+    [serverChatId, stableHistoryId],
+  );
 
   React.useEffect(() => {
     if (!playgroundReady || !serverChatId || !stableHistoryId) {
-      return
+      return;
     }
-    let cancelled = false
-    const threadKey = `${serverChatId}::${stableHistoryId}`
+    let cancelled = false;
+    const threadKey = `${serverChatId}::${stableHistoryId}`;
 
     const restorePersistedAttachment = async () => {
       try {
         const settings = await syncChatSettingsForServerChat({
           historyId: stableHistoryId,
-          serverChatId
-        })
+          serverChatId,
+        });
         if (cancelled || previousThreadRef.current !== threadKey) {
-          return
+          return;
         }
         const restoredAttachment = settings?.deepResearchAttachment
           ? fromPersistedDeepResearchAttachment(settings.deepResearchAttachment)
-          : null
+          : null;
         const restoredPinnedAttachment = settings?.deepResearchPinnedAttachment
           ? fromPersistedDeepResearchAttachment(
-              settings.deepResearchPinnedAttachment
+              settings.deepResearchPinnedAttachment,
             )
-          : null
-        const restoredHistory = Array.isArray(settings?.deepResearchAttachmentHistory)
+          : null;
+        const restoredHistory = Array.isArray(
+          settings?.deepResearchAttachmentHistory,
+        )
           ? settings.deepResearchAttachmentHistory.map(
-              fromPersistedDeepResearchAttachment
+              fromPersistedDeepResearchAttachment,
             )
-          : []
-        const restoredActive = restoredAttachment ?? restoredPinnedAttachment
-        setAttachedResearchContext((current) => current ?? restoredActive)
-        setAttachedResearchContextBaseline((current) => current ?? restoredActive)
+          : [];
+        const restoredActive = restoredAttachment ?? restoredPinnedAttachment;
+        setAttachedResearchContext((current) => current ?? restoredActive);
+        setAttachedResearchContextBaseline(
+          (current) => current ?? restoredActive,
+        );
         setAttachedResearchContextPinned(
-          (current) => current ?? restoredPinnedAttachment
-        )
+          (current) => current ?? restoredPinnedAttachment,
+        );
         setAttachedResearchContextHistory((current) =>
-          current.length > 0 ? current : restoredHistory
-        )
+          current.length > 0 ? current : restoredHistory,
+        );
       } catch {
         // Silent, non-blocking auxiliary restore.
       }
-    }
+    };
 
-    void restorePersistedAttachment()
+    void restorePersistedAttachment();
 
     return () => {
-      cancelled = true
-    }
-  }, [playgroundReady, serverChatId, stableHistoryId])
+      cancelled = true;
+    };
+  }, [playgroundReady, serverChatId, stableHistoryId]);
 
   const handleAttachResearchContext = React.useCallback(
     (context: AttachedResearchContext) => {
@@ -438,100 +446,106 @@ export const Playground = () => {
         baseline: attachedResearchContextBaseline,
         pinned: attachedResearchContextPinned,
         history: attachedResearchContextHistory,
-        nextActive: context
-      })
-      setAttachedResearchContext(nextState.active)
-      setAttachedResearchContextBaseline(nextState.baseline)
-      setAttachedResearchContextPinned(nextState.pinned)
-      setAttachedResearchContextHistory(nextState.history)
+        nextActive: context,
+      });
+      setAttachedResearchContext(nextState.active);
+      setAttachedResearchContextBaseline(nextState.baseline);
+      setAttachedResearchContextPinned(nextState.pinned);
+      setAttachedResearchContextHistory(nextState.history);
       void persistAttachedResearchContext(
         nextState.active,
         nextState.pinned,
-        nextState.history
-      )
+        nextState.history,
+      );
     },
     [
       attachedResearchContext,
       attachedResearchContextBaseline,
       attachedResearchContextPinned,
       attachedResearchContextHistory,
-      persistAttachedResearchContext
-    ]
-  )
+      persistAttachedResearchContext,
+    ],
+  );
 
   const handlePrepareResearchFollowUp = React.useCallback(
     async (target: ResearchFollowUpTarget) => {
       if (attachedResearchContext?.run_id !== target.run_id) {
         try {
-          await tldwClient.initialize().catch(() => null)
-          const bundle = await tldwClient.getResearchBundle(target.run_id)
+          await tldwClient.initialize().catch(() => null);
+          const bundle = await tldwClient.getResearchBundle(target.run_id);
           handleAttachResearchContext(
-            deriveAttachedResearchContext(bundle, target.run_id, target.query)
-          )
+            deriveAttachedResearchContext(bundle, target.run_id, target.query),
+          );
         } catch {
           // Keep prompt preparation available even if bundle reload fails.
         }
       }
 
-      setSelectedQuickPrompt(buildResearchFollowUpPrompt(target.query))
+      setSelectedQuickPrompt(buildResearchFollowUpPrompt(target.query));
     },
-    [attachedResearchContext?.run_id, handleAttachResearchContext, setSelectedQuickPrompt]
-  )
+    [
+      attachedResearchContext?.run_id,
+      handleAttachResearchContext,
+      setSelectedQuickPrompt,
+    ],
+  );
 
   const handleApplyAttachedResearchContext = React.useCallback(
     (context: AttachedResearchContext) => {
-      setAttachedResearchContext(context)
+      setAttachedResearchContext(context);
       void persistAttachedResearchContext(
         context,
         attachedResearchContextPinned,
-        attachedResearchContextHistory
-      )
+        attachedResearchContextHistory,
+      );
     },
     [
       attachedResearchContextHistory,
       attachedResearchContextPinned,
-      persistAttachedResearchContext
-    ]
-  )
+      persistAttachedResearchContext,
+    ],
+  );
 
   const handleResetAttachedResearchContext = React.useCallback(() => {
-    const resetContext = resetAttachedResearchContext(attachedResearchContextBaseline)
-    setAttachedResearchContext(resetContext)
+    const resetContext = resetAttachedResearchContext(
+      attachedResearchContextBaseline,
+    );
+    setAttachedResearchContext(resetContext);
     void persistAttachedResearchContext(
       resetContext,
       attachedResearchContextPinned,
-      attachedResearchContextHistory
-    )
+      attachedResearchContextHistory,
+    );
   }, [
     attachedResearchContextBaseline,
     attachedResearchContextHistory,
     attachedResearchContextPinned,
-    persistAttachedResearchContext
-  ])
+    persistAttachedResearchContext,
+  ]);
 
   const handleRemoveAttachedResearchContext = React.useCallback(() => {
     const cleared = clearAttachedResearchContext({
       active: attachedResearchContext,
       baseline: attachedResearchContextBaseline,
       pinned: attachedResearchContextPinned,
-      history: attachedResearchContextHistory
-    })
-    setAttachedResearchContext(cleared.active)
-    setAttachedResearchContextBaseline(cleared.baseline)
-    setAttachedResearchContextPinned(cleared.pinned)
-    setAttachedResearchContextHistory(cleared.history)
+      history: attachedResearchContextHistory,
+    });
+    setAttachedResearchContext(cleared.active);
+    setAttachedResearchContextBaseline(cleared.baseline);
+    setAttachedResearchContextPinned(cleared.pinned);
+    setAttachedResearchContextHistory(cleared.history);
     void persistAttachedResearchContext(
       cleared.active,
       cleared.pinned,
-      cleared.history
-    )
+      cleared.history,
+    );
   }, [
     attachedResearchContext,
     attachedResearchContextBaseline,
     attachedResearchContextPinned,
     attachedResearchContextHistory,
-    persistAttachedResearchContext
-  ])
+    persistAttachedResearchContext,
+  ]);
 
   const handleSelectAttachedResearchContextHistory = React.useCallback(
     (context: AttachedResearchContext) => {
@@ -540,50 +554,50 @@ export const Playground = () => {
         baseline: attachedResearchContextBaseline,
         pinned: attachedResearchContextPinned,
         history: attachedResearchContextHistory,
-        nextActive: context
-      })
-      setAttachedResearchContext(nextState.active)
-      setAttachedResearchContextBaseline(nextState.baseline)
-      setAttachedResearchContextPinned(nextState.pinned)
-      setAttachedResearchContextHistory(nextState.history)
+        nextActive: context,
+      });
+      setAttachedResearchContext(nextState.active);
+      setAttachedResearchContextBaseline(nextState.baseline);
+      setAttachedResearchContextPinned(nextState.pinned);
+      setAttachedResearchContextHistory(nextState.history);
       void persistAttachedResearchContext(
         nextState.active,
         nextState.pinned,
-        nextState.history
-      )
+        nextState.history,
+      );
     },
     [
       attachedResearchContext,
       attachedResearchContextBaseline,
       attachedResearchContextPinned,
       attachedResearchContextHistory,
-      persistAttachedResearchContext
-    ]
-  )
+      persistAttachedResearchContext,
+    ],
+  );
 
   const handlePinAttachedResearchContext = React.useCallback(() => {
     const nextState = pinAttachedResearchContext({
       active: attachedResearchContext,
       baseline: attachedResearchContextBaseline,
       pinned: attachedResearchContextPinned,
-      history: attachedResearchContextHistory
-    })
-    setAttachedResearchContext(nextState.active)
-    setAttachedResearchContextBaseline(nextState.baseline)
-    setAttachedResearchContextPinned(nextState.pinned)
-    setAttachedResearchContextHistory(nextState.history)
+      history: attachedResearchContextHistory,
+    });
+    setAttachedResearchContext(nextState.active);
+    setAttachedResearchContextBaseline(nextState.baseline);
+    setAttachedResearchContextPinned(nextState.pinned);
+    setAttachedResearchContextHistory(nextState.history);
     void persistAttachedResearchContext(
       nextState.active,
       nextState.pinned,
-      nextState.history
-    )
+      nextState.history,
+    );
   }, [
     attachedResearchContext,
     attachedResearchContextBaseline,
     attachedResearchContextPinned,
     attachedResearchContextHistory,
-    persistAttachedResearchContext
-  ])
+    persistAttachedResearchContext,
+  ]);
 
   const handlePinAttachedResearchContextHistory = React.useCallback(
     (context: AttachedResearchContext) => {
@@ -592,74 +606,74 @@ export const Playground = () => {
         baseline: attachedResearchContextBaseline,
         pinned: attachedResearchContextPinned,
         history: attachedResearchContextHistory,
-        nextPinned: context
-      })
-      setAttachedResearchContext(nextState.active)
-      setAttachedResearchContextBaseline(nextState.baseline)
-      setAttachedResearchContextPinned(nextState.pinned)
-      setAttachedResearchContextHistory(nextState.history)
+        nextPinned: context,
+      });
+      setAttachedResearchContext(nextState.active);
+      setAttachedResearchContextBaseline(nextState.baseline);
+      setAttachedResearchContextPinned(nextState.pinned);
+      setAttachedResearchContextHistory(nextState.history);
       void persistAttachedResearchContext(
         nextState.active,
         nextState.pinned,
-        nextState.history
-      )
+        nextState.history,
+      );
     },
     [
       attachedResearchContext,
       attachedResearchContextBaseline,
       attachedResearchContextPinned,
       attachedResearchContextHistory,
-      persistAttachedResearchContext
-    ]
-  )
+      persistAttachedResearchContext,
+    ],
+  );
 
   const handleUnpinAttachedResearchContext = React.useCallback(() => {
     const nextState = unpinAttachedResearchContext({
       active: attachedResearchContext,
       baseline: attachedResearchContextBaseline,
       pinned: attachedResearchContextPinned,
-      history: attachedResearchContextHistory
-    })
-    setAttachedResearchContext(nextState.active)
-    setAttachedResearchContextBaseline(nextState.baseline)
-    setAttachedResearchContextPinned(nextState.pinned)
-    setAttachedResearchContextHistory(nextState.history)
+      history: attachedResearchContextHistory,
+    });
+    setAttachedResearchContext(nextState.active);
+    setAttachedResearchContextBaseline(nextState.baseline);
+    setAttachedResearchContextPinned(nextState.pinned);
+    setAttachedResearchContextHistory(nextState.history);
     void persistAttachedResearchContext(
       nextState.active,
       nextState.pinned,
-      nextState.history
-    )
+      nextState.history,
+    );
   }, [
     attachedResearchContext,
     attachedResearchContextBaseline,
     attachedResearchContextPinned,
     attachedResearchContextHistory,
-    persistAttachedResearchContext
-  ])
+    persistAttachedResearchContext,
+  ]);
 
   const handleRestorePinnedResearchContext = React.useCallback(() => {
     const nextState = restorePinnedResearchContext({
       active: attachedResearchContext,
       baseline: attachedResearchContextBaseline,
       pinned: attachedResearchContextPinned,
-      history: attachedResearchContextHistory
-    })
-    setAttachedResearchContext(nextState.active)
-    setAttachedResearchContextBaseline(nextState.baseline)
-    setAttachedResearchContextPinned(nextState.pinned)
-    setAttachedResearchContextHistory(nextState.history)
+      history: attachedResearchContextHistory,
+    });
+    setAttachedResearchContext(nextState.active);
+    setAttachedResearchContextBaseline(nextState.baseline);
+    setAttachedResearchContextPinned(nextState.pinned);
+    setAttachedResearchContextHistory(nextState.history);
     void persistAttachedResearchContext(
       nextState.active,
       nextState.pinned,
-      nextState.history
-    )
+      nextState.history,
+    );
   }, [
     attachedResearchContext,
     attachedResearchContextBaseline,
     attachedResearchContextPinned,
     attachedResearchContextHistory,
-    persistAttachedResearchContext
-  ])
+    persistAttachedResearchContext,
+  ]);
 
   // Session persistence for draft restoration
   const {
@@ -667,8 +681,8 @@ export const Playground = () => {
     sessionScopeReady,
     hasPersistedSession,
     persistedHistoryId,
-    persistedServerChatId
-  } = usePlaygroundSessionPersistence()
+    persistedServerChatId,
+  } = usePlaygroundSessionPersistence();
 
   const initializePlayground = React.useCallback(async () => {
     // 1. Try session persistence first (restores exact state from nav-away)
@@ -680,38 +694,38 @@ export const Playground = () => {
         currentHistoryId: historyId ?? null,
         currentServerChatId: serverChatId ?? null,
         currentMessagesLength: messages.length,
-        currentHistoryLength: history.length
-      })
+        currentHistoryLength: history.length,
+      });
 
     if (shouldRestorePersistedSession) {
-      const restored = await restoreSession()
-      if (restored) return
+      const restored = await restoreSession();
+      if (restored) return;
     }
 
     // 2. Fall back to existing webUIResumeLastChat behavior
-    const isEnabled = await webUIResumeLastChat()
-    if (!isEnabled) return
+    const isEnabled = await webUIResumeLastChat();
+    if (!isEnabled) return;
 
     if (messages.length === 0 && history.length === 0) {
-      const recentChat = await getRecentChatFromWebUI()
+      const recentChat = await getRecentChatFromWebUI();
       if (recentChat) {
-        setHistoryId(recentChat.history.id)
-        setHistory(formatToChatHistory(recentChat.messages))
-        setMessages(formatToMessage(recentChat.messages))
+        setHistoryId(recentChat.history.id);
+        setHistory(formatToChatHistory(recentChat.messages));
+        setMessages(formatToMessage(recentChat.messages));
 
-        const lastUsedPrompt = recentChat?.history?.last_used_prompt
+        const lastUsedPrompt = recentChat?.history?.last_used_prompt;
         if (lastUsedPrompt) {
           if (lastUsedPrompt.prompt_id) {
-            const prompt = await getPromptById(lastUsedPrompt.prompt_id)
+            const prompt = await getPromptById(lastUsedPrompt.prompt_id);
             if (prompt) {
-              setSelectedSystemPrompt(lastUsedPrompt.prompt_id)
+              setSelectedSystemPrompt(lastUsedPrompt.prompt_id);
               if (!lastUsedPrompt.prompt_content?.trim()) {
-                setSystemPrompt(prompt.content)
+                setSystemPrompt(prompt.content);
               }
             }
           }
           if (lastUsedPrompt.prompt_content?.trim()) {
-            setSystemPrompt(lastUsedPrompt.prompt_content)
+            setSystemPrompt(lastUsedPrompt.prompt_content);
           }
         }
       }
@@ -729,29 +743,29 @@ export const Playground = () => {
     setHistoryId,
     setMessages,
     setSelectedSystemPrompt,
-    setSystemPrompt
-  ])
+    setSystemPrompt,
+  ]);
 
   React.useEffect(() => {
     if (!sessionScopeReady) {
-      return
+      return;
     }
     if (initializePlaygroundRef.current) {
-      return
+      return;
     }
-    initializePlaygroundRef.current = true
-    let cancelled = false
+    initializePlaygroundRef.current = true;
+    let cancelled = false;
     const run = async () => {
-      await initializePlayground()
+      await initializePlayground();
       if (!cancelled) {
-        setPlaygroundReady(true)
+        setPlaygroundReady(true);
       }
-    }
-    void run()
+    };
+    void run();
     return () => {
-      cancelled = true
-    }
-  }, [initializePlayground, sessionScopeReady])
+      cancelled = true;
+    };
+  }, [initializePlayground, sessionScopeReady]);
 
   useCharacterGreeting({
     playgroundReady,
@@ -761,8 +775,8 @@ export const Playground = () => {
     messagesLength: messages.length,
     setMessages,
     setHistory,
-    setSelectedCharacter
-  })
+    setSelectedCharacter,
+  });
 
   const loadLocalConversation = useLoadLocalConversation(
     {
@@ -773,114 +787,114 @@ export const Playground = () => {
       setSelectedModel: (id) => setSelectedModel(id),
       setSelectedSystemPrompt: (id) => {
         if (id) {
-          setSelectedSystemPrompt(id)
+          setSelectedSystemPrompt(id);
         }
       },
       setSystemPrompt,
-      setContextFiles
+      setContextFiles,
     },
     {
       t,
       errorLogPrefix: t(
         "playground:errors.loadLocalHistoryPrefix",
-        "Failed to load local chat history"
+        "Failed to load local chat history",
       ),
       errorDefaultMessage: t(
         "playground:errors.loadLocalHistoryDefault",
-        "Something went wrong while loading local chat history."
-      )
-    }
-  )
+        "Something went wrong while loading local chat history.",
+      ),
+    },
+  );
 
   const settingsReturnContext = React.useMemo(() => {
     if (typeof window === "undefined") {
       return {
         historyId: null as string | null,
         serverChatId: null as string | null,
-        researchReturnRunId: null as string | null
-      }
+        researchReturnRunId: null as string | null,
+      };
     }
-    const params = new URLSearchParams(window.location.search)
-    const historyId = params.get(SETTINGS_HISTORY_ID_PARAM)?.trim() || null
+    const params = new URLSearchParams(window.location.search);
+    const historyId = params.get(SETTINGS_HISTORY_ID_PARAM)?.trim() || null;
     const serverChatId =
-      params.get(SETTINGS_SERVER_CHAT_ID_PARAM)?.trim() || null
+      params.get(SETTINGS_SERVER_CHAT_ID_PARAM)?.trim() || null;
     const researchReturnRunId =
-      params.get(RESEARCH_RETURN_RUN_ID_PARAM)?.trim() || null
-    return { historyId, serverChatId, researchReturnRunId }
-  }, [])
+      params.get(RESEARCH_RETURN_RUN_ID_PARAM)?.trim() || null;
+    return { historyId, serverChatId, researchReturnRunId };
+  }, []);
 
-  const returnHistoryIdFromSettings = settingsReturnContext.historyId
-  const returnServerChatIdFromSettings = settingsReturnContext.serverChatId
+  const returnHistoryIdFromSettings = settingsReturnContext.historyId;
+  const returnServerChatIdFromSettings = settingsReturnContext.serverChatId;
   const returnResearchRunIdFromSettings =
-    settingsReturnContext.researchReturnRunId
+    settingsReturnContext.researchReturnRunId;
 
   React.useEffect(() => {
-    if (!playgroundReady) return
+    if (!playgroundReady) return;
     if (
       !returnHistoryIdFromSettings &&
       !returnServerChatIdFromSettings &&
       !returnResearchRunIdFromSettings
     ) {
-      return
+      return;
     }
 
-    let cancelled = false
+    let cancelled = false;
 
     const restoreFromSettingsReturnTarget = async () => {
       if (
         returnHistoryIdFromSettings &&
         returnHistoryIdFromSettings !== historyId
       ) {
-        await loadLocalConversation(returnHistoryIdFromSettings)
+        await loadLocalConversation(returnHistoryIdFromSettings);
       } else if (
         !returnHistoryIdFromSettings &&
         returnServerChatIdFromSettings &&
         returnServerChatIdFromSettings !== serverChatId
       ) {
         const existingHistory = await getHistoryByServerChatId(
-          returnServerChatIdFromSettings
-        )
+          returnServerChatIdFromSettings,
+        );
         const fallbackHistoryId =
           existingHistory?.id && existingHistory.id.trim().length > 0
             ? existingHistory.id
-            : null
+            : null;
         if (fallbackHistoryId) {
-          await loadLocalConversation(fallbackHistoryId)
+          await loadLocalConversation(fallbackHistoryId);
         }
       }
 
-      if (cancelled) return
+      if (cancelled) return;
 
       if (
         returnServerChatIdFromSettings &&
         returnServerChatIdFromSettings !== serverChatId
       ) {
-        setServerChatId(returnServerChatIdFromSettings)
+        setServerChatId(returnServerChatIdFromSettings);
       }
 
       if (
         returnResearchRunIdFromSettings &&
         returnResearchRunIdFromSettings !== dismissedReturnedResearchRunId
       ) {
-        setPendingReturnedResearchRunId(returnResearchRunIdFromSettings)
+        setPendingReturnedResearchRunId(returnResearchRunIdFromSettings);
       }
 
       if (typeof window !== "undefined") {
-        const url = new URL(window.location.href)
-        url.searchParams.delete(SETTINGS_HISTORY_ID_PARAM)
-        url.searchParams.delete(SETTINGS_SERVER_CHAT_ID_PARAM)
-        url.searchParams.delete(RESEARCH_RETURN_RUN_ID_PARAM)
-        const nextQuery = url.searchParams.toString()
-        const nextPath = `${url.pathname}${nextQuery ? `?${nextQuery}` : ""}${url.hash}`
-        window.history.replaceState(window.history.state, "", nextPath)
+        const url = new URL(window.location.href);
+        url.searchParams.delete(SETTINGS_HISTORY_ID_PARAM);
+        url.searchParams.delete(SETTINGS_SERVER_CHAT_ID_PARAM);
+        url.searchParams.delete(RESEARCH_RETURN_RUN_ID_PARAM);
+        const nextQuery = url.searchParams.toString();
+        const nextPath = `${url.pathname}${nextQuery ? `?${nextQuery}` : ""}${url.hash}`;
+        window.history.replaceState(window.history.state, "", nextPath);
       }
-    }
+    };
 
-    void restoreFromSettingsReturnTarget()
+    void restoreFromSettingsReturnTarget();
 
     return () => {
-      cancelled = true
-    }
+      cancelled = true;
+    };
   }, [
     historyId,
     loadLocalConversation,
@@ -890,105 +904,109 @@ export const Playground = () => {
     returnServerChatIdFromSettings,
     serverChatId,
     setServerChatId,
-    dismissedReturnedResearchRunId
-  ])
+    dismissedReturnedResearchRunId,
+  ]);
 
-  const pendingTimelineActionRef = React.useRef<TimelineActionDetail | null>(null)
+  const pendingTimelineActionRef = React.useRef<TimelineActionDetail | null>(
+    null,
+  );
   const threadSearchMatches = React.useMemo(
     () => collectThreadSearchMatches(messages, debouncedSearchQuery),
-    [messages, debouncedSearchQuery]
-  )
+    [messages, debouncedSearchQuery],
+  );
   const threadSearchMatchSet = React.useMemo(
     () => new Set(threadSearchMatches),
-    [threadSearchMatches]
-  )
+    [threadSearchMatches],
+  );
   const threadSearchActiveMessageIndex =
     threadSearchMatches.length > 0
       ? threadSearchMatches[
           Math.max(
             0,
-            Math.min(threadSearchActiveIndex, threadSearchMatches.length - 1)
+            Math.min(threadSearchActiveIndex, threadSearchMatches.length - 1),
           )
         ]
-      : null
+      : null;
 
   const findMessageIndex = React.useCallback(
     (messageId: string) =>
       messages.findIndex(
         (message) =>
-          message.id === messageId || message.serverMessageId === messageId
+          message.id === messageId || message.serverMessageId === messageId,
       ),
-    [messages]
-  )
+    [messages],
+  );
 
   const scrollToMessage = React.useCallback(
     (messageId: string) => {
-      const container = containerRef.current
-      if (!container) return false
+      const container = containerRef.current;
+      if (!container) return false;
       const target = container.querySelector<HTMLElement>(
-        `[data-message-id="${messageId}"], [data-server-message-id="${messageId}"]`
-      )
-      if (!target) return false
-      target.scrollIntoView({ block: "center", behavior: "smooth" })
-      return true
+        `[data-message-id="${messageId}"], [data-server-message-id="${messageId}"]`,
+      );
+      if (!target) return false;
+      target.scrollIntoView({ block: "center", behavior: "smooth" });
+      return true;
     },
-    [containerRef]
-  )
+    [containerRef],
+  );
   const scrollToMessageIndex = React.useCallback(
     (index: number) => {
-      const container = containerRef.current
-      if (!container) return false
-      const target = container.querySelector<HTMLElement>(`[data-index="${index}"]`)
-      if (!target) return false
-      target.scrollIntoView({ block: "center", behavior: "smooth" })
-      return true
+      const container = containerRef.current;
+      if (!container) return false;
+      const target = container.querySelector<HTMLElement>(
+        `[data-index="${index}"]`,
+      );
+      if (!target) return false;
+      target.scrollIntoView({ block: "center", behavior: "smooth" });
+      return true;
     },
-    [containerRef]
-  )
+    [containerRef],
+  );
 
   const dispatchEditMessage = React.useCallback((messageId: string) => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
     window.dispatchEvent(
-      new CustomEvent(EDIT_MESSAGE_EVENT, { detail: { messageId } })
-    )
-  }, [])
+      new CustomEvent(EDIT_MESSAGE_EVENT, { detail: { messageId } }),
+    );
+  }, []);
 
   const performTimelineAction = React.useCallback(
     (detail: TimelineActionDetail) => {
-      if (!detail?.historyId) return true
-      if (detail.historyId !== historyId) return false
+      if (!detail?.historyId) return true;
+      if (detail.historyId !== historyId) return false;
 
       if (detail.action === "branch") {
-        if (!detail.messageId) return true
-        if (messages.length === 0) return false
-        const index = findMessageIndex(detail.messageId)
-        if (index < 0) return true
-        void createChatBranch(index)
-        return true
+        if (!detail.messageId) return true;
+        if (messages.length === 0) return false;
+        const index = findMessageIndex(detail.messageId);
+        if (index < 0) return true;
+        void createChatBranch(index);
+        return true;
       }
 
-      if (!detail.messageId) return true
+      if (!detail.messageId) return true;
 
-      const scrolled = scrollToMessage(detail.messageId)
+      const scrolled = scrollToMessage(detail.messageId);
       if (!scrolled) {
-        if (!containerRef.current) return false
+        if (!containerRef.current) return false;
         if (timelineActionRetryTimeoutRef.current) {
-          clearTimeout(timelineActionRetryTimeoutRef.current)
+          clearTimeout(timelineActionRetryTimeoutRef.current);
         }
         timelineActionRetryTimeoutRef.current = setTimeout(() => {
-          timelineActionRetryTimeoutRef.current = null
-          const retry = scrollToMessage(detail.messageId)
+          timelineActionRetryTimeoutRef.current = null;
+          const retry = scrollToMessage(detail.messageId);
           if (retry && detail.action === "edit") {
-            dispatchEditMessage(detail.messageId)
+            dispatchEditMessage(detail.messageId);
           }
-        }, 80)
-        return true
+        }, 80);
+        return true;
       }
 
       if (detail.action === "edit") {
-        dispatchEditMessage(detail.messageId)
+        dispatchEditMessage(detail.messageId);
       }
-      return true
+      return true;
     },
     [
       containerRef,
@@ -998,167 +1016,170 @@ export const Playground = () => {
       historyId,
       messages.length,
       scrollToMessage,
-      timelineActionRetryTimeoutRef
-    ]
-  )
+      timelineActionRetryTimeoutRef,
+    ],
+  );
 
   const enqueueTimelineAction = React.useCallback(
     (detail: TimelineActionDetail) => {
-      if (!detail?.historyId) return
+      if (!detail?.historyId) return;
       if (detail.historyId !== historyId) {
-        pendingTimelineActionRef.current = detail
-        void loadLocalConversation(detail.historyId)
-        return
+        pendingTimelineActionRef.current = detail;
+        void loadLocalConversation(detail.historyId);
+        return;
       }
 
-      const handled = performTimelineAction(detail)
+      const handled = performTimelineAction(detail);
       if (!handled) {
-        pendingTimelineActionRef.current = detail
+        pendingTimelineActionRef.current = detail;
       }
     },
-    [historyId, loadLocalConversation, performTimelineAction]
-  )
+    [historyId, loadLocalConversation, performTimelineAction],
+  );
 
   React.useEffect(() => {
-    const pending = pendingTimelineActionRef.current
-    if (!pending) return
-    const handled = performTimelineAction(pending)
+    const pending = pendingTimelineActionRef.current;
+    if (!pending) return;
+    const handled = performTimelineAction(pending);
     if (handled) {
-      pendingTimelineActionRef.current = null
+      pendingTimelineActionRef.current = null;
     }
-  }, [historyId, messages, performTimelineAction])
+  }, [historyId, messages, performTimelineAction]);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
 
     const handleTimelineActionEvent = (event: Event) => {
-      const detail = (event as CustomEvent<TimelineActionDetail>).detail
-      if (!detail?.historyId) return
-      enqueueTimelineAction(detail)
-    }
+      const detail = (event as CustomEvent<TimelineActionDetail>).detail;
+      if (!detail?.historyId) return;
+      enqueueTimelineAction(detail);
+    };
 
     const handleOpenHistoryEvent = (event: Event) => {
-      const detail = (event as CustomEvent<OpenHistoryDetail>).detail
-      if (!detail?.historyId) return
+      const detail = (event as CustomEvent<OpenHistoryDetail>).detail;
+      if (!detail?.historyId) return;
       enqueueTimelineAction({
         action: "go",
         historyId: detail.historyId,
-        messageId: detail.messageId
-      })
-    }
+        messageId: detail.messageId,
+      });
+    };
     const handleScrollToLatestEvent = () => {
-      autoScrollToBottom()
-    }
+      autoScrollToBottom();
+    };
 
-    window.addEventListener(TIMELINE_ACTION_EVENT, handleTimelineActionEvent)
-    window.addEventListener(OPEN_HISTORY_EVENT, handleOpenHistoryEvent)
-    window.addEventListener("tldw:scroll-to-latest", handleScrollToLatestEvent)
+    window.addEventListener(TIMELINE_ACTION_EVENT, handleTimelineActionEvent);
+    window.addEventListener(OPEN_HISTORY_EVENT, handleOpenHistoryEvent);
+    window.addEventListener("tldw:scroll-to-latest", handleScrollToLatestEvent);
     return () => {
-      window.removeEventListener(TIMELINE_ACTION_EVENT, handleTimelineActionEvent)
-      window.removeEventListener(OPEN_HISTORY_EVENT, handleOpenHistoryEvent)
+      window.removeEventListener(
+        TIMELINE_ACTION_EVENT,
+        handleTimelineActionEvent,
+      );
+      window.removeEventListener(OPEN_HISTORY_EVENT, handleOpenHistoryEvent);
       window.removeEventListener(
         "tldw:scroll-to-latest",
-        handleScrollToLatestEvent
-      )
-    }
-  }, [autoScrollToBottom, enqueueTimelineAction])
+        handleScrollToLatestEvent,
+      );
+    };
+  }, [autoScrollToBottom, enqueueTimelineAction]);
 
   const compareParentByHistory = useStoreMessageOption(
-    (state) => state.compareParentByHistory
-  )
-  const artifactsOpen = useArtifactsStore((state) => state.isOpen)
-  const activeArtifact = useArtifactsStore((state) => state.active)
-  const artifactsPinned = useArtifactsStore((state) => state.isPinned)
-  const artifactHistory = useArtifactsStore((state) => state.history)
-  const artifactUnreadCount = useArtifactsStore((state) => state.unreadCount)
-  const setArtifactsOpen = useArtifactsStore((state) => state.setOpen)
-  const closeArtifacts = useArtifactsStore((state) => state.closeArtifact)
-  const markArtifactsRead = useArtifactsStore((state) => state.markRead)
+    (state) => state.compareParentByHistory,
+  );
+  const artifactsOpen = useArtifactsStore((state) => state.isOpen);
+  const activeArtifact = useArtifactsStore((state) => state.active);
+  const artifactsPinned = useArtifactsStore((state) => state.isPinned);
+  const artifactHistory = useArtifactsStore((state) => state.history);
+  const artifactUnreadCount = useArtifactsStore((state) => state.unreadCount);
+  const setArtifactsOpen = useArtifactsStore((state) => state.setOpen);
+  const closeArtifacts = useArtifactsStore((state) => state.closeArtifact);
+  const markArtifactsRead = useArtifactsStore((state) => state.markRead);
 
   const parentMeta =
     historyId && compareParentByHistory
       ? compareParentByHistory[historyId]
-      : undefined
+      : undefined;
   const branchDepth = React.useMemo(() => {
-    if (!historyId || !compareParentByHistory) return 0
-    let depth = 0
-    let cursor = historyId
-    const seen = new Set<string>()
+    if (!historyId || !compareParentByHistory) return 0;
+    let depth = 0;
+    let cursor = historyId;
+    const seen = new Set<string>();
     while (cursor && !seen.has(cursor)) {
-      seen.add(cursor)
-      const meta = compareParentByHistory[cursor]
-      if (!meta?.parentHistoryId) break
-      depth += 1
-      cursor = meta.parentHistoryId
+      seen.add(cursor);
+      const meta = compareParentByHistory[cursor];
+      if (!meta?.parentHistoryId) break;
+      depth += 1;
+      cursor = meta.parentHistoryId;
     }
-    return depth
-  }, [compareParentByHistory, historyId])
+    return depth;
+  }, [compareParentByHistory, historyId]);
   const branchForkPointLabel = React.useMemo(() => {
-    if (!parentMeta?.parentHistoryId) return null
+    if (!parentMeta?.parentHistoryId) return null;
     if (parentMeta.clusterId) {
       return toText(
         t("playground:branching.forkPointCluster", "Fork point: {{cluster}}", {
-          cluster: parentMeta.clusterId
-        } as any)
-      )
+          cluster: parentMeta.clusterId,
+        } as any),
+      );
     }
     return toText(
       t("playground:branching.forkPointParent", "Fork point: {{historyId}}", {
-        historyId: parentMeta.parentHistoryId
-      } as any)
-    )
-  }, [parentMeta?.clusterId, parentMeta?.parentHistoryId, t])
+        historyId: parentMeta.parentHistoryId,
+      } as any),
+    );
+  }, [parentMeta?.clusterId, parentMeta?.parentHistoryId, t]);
   const branchDepthLabel = React.useMemo(() => {
-    if (branchDepth <= 0) return null
+    if (branchDepth <= 0) return null;
     return toText(
       t("playground:branching.depth", "Depth {{depth}}", {
-        depth: branchDepth
-      } as any)
-    )
-  }, [branchDepth, t])
-  const compareActive = compareFeatureEnabled && compareMode
+        depth: branchDepth,
+      } as any),
+    );
+  }, [branchDepth, t]);
+  const compareActive = compareFeatureEnabled && compareMode;
   const compactFeatureNoticeVisible =
-    isMobileViewport &&
-    (compareActive || Boolean(parentMeta?.parentHistoryId))
-  const artifactPinnedCount =
-    activeArtifact && artifactsPinned ? 1 : 0
-  const artifactHistoryCount = artifactHistory.length
+    isMobileViewport && (compareActive || Boolean(parentMeta?.parentHistoryId));
+  const artifactPinnedCount = activeArtifact && artifactsPinned ? 1 : 0;
+  const artifactHistoryCount = artifactHistory.length;
   const artifactBadgeLabel = artifactsOpen
     ? toText(t("playground:regions.artifactsOpen", "Artifacts panel open"))
     : activeArtifact
       ? toText(t("playground:regions.artifactsAvailable", "Artifacts ready"))
-      : toText(t("playground:regions.artifactsClosed", "Artifacts panel closed"))
+      : toText(
+          t("playground:regions.artifactsClosed", "Artifacts panel closed"),
+        );
   const closeArtifactsWithFocusReturn = React.useCallback(() => {
-    closeArtifacts()
+    closeArtifacts();
     requestAnimationFrame(() => {
-      artifactsTriggerRef.current?.focus()
-    })
-  }, [closeArtifacts])
+      artifactsTriggerRef.current?.focus();
+    });
+  }, [closeArtifacts]);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
 
     const handleShortcut = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null
+      const target = event.target as HTMLElement | null;
       const isEditableTarget = Boolean(
         target &&
-          (target.tagName === "INPUT" ||
-            target.tagName === "TEXTAREA" ||
-            target.isContentEditable)
-      )
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable),
+      );
       if (
         (event.metaKey || event.ctrlKey) &&
         !event.altKey &&
         !event.shiftKey &&
         event.key.toLowerCase() === "f"
       ) {
-        event.preventDefault()
-        setThreadSearchOpen(true)
+        event.preventDefault();
+        setThreadSearchOpen(true);
         requestAnimationFrame(() => {
-          threadSearchInputRef.current?.focus()
-          threadSearchInputRef.current?.select()
-        })
-        return
+          threadSearchInputRef.current?.focus();
+          threadSearchInputRef.current?.select();
+        });
+        return;
       }
       if (
         !event.altKey &&
@@ -1167,54 +1188,54 @@ export const Playground = () => {
         event.shiftKey &&
         event.key === "?"
       ) {
-        event.preventDefault()
-        setShortcutsHelpOpen(true)
-        return
+        event.preventDefault();
+        setShortcutsHelpOpen(true);
+        return;
       }
       if (shortcutsHelpOpen && event.key === "Escape") {
-        event.preventDefault()
-        setShortcutsHelpOpen(false)
+        event.preventDefault();
+        setShortcutsHelpOpen(false);
         requestAnimationFrame(() => {
-          shortcutsTriggerRef.current?.focus()
-        })
-        return
+          shortcutsTriggerRef.current?.focus();
+        });
+        return;
       }
       if (threadSearchOpen && event.key === "Escape") {
-        event.preventDefault()
-        setThreadSearchOpen(false)
-        return
+        event.preventDefault();
+        setThreadSearchOpen(false);
+        return;
       }
 
-      const action = resolvePlaygroundShortcutAction(event)
-      if (!action) return
-      if (isEditableTarget) return
-      event.preventDefault()
+      const action = resolvePlaygroundShortcutAction(event);
+      if (!action) return;
+      if (isEditableTarget) return;
+      event.preventDefault();
 
       if (action === "toggle_artifacts") {
         if (artifactsOpen) {
-          closeArtifacts()
-          return
+          closeArtifacts();
+          return;
         }
-        if (!activeArtifact) return
-        setArtifactsOpen(true)
-        markArtifactsRead()
-        return
+        if (!activeArtifact) return;
+        setArtifactsOpen(true);
+        markArtifactsRead();
+        return;
       }
 
       if (action === "toggle_compare") {
-        window.dispatchEvent(new CustomEvent("tldw:toggle-compare-mode"))
-        return
+        window.dispatchEvent(new CustomEvent("tldw:toggle-compare-mode"));
+        return;
       }
 
       if (action === "toggle_modes") {
-        window.dispatchEvent(new CustomEvent("tldw:toggle-mode-launcher"))
+        window.dispatchEvent(new CustomEvent("tldw:toggle-mode-launcher"));
       }
-    }
+    };
 
-    window.addEventListener("keydown", handleShortcut)
+    window.addEventListener("keydown", handleShortcut);
     return () => {
-      window.removeEventListener("keydown", handleShortcut)
-    }
+      window.removeEventListener("keydown", handleShortcut);
+    };
   }, [
     activeArtifact,
     artifactsOpen,
@@ -1222,89 +1243,89 @@ export const Playground = () => {
     markArtifactsRead,
     setArtifactsOpen,
     shortcutsHelpOpen,
-    threadSearchOpen
-  ])
+    threadSearchOpen,
+  ]);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
     const handleFocusArtifactsTrigger = () => {
-      artifactsTriggerRef.current?.focus()
-    }
+      artifactsTriggerRef.current?.focus();
+    };
     window.addEventListener(
       "tldw:focus-artifacts-trigger",
-      handleFocusArtifactsTrigger
-    )
+      handleFocusArtifactsTrigger,
+    );
     return () => {
       window.removeEventListener(
         "tldw:focus-artifacts-trigger",
-        handleFocusArtifactsTrigger
-      )
-    }
-  }, [])
+        handleFocusArtifactsTrigger,
+      );
+    };
+  }, []);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
     const handleOpenShortcutHelp = () => {
-      setShortcutsHelpOpen(true)
-    }
+      setShortcutsHelpOpen(true);
+    };
     window.addEventListener(
       "tldw:open-playground-shortcuts",
-      handleOpenShortcutHelp
-    )
+      handleOpenShortcutHelp,
+    );
     return () => {
       window.removeEventListener(
         "tldw:open-playground-shortcuts",
-        handleOpenShortcutHelp
-      )
-    }
-  }, [])
+        handleOpenShortcutHelp,
+      );
+    };
+  }, []);
 
   React.useEffect(() => {
-    if (!shortcutsHelpOpen) return
+    if (!shortcutsHelpOpen) return;
     requestAnimationFrame(() => {
-      shortcutsCloseRef.current?.focus()
-    })
-  }, [shortcutsHelpOpen])
+      shortcutsCloseRef.current?.focus();
+    });
+  }, [shortcutsHelpOpen]);
 
   React.useEffect(() => {
-    if (!threadSearchOpen) return
+    if (!threadSearchOpen) return;
     if (threadSearchMatches.length === 0) {
-      setThreadSearchActiveIndex(0)
-      return
+      setThreadSearchActiveIndex(0);
+      return;
     }
     setThreadSearchActiveIndex((previous) => {
       const bounded =
-        previous >= 0 && previous < threadSearchMatches.length ? previous : 0
-      const messageIndex = threadSearchMatches[bounded]
+        previous >= 0 && previous < threadSearchMatches.length ? previous : 0;
+      const messageIndex = threadSearchMatches[bounded];
       if (typeof messageIndex === "number") {
         requestAnimationFrame(() => {
-          scrollToMessageIndex(messageIndex)
-        })
+          scrollToMessageIndex(messageIndex);
+        });
       }
-      return bounded
-    })
-  }, [scrollToMessageIndex, threadSearchMatches, threadSearchOpen])
+      return bounded;
+    });
+  }, [scrollToMessageIndex, threadSearchMatches, threadSearchOpen]);
 
   const stepThreadSearchMatch = React.useCallback(
     (direction: 1 | -1) => {
-      if (threadSearchMatches.length === 0) return
+      if (threadSearchMatches.length === 0) return;
       setThreadSearchActiveIndex((previous) => {
         const next = getWrappedMatchIndex(
           previous,
           threadSearchMatches.length,
-          direction
-        )
-        const messageIndex = threadSearchMatches[next]
+          direction,
+        );
+        const messageIndex = threadSearchMatches[next];
         if (typeof messageIndex === "number") {
           requestAnimationFrame(() => {
-            scrollToMessageIndex(messageIndex)
-          })
+            scrollToMessageIndex(messageIndex);
+          });
         }
-        return next
-      })
+        return next;
+      });
     },
-    [scrollToMessageIndex, threadSearchMatches]
-  )
+    [scrollToMessageIndex, threadSearchMatches],
+  );
 
   return (
     <div
@@ -1317,10 +1338,11 @@ export const Playground = () => {
               backgroundImage: `url(${chatBackgroundImage})`,
               backgroundSize: "cover",
               backgroundPosition: "center",
-              backgroundRepeat: "no-repeat"
+              backgroundRepeat: "no-repeat",
             }
           : {}
-      }>
+      }
+    >
       {/* Background overlay for opacity effect */}
       {chatBackgroundImage && (
         <div
@@ -1332,7 +1354,10 @@ export const Playground = () => {
       {dropState === "dragging" && (
         <div className="pointer-events-none absolute inset-0 z-30 flex flex-col items-center justify-center">
           <div className="rounded-2xl border border-dashed border-border bg-elevated px-6 py-4 text-center text-sm font-medium text-text shadow-card">
-            {t("playground:drop.hint", "Drop files to attach them to your message")}
+            {t(
+              "playground:drop.hint",
+              "Drop files to attach them to your message",
+            )}
           </div>
         </div>
       )}
@@ -1365,20 +1390,21 @@ export const Playground = () => {
                   className="inline-flex items-center gap-2 rounded-full border border-primary bg-surface2 px-3 py-1 text-[11px] font-medium text-primaryStrong hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
                   title={t(
                     "playground:composer.compareBreadcrumb",
-                    "Back to comparison chat"
+                    "Back to comparison chat",
                   )}
                   onClick={() => {
                     window.dispatchEvent(
                       new CustomEvent("tldw:open-history", {
-                        detail: { historyId: parentMeta.parentHistoryId }
-                      })
-                    )
-                  }}>
+                        detail: { historyId: parentMeta.parentHistoryId },
+                      }),
+                    );
+                  }}
+                >
                   <span aria-hidden="true">←</span>
                   <span>
                     {t(
                       "playground:composer.compareBreadcrumb",
-                      "Back to comparison chat"
+                      "Back to comparison chat",
                     )}
                   </span>
                 </button>
@@ -1415,7 +1441,7 @@ export const Playground = () => {
                   title={
                     t(
                       "playground:shortcuts.openHelp",
-                      "Open keyboard shortcuts (Shift+/)"
+                      "Open keyboard shortcuts (Shift+/)",
                     ) as string
                   }
                   className="inline-flex items-center gap-1 rounded-full border border-border bg-surface2 px-2 py-0.5 text-text hover:bg-surface"
@@ -1430,14 +1456,14 @@ export const Playground = () => {
                   disabled={!activeArtifact && !artifactsOpen}
                   onClick={() => {
                     if (artifactsOpen) {
-                      closeArtifacts()
-                      return
+                      closeArtifacts();
+                      return;
                     }
                     if (!activeArtifact) {
-                      return
+                      return;
                     }
-                    setArtifactsOpen(true)
-                    markArtifactsRead()
+                    setArtifactsOpen(true);
+                    markArtifactsRead();
                   }}
                   title={artifactBadgeLabel as string}
                   className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 transition ${
@@ -1454,8 +1480,8 @@ export const Playground = () => {
                     >
                       {toText(
                         t("playground:regions.artifactsNew", "New {{count}}", {
-                          count: artifactUnreadCount
-                        } as any)
+                          count: artifactUnreadCount,
+                        } as any),
                       )}
                     </span>
                   )}
@@ -1469,9 +1495,9 @@ export const Playground = () => {
                           "playground:regions.artifactsPinned",
                           "Pinned {{count}}",
                           {
-                            count: artifactPinnedCount
-                          } as any
-                        )
+                            count: artifactPinnedCount,
+                          } as any,
+                        ),
                       )}
                     </span>
                   )}
@@ -1481,9 +1507,13 @@ export const Playground = () => {
                       className="rounded-full border border-border bg-surface px-1.5 py-0.5 text-[10px] text-text-subtle"
                     >
                       {toText(
-                        t("playground:regions.artifactsCount", "{{count}} total", {
-                          count: artifactHistoryCount
-                        } as any)
+                        t(
+                          "playground:regions.artifactsCount",
+                          "{{count}} total",
+                          {
+                            count: artifactHistoryCount,
+                          } as any,
+                        ),
                       )}
                     </span>
                   )}
@@ -1507,10 +1537,10 @@ export const Playground = () => {
                     type="button"
                     data-testid="playground-shortcuts-help-close"
                     onClick={() => {
-                      setShortcutsHelpOpen(false)
+                      setShortcutsHelpOpen(false);
                       requestAnimationFrame(() => {
-                        shortcutsTriggerRef.current?.focus()
-                      })
+                        shortcutsTriggerRef.current?.focus();
+                      });
                     }}
                     className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] font-medium text-text hover:bg-surface2"
                   >
@@ -1518,14 +1548,63 @@ export const Playground = () => {
                   </button>
                 </div>
                 <div className="grid gap-1 sm:grid-cols-2">
-                  <p><span className="font-medium">Shift+Esc</span> {t("playground:shortcuts.focusComposer", "Focus composer")}</p>
-                  <p><span className="font-medium">{t("playground:shortcuts.findCombo", "Cmd/Ctrl+F")}</span> {t("playground:shortcuts.searchThread", "Search this thread")}</p>
-                  <p><span className="font-medium">{t("playground:shortcuts.helpCombo", "Shift+/")}</span> {t("playground:shortcuts.openHelp", "Open keyboard shortcuts (Shift+/)")}</p>
-                  <p><span className="font-medium">Alt+Shift+A</span> {t("playground:shortcuts.toggleArtifacts", "Toggle artifacts panel")}</p>
-                  <p><span className="font-medium">Alt+Shift+C</span> {t("playground:shortcuts.toggleCompare", "Toggle compare mode")}</p>
-                  <p><span className="font-medium">Alt+Shift+M</span> {t("playground:shortcuts.toggleModes", "Open mode launcher")}</p>
-                  <p><span className="font-medium">Alt+Shift+← / →</span> {t("playground:shortcuts.variantSwitch", "Switch response variant")}</p>
-                  <p><span className="font-medium">Alt+Shift+B / R</span> {t("playground:shortcuts.branchRegenerate", "Fork branch / regenerate")}</p>
+                  <p>
+                    <span className="font-medium">Shift+Esc</span>{" "}
+                    {t("playground:shortcuts.focusComposer", "Focus composer")}
+                  </p>
+                  <p>
+                    <span className="font-medium">
+                      {t("playground:shortcuts.findCombo", "Cmd/Ctrl+F")}
+                    </span>{" "}
+                    {t(
+                      "playground:shortcuts.searchThread",
+                      "Search this thread",
+                    )}
+                  </p>
+                  <p>
+                    <span className="font-medium">
+                      {t("playground:shortcuts.helpCombo", "Shift+/")}
+                    </span>{" "}
+                    {t(
+                      "playground:shortcuts.openHelp",
+                      "Open keyboard shortcuts (Shift+/)",
+                    )}
+                  </p>
+                  <p>
+                    <span className="font-medium">Alt+Shift+A</span>{" "}
+                    {t(
+                      "playground:shortcuts.toggleArtifacts",
+                      "Toggle artifacts panel",
+                    )}
+                  </p>
+                  <p>
+                    <span className="font-medium">Alt+Shift+C</span>{" "}
+                    {t(
+                      "playground:shortcuts.toggleCompare",
+                      "Toggle compare mode",
+                    )}
+                  </p>
+                  <p>
+                    <span className="font-medium">Alt+Shift+M</span>{" "}
+                    {t(
+                      "playground:shortcuts.toggleModes",
+                      "Open mode launcher",
+                    )}
+                  </p>
+                  <p>
+                    <span className="font-medium">Alt+Shift+← / →</span>{" "}
+                    {t(
+                      "playground:shortcuts.variantSwitch",
+                      "Switch response variant",
+                    )}
+                  </p>
+                  <p>
+                    <span className="font-medium">Alt+Shift+B / R</span>{" "}
+                    {t(
+                      "playground:shortcuts.branchRegenerate",
+                      "Fork branch / regenerate",
+                    )}
+                  </p>
                 </div>
               </div>
             )}
@@ -1540,18 +1619,18 @@ export const Playground = () => {
                     ref={threadSearchInputRef}
                     value={threadSearchQuery}
                     onChange={(event) => {
-                      setThreadSearchQuery(event.target.value)
-                      setThreadSearchActiveIndex(0)
+                      setThreadSearchQuery(event.target.value);
+                      setThreadSearchActiveIndex(0);
                     }}
                     onKeyDown={(event) => {
                       if (event.key === "Enter") {
-                        event.preventDefault()
-                        stepThreadSearchMatch(event.shiftKey ? -1 : 1)
+                        event.preventDefault();
+                        stepThreadSearchMatch(event.shiftKey ? -1 : 1);
                       }
                     }}
                     placeholder={t(
                       "playground:search.placeholder",
-                      "Search messages in this conversation"
+                      "Search messages in this conversation",
                     )}
                     className="h-7 w-full rounded border border-border bg-surface pl-7 pr-2 text-xs text-text placeholder:text-text-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
                   />
@@ -1568,11 +1647,11 @@ export const Playground = () => {
                           {
                             current: Math.min(
                               threadSearchActiveIndex + 1,
-                              threadSearchMatches.length
+                              threadSearchMatches.length,
                             ),
-                            total: threadSearchMatches.length
-                          } as any
-                        )
+                            total: threadSearchMatches.length,
+                          } as any,
+                        ),
                       )
                     : toText(t("playground:search.noMatches", "No matches"))}
                 </span>
@@ -1618,19 +1697,22 @@ export const Playground = () => {
               >
                 {t(
                   "playground:regions.compactFeatureNotice",
-                  "Limited on this device: compare and branch workflows use compact controls. Use full-chat opens from model cards for detailed review."
+                  "Limited on this device: compare and branch workflows use compact controls. Use full-chat opens from model cards for detailed review.",
                 )}
               </div>
             )}
           </div>
           <div
             ref={containerRef}
-            data-testid={stickyChatInput ? "playground-chat-transcript" : undefined}
+            data-testid={
+              stickyChatInput ? "playground-chat-transcript" : undefined
+            }
             role="log"
             aria-live="polite"
             aria-relevant="additions"
             aria-label={t("playground:aria.chatTranscript", "Chat messages")}
-            className="custom-scrollbar flex-1 min-h-0 w-full overflow-x-hidden overflow-y-auto px-4">
+            className="custom-scrollbar flex-1 min-h-0 w-full overflow-x-hidden overflow-y-auto px-4"
+          >
             <div className="mx-auto w-full max-w-[64rem] pb-6">
               <ChatErrorBoundary>
                 <PlaygroundChat
@@ -1642,10 +1724,12 @@ export const Playground = () => {
                   returnedResearchRunId={pendingReturnedResearchRunId}
                   onDismissReturnedResearchRun={() => {
                     if (!pendingReturnedResearchRunId) {
-                      return
+                      return;
                     }
-                    setDismissedReturnedResearchRunId(pendingReturnedResearchRunId)
-                    setPendingReturnedResearchRunId(null)
+                    setDismissedReturnedResearchRunId(
+                      pendingReturnedResearchRunId,
+                    );
+                    setPendingReturnedResearchRunId(null);
                   }}
                 />
               </ChatErrorBoundary>
@@ -1653,7 +1737,9 @@ export const Playground = () => {
           </div>
           <div
             ref={composerDockRef}
-            data-testid={stickyChatInput ? "playground-chat-composer-dock" : undefined}
+            data-testid={
+              stickyChatInput ? "playground-chat-composer-dock" : undefined
+            }
             className={`relative w-full ${
               stickyChatInput
                 ? "sticky bottom-0 z-20 border-t border-border bg-surface/95 backdrop-blur"
@@ -1669,10 +1755,22 @@ export const Playground = () => {
               <div className="pointer-events-none absolute -top-12 left-0 right-0 flex justify-center">
                 <button
                   onClick={() => autoScrollToBottom()}
-                  aria-label={t("playground:composer.scrollToLatest", "Scroll to latest messages")}
-                  title={t("playground:composer.scrollToLatest", "Scroll to latest messages") as string}
-                  className="pointer-events-auto rounded-full border border-border bg-surface p-2.5 text-text-subtle shadow-md transition-all duration-200 animate-in fade-in zoom-in-95 hover:bg-surface2 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus">
-                  <ChevronDown className="size-4 text-text-subtle" aria-hidden="true" />
+                  aria-label={t(
+                    "playground:composer.scrollToLatest",
+                    "Scroll to latest messages",
+                  )}
+                  title={
+                    t(
+                      "playground:composer.scrollToLatest",
+                      "Scroll to latest messages",
+                    ) as string
+                  }
+                  className="pointer-events-auto rounded-full border border-border bg-surface p-2.5 text-text-subtle shadow-md transition-all duration-200 animate-in fade-in zoom-in-95 hover:bg-surface2 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                >
+                  <ChevronDown
+                    className="size-4 text-text-subtle"
+                    aria-hidden="true"
+                  />
                 </button>
               </div>
             )}
@@ -1686,14 +1784,22 @@ export const Playground = () => {
               attachedResearchContextBaseline={attachedResearchContextBaseline}
               attachedResearchContextPinned={attachedResearchContextPinned}
               attachedResearchContextHistory={attachedResearchContextHistory}
-              onApplyAttachedResearchContext={handleApplyAttachedResearchContext}
-              onResetAttachedResearchContext={handleResetAttachedResearchContext}
-              onRemoveAttachedResearchContext={handleRemoveAttachedResearchContext}
+              onApplyAttachedResearchContext={
+                handleApplyAttachedResearchContext
+              }
+              onResetAttachedResearchContext={
+                handleResetAttachedResearchContext
+              }
+              onRemoveAttachedResearchContext={
+                handleRemoveAttachedResearchContext
+              }
               onPinAttachedResearchContext={handlePinAttachedResearchContext}
               onPinAttachedResearchContextHistory={
                 handlePinAttachedResearchContextHistory
               }
-              onUnpinAttachedResearchContext={handleUnpinAttachedResearchContext}
+              onUnpinAttachedResearchContext={
+                handleUnpinAttachedResearchContext
+              }
               onRestorePinnedResearchContext={
                 handleRestorePinnedResearchContext
               }
@@ -1715,13 +1821,13 @@ export const Playground = () => {
                 aria-label={
                   t(
                     "playground:regions.closeArtifactsDrawer",
-                    "Close artifacts drawer"
+                    "Close artifacts drawer",
                   ) as string
                 }
                 title={
                   t(
                     "playground:regions.closeArtifactsDrawer",
-                    "Close artifacts drawer"
+                    "Close artifacts drawer",
                   ) as string
                 }
                 onClick={closeArtifactsWithFocusReturn}
@@ -1731,7 +1837,10 @@ export const Playground = () => {
                 data-testid="playground-mobile-artifacts-sheet"
                 role="dialog"
                 aria-modal="true"
-                aria-label={t("playground:regions.artifacts", "Artifacts panel")}
+                aria-label={t(
+                  "playground:regions.artifacts",
+                  "Artifacts panel",
+                )}
                 className="fixed inset-y-0 right-0 z-50 flex w-full max-w-[520px] flex-col border-l border-border bg-surface"
               >
                 <div className="flex items-center justify-between border-b border-border px-3 py-2 text-xs text-text">
@@ -1747,17 +1856,18 @@ export const Playground = () => {
                     onClick={closeArtifactsWithFocusReturn}
                     className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] font-medium text-text hover:bg-surface"
                   >
-                    {t("playground:regions.returnToTimeline", "Back to timeline")}
+                    {t(
+                      "playground:regions.returnToTimeline",
+                      "Back to timeline",
+                    )}
                   </button>
                 </div>
-                <div className="min-h-0 flex-1">
-                  {renderArtifactsPanel()}
-                </div>
+                <div className="min-h-0 flex-1">{renderArtifactsPanel()}</div>
               </div>
             </div>
           </>
         )}
       </div>
     </div>
-  )
-}
+  );
+};

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -31,6 +31,20 @@ import { useAntdNotification } from "@/hooks/useAntdNotification"
 import { useAudioSourceCatalog } from "@/hooks/useAudioSourceCatalog"
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
 import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference"
+import { AttachedResearchContextChip } from "./AttachedResearchContextChip"
+import { MentionsDropdown } from "./MentionsDropdown"
+import { ComposerTextarea } from "./ComposerTextarea"
+import { ComposerToolbar } from "./ComposerToolbar"
+// ContextFootprintPanel moved to PlaygroundContextWindowModal
+import { CompareToggle } from "./CompareToggle"
+import { useMobileComposerViewport } from "./useMobileComposerViewport"
+import {
+  resolveStickyComposerTextareaMaxHeight,
+  type ComposerDockLayoutMetrics
+} from "./mobile-composer-layout"
+import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant"
+import { isFireFoxPrivateMode } from "@/utils/is-private-mode"
+import { ChatQueuePanel } from "@/components/Common/ChatQueuePanel"
 import { useConnectionState } from "@/hooks/useConnectionState"
 import type { DictationModePreference } from "@/hooks/useDictationStrategy"
 import { useMcpTools } from "@/hooks/useMcpTools"
@@ -220,6 +234,8 @@ type Props = {
     context: AttachedResearchContext
   ) => void
   onPrepareResearchFollowUp?: (target: ResearchFollowUpTarget) => void
+  stickyDockEnabled?: boolean
+  onComposerLayoutChange?: (metrics: ComposerDockLayoutMetrics) => void
 }
 
 type DefaultCharacterPreferenceQueryResult = {
@@ -233,6 +249,8 @@ type PlaygroundQueuedSourceContext = {
 }
 
 const FOLLOW_UP_RESEARCH_PROMPT_PREFIX = "Follow up on this research:"
+const CASUAL_COMPOSER_MAX_HEIGHT_PX = 120
+const PRO_COMPOSER_MAX_HEIGHT_PX = 160
 
 const buildFollowUpResearchBackground = (
   context: AttachedResearchContext
@@ -387,7 +405,9 @@ export const PlaygroundForm = ({
   onRestorePinnedResearchContext,
   onPinAttachedResearchContextHistory,
   onSelectAttachedResearchContextHistory,
-  onPrepareResearchFollowUp
+  onPrepareResearchFollowUp,
+  stickyDockEnabled = false,
+  onComposerLayoutChange
 }: Props) => {
   const { t } = useTranslation(["playground", "common", "option"])
   const notificationApi = useAntdNotification()
@@ -534,6 +554,9 @@ export const PlaygroundForm = ({
   const [autoSubmitVoiceMessage] = useStorage("autoSubmitVoiceMessage", false)
   const isMobileViewport = useMobile()
   const mobileComposerViewport = useMobileComposerViewport(isMobileViewport)
+  const [viewportHeightPx, setViewportHeightPx] = React.useState(() =>
+    typeof window === "undefined" ? 0 : window.innerHeight
+  )
   const [openModelSettings, setOpenModelSettings] = React.useState(false)
   const [openActorSettings, setOpenActorSettings] = React.useState(false)
   const [noticesExpanded, setNoticesExpanded] = React.useState(false)
@@ -887,6 +910,29 @@ export const PlaygroundForm = ({
   // showServerPersistenceHint and serverSaveInFlightRef moved to usePlaygroundPersistence
   const uiMode = useUiModeStore((state) => state.mode)
   const isProMode = uiMode === "pro"
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const updateViewportHeight = () => {
+      setViewportHeightPx((previousHeightPx) => {
+        const nextHeightPx = window.innerHeight
+        return previousHeightPx === nextHeightPx
+          ? previousHeightPx
+          : nextHeightPx
+      })
+    }
+
+    updateViewportHeight()
+    window.addEventListener("resize", updateViewportHeight)
+    window.visualViewport?.addEventListener("resize", updateViewportHeight)
+
+    return () => {
+      window.removeEventListener("resize", updateViewportHeight)
+      window.visualViewport?.removeEventListener("resize", updateViewportHeight)
+    }
+  }, [])
+
   const [contextToolsOpen, setContextToolsOpen] = useStorage(
     "playgroundKnowledgeSearchOpen",
     false
@@ -1483,6 +1529,27 @@ export const PlaygroundForm = ({
     restoreMessageValue: restoreCollapseState
   } = msgCollapse
 
+  const stickyTextareaMaxHeight = React.useMemo(() => {
+    if (!stickyDockEnabled) {
+      return undefined
+    }
+
+    return resolveStickyComposerTextareaMaxHeight({
+      viewportHeightPx,
+      keyboardInsetPx: mobileComposerViewport.keyboardInsetPx,
+      isMobileViewport,
+      defaultMaxHeightPx: isProMode
+        ? PRO_COMPOSER_MAX_HEIGHT_PX
+        : CASUAL_COMPOSER_MAX_HEIGHT_PX
+    })
+  }, [
+    isMobileViewport,
+    isProMode,
+    mobileComposerViewport.keyboardInsetPx,
+    stickyDockEnabled,
+    viewportHeightPx
+  ])
+
   const composerInput = useComposerInput({
     textareaRef,
     isMessageCollapsed,
@@ -1505,7 +1572,8 @@ export const PlaygroundForm = ({
     selectionFromPointerRef,
     tabMentionsEnabled,
     handleTextChange,
-    isProMode
+    isProMode,
+    textareaMaxHeightOverride: stickyTextareaMaxHeight
   })
   const {
     form,
@@ -3681,6 +3749,7 @@ export const PlaygroundForm = ({
   const composerShellRef = React.useRef<HTMLDivElement>(null)
 
   const keepComposerBottomInView = React.useCallback(() => {
+    if (stickyDockEnabled) return
     if (typeof window === "undefined") return
     const composerEl = composerShellRef.current
     if (!composerEl) return
@@ -3725,7 +3794,74 @@ export const PlaygroundForm = ({
     }
 
     adjustAncestor(scrollingElement)
-  }, [])
+  }, [stickyDockEnabled])
+
+  const notifyComposerLayoutChange = React.useCallback(() => {
+    if (!onComposerLayoutChange) return
+
+    const composerEl = composerShellRef.current
+    onComposerLayoutChange({
+      occupiedHeightPx: composerEl
+        ? Math.round(composerEl.getBoundingClientRect().height)
+        : 0,
+      keyboardInsetPx:
+        stickyDockEnabled && isMobileViewport
+          ? mobileComposerViewport.keyboardInsetPx
+          : 0
+    })
+  }, [
+    isMobileViewport,
+    mobileComposerViewport.keyboardInsetPx,
+    onComposerLayoutChange,
+    stickyDockEnabled
+  ])
+
+  React.useEffect(() => {
+    if (!onComposerLayoutChange) return
+    if (typeof window === "undefined") return
+
+    let rafId = 0
+    const scheduleMeasurement = () => {
+      if (rafId) {
+        window.cancelAnimationFrame(rafId)
+      }
+      rafId = window.requestAnimationFrame(() => {
+        rafId = 0
+        notifyComposerLayoutChange()
+      })
+    }
+
+    const composerEl = composerShellRef.current
+    scheduleMeasurement()
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" && composerEl
+        ? new ResizeObserver(() => {
+            scheduleMeasurement()
+          })
+        : null
+    resizeObserver?.observe(composerEl)
+    window.addEventListener("resize", scheduleMeasurement)
+
+    return () => {
+      if (rafId) {
+        window.cancelAnimationFrame(rafId)
+      }
+      resizeObserver?.disconnect()
+      window.removeEventListener("resize", scheduleMeasurement)
+    }
+  }, [notifyComposerLayoutChange, onComposerLayoutChange])
+
+  React.useEffect(() => {
+    if (!onComposerLayoutChange) return
+
+    return () => {
+      onComposerLayoutChange({
+        occupiedHeightPx: 0,
+        keyboardInsetPx: 0
+      })
+    }
+  }, [onComposerLayoutChange])
 
   const previousActionBarVisibleRef = React.useRef(actionBarVisible)
 

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -31,20 +31,10 @@ import { useAntdNotification } from "@/hooks/useAntdNotification";
 import { useAudioSourceCatalog } from "@/hooks/useAudioSourceCatalog";
 import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig";
 import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference";
-import { AttachedResearchContextChip } from "./AttachedResearchContextChip";
-import { MentionsDropdown } from "./MentionsDropdown";
-import { ComposerTextarea } from "./ComposerTextarea";
-import { ComposerToolbar } from "./ComposerToolbar";
-// ContextFootprintPanel moved to PlaygroundContextWindowModal
-import { CompareToggle } from "./CompareToggle";
-import { useMobileComposerViewport } from "./useMobileComposerViewport";
 import {
   resolveStickyComposerTextareaMaxHeight,
   type ComposerDockLayoutMetrics,
 } from "./mobile-composer-layout";
-import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant";
-import { isFireFoxPrivateMode } from "@/utils/is-private-mode";
-import { ChatQueuePanel } from "@/components/Common/ChatQueuePanel";
 import { useConnectionState } from "@/hooks/useConnectionState";
 import type { DictationModePreference } from "@/hooks/useDictationStrategy";
 import { useMcpTools } from "@/hooks/useMcpTools";

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -1,19 +1,19 @@
 import {
   ChatComposer,
-  useComposerVariantPreference
-} from "@/components/Chat/composer/ChatComposer"
-import { useComposerEnabledPreference } from "@/components/Chat/composer/hooks/useComposerEnabledPreference"
-import { AudioSourcePicker } from "@/components/Common/AudioSourcePicker"
-import { BetaTag } from "@/components/Common/Beta"
+  useComposerVariantPreference,
+} from "@/components/Chat/composer/ChatComposer";
+import { useComposerEnabledPreference } from "@/components/Chat/composer/hooks/useComposerEnabledPreference";
+import { AudioSourcePicker } from "@/components/Common/AudioSourcePicker";
+import { BetaTag } from "@/components/Common/Beta";
 // getImageBackendConfigs, normalizeImageBackendConfig, resolveImageBackendConfig moved to usePlaygroundImageGen
-import { CharacterSelect } from "@/components/Common/CharacterSelect"
-import { ChatQueuePanel } from "@/components/Common/ChatQueuePanel"
-import { ProviderIcons } from "@/components/Common/ProviderIcon"
-import { type KnowledgeTab } from "@/components/Knowledge"
-import type { SlashCommandItem } from "@/components/Sidepanel/Chat/SlashCommandMenu"
-import { isFirefoxTarget } from "@/config/platform"
-import { getAllPrompts } from "@/db/dexie/helpers"
-import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord"
+import { CharacterSelect } from "@/components/Common/CharacterSelect";
+import { ChatQueuePanel } from "@/components/Common/ChatQueuePanel";
+import { ProviderIcons } from "@/components/Common/ProviderIcon";
+import { type KnowledgeTab } from "@/components/Knowledge";
+import type { SlashCommandItem } from "@/components/Sidepanel/Chat/SlashCommandMenu";
+import { isFirefoxTarget } from "@/config/platform";
+import { getAllPrompts } from "@/db/dexie/helpers";
+import { useChatSettingsRecord } from "@/hooks/chat/useChatSettingsRecord";
 import {
   type CollapsedRange,
   type ModelSortMode,
@@ -24,82 +24,82 @@ import {
   useMcpToolsControl,
   useMessageCollapse,
   useModelSelector,
-  useSlashCommands
-} from "@/hooks/playground"
+  useSlashCommands,
+} from "@/hooks/playground";
 // TldwButton moved to extracted sub-components
-import { useAntdNotification } from "@/hooks/useAntdNotification"
-import { useAudioSourceCatalog } from "@/hooks/useAudioSourceCatalog"
-import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig"
-import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference"
-import { AttachedResearchContextChip } from "./AttachedResearchContextChip"
-import { MentionsDropdown } from "./MentionsDropdown"
-import { ComposerTextarea } from "./ComposerTextarea"
-import { ComposerToolbar } from "./ComposerToolbar"
+import { useAntdNotification } from "@/hooks/useAntdNotification";
+import { useAudioSourceCatalog } from "@/hooks/useAudioSourceCatalog";
+import { useCanonicalConnectionConfig } from "@/hooks/useCanonicalConnectionConfig";
+import { useChatMoodBadgePreference } from "@/hooks/useChatMoodBadgePreference";
+import { AttachedResearchContextChip } from "./AttachedResearchContextChip";
+import { MentionsDropdown } from "./MentionsDropdown";
+import { ComposerTextarea } from "./ComposerTextarea";
+import { ComposerToolbar } from "./ComposerToolbar";
 // ContextFootprintPanel moved to PlaygroundContextWindowModal
-import { CompareToggle } from "./CompareToggle"
-import { useMobileComposerViewport } from "./useMobileComposerViewport"
+import { CompareToggle } from "./CompareToggle";
+import { useMobileComposerViewport } from "./useMobileComposerViewport";
 import {
   resolveStickyComposerTextareaMaxHeight,
-  type ComposerDockLayoutMetrics
-} from "./mobile-composer-layout"
-import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant"
-import { isFireFoxPrivateMode } from "@/utils/is-private-mode"
-import { ChatQueuePanel } from "@/components/Common/ChatQueuePanel"
-import { useConnectionState } from "@/hooks/useConnectionState"
-import type { DictationModePreference } from "@/hooks/useDictationStrategy"
-import { useMcpTools } from "@/hooks/useMcpTools"
-import { useMobile } from "@/hooks/useMediaQuery"
+  type ComposerDockLayoutMetrics,
+} from "./mobile-composer-layout";
+import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant";
+import { isFireFoxPrivateMode } from "@/utils/is-private-mode";
+import { ChatQueuePanel } from "@/components/Common/ChatQueuePanel";
+import { useConnectionState } from "@/hooks/useConnectionState";
+import type { DictationModePreference } from "@/hooks/useDictationStrategy";
+import { useMcpTools } from "@/hooks/useMcpTools";
+import { useMobile } from "@/hooks/useMediaQuery";
 // isMac moved to PlaygroundSendControl
-import { useSelectedCharacter } from "@/hooks/useSelectedCharacter"
-import { useServerCapabilities } from "@/hooks/useServerCapabilities"
-import { useTldwAudioStatus } from "@/hooks/useTldwAudioStatus"
-import { useVoiceChatMessages } from "@/hooks/useVoiceChatMessages"
-import { useVoiceChatSettings } from "@/hooks/useVoiceChatSettings"
-import { useVoiceChatStream } from "@/hooks/useVoiceChatStream"
+import { useSelectedCharacter } from "@/hooks/useSelectedCharacter";
+import { useServerCapabilities } from "@/hooks/useServerCapabilities";
+import { useTldwAudioStatus } from "@/hooks/useTldwAudioStatus";
+import { useVoiceChatMessages } from "@/hooks/useVoiceChatMessages";
+import { useVoiceChatSettings } from "@/hooks/useVoiceChatSettings";
+import { useVoiceChatStream } from "@/hooks/useVoiceChatStream";
 // useQueuedRequests moved to usePlaygroundQueueManagement
-import type { ChatDocuments } from "@/models/ChatTypes"
-import { clearSetting, getSetting } from "@/services/settings/registry"
+import type { ChatDocuments } from "@/models/ChatTypes";
+import { clearSetting, getSetting } from "@/services/settings/registry";
 import {
   DISCUSS_MEDIA_PROMPT_SETTING,
-  DISCUSS_WATCHLIST_PROMPT_SETTING
-} from "@/services/settings/ui-settings"
-import { fetchChatModels, fetchImageModels } from "@/services/tldw-server"
+  DISCUSS_WATCHLIST_PROMPT_SETTING,
+} from "@/services/settings/ui-settings";
+import { fetchChatModels, fetchImageModels } from "@/services/tldw-server";
 import {
   type ResearchRunCreateRequest,
   type ResearchRunFollowUpBackground,
-  tldwClient
-} from "@/services/tldw/TldwApiClient"
+  tldwClient,
+} from "@/services/tldw/TldwApiClient";
 // ChatRequestDebugSnapshot moved to usePlaygroundRawPreview
 import {
   buildDiscussMediaHint,
   getMediaChatHandoffMode,
   normalizeMediaChatHandoffPayload,
-  parseMediaIdAsNumber
-} from "@/services/tldw/media-chat-handoff"
+  parseMediaIdAsNumber,
+} from "@/services/tldw/media-chat-handoff";
 import {
   normalizeVoiceConversationRuntimeError,
   resolveVoiceConversationAvailability,
   resolveVoiceConversationTtsConfig,
-  shouldProbeVoiceConversationAudioHealth
-} from "@/services/tldw/voice-conversation"
+  shouldProbeVoiceConversationAudioHealth,
+} from "@/services/tldw/voice-conversation";
 import {
   buildWatchlistChatHint,
-  normalizeWatchlistChatHandoffPayload
-} from "@/services/tldw/watchlist-chat-handoff"
+  normalizeWatchlistChatHandoffPayload,
+} from "@/services/tldw/watchlist-chat-handoff";
 import {
   shouldEnableOptionalResource,
-  useChatSurfaceCoordinatorStore
-} from "@/store/chat-surface-coordinator"
+  useChatSurfaceCoordinatorStore,
+} from "@/store/chat-surface-coordinator";
 import {
   type ChatModelSettings,
-  useStoreChatModelSettings
-} from "@/store/model"
-import { useStoreMessageOption } from "@/store/option"
-import { useUiModeStore } from "@/store/ui-mode"
-import type { Character } from "@/types/character"
-import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings"
-import { ConnectionPhase, deriveConnectionUxState } from "@/types/connection"
-import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant"
+  useStoreChatModelSettings,
+} from "@/store/model";
+import { useStoreMessageOption } from "@/store/option";
+import { useUiModeStore } from "@/store/ui-mode";
+import type { Character } from "@/types/character";
+import { DEFAULT_CHAT_SETTINGS } from "@/types/chat-settings";
+import { ConnectionPhase, deriveConnectionUxState } from "@/types/connection";
+import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant";
 // resolveApiProviderForModel moved to usePlaygroundRawPreview and usePlaygroundImageGen
 import {
   DEFAULT_CHARACTER_STORAGE_KEY,
@@ -107,8 +107,8 @@ import {
   isFreshChatState,
   resolveCharacterSelectionId,
   shouldApplyDefaultCharacter,
-  shouldResetDefaultCharacterBootstrap
-} from "@/utils/default-character-preference"
+  shouldResetDefaultCharacterBootstrap,
+} from "@/utils/default-character-preference";
 import {
   type ImageGenerationEventSyncMode,
   type ImageGenerationEventSyncPolicy,
@@ -117,15 +117,15 @@ import {
   PLAYGROUND_IMAGE_EVENT_SYNC_DEFAULT_STORAGE_KEY,
   normalizeImageGenerationEventSyncMode,
   normalizeImageGenerationEventSyncPolicy,
-  resolveImageGenerationEventSyncMode
-} from "@/utils/image-generation-chat"
-import { isFireFoxPrivateMode } from "@/utils/is-private-mode"
-import { handleChatInputKeyDown } from "@/utils/key-down"
-import { resolveStartupSelectedModel } from "@/utils/model-startup-selection"
-import { trackOnboardingChatSubmitSuccess } from "@/utils/onboarding-ingestion-telemetry"
-import { getProviderDisplayName } from "@/utils/provider-registry"
-import { getVariable } from "@/utils/select-variable"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+  resolveImageGenerationEventSyncMode,
+} from "@/utils/image-generation-chat";
+import { isFireFoxPrivateMode } from "@/utils/is-private-mode";
+import { handleChatInputKeyDown } from "@/utils/key-down";
+import { resolveStartupSelectedModel } from "@/utils/model-startup-selection";
+import { trackOnboardingChatSubmitSuccess } from "@/utils/onboarding-ingestion-telemetry";
+import { getProviderDisplayName } from "@/utils/provider-registry";
+import { getVariable } from "@/utils/select-variable";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Button,
   Checkbox,
@@ -136,8 +136,8 @@ import {
   Radio,
   Select,
   Switch,
-  Tooltip
-} from "antd"
+  Tooltip,
+} from "antd";
 import {
   ArrowRight,
   ChevronRight,
@@ -145,39 +145,39 @@ import {
   Headphones,
   HelpCircle,
   ImageIcon,
-  X
-} from "lucide-react"
-import React from "react"
-import { useTranslation } from "react-i18next"
-import { Link, useNavigate } from "react-router-dom"
+  X,
+} from "lucide-react";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
 
-import { useStorage } from "@plasmohq/storage/hook"
+import { useStorage } from "@plasmohq/storage/hook";
 
-import { useFocusShortcuts } from "~/hooks/keyboard"
-import { useMessageOption } from "~/hooks/useMessageOption"
-import { useTabMentions } from "~/hooks/useTabMentions"
-import { useWebUI } from "~/store/webui"
+import { useFocusShortcuts } from "~/hooks/keyboard";
+import { useMessageOption } from "~/hooks/useMessageOption";
+import { useTabMentions } from "~/hooks/useTabMentions";
+import { useWebUI } from "~/store/webui";
 
-import { AttachedResearchContextChip } from "./AttachedResearchContextChip"
-import { AttachmentsSummary } from "./AttachmentsSummary"
+import { AttachedResearchContextChip } from "./AttachedResearchContextChip";
+import { AttachmentsSummary } from "./AttachmentsSummary";
 // ContextFootprintPanel moved to PlaygroundContextWindowModal
-import { CompareToggle } from "./CompareToggle"
-import { ComposerTextarea } from "./ComposerTextarea"
-import { ComposerToolbar } from "./ComposerToolbar"
-import { MentionsDropdown } from "./MentionsDropdown"
-import { getPresetByKey } from "./ParameterPresets"
-import { PlaygroundComposerNotices } from "./PlaygroundComposerNotices"
-import { PlaygroundKnowledgeSection } from "./PlaygroundKnowledgeSection"
-import { PlaygroundMcpControl } from "./PlaygroundMcpControl"
-import { PlaygroundModeLauncher } from "./PlaygroundModeLauncher"
+import { CompareToggle } from "./CompareToggle";
+import { ComposerTextarea } from "./ComposerTextarea";
+import { ComposerToolbar } from "./ComposerToolbar";
+import { MentionsDropdown } from "./MentionsDropdown";
+import { getPresetByKey } from "./ParameterPresets";
+import { PlaygroundComposerNotices } from "./PlaygroundComposerNotices";
+import { PlaygroundKnowledgeSection } from "./PlaygroundKnowledgeSection";
+import { PlaygroundMcpControl } from "./PlaygroundMcpControl";
+import { PlaygroundModeLauncher } from "./PlaygroundModeLauncher";
 import {
   PlaygroundAttachmentButton,
-  PlaygroundSendControl
-} from "./PlaygroundSendControl"
-import { PlaygroundToolsPopover } from "./PlaygroundToolsPopover"
-import { TokenProgressBar } from "./TokenProgressBar"
-import { VoiceChatIndicator } from "./VoiceChatIndicator"
-import { buildConversationSummaryCheckpointPrompt } from "./conversation-summary-checkpoint"
+  PlaygroundSendControl,
+} from "./PlaygroundSendControl";
+import { PlaygroundToolsPopover } from "./PlaygroundToolsPopover";
+import { TokenProgressBar } from "./TokenProgressBar";
+import { VoiceChatIndicator } from "./VoiceChatIndicator";
+import { buildConversationSummaryCheckpointPrompt } from "./conversation-summary-checkpoint";
 // buildImagePromptRefineMessages, extractImagePromptRefineCandidate moved to usePlaygroundImageGen
 // QueuedRequest moved to usePlaygroundQueueManagement
 // WeightedImagePromptContextEntry moved to usePlaygroundImageGen
@@ -197,76 +197,76 @@ import {
   usePlaygroundSettings,
   usePlaygroundSubmit,
   usePlaygroundVoiceChat,
-  usePromptTemplates
-} from "./hooks"
+  usePromptTemplates,
+} from "./hooks";
 // SessionInsightsPanel moved to PlaygroundContextWindowModal
-import { type ModelRecommendationAction } from "./model-recommendations"
+import { type ModelRecommendationAction } from "./model-recommendations";
 import {
   type AttachedResearchContext,
   type ResearchFollowUpTarget,
   applyAttachedResearchContextEdits,
   resetAttachedResearchContext,
-  toChatResearchContext
-} from "./research-chat-context"
+  toChatResearchContext,
+} from "./research-chat-context";
 import {
   type StartupTemplateBundle,
   describeStartupTemplatePrompt,
-  resolveStartupTemplatePrompt
-} from "./startup-template-bundles"
-import { useMobileComposerViewport } from "./useMobileComposerViewport"
+  resolveStartupTemplatePrompt,
+} from "./startup-template-bundles";
+import { useMobileComposerViewport } from "./useMobileComposerViewport";
 
 type Props = {
-  droppedFiles: File[]
-  attachedResearchContext?: AttachedResearchContext | null
-  attachedResearchContextBaseline?: AttachedResearchContext | null
-  attachedResearchContextPinned?: AttachedResearchContext | null
-  attachedResearchContextHistory?: AttachedResearchContext[]
-  onApplyAttachedResearchContext?: (context: AttachedResearchContext) => void
-  onResetAttachedResearchContext?: () => void
-  onRemoveAttachedResearchContext?: () => void
-  onPinAttachedResearchContext?: () => void
-  onUnpinAttachedResearchContext?: () => void
-  onRestorePinnedResearchContext?: () => void
+  droppedFiles: File[];
+  attachedResearchContext?: AttachedResearchContext | null;
+  attachedResearchContextBaseline?: AttachedResearchContext | null;
+  attachedResearchContextPinned?: AttachedResearchContext | null;
+  attachedResearchContextHistory?: AttachedResearchContext[];
+  onApplyAttachedResearchContext?: (context: AttachedResearchContext) => void;
+  onResetAttachedResearchContext?: () => void;
+  onRemoveAttachedResearchContext?: () => void;
+  onPinAttachedResearchContext?: () => void;
+  onUnpinAttachedResearchContext?: () => void;
+  onRestorePinnedResearchContext?: () => void;
   onPinAttachedResearchContextHistory?: (
-    context: AttachedResearchContext
-  ) => void
+    context: AttachedResearchContext,
+  ) => void;
   onSelectAttachedResearchContextHistory?: (
-    context: AttachedResearchContext
-  ) => void
-  onPrepareResearchFollowUp?: (target: ResearchFollowUpTarget) => void
-  stickyDockEnabled?: boolean
-  onComposerLayoutChange?: (metrics: ComposerDockLayoutMetrics) => void
-}
+    context: AttachedResearchContext,
+  ) => void;
+  onPrepareResearchFollowUp?: (target: ResearchFollowUpTarget) => void;
+  stickyDockEnabled?: boolean;
+  onComposerLayoutChange?: (metrics: ComposerDockLayoutMetrics) => void;
+};
 
 type DefaultCharacterPreferenceQueryResult = {
-  defaultCharacterId: string | null
-}
+  defaultCharacterId: string | null;
+};
 
 type PlaygroundQueuedSourceContext = {
-  documents?: ChatDocuments
-  imageBackendOverride?: string
-  isImageCommand?: boolean
-}
+  documents?: ChatDocuments;
+  imageBackendOverride?: string;
+  isImageCommand?: boolean;
+};
 
-const FOLLOW_UP_RESEARCH_PROMPT_PREFIX = "Follow up on this research:"
-const CASUAL_COMPOSER_MAX_HEIGHT_PX = 120
-const PRO_COMPOSER_MAX_HEIGHT_PX = 160
+const FOLLOW_UP_RESEARCH_PROMPT_PREFIX = "Follow up on this research:";
+const CASUAL_COMPOSER_MAX_HEIGHT_PX = 120;
+const PRO_COMPOSER_MAX_HEIGHT_PX = 160;
 
 const buildFollowUpResearchBackground = (
-  context: AttachedResearchContext
+  context: AttachedResearchContext,
 ): ResearchRunFollowUpBackground => {
   const unsupportedClaimCount =
     typeof context.verification_summary?.unsupported_claim_count === "number" &&
     Number.isFinite(context.verification_summary.unsupported_claim_count) &&
     context.verification_summary.unsupported_claim_count >= 0
       ? Math.trunc(context.verification_summary.unsupported_claim_count)
-      : 0
+      : 0;
   const highTrustCount =
     typeof context.source_trust_summary?.high_trust_count === "number" &&
     Number.isFinite(context.source_trust_summary.high_trust_count) &&
     context.source_trust_summary.high_trust_count >= 0
       ? Math.trunc(context.source_trust_summary.high_trust_count)
-      : 0
+      : 0;
 
   return {
     question: context.question || context.query,
@@ -275,7 +275,7 @@ const buildFollowUpResearchBackground = (
           .filter(
             (section) =>
               typeof section?.title === "string" &&
-              section.title.trim().length > 0
+              section.title.trim().length > 0,
           )
           .map((section) => ({ title: section.title.trim() }))
       : [],
@@ -285,34 +285,34 @@ const buildFollowUpResearchBackground = (
             typeof claim?.text === "string" && claim.text.trim().length > 0
               ? {
                   claim_id: `claim_${index + 1}`,
-                  text: claim.text.trim()
+                  text: claim.text.trim(),
                 }
-              : null
+              : null,
           )
           .filter(
             (claim): claim is { claim_id: string; text: string } =>
-              claim !== null
+              claim !== null,
           )
       : [],
     unresolved_questions: Array.isArray(context.unresolved_questions)
       ? context.unresolved_questions.filter(
           (question): question is string =>
-            typeof question === "string" && question.trim().length > 0
+            typeof question === "string" && question.trim().length > 0,
         )
       : [],
     verification_summary: {
       supported_claim_count: 0,
-      unsupported_claim_count: unsupportedClaimCount
+      unsupported_claim_count: unsupportedClaimCount,
     },
     source_trust_summary: {
       high_trust_count: highTrustCount,
-      low_trust_count: 0
-    }
-  }
-}
+      low_trust_count: 0,
+    },
+  };
+};
 
 const cloneAttachedResearchContext = (
-  context: AttachedResearchContext | null
+  context: AttachedResearchContext | null,
 ): AttachedResearchContext | null =>
   context
     ? {
@@ -325,71 +325,71 @@ const cloneAttachedResearchContext = (
           : undefined,
         source_trust_summary: context.source_trust_summary
           ? { ...context.source_trust_summary }
-          : undefined
+          : undefined,
       }
-    : null
+    : null;
 
 const stringifyOutline = (context: AttachedResearchContext | null): string =>
-  context?.outline.map((section) => section.title).join("\n") ?? ""
+  context?.outline.map((section) => section.title).join("\n") ?? "";
 
 const stringifyKeyClaims = (context: AttachedResearchContext | null): string =>
-  context?.key_claims.map((claim) => claim.text).join("\n") ?? ""
+  context?.key_claims.map((claim) => claim.text).join("\n") ?? "";
 
 const stringifyUnresolvedQuestions = (
-  context: AttachedResearchContext | null
-): string => context?.unresolved_questions.join("\n") ?? ""
+  context: AttachedResearchContext | null,
+): string => context?.unresolved_questions.join("\n") ?? "";
 
 const LazyCurrentChatModelSettings = React.lazy(() =>
   import("@/components/Common/Settings/CurrentChatModelSettings").then(
-    (module) => ({ default: module.CurrentChatModelSettings })
-  )
-)
+    (module) => ({ default: module.CurrentChatModelSettings }),
+  ),
+);
 
 const LazyActorPopout = React.lazy(() =>
   import("@/components/Common/Settings/ActorPopout").then((module) => ({
-    default: module.ActorPopout
-  }))
-)
+    default: module.ActorPopout,
+  })),
+);
 
 const LazyDocumentGeneratorDrawer = React.lazy(
-  () => import("@/components/Common/Playground/DocumentGeneratorDrawer")
-)
+  () => import("@/components/Common/Playground/DocumentGeneratorDrawer"),
+);
 
 const LazyVoiceModeSelector = React.lazy(() =>
   import("./VoiceModeSelector").then((module) => ({
-    default: module.VoiceModeSelector
-  }))
-)
+    default: module.VoiceModeSelector,
+  })),
+);
 
 const LazyPlaygroundImageGenModal = React.lazy(() =>
   import("./PlaygroundImageGenModal").then((module) => ({
-    default: module.PlaygroundImageGenModal
-  }))
-)
+    default: module.PlaygroundImageGenModal,
+  })),
+);
 
 const LazyPlaygroundRawRequestModal = React.lazy(() =>
   import("./PlaygroundRawRequestModal").then((module) => ({
-    default: module.PlaygroundRawRequestModal
-  }))
-)
+    default: module.PlaygroundRawRequestModal,
+  })),
+);
 
 const LazyPlaygroundStartupTemplateModal = React.lazy(() =>
   import("./PlaygroundStartupTemplateModal").then((module) => ({
-    default: module.PlaygroundStartupTemplateModal
-  }))
-)
+    default: module.PlaygroundStartupTemplateModal,
+  })),
+);
 
 const LazyPlaygroundContextWindowModal = React.lazy(() =>
   import("./PlaygroundContextWindowModal").then((module) => ({
-    default: module.PlaygroundContextWindowModal
-  }))
-)
+    default: module.PlaygroundContextWindowModal,
+  })),
+);
 
 const LazyPlaygroundMcpSettingsModal = React.lazy(() =>
   import("./PlaygroundMcpSettingsModal").then((module) => ({
-    default: module.PlaygroundMcpSettingsModal
-  }))
-)
+    default: module.PlaygroundMcpSettingsModal,
+  })),
+);
 
 export const PlaygroundForm = ({
   droppedFiles,
@@ -407,39 +407,39 @@ export const PlaygroundForm = ({
   onSelectAttachedResearchContextHistory,
   onPrepareResearchFollowUp,
   stickyDockEnabled = false,
-  onComposerLayoutChange
+  onComposerLayoutChange,
 }: Props) => {
-  const { t } = useTranslation(["playground", "common", "option"])
-  const notificationApi = useAntdNotification()
-  const navigate = useNavigate()
+  const { t } = useTranslation(["playground", "common", "option"]);
+  const notificationApi = useAntdNotification();
+  const navigate = useNavigate();
   const [attachedResearchContextDraft, setAttachedResearchContextDraft] =
-    React.useState<AttachedResearchContext | null>(null)
+    React.useState<AttachedResearchContext | null>(null);
   const [followUpResearchModalOpen, setFollowUpResearchModalOpen] =
-    React.useState(false)
+    React.useState(false);
   const [
     includeAttachedResearchAsBackground,
-    setIncludeAttachedResearchAsBackground
-  ] = React.useState(Boolean(attachedResearchContext))
+    setIncludeAttachedResearchAsBackground,
+  ] = React.useState(Boolean(attachedResearchContext));
   const [pendingAttachmentFollowUp, setPendingAttachmentFollowUp] =
-    React.useState<ResearchFollowUpTarget | null>(null)
+    React.useState<ResearchFollowUpTarget | null>(null);
   const [followUpResearchPending, setFollowUpResearchPending] =
-    React.useState(false)
-  const followUpResearchPendingRef = React.useRef(false)
-  const voiceChatSubmitFormRef = React.useRef<() => void>(() => undefined)
+    React.useState(false);
+  const followUpResearchPendingRef = React.useRef(false);
+  const voiceChatSubmitFormRef = React.useRef<() => void>(() => undefined);
 
-  const [checkWideMode] = useStorage("checkWideMode", false)
+  const [checkWideMode] = useStorage("checkWideMode", false);
   const [allowExternalImages, setAllowExternalImages] = useStorage(
     "allowExternalImages",
-    DEFAULT_CHAT_SETTINGS.allowExternalImages
-  )
-  const [showMoodBadge, setShowMoodBadge] = useChatMoodBadgePreference()
+    DEFAULT_CHAT_SETTINGS.allowExternalImages,
+  );
+  const [showMoodBadge, setShowMoodBadge] = useChatMoodBadgePreference();
   const researchContext = React.useMemo(
     () =>
       attachedResearchContext
         ? toChatResearchContext(attachedResearchContext)
         : undefined,
-    [attachedResearchContext]
-  )
+    [attachedResearchContext],
+  );
   const {
     onSubmit,
     messages,
@@ -504,13 +504,13 @@ export const PlaygroundForm = ({
     chatLoopState = {
       status: "idle",
       pendingApprovals: [],
-      inflightToolCallIds: []
-    }
-  } = useMessageOption()
-  const setRagMediaIds = useStoreMessageOption((s) => s.setRagMediaIds)
+      inflightToolCallIds: [],
+    },
+  } = useMessageOption();
+  const setRagMediaIds = useStoreMessageOption((s) => s.setRagMediaIds);
   const setRagPinnedResults = useStoreMessageOption(
-    (s) => s.setRagPinnedResults
-  )
+    (s) => s.setRagPinnedResults,
+  );
 
   // Experimental Primer composer wire-up — opt in via ?nextgenComposer=1
   // query param OR the Settings "Enable new composer" toggle. When ON,
@@ -521,49 +521,49 @@ export const PlaygroundForm = ({
   // hook so cross-tab flips and server-profile hydrates flow through
   // without a reload.
   const [urlFlagEnabled] = React.useState(() => {
-    if (typeof window === "undefined") return false
+    if (typeof window === "undefined") return false;
     try {
-      const params = new URLSearchParams(window.location.search)
-      return params.get("nextgenComposer") === "1"
+      const params = new URLSearchParams(window.location.search);
+      return params.get("nextgenComposer") === "1";
     } catch {
-      return false
+      return false;
     }
-  })
-  const [toggleEnabled] = useComposerEnabledPreference()
-  const nextgenComposerEnabled = urlFlagEnabled || toggleEnabled
-  const [nextgenComposerVariant] = useComposerVariantPreference()
+  });
+  const [toggleEnabled] = useComposerEnabledPreference();
+  const nextgenComposerEnabled = urlFlagEnabled || toggleEnabled;
+  const [nextgenComposerVariant] = useComposerVariantPreference();
   const { settings: chatSettings, updateSettings: updateChatSettings } =
     useChatSettingsRecord({
       historyId,
-      serverChatId
-    })
+      serverChatId,
+    });
   const [imageEventSyncGlobalDefault, setImageEventSyncGlobalDefault] =
     useStorage<ImageGenerationEventSyncMode>(
       PLAYGROUND_IMAGE_EVENT_SYNC_DEFAULT_STORAGE_KEY,
-      "off"
-    )
+      "off",
+    );
   const imageEventSyncChatMode = React.useMemo(
     () =>
       normalizeImageGenerationEventSyncMode(
         chatSettings?.imageEventSyncMode,
-        "off"
+        "off",
       ),
-    [chatSettings?.imageEventSyncMode]
-  )
+    [chatSettings?.imageEventSyncMode],
+  );
 
-  const [autoSubmitVoiceMessage] = useStorage("autoSubmitVoiceMessage", false)
-  const isMobileViewport = useMobile()
-  const mobileComposerViewport = useMobileComposerViewport(isMobileViewport)
+  const [autoSubmitVoiceMessage] = useStorage("autoSubmitVoiceMessage", false);
+  const isMobileViewport = useMobile();
+  const mobileComposerViewport = useMobileComposerViewport(isMobileViewport);
   const [viewportHeightPx, setViewportHeightPx] = React.useState(() =>
-    typeof window === "undefined" ? 0 : window.innerHeight
-  )
-  const [openModelSettings, setOpenModelSettings] = React.useState(false)
-  const [openActorSettings, setOpenActorSettings] = React.useState(false)
-  const [noticesExpanded, setNoticesExpanded] = React.useState(false)
-  const systemPrompt = useStoreChatModelSettings((state) => state.systemPrompt)
+    typeof window === "undefined" ? 0 : window.innerHeight,
+  );
+  const [openModelSettings, setOpenModelSettings] = React.useState(false);
+  const [openActorSettings, setOpenActorSettings] = React.useState(false);
+  const [noticesExpanded, setNoticesExpanded] = React.useState(false);
+  const systemPrompt = useStoreChatModelSettings((state) => state.systemPrompt);
   const setSystemPrompt = useStoreChatModelSettings(
-    (state) => state.setSystemPrompt
-  )
+    (state) => state.setSystemPrompt,
+  );
   const currentChatModelSettings = useStoreChatModelSettings((state) => ({
     temperature: state.temperature,
     numPredict: state.numPredict,
@@ -584,19 +584,19 @@ export const PlaygroundForm = ({
     llamaGrammarId: state.llamaGrammarId,
     llamaGrammarInline: state.llamaGrammarInline,
     llamaGrammarOverride: state.llamaGrammarOverride,
-    jsonMode: state.jsonMode
-  }))
-  const numCtx = useStoreChatModelSettings((state) => state.numCtx)
+    jsonMode: state.jsonMode,
+  }));
+  const numCtx = useStoreChatModelSettings((state) => state.numCtx);
   const updateChatModelSetting = useStoreChatModelSettings(
-    (state) => state.updateSetting
-  )
+    (state) => state.updateSetting,
+  );
   const updateChatModelSettings = useStoreChatModelSettings(
-    (state) => state.updateSettings
-  )
+    (state) => state.updateSettings,
+  );
   const { data: promptLibrary = [] } = useQuery({
     queryKey: ["playgroundStartupPromptLibrary"],
-    queryFn: getAllPrompts
-  })
+    queryFn: getAllPrompts,
+  });
   const {
     voiceChatEnabled,
     setVoiceChatEnabled,
@@ -611,55 +611,55 @@ export const PlaygroundForm = ({
     voiceChatBargeIn,
     setVoiceChatBargeIn,
     voiceChatTtsMode,
-    setVoiceChatTtsMode
-  } = useVoiceChatSettings()
-  const voiceChatMessages = useVoiceChatMessages()
-  const { devices: audioInputDevices } = useAudioSourceCatalog()
+    setVoiceChatTtsMode,
+  } = useVoiceChatSettings();
+  const voiceChatMessages = useVoiceChatMessages();
+  const { devices: audioInputDevices } = useAudioSourceCatalog();
   const {
     config: canonicalConnectionConfig,
-    loading: canonicalConnectionLoading
-  } = useCanonicalConnectionConfig()
-  const [ttsProvider] = useStorage("ttsProvider", "browser")
-  const [tldwTtsModel] = useStorage("tldwTtsModel", "kokoro")
-  const [tldwTtsVoice] = useStorage("tldwTtsVoice", "af_heart")
-  const [tldwTtsSpeed] = useStorage("tldwTtsSpeed", 1)
-  const [tldwTtsResponseFormat] = useStorage("tldwTtsResponseFormat", "mp3")
-  const [openAITTSModel] = useStorage("openAITTSModel", "tts-1")
-  const [openAITTSVoice] = useStorage("openAITTSVoice", "alloy")
-  const [elevenLabsModel] = useStorage("elevenLabsModel", "")
-  const [elevenLabsVoiceId] = useStorage("elevenLabsVoiceId", "")
-  const [speechPlaybackSpeed] = useStorage("speechPlaybackSpeed", 1)
+    loading: canonicalConnectionLoading,
+  } = useCanonicalConnectionConfig();
+  const [ttsProvider] = useStorage("ttsProvider", "browser");
+  const [tldwTtsModel] = useStorage("tldwTtsModel", "kokoro");
+  const [tldwTtsVoice] = useStorage("tldwTtsVoice", "af_heart");
+  const [tldwTtsSpeed] = useStorage("tldwTtsSpeed", 1);
+  const [tldwTtsResponseFormat] = useStorage("tldwTtsResponseFormat", "mp3");
+  const [openAITTSModel] = useStorage("openAITTSModel", "tts-1");
+  const [openAITTSVoice] = useStorage("openAITTSVoice", "alloy");
+  const [elevenLabsModel] = useStorage("elevenLabsModel", "");
+  const [elevenLabsVoiceId] = useStorage("elevenLabsVoiceId", "");
+  const [speechPlaybackSpeed] = useStorage("speechPlaybackSpeed", 1);
   const [voiceChatTriggerInput, setVoiceChatTriggerInput] = React.useState(
-    voiceChatTriggerPhrases.join(", ")
-  )
+    voiceChatTriggerPhrases.join(", "),
+  );
   React.useEffect(() => {
-    const next = voiceChatTriggerPhrases.join(", ")
-    setVoiceChatTriggerInput((prev) => (prev === next ? prev : next))
-  }, [voiceChatTriggerPhrases])
+    const next = voiceChatTriggerPhrases.join(", ");
+    setVoiceChatTriggerInput((prev) => (prev === next ? prev : next));
+  }, [voiceChatTriggerPhrases]);
 
-  const connectionState = useConnectionState()
-  const { phase, isConnected } = connectionState
+  const connectionState = useConnectionState();
+  const { phase, isConnected } = connectionState;
   const connectionUxState = React.useMemo(
     () => deriveConnectionUxState(connectionState),
-    [connectionState]
-  )
+    [connectionState],
+  );
   const setOptionalPanelVisible = useChatSurfaceCoordinatorStore(
-    (state) => state.setPanelVisible
-  )
+    (state) => state.setPanelVisible,
+  );
   const markOptionalPanelEngaged = useChatSurfaceCoordinatorStore(
-    (state) => state.markPanelEngaged
-  )
+    (state) => state.markPanelEngaged,
+  );
   const mcpToolsEnabled = useChatSurfaceCoordinatorStore((state) =>
-    shouldEnableOptionalResource(state, "mcp-tools")
-  )
+    shouldEnableOptionalResource(state, "mcp-tools"),
+  );
   const audioHealthEnabled = useChatSurfaceCoordinatorStore((state) =>
-    shouldEnableOptionalResource(state, "audio-health")
-  )
+    shouldEnableOptionalResource(state, "audio-health"),
+  );
   const modelCatalogEnabled = useChatSurfaceCoordinatorStore((state) =>
-    shouldEnableOptionalResource(state, "model-catalog")
-  )
-  const isConnectionReady = isConnected && phase === ConnectionPhase.CONNECTED
-  const { capabilities, loading: capsLoading } = useServerCapabilities()
+    shouldEnableOptionalResource(state, "model-catalog"),
+  );
+  const isConnectionReady = isConnected && phase === ConnectionPhase.CONNECTED;
+  const { capabilities, loading: capsLoading } = useServerCapabilities();
   const {
     hasMcp,
     healthState: mcpHealthState,
@@ -676,8 +676,8 @@ export const PlaygroundForm = ({
     setToolCatalog,
     setToolCatalogId,
     setToolModules,
-    setToolCatalogStrict
-  } = useMcpTools({ enabled: mcpToolsEnabled })
+    setToolCatalogStrict,
+  } = useMcpTools({ enabled: mcpToolsEnabled });
   const mcpCtrl = useMcpToolsControl({
     hasMcp,
     mcpHealthState,
@@ -688,45 +688,45 @@ export const PlaygroundForm = ({
     toolCatalogId,
     setToolCatalog,
     setToolCatalogId,
-    toolChoice
-  })
+    toolChoice,
+  });
   const handleModuleSelect = React.useCallback(
     (value?: string[]) => {
-      setToolModules(Array.isArray(value) ? value : [])
+      setToolModules(Array.isArray(value) ? value : []);
     },
-    [setToolModules]
-  )
+    [setToolModules],
+  );
   const hasServerVoiceChat =
     isConnectionReady &&
     !capsLoading &&
     Boolean(
       capabilities?.hasVoiceChat ??
-      (capabilities?.hasStt && capabilities?.hasTts)
-    )
+      (capabilities?.hasStt && capabilities?.hasTts),
+    );
   const hasServerStt =
-    isConnectionReady && !capsLoading && Boolean(capabilities?.hasStt)
+    isConnectionReady && !capsLoading && Boolean(capabilities?.hasStt);
   const shouldProbeAudioHealth = React.useMemo(
     () =>
       shouldProbeVoiceConversationAudioHealth({
         isConnectionReady,
         hasServerVoiceChat,
         hasServerStt,
-        optionalAudioHealthEnabled: audioHealthEnabled
+        optionalAudioHealthEnabled: audioHealthEnabled,
       }),
-    [audioHealthEnabled, hasServerStt, hasServerVoiceChat, isConnectionReady]
-  )
+    [audioHealthEnabled, hasServerStt, hasServerVoiceChat, isConnectionReady],
+  );
   const {
     healthState: audioHealthState,
     sttHealthState,
-    hasVoiceConversationTransport
+    hasVoiceConversationTransport,
   } = useTldwAudioStatus({
     enabled: shouldProbeAudioHealth,
     ttsProvider,
-    tldwTtsModel
-  })
+    tldwTtsModel,
+  });
   const canUseServerAudio =
-    hasServerVoiceChat && audioHealthState !== "unhealthy"
-  const canUseServerStt = hasServerStt && sttHealthState !== "unhealthy"
+    hasServerVoiceChat && audioHealthState !== "unhealthy";
+  const canUseServerStt = hasServerStt && sttHealthState !== "unhealthy";
   const voiceConversationTtsConfig = React.useMemo(
     () =>
       resolveVoiceConversationTtsConfig({
@@ -740,7 +740,7 @@ export const PlaygroundForm = ({
         elevenLabsModel,
         elevenLabsVoiceId,
         speechPlaybackSpeed,
-        voiceChatTtsMode
+        voiceChatTtsMode,
       }),
     [
       elevenLabsModel,
@@ -753,9 +753,9 @@ export const PlaygroundForm = ({
       tldwTtsSpeed,
       tldwTtsVoice,
       ttsProvider,
-      voiceChatTtsMode
-    ]
-  )
+      voiceChatTtsMode,
+    ],
+  );
   const voiceConversationAvailability = React.useMemo(
     () =>
       resolveVoiceConversationAvailability({
@@ -765,13 +765,13 @@ export const PlaygroundForm = ({
           canonicalConnectionConfig?.serverUrl &&
           (canonicalConnectionConfig?.authMode === "multi-user"
             ? canonicalConnectionConfig.accessToken
-            : canonicalConnectionConfig.apiKey)
+            : canonicalConnectionConfig.apiKey),
         ),
         sttHealthState,
         ttsHealthState: audioHealthState,
         selectedModel,
         allowBackendDefaultModel: true,
-        ttsConfigReady: voiceConversationTtsConfig.ok
+        ttsConfigReady: voiceConversationTtsConfig.ok,
       }),
     [
       audioHealthState,
@@ -784,325 +784,328 @@ export const PlaygroundForm = ({
       isConnectionReady,
       selectedModel,
       sttHealthState,
-      voiceConversationTtsConfig.ok
-    ]
-  )
-  const voiceChatAvailable = voiceConversationAvailability.available
+      voiceConversationTtsConfig.ok,
+    ],
+  );
+  const voiceChatAvailable = voiceConversationAvailability.available;
   const voiceChatUnavailableReason = React.useMemo(() => {
     const fallback = t(
       "playground:voiceChat.unavailableBody",
-      "Connect to a tldw server with audio chat streaming enabled."
-    )
+      "Connect to a tldw server with audio chat streaming enabled.",
+    );
     return voiceConversationAvailability.message
       ? t(voiceConversationAvailability.message, fallback)
-      : fallback
-  }, [t, voiceConversationAvailability.message])
+      : fallback;
+  }, [t, voiceConversationAvailability.message]);
   const voiceChat = useVoiceChatStream({
     active: voiceChatEnabled && voiceChatAvailable,
     onTranscript: (text) => {
-      voiceChatMessages.beginTurn(text)
+      voiceChatMessages.beginTurn(text);
     },
     onAssistantDelta: (delta) => {
-      voiceChatMessages.appendAssistantDelta(delta)
+      voiceChatMessages.appendAssistantDelta(delta);
     },
     onAssistantMessage: (text) => {
-      void voiceChatMessages.finalizeAssistant(text)
+      void voiceChatMessages.finalizeAssistant(text);
     },
     onError: (msg) => {
-      const runtimeError = normalizeVoiceConversationRuntimeError(msg)
+      const runtimeError = normalizeVoiceConversationRuntimeError(msg);
       notificationApi.error({
         message: t("playground:voiceChat.errorTitle", "Voice chat error"),
-        description: runtimeError.message
-      })
-      void voiceChatMessages.failTurn(runtimeError.reason)
-      setVoiceChatEnabled(false)
+        description: runtimeError.message,
+      });
+      void voiceChatMessages.failTurn(runtimeError.reason);
+      setVoiceChatEnabled(false);
     },
     onWarning: (msg) => {
       notificationApi.warning({
         message: t("playground:voiceChat.warningTitle", "Voice chat warning"),
-        description: msg
-      })
-    }
-  })
+        description: msg,
+      });
+    },
+  });
   const [hasShownConnectBanner, setHasShownConnectBanner] =
-    React.useState(false)
-  const [showConnectBanner, setShowConnectBanner] = React.useState(false)
+    React.useState(false);
+  const [showConnectBanner, setShowConnectBanner] = React.useState(false);
   const [documentGeneratorOpen, setDocumentGeneratorOpen] =
-    React.useState(false)
+    React.useState(false);
   const [voiceModeSelectorOpen, setVoiceModeSelectorOpen] =
-    React.useState(false)
-  const [modeLauncherOpen, setModeLauncherOpen] = React.useState(false)
+    React.useState(false);
+  const [modeLauncherOpen, setModeLauncherOpen] = React.useState(false);
   const [modeAnnouncement, setModeAnnouncement] = React.useState<string | null>(
-    null
-  )
-  const previousPresetKeyRef = React.useRef<string | null>(null)
-  const previousJsonModeRef = React.useRef<boolean | null>(null)
-  const previousCharacterNameRef = React.useRef<string | null>(null)
-  const [toolsPopoverOpen, setToolsPopoverOpen] = React.useState(false)
-  const [attachmentMenuOpen, setAttachmentMenuOpen] = React.useState(false)
-  const [sendMenuOpen, setSendMenuOpen] = React.useState(false)
+    null,
+  );
+  const previousPresetKeyRef = React.useRef<string | null>(null);
+  const previousJsonModeRef = React.useRef<boolean | null>(null);
+  const previousCharacterNameRef = React.useRef<string | null>(null);
+  const [toolsPopoverOpen, setToolsPopoverOpen] = React.useState(false);
+  const [attachmentMenuOpen, setAttachmentMenuOpen] = React.useState(false);
+  const [sendMenuOpen, setSendMenuOpen] = React.useState(false);
   const [documentGeneratorSeed, setDocumentGeneratorSeed] = React.useState<{
-    conversationId?: string | null
-    message?: string | null
-    messageId?: string | null
-  }>({})
-  const [autoStopTimeout] = useStorage("autoStopTimeout", 2000)
+    conversationId?: string | null;
+    message?: string | null;
+    messageId?: string | null;
+  }>({});
+  const [autoStopTimeout] = useStorage("autoStopTimeout", 2000);
   const [dictationAutoFallbackEnabled] = useStorage(
     "dictation_auto_fallback",
-    false
-  )
+    false,
+  );
   const [dictationModeOverride] = useStorage<DictationModePreference | null>(
     "dictationModeOverride",
-    null
-  )
-  const [sttModel] = useStorage("sttModel", "whisper-1")
-  const [sttUseSegmentation] = useStorage("sttUseSegmentation", false)
+    null,
+  );
+  const [sttModel] = useStorage("sttModel", "whisper-1");
+  const [sttUseSegmentation] = useStorage("sttUseSegmentation", false);
   const [sttTimestampGranularities] = useStorage(
     "sttTimestampGranularities",
-    "segment"
-  )
-  const [sttPrompt] = useStorage("sttPrompt", "")
-  const [sttTask] = useStorage("sttTask", "transcribe")
-  const [sttResponseFormat] = useStorage("sttResponseFormat", "json")
-  const [sttTemperature] = useStorage("sttTemperature", 0)
-  const [sttSegK] = useStorage("sttSegK", 6)
-  const [sttSegMinSegmentSize] = useStorage("sttSegMinSegmentSize", 5)
-  const [sttSegLambdaBalance] = useStorage("sttSegLambdaBalance", 0.01)
+    "segment",
+  );
+  const [sttPrompt] = useStorage("sttPrompt", "");
+  const [sttTask] = useStorage("sttTask", "transcribe");
+  const [sttResponseFormat] = useStorage("sttResponseFormat", "json");
+  const [sttTemperature] = useStorage("sttTemperature", 0);
+  const [sttSegK] = useStorage("sttSegK", 6);
+  const [sttSegMinSegmentSize] = useStorage("sttSegMinSegmentSize", 5);
+  const [sttSegLambdaBalance] = useStorage("sttSegLambdaBalance", 0.01);
   const [sttSegUtteranceExpansionWidth] = useStorage(
     "sttSegUtteranceExpansionWidth",
-    2
-  )
-  const [sttSegEmbeddingsProvider] = useStorage("sttSegEmbeddingsProvider", "")
-  const [sttSegEmbeddingsModel] = useStorage("sttSegEmbeddingsModel", "")
+    2,
+  );
+  const [sttSegEmbeddingsProvider] = useStorage("sttSegEmbeddingsProvider", "");
+  const [sttSegEmbeddingsModel] = useStorage("sttSegEmbeddingsModel", "");
   const [selectedCharacter, setSelectedCharacter] =
-    useSelectedCharacter<Character | null>(null)
+    useSelectedCharacter<Character | null>(null);
   const [defaultCharacter, setDefaultCharacter] = useStorage<Character | null>(
     {
       key: DEFAULT_CHARACTER_STORAGE_KEY,
-      instance: defaultCharacterStorage
+      instance: defaultCharacterStorage,
     },
-    null
-  )
+    null,
+  );
   const { data: defaultCharacterPreference } =
     useQuery<DefaultCharacterPreferenceQueryResult>({
       queryKey: ["tldw:defaultCharacterPreference:playground"],
       queryFn: async () => {
-        await tldwClient.initialize()
+        await tldwClient.initialize();
         const defaultCharacterId =
-          await tldwClient.getDefaultCharacterPreference()
-        return { defaultCharacterId }
+          await tldwClient.getDefaultCharacterPreference();
+        return { defaultCharacterId };
       },
       staleTime: 60 * 1000,
-      throwOnError: false
-    })
+      throwOnError: false,
+    });
   const [showMoodConfidence, setShowMoodConfidence] = useStorage(
     "chatShowMoodConfidence",
-    Boolean(selectedCharacter?.id) && !compareMode
-  )
+    Boolean(selectedCharacter?.id) && !compareMode,
+  );
   const [startupTemplatesRaw, setStartupTemplatesRaw] = useStorage(
     "playgroundStartupTemplateBundles",
-    "[]"
-  )
+    "[]",
+  );
   const [serverPersistenceHintSeen, setServerPersistenceHintSeen] = useStorage(
     "serverPersistenceHintSeen",
-    false
-  )
+    false,
+  );
   // showServerPersistenceHint and serverSaveInFlightRef moved to usePlaygroundPersistence
-  const uiMode = useUiModeStore((state) => state.mode)
-  const isProMode = uiMode === "pro"
+  const uiMode = useUiModeStore((state) => state.mode);
+  const isProMode = uiMode === "pro";
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
 
     const updateViewportHeight = () => {
       setViewportHeightPx((previousHeightPx) => {
-        const nextHeightPx = window.innerHeight
+        const nextHeightPx = window.innerHeight;
         return previousHeightPx === nextHeightPx
           ? previousHeightPx
-          : nextHeightPx
-      })
-    }
+          : nextHeightPx;
+      });
+    };
 
-    updateViewportHeight()
-    window.addEventListener("resize", updateViewportHeight)
-    window.visualViewport?.addEventListener("resize", updateViewportHeight)
+    updateViewportHeight();
+    window.addEventListener("resize", updateViewportHeight);
+    window.visualViewport?.addEventListener("resize", updateViewportHeight);
 
     return () => {
-      window.removeEventListener("resize", updateViewportHeight)
-      window.visualViewport?.removeEventListener("resize", updateViewportHeight)
-    }
-  }, [])
+      window.removeEventListener("resize", updateViewportHeight);
+      window.visualViewport?.removeEventListener(
+        "resize",
+        updateViewportHeight,
+      );
+    };
+  }, []);
 
   const [contextToolsOpen, setContextToolsOpen] = useStorage(
     "playgroundKnowledgeSearchOpen",
-    false
-  )
+    false,
+  );
   const [simpleInternetSearch, setSimpleInternetSearch] = useStorage(
     "isSimpleInternetSearch",
-    true
-  )
+    true,
+  );
   const [, setDefaultInternetSearchOnSetting] = useStorage(
     "defaultInternetSearchOn",
-    false
-  )
+    false,
+  );
   const [knowledgePanelTab, setKnowledgePanelTab] =
-    React.useState<KnowledgeTab>("search")
+    React.useState<KnowledgeTab>("search");
   const [knowledgePanelTabRequestId, setKnowledgePanelTabRequestId] =
-    React.useState(0)
+    React.useState(0);
   const [lastSubmittedContext, setLastSubmittedContext] = React.useState<{
-    model: string | null
-    compareEnabled: boolean
-    compareCount: number
-    characterName: string | null
-    promptSummary: string
-    jsonMode: boolean
-    temporaryChat: boolean
-    webSearch: boolean
-    contextToolsOpen: boolean
-  } | null>(null)
+    model: string | null;
+    compareEnabled: boolean;
+    compareCount: number;
+    characterName: string | null;
+    promptSummary: string;
+    jsonMode: boolean;
+    temporaryChat: boolean;
+    webSearch: boolean;
+    contextToolsOpen: boolean;
+  } | null>(null);
   const replyLabel = replyTarget
     ? [
         t("common:replyingTo", "Replying to"),
         replyTarget.name ? `${replyTarget.name}:` : null,
-        replyTarget.preview
+        replyTarget.preview,
       ]
         .filter(Boolean)
         .join(" ")
-    : ""
+    : "";
 
   const storedCharacterId = React.useMemo(
     () => resolveCharacterSelectionId(selectedCharacter),
-    [selectedCharacter]
-  )
+    [selectedCharacter],
+  );
   const localDefaultCharacterId = React.useMemo(
     () => resolveCharacterSelectionId(defaultCharacter),
-    [defaultCharacter]
-  )
+    [defaultCharacter],
+  );
   const serverDefaultCharacterId =
-    defaultCharacterPreference?.defaultCharacterId
+    defaultCharacterPreference?.defaultCharacterId;
   const effectiveDefaultCharacter = React.useMemo<Character | null>(() => {
     if (typeof serverDefaultCharacterId === "undefined") {
-      return defaultCharacter
+      return defaultCharacter;
     }
     if (!serverDefaultCharacterId) {
-      return null
+      return null;
     }
     if (
       localDefaultCharacterId === serverDefaultCharacterId &&
       defaultCharacter
     ) {
-      return defaultCharacter
+      return defaultCharacter;
     }
-    return { id: serverDefaultCharacterId } as Character
-  }, [defaultCharacter, localDefaultCharacterId, serverDefaultCharacterId])
+    return { id: serverDefaultCharacterId } as Character;
+  }, [defaultCharacter, localDefaultCharacterId, serverDefaultCharacterId]);
   const effectiveDefaultCharacterId = React.useMemo(
     () => resolveCharacterSelectionId(effectiveDefaultCharacter),
-    [effectiveDefaultCharacter]
-  )
+    [effectiveDefaultCharacter],
+  );
   const isFreshChat = React.useMemo(
     () => isFreshChatState(serverChatId, messages.length),
-    [messages.length, serverChatId]
-  )
-  const defaultCharacterBootstrapAppliedRef = React.useRef(false)
-  const previousFreshChatRef = React.useRef(isFreshChat)
+    [messages.length, serverChatId],
+  );
+  const defaultCharacterBootstrapAppliedRef = React.useRef(false);
+  const previousFreshChatRef = React.useRef(isFreshChat);
 
   React.useEffect(() => {
-    if (typeof serverDefaultCharacterId === "undefined") return
+    if (typeof serverDefaultCharacterId === "undefined") return;
 
     if (!serverDefaultCharacterId) {
       if (localDefaultCharacterId) {
-        void setDefaultCharacter(null)
+        void setDefaultCharacter(null);
       }
-      return
+      return;
     }
 
-    if (localDefaultCharacterId === serverDefaultCharacterId) return
-    void setDefaultCharacter({ id: serverDefaultCharacterId } as Character)
-  }, [localDefaultCharacterId, serverDefaultCharacterId, setDefaultCharacter])
+    if (localDefaultCharacterId === serverDefaultCharacterId) return;
+    void setDefaultCharacter({ id: serverDefaultCharacterId } as Character);
+  }, [localDefaultCharacterId, serverDefaultCharacterId, setDefaultCharacter]);
 
   React.useEffect(() => {
-    defaultCharacterBootstrapAppliedRef.current = false
-  }, [effectiveDefaultCharacterId])
+    defaultCharacterBootstrapAppliedRef.current = false;
+  }, [effectiveDefaultCharacterId]);
 
   React.useEffect(() => {
     if (
       shouldResetDefaultCharacterBootstrap(
         previousFreshChatRef.current,
-        isFreshChat
+        isFreshChat,
       )
     ) {
-      defaultCharacterBootstrapAppliedRef.current = false
+      defaultCharacterBootstrapAppliedRef.current = false;
     }
-    previousFreshChatRef.current = isFreshChat
-  }, [isFreshChat])
+    previousFreshChatRef.current = isFreshChat;
+  }, [isFreshChat]);
 
   React.useEffect(() => {
-    if (!effectiveDefaultCharacter || !effectiveDefaultCharacterId) return
+    if (!effectiveDefaultCharacter || !effectiveDefaultCharacterId) return;
     if (
       !shouldApplyDefaultCharacter({
         defaultCharacterId: effectiveDefaultCharacterId,
         selectedCharacterId: storedCharacterId,
         isFreshChat,
-        hasAppliedInSession: defaultCharacterBootstrapAppliedRef.current
+        hasAppliedInSession: defaultCharacterBootstrapAppliedRef.current,
       })
     ) {
-      return
+      return;
     }
 
-    defaultCharacterBootstrapAppliedRef.current = true
-    void setSelectedCharacter(effectiveDefaultCharacter)
+    defaultCharacterBootstrapAppliedRef.current = true;
+    void setSelectedCharacter(effectiveDefaultCharacter);
   }, [
     effectiveDefaultCharacter,
     effectiveDefaultCharacterId,
     isFreshChat,
     setSelectedCharacter,
-    storedCharacterId
-  ])
+    storedCharacterId,
+  ]);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
-    const handler = () => setOpenActorSettings(true)
-    window.addEventListener("tldw:open-actor-settings", handler)
+    if (typeof window === "undefined") return;
+    const handler = () => setOpenActorSettings(true);
+    window.addEventListener("tldw:open-actor-settings", handler);
     return () => {
-      window.removeEventListener("tldw:open-actor-settings", handler)
-    }
-  }, [])
+      window.removeEventListener("tldw:open-actor-settings", handler);
+    };
+  }, []);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
-    const handler = () => setOpenModelSettings(true)
-    window.addEventListener("tldw:open-model-settings", handler)
+    if (typeof window === "undefined") return;
+    const handler = () => setOpenModelSettings(true);
+    window.addEventListener("tldw:open-model-settings", handler);
     return () => {
-      window.removeEventListener("tldw:open-model-settings", handler)
-    }
-  }, [])
+      window.removeEventListener("tldw:open-model-settings", handler);
+    };
+  }, []);
 
   React.useEffect(() => {
-    if (!modeAnnouncement) return
+    if (!modeAnnouncement) return;
     const timer = window.setTimeout(() => {
-      setModeAnnouncement(null)
-    }, 3000)
+      setModeAnnouncement(null);
+    }, 3000);
     return () => {
-      window.clearTimeout(timer)
-    }
-  }, [modeAnnouncement])
+      window.clearTimeout(timer);
+    };
+  }, [modeAnnouncement]);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
     const handler = (event: Event) => {
-      const detail = (event as CustomEvent)?.detail || {}
+      const detail = (event as CustomEvent)?.detail || {};
       setDocumentGeneratorSeed({
         conversationId: detail?.conversationId ?? serverChatId ?? null,
         message: detail?.message ?? null,
-        messageId: detail?.messageId ?? null
-      })
-      setDocumentGeneratorOpen(true)
-    }
-    window.addEventListener("tldw:open-document-generator", handler)
+        messageId: detail?.messageId ?? null,
+      });
+      setDocumentGeneratorOpen(true);
+    };
+    window.addEventListener("tldw:open-document-generator", handler);
     return () => {
-      window.removeEventListener("tldw:open-document-generator", handler)
-    }
-  }, [serverChatId])
+      window.removeEventListener("tldw:open-document-generator", handler);
+    };
+  }, [serverChatId]);
 
   const {
     tabMentionsEnabled,
@@ -1118,19 +1121,19 @@ export const PlaygroundForm = ({
     removeDocument,
     clearSelectedDocuments,
     reloadTabs,
-    handleMentionsOpen
-  } = useTabMentions(textareaRef)
+    handleMentionsOpen,
+  } = useTabMentions(textareaRef);
 
   const { data: composerModels } = useQuery({
     queryKey: ["playground:chatModels"],
     queryFn: () => fetchChatModels({ returnEmpty: true }),
-    enabled: modelCatalogEnabled
-  })
+    enabled: modelCatalogEnabled,
+  });
   const { data: imageModels = [] } = useQuery({
     queryKey: ["playground:imageModels"],
     queryFn: () => fetchImageModels({ returnEmpty: true }),
-    enabled: true
-  })
+    enabled: true,
+  });
 
   const {
     modelDropdownOpen,
@@ -1154,35 +1157,35 @@ export const PlaygroundForm = ({
     toggleFavoriteModel,
     filteredModels,
     modelDropdownMenuItems,
-    isSmallModel
+    isSmallModel,
   } = useModelSelector({
     composerModels,
     selectedModel,
     setSelectedModel,
-    navigate
-  })
+    navigate,
+  });
 
   React.useEffect(() => {
-    setOptionalPanelVisible("model-catalog", modelDropdownOpen)
+    setOptionalPanelVisible("model-catalog", modelDropdownOpen);
     if (modelDropdownOpen) {
-      markOptionalPanelEngaged("model-catalog")
+      markOptionalPanelEngaged("model-catalog");
     }
 
     return () => {
-      setOptionalPanelVisible("model-catalog", false)
-    }
-  }, [markOptionalPanelEngaged, modelDropdownOpen, setOptionalPanelVisible])
+      setOptionalPanelVisible("model-catalog", false);
+    };
+  }, [markOptionalPanelEngaged, modelDropdownOpen, setOptionalPanelVisible]);
 
   React.useEffect(() => {
-    setOptionalPanelVisible("audio-health", voiceChatEnabled)
+    setOptionalPanelVisible("audio-health", voiceChatEnabled);
     if (voiceChatEnabled) {
-      markOptionalPanelEngaged("audio-health")
+      markOptionalPanelEngaged("audio-health");
     }
 
     return () => {
-      setOptionalPanelVisible("audio-health", false)
-    }
-  }, [markOptionalPanelEngaged, setOptionalPanelVisible, voiceChatEnabled])
+      setOptionalPanelVisible("audio-health", false);
+    };
+  }, [markOptionalPanelEngaged, setOptionalPanelVisible, voiceChatEnabled]);
 
   // Auto-select model on initial load when no model is selected
   // Priority: 1) First favorite model, 2) First available model
@@ -1192,10 +1195,10 @@ export const PlaygroundForm = ({
       models: (composerModels as any[]) || [],
       preferredModelIds: favoriteModels,
       isCurrentModelHydrating: selectedModelIsLoading,
-      arePreferencesHydrating: favoriteModelsIsLoading
-    })
+      arePreferencesHydrating: favoriteModelsIsLoading,
+    });
     if (nextModel) {
-      setSelectedModel(nextModel)
+      setSelectedModel(nextModel);
     }
   }, [
     composerModels,
@@ -1203,16 +1206,16 @@ export const PlaygroundForm = ({
     favoriteModelsIsLoading,
     selectedModel,
     selectedModelIsLoading,
-    setSelectedModel
-  ])
+    setSelectedModel,
+  ]);
 
   const hasPromptContext = React.useMemo(
     () =>
       Boolean(selectedSystemPrompt) ||
       Boolean(selectedQuickPrompt) ||
       String(systemPrompt || "").trim().length > 0,
-    [selectedQuickPrompt, selectedSystemPrompt, systemPrompt]
-  )
+    [selectedQuickPrompt, selectedSystemPrompt, systemPrompt],
+  );
 
   const modelComparison = useModelComparison({
     composerModels,
@@ -1230,8 +1233,8 @@ export const PlaygroundForm = ({
     hasPromptContext,
     jsonMode: Boolean(currentChatModelSettings.jsonMode),
     voiceChatEnabled,
-    t
-  })
+    t,
+  });
   const {
     compareModeActive,
     compareModelMetaById,
@@ -1244,28 +1247,28 @@ export const PlaygroundForm = ({
     toggleCompareMode,
     handleAddCompareModel,
     handleRemoveCompareModel,
-    sendLabel
-  } = modelComparison
+    sendLabel,
+  } = modelComparison;
 
   const voiceChatModelOptions = React.useMemo(() => {
     const options = [
       {
         value: "",
-        label: t("playground:voiceChat.useChatModel", "Use chat model")
-      }
-    ]
-    const models = (composerModels as any[]) || []
+        label: t("playground:voiceChat.useChatModel", "Use chat model"),
+      },
+    ];
+    const models = (composerModels as any[]) || [];
     for (const model of models) {
-      const pLabel = getProviderDisplayName(model.provider || "")
-      const modelLabel = model.nickname || model.model || model.name
-      const label = pLabel ? `${pLabel} - ${modelLabel}` : modelLabel
+      const pLabel = getProviderDisplayName(model.provider || "");
+      const modelLabel = model.nickname || model.model || model.name;
+      const label = pLabel ? `${pLabel} - ${modelLabel}` : modelLabel;
       options.push({
         value: model.model || model.name,
-        label
-      })
+        label,
+      });
     }
-    return options
-  }, [composerModels, t])
+    return options;
+  }, [composerModels, t]);
 
   const promptTemplates = usePromptTemplates({
     startupTemplatesRaw,
@@ -1288,8 +1291,8 @@ export const PlaygroundForm = ({
     compareModeActive,
     setCompareSelectedModels,
     setModeAnnouncement,
-    t
-  })
+    t,
+  });
   const {
     currentPresetKey,
     currentPreset,
@@ -1305,48 +1308,48 @@ export const PlaygroundForm = ({
     handleApplyStartupTemplate,
     handleDeleteStartupTemplate,
     handleTemplateSelect,
-    promptSummaryLabel
-  } = promptTemplates
+    promptSummaryLabel,
+  } = promptTemplates;
   React.useEffect(() => {
     if (previousPresetKeyRef.current == null) {
-      previousPresetKeyRef.current = currentPresetKey
-      return
+      previousPresetKeyRef.current = currentPresetKey;
+      return;
     }
     if (previousPresetKeyRef.current !== currentPresetKey) {
       if (currentPresetKey === "custom") {
         setModeAnnouncement(
           t(
             "playground:composer.presetChangedCustom",
-            "Preset switched to Custom."
-          )
-        )
+            "Preset switched to Custom.",
+          ),
+        );
       } else {
         const presetLabel = currentPreset
           ? t(
               `playground:presets.${currentPreset.key}.label`,
-              currentPreset.label
+              currentPreset.label,
             )
-          : currentPresetKey
+          : currentPresetKey;
         setModeAnnouncement(
           toText(
             t(
               "playground:composer.presetChanged",
               "{{preset}} preset applied.",
               {
-                preset: presetLabel
-              } as any
-            )
-          )
-        )
+                preset: presetLabel,
+              } as any,
+            ),
+          ),
+        );
       }
     }
-    previousPresetKeyRef.current = currentPresetKey
-  }, [currentPreset, currentPresetKey, t])
-  const isJsonModeActive = Boolean(currentChatModelSettings.jsonMode)
+    previousPresetKeyRef.current = currentPresetKey;
+  }, [currentPreset, currentPresetKey, t]);
+  const isJsonModeActive = Boolean(currentChatModelSettings.jsonMode);
   React.useEffect(() => {
     if (previousJsonModeRef.current == null) {
-      previousJsonModeRef.current = isJsonModeActive
-      return
+      previousJsonModeRef.current = isJsonModeActive;
+      return;
     }
     if (previousJsonModeRef.current !== isJsonModeActive) {
       setModeAnnouncement(
@@ -1354,50 +1357,50 @@ export const PlaygroundForm = ({
           ? t("playground:composer.jsonModeEnabledNotice", "JSON mode enabled.")
           : t(
               "playground:composer.jsonModeDisabledNotice",
-              "JSON mode disabled."
-            )
-      )
+              "JSON mode disabled.",
+            ),
+      );
     }
-    previousJsonModeRef.current = isJsonModeActive
-  }, [isJsonModeActive, t])
+    previousJsonModeRef.current = isJsonModeActive;
+  }, [isJsonModeActive, t]);
   React.useEffect(() => {
     const currentCharacterName =
       typeof selectedCharacter?.name === "string" &&
       selectedCharacter.name.trim().length > 0
         ? selectedCharacter.name.trim()
-        : null
+        : null;
     if (previousCharacterNameRef.current == null) {
-      previousCharacterNameRef.current = currentCharacterName
-      return
+      previousCharacterNameRef.current = currentCharacterName;
+      return;
     }
     if (currentCharacterName !== previousCharacterNameRef.current) {
       setModeAnnouncement(
         currentCharacterName
           ? t(
               "playground:composer.characterAppliesNextTurn",
-              "Character updates apply on the next turn."
+              "Character updates apply on the next turn.",
             )
           : t(
               "playground:composer.characterClearedNotice",
-              "Character mode cleared."
-            )
-      )
+              "Character mode cleared.",
+            ),
+      );
     }
-    previousCharacterNameRef.current = currentCharacterName
-  }, [selectedCharacter?.name, t])
+    previousCharacterNameRef.current = currentCharacterName;
+  }, [selectedCharacter?.name, t]);
   const connectionStatusLabel = React.useMemo(() => {
     if (!isConnectionReady) {
-      return t("playground:composer.providerStatusOffline", "Offline")
+      return t("playground:composer.providerStatusOffline", "Offline");
     }
     if (connectionUxState === "connected_degraded") {
-      return t("playground:composer.providerStatusDegraded", "Degraded")
+      return t("playground:composer.providerStatusDegraded", "Degraded");
     }
-    return t("playground:composer.providerStatusHealthy", "Healthy")
-  }, [connectionUxState, isConnectionReady, t])
+    return t("playground:composer.providerStatusHealthy", "Healthy");
+  }, [connectionUxState, isConnectionReady, t]);
   const isSessionDegraded = React.useMemo(
     () => !isConnectionReady || connectionUxState === "connected_degraded",
-    [connectionUxState, isConnectionReady]
-  )
+    [connectionUxState, isConnectionReady],
+  );
   const currentContextSnapshot = React.useMemo(
     () => ({
       model: selectedModel || null,
@@ -1408,7 +1411,7 @@ export const PlaygroundForm = ({
       jsonMode: Boolean(currentChatModelSettings.jsonMode),
       temporaryChat,
       webSearch,
-      contextToolsOpen
+      contextToolsOpen,
     }),
     [
       compareModeActive,
@@ -1419,14 +1422,14 @@ export const PlaygroundForm = ({
       selectedCharacter?.name,
       selectedModel,
       temporaryChat,
-      webSearch
-    ]
-  )
+      webSearch,
+    ],
+  );
   const contextDeltaLabels = React.useMemo(() => {
-    if (!lastSubmittedContext) return []
-    const deltas: string[] = []
+    if (!lastSubmittedContext) return [];
+    const deltas: string[] = [];
     if (lastSubmittedContext.model !== currentContextSnapshot.model) {
-      deltas.push(t("playground:composer.delta.model", "Model changed"))
+      deltas.push(t("playground:composer.delta.model", "Model changed"));
     }
     if (
       lastSubmittedContext.compareEnabled !==
@@ -1434,36 +1437,40 @@ export const PlaygroundForm = ({
       lastSubmittedContext.compareCount !== currentContextSnapshot.compareCount
     ) {
       deltas.push(
-        t("playground:composer.delta.compare", "Compare settings changed")
-      )
+        t("playground:composer.delta.compare", "Compare settings changed"),
+      );
     }
     if (
       lastSubmittedContext.characterName !==
       currentContextSnapshot.characterName
     ) {
-      deltas.push(t("playground:composer.delta.character", "Character changed"))
+      deltas.push(
+        t("playground:composer.delta.character", "Character changed"),
+      );
     }
     if (
       lastSubmittedContext.promptSummary !==
       currentContextSnapshot.promptSummary
     ) {
       deltas.push(
-        t("playground:composer.delta.prompt", "Prompt settings changed")
-      )
+        t("playground:composer.delta.prompt", "Prompt settings changed"),
+      );
     }
     if (lastSubmittedContext.jsonMode !== currentContextSnapshot.jsonMode) {
-      deltas.push(t("playground:composer.delta.json", "JSON mode changed"))
+      deltas.push(t("playground:composer.delta.json", "JSON mode changed"));
     }
     if (
       lastSubmittedContext.temporaryChat !==
       currentContextSnapshot.temporaryChat
     ) {
-      deltas.push(t("playground:composer.delta.temporary", "Save mode changed"))
+      deltas.push(
+        t("playground:composer.delta.temporary", "Save mode changed"),
+      );
     }
     if (lastSubmittedContext.webSearch !== currentContextSnapshot.webSearch) {
       deltas.push(
-        t("playground:composer.delta.webSearch", "Web search changed")
-      )
+        t("playground:composer.delta.webSearch", "Web search changed"),
+      );
     }
     if (
       lastSubmittedContext.contextToolsOpen !==
@@ -1472,40 +1479,40 @@ export const PlaygroundForm = ({
       deltas.push(
         t(
           "playground:composer.delta.knowledge",
-          "Knowledge panel state changed"
-        )
-      )
+          "Knowledge panel state changed",
+        ),
+      );
     }
-    return deltas
-  }, [currentContextSnapshot, lastSubmittedContext, t])
+    return deltas;
+  }, [currentContextSnapshot, lastSubmittedContext, t]);
   const characterPendingApply = React.useMemo(() => {
     const currentName =
       typeof selectedCharacter?.name === "string"
         ? selectedCharacter.name.trim()
-        : ""
+        : "";
     const previousName =
       typeof lastSubmittedContext?.characterName === "string"
         ? lastSubmittedContext.characterName.trim()
-        : ""
-    if (!currentName) return false
-    if (!lastSubmittedContext) return false
-    return currentName !== previousName
-  }, [lastSubmittedContext, selectedCharacter?.name])
+        : "";
+    if (!currentName) return false;
+    if (!lastSubmittedContext) return false;
+    return currentName !== previousName;
+  }, [lastSubmittedContext, selectedCharacter?.name]);
   const selectedCharacterGreeting = React.useMemo(() => {
     const raw =
       typeof selectedCharacter?.greeting === "string"
         ? selectedCharacter.greeting
-        : ""
-    const trimmed = raw.trim()
-    return trimmed.length > 0 ? trimmed : null
-  }, [selectedCharacter?.greeting])
+        : "";
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }, [selectedCharacter?.greeting]);
 
   // Enable focus shortcuts (Shift+Esc to focus textarea)
-  useFocusShortcuts(textareaRef, true)
+  useFocusShortcuts(textareaRef, true);
 
-  const [pasteLargeTextAsFile] = useStorage("pasteLargeTextAsFile", false)
+  const [pasteLargeTextAsFile] = useStorage("pasteLargeTextAsFile", false);
 
-  const msgCollapse = useMessageCollapse({ textareaRef })
+  const msgCollapse = useMessageCollapse({ textareaRef });
   const {
     isMessageCollapsed,
     setIsMessageCollapsed,
@@ -1526,12 +1533,12 @@ export const PlaygroundForm = ({
     getMessageCaretFromDisplay,
     collapseLargeMessage,
     expandLargeMessage,
-    restoreMessageValue: restoreCollapseState
-  } = msgCollapse
+    restoreMessageValue: restoreCollapseState,
+  } = msgCollapse;
 
   const stickyTextareaMaxHeight = React.useMemo(() => {
     if (!stickyDockEnabled) {
-      return undefined
+      return undefined;
     }
 
     return resolveStickyComposerTextareaMaxHeight({
@@ -1540,15 +1547,15 @@ export const PlaygroundForm = ({
       isMobileViewport,
       defaultMaxHeightPx: isProMode
         ? PRO_COMPOSER_MAX_HEIGHT_PX
-        : CASUAL_COMPOSER_MAX_HEIGHT_PX
-    })
+        : CASUAL_COMPOSER_MAX_HEIGHT_PX,
+    });
   }, [
     isMobileViewport,
     isProMode,
     mobileComposerViewport.keyboardInsetPx,
     stickyDockEnabled,
-    viewportHeightPx
-  ])
+    viewportHeightPx,
+  ]);
 
   const composerInput = useComposerInput({
     textareaRef,
@@ -1573,8 +1580,8 @@ export const PlaygroundForm = ({
     tabMentionsEnabled,
     handleTextChange,
     isProMode,
-    textareaMaxHeightOverride: stickyTextareaMaxHeight
-  })
+    textareaMaxHeightOverride: stickyTextareaMaxHeight,
+  });
   const {
     form,
     typing,
@@ -1596,12 +1603,12 @@ export const PlaygroundForm = ({
     measureComposerPerf,
     onComposerRenderProfile,
     wrapComposerProfile,
-    draftSaved
-  } = composerInput
+    draftSaved,
+  } = composerInput;
 
   const { deferredInput: deferredComposerInput } = useDeferredComposerInput(
-    form.values.message || ""
-  )
+    form.values.message || "",
+  );
 
   const {
     draftTokenCount,
@@ -1609,16 +1616,18 @@ export const PlaygroundForm = ({
     tokenUsageLabel,
     tokenUsageCompactLabel,
     tokenUsageTooltip,
-    estimateTokensForText
+    estimateTokensForText,
   } = useComposerTokens({
     message: form.values.message || "",
     messages,
     systemPrompt,
     resolvedMaxContext,
     apiModelLabel,
-    isSending
-  })
-  const tokenUsageDisplay = isProMode ? tokenUsageLabel : tokenUsageCompactLabel
+    isSending,
+  });
+  const tokenUsageDisplay = isProMode
+    ? tokenUsageLabel
+    : tokenUsageCompactLabel;
 
   const contextWindow = useContextWindow({
     draftTokenCount,
@@ -1641,8 +1650,8 @@ export const PlaygroundForm = ({
     jsonMode: Boolean(currentChatModelSettings.jsonMode),
     hasImageAttachment: Boolean(form.values.image),
     measureComposerPerf,
-    t
-  })
+    t,
+  });
   const {
     contextWindowModalOpen,
     setContextWindowModalOpen,
@@ -1678,27 +1687,27 @@ export const PlaygroundForm = ({
     openContextWindowModal,
     saveContextWindowSetting,
     resetContextWindowSetting,
-    openSessionInsightsModal
-  } = contextWindow
+    openSessionInsightsModal,
+  } = contextWindow;
   const handleModelRecommendationAction = React.useCallback(
     (action: ModelRecommendationAction) => {
       if (action === "open_model_settings") {
-        setOpenModelSettings(true)
-        return
+        setOpenModelSettings(true);
+        return;
       }
       if (action === "enable_json_mode") {
         if (!currentChatModelSettings.jsonMode) {
-          updateChatModelSetting("jsonMode", true)
+          updateChatModelSetting("jsonMode", true);
         }
-        setOpenModelSettings(true)
-        return
+        setOpenModelSettings(true);
+        return;
       }
       if (action === "open_context_window") {
-        openContextWindowModal()
-        return
+        openContextWindowModal();
+        return;
       }
       if (action === "open_session_insights") {
-        openSessionInsightsModal()
+        openSessionInsightsModal();
       }
     },
     [
@@ -1706,83 +1715,83 @@ export const PlaygroundForm = ({
       openContextWindowModal,
       openSessionInsightsModal,
       setOpenModelSettings,
-      updateChatModelSetting
-    ]
-  )
+      updateChatModelSetting,
+    ],
+  );
   const openModelApiSelector = React.useCallback(() => {
-    setModelDropdownOpen(true)
-  }, [setModelDropdownOpen])
+    setModelDropdownOpen(true);
+  }, [setModelDropdownOpen]);
   const getModelRecommendationActionLabel = React.useCallback(
     (action: ModelRecommendationAction) => {
       if (action === "enable_json_mode") {
-        return t("playground:composer.recommendationEnableJson", "Enable JSON")
+        return t("playground:composer.recommendationEnableJson", "Enable JSON");
       }
       if (action === "open_context_window") {
         return t(
           "playground:composer.recommendationAdjustContext",
-          "Adjust context"
-        )
+          "Adjust context",
+        );
       }
       if (action === "open_session_insights") {
         return t(
           "playground:composer.recommendationOpenInsights",
-          "Open insights"
-        )
+          "Open insights",
+        );
       }
       return t(
         "playground:composer.recommendationReviewModels",
-        "Review models"
-      )
+        "Review models",
+      );
     },
-    [t]
-  )
+    [t],
+  );
   const clearPromptContext = React.useCallback(() => {
-    setSelectedQuickPrompt(null)
-    setSelectedSystemPrompt("")
-    setSystemPrompt("")
-  }, [setSelectedQuickPrompt, setSelectedSystemPrompt, setSystemPrompt])
+    setSelectedQuickPrompt(null);
+    setSelectedSystemPrompt("");
+    setSystemPrompt("");
+  }, [setSelectedQuickPrompt, setSelectedSystemPrompt, setSystemPrompt]);
   const clearPinnedSourceContext = React.useCallback(() => {
-    setRagPinnedResults([])
-  }, [setRagPinnedResults])
+    setRagPinnedResults([]);
+  }, [setRagPinnedResults]);
   const clearHistoryContext = React.useCallback(() => {
-    clearChat()
-  }, [clearChat])
+    clearChat();
+  }, [clearChat]);
   const trimLargestContextContributor = React.useCallback(() => {
-    if (!largestContextContributor) return
+    if (!largestContextContributor) return;
     if (largestContextContributor.id === "character") {
-      setOpenActorSettings(true)
-      return
+      setOpenActorSettings(true);
+      return;
     }
     if (largestContextContributor.id === "prompt") {
-      clearPromptContext()
-      return
+      clearPromptContext();
+      return;
     }
     if (largestContextContributor.id === "pinned") {
-      clearPinnedSourceContext()
-      return
+      clearPinnedSourceContext();
+      return;
     }
     if (largestContextContributor.id === "history") {
-      clearHistoryContext()
+      clearHistoryContext();
     }
   }, [
     clearHistoryContext,
     clearPinnedSourceContext,
     clearPromptContext,
-    largestContextContributor
-  ])
+    largestContextContributor,
+  ]);
   const insertSummaryCheckpointPrompt = React.useCallback(() => {
     const checkpointPrompt = buildConversationSummaryCheckpointPrompt(
       messages,
       {
-        maxRecentMessages: 10
-      }
-    )
+        maxRecentMessages: 10,
+      },
+    );
     setMessageValue(checkpointPrompt, {
       collapseLarge: true,
-      forceCollapse: true
-    })
-    textAreaFocus()
-  }, [messages, setMessageValue, textAreaFocus])
+      forceCollapse: true,
+    });
+    textAreaFocus();
+  }, [messages, setMessageValue, textAreaFocus]);
 
   const {
     imageBackendDefault: imageBackendDefaultTrimmed,
@@ -1791,22 +1800,22 @@ export const PlaygroundForm = ({
     imageBackendLabel,
     imageBackendActiveKey,
     imageBackendMenuItems,
-    imageBackendBadgeLabel
-  } = useImageBackend({ imageModels })
+    imageBackendBadgeLabel,
+  } = useImageBackend({ imageModels });
 
   const modelSelectButton = (
     <Dropdown
       open={modelDropdownOpen}
       onOpenChange={(open) => {
-        setModelDropdownOpen(open)
+        setModelDropdownOpen(open);
         if (!open) {
-          setModelSearchQuery("")
+          setModelSearchQuery("");
         }
       }}
       menu={{
         items: modelDropdownMenuItems,
         className: "no-scrollbar",
-        activeKey: selectedModel ?? undefined
+        activeKey: selectedModel ?? undefined,
       }}
       popupRender={(menu) => (
         <div className="bg-surface rounded-lg shadow-lg border border-border">
@@ -1815,7 +1824,7 @@ export const PlaygroundForm = ({
               size="small"
               placeholder={t(
                 "playground:composer.modelSearchPlaceholder",
-                "Search models"
+                "Search models",
               )}
               value={modelSearchQuery}
               allowClear
@@ -1830,17 +1839,20 @@ export const PlaygroundForm = ({
               options={[
                 {
                   value: "favorites",
-                  label: t("playground:composer.sort.favorites", "Favorites")
+                  label: t("playground:composer.sort.favorites", "Favorites"),
                 },
                 { value: "az", label: t("playground:composer.sort.az", "A-Z") },
                 {
                   value: "provider",
-                  label: t("playground:composer.sort.provider", "Provider")
+                  label: t("playground:composer.sort.provider", "Provider"),
                 },
                 {
                   value: "localFirst",
-                  label: t("playground:composer.sort.localFirst", "Local-first")
-                }
+                  label: t(
+                    "playground:composer.sort.localFirst",
+                    "Local-first",
+                  ),
+                },
               ]}
               className="min-w-[120px]"
               onKeyDown={(event) => event.stopPropagation()}
@@ -1853,12 +1865,13 @@ export const PlaygroundForm = ({
             <Link
               to="/docs/models"
               className="flex items-center gap-1.5 text-xs text-primary hover:text-primary/80 transition-colors"
-              onClick={() => setModelDropdownOpen(false)}>
+              onClick={() => setModelDropdownOpen(false)}
+            >
               <HelpCircle className="h-3.5 w-3.5" />
               <span>
                 {t(
                   "playground:composer.helpMeChoose",
-                  "Help me choose a model"
+                  "Help me choose a model",
                 )}
               </span>
               <ArrowRight className="h-3 w-3" />
@@ -1867,17 +1880,19 @@ export const PlaygroundForm = ({
         </div>
       )}
       trigger={["click"]}
-      placement="topLeft">
+      placement="topLeft"
+    >
       <Tooltip
         title={
           modelSelectorWarning
             ? t(
                 "playground:composer.selectModelTooltip",
-                "Click to select a model"
+                "Click to select a model",
               )
             : apiModelLabel
         }
-        placement="top">
+        placement="top"
+      >
         <button
           type="button"
           title={apiModelLabel}
@@ -1889,7 +1904,8 @@ export const PlaygroundForm = ({
             modelSelectorWarning
               ? "border-warn/50 bg-warn/10 text-warn hover:bg-warn/20"
               : "border-border bg-surface hover:bg-surface-hover"
-          }`}>
+          }`}
+        >
           <ProviderIcons
             provider={resolvedProviderKey}
             className={`h-3 w-3 ${modelSelectorWarning ? "text-warn" : "text-text-subtle"}`}
@@ -1904,15 +1920,16 @@ export const PlaygroundForm = ({
             title={
               t(
                 "playground:composer.providerStatusTooltip",
-                "Provider status"
+                "Provider status",
               ) as string
-            }>
+            }
+          >
             {connectionStatusLabel}
           </span>
         </button>
       </Tooltip>
     </Dropdown>
-  )
+  );
 
   const modelUsageBadge = wrapComposerProfile(
     "token-progress",
@@ -1923,8 +1940,8 @@ export const PlaygroundForm = ({
       modelLabel={isProMode ? apiModelLabel : undefined}
       compact={!isProMode}
       onClick={openContextWindowModal}
-    />
-  )
+    />,
+  );
   const compareControl = (
     <CompareToggle
       featureEnabled={compareFeatureEnabled}
@@ -1937,23 +1954,25 @@ export const PlaygroundForm = ({
       onRemoveModel={handleRemoveCompareModel}
       onOpenSettings={() => setOpenModelSettings(true)}
     />
-  )
+  );
   const imageProviderControl = (
     <Dropdown
       menu={{
         items: imageBackendMenuItems,
-        activeKey: imageBackendActiveKey
+        activeKey: imageBackendActiveKey,
       }}
       trigger={["hover", "click"]}
-      placement="topRight">
+      placement="topRight"
+    >
       <button
         type="button"
         title={t(
           "playground:imageBackend.tooltip",
-          "Default image provider for /generate-image."
+          "Default image provider for /generate-image.",
         )}
         aria-label={imageBackendBadgeLabel}
-        className="flex w-full items-center justify-between rounded-md px-2 py-1 text-sm text-text transition hover:bg-surface2">
+        className="flex w-full items-center justify-between rounded-md px-2 py-1 text-sm text-text transition hover:bg-surface2"
+      >
         <span className="flex min-w-0 items-center gap-2">
           <ImageIcon className="h-4 w-4 text-text-subtle" />
           <span className="truncate">
@@ -1970,204 +1989,207 @@ export const PlaygroundForm = ({
         </span>
       </button>
     </Dropdown>
-  )
+  );
 
   // Allow other components (e.g., connection card) to request focus
   React.useEffect(() => {
     const handler = () => {
       if (document.visibilityState === "visible") {
-        textAreaFocus()
+        textAreaFocus();
       }
-    }
-    window.addEventListener("tldw:focus-composer", handler)
-    return () => window.removeEventListener("tldw:focus-composer", handler)
-  }, [textAreaFocus])
+    };
+    window.addEventListener("tldw:focus-composer", handler);
+    return () => window.removeEventListener("tldw:focus-composer", handler);
+  }, [textAreaFocus]);
 
   // Allow other components (e.g., empty state) to set the composer message
   React.useEffect(() => {
     const handler = (event: CustomEvent<{ message: string }>) => {
       if (event.detail?.message) {
-        form.setFieldValue("message", event.detail.message)
+        form.setFieldValue("message", event.detail.message);
       }
-    }
+    };
     window.addEventListener(
       "tldw:set-composer-message",
-      handler as EventListener
-    )
+      handler as EventListener,
+    );
     return () =>
       window.removeEventListener(
         "tldw:set-composer-message",
-        handler as EventListener
-      )
-  }, [form])
+        handler as EventListener,
+      );
+  }, [form]);
 
   React.useEffect(() => {
     const handleToggleCompareMode = () => {
-      toggleCompareMode()
-    }
+      toggleCompareMode();
+    };
     const handleToggleModeLauncher = () => {
-      setModeLauncherOpen((prev) => !prev)
-    }
+      setModeLauncherOpen((prev) => !prev);
+    };
 
-    window.addEventListener("tldw:toggle-compare-mode", handleToggleCompareMode)
+    window.addEventListener(
+      "tldw:toggle-compare-mode",
+      handleToggleCompareMode,
+    );
     window.addEventListener(
       "tldw:toggle-mode-launcher",
-      handleToggleModeLauncher
-    )
+      handleToggleModeLauncher,
+    );
     return () => {
       window.removeEventListener(
         "tldw:toggle-compare-mode",
-        handleToggleCompareMode
-      )
+        handleToggleCompareMode,
+      );
       window.removeEventListener(
         "tldw:toggle-mode-launcher",
-        handleToggleModeLauncher
-      )
-    }
-  }, [toggleCompareMode])
+        handleToggleModeLauncher,
+      );
+    };
+  }, [toggleCompareMode]);
 
   const applyDiscussMediaPayload = React.useCallback(
     (
       rawPayload: unknown,
       options?: {
-        clearAfterUse?: boolean
-      }
+        clearAfterUse?: boolean;
+      },
     ) => {
-      const payload = normalizeMediaChatHandoffPayload(rawPayload)
+      const payload = normalizeMediaChatHandoffPayload(rawPayload);
       if (!payload) {
         if (options?.clearAfterUse) {
-          void clearSetting(DISCUSS_MEDIA_PROMPT_SETTING)
+          void clearSetting(DISCUSS_MEDIA_PROMPT_SETTING);
         }
-        return
+        return;
       }
       if (options?.clearAfterUse) {
-        void clearSetting(DISCUSS_MEDIA_PROMPT_SETTING)
+        void clearSetting(DISCUSS_MEDIA_PROMPT_SETTING);
       }
-      const mode = getMediaChatHandoffMode(payload)
+      const mode = getMediaChatHandoffMode(payload);
       if (mode === "rag_media") {
-        const mediaId = parseMediaIdAsNumber(payload)
+        const mediaId = parseMediaIdAsNumber(payload);
         if (mediaId != null) {
-          setChatMode("rag")
-          setRagMediaIds([mediaId])
+          setChatMode("rag");
+          setRagMediaIds([mediaId]);
         }
       } else {
-        setChatMode("normal")
-        setRagMediaIds(null)
+        setChatMode("normal");
+        setRagMediaIds(null);
       }
-      const hint = buildDiscussMediaHint(payload)
-      if (!hint) return
-      setMessageValue(hint, { collapseLarge: true, forceCollapse: true })
-      textAreaFocus()
+      const hint = buildDiscussMediaHint(payload);
+      if (!hint) return;
+      setMessageValue(hint, { collapseLarge: true, forceCollapse: true });
+      textAreaFocus();
     },
-    [setChatMode, setMessageValue, setRagMediaIds, textAreaFocus]
-  )
+    [setChatMode, setMessageValue, setRagMediaIds, textAreaFocus],
+  );
 
   // Seed composer when a media item requests discussion (e.g., from Quick ingest or Review page)
   React.useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
     void (async () => {
-      const payload = await getSetting(DISCUSS_MEDIA_PROMPT_SETTING)
-      if (cancelled || !payload) return
-      applyDiscussMediaPayload(payload, { clearAfterUse: true })
-    })()
+      const payload = await getSetting(DISCUSS_MEDIA_PROMPT_SETTING);
+      if (cancelled || !payload) return;
+      applyDiscussMediaPayload(payload, { clearAfterUse: true });
+    })();
     return () => {
-      cancelled = true
-    }
-  }, [applyDiscussMediaPayload])
+      cancelled = true;
+    };
+  }, [applyDiscussMediaPayload]);
 
   React.useEffect(() => {
     const handler = (event: Event) => {
-      const detail = (event as CustomEvent).detail
-      applyDiscussMediaPayload(detail)
-    }
-    window.addEventListener("tldw:discuss-media", handler as any)
+      const detail = (event as CustomEvent).detail;
+      applyDiscussMediaPayload(detail);
+    };
+    window.addEventListener("tldw:discuss-media", handler as any);
     return () => {
-      window.removeEventListener("tldw:discuss-media", handler as any)
-    }
-  }, [applyDiscussMediaPayload])
+      window.removeEventListener("tldw:discuss-media", handler as any);
+    };
+  }, [applyDiscussMediaPayload]);
 
   const applyDiscussWatchlistPayload = React.useCallback(
     (rawPayload: unknown, options?: { clearAfterUse?: boolean }) => {
-      const payload = normalizeWatchlistChatHandoffPayload(rawPayload)
+      const payload = normalizeWatchlistChatHandoffPayload(rawPayload);
       if (!payload) {
         if (options?.clearAfterUse) {
-          void clearSetting(DISCUSS_WATCHLIST_PROMPT_SETTING)
+          void clearSetting(DISCUSS_WATCHLIST_PROMPT_SETTING);
         }
-        return
+        return;
       }
       if (options?.clearAfterUse) {
-        void clearSetting(DISCUSS_WATCHLIST_PROMPT_SETTING)
+        void clearSetting(DISCUSS_WATCHLIST_PROMPT_SETTING);
       }
-      setChatMode("normal")
-      setRagMediaIds(null)
-      const hint = buildWatchlistChatHint(payload)
-      if (!hint) return
-      setMessageValue(hint, { collapseLarge: true, forceCollapse: true })
-      textAreaFocus()
+      setChatMode("normal");
+      setRagMediaIds(null);
+      const hint = buildWatchlistChatHint(payload);
+      if (!hint) return;
+      setMessageValue(hint, { collapseLarge: true, forceCollapse: true });
+      textAreaFocus();
     },
-    [setChatMode, setMessageValue, setRagMediaIds, textAreaFocus]
-  )
+    [setChatMode, setMessageValue, setRagMediaIds, textAreaFocus],
+  );
 
   // Seed composer when a watchlist item requests discussion
   React.useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
     void (async () => {
-      const payload = await getSetting(DISCUSS_WATCHLIST_PROMPT_SETTING)
-      if (cancelled || !payload) return
-      applyDiscussWatchlistPayload(payload, { clearAfterUse: true })
-    })()
+      const payload = await getSetting(DISCUSS_WATCHLIST_PROMPT_SETTING);
+      if (cancelled || !payload) return;
+      applyDiscussWatchlistPayload(payload, { clearAfterUse: true });
+    })();
     return () => {
-      cancelled = true
-    }
-  }, [applyDiscussWatchlistPayload])
+      cancelled = true;
+    };
+  }, [applyDiscussWatchlistPayload]);
 
   React.useEffect(() => {
     const handler = (event: Event) => {
-      const detail = (event as CustomEvent).detail
-      applyDiscussWatchlistPayload(detail)
-    }
-    window.addEventListener("tldw:discuss-watchlist", handler as any)
+      const detail = (event as CustomEvent).detail;
+      applyDiscussWatchlistPayload(detail);
+    };
+    window.addEventListener("tldw:discuss-watchlist", handler as any);
     return () => {
-      window.removeEventListener("tldw:discuss-watchlist", handler as any)
-    }
-  }, [applyDiscussWatchlistPayload])
+      window.removeEventListener("tldw:discuss-watchlist", handler as any);
+    };
+  }, [applyDiscussWatchlistPayload]);
 
   React.useEffect(() => {
-    textAreaFocus()
-  }, [textAreaFocus])
+    textAreaFocus();
+  }, [textAreaFocus]);
 
   React.useEffect(() => {
     // Apply global default when the preference changes, but do not override per-chat toggles.
     if (defaultInternetSearchOn) {
-      setWebSearch(true)
+      setWebSearch(true);
     }
-  }, [defaultInternetSearchOn, setWebSearch])
+  }, [defaultInternetSearchOn, setWebSearch]);
 
   React.useEffect(() => {
     if (isConnectionReady) {
-      setShowConnectBanner(false)
+      setShowConnectBanner(false);
     }
-  }, [isConnectionReady])
+  }, [isConnectionReady]);
 
   const notifyImageAttachmentDisabled = React.useCallback(() => {
     notificationApi.warning({
       message: t(
         "playground:attachments.imageDisabledTitle",
-        "Image attachments disabled"
+        "Image attachments disabled",
       ),
       description: t(
         "playground:attachments.imageDisabledBody",
-        "Disable Knowledge Search to attach images."
-      )
-    })
-  }, [notificationApi, t])
+        "Disable Knowledge Search to attach images.",
+      ),
+    });
+  }, [notificationApi, t]);
 
   const attachments = usePlaygroundAttachments({
     chatMode,
     setFieldValue: form.setFieldValue,
     handleFileUpload,
-    notifyImageAttachmentDisabled
-  })
+    notifyImageAttachmentDisabled,
+  });
   const {
     inputRef,
     fileInputRef,
@@ -2175,79 +2197,79 @@ export const PlaygroundForm = ({
     onInputChange,
     handleImageUpload,
     handleDocumentUpload,
-    useDroppedFiles
-  } = attachments
+    useDroppedFiles,
+  } = attachments;
 
   // Process dropped files
-  useDroppedFiles(droppedFiles)
+  useDroppedFiles(droppedFiles);
 
   const handlePaste = React.useCallback(
     async (e: React.ClipboardEvent) => {
       if (e.clipboardData.files.length > 0) {
         try {
-          await onInputChange(e.clipboardData.files[0])
+          await onInputChange(e.clipboardData.files[0]);
         } catch (error) {
-          console.error("Failed to handle pasted file:", error)
+          console.error("Failed to handle pasted file:", error);
         }
-        return
+        return;
       }
 
-      const pastedText = e.clipboardData.getData("text/plain")
-      if (!pastedText) return
+      const pastedText = e.clipboardData.getData("text/plain");
+      if (!pastedText) return;
 
       if (pasteLargeTextAsFile && pastedText.length > PASTED_TEXT_CHAR_LIMIT) {
-        e.preventDefault()
-        const blob = new Blob([pastedText], { type: "text/plain" })
+        e.preventDefault();
+        const blob = new Blob([pastedText], { type: "text/plain" });
         const file = new File([blob], `pasted-text-${Date.now()}.txt`, {
-          type: "text/plain"
-        })
+          type: "text/plain",
+        });
 
-        await handleFileUpload(file)
-        return
+        await handleFileUpload(file);
+        return;
       }
 
       if (isMessageCollapsed && collapsedRange) {
-        e.preventDefault()
-        const currentValue = form.values.message || ""
-        const meta = getCollapsedDisplayMeta(currentValue, collapsedRange)
-        const textarea = textareaRef.current
-        const rawStart = textarea?.selectionStart ?? meta.labelEnd
-        const rawEnd = textarea?.selectionEnd ?? rawStart
-        const displayStart = Math.min(rawStart, rawEnd)
-        const displayEnd = Math.max(rawStart, rawEnd)
-        const hasSelection = displayStart !== displayEnd
+        e.preventDefault();
+        const currentValue = form.values.message || "";
+        const meta = getCollapsedDisplayMeta(currentValue, collapsedRange);
+        const textarea = textareaRef.current;
+        const rawStart = textarea?.selectionStart ?? meta.labelEnd;
+        const rawEnd = textarea?.selectionEnd ?? rawStart;
+        const displayStart = Math.min(rawStart, rawEnd);
+        const displayEnd = Math.max(rawStart, rawEnd);
+        const hasSelection = displayStart !== displayEnd;
         const selectionTouchesLabel =
-          displayStart < meta.labelEnd && displayEnd > meta.labelStart
+          displayStart < meta.labelEnd && displayEnd > meta.labelStart;
         if (hasSelection) {
           const startPrefer =
             displayStart > meta.labelStart && displayStart < meta.labelEnd
               ? "before"
-              : undefined
+              : undefined;
           const endPrefer =
             displayEnd > meta.labelStart && displayEnd < meta.labelEnd
               ? "after"
-              : undefined
+              : undefined;
           let editStart = getMessageCaretFromDisplay(displayStart, meta, {
-            prefer: startPrefer
-          })
+            prefer: startPrefer,
+          });
           let editEnd = getMessageCaretFromDisplay(displayEnd, meta, {
-            prefer: endPrefer
-          })
+            prefer: endPrefer,
+          });
           if (editStart > editEnd) {
-            ;[editStart, editEnd] = [editEnd, editStart]
+            [editStart, editEnd] = [editEnd, editStart];
           }
           if (selectionTouchesLabel) {
-            editStart = Math.min(editStart, meta.rangeStart)
-            editEnd = Math.max(editEnd, meta.rangeEnd)
+            editStart = Math.min(editStart, meta.rangeStart);
+            editEnd = Math.max(editEnd, meta.rangeEnd);
           }
           replaceCollapsedRange(
             currentValue,
             meta,
             editStart,
             editEnd,
-            pastedText
-          )
-          return
+            pastedText,
+          );
+          return;
         }
         const caretPrefer =
           rawStart > meta.labelStart && rawStart < meta.labelEnd
@@ -2255,55 +2277,55 @@ export const PlaygroundForm = ({
               pendingCaretRef.current <= meta.rangeStart
               ? "before"
               : "after"
-            : undefined
+            : undefined;
         let caret = getMessageCaretFromDisplay(rawStart, meta, {
-          prefer: caretPrefer
-        })
+          prefer: caretPrefer,
+        });
         if (caret > meta.rangeStart && caret < meta.rangeEnd) {
-          caret = meta.rangeEnd
+          caret = meta.rangeEnd;
         }
         const insertAt =
           caret <= meta.rangeStart
             ? caret
             : caret >= meta.rangeEnd
               ? caret
-              : meta.rangeEnd
+              : meta.rangeEnd;
         replaceCollapsedRange(
           currentValue,
           meta,
           insertAt,
           insertAt,
-          pastedText
-        )
-        return
+          pastedText,
+        );
+        return;
       }
 
-      const currentValue = form.values.message || ""
-      const textarea = textareaRef.current
-      const selectionStart = textarea?.selectionStart ?? currentValue.length
-      const selectionEnd = textarea?.selectionEnd ?? selectionStart
+      const currentValue = form.values.message || "";
+      const textarea = textareaRef.current;
+      const selectionStart = textarea?.selectionStart ?? currentValue.length;
+      const selectionEnd = textarea?.selectionEnd ?? selectionStart;
       const nextValue =
         currentValue.slice(0, selectionStart) +
         pastedText +
-        currentValue.slice(selectionEnd)
+        currentValue.slice(selectionEnd);
 
       if (nextValue.length > PASTED_TEXT_CHAR_LIMIT) {
-        e.preventDefault()
+        e.preventDefault();
         const blockRange = {
           start: selectionStart,
-          end: selectionStart + pastedText.length
-        }
-        pendingCaretRef.current = blockRange.end
+          end: selectionStart + pastedText.length,
+        };
+        pendingCaretRef.current = blockRange.end;
         pendingCollapsedStateRef.current = {
           message: nextValue,
           range: blockRange,
-          caret: blockRange.end
-        }
+          caret: blockRange.end,
+        };
         setMessageValue(nextValue, {
           collapseLarge: true,
           forceCollapse: true,
-          collapsedRange: blockRange
-        })
+          collapsedRange: blockRange,
+        });
       }
     },
     [
@@ -2317,77 +2339,77 @@ export const PlaygroundForm = ({
       pasteLargeTextAsFile,
       replaceCollapsedRange,
       setMessageValue,
-      textareaRef
-    ]
-  )
+      textareaRef,
+    ],
+  );
   const handleDisconnectedFocus = React.useCallback(() => {
     if (!isConnectionReady && !hasShownConnectBanner) {
-      setShowConnectBanner(true)
-      setHasShownConnectBanner(true)
+      setShowConnectBanner(true);
+      setHasShownConnectBanner(true);
     }
-  }, [hasShownConnectBanner, isConnectionReady])
+  }, [hasShownConnectBanner, isConnectionReady]);
 
   const handleTextareaKeyDown = (
-    e: React.KeyboardEvent<HTMLTextAreaElement>
+    e: React.KeyboardEvent<HTMLTextAreaElement>,
   ) => {
-    if (handleCollapsedKeyDown(e)) return
-    handleKeyDown(e)
-  }
+    if (handleCollapsedKeyDown(e)) return;
+    handleKeyDown(e);
+  };
 
   const handleTextareaFocus = React.useCallback(() => {
-    handleDisconnectedFocus()
-    if (!isMessageCollapsed) return
-    const wasPointer = pointerDownRef.current
-    pointerDownRef.current = false
-    if (wasPointer) return
-    const textarea = textareaRef.current
+    handleDisconnectedFocus();
+    if (!isMessageCollapsed) return;
+    const wasPointer = pointerDownRef.current;
+    pointerDownRef.current = false;
+    if (wasPointer) return;
+    const textarea = textareaRef.current;
     if (pendingCaretRef.current === null && textarea) {
       lastDisplaySelectionRef.current = {
         start: textarea.selectionStart ?? 0,
-        end: textarea.selectionEnd ?? textarea.selectionStart ?? 0
-      }
+        end: textarea.selectionEnd ?? textarea.selectionStart ?? 0,
+      };
     }
-    syncCollapsedCaret()
+    syncCollapsedCaret();
   }, [
     handleDisconnectedFocus,
     isMessageCollapsed,
     syncCollapsedCaret,
-    textareaRef
-  ])
+    textareaRef,
+  ]);
 
   const handleMentionSelect = React.useCallback(
     (tab: any) =>
       insertMention(tab, form.values.message, (value: string) =>
-        form.setFieldValue("message", value)
+        form.setFieldValue("message", value),
       ),
-    [insertMention, form]
-  )
+    [insertMention, form],
+  );
 
   const handleMentionRefetch = React.useCallback(async () => {
-    await reloadTabs()
-  }, [reloadTabs])
+    await reloadTabs();
+  }, [reloadTabs]);
 
   const handleKnowledgeInsert = React.useCallback(
     (text: string) => {
-      const current = textareaRef.current?.value || ""
-      const next = current ? `${current}\n\n${text}` : text
-      setMessageValue(next, { collapseLarge: true })
-      textAreaFocus()
+      const current = textareaRef.current?.value || "";
+      const next = current ? `${current}\n\n${text}` : text;
+      setMessageValue(next, { collapseLarge: true });
+      textAreaFocus();
     },
-    [setMessageValue, textAreaFocus, textareaRef]
-  )
+    [setMessageValue, textAreaFocus, textareaRef],
+  );
   const handleKnowledgePanelOpenChange = React.useCallback(
     (nextOpen: boolean) => {
-      setContextToolsOpen(nextOpen)
+      setContextToolsOpen(nextOpen);
     },
-    []
-  )
+    [],
+  );
   const handleKnowledgeRemoveImage = React.useCallback(() => {
-    form.setFieldValue("image", "")
-  }, [form.setFieldValue])
+    form.setFieldValue("image", "");
+  }, [form.setFieldValue]);
   const handleKnowledgeAddFile = React.useCallback(() => {
-    fileInputRef.current?.click()
-  }, [])
+    fileInputRef.current?.click();
+  }, []);
 
   const voiceChatHook = usePlaygroundVoiceChat({
     voiceConversationAvailability,
@@ -2420,8 +2442,8 @@ export const PlaygroundForm = ({
     isSending,
     isListening: false,
     isServerDictating: false,
-    t
-  })
+    t,
+  });
   const {
     isListening,
     browserSupportsSpeechRecognition,
@@ -2435,176 +2457,176 @@ export const PlaygroundForm = ({
     speechTooltipText,
     handleVoiceChatToggle,
     handleDictationToggle,
-    stopListening
-  } = voiceChatHook
-  const { sendWhenEnter, setSendWhenEnter } = useWebUI()
+    stopListening,
+  } = voiceChatHook;
+  const { sendWhenEnter, setSendWhenEnter } = useWebUI();
 
   React.useEffect(() => {
     if (!selectedQuickPrompt) {
-      return
+      return;
     }
 
-    const currentMessage = form.values.message || ""
-    const promptText = selectedQuickPrompt
+    const currentMessage = form.values.message || "";
+    const promptText = selectedQuickPrompt;
 
     const applyOverwrite = () => {
-      const word = getVariable(promptText)
-      setMessageValue(promptText, { collapseLarge: true })
+      const word = getVariable(promptText);
+      setMessageValue(promptText, { collapseLarge: true });
       if (word) {
-        textareaRef.current?.focus()
+        textareaRef.current?.focus();
         const interval = setTimeout(() => {
-          textareaRef.current?.setSelectionRange(word.start, word.end)
-          setSelectedQuickPrompt(null)
-        }, 100)
+          textareaRef.current?.setSelectionRange(word.start, word.end);
+          setSelectedQuickPrompt(null);
+        }, 100);
         return () => {
-          clearInterval(interval)
-        }
+          clearInterval(interval);
+        };
       }
-      setSelectedQuickPrompt(null)
-      return
-    }
+      setSelectedQuickPrompt(null);
+      return;
+    };
 
     const applyAppend = () => {
       const next =
         currentMessage.trim().length > 0
           ? `${currentMessage}\n\n${promptText}`
-          : promptText
-      setMessageValue(next, { collapseLarge: true })
-      setSelectedQuickPrompt(null)
-    }
+          : promptText;
+      setMessageValue(next, { collapseLarge: true });
+      setSelectedQuickPrompt(null);
+    };
 
     if (!currentMessage.trim()) {
-      applyOverwrite()
-      return
+      applyOverwrite();
+      return;
     }
 
     Modal.confirm({
       title: t("option:promptInsert.confirmTitle", {
-        defaultValue: "Use prompt in chat?"
+        defaultValue: "Use prompt in chat?",
       }),
       content: t("option:promptInsert.confirmDescription", {
         defaultValue:
-          "Your message already has text. Do you want to overwrite it with this prompt or append the prompt below it?"
+          "Your message already has text. Do you want to overwrite it with this prompt or append the prompt below it?",
       }),
       okText: t("option:promptInsert.overwrite", {
-        defaultValue: "Overwrite message"
+        defaultValue: "Overwrite message",
       }),
       cancelText: t("option:promptInsert.append", {
-        defaultValue: "Append"
+        defaultValue: "Append",
       }),
       closable: false,
       maskClosable: false,
       onOk: () => {
-        applyOverwrite()
+        applyOverwrite();
       },
       onCancel: () => {
-        applyAppend()
-      }
-    })
+        applyAppend();
+      },
+    });
   }, [
     selectedQuickPrompt,
     form.values.message,
     setMessageValue,
     setSelectedQuickPrompt,
     t,
-    textareaRef
-  ])
+    textareaRef,
+  ]);
 
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient();
   const invalidateServerChatHistory = React.useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ["serverChatHistory"] })
-  }, [queryClient])
+    queryClient.invalidateQueries({ queryKey: ["serverChatHistory"] });
+  }, [queryClient]);
 
   const { mutateAsync: sendMessage } = useMutation({
     mutationFn: onSubmit,
     onSuccess: () => {
       void trackOnboardingChatSubmitSuccess(
-        typeof window !== "undefined" ? window.location.pathname : "/chat"
-      )
-      textAreaFocus()
+        typeof window !== "undefined" ? window.location.pathname : "/chat",
+      );
+      textAreaFocus();
       queryClient.invalidateQueries({
-        queryKey: ["fetchChatHistory"]
-      })
+        queryKey: ["fetchChatHistory"],
+      });
     },
     onError: (error) => {
-      textAreaFocus()
-    }
-  })
+      textAreaFocus();
+    },
+  });
 
   const followUpResearchDraftQuery = React.useMemo(() => {
-    const trimmed = form.values.message.trim()
+    const trimmed = form.values.message.trim();
     if (!trimmed.startsWith(FOLLOW_UP_RESEARCH_PROMPT_PREFIX)) {
-      return trimmed
+      return trimmed;
     }
     const unwrapped = trimmed
       .slice(FOLLOW_UP_RESEARCH_PROMPT_PREFIX.length)
-      .trim()
-    return unwrapped || trimmed
-  }, [form.values.message])
+      .trim();
+    return unwrapped || trimmed;
+  }, [form.values.message]);
   const canLaunchFollowUpResearch =
     !temporaryChat &&
     Boolean(serverChatId) &&
-    followUpResearchDraftQuery.length > 0
+    followUpResearchDraftQuery.length > 0;
   const showFollowUpResearchButton =
-    Boolean(attachedResearchContext) && canLaunchFollowUpResearch
+    Boolean(attachedResearchContext) && canLaunchFollowUpResearch;
 
   const openFollowUpResearchModal = React.useCallback(() => {
-    if (!canLaunchFollowUpResearch) return
-    setIncludeAttachedResearchAsBackground(Boolean(attachedResearchContext))
-    setFollowUpResearchModalOpen(true)
-  }, [attachedResearchContext, canLaunchFollowUpResearch])
+    if (!canLaunchFollowUpResearch) return;
+    setIncludeAttachedResearchAsBackground(Boolean(attachedResearchContext));
+    setFollowUpResearchModalOpen(true);
+  }, [attachedResearchContext, canLaunchFollowUpResearch]);
 
   const closeFollowUpResearchModal = React.useCallback(() => {
-    if (followUpResearchPendingRef.current) return
-    setFollowUpResearchModalOpen(false)
-  }, [])
+    if (followUpResearchPendingRef.current) return;
+    setFollowUpResearchModalOpen(false);
+  }, []);
 
   const handleStartFollowUpResearch = React.useCallback(async () => {
-    if (followUpResearchPendingRef.current) return
-    if (!serverChatId || temporaryChat) return
-    if (!followUpResearchDraftQuery) return
+    if (followUpResearchPendingRef.current) return;
+    if (!serverChatId || temporaryChat) return;
+    if (!followUpResearchDraftQuery) return;
 
     const payload: ResearchRunCreateRequest = {
       query: followUpResearchDraftQuery,
       source_policy: "balanced",
       autonomy_mode: "checkpointed",
       chat_handoff: {
-        chat_id: serverChatId
+        chat_id: serverChatId,
       },
       follow_up: {
         question: followUpResearchDraftQuery,
         background:
           includeAttachedResearchAsBackground && attachedResearchContext
             ? buildFollowUpResearchBackground(attachedResearchContext)
-            : undefined
-      }
-    }
+            : undefined,
+      },
+    };
 
-    followUpResearchPendingRef.current = true
-    setFollowUpResearchPending(true)
+    followUpResearchPendingRef.current = true;
+    setFollowUpResearchPending(true);
     try {
-      await tldwClient.createResearchRun(payload)
+      await tldwClient.createResearchRun(payload);
       void queryClient.invalidateQueries({
-        queryKey: ["playground:chat-linked-research-runs", serverChatId]
-      })
-      setFollowUpResearchModalOpen(false)
+        queryKey: ["playground:chat-linked-research-runs", serverChatId],
+      });
+      setFollowUpResearchModalOpen(false);
       notificationApi.success?.({
         message: t(
           "playground:actions.followUpResearchStarted",
-          "Follow-up research started."
-        )
-      })
+          "Follow-up research started.",
+        ),
+      });
     } catch (error) {
       notificationApi.error({
         message: t(
           "playground:actions.followUpResearchFailed",
-          "Unable to start follow-up research."
+          "Unable to start follow-up research.",
         ),
-        description: error instanceof Error ? error.message : undefined
-      })
+        description: error instanceof Error ? error.message : undefined,
+      });
     } finally {
-      followUpResearchPendingRef.current = false
-      setFollowUpResearchPending(false)
+      followUpResearchPendingRef.current = false;
+      setFollowUpResearchPending(false);
     }
   }, [
     attachedResearchContext,
@@ -2614,8 +2636,8 @@ export const PlaygroundForm = ({
     queryClient,
     serverChatId,
     t,
-    temporaryChat
-  ])
+    temporaryChat,
+  ]);
 
   const queueMgmt = usePlaygroundQueueManagement({
     composerModels,
@@ -2663,8 +2685,8 @@ export const PlaygroundForm = ({
     clearUploadedFiles,
     textAreaFocus,
     notificationApi,
-    t
-  })
+    t,
+  });
   const {
     availableChatModelIds,
     isQueuedDispatchBlockedByComposerState,
@@ -2673,15 +2695,15 @@ export const PlaygroundForm = ({
     cancelCurrentAndRunDisabledReason,
     handleRunQueuedRequest,
     handleRunNextQueuedRequest,
-    validateSelectedChatModelsAvailability
-  } = queueMgmt
+    validateSelectedChatModelsAvailability,
+  } = queueMgmt;
 
   const handleToggleWebSearch = React.useCallback(() => {
-    setWebSearch(!webSearch)
-  }, [setWebSearch, webSearch])
+    setWebSearch(!webSearch);
+  }, [setWebSearch, webSearch]);
   const handleOpenModelSettings = React.useCallback(() => {
-    setOpenModelSettings(true)
-  }, [setOpenModelSettings])
+    setOpenModelSettings(true);
+  }, [setOpenModelSettings]);
   const {
     showSlashMenu,
     slashActiveIndex,
@@ -2689,7 +2711,7 @@ export const PlaygroundForm = ({
     filteredSlashCommands,
     resolveSubmissionIntent,
     activeImageCommand,
-    handleSlashCommandSelect: slashHandleSelect
+    handleSlashCommandSelect: slashHandleSelect,
   } = useSlashCommands({
     chatMode,
     setChatMode,
@@ -2699,15 +2721,15 @@ export const PlaygroundForm = ({
     imageBackendDefaultTrimmed,
     imageBackendLabel,
     setOpenModelSettings,
-    currentMessage: form.values.message
-  })
+    currentMessage: form.values.message,
+  });
 
   const handleSlashCommandSelect = React.useCallback(
     (command: SlashCommandItem) => {
-      slashHandleSelect(command, form.setFieldValue.bind(form), textareaRef)
+      slashHandleSelect(command, form.setFieldValue.bind(form), textareaRef);
     },
-    [slashHandleSelect, form, textareaRef]
-  )
+    [slashHandleSelect, form, textareaRef],
+  );
 
   const { submitForm, submitFormRef } = usePlaygroundSubmit({
     form,
@@ -2739,27 +2761,27 @@ export const PlaygroundForm = ({
     validateSelectedChatModelsAvailability,
     compareModelsSupportCapability,
     notificationApi,
-    t
-  })
+    t,
+  });
   React.useEffect(() => {
     voiceChatSubmitFormRef.current = () => {
-      submitForm()
-    }
-  }, [submitForm])
+      submitForm();
+    };
+  }, [submitForm]);
 
   const handleKnowledgeAsk = React.useCallback(
     (text: string, options?: { ignorePinnedResults?: boolean }) => {
-      const trimmed = text.trim()
-      if (!trimmed) return
-      setMessageValue(trimmed, { collapseLarge: true })
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      setMessageValue(trimmed, { collapseLarge: true });
       queueMicrotask(() =>
         submitFormRef.current({
-          ignorePinnedResults: options?.ignorePinnedResults
-        })
-      )
+          ignorePinnedResults: options?.ignorePinnedResults,
+        }),
+      );
     },
-    [setMessageValue, submitFormRef]
-  )
+    [setMessageValue, submitFormRef],
+  );
 
   const persistence = usePlaygroundPersistence({
     isFireFoxPrivateMode,
@@ -2781,8 +2803,8 @@ export const PlaygroundForm = ({
     invalidateServerChatHistory,
     navigate,
     notificationApi,
-    t
-  })
+    t,
+  });
   const {
     persistenceTooltip,
     focusConnectionCard,
@@ -2792,160 +2814,163 @@ export const PlaygroundForm = ({
     handleToggleTemporaryChat,
     handleSaveChatToServer,
     persistChatMetadata,
-    handleDismissServerPersistenceHint
-  } = persistence
+    handleDismissServerPersistenceHint,
+  } = persistence;
 
   const handleClearContext = React.useCallback(() => {
     // Only show confirmation if there's history to clear
     if (history.length === 0) {
-      return
+      return;
     }
 
     Modal.confirm({
       title: t(
         "playground:composer.clearContextConfirmTitle",
-        "Clear conversation?"
+        "Clear conversation?",
       ),
       content: t(
         "playground:composer.clearContextConfirmContent",
-        "This will remove all messages from the current conversation. This action cannot be undone."
+        "This will remove all messages from the current conversation. This action cannot be undone.",
       ),
       okText: t("common:confirm", "Confirm"),
       okButtonProps: { danger: true },
       cancelText: t("common:cancel", "Cancel"),
       onOk: () => {
-        setHistory([])
+        setHistory([]);
         notificationApi.success({
           message: t(
             "playground:composer.clearContextSuccess",
-            "Conversation cleared"
+            "Conversation cleared",
           ),
-          duration: 2
-        })
-      }
-    })
-  }, [history.length, notificationApi, setHistory, t])
+          duration: 2,
+        });
+      },
+    });
+  }, [history.length, notificationApi, setHistory, t]);
 
   const requestKnowledgePanelTab = React.useCallback((tab: KnowledgeTab) => {
-    setKnowledgePanelTab(tab)
-    setKnowledgePanelTabRequestId((id) => id + 1)
-  }, [])
+    setKnowledgePanelTab(tab);
+    setKnowledgePanelTabRequestId((id) => id + 1);
+  }, []);
 
   const openKnowledgePanel = React.useCallback(
     (tab: KnowledgeTab) => {
-      requestKnowledgePanelTab(tab)
-      setContextToolsOpen(true)
+      requestKnowledgePanelTab(tab);
+      setContextToolsOpen(true);
     },
-    [requestKnowledgePanelTab, setContextToolsOpen]
-  )
+    [requestKnowledgePanelTab, setContextToolsOpen],
+  );
 
   const toggleKnowledgePanel = React.useCallback(
     (tab: KnowledgeTab = "search") => {
-      const nextOpen = !contextToolsOpen
+      const nextOpen = !contextToolsOpen;
       if (nextOpen) {
-        requestKnowledgePanelTab(tab)
+        requestKnowledgePanelTab(tab);
       }
-      setContextToolsOpen(nextOpen)
+      setContextToolsOpen(nextOpen);
     },
-    [contextToolsOpen, requestKnowledgePanelTab, setContextToolsOpen]
-  )
+    [contextToolsOpen, requestKnowledgePanelTab, setContextToolsOpen],
+  );
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
     const handler = (event: Event) => {
-      const detail = (event as CustomEvent<{ tab?: KnowledgeTab }>).detail
-      const tab = detail?.tab === "context" ? "context" : "search"
-      openKnowledgePanel(tab)
+      const detail = (event as CustomEvent<{ tab?: KnowledgeTab }>).detail;
+      const tab = detail?.tab === "context" ? "context" : "search";
+      openKnowledgePanel(tab);
       setModeAnnouncement(
         t(
           "playground:starter.noticeKnowledge",
-          "Opened Search & Context panel."
-        )
-      )
-    }
+          "Opened Search & Context panel.",
+        ),
+      );
+    };
     window.addEventListener(
       "tldw:open-knowledge-panel",
-      handler as EventListener
-    )
+      handler as EventListener,
+    );
     return () => {
       window.removeEventListener(
         "tldw:open-knowledge-panel",
-        handler as EventListener
-      )
-    }
-  }, [openKnowledgePanel, t])
+        handler as EventListener,
+      );
+    };
+  }, [openKnowledgePanel, t]);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === "undefined") return;
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<{ mode?: string; prompt?: string }>)
-        .detail
+        .detail;
       const mode = String(detail?.mode || "")
         .trim()
-        .toLowerCase()
+        .toLowerCase();
       if (mode === "compare") {
         if (!compareFeatureEnabled) {
           notificationApi.warning({
             message: t(
               "playground:starter.compareUnavailable",
-              "Compare mode unavailable"
-            )
-          })
-          return
+              "Compare mode unavailable",
+            ),
+          });
+          return;
         }
-        setCompareMode(true)
+        setCompareMode(true);
         if (selectedModel && compareSelectedModels.length === 0) {
-          setCompareSelectedModels([selectedModel])
+          setCompareSelectedModels([selectedModel]);
         }
         setModeAnnouncement(
           t(
             "playground:starter.noticeCompare",
-            "Compare mode enabled. Select models and send your first prompt."
-          )
-        )
-        textAreaFocus()
-        return
+            "Compare mode enabled. Select models and send your first prompt.",
+          ),
+        );
+        textAreaFocus();
+        return;
       }
       if (mode === "character") {
-        setOpenActorSettings(true)
+        setOpenActorSettings(true);
         setModeAnnouncement(
           t(
             "playground:starter.noticeCharacter",
-            "Character mode starter selected. Choose a character before sending."
-          )
-        )
-        return
+            "Character mode starter selected. Choose a character before sending.",
+          ),
+        );
+        return;
       }
       if (mode === "rag" || mode === "knowledge") {
-        setChatMode("rag")
-        openKnowledgePanel("search")
+        setChatMode("rag");
+        openKnowledgePanel("search");
         setModeAnnouncement(
           t(
             "playground:starter.noticeRag",
-            "Knowledge starter selected. Search and pin sources before sending."
-          )
-        )
+            "Knowledge starter selected. Search and pin sources before sending.",
+          ),
+        );
         if (detail?.prompt) {
-          form.setFieldValue("message", String(detail.prompt))
+          form.setFieldValue("message", String(detail.prompt));
         }
-        textAreaFocus()
-        return
+        textAreaFocus();
+        return;
       }
       if (detail?.prompt) {
-        form.setFieldValue("message", String(detail.prompt))
+        form.setFieldValue("message", String(detail.prompt));
       }
       setModeAnnouncement(
-        t("playground:starter.noticeGeneral", "General chat starter selected.")
-      )
-      textAreaFocus()
-    }
-    window.addEventListener("tldw:playground-starter", handler as EventListener)
+        t("playground:starter.noticeGeneral", "General chat starter selected."),
+      );
+      textAreaFocus();
+    };
+    window.addEventListener(
+      "tldw:playground-starter",
+      handler as EventListener,
+    );
     return () => {
       window.removeEventListener(
         "tldw:playground-starter",
-        handler as EventListener
-      )
-    }
+        handler as EventListener,
+      );
+    };
   }, [
     compareFeatureEnabled,
     compareSelectedModels.length,
@@ -2957,8 +2982,8 @@ export const PlaygroundForm = ({
     setCompareMode,
     setCompareSelectedModels,
     t,
-    textAreaFocus
-  ])
+    textAreaFocus,
+  ]);
 
   const voiceChatSettingsFields = (
     <>
@@ -2995,17 +3020,17 @@ export const PlaygroundForm = ({
           size="small"
           placeholder={t(
             "playground:voiceChat.triggerPlaceholder",
-            "e.g. send it, over"
+            "e.g. send it, over",
           )}
           value={voiceChatTriggerInput}
           onChange={(e) => {
-            const value = e.target.value
-            setVoiceChatTriggerInput(value)
+            const value = e.target.value;
+            setVoiceChatTriggerInput(value);
             const parsed = value
               .split(",")
               .map((entry) => entry.trim())
-              .filter(Boolean)
-            setVoiceChatTriggerPhrases(parsed)
+              .filter(Boolean);
+            setVoiceChatTriggerPhrases(parsed);
           }}
         />
       </div>
@@ -3017,7 +3042,8 @@ export const PlaygroundForm = ({
           size="small"
           optionType="button"
           value={voiceChatTtsMode}
-          onChange={(e) => setVoiceChatTtsMode(e.target.value)}>
+          onChange={(e) => setVoiceChatTtsMode(e.target.value)}
+        >
           <Radio.Button value="stream">
             {t("playground:voiceChat.ttsModeStream", "Stream")}
           </Radio.Button>
@@ -3033,7 +3059,7 @@ export const PlaygroundForm = ({
         <AudioSourcePicker
           ariaLabel={t(
             "playground:voiceChat.sourcePickerLabel",
-            "Dictation input source"
+            "Dictation input source",
           )}
           devices={audioInputDevices}
           requestedSourceKind={dictationAudioSourcePreference.sourceKind}
@@ -3045,7 +3071,7 @@ export const PlaygroundForm = ({
               featureGroup: "dictation",
               sourceKind: nextValue.sourceKind,
               deviceId: nextValue.deviceId ?? null,
-              lastKnownLabel: nextValue.lastKnownLabel ?? null
+              lastKnownLabel: nextValue.lastKnownLabel ?? null,
             })
           }
         />
@@ -3054,7 +3080,7 @@ export const PlaygroundForm = ({
         <span className="text-[11px] text-text-muted">
           {t(
             "playground:voiceChat.autoResume",
-            "Continue listening after response"
+            "Continue listening after response",
           )}
         </span>
         <Switch
@@ -3074,17 +3100,17 @@ export const PlaygroundForm = ({
         />
       </div>
     </>
-  )
+  );
 
   React.useEffect(() => {
     if (contextToolsOpen) {
-      reloadTabs()
+      reloadTabs();
     }
-  }, [contextToolsOpen, reloadTabs])
+  }, [contextToolsOpen, reloadTabs]);
 
   // State for collapsible advanced section in tools popover
   const [advancedToolsExpanded, setAdvancedToolsExpanded] =
-    React.useState(isProMode)
+    React.useState(isProMode);
 
   const imageGen = usePlaygroundImageGen({
     imageBackendDefaultTrimmed: imageBackendDefaultTrimmed,
@@ -3102,8 +3128,8 @@ export const PlaygroundForm = ({
     textAreaFocus,
     notificationApi,
     t,
-    setToolsPopoverOpen
-  })
+    setToolsPopoverOpen,
+  });
   const {
     imageGenerateModalOpen,
     imageGenerateBackend,
@@ -3163,24 +3189,24 @@ export const PlaygroundForm = ({
     rejectRefinedImagePromptCandidate,
     submitImageGenerateModal,
     normalizeImageGenerationEventSyncMode: normalizeImageGenSyncMode,
-    normalizeImageGenerationEventSyncPolicy: normalizeImageGenSyncPolicy
-  } = imageGen
-  const { mcpSettingsOpen, setMcpSettingsOpen } = mcpCtrl
+    normalizeImageGenerationEventSyncPolicy: normalizeImageGenSyncPolicy,
+  } = imageGen;
+  const { mcpSettingsOpen, setMcpSettingsOpen } = mcpCtrl;
   React.useEffect(() => {
-    setOptionalPanelVisible("mcp-tools", mcpSettingsOpen)
+    setOptionalPanelVisible("mcp-tools", mcpSettingsOpen);
     if (mcpSettingsOpen || toolChoice !== "none") {
-      markOptionalPanelEngaged("mcp-tools")
+      markOptionalPanelEngaged("mcp-tools");
     }
 
     return () => {
-      setOptionalPanelVisible("mcp-tools", false)
-    }
+      setOptionalPanelVisible("mcp-tools", false);
+    };
   }, [
     markOptionalPanelEngaged,
     mcpSettingsOpen,
     setOptionalPanelVisible,
-    toolChoice
-  ])
+    toolChoice,
+  ]);
 
   // Image generation logic is now in usePlaygroundImageGen hook above.
 
@@ -3220,8 +3246,8 @@ export const PlaygroundForm = ({
     researchContext: compareModeActive ? undefined : researchContext,
     notificationApi,
     t,
-    setToolsPopoverOpen
-  })
+    setToolsPopoverOpen,
+  });
   const {
     rawRequestModalOpen,
     setRawRequestModalOpen,
@@ -3229,124 +3255,127 @@ export const PlaygroundForm = ({
     rawRequestJson,
     refreshRawRequestSnapshot,
     openRawRequestModal,
-    copyRawRequestJson
-  } = rawPreview
+    copyRawRequestJson,
+  } = rawPreview;
   React.useEffect(() => {
     setAttachedResearchContextDraft(
-      cloneAttachedResearchContext(attachedResearchContext)
-    )
-  }, [attachedResearchContext])
+      cloneAttachedResearchContext(attachedResearchContext),
+    );
+  }, [attachedResearchContext]);
   const attachedResearchPreviewSuppressed =
     Boolean(attachedResearchContext) &&
     Boolean(rawRequestSnapshot) &&
-    !(rawRequestSnapshot?.body as any)?.research_context
+    !(rawRequestSnapshot?.body as any)?.research_context;
 
   const applyAttachedResearchDraft = React.useCallback(() => {
-    if (!attachedResearchContext || !attachedResearchContextDraft) return
+    if (!attachedResearchContext || !attachedResearchContextDraft) return;
     const nextContext = applyAttachedResearchContextEdits(
       attachedResearchContext,
-      attachedResearchContextDraft
-    )
-    onApplyAttachedResearchContext?.(nextContext)
-    setAttachedResearchContextDraft(cloneAttachedResearchContext(nextContext))
+      attachedResearchContextDraft,
+    );
+    onApplyAttachedResearchContext?.(nextContext);
+    setAttachedResearchContextDraft(cloneAttachedResearchContext(nextContext));
   }, [
     attachedResearchContext,
     attachedResearchContextDraft,
-    onApplyAttachedResearchContext
-  ])
+    onApplyAttachedResearchContext,
+  ]);
 
   const handleResetAttachedResearchDraft = React.useCallback(() => {
     const resetContext = resetAttachedResearchContext(
-      attachedResearchContextBaseline
-    )
-    if (!resetContext) return
-    onResetAttachedResearchContext?.()
-    setAttachedResearchContextDraft(cloneAttachedResearchContext(resetContext))
-  }, [attachedResearchContextBaseline, onResetAttachedResearchContext])
+      attachedResearchContextBaseline,
+    );
+    if (!resetContext) return;
+    onResetAttachedResearchContext?.();
+    setAttachedResearchContextDraft(cloneAttachedResearchContext(resetContext));
+  }, [attachedResearchContextBaseline, onResetAttachedResearchContext]);
 
   const handleAttachedResearchDraftQuestionChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const nextQuestion = event.target.value
+      const nextQuestion = event.target.value;
       setAttachedResearchContextDraft((current) =>
-        current ? { ...current, question: nextQuestion } : current
-      )
+        current ? { ...current, question: nextQuestion } : current,
+      );
     },
-    []
-  )
+    [],
+  );
 
   const handleAttachedResearchDraftOutlineChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
       const nextOutline = event.target.value
         .split("\n")
-        .map((title) => ({ title }))
+        .map((title) => ({ title }));
       setAttachedResearchContextDraft((current) =>
-        current ? { ...current, outline: nextOutline } : current
-      )
+        current ? { ...current, outline: nextOutline } : current,
+      );
     },
-    []
-  )
+    [],
+  );
 
   const handleAttachedResearchDraftClaimsChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
       const nextClaims = event.target.value
         .split("\n")
-        .map((text) => ({ text }))
+        .map((text) => ({ text }));
       setAttachedResearchContextDraft((current) =>
-        current ? { ...current, key_claims: nextClaims } : current
-      )
+        current ? { ...current, key_claims: nextClaims } : current,
+      );
     },
-    []
-  )
+    [],
+  );
 
   const handleAttachedResearchDraftUnresolvedChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const nextQuestions = event.target.value.split("\n")
+      const nextQuestions = event.target.value.split("\n");
       setAttachedResearchContextDraft((current) =>
-        current ? { ...current, unresolved_questions: nextQuestions } : current
-      )
+        current ? { ...current, unresolved_questions: nextQuestions } : current,
+      );
     },
-    []
-  )
+    [],
+  );
 
   const navigateToWebSearchSettings = React.useCallback(() => {
-    navigate("/settings")
-  }, [navigate])
+    navigate("/settings");
+  }, [navigate]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (!isFirefoxTarget) {
-      if (e.key === "Process" || e.key === "229") return
+      if (e.key === "Process" || e.key === "229") return;
     }
 
     if (showSlashMenu) {
       if (e.key === "ArrowDown" && filteredSlashCommands.length > 0) {
-        e.preventDefault()
+        e.preventDefault();
         setSlashActiveIndex((prev) =>
-          prev + 1 >= filteredSlashCommands.length ? 0 : prev + 1
-        )
-        return
+          prev + 1 >= filteredSlashCommands.length ? 0 : prev + 1,
+        );
+        return;
       }
       if (e.key === "ArrowUp" && filteredSlashCommands.length > 0) {
-        e.preventDefault()
+        e.preventDefault();
         setSlashActiveIndex((prev) =>
-          prev <= 0 ? filteredSlashCommands.length - 1 : prev - 1
-        )
-        return
+          prev <= 0 ? filteredSlashCommands.length - 1 : prev - 1,
+        );
+        return;
       }
       if (
         (e.key === "Enter" || (e.key === "Tab" && !e.shiftKey)) &&
         filteredSlashCommands.length > 0
       ) {
-        e.preventDefault()
-        const command = filteredSlashCommands[slashActiveIndex]
+        e.preventDefault();
+        const command = filteredSlashCommands[slashActiveIndex];
         if (command) {
-          handleSlashCommandSelect(command)
+          handleSlashCommandSelect(command);
         }
-        return
+        return;
       }
       if (e.key === "Escape") {
-        e.preventDefault()
-        form.setFieldValue("message", form.values.message.replace(/^\s*\//, ""))
-        return
+        e.preventDefault();
+        form.setFieldValue(
+          "message",
+          form.values.message.replace(/^\s*\//, ""),
+        );
+        return;
       }
     }
 
@@ -3357,14 +3386,14 @@ export const PlaygroundForm = ({
         e.key === "Enter" ||
         e.key === "Escape")
     ) {
-      return
+      return;
     }
 
     if (!isConnectionReady) {
       if (e.key === "Enter") {
-        e.preventDefault()
+        e.preventDefault();
       }
-      return
+      return;
     }
 
     if (
@@ -3372,57 +3401,57 @@ export const PlaygroundForm = ({
         e,
         sendWhenEnter,
         typing,
-        isSending: false
+        isSending: false,
       })
     ) {
-      e.preventDefault()
-      stopListening()
-      submitForm()
+      e.preventDefault();
+      stopListening();
+      submitForm();
     }
-  }
+  };
 
   const handleCollapsedKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
-      if (!isMessageCollapsed || !collapsedRange) return false
+      if (!isMessageCollapsed || !collapsedRange) return false;
 
       const shouldSend = handleChatInputKeyDown({
         e,
         sendWhenEnter,
         typing,
-        isSending: false
-      })
-      if (shouldSend) return false
+        isSending: false,
+      });
+      if (shouldSend) return false;
 
-      const currentValue = form.values.message || ""
-      const meta = getCollapsedDisplayMeta(currentValue, collapsedRange)
-      const textarea = textareaRef.current
-      const rawStart = textarea?.selectionStart ?? meta.labelEnd
-      const rawEnd = textarea?.selectionEnd ?? rawStart
-      const displayStart = Math.min(rawStart, rawEnd)
-      const displayEnd = Math.max(rawStart, rawEnd)
-      const hasSelection = displayStart !== displayEnd
+      const currentValue = form.values.message || "";
+      const meta = getCollapsedDisplayMeta(currentValue, collapsedRange);
+      const textarea = textareaRef.current;
+      const rawStart = textarea?.selectionStart ?? meta.labelEnd;
+      const rawEnd = textarea?.selectionEnd ?? rawStart;
+      const displayStart = Math.min(rawStart, rawEnd);
+      const displayEnd = Math.max(rawStart, rawEnd);
+      const hasSelection = displayStart !== displayEnd;
       const selectionTouchesLabel =
-        displayStart < meta.labelEnd && displayEnd > meta.labelStart
+        displayStart < meta.labelEnd && displayEnd > meta.labelStart;
       const startPrefer =
         displayStart > meta.labelStart && displayStart < meta.labelEnd
           ? "before"
-          : undefined
+          : undefined;
       const endPrefer =
         displayEnd > meta.labelStart && displayEnd < meta.labelEnd
           ? "after"
-          : undefined
+          : undefined;
       let selectionStart = getMessageCaretFromDisplay(displayStart, meta, {
-        prefer: startPrefer
-      })
+        prefer: startPrefer,
+      });
       let selectionEnd = getMessageCaretFromDisplay(displayEnd, meta, {
-        prefer: endPrefer
-      })
+        prefer: endPrefer,
+      });
       if (selectionStart > selectionEnd) {
-        ;[selectionStart, selectionEnd] = [selectionEnd, selectionStart]
+        [selectionStart, selectionEnd] = [selectionEnd, selectionStart];
       }
       if (selectionTouchesLabel) {
-        selectionStart = Math.min(selectionStart, meta.rangeStart)
-        selectionEnd = Math.max(selectionEnd, meta.rangeEnd)
+        selectionStart = Math.min(selectionStart, meta.rangeStart);
+        selectionEnd = Math.max(selectionEnd, meta.rangeEnd);
       }
       const caretPrefer =
         rawStart > meta.labelStart && rawStart < meta.labelEnd
@@ -3430,21 +3459,21 @@ export const PlaygroundForm = ({
             pendingCaretRef.current <= meta.rangeStart
             ? "before"
             : "after"
-          : undefined
+          : undefined;
       let caret = getMessageCaretFromDisplay(rawStart, meta, {
-        prefer: caretPrefer
-      })
+        prefer: caretPrefer,
+      });
       if (caret > meta.rangeStart && caret < meta.rangeEnd) {
-        caret = meta.rangeEnd
+        caret = meta.rangeEnd;
       }
 
       const deleteCollapsedBlock = () => {
         const nextValue =
           currentValue.slice(0, meta.rangeStart) +
-          currentValue.slice(meta.rangeEnd)
-        const nextCaret = Math.min(meta.rangeStart, nextValue.length)
-        commitCollapsedEdit(nextValue, nextCaret, null)
-      }
+          currentValue.slice(meta.rangeEnd);
+        const nextCaret = Math.min(meta.rangeStart, nextValue.length);
+        commitCollapsedEdit(nextValue, nextCaret, null);
+      };
 
       const insertAtCaret = (text: string) => {
         const insertAt =
@@ -3452,149 +3481,149 @@ export const PlaygroundForm = ({
             ? caret
             : caret >= meta.rangeEnd
               ? caret
-              : meta.rangeEnd
-        replaceCollapsedRange(currentValue, meta, insertAt, insertAt, text)
-      }
+              : meta.rangeEnd;
+        replaceCollapsedRange(currentValue, meta, insertAt, insertAt, text);
+      };
 
       if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
-        if (e.shiftKey) return false
-        e.preventDefault()
-        let nextCaret = caret
+        if (e.shiftKey) return false;
+        e.preventDefault();
+        let nextCaret = caret;
         if (hasSelection) {
-          nextCaret = e.key === "ArrowLeft" ? selectionStart : selectionEnd
+          nextCaret = e.key === "ArrowLeft" ? selectionStart : selectionEnd;
         } else {
           nextCaret =
             e.key === "ArrowLeft"
               ? Math.max(0, caret - 1)
-              : Math.min(meta.messageLength, caret + 1)
+              : Math.min(meta.messageLength, caret + 1);
           if (nextCaret > meta.rangeStart && nextCaret < meta.rangeEnd) {
-            nextCaret = e.key === "ArrowLeft" ? meta.rangeStart : meta.rangeEnd
+            nextCaret = e.key === "ArrowLeft" ? meta.rangeStart : meta.rangeEnd;
           }
         }
-        pendingCaretRef.current = nextCaret
-        syncCollapsedCaret({ caret: nextCaret })
-        return true
+        pendingCaretRef.current = nextCaret;
+        syncCollapsedCaret({ caret: nextCaret });
+        return true;
       }
 
       if (e.key === "Backspace") {
         if (hasSelection) {
-          e.preventDefault()
+          e.preventDefault();
           replaceCollapsedRange(
             currentValue,
             meta,
             selectionStart,
             selectionEnd,
-            ""
-          )
-          return true
+            "",
+          );
+          return true;
         }
         if (caret === meta.rangeEnd) {
-          e.preventDefault()
-          deleteCollapsedBlock()
-          return true
+          e.preventDefault();
+          deleteCollapsedBlock();
+          return true;
         }
         if (caret === 0) {
-          e.preventDefault()
-          return true
+          e.preventDefault();
+          return true;
         }
         if (caret > meta.rangeStart && caret <= meta.rangeEnd) {
-          e.preventDefault()
-          deleteCollapsedBlock()
-          return true
+          e.preventDefault();
+          deleteCollapsedBlock();
+          return true;
         }
-        e.preventDefault()
+        e.preventDefault();
         replaceCollapsedRange(
           currentValue,
           meta,
           Math.max(0, caret - 1),
           caret,
-          ""
-        )
-        return true
+          "",
+        );
+        return true;
       }
 
       if (e.key === "Delete") {
         if (hasSelection) {
-          e.preventDefault()
+          e.preventDefault();
           replaceCollapsedRange(
             currentValue,
             meta,
             selectionStart,
             selectionEnd,
-            ""
-          )
-          return true
+            "",
+          );
+          return true;
         }
         if (caret === meta.rangeStart) {
-          e.preventDefault()
-          deleteCollapsedBlock()
-          return true
+          e.preventDefault();
+          deleteCollapsedBlock();
+          return true;
         }
         if (caret >= meta.messageLength) {
-          e.preventDefault()
-          return true
+          e.preventDefault();
+          return true;
         }
         if (caret >= meta.rangeStart && caret < meta.rangeEnd) {
-          e.preventDefault()
-          deleteCollapsedBlock()
-          return true
+          e.preventDefault();
+          deleteCollapsedBlock();
+          return true;
         }
-        e.preventDefault()
-        replaceCollapsedRange(currentValue, meta, caret, caret + 1, "")
-        return true
+        e.preventDefault();
+        replaceCollapsedRange(currentValue, meta, caret, caret + 1, "");
+        return true;
       }
 
       if (e.key === "Enter") {
-        e.preventDefault()
+        e.preventDefault();
         if (hasSelection) {
           replaceCollapsedRange(
             currentValue,
             meta,
             selectionStart,
             selectionEnd,
-            "\n"
-          )
+            "\n",
+          );
         } else {
-          insertAtCaret("\n")
+          insertAtCaret("\n");
         }
-        return true
+        return true;
       }
 
       if (e.key === " " || e.key === "Spacebar") {
-        e.preventDefault()
+        e.preventDefault();
         if (hasSelection) {
           replaceCollapsedRange(
             currentValue,
             meta,
             selectionStart,
             selectionEnd,
-            " "
-          )
+            " ",
+          );
         } else {
-          insertAtCaret(" ")
+          insertAtCaret(" ");
         }
-        return true
+        return true;
       }
 
       const isPrintable =
-        e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey
+        e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey;
       if (isPrintable) {
-        e.preventDefault()
+        e.preventDefault();
         if (hasSelection) {
           replaceCollapsedRange(
             currentValue,
             meta,
             selectionStart,
             selectionEnd,
-            e.key
-          )
+            e.key,
+          );
         } else {
-          insertAtCaret(e.key)
+          insertAtCaret(e.key);
         }
-        return true
+        return true;
       }
 
-      return false
+      return false;
     },
     [
       collapsedRange,
@@ -3608,9 +3637,9 @@ export const PlaygroundForm = ({
       sendWhenEnter,
       syncCollapsedCaret,
       textareaRef,
-      typing
-    ]
-  )
+      typing,
+    ],
+  );
 
   const contextItems = usePlaygroundContextItems({
     selectedModel,
@@ -3649,8 +3678,8 @@ export const PlaygroundForm = ({
     openContextWindowModal,
     openSessionInsightsModal,
     updateChatModelSetting,
-    t
-  })
+    t,
+  });
 
   const settingsHook = usePlaygroundSettings({
     selectedCharacterName: selectedCharacter?.name || null,
@@ -3679,13 +3708,13 @@ export const PlaygroundForm = ({
     setOpenActorSettings,
     trimLargestContextContributor,
     insertSummaryCheckpointPrompt,
-    t
-  })
+    t,
+  });
   const {
     compareSharedContextLabels,
     compareInteroperabilityNotices,
-    contextConflictWarnings
-  } = settingsHook
+    contextConflictWarnings,
+  } = settingsHook;
 
   const modeLauncherButton = (
     <PlaygroundModeLauncher
@@ -3709,7 +3738,7 @@ export const PlaygroundForm = ({
       onModeAnnouncement={setModeAnnouncement}
       t={t}
     />
-  )
+  );
 
   const externalPinSources =
     contextToolsOpen ||
@@ -3726,18 +3755,18 @@ export const PlaygroundForm = ({
     modeLauncherOpen ||
     toolsPopoverOpen ||
     attachmentMenuOpen ||
-    sendMenuOpen
+    sendMenuOpen;
 
   const {
     actionBarVisible,
     composerFocusWithin,
     actionBarVisibilityClass,
-    handlers: actionBarHandlers
-  } = useActionBarVisibility({ externalPinSources })
+    handlers: actionBarHandlers,
+  } = useActionBarVisibility({ externalPinSources });
   const [composerOptionsExpanded, setComposerOptionsExpanded] = useStorage(
     "playgroundComposerOptionsExpanded",
-    true
-  )
+    true,
+  );
   const shouldCompactComposerTextarea =
     !composerFocusWithin &&
     !contextToolsOpen &&
@@ -3745,61 +3774,61 @@ export const PlaygroundForm = ({
     !showMentions &&
     !isSending &&
     !isMessageCollapsed &&
-    messageDisplayValue.trim().length === 0
-  const composerShellRef = React.useRef<HTMLDivElement>(null)
+    messageDisplayValue.trim().length === 0;
+  const composerShellRef = React.useRef<HTMLDivElement>(null);
 
   const keepComposerBottomInView = React.useCallback(() => {
-    if (stickyDockEnabled) return
-    if (typeof window === "undefined") return
-    const composerEl = composerShellRef.current
-    if (!composerEl) return
+    if (stickyDockEnabled) return;
+    if (typeof window === "undefined") return;
+    const composerEl = composerShellRef.current;
+    if (!composerEl) return;
 
-    const bottomPadding = 8
-    const scrollingElement = document.scrollingElement as HTMLElement | null
+    const bottomPadding = 8;
+    const scrollingElement = document.scrollingElement as HTMLElement | null;
 
     const adjustAncestor = (ancestor: HTMLElement | null) => {
-      if (!ancestor) return
-      const composerRect = composerEl.getBoundingClientRect()
+      if (!ancestor) return;
+      const composerRect = composerEl.getBoundingClientRect();
 
       if (ancestor === scrollingElement) {
-        const viewportBottom = window.innerHeight - bottomPadding
-        const overflow = composerRect.bottom - viewportBottom
+        const viewportBottom = window.innerHeight - bottomPadding;
+        const overflow = composerRect.bottom - viewportBottom;
         if (overflow > 0) {
-          window.scrollBy({ top: overflow, behavior: "auto" })
+          window.scrollBy({ top: overflow, behavior: "auto" });
         }
-        return
+        return;
       }
 
-      const ancestorRect = ancestor.getBoundingClientRect()
+      const ancestorRect = ancestor.getBoundingClientRect();
       const overflow =
-        composerRect.bottom - (ancestorRect.bottom - bottomPadding)
+        composerRect.bottom - (ancestorRect.bottom - bottomPadding);
       if (overflow > 0) {
-        ancestor.scrollTop += overflow
+        ancestor.scrollTop += overflow;
       }
-    }
+    };
 
-    let parent = composerEl.parentElement
+    let parent = composerEl.parentElement;
     while (parent) {
-      const style = window.getComputedStyle(parent)
+      const style = window.getComputedStyle(parent);
       const allowsVerticalScroll = /(auto|scroll|overlay)/.test(
-        `${style.overflowY} ${style.overflow}`
-      )
+        `${style.overflowY} ${style.overflow}`,
+      );
       if (
         allowsVerticalScroll &&
         parent.scrollHeight > parent.clientHeight + 1
       ) {
-        adjustAncestor(parent)
+        adjustAncestor(parent);
       }
-      parent = parent.parentElement
+      parent = parent.parentElement;
     }
 
-    adjustAncestor(scrollingElement)
-  }, [stickyDockEnabled])
+    adjustAncestor(scrollingElement);
+  }, [stickyDockEnabled]);
 
   const notifyComposerLayoutChange = React.useCallback(() => {
-    if (!onComposerLayoutChange) return
+    if (!onComposerLayoutChange) return;
 
-    const composerEl = composerShellRef.current
+    const composerEl = composerShellRef.current;
     onComposerLayoutChange({
       occupiedHeightPx: composerEl
         ? Math.round(composerEl.getBoundingClientRect().height)
@@ -3807,192 +3836,192 @@ export const PlaygroundForm = ({
       keyboardInsetPx:
         stickyDockEnabled && isMobileViewport
           ? mobileComposerViewport.keyboardInsetPx
-          : 0
-    })
+          : 0,
+    });
   }, [
     isMobileViewport,
     mobileComposerViewport.keyboardInsetPx,
     onComposerLayoutChange,
-    stickyDockEnabled
-  ])
+    stickyDockEnabled,
+  ]);
 
   React.useEffect(() => {
-    if (!onComposerLayoutChange) return
-    if (typeof window === "undefined") return
+    if (!onComposerLayoutChange) return;
+    if (typeof window === "undefined") return;
 
-    let rafId = 0
+    let rafId = 0;
     const scheduleMeasurement = () => {
       if (rafId) {
-        window.cancelAnimationFrame(rafId)
+        window.cancelAnimationFrame(rafId);
       }
       rafId = window.requestAnimationFrame(() => {
-        rafId = 0
-        notifyComposerLayoutChange()
-      })
-    }
+        rafId = 0;
+        notifyComposerLayoutChange();
+      });
+    };
 
-    const composerEl = composerShellRef.current
-    scheduleMeasurement()
+    const composerEl = composerShellRef.current;
+    scheduleMeasurement();
 
     const resizeObserver =
       typeof ResizeObserver !== "undefined" && composerEl
         ? new ResizeObserver(() => {
-            scheduleMeasurement()
+            scheduleMeasurement();
           })
-        : null
-    resizeObserver?.observe(composerEl)
-    window.addEventListener("resize", scheduleMeasurement)
+        : null;
+    resizeObserver?.observe(composerEl);
+    window.addEventListener("resize", scheduleMeasurement);
 
     return () => {
       if (rafId) {
-        window.cancelAnimationFrame(rafId)
+        window.cancelAnimationFrame(rafId);
       }
-      resizeObserver?.disconnect()
-      window.removeEventListener("resize", scheduleMeasurement)
-    }
-  }, [notifyComposerLayoutChange, onComposerLayoutChange])
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleMeasurement);
+    };
+  }, [notifyComposerLayoutChange, onComposerLayoutChange]);
 
   React.useEffect(() => {
-    if (!onComposerLayoutChange) return
+    if (!onComposerLayoutChange) return;
 
     return () => {
       onComposerLayoutChange({
         occupiedHeightPx: 0,
-        keyboardInsetPx: 0
-      })
-    }
-  }, [onComposerLayoutChange])
+        keyboardInsetPx: 0,
+      });
+    };
+  }, [onComposerLayoutChange]);
 
-  const previousActionBarVisibleRef = React.useRef(actionBarVisible)
+  const previousActionBarVisibleRef = React.useRef(actionBarVisible);
 
   React.useEffect(() => {
-    const wasVisible = previousActionBarVisibleRef.current
-    previousActionBarVisibleRef.current = actionBarVisible
+    const wasVisible = previousActionBarVisibleRef.current;
+    previousActionBarVisibleRef.current = actionBarVisible;
 
-    if (!actionBarVisible || wasVisible) return
+    if (!actionBarVisible || wasVisible) return;
 
-    let timeoutId: number | null = null
+    let timeoutId: number | null = null;
     const rafId = window.requestAnimationFrame(() => {
-      keepComposerBottomInView()
+      keepComposerBottomInView();
       timeoutId = window.setTimeout(() => {
-        keepComposerBottomInView()
-      }, 220)
-    })
+        keepComposerBottomInView();
+      }, 220);
+    });
 
     return () => {
-      window.cancelAnimationFrame(rafId)
+      window.cancelAnimationFrame(rafId);
       if (timeoutId !== null) {
-        window.clearTimeout(timeoutId)
+        window.clearTimeout(timeoutId);
       }
-    }
-  }, [actionBarVisible, keepComposerBottomInView])
+    };
+  }, [actionBarVisible, keepComposerBottomInView]);
 
-  const previousKeyboardOpenRef = React.useRef(false)
+  const previousKeyboardOpenRef = React.useRef(false);
   React.useEffect(() => {
-    if (!isMobileViewport) return
-    if (typeof window === "undefined") return
+    if (!isMobileViewport) return;
+    if (typeof window === "undefined") return;
 
-    const wasOpen = previousKeyboardOpenRef.current
-    previousKeyboardOpenRef.current = mobileComposerViewport.keyboardOpen
+    const wasOpen = previousKeyboardOpenRef.current;
+    previousKeyboardOpenRef.current = mobileComposerViewport.keyboardOpen;
 
     if (!mobileComposerViewport.keyboardOpen && !wasOpen) {
-      return
+      return;
     }
 
-    let timeoutId: number | null = null
+    let timeoutId: number | null = null;
     const rafId = window.requestAnimationFrame(() => {
-      keepComposerBottomInView()
+      keepComposerBottomInView();
       timeoutId = window.setTimeout(() => {
-        keepComposerBottomInView()
-      }, 120)
-    })
+        keepComposerBottomInView();
+      }, 120);
+    });
 
     return () => {
-      window.cancelAnimationFrame(rafId)
+      window.cancelAnimationFrame(rafId);
       if (timeoutId != null) {
-        window.clearTimeout(timeoutId)
+        window.clearTimeout(timeoutId);
       }
-    }
+    };
   }, [
     isMobileViewport,
     keepComposerBottomInView,
     mobileComposerViewport.keyboardInsetPx,
-    mobileComposerViewport.keyboardOpen
-  ])
+    mobileComposerViewport.keyboardOpen,
+  ]);
 
   React.useEffect(() => {
-    if (typeof document === "undefined") return
+    if (typeof document === "undefined") return;
 
     const handleFocusIn = (event: FocusEvent) => {
-      const target = event.target
-      if (!(target instanceof Node)) return
-      if (!composerShellRef.current?.contains(target)) return
-      keepComposerBottomInView()
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (!composerShellRef.current?.contains(target)) return;
+      keepComposerBottomInView();
       if (typeof window !== "undefined") {
         window.setTimeout(() => {
-          keepComposerBottomInView()
-        }, 80)
+          keepComposerBottomInView();
+        }, 80);
       }
-    }
+    };
 
-    document.addEventListener("focusin", handleFocusIn)
+    document.addEventListener("focusin", handleFocusIn);
     return () => {
-      document.removeEventListener("focusin", handleFocusIn)
-    }
-  }, [keepComposerBottomInView])
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, [keepComposerBottomInView]);
 
-  const previousSendStateRef = React.useRef(isSending)
+  const previousSendStateRef = React.useRef(isSending);
   React.useEffect(() => {
     if (!isMobileViewport) {
-      previousSendStateRef.current = isSending
-      return
+      previousSendStateRef.current = isSending;
+      return;
     }
     if (typeof window === "undefined") {
-      previousSendStateRef.current = isSending
-      return
+      previousSendStateRef.current = isSending;
+      return;
     }
 
-    const wasSending = previousSendStateRef.current
-    previousSendStateRef.current = isSending
+    const wasSending = previousSendStateRef.current;
+    previousSendStateRef.current = isSending;
 
     if (!isSending && !wasSending) {
-      return
+      return;
     }
 
-    let timeoutId: number | null = null
+    let timeoutId: number | null = null;
     const rafId = window.requestAnimationFrame(() => {
-      keepComposerBottomInView()
+      keepComposerBottomInView();
       timeoutId = window.setTimeout(() => {
-        keepComposerBottomInView()
-      }, 100)
-    })
+        keepComposerBottomInView();
+      }, 100);
+    });
 
     return () => {
-      window.cancelAnimationFrame(rafId)
+      window.cancelAnimationFrame(rafId);
       if (timeoutId != null) {
-        window.clearTimeout(timeoutId)
+        window.clearTimeout(timeoutId);
       }
-    }
-  }, [isMobileViewport, isSending, keepComposerBottomInView])
+    };
+  }, [isMobileViewport, isSending, keepComposerBottomInView]);
 
   const toolRunStatusLabel = React.useMemo(() => {
     if (chatLoopState.pendingApprovals.length > 0) {
-      return t("playground:composer.toolRunPending", "Pending approval")
+      return t("playground:composer.toolRunPending", "Pending approval");
     }
     if (
       chatLoopState.inflightToolCallIds.length > 0 ||
       chatLoopState.status === "running"
     ) {
-      return t("playground:composer.toolRunRunning", "Running")
+      return t("playground:composer.toolRunRunning", "Running");
     }
     if (chatLoopState.status === "error") {
-      return t("playground:composer.toolRunFailed", "Failed")
+      return t("playground:composer.toolRunFailed", "Failed");
     }
     if (chatLoopState.status === "complete") {
-      return t("playground:composer.toolRunDone", "Done")
+      return t("playground:composer.toolRunDone", "Done");
     }
-    return t("playground:composer.toolRunIdle", "Idle")
-  }, [chatLoopState, t])
+    return t("playground:composer.toolRunIdle", "Idle");
+  }, [chatLoopState, t]);
 
   const mcpControl = (
     <PlaygroundMcpControl
@@ -4012,7 +4041,7 @@ export const PlaygroundForm = ({
       onOpenMcpSettings={() => setMcpSettingsOpen(true)}
       t={t}
     />
-  )
+  );
 
   const voiceChatButton = voiceChatAvailable ? (
     <Tooltip
@@ -4020,7 +4049,8 @@ export const PlaygroundForm = ({
         voiceChatEnabled
           ? t("playground:voiceChat.toolbarStop", "Stop voice chat")
           : t("playground:voiceChat.toolbarStart", "Start voice chat")
-      }>
+      }
+    >
       <button
         type="button"
         onClick={handleVoiceChatToggle}
@@ -4033,14 +4063,15 @@ export const PlaygroundForm = ({
             : voiceChatEnabled && voiceChat.state !== "idle"
               ? "bg-primary/10 text-primary animate-pulse"
               : "hover:bg-surface2 text-text-muted"
-        }`}>
+        }`}
+      >
         <Headphones className="h-4 w-4" />
         {voiceChatEnabled && voiceChat.state !== "idle" && (
           <span className="text-xs">{voiceChatStatusLabel}</span>
         )}
       </button>
     </Tooltip>
-  ) : null
+  ) : null;
 
   const toolsButton = (
     <PlaygroundToolsPopover
@@ -4081,7 +4112,7 @@ export const PlaygroundForm = ({
       onClearContext={handleClearContext}
       t={t}
     />
-  )
+  );
 
   const attachmentButton = (
     <PlaygroundAttachmentButton
@@ -4095,7 +4126,7 @@ export const PlaygroundForm = ({
       onAttachmentMenuChange={setAttachmentMenuOpen}
       t={t}
     />
-  )
+  );
   const sendControl = (
     <PlaygroundSendControl
       isProMode={isProMode}
@@ -4113,40 +4144,41 @@ export const PlaygroundForm = ({
       onSendMenuChange={setSendMenuOpen}
       t={t}
     />
-  )
+  );
 
   const startupTemplatePromptResolution = startupTemplatePreview
     ? resolveStartupTemplatePrompt(startupTemplatePreview, promptLibrary)
-    : null
+    : null;
   const startupTemplatePromptDescription = startupTemplatePreview
     ? describeStartupTemplatePrompt(startupTemplatePreview, promptLibrary)
-    : null
+    : null;
   const startupTemplatePreset = startupTemplatePreview
     ? getPresetByKey(startupTemplatePreview.presetKey)
-    : undefined
+    : undefined;
   const rawRequestModalFooterExtras = attachedResearchContextDraft ? (
     <>
       <Button onClick={handleResetAttachedResearchDraft}>
         {t(
           "playground:actions.resetAttachedResearchContext",
-          "Reset to Attached Run"
+          "Reset to Attached Run",
         )}
       </Button>
       <Button type="primary" onClick={applyAttachedResearchDraft}>
         {t("playground:actions.applyAttachedResearchContext", "Apply")}
       </Button>
     </>
-  ) : null
+  ) : null;
   const rawRequestAttachedResearchPanel = attachedResearchContextDraft ? (
     <div
       data-testid="attached-research-context-panel"
-      className="space-y-3 rounded-md border border-border bg-surface px-3 py-3">
+      className="space-y-3 rounded-md border border-border bg-surface px-3 py-3"
+    >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h3 className="text-sm font-medium text-text">
             {t(
               "playground:tools.attachedResearchContextTitle",
-              "Attached Research Context"
+              "Attached Research Context",
             )}
           </h3>
           <p className="text-xs text-text-muted">
@@ -4163,7 +4195,7 @@ export const PlaygroundForm = ({
           <div>
             {t("playground:tools.attachedResearchAttachedAt", "Attached")}:{" "}
             {new Date(
-              attachedResearchContextDraft.attached_at
+              attachedResearchContextDraft.attached_at,
             ).toLocaleString()}
           </div>
         </div>
@@ -4172,7 +4204,7 @@ export const PlaygroundForm = ({
         <p className="text-xs text-text-muted">
           {t(
             "playground:tools.attachedResearchContextSuppressed",
-            "Attached research is active but omitted from this request preview."
+            "Attached research is active but omitted from this request preview.",
           )}
         </p>
       ) : null}
@@ -4219,7 +4251,7 @@ export const PlaygroundForm = ({
           <label className="text-xs font-medium text-text-muted">
             {t(
               "playground:composer.context.unresolvedQuestions",
-              "Unresolved questions"
+              "Unresolved questions",
             )}
           </label>
           <Input.TextArea
@@ -4231,17 +4263,19 @@ export const PlaygroundForm = ({
         </div>
       </div>
     </div>
-  ) : null
+  ) : null;
 
   return (
     <React.Profiler
       id="playground-form-root"
-      onRender={onComposerRenderProfile}>
+      onRender={onComposerRenderProfile}
+    >
       <div className="flex w-full flex-col items-center px-4 pb-6">
         <div
           data-checkwidemode={checkWideMode}
           data-ui-mode={uiMode}
-          className="relative z-10 flex w-full max-w-[64rem] flex-col items-center justify-center gap-2 text-base data-[checkwidemode='true']:max-w-none">
+          className="relative z-10 flex w-full max-w-[64rem] flex-col items-center justify-center gap-2 text-base data-[checkwidemode='true']:max-w-none"
+        >
           <div className="relative flex w-full flex-row justify-center">
             <div
               ref={composerShellRef}
@@ -4262,16 +4296,17 @@ export const PlaygroundForm = ({
                   ? {
                       scrollMarginBottom: `${Math.max(
                         mobileComposerViewport.keyboardInsetPx,
-                        16
+                        16,
                       )}px`,
                       paddingBottom:
-                        "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)"
+                        "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)",
                     }
                   : undefined
               }
               className={`relative w-full rounded-3xl border border-transparent bg-surface/95 p-3 text-text shadow-card backdrop-blur-lg transition-all duration-200 data-[istemporary-chat='true']:border-t-4 data-[istemporary-chat='true']:border-t-purple-500 data-[istemporary-chat='true']:border-dashed data-[istemporary-chat='true']:opacity-90 ${
                 !isConnectionReady ? "opacity-80" : ""
-              }`}>
+              }`}
+            >
               {/* Attachments summary (collapsed context management) */}
               {wrapComposerProfile(
                 "attachments-summary",
@@ -4286,18 +4321,19 @@ export const PlaygroundForm = ({
                   onClearFiles={clearUploadedFiles}
                   onOpenKnowledgePanel={() => openKnowledgePanel("context")}
                   readOnly
-                />
+                />,
               )}
               {/* Link to Model Playground for Compare mode */}
               <div>
                 <div className="flex w-full min-w-0 bg-transparent">
                   <form
                     onSubmit={(event) => {
-                      event.preventDefault()
-                      stopListening()
-                      submitForm()
+                      event.preventDefault();
+                      stopListening();
+                      submitForm();
                     }}
-                    className="flex w-full min-w-0 flex-col items-center">
+                    className="flex w-full min-w-0 flex-col items-center"
+                  >
                     <input
                       id="file-upload"
                       name="file-upload"
@@ -4311,7 +4347,7 @@ export const PlaygroundForm = ({
                       aria-label={
                         t(
                           "playground:actions.attachImage",
-                          "Attach image"
+                          "Attach image",
                         ) as string
                       }
                       onChange={onInputChange}
@@ -4329,7 +4365,7 @@ export const PlaygroundForm = ({
                       aria-label={
                         t(
                           "playground:actions.attachDocument",
-                          "Attach document"
+                          "Attach document",
                         ) as string
                       }
                       onChange={onFileInputChange}
@@ -4340,15 +4376,17 @@ export const PlaygroundForm = ({
                         !isConnectionReady
                           ? "rounded-md border border-dashed border-border bg-surface2"
                           : ""
-                      }`}>
+                      }`}
+                    >
                       {showFollowUpResearchButton ? (
                         <div className="mb-2 flex flex-wrap items-center gap-2">
                           <Button
                             onClick={openFollowUpResearchModal}
-                            disabled={followUpResearchPending}>
+                            disabled={followUpResearchPending}
+                          >
                             {t(
                               "playground:actions.followUpResearch",
-                              "Follow-up Research"
+                              "Follow-up Research",
                             )}
                           </Button>
                         </div>
@@ -4379,13 +4417,14 @@ export const PlaygroundForm = ({
                           {attachedResearchContextPinned ? (
                             <div
                               data-testid="pinned-research-fallback-card"
-                              className="rounded-md border border-border bg-surface2 px-3 py-3 text-xs text-text">
+                              className="rounded-md border border-border bg-surface2 px-3 py-3 text-xs text-text"
+                            >
                               <div className="flex flex-col gap-2">
                                 <div className="flex flex-wrap items-center gap-2">
                                   <span className="font-medium text-text-muted">
                                     {t(
                                       "playground:composer.pinnedResearch",
-                                      "Pinned research"
+                                      "Pinned research",
                                     )}
                                   </span>
                                   <span className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text">
@@ -4395,7 +4434,7 @@ export const PlaygroundForm = ({
                                 <p className="text-[11px] text-text-muted">
                                   {t(
                                     "playground:composer.pinnedResearchFallbackDescription",
-                                    "This thread keeps this research as its default context."
+                                    "This thread keeps this research as its default context.",
                                   )}
                                 </p>
                                 <div className="flex flex-wrap items-center gap-2">
@@ -4404,10 +4443,11 @@ export const PlaygroundForm = ({
                                     onClick={() =>
                                       onRestorePinnedResearchContext?.()
                                     }
-                                    className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                    className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                  >
                                     {t(
                                       "playground:actions.usePinnedResearchNow",
-                                      "Use now"
+                                      "Use now",
                                     )}
                                   </button>
                                   <button
@@ -4415,20 +4455,22 @@ export const PlaygroundForm = ({
                                     onClick={() =>
                                       onUnpinAttachedResearchContext?.()
                                     }
-                                    className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                    className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                  >
                                     {t(
                                       "playground:actions.unpinResearchContext",
-                                      "Unpin"
+                                      "Unpin",
                                     )}
                                   </button>
                                   <Link
                                     to={
                                       attachedResearchContextPinned.research_url
                                     }
-                                    className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                    className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                  >
                                     {t(
                                       "playground:actions.openInResearch",
-                                      "Open in Research"
+                                      "Open in Research",
                                     )}
                                   </Link>
                                   {onPrepareResearchFollowUp ? (
@@ -4439,13 +4481,14 @@ export const PlaygroundForm = ({
                                           run_id:
                                             attachedResearchContextPinned.run_id,
                                           query:
-                                            attachedResearchContextPinned.query
+                                            attachedResearchContextPinned.query,
                                         })
                                       }
-                                      className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                      className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                    >
                                       {t(
                                         "playground:actions.followUp",
-                                        "Follow up"
+                                        "Follow up",
                                       )}
                                     </button>
                                   ) : null}
@@ -4456,7 +4499,7 @@ export const PlaygroundForm = ({
                                     <div className="font-medium">
                                       {t(
                                         "playground:actions.prepareFollowUpTitle",
-                                        "Prepare follow-up?"
+                                        "Prepare follow-up?",
                                       )}
                                     </div>
                                     <div className="text-text-muted">
@@ -4464,8 +4507,9 @@ export const PlaygroundForm = ({
                                         "playground:actions.prepareFollowUpBody",
                                         'This will use "{{query}}" and prefill a follow-up research prompt in the composer.',
                                         {
-                                          query: pendingAttachmentFollowUp.query
-                                        }
+                                          query:
+                                            pendingAttachmentFollowUp.query,
+                                        },
                                       )}
                                     </div>
                                     <div className="flex flex-wrap items-center gap-2">
@@ -4473,14 +4517,15 @@ export const PlaygroundForm = ({
                                         type="button"
                                         onClick={() => {
                                           onPrepareResearchFollowUp?.(
-                                            pendingAttachmentFollowUp
-                                          )
-                                          setPendingAttachmentFollowUp(null)
+                                            pendingAttachmentFollowUp,
+                                          );
+                                          setPendingAttachmentFollowUp(null);
                                         }}
-                                        className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                        className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                      >
                                         {t(
                                           "playground:actions.prepareFollowUp",
-                                          "Prepare follow-up"
+                                          "Prepare follow-up",
                                         )}
                                       </button>
                                       <button
@@ -4488,7 +4533,8 @@ export const PlaygroundForm = ({
                                         onClick={() =>
                                           setPendingAttachmentFollowUp(null)
                                         }
-                                        className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                        className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                      >
                                         {t("common:cancel", "Cancel")}
                                       </button>
                                     </div>
@@ -4500,18 +4546,20 @@ export const PlaygroundForm = ({
                           {attachedResearchContextHistory.length > 0 ? (
                             <div
                               data-testid="pinned-research-history-block"
-                              className="rounded-md border border-border bg-surface2 px-3 py-3 text-xs text-text">
+                              className="rounded-md border border-border bg-surface2 px-3 py-3 text-xs text-text"
+                            >
                               <div className="mb-2 font-medium text-text-muted">
                                 {t(
                                   "playground:composer.recentResearch",
-                                  "Recent research"
+                                  "Recent research",
                                 )}
                               </div>
                               <div className="flex flex-col gap-2">
                                 {attachedResearchContextHistory.map((entry) => (
                                   <div
                                     key={entry.run_id}
-                                    className="rounded border border-border bg-surface px-3 py-2">
+                                    className="rounded border border-border bg-surface px-3 py-2"
+                                  >
                                     <div className="flex flex-wrap items-center justify-between gap-2">
                                       <div className="min-w-0">
                                         <div className="truncate font-medium text-text">
@@ -4526,26 +4574,28 @@ export const PlaygroundForm = ({
                                           type="button"
                                           onClick={() =>
                                             onSelectAttachedResearchContextHistory?.(
-                                              entry
+                                              entry,
                                             )
                                           }
-                                          className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                          className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                        >
                                           {t(
                                             "playground:actions.usePinnedResearchNow",
-                                            "Use now"
+                                            "Use now",
                                           )}
                                         </button>
                                         <button
                                           type="button"
                                           onClick={() =>
                                             onPinAttachedResearchContextHistory?.(
-                                              entry
+                                              entry,
                                             )
                                           }
-                                          className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                          className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                        >
                                           {t(
                                             "playground:actions.pinResearchContext",
-                                            "Pin"
+                                            "Pin",
                                           )}
                                         </button>
                                         {onPrepareResearchFollowUp ? (
@@ -4554,13 +4604,14 @@ export const PlaygroundForm = ({
                                             onClick={() =>
                                               setPendingAttachmentFollowUp({
                                                 run_id: entry.run_id,
-                                                query: entry.query
+                                                query: entry.query,
                                               })
                                             }
-                                            className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                            className="rounded border border-border bg-surface2 px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                          >
                                             {t(
                                               "playground:actions.followUp",
-                                              "Follow up"
+                                              "Follow up",
                                             )}
                                           </button>
                                         ) : null}
@@ -4572,7 +4623,7 @@ export const PlaygroundForm = ({
                                         <div className="font-medium">
                                           {t(
                                             "playground:actions.prepareFollowUpTitle",
-                                            "Prepare follow-up?"
+                                            "Prepare follow-up?",
                                           )}
                                         </div>
                                         <div className="text-text-muted">
@@ -4581,8 +4632,8 @@ export const PlaygroundForm = ({
                                             'This will use "{{query}}" and prefill a follow-up research prompt in the composer.',
                                             {
                                               query:
-                                                pendingAttachmentFollowUp.query
-                                            }
+                                                pendingAttachmentFollowUp.query,
+                                            },
                                           )}
                                         </div>
                                         <div className="flex flex-wrap items-center gap-2">
@@ -4590,14 +4641,17 @@ export const PlaygroundForm = ({
                                             type="button"
                                             onClick={() => {
                                               onPrepareResearchFollowUp?.(
-                                                pendingAttachmentFollowUp
-                                              )
-                                              setPendingAttachmentFollowUp(null)
+                                                pendingAttachmentFollowUp,
+                                              );
+                                              setPendingAttachmentFollowUp(
+                                                null,
+                                              );
                                             }}
-                                            className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                            className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                          >
                                             {t(
                                               "playground:actions.prepareFollowUp",
-                                              "Prepare follow-up"
+                                              "Prepare follow-up",
                                             )}
                                           </button>
                                           <button
@@ -4605,7 +4659,8 @@ export const PlaygroundForm = ({
                                             onClick={() =>
                                               setPendingAttachmentFollowUp(null)
                                             }
-                                            className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3">
+                                            className="rounded border border-border bg-surface px-2 py-0.5 text-[11px] text-text hover:bg-surface3"
+                                          >
                                             {t("common:cancel", "Cancel")}
                                           </button>
                                         </div>
@@ -4659,19 +4714,20 @@ export const PlaygroundForm = ({
                                 onClick={clearReplyTarget}
                                 aria-label={t(
                                   "common:clearReply",
-                                  "Clear reply target"
+                                  "Clear reply target",
                                 )}
                                 title={
                                   t(
                                     "common:clearReply",
-                                    "Clear reply target"
+                                    "Clear reply target",
                                   ) as string
                                 }
-                                className="rounded p-1 text-text-subtle hover:bg-surface hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus">
+                                className="rounded p-1 text-text-subtle hover:bg-surface hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+                              >
                                 <X className="h-3.5 w-3.5" aria-hidden="true" />
                               </button>
                             </div>
-                          ) : null
+                          ) : null;
 
                         const composerTextareaNode = (
                           <div className="relative">
@@ -4686,34 +4742,35 @@ export const PlaygroundForm = ({
                                   composerOptionsExpanded
                                     ? (t(
                                         "playground:composer.hideOptions",
-                                        "Hide composer options"
+                                        "Hide composer options",
                                       ) as string)
                                     : (t(
                                         "playground:composer.showOptions",
-                                        "Show composer options"
+                                        "Show composer options",
                                       ) as string)
                                 }
                                 title={
                                   composerOptionsExpanded
                                     ? (t(
                                         "playground:composer.hideOptions",
-                                        "Hide composer options"
+                                        "Hide composer options",
                                       ) as string)
                                     : (t(
                                         "playground:composer.showOptions",
-                                        "Show composer options"
+                                        "Show composer options",
                                       ) as string)
                                 }
                                 onClick={() =>
                                   setComposerOptionsExpanded(
-                                    !composerOptionsExpanded
+                                    !composerOptionsExpanded,
                                   )
                                 }
                                 className={`inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-border/70 bg-surface/80 text-text-muted transition hover:bg-surface2 hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/40 ${
                                   composerOptionsExpanded
                                     ? "border-primary/40 text-primaryStrong"
                                     : ""
-                                }`}>
+                                }`}
+                              >
                                 <ChevronRight
                                   className={`h-4 w-4 transition-transform ${
                                     composerOptionsExpanded ? "rotate-90" : ""
@@ -4741,11 +4798,11 @@ export const PlaygroundForm = ({
                                       isConnectionReady
                                         ? t(
                                             "playground:composer.placeholderWithMentions",
-                                            "Type a message... (/ commands, @ mentions)"
+                                            "Type a message... (/ commands, @ mentions)",
                                           )
                                         : t(
                                             "playground:composer.connectionPlaceholder",
-                                            "Connect to tldw to start chatting."
+                                            "Connect to tldw to start chatting.",
                                           )
                                     }
                                     isProMode={isProMode}
@@ -4757,7 +4814,7 @@ export const PlaygroundForm = ({
                                       shouldCompactComposerTextarea
                                     }
                                     formInputProps={form.getInputProps(
-                                      "message"
+                                      "message",
                                     )}
                                     showSlashMenu={showSlashMenu}
                                     slashCommands={filteredSlashCommands}
@@ -4768,7 +4825,7 @@ export const PlaygroundForm = ({
                                     }
                                     slashEmptyLabel={t(
                                       "common:commandPalette.noResults",
-                                      "No results found"
+                                      "No results found",
                                     )}
                                     showMentions={showMentions}
                                     filteredTabs={filteredTabs}
@@ -4778,17 +4835,18 @@ export const PlaygroundForm = ({
                                     onMentionRefetch={handleMentionRefetch}
                                     onMentionsOpen={handleMentionsOpen}
                                     draftSaved={draftSaved}
-                                  />
+                                  />,
                                 )}
                               </div>
                               <div
                                 data-testid="composer-inline-send-control"
-                                className="flex shrink-0 items-end self-end">
+                                className="flex shrink-0 items-end self-end"
+                              >
                                 {sendControl}
                               </div>
                             </div>
                           </div>
-                        )
+                        );
 
                         const composerInlineMessagesNode = (
                           <>
@@ -4797,12 +4855,14 @@ export const PlaygroundForm = ({
                                 role="alert"
                                 aria-live="assertive"
                                 aria-atomic="true"
-                                className="flex items-center justify-between gap-2 px-2 py-1 text-xs text-danger animate-shake">
+                                className="flex items-center justify-between gap-2 px-2 py-1 text-xs text-danger animate-shake"
+                              >
                                 <div className="flex items-center gap-2">
                                   <svg
                                     className="h-3.5 w-3.5 flex-shrink-0"
                                     fill="currentColor"
-                                    viewBox="0 0 20 20">
+                                    viewBox="0 0 20 20"
+                                  >
                                     <path
                                       fillRule="evenodd"
                                       d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
@@ -4822,7 +4882,8 @@ export const PlaygroundForm = ({
                                   }
                                   title={
                                     t("common:dismiss", "Dismiss") as string
-                                  }>
+                                  }
+                                >
                                   <X className="h-3 w-3" />
                                 </button>
                               </div>
@@ -4838,7 +4899,8 @@ export const PlaygroundForm = ({
                                         className="h-3 w-3"
                                         fill="none"
                                         stroke="currentColor"
-                                        viewBox="0 0 24 24">
+                                        viewBox="0 0 24 24"
+                                      >
                                         <path
                                           strokeLinecap="round"
                                           strokeLinejoin="round"
@@ -4848,7 +4910,7 @@ export const PlaygroundForm = ({
                                       </svg>
                                       {t(
                                         "sidepanel:composer.hints.selectModel",
-                                        "Select a model above to start chatting"
+                                        "Select a model above to start chatting",
                                       )}
                                     </span>
                                   ) : form.values.message.trim().length === 0 &&
@@ -4857,18 +4919,18 @@ export const PlaygroundForm = ({
                                       {sendWhenEnter
                                         ? t(
                                             "sidepanel:composer.hints.typeAndEnter",
-                                            "Type a message and press Enter to send"
+                                            "Type a message and press Enter to send",
                                           )
                                         : t(
                                             "sidepanel:composer.hints.typeAndClick",
-                                            "Type a message and click Send"
+                                            "Type a message and click Send",
                                           )}
                                     </span>
                                   ) : null}
                                 </div>
                               )}
                           </>
-                        )
+                        );
                         /* Guarded top-level notice/modal contract:
                           Changed since last send:
                           playground:composer.providerDegraded
@@ -4941,7 +5003,7 @@ export const PlaygroundForm = ({
                               sessionInsights.totals.totalTokens
                             }
                             jsonMode={Boolean(
-                              currentChatModelSettings.jsonMode
+                              currentChatModelSettings.jsonMode,
                             )}
                             isConnectionReady={isConnectionReady}
                             connectionUxState={connectionUxState}
@@ -4979,13 +5041,14 @@ export const PlaygroundForm = ({
                             wrapComposerProfile={wrapComposerProfile}
                             t={t}
                           />
-                        )
+                        );
 
                         const composerToolbarNode = (
                           <div
                             id="composer-options-panel"
                             aria-hidden={!actionBarVisible}
-                            className={`w-full transition-all duration-200 overflow-hidden ${actionBarVisibilityClass}`}>
+                            className={`w-full transition-all duration-200 overflow-hidden ${actionBarVisibilityClass}`}
+                          >
                             {wrapComposerProfile(
                               "composer-toolbar",
                               <ComposerToolbar
@@ -5056,10 +5119,10 @@ export const PlaygroundForm = ({
                                 }
                                 onFocusConnectionCard={focusConnectionCard}
                                 contextItems={contextItems}
-                              />
+                              />,
                             )}
                           </div>
-                        )
+                        );
 
                         if (nextgenComposerEnabled) {
                           const sharedNoticesSlot = (
@@ -5067,14 +5130,14 @@ export const PlaygroundForm = ({
                               {composerInlineMessagesNode}
                               {composerNoticesNode}
                             </>
-                          )
+                          );
                           const tokensProp =
                             resolvedMaxContext > 0
                               ? {
                                   used: conversationTokenCount,
-                                  max: resolvedMaxContext
+                                  max: resolvedMaxContext,
                                 }
-                              : undefined
+                              : undefined;
 
                           // V3 brief panel + V5 facet row data sourced from the
                           // same Playground state the legacy composer reads.
@@ -5082,12 +5145,12 @@ export const PlaygroundForm = ({
                           // legacy toolbar exposes — model picker, character
                           // sheet, knowledge panel, web-search toggle.
                           const briefFields: Array<{
-                            id: string
-                            fieldKey: string
-                            value: string
-                            active?: boolean
-                            onClick?: () => void
-                            "aria-label"?: string
+                            id: string;
+                            fieldKey: string;
+                            value: string;
+                            active?: boolean;
+                            onClick?: () => void;
+                            "aria-label"?: string;
                           }> = [
                             {
                               id: "model",
@@ -5097,7 +5160,7 @@ export const PlaygroundForm = ({
                               onClick: handleOpenModelSettings,
                               "aria-label": selectedModel
                                 ? `Change model (current: ${selectedModel})`
-                                : "Pick a model"
+                                : "Pick a model",
                             },
                             {
                               id: "character",
@@ -5107,20 +5170,20 @@ export const PlaygroundForm = ({
                               onClick: () => setOpenActorSettings(true),
                               "aria-label": selectedCharacter?.name
                                 ? `Change character (current: ${selectedCharacter.name})`
-                                : "Pick a character"
+                                : "Pick a character",
                             },
                             {
                               id: "sources",
                               fieldKey: "src",
                               value: String(
-                                selectedDocuments.length + uploadedFiles.length
+                                selectedDocuments.length + uploadedFiles.length,
                               ),
                               active:
                                 selectedDocuments.length +
                                   uploadedFiles.length >
                                 0,
                               onClick: () => toggleKnowledgePanel(),
-                              "aria-label": "Open knowledge panel"
+                              "aria-label": "Open knowledge panel",
                             },
                             {
                               id: "web",
@@ -5130,16 +5193,16 @@ export const PlaygroundForm = ({
                               onClick: handleToggleWebSearch,
                               "aria-label": webSearch
                                 ? "Turn web search off"
-                                : "Turn web search on"
-                            }
-                          ]
+                                : "Turn web search on",
+                            },
+                          ];
                           const briefSections = [
                             {
                               id: "playground-brief",
                               label: "Brief",
-                              fields: briefFields
-                            }
-                          ]
+                              fields: briefFields,
+                            },
+                          ];
 
                           const variantNode =
                             nextgenComposerVariant === "v5" ? (
@@ -5158,14 +5221,14 @@ export const PlaygroundForm = ({
                                   // textarea, opening the existing
                                   // ComposerTextarea slash menu instead
                                   // of a separate palette surface.
-                                  const current = form.values.message
+                                  const current = form.values.message;
                                   form.setFieldValue(
                                     "message",
                                     current.endsWith("/")
                                       ? current
-                                      : `${current}/`
-                                  )
-                                  textareaRef.current?.focus()
+                                      : `${current}/`,
+                                  );
+                                  textareaRef.current?.focus();
                                 }}
                                 textareaSlot={composerTextareaNode}
                                 facetsSlot={composerToolbarNode}
@@ -5202,13 +5265,13 @@ export const PlaygroundForm = ({
                                 bottomBarSlot={composerToolbarNode}
                                 noticesSlot={sharedNoticesSlot}
                               />
-                            )
+                            );
 
                           return (
                             <div data-testid="nextgen-composer-wrapper">
                               {variantNode}
                             </div>
-                          )
+                          );
                         }
 
                         return (
@@ -5218,28 +5281,30 @@ export const PlaygroundForm = ({
                             {composerNoticesNode}
                             {composerToolbarNode}
                           </>
-                        )
+                        );
                       })()}
                       {showConnectBanner && !isConnectionReady && (
                         <div className="mt-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-warn/30 bg-warn/10 px-3 py-2 text-xs text-warn">
                           <p className="max-w-xs text-left">
                             {t(
                               "playground:composer.connectNotice",
-                              "Connect to your tldw server in Settings to send messages."
+                              "Connect to your tldw server in Settings to send messages.",
                             )}
                           </p>
                           <div className="flex flex-wrap items-center gap-2">
                             <Link
                               to="/settings/tldw"
-                              className="text-xs font-medium text-warn underline hover:text-warn">
+                              className="text-xs font-medium text-warn underline hover:text-warn"
+                            >
                               {t("settings:tldw.setupLink", "Set up server")}
                             </Link>
                             <Link
                               to="/settings/health"
-                              className="text-xs font-medium text-warn underline hover:text-warn">
+                              className="text-xs font-medium text-warn underline hover:text-warn"
+                            >
                               {t(
                                 "settings:healthSummary.diagnostics",
-                                "Health & diagnostics"
+                                "Health & diagnostics",
                               )}
                             </Link>
                             <button
@@ -5247,7 +5312,8 @@ export const PlaygroundForm = ({
                               onClick={() => setShowConnectBanner(false)}
                               className="inline-flex items-center rounded-full p-1 text-warn hover:bg-warn/10"
                               aria-label={t("common:close", "Dismiss")}
-                              title={t("common:close", "Dismiss") as string}>
+                              title={t("common:close", "Dismiss") as string}
+                            >
                               <X className="h-3 w-3" />
                             </button>
                           </div>
@@ -5352,25 +5418,28 @@ export const PlaygroundForm = ({
             <div className="flex flex-wrap justify-end gap-2">
               <Button
                 onClick={closeFollowUpResearchModal}
-                disabled={followUpResearchPending}>
+                disabled={followUpResearchPending}
+              >
                 {t("common:cancel", "Cancel")}
               </Button>
               <Button
                 type="primary"
                 onClick={() => {
-                  void handleStartFollowUpResearch()
+                  void handleStartFollowUpResearch();
                 }}
                 disabled={!canLaunchFollowUpResearch || followUpResearchPending}
-                loading={followUpResearchPending}>
+                loading={followUpResearchPending}
+              >
                 {t("playground:actions.startResearch", "Start research")}
               </Button>
             </div>
-          }>
+          }
+        >
           <div className="space-y-3">
             <p className="text-sm text-text-muted">
               {t(
                 "playground:actions.followUpResearchBody",
-                "Start a new linked research run from the current draft without sending a chat message."
+                "Start a new linked research run from the current draft without sending a chat message.",
               )}
             </p>
             <div className="rounded-md border border-border bg-surface px-3 py-2">
@@ -5387,10 +5456,11 @@ export const PlaygroundForm = ({
                 onChange={(event) =>
                   setIncludeAttachedResearchAsBackground(event.target.checked)
                 }
-                disabled={followUpResearchPending}>
+                disabled={followUpResearchPending}
+              >
                 {t(
                   "playground:actions.followUpResearchUseAttachedBackground",
-                  "Use attached research as background"
+                  "Use attached research as background",
                 )}
               </Checkbox>
             ) : null}
@@ -5506,8 +5576,8 @@ export const PlaygroundForm = ({
             <LazyDocumentGeneratorDrawer
               open={documentGeneratorOpen}
               onClose={() => {
-                setDocumentGeneratorOpen(false)
-                setDocumentGeneratorSeed({})
+                setDocumentGeneratorOpen(false);
+                setDocumentGeneratorSeed({});
               }}
               conversationId={
                 documentGeneratorSeed?.conversationId ?? serverChatId ?? null
@@ -5539,5 +5609,5 @@ export const PlaygroundForm = ({
         )}
       </div>
     </React.Profiler>
-  )
-}
+  );
+};

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { Playground } from "../Playground"
+
+const messageOptionState = vi.hoisted(() => ({
+  value: {
+    messages: [],
+    history: [],
+    historyId: "history-1",
+    serverChatId: "chat-1",
+    isLoading: false,
+    setHistoryId: vi.fn(),
+    setHistory: vi.fn(),
+    setMessages: vi.fn(),
+    setSelectedSystemPrompt: vi.fn(),
+    setSelectedModel: vi.fn(),
+    setServerChatId: vi.fn(),
+    setContextFiles: vi.fn(),
+    createChatBranch: vi.fn(),
+    streaming: false,
+    selectedCharacter: null,
+    setSelectedCharacter: vi.fn(),
+    compareMode: false,
+    compareFeatureEnabled: false
+  }
+}))
+
+const sessionPersistenceState = vi.hoisted(() => ({
+  value: {
+    restoreSession: vi.fn(async () => false),
+    sessionScopeReady: true,
+    hasPersistedSession: false,
+    persistedHistoryId: null as string | null,
+    persistedServerChatId: null as string | null
+  }
+}))
+
+const smartScrollState = vi.hoisted(() => ({
+  value: {
+    containerRef: { current: null } as React.MutableRefObject<HTMLDivElement | null>,
+    isAutoScrollToBottom: true,
+    autoScrollToBottom: vi.fn()
+  }
+}))
+
+const artifactsState = vi.hoisted(() => ({
+  value: {
+    isOpen: false,
+    active: null,
+    isPinned: false,
+    history: [],
+    unreadCount: 0,
+    setOpen: vi.fn(),
+    closeArtifact: vi.fn(),
+    markRead: vi.fn()
+  }
+}))
+
+const storeOptionState = vi.hoisted(() => ({
+  value: {
+    compareParentByHistory: {} as Record<
+      string,
+      { parentHistoryId: string; clusterId?: string }
+    >,
+    setSelectedQuickPrompt: vi.fn()
+  }
+}))
+
+const storageState = vi.hoisted(() => ({
+  value: {
+    stickyChatInput: true
+  }
+}))
+
+const chatSettingsState = vi.hoisted(() => ({
+  syncChatSettingsForServerChat: vi.fn(async () => null),
+  applyChatSettingsPatch: vi.fn(async () => null)
+}))
+
+const researchClientMocks = vi.hoisted(() => ({
+  initialize: vi.fn().mockResolvedValue(undefined),
+  getResearchBundle: vi.fn().mockResolvedValue(null)
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string) => defaultValue || key
+  })
+}))
+
+vi.mock("@/components/Option/Playground/PlaygroundForm", () => ({
+  PlaygroundForm: () => <div data-testid="playground-form">Mock composer</div>
+}))
+
+vi.mock("@/components/Option/Playground/PlaygroundChat", () => ({
+  PlaygroundChat: () => <div data-testid="playground-chat" />
+}))
+
+vi.mock("@/components/Sidepanel/Chat/ArtifactsPanel", () => ({
+  ArtifactsPanel: () => null
+}))
+
+vi.mock("@/hooks/useMessageOption", () => ({
+  useMessageOption: () => messageOptionState.value
+}))
+
+vi.mock("@/hooks/usePlaygroundSessionPersistence", () => ({
+  usePlaygroundSessionPersistence: () => sessionPersistenceState.value
+}))
+
+vi.mock("@/hooks/playground-session-restore", () => ({
+  shouldRestorePersistedPlaygroundSession: () => false
+}))
+
+vi.mock("@/services/app", () => ({
+  webUIResumeLastChat: vi.fn(async () => false)
+}))
+
+vi.mock("@/db/dexie/helpers", () => ({
+  formatToChatHistory: vi.fn(),
+  formatToMessage: vi.fn(),
+  getHistoryByServerChatId: vi.fn(async () => null),
+  getPromptById: vi.fn(async () => null),
+  getRecentChatFromWebUI: vi.fn(async () => null)
+}))
+
+vi.mock("@/store/model", () => ({
+  useStoreChatModelSettings: () => ({ setSystemPrompt: vi.fn() })
+}))
+
+vi.mock("@/hooks/useSmartScroll", () => ({
+  useSmartScroll: () => smartScrollState.value
+}))
+
+vi.mock("@/services/settings/ui-settings", () => ({
+  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage"
+}))
+
+vi.mock("../Knowledge/utils/unsupported-types", () => ({
+  otherUnsupportedTypes: []
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (
+    selector: (state: typeof storeOptionState.value) => unknown
+  ) => selector(storeOptionState.value)
+}))
+
+vi.mock("@/store/artifacts", () => ({
+  useArtifactsStore: (selector: (state: typeof artifactsState.value) => unknown) =>
+    selector(artifactsState.value)
+}))
+
+vi.mock("@/hooks/useSetting", () => ({
+  useSetting: () => [""]
+}))
+
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (key: string, defaultValue: unknown) => {
+    if (key === "stickyChatInput") {
+      return [storageState.value.stickyChatInput]
+    }
+    return [defaultValue]
+  }
+}))
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+  useMobile: () => false
+}))
+
+vi.mock("@/services/chat-settings", () => ({
+  syncChatSettingsForServerChat: (...args: unknown[]) =>
+    chatSettingsState.syncChatSettingsForServerChat(...args),
+  applyChatSettingsPatch: (...args: unknown[]) =>
+    chatSettingsState.applyChatSettingsPatch(...args)
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: researchClientMocks
+}))
+
+vi.mock("@/hooks/useLoadLocalConversation", () => ({
+  useLoadLocalConversation: () => vi.fn(async () => {})
+}))
+
+vi.mock("../playground-shortcuts", () => ({
+  resolvePlaygroundShortcutAction: () => null
+}))
+
+vi.mock("@/hooks/useCharacterGreeting", () => ({
+  useCharacterGreeting: () => undefined
+}))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom"
+  )
+  return {
+    ...actual,
+    useNavigate: () => vi.fn()
+  }
+})
+
+const findCenteredWidthContract = (root: HTMLElement): HTMLElement | undefined =>
+  Array.from(root.querySelectorAll<HTMLElement>("div")).find((node) =>
+    typeof node.className === "string" && node.className.includes("max-w-[64rem]")
+  )
+
+describe("Playground sticky composer layout integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storageState.value.stickyChatInput = true
+    storeOptionState.value.setSelectedQuickPrompt = vi.fn()
+  })
+
+  it("renders a separate transcript region and persistent composer dock when sticky chat input is enabled", () => {
+    render(<Playground />)
+
+    const transcript = screen.getByTestId("playground-chat-transcript")
+    const dock = screen.getByTestId("playground-chat-composer-dock")
+
+    expect(transcript).toBeInTheDocument()
+    expect(dock).toBeInTheDocument()
+    expect(dock.className).toContain("sticky")
+    expect(dock.className).toContain("bottom-0")
+    expect(
+      transcript.compareDocumentPosition(dock) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(findCenteredWidthContract(dock)).toBeDefined()
+  })
+
+  it("keeps the legacy non-docked composer branch when sticky chat input is disabled", () => {
+    storageState.value.stickyChatInput = false
+
+    render(<Playground />)
+
+    expect(screen.queryByTestId("playground-chat-composer-dock")).not.toBeInTheDocument()
+    expect(screen.getByTestId("playground-form")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
-import React from "react"
-import { render, screen } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Playground } from "../Playground"
+import { Playground } from "../Playground";
 
 const messageOptionState = vi.hoisted(() => ({
   value: {
@@ -24,9 +24,9 @@ const messageOptionState = vi.hoisted(() => ({
     selectedCharacter: null,
     setSelectedCharacter: vi.fn(),
     compareMode: false,
-    compareFeatureEnabled: false
-  }
-}))
+    compareFeatureEnabled: false,
+  },
+}));
 
 const sessionPersistenceState = vi.hoisted(() => ({
   value: {
@@ -34,17 +34,19 @@ const sessionPersistenceState = vi.hoisted(() => ({
     sessionScopeReady: true,
     hasPersistedSession: false,
     persistedHistoryId: null as string | null,
-    persistedServerChatId: null as string | null
-  }
-}))
+    persistedServerChatId: null as string | null,
+  },
+}));
 
 const smartScrollState = vi.hoisted(() => ({
   value: {
-    containerRef: { current: null } as React.MutableRefObject<HTMLDivElement | null>,
+    containerRef: {
+      current: null,
+    } as React.MutableRefObject<HTMLDivElement | null>,
     isAutoScrollToBottom: true,
-    autoScrollToBottom: vi.fn()
-  }
-}))
+    autoScrollToBottom: vi.fn(),
+  },
+}));
 
 const artifactsState = vi.hoisted(() => ({
   value: {
@@ -55,9 +57,9 @@ const artifactsState = vi.hoisted(() => ({
     unreadCount: 0,
     setOpen: vi.fn(),
     closeArtifact: vi.fn(),
-    markRead: vi.fn()
-  }
-}))
+    markRead: vi.fn(),
+  },
+}));
 
 const storeOptionState = vi.hoisted(() => ({
   value: {
@@ -65,179 +67,188 @@ const storeOptionState = vi.hoisted(() => ({
       string,
       { parentHistoryId: string; clusterId?: string }
     >,
-    setSelectedQuickPrompt: vi.fn()
-  }
-}))
+    setSelectedQuickPrompt: vi.fn(),
+  },
+}));
 
 const storageState = vi.hoisted(() => ({
   value: {
-    stickyChatInput: true
-  }
-}))
+    stickyChatInput: true,
+  },
+}));
 
 const chatSettingsState = vi.hoisted(() => ({
   syncChatSettingsForServerChat: vi.fn(async () => null),
-  applyChatSettingsPatch: vi.fn(async () => null)
-}))
+  applyChatSettingsPatch: vi.fn(async () => null),
+}));
 
 const researchClientMocks = vi.hoisted(() => ({
   initialize: vi.fn().mockResolvedValue(undefined),
-  getResearchBundle: vi.fn().mockResolvedValue(null)
-}))
+  getResearchBundle: vi.fn().mockResolvedValue(null),
+}));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, defaultValue?: string) => defaultValue || key
-  })
-}))
+    t: (key: string, defaultValue?: string) => defaultValue || key,
+  }),
+}));
 
 vi.mock("@/components/Option/Playground/PlaygroundForm", () => ({
-  PlaygroundForm: () => <div data-testid="playground-form">Mock composer</div>
-}))
+  PlaygroundForm: () => <div data-testid="playground-form">Mock composer</div>,
+}));
 
 vi.mock("@/components/Option/Playground/PlaygroundChat", () => ({
-  PlaygroundChat: () => <div data-testid="playground-chat" />
-}))
+  PlaygroundChat: () => <div data-testid="playground-chat" />,
+}));
 
 vi.mock("@/components/Sidepanel/Chat/ArtifactsPanel", () => ({
-  ArtifactsPanel: () => null
-}))
+  ArtifactsPanel: () => null,
+}));
 
 vi.mock("@/hooks/useMessageOption", () => ({
-  useMessageOption: () => messageOptionState.value
-}))
+  useMessageOption: () => messageOptionState.value,
+}));
 
 vi.mock("@/hooks/usePlaygroundSessionPersistence", () => ({
-  usePlaygroundSessionPersistence: () => sessionPersistenceState.value
-}))
+  usePlaygroundSessionPersistence: () => sessionPersistenceState.value,
+}));
 
 vi.mock("@/hooks/playground-session-restore", () => ({
-  shouldRestorePersistedPlaygroundSession: () => false
-}))
+  shouldRestorePersistedPlaygroundSession: () => false,
+}));
 
 vi.mock("@/services/app", () => ({
-  webUIResumeLastChat: vi.fn(async () => false)
-}))
+  webUIResumeLastChat: vi.fn(async () => false),
+}));
 
 vi.mock("@/db/dexie/helpers", () => ({
   formatToChatHistory: vi.fn(),
   formatToMessage: vi.fn(),
   getHistoryByServerChatId: vi.fn(async () => null),
   getPromptById: vi.fn(async () => null),
-  getRecentChatFromWebUI: vi.fn(async () => null)
-}))
+  getRecentChatFromWebUI: vi.fn(async () => null),
+}));
 
 vi.mock("@/store/model", () => ({
-  useStoreChatModelSettings: () => ({ setSystemPrompt: vi.fn() })
-}))
+  useStoreChatModelSettings: () => ({ setSystemPrompt: vi.fn() }),
+}));
 
 vi.mock("@/hooks/useSmartScroll", () => ({
-  useSmartScroll: () => smartScrollState.value
-}))
+  useSmartScroll: () => smartScrollState.value,
+}));
 
 vi.mock("@/services/settings/ui-settings", () => ({
-  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage"
-}))
+  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
+}));
 
 vi.mock("../Knowledge/utils/unsupported-types", () => ({
-  otherUnsupportedTypes: []
-}))
+  otherUnsupportedTypes: [],
+}));
 
 vi.mock("@/store/option", () => ({
   useStoreMessageOption: (
-    selector: (state: typeof storeOptionState.value) => unknown
-  ) => selector(storeOptionState.value)
-}))
+    selector: (state: typeof storeOptionState.value) => unknown,
+  ) => selector(storeOptionState.value),
+}));
 
 vi.mock("@/store/artifacts", () => ({
-  useArtifactsStore: (selector: (state: typeof artifactsState.value) => unknown) =>
-    selector(artifactsState.value)
-}))
+  useArtifactsStore: (
+    selector: (state: typeof artifactsState.value) => unknown,
+  ) => selector(artifactsState.value),
+}));
 
 vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [""]
-}))
+  useSetting: () => [""],
+}));
 
 vi.mock("@plasmohq/storage/hook", () => ({
   useStorage: (key: string, defaultValue: unknown) => {
     if (key === "stickyChatInput") {
-      return [storageState.value.stickyChatInput]
+      return [storageState.value.stickyChatInput];
     }
-    return [defaultValue]
-  }
-}))
+    return [defaultValue];
+  },
+}));
 
 vi.mock("@/hooks/useMediaQuery", () => ({
-  useMobile: () => false
-}))
+  useMobile: () => false,
+}));
 
 vi.mock("@/services/chat-settings", () => ({
   syncChatSettingsForServerChat: (...args: unknown[]) =>
     chatSettingsState.syncChatSettingsForServerChat(...args),
   applyChatSettingsPatch: (...args: unknown[]) =>
-    chatSettingsState.applyChatSettingsPatch(...args)
-}))
+    chatSettingsState.applyChatSettingsPatch(...args),
+}));
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
-  tldwClient: researchClientMocks
-}))
+  tldwClient: researchClientMocks,
+}));
 
 vi.mock("@/hooks/useLoadLocalConversation", () => ({
-  useLoadLocalConversation: () => vi.fn(async () => {})
-}))
+  useLoadLocalConversation: () => vi.fn(async () => {}),
+}));
 
 vi.mock("../playground-shortcuts", () => ({
-  resolvePlaygroundShortcutAction: () => null
-}))
+  resolvePlaygroundShortcutAction: () => null,
+}));
 
 vi.mock("@/hooks/useCharacterGreeting", () => ({
-  useCharacterGreeting: () => undefined
-}))
+  useCharacterGreeting: () => undefined,
+}));
 
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>(
-    "react-router-dom"
-  )
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
-    useNavigate: () => vi.fn()
-  }
-})
+    useNavigate: () => vi.fn(),
+  };
+});
 
-const findCenteredWidthContract = (root: HTMLElement): HTMLElement | undefined =>
-  Array.from(root.querySelectorAll<HTMLElement>("div")).find((node) =>
-    typeof node.className === "string" && node.className.includes("max-w-[64rem]")
-  )
+const findCenteredWidthContract = (
+  root: HTMLElement,
+): HTMLElement | undefined =>
+  Array.from(root.querySelectorAll<HTMLElement>("div")).find(
+    (node) =>
+      typeof node.className === "string" &&
+      node.className.includes("max-w-[64rem]"),
+  );
 
 describe("Playground sticky composer layout integration", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    storageState.value.stickyChatInput = true
-    storeOptionState.value.setSelectedQuickPrompt = vi.fn()
-  })
+    vi.clearAllMocks();
+    storageState.value.stickyChatInput = true;
+    storeOptionState.value.setSelectedQuickPrompt = vi.fn();
+  });
 
   it("renders a separate transcript region and persistent composer dock when sticky chat input is enabled", () => {
-    render(<Playground />)
+    render(<Playground />);
 
-    const transcript = screen.getByTestId("playground-chat-transcript")
-    const dock = screen.getByTestId("playground-chat-composer-dock")
+    const transcript = screen.getByTestId("playground-chat-transcript");
+    const dock = screen.getByTestId("playground-chat-composer-dock");
 
-    expect(transcript).toBeInTheDocument()
-    expect(dock).toBeInTheDocument()
-    expect(dock.className).toContain("sticky")
-    expect(dock.className).toContain("bottom-0")
+    expect(transcript).toBeInTheDocument();
+    expect(dock).toBeInTheDocument();
+    expect(dock.className).toContain("sticky");
+    expect(dock.className).toContain("bottom-0");
     expect(
-      transcript.compareDocumentPosition(dock) & Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy()
-    expect(findCenteredWidthContract(dock)).toBeDefined()
-  })
+      transcript.compareDocumentPosition(dock) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(findCenteredWidthContract(dock)).toBeDefined();
+  });
 
   it("keeps the legacy non-docked composer branch when sticky chat input is disabled", () => {
-    storageState.value.stickyChatInput = false
+    storageState.value.stickyChatInput = false;
 
-    render(<Playground />)
+    render(<Playground />);
 
-    expect(screen.queryByTestId("playground-chat-composer-dock")).not.toBeInTheDocument()
-    expect(screen.getByTestId("playground-form")).toBeInTheDocument()
-  })
-})
+    expect(
+      screen.queryByTestId("playground-chat-composer-dock"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("playground-form")).toBeInTheDocument();
+  });
+});

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/mobile-composer-layout.test.ts
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/mobile-composer-layout.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest"
 import {
   computeKeyboardInsetPx,
   isKeyboardLikelyOpen,
-  resolveMobileComposerViewportState
+  resolveMobileComposerViewportState,
+  resolveStickyComposerTextareaMaxHeight
 } from "../mobile-composer-layout"
 
 describe("mobile-composer-layout", () => {
@@ -42,5 +43,16 @@ describe("mobile-composer-layout", () => {
       keyboardInsetPx: 0,
       keyboardOpen: false
     })
+  })
+
+  it("keeps sticky composer textarea height below the viewport cap", () => {
+    expect(
+      resolveStickyComposerTextareaMaxHeight({
+        viewportHeightPx: 480,
+        keyboardInsetPx: 0,
+        isMobileViewport: true,
+        defaultMaxHeightPx: 480
+      })
+    ).toBe(220)
   })
 })

--- a/apps/packages/ui/src/components/Option/Playground/hooks/useComposerInput.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/useComposerInput.tsx
@@ -56,6 +56,8 @@ export interface UseComposerInputDeps {
   handleTextChange: (value: string, cursorPosition: number) => void
   /** Pro mode */
   isProMode: boolean
+  /** Sticky dock-specific textarea cap */
+  textareaMaxHeightOverride?: number
 }
 
 // ---------------------------------------------------------------------------
@@ -85,7 +87,8 @@ export function useComposerInput(deps: UseComposerInputDeps) {
     selectionFromPointerRef,
     tabMentionsEnabled,
     handleTextChange,
-    isProMode
+    isProMode,
+    textareaMaxHeightOverride
   } = deps
 
   // --- Shared text/draft/focus primitive ---
@@ -96,6 +99,7 @@ export function useComposerInput(deps: UseComposerInputDeps) {
     draftKey: "tldw:playgroundChatDraft",
     textareaRef,
     isProMode,
+    maxHeight: textareaMaxHeightOverride,
     getDraftMetadata: () => ({
       wasExpanded: hasExpandedLargeText,
       collapsedRange: collapsedRange

--- a/apps/packages/ui/src/components/Option/Playground/hooks/useComposerInput.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/hooks/useComposerInput.tsx
@@ -1,12 +1,12 @@
-import React from "react"
-import useDynamicTextareaSize from "~/hooks/useDynamicTextareaSize"
-import { useComposerText } from "@/components/Chat/composer/hooks/useComposerText"
-import { handleChatInputKeyDown } from "@/utils/key-down"
-import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant"
-import { isFirefoxTarget } from "@/config/platform"
-import { createComposerPerfTracker } from "@/utils/perf/composer-perf"
-import { createRenderPerfTracker } from "@/utils/perf/render-profiler"
-import type { CollapsedRange } from "@/hooks/playground"
+import React from "react";
+import useDynamicTextareaSize from "~/hooks/useDynamicTextareaSize";
+import { useComposerText } from "@/components/Chat/composer/hooks/useComposerText";
+import { handleChatInputKeyDown } from "@/utils/key-down";
+import { PASTED_TEXT_CHAR_LIMIT } from "@/utils/constant";
+import { isFirefoxTarget } from "@/config/platform";
+import { createComposerPerfTracker } from "@/utils/perf/composer-perf";
+import { createRenderPerfTracker } from "@/utils/perf/render-profiler";
+import type { CollapsedRange } from "@/hooks/playground";
 
 // ---------------------------------------------------------------------------
 // Deps interface
@@ -14,50 +14,56 @@ import type { CollapsedRange } from "@/hooks/playground"
 
 export interface UseComposerInputDeps {
   /** Textarea ref shared with parent */
-  textareaRef: React.RefObject<HTMLTextAreaElement>
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
   /** Message collapse controls from useMessageCollapse */
-  isMessageCollapsed: boolean
-  setIsMessageCollapsed: (collapsed: boolean) => void
-  collapsedRange: CollapsedRange | null
-  setCollapsedRange: (range: CollapsedRange | null) => void
-  hasExpandedLargeText: boolean
-  setHasExpandedLargeText: (expanded: boolean) => void
+  isMessageCollapsed: boolean;
+  setIsMessageCollapsed: (collapsed: boolean) => void;
+  collapsedRange: CollapsedRange | null;
+  setCollapsedRange: (range: CollapsedRange | null) => void;
+  hasExpandedLargeText: boolean;
+  setHasExpandedLargeText: (expanded: boolean) => void;
   collapseLargeMessage: (
     value: string,
-    options?: { force?: boolean; range?: CollapsedRange }
-  ) => void
+    options?: { force?: boolean; range?: CollapsedRange },
+  ) => void;
   restoreCollapseState: (
     value: string,
-    metadata?: { wasExpanded?: boolean; collapsedRange?: CollapsedRange | null }
-  ) => void
-  getCollapsedDisplayMeta: (message: string, range: CollapsedRange) => any
-  getDisplayCaretFromMessage: (caret: number, meta: any) => number
+    metadata?: {
+      wasExpanded?: boolean;
+      collapsedRange?: CollapsedRange | null;
+    },
+  ) => void;
+  getCollapsedDisplayMeta: (message: string, range: CollapsedRange) => any;
+  getDisplayCaretFromMessage: (caret: number, meta: any) => number;
   getMessageCaretFromDisplay: (
     displayCaret: number,
     meta: any,
-    options?: { prefer?: string }
-  ) => number
-  normalizeCollapsedRange: (range: CollapsedRange, length: number) => CollapsedRange
-  expandLargeMessage: (options?: { force?: boolean }) => void
-  pendingCaretRef: React.MutableRefObject<number | null>
+    options?: { prefer?: string },
+  ) => number;
+  normalizeCollapsedRange: (
+    range: CollapsedRange,
+    length: number,
+  ) => CollapsedRange;
+  expandLargeMessage: (options?: { force?: boolean }) => void;
+  pendingCaretRef: React.MutableRefObject<number | null>;
   lastDisplaySelectionRef: React.MutableRefObject<{
-    start: number
-    end: number
-  } | null>
+    start: number;
+    end: number;
+  } | null>;
   pendingCollapsedStateRef: React.MutableRefObject<{
-    message: string
-    range: CollapsedRange
-    caret: number
-  } | null>
-  pointerDownRef: React.MutableRefObject<boolean>
-  selectionFromPointerRef: React.MutableRefObject<boolean>
+    message: string;
+    range: CollapsedRange;
+    caret: number;
+  } | null>;
+  pointerDownRef: React.MutableRefObject<boolean>;
+  selectionFromPointerRef: React.MutableRefObject<boolean>;
   /** Tab mentions */
-  tabMentionsEnabled: boolean
-  handleTextChange: (value: string, cursorPosition: number) => void
+  tabMentionsEnabled: boolean;
+  handleTextChange: (value: string, cursorPosition: number) => void;
   /** Pro mode */
-  isProMode: boolean
+  isProMode: boolean;
   /** Sticky dock-specific textarea cap */
-  textareaMaxHeightOverride?: number
+  textareaMaxHeightOverride?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -88,8 +94,8 @@ export function useComposerInput(deps: UseComposerInputDeps) {
     tabMentionsEnabled,
     handleTextChange,
     isProMode,
-    textareaMaxHeightOverride
-  } = deps
+    textareaMaxHeightOverride,
+  } = deps;
 
   // --- Shared text/draft/focus primitive ---
   // See apps/packages/ui/src/components/Chat/composer/hooks/useComposerText.ts.
@@ -104,223 +110,235 @@ export function useComposerInput(deps: UseComposerInputDeps) {
       wasExpanded: hasExpandedLargeText,
       collapsedRange: collapsedRange
         ? { start: collapsedRange.start, end: collapsedRange.end }
-        : null
+        : null,
     }),
     restoreWithMetadata: (value, metadata) => {
       // `useComposerText` already wrote the message into the form; layer on
       // the Playground-specific collapse-state restore.
-      restoreCollapseState(value, metadata as any)
-    }
-  })
-  const { form, textAreaFocus, draftSaved, textareaMaxHeight } = composerText
+      restoreCollapseState(value, metadata as any);
+    },
+  });
+  const { form, textAreaFocus, draftSaved, textareaMaxHeight } = composerText;
 
-  const setFieldValueRef = React.useRef(form.setFieldValue)
+  const setFieldValueRef = React.useRef(form.setFieldValue);
   React.useEffect(() => {
-    setFieldValueRef.current = form.setFieldValue
-  }, [form.setFieldValue])
+    setFieldValueRef.current = form.setFieldValue;
+  }, [form.setFieldValue]);
 
   // --- Perf tracking ---
   const composerPerfTrackerRef = React.useRef(
     createComposerPerfTracker({
-      enabled: Boolean((globalThis as any).__TLDW_CHAT_PERF__)
-    })
-  )
+      enabled: Boolean((globalThis as any).__TLDW_CHAT_PERF__),
+    }),
+  );
   const renderPerfTrackerRef = React.useRef(
     createRenderPerfTracker({
-      enabled: Boolean((globalThis as any).__TLDW_CHAT_PERF__)
-    })
-  )
+      enabled: Boolean((globalThis as any).__TLDW_CHAT_PERF__),
+    }),
+  );
 
   const markComposerPerf = React.useCallback((label: string) => {
-    return composerPerfTrackerRef.current.start(label)
-  }, [])
+    return composerPerfTrackerRef.current.start(label);
+  }, []);
 
-  const onComposerRenderProfile = React.useCallback<React.ProfilerOnRenderCallback>(
-    (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-      renderPerfTrackerRef.current.onRender(
-        String(id),
-        phase,
-        actualDuration,
-        baseDuration,
-        startTime,
-        commitTime
-      )
-    },
-    []
-  )
+  const onComposerRenderProfile =
+    React.useCallback<React.ProfilerOnRenderCallback>(
+      (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
+        renderPerfTrackerRef.current.onRender(
+          String(id),
+          phase,
+          actualDuration,
+          baseDuration,
+          startTime,
+          commitTime,
+        );
+      },
+      [],
+    );
 
   const measureComposerPerf = React.useCallback(
     <T,>(label: string, fn: () => T): T => {
-      const end = markComposerPerf(label)
+      const end = markComposerPerf(label);
       try {
-        return fn()
+        return fn();
       } finally {
-        end()
+        end();
       }
     },
-    [markComposerPerf]
-  )
+    [markComposerPerf],
+  );
 
   const wrapComposerProfile = React.useCallback(
     (id: string, node: React.ReactNode): React.ReactNode => {
-      if (!renderPerfTrackerRef.current.isEnabled()) return node
+      if (!renderPerfTrackerRef.current.isEnabled()) return node;
       return (
         <React.Profiler id={id} onRender={onComposerRenderProfile}>
           {node}
         </React.Profiler>
-      )
+      );
     },
-    [onComposerRenderProfile]
-  )
+    [onComposerRenderProfile],
+  );
 
   // Expose perf APIs on window
   React.useEffect(() => {
-    const inputTracker = composerPerfTrackerRef.current
-    const renderTracker = renderPerfTrackerRef.current
-    if (!inputTracker.isEnabled() || typeof window === "undefined") return
-    ;(window as any).__TLDW_CHAT_PERF_SNAPSHOT__ = () => inputTracker.snapshot()
-    ;(window as any).__TLDW_CHAT_PERF_CLEAR__ = () => {
-      inputTracker.clear()
-      renderTracker.clear()
-    }
-    ;(window as any).__TLDW_CHAT_RENDER_PERF_SNAPSHOT__ = () =>
-      renderTracker.snapshot()
-    ;(window as any).__TLDW_CHAT_RENDER_PERF_SUMMARY__ = () =>
-      renderTracker.summarize()
-    ;(window as any).__TLDW_CHAT_RENDER_PERF_CLEAR__ = () =>
-      renderTracker.clear()
+    const inputTracker = composerPerfTrackerRef.current;
+    const renderTracker = renderPerfTrackerRef.current;
+    if (!inputTracker.isEnabled() || typeof window === "undefined") return;
+    (window as any).__TLDW_CHAT_PERF_SNAPSHOT__ = () => inputTracker.snapshot();
+    (window as any).__TLDW_CHAT_PERF_CLEAR__ = () => {
+      inputTracker.clear();
+      renderTracker.clear();
+    };
+    (window as any).__TLDW_CHAT_RENDER_PERF_SNAPSHOT__ = () =>
+      renderTracker.snapshot();
+    (window as any).__TLDW_CHAT_RENDER_PERF_SUMMARY__ = () =>
+      renderTracker.summarize();
+    (window as any).__TLDW_CHAT_RENDER_PERF_CLEAR__ = () =>
+      renderTracker.clear();
     return () => {
-      delete (window as any).__TLDW_CHAT_PERF_SNAPSHOT__
-      delete (window as any).__TLDW_CHAT_PERF_CLEAR__
-      delete (window as any).__TLDW_CHAT_RENDER_PERF_SNAPSHOT__
-      delete (window as any).__TLDW_CHAT_RENDER_PERF_SUMMARY__
-      delete (window as any).__TLDW_CHAT_RENDER_PERF_CLEAR__
-    }
-  }, [])
+      delete (window as any).__TLDW_CHAT_PERF_SNAPSHOT__;
+      delete (window as any).__TLDW_CHAT_PERF_CLEAR__;
+      delete (window as any).__TLDW_CHAT_RENDER_PERF_SNAPSHOT__;
+      delete (window as any).__TLDW_CHAT_RENDER_PERF_SUMMARY__;
+      delete (window as any).__TLDW_CHAT_RENDER_PERF_CLEAR__;
+    };
+  }, []);
 
   // --- Message value helpers ---
   const restoreMessageValue = React.useCallback(
     (
       value: string,
-      metadata?: { wasExpanded?: boolean; collapsedRange?: CollapsedRange | null }
+      metadata?: {
+        wasExpanded?: boolean;
+        collapsedRange?: CollapsedRange | null;
+      },
     ) => {
-      setFieldValueRef.current("message", value)
-      restoreCollapseState(value, metadata)
+      setFieldValueRef.current("message", value);
+      restoreCollapseState(value, metadata);
     },
-    [restoreCollapseState]
-  )
+    [restoreCollapseState],
+  );
 
   const setMessageValue = React.useCallback(
     (
       nextValue: string,
       options?: {
-        collapseLarge?: boolean
-        forceCollapse?: boolean
-        collapsedRange?: CollapsedRange
-      }
+        collapseLarge?: boolean;
+        forceCollapse?: boolean;
+        collapsedRange?: CollapsedRange;
+      },
     ) => {
-      form.setFieldValue("message", nextValue)
+      form.setFieldValue("message", nextValue);
       if (options?.collapseLarge) {
         collapseLargeMessage(nextValue, {
           force: options?.forceCollapse,
-          range: options?.collapsedRange
-        })
+          range: options?.collapsedRange,
+        });
       }
     },
-    [collapseLargeMessage, form.setFieldValue]
-  )
+    [collapseLargeMessage, form.setFieldValue],
+  );
 
   // --- Display value ---
   const collapsedDisplayMeta = React.useMemo(() => {
-    const message = form.values.message || ""
-    if (!message || !collapsedRange) return null
-    return getCollapsedDisplayMeta(message, collapsedRange)
-  }, [collapsedRange, form.values.message, getCollapsedDisplayMeta])
+    const message = form.values.message || "";
+    if (!message || !collapsedRange) return null;
+    return getCollapsedDisplayMeta(message, collapsedRange);
+  }, [collapsedRange, form.values.message, getCollapsedDisplayMeta]);
 
   const messageDisplayValue = React.useMemo(() => {
-    const message = form.values.message || ""
-    if (!message) return ""
-    if (!isMessageCollapsed || !collapsedDisplayMeta) return message
-    return collapsedDisplayMeta.display
-  }, [collapsedDisplayMeta, form.values.message, isMessageCollapsed])
+    const message = form.values.message || "";
+    if (!message) return "";
+    if (!isMessageCollapsed || !collapsedDisplayMeta) return message;
+    return collapsedDisplayMeta.display;
+  }, [collapsedDisplayMeta, form.values.message, isMessageCollapsed]);
 
   // Reset collapse state when message is short
   React.useEffect(() => {
-    const message = form.values.message || ""
+    const message = form.values.message || "";
     if (!message || message.length <= PASTED_TEXT_CHAR_LIMIT) {
-      setIsMessageCollapsed(false)
-      setHasExpandedLargeText(false)
-      setCollapsedRange(null)
+      setIsMessageCollapsed(false);
+      setHasExpandedLargeText(false);
+      setCollapsedRange(null);
     }
-  }, [form.values.message])
+  }, [form.values.message]);
 
   // --- Textarea sizing ---
   // Sized against `messageDisplayValue` (not the raw form value) so the
   // textarea shrinks when the paste-collapse overlay swaps in a short label.
-  useDynamicTextareaSize(textareaRef, messageDisplayValue, textareaMaxHeight)
+  useDynamicTextareaSize(textareaRef, messageDisplayValue, textareaMaxHeight);
 
   // --- Collapsed caret sync ---
   const syncCollapsedCaret = React.useCallback(
     (options?: {
-      message?: string
-      range?: CollapsedRange | null
-      caret?: number
+      message?: string;
+      range?: CollapsedRange | null;
+      caret?: number;
     }) => {
-      if (!isMessageCollapsed) return
-      const pendingState = pendingCollapsedStateRef.current
+      if (!isMessageCollapsed) return;
+      const pendingState = pendingCollapsedStateRef.current;
       const message =
-        options?.message ?? pendingState?.message ?? form.values.message ?? ""
-      const range = options?.range ?? pendingState?.range ?? collapsedRange
-      if (!range) return
-      if (!message) return
+        options?.message ?? pendingState?.message ?? form.values.message ?? "";
+      const range = options?.range ?? pendingState?.range ?? collapsedRange;
+      if (!range) return;
+      if (!message) return;
       requestAnimationFrame(() => {
-        const el = textareaRef.current
-        if (!el) return
-        const meta = getCollapsedDisplayMeta(message, range)
+        const el = textareaRef.current;
+        if (!el) return;
+        const meta = getCollapsedDisplayMeta(message, range);
         const selection =
           lastDisplaySelectionRef.current ??
           (el.selectionStart !== null
             ? {
                 start: el.selectionStart ?? 0,
-                end: el.selectionEnd ?? el.selectionStart ?? 0
+                end: el.selectionEnd ?? el.selectionStart ?? 0,
               }
-            : null)
-        const hasSelection = selection ? selection.start !== selection.end : false
+            : null);
+        const hasSelection = selection
+          ? selection.start !== selection.end
+          : false;
         let caret =
-          options?.caret ?? pendingState?.caret ?? pendingCaretRef.current
+          options?.caret ?? pendingState?.caret ?? pendingCaretRef.current;
         if (caret === undefined || caret === null) {
           if (selection && hasSelection) {
-            const start = Math.max(0, Math.min(selection.start, meta.display.length))
-            const end = Math.max(0, Math.min(selection.end, meta.display.length))
-            el.focus()
-            el.setSelectionRange(start, end)
-            pendingCollapsedStateRef.current = null
-            return
+            const start = Math.max(
+              0,
+              Math.min(selection.start, meta.display.length),
+            );
+            const end = Math.max(
+              0,
+              Math.min(selection.end, meta.display.length),
+            );
+            el.focus();
+            el.setSelectionRange(start, end);
+            pendingCollapsedStateRef.current = null;
+            return;
           }
           if (selection) {
             const displayCaret = Math.max(
               0,
-              Math.min(selection.start, meta.display.length)
-            )
+              Math.min(selection.start, meta.display.length),
+            );
             const prefer =
               displayCaret > meta.labelStart && displayCaret < meta.labelEnd
                 ? "after"
-                : undefined
-            caret = getMessageCaretFromDisplay(displayCaret, meta, { prefer })
+                : undefined;
+            caret = getMessageCaretFromDisplay(displayCaret, meta, { prefer });
           } else {
-            caret = meta.messageLength
+            caret = meta.messageLength;
           }
         }
         if (caret > meta.rangeStart && caret < meta.rangeEnd) {
-          caret = meta.rangeEnd
+          caret = meta.rangeEnd;
         }
-        caret = Math.max(0, Math.min(caret, meta.messageLength))
-        pendingCaretRef.current = caret
-        pendingCollapsedStateRef.current = null
-        const displayCaret = getDisplayCaretFromMessage(caret, meta)
-        el.focus()
-        el.setSelectionRange(displayCaret, displayCaret)
-      })
+        caret = Math.max(0, Math.min(caret, meta.messageLength));
+        pendingCaretRef.current = caret;
+        pendingCollapsedStateRef.current = null;
+        const displayCaret = getDisplayCaretFromMessage(caret, meta);
+        el.focus();
+        el.setSelectionRange(displayCaret, displayCaret);
+      });
     },
     [
       collapsedRange,
@@ -328,57 +346,66 @@ export function useComposerInput(deps: UseComposerInputDeps) {
       getDisplayCaretFromMessage,
       getCollapsedDisplayMeta,
       isMessageCollapsed,
-      textareaRef
-    ]
-  )
+      textareaRef,
+    ],
+  );
 
   // Sync caret after collapsed range changes
   React.useEffect(() => {
-    if (!isMessageCollapsed || !collapsedRange) return
+    if (!isMessageCollapsed || !collapsedRange) return;
     if (!pendingCollapsedStateRef.current && pendingCaretRef.current === null) {
-      const el = textareaRef.current
+      const el = textareaRef.current;
       if (el) {
         lastDisplaySelectionRef.current = {
           start: el.selectionStart ?? 0,
-          end: el.selectionEnd ?? el.selectionStart ?? 0
-        }
+          end: el.selectionEnd ?? el.selectionStart ?? 0,
+        };
       }
     }
-    syncCollapsedCaret()
-  }, [collapsedRange, form.values.message, isMessageCollapsed, syncCollapsedCaret])
+    syncCollapsedCaret();
+  }, [
+    collapsedRange,
+    form.values.message,
+    isMessageCollapsed,
+    syncCollapsedCaret,
+  ]);
 
   // --- Collapsed editing helpers ---
   const commitCollapsedEdit = React.useCallback(
-    (nextValue: string, nextCaret: number, nextRange: CollapsedRange | null) => {
-      const shouldCollapse = nextValue.length > PASTED_TEXT_CHAR_LIMIT
+    (
+      nextValue: string,
+      nextCaret: number,
+      nextRange: CollapsedRange | null,
+    ) => {
+      const shouldCollapse = nextValue.length > PASTED_TEXT_CHAR_LIMIT;
       const range = shouldCollapse
         ? normalizeCollapsedRange(
             nextRange ?? { start: 0, end: nextValue.length },
-            nextValue.length
+            nextValue.length,
           )
-        : null
-      pendingCaretRef.current = nextCaret
+        : null;
+      pendingCaretRef.current = nextCaret;
       pendingCollapsedStateRef.current = range
         ? { message: nextValue, range, caret: nextCaret }
-        : null
+        : null;
       setMessageValue(nextValue, {
         collapseLarge: shouldCollapse,
         forceCollapse: shouldCollapse,
-        collapsedRange: range ?? undefined
-      })
+        collapsedRange: range ?? undefined,
+      });
       if (range) {
-        syncCollapsedCaret({ message: nextValue, range, caret: nextCaret })
-        return
+        syncCollapsedCaret({ message: nextValue, range, caret: nextCaret });
+        return;
       }
       requestAnimationFrame(() => {
-        const el = textareaRef.current
-        if (!el) return
-        el.focus()
-        el.setSelectionRange(nextCaret, nextCaret)
-      })
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(nextCaret, nextCaret);
+      });
     },
-    [normalizeCollapsedRange, setMessageValue, syncCollapsedCaret, textareaRef]
-  )
+    [normalizeCollapsedRange, setMessageValue, syncCollapsedCaret, textareaRef],
+  );
 
   const replaceCollapsedRange = React.useCallback(
     (
@@ -386,69 +413,75 @@ export function useComposerInput(deps: UseComposerInputDeps) {
       meta: ReturnType<typeof getCollapsedDisplayMeta>,
       editStart: number,
       editEnd: number,
-      replacement: string
+      replacement: string,
     ) => {
-      const safeStart = Math.max(0, Math.min(editStart, currentValue.length))
-      const safeEnd = Math.max(safeStart, Math.min(editEnd, currentValue.length))
+      const safeStart = Math.max(0, Math.min(editStart, currentValue.length));
+      const safeEnd = Math.max(
+        safeStart,
+        Math.min(editEnd, currentValue.length),
+      );
       const nextValue =
         currentValue.slice(0, safeStart) +
         replacement +
-        currentValue.slice(safeEnd)
-      const nextCaret = safeStart + replacement.length
+        currentValue.slice(safeEnd);
+      const nextCaret = safeStart + replacement.length;
       const overlapsBlock =
-        safeStart < meta.rangeEnd && safeEnd > meta.rangeStart
+        safeStart < meta.rangeEnd && safeEnd > meta.rangeStart;
       if (overlapsBlock) {
-        commitCollapsedEdit(nextValue, nextCaret, null)
-        return
+        commitCollapsedEdit(nextValue, nextCaret, null);
+        return;
       }
-      const delta = replacement.length - (safeEnd - safeStart)
+      const delta = replacement.length - (safeEnd - safeStart);
       const nextRng =
         safeEnd <= meta.rangeStart
           ? { start: meta.rangeStart + delta, end: meta.rangeEnd + delta }
-          : { start: meta.rangeStart, end: meta.rangeEnd }
-      commitCollapsedEdit(nextValue, nextCaret, nextRng)
+          : { start: meta.rangeStart, end: meta.rangeEnd };
+      commitCollapsedEdit(nextValue, nextCaret, nextRng);
     },
-    [commitCollapsedEdit]
-  )
+    [commitCollapsedEdit],
+  );
 
   // --- Textarea event handlers ---
-  const [typing, setTyping] = React.useState<boolean>(false)
+  const [typing, setTyping] = React.useState<boolean>(false);
 
   const handleCompositionStart = React.useCallback(() => {
-    if (!isFirefoxTarget) setTyping(true)
-  }, [])
+    if (!isFirefoxTarget) setTyping(true);
+  }, []);
 
   const handleCompositionEnd = React.useCallback(() => {
-    if (!isFirefoxTarget) setTyping(false)
-  }, [])
+    if (!isFirefoxTarget) setTyping(false);
+  }, []);
 
   const handleTextareaMouseDown = React.useCallback(() => {
     if (isMessageCollapsed) {
-      pointerDownRef.current = true
-      selectionFromPointerRef.current = true
+      pointerDownRef.current = true;
+      selectionFromPointerRef.current = true;
     }
-  }, [isMessageCollapsed])
+  }, [isMessageCollapsed]);
 
   const handleTextareaMouseUp = React.useCallback(() => {
-    pointerDownRef.current = false
+    pointerDownRef.current = false;
     if (selectionFromPointerRef.current) {
       requestAnimationFrame(() => {
-        selectionFromPointerRef.current = false
-      })
+        selectionFromPointerRef.current = false;
+      });
     }
-  }, [])
+  }, []);
 
   const handleTextareaChange = React.useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const endPerf = markComposerPerf("input:textarea-change")
+      const endPerf = markComposerPerf("input:textarea-change");
       try {
-        if (isMessageCollapsed) return
-        form.getInputProps("message").onChange(e)
+        if (isMessageCollapsed) return;
+        form.getInputProps("message").onChange(e);
         if (tabMentionsEnabled && textareaRef.current) {
-          handleTextChange(e.target.value, textareaRef.current.selectionStart || 0)
+          handleTextChange(
+            e.target.value,
+            textareaRef.current.selectionStart || 0,
+          );
         }
       } finally {
-        endPerf()
+        endPerf();
       }
     },
     [
@@ -457,62 +490,63 @@ export function useComposerInput(deps: UseComposerInputDeps) {
       tabMentionsEnabled,
       textareaRef,
       handleTextChange,
-      markComposerPerf
-    ]
-  )
+      markComposerPerf,
+    ],
+  );
 
   const handleTextareaSelect = React.useCallback(() => {
-    const textarea = textareaRef.current
+    const textarea = textareaRef.current;
     if (textarea) {
       lastDisplaySelectionRef.current = {
         start: textarea.selectionStart ?? 0,
-        end: textarea.selectionEnd ?? textarea.selectionStart ?? 0
-      }
+        end: textarea.selectionEnd ?? textarea.selectionStart ?? 0,
+      };
     }
     if (isMessageCollapsed && collapsedRange) {
-      const message = form.values.message || ""
-      if (!message || !textarea) return
+      const message = form.values.message || "";
+      if (!message || !textarea) return;
       const meta =
-        collapsedDisplayMeta ?? getCollapsedDisplayMeta(message, collapsedRange)
-      const selectionStart = textarea.selectionStart ?? meta.labelStart
-      const selectionEnd = textarea.selectionEnd ?? selectionStart
-      const displayStart = Math.min(selectionStart, selectionEnd)
-      const displayEnd = Math.max(selectionStart, selectionEnd)
-      const hasSelection = displayStart !== displayEnd
+        collapsedDisplayMeta ??
+        getCollapsedDisplayMeta(message, collapsedRange);
+      const selectionStart = textarea.selectionStart ?? meta.labelStart;
+      const selectionEnd = textarea.selectionEnd ?? selectionStart;
+      const displayStart = Math.min(selectionStart, selectionEnd);
+      const displayEnd = Math.max(selectionStart, selectionEnd);
+      const hasSelection = displayStart !== displayEnd;
       const selectionTouchesLabel =
-        displayStart < meta.labelEnd && displayEnd > meta.labelStart
-      const fromPointer = selectionFromPointerRef.current
-      selectionFromPointerRef.current = false
+        displayStart < meta.labelEnd && displayEnd > meta.labelStart;
+      const fromPointer = selectionFromPointerRef.current;
+      selectionFromPointerRef.current = false;
       if (hasSelection) {
-        pendingCaretRef.current = null
-        return
+        pendingCaretRef.current = null;
+        return;
       }
       const caretInsideLabel =
-        displayStart > meta.labelStart && displayStart < meta.labelEnd
+        displayStart > meta.labelStart && displayStart < meta.labelEnd;
       if (selectionTouchesLabel && fromPointer && caretInsideLabel) {
-        pendingCaretRef.current = meta.rangeEnd
-        expandLargeMessage({ force: true })
-        return
+        pendingCaretRef.current = meta.rangeEnd;
+        expandLargeMessage({ force: true });
+        return;
       }
       const prefer =
         caretInsideLabel &&
         (pendingCaretRef.current ?? meta.rangeEnd) <= meta.rangeStart
           ? "before"
-          : "after"
+          : "after";
       const caret = getMessageCaretFromDisplay(displayStart, meta, {
-        prefer: caretInsideLabel ? prefer : undefined
-      })
-      pendingCaretRef.current = caret
+        prefer: caretInsideLabel ? prefer : undefined,
+      });
+      pendingCaretRef.current = caret;
       if (caretInsideLabel) {
-        syncCollapsedCaret({ caret })
+        syncCollapsedCaret({ caret });
       }
-      return
+      return;
     }
     if (tabMentionsEnabled && textareaRef.current) {
       handleTextChange(
         textareaRef.current.value,
-        textareaRef.current.selectionStart || 0
-      )
+        textareaRef.current.selectionStart || 0,
+      );
     }
   }, [
     textareaRef,
@@ -525,8 +559,8 @@ export function useComposerInput(deps: UseComposerInputDeps) {
     getMessageCaretFromDisplay,
     syncCollapsedCaret,
     tabMentionsEnabled,
-    handleTextChange
-  ])
+    handleTextChange,
+  ]);
 
   return {
     form,
@@ -554,6 +588,6 @@ export function useComposerInput(deps: UseComposerInputDeps) {
     onComposerRenderProfile,
     wrapComposerProfile,
     // Draft persistence
-    draftSaved
-  }
+    draftSaved,
+  };
 }

--- a/apps/packages/ui/src/components/Option/Playground/mobile-composer-layout.ts
+++ b/apps/packages/ui/src/components/Option/Playground/mobile-composer-layout.ts
@@ -12,6 +12,11 @@ export type MobileComposerViewportState = {
   keyboardOpen: boolean
 }
 
+export type ComposerDockLayoutMetrics = {
+  occupiedHeightPx: number
+  keyboardInsetPx: number
+}
+
 export const computeKeyboardInsetPx = (params: {
   layoutViewportHeight: number
   visualViewportHeight: number
@@ -63,4 +68,56 @@ export const resolveMobileComposerViewportState = (params: {
       thresholdPx: params.thresholdPx
     })
   }
+}
+
+export const resolveStickyComposerTextareaMaxHeight = (params: {
+  viewportHeightPx: number
+  keyboardInsetPx?: number
+  isMobileViewport: boolean
+  defaultMaxHeightPx: number
+}): number => {
+  const viewportHeight = toFiniteNumber(params.viewportHeightPx)
+  const keyboardInsetPx = toFiniteNumber(params.keyboardInsetPx) ?? 0
+  const defaultMaxHeightPx = Math.max(
+    0,
+    Math.round(params.defaultMaxHeightPx)
+  )
+
+  if (viewportHeight == null || viewportHeight <= 0) {
+    return defaultMaxHeightPx
+  }
+
+  const availableViewportHeight = Math.max(
+    0,
+    Math.round(
+      viewportHeight - (params.isMobileViewport ? keyboardInsetPx : 0)
+    )
+  )
+  const viewportRatio = params.isMobileViewport ? 0.22 : 0.33
+  const maxCap = params.isMobileViewport ? 220 : 320
+  const targetHeight = Math.round(availableViewportHeight * viewportRatio)
+
+  return Math.max(
+    defaultMaxHeightPx,
+    Math.min(maxCap, Math.max(defaultMaxHeightPx, targetHeight))
+  )
+}
+
+export const resolveComposerBottomOffsetPx = (
+  metrics: ComposerDockLayoutMetrics | null | undefined
+): number => {
+  if (!metrics) {
+    return 0
+  }
+
+  const occupiedHeightPx = Math.max(
+    0,
+    Math.round(toFiniteNumber(metrics.occupiedHeightPx) ?? 0)
+  )
+  const keyboardInsetPx = Math.max(
+    0,
+    Math.round(toFiniteNumber(metrics.keyboardInsetPx) ?? 0)
+  )
+
+  return occupiedHeightPx + keyboardInsetPx
 }

--- a/apps/packages/ui/src/components/Option/Playground/mobile-composer-layout.ts
+++ b/apps/packages/ui/src/components/Option/Playground/mobile-composer-layout.ts
@@ -1,31 +1,30 @@
-const DEFAULT_KEYBOARD_INSET_THRESHOLD = 90
+const DEFAULT_KEYBOARD_INSET_THRESHOLD = 90;
 
 const toFiniteNumber = (value: unknown): number | null => {
   if (typeof value !== "number" || !Number.isFinite(value)) {
-    return null
+    return null;
   }
-  return value
-}
+  return value;
+};
 
 export type MobileComposerViewportState = {
-  keyboardInsetPx: number
-  keyboardOpen: boolean
-}
+  keyboardInsetPx: number;
+  keyboardOpen: boolean;
+};
 
 export type ComposerDockLayoutMetrics = {
-  occupiedHeightPx: number
-  keyboardInsetPx: number
-}
+  occupiedHeightPx: number;
+  keyboardInsetPx: number;
+};
 
 export const computeKeyboardInsetPx = (params: {
-  layoutViewportHeight: number
-  visualViewportHeight: number
-  visualViewportOffsetTop?: number
+  layoutViewportHeight: number;
+  visualViewportHeight: number;
+  visualViewportOffsetTop?: number;
 }): number => {
-  const layoutHeight = toFiniteNumber(params.layoutViewportHeight)
-  const visualHeight = toFiniteNumber(params.visualViewportHeight)
-  const viewportOffsetTop =
-    toFiniteNumber(params.visualViewportOffsetTop) ?? 0
+  const layoutHeight = toFiniteNumber(params.layoutViewportHeight);
+  const visualHeight = toFiniteNumber(params.visualViewportHeight);
+  const viewportOffsetTop = toFiniteNumber(params.visualViewportOffsetTop) ?? 0;
 
   if (
     layoutHeight == null ||
@@ -33,91 +32,88 @@ export const computeKeyboardInsetPx = (params: {
     layoutHeight <= 0 ||
     visualHeight <= 0
   ) {
-    return 0
+    return 0;
   }
 
-  const inset = layoutHeight - (visualHeight + viewportOffsetTop)
+  const inset = layoutHeight - (visualHeight + viewportOffsetTop);
   if (!Number.isFinite(inset) || inset <= 0) {
-    return 0
+    return 0;
   }
-  return Math.max(0, Math.round(inset))
-}
+  return Math.max(0, Math.round(inset));
+};
 
 export const isKeyboardLikelyOpen = (params: {
-  keyboardInsetPx: number
-  thresholdPx?: number
+  keyboardInsetPx: number;
+  thresholdPx?: number;
 }): boolean => {
-  const inset = toFiniteNumber(params.keyboardInsetPx)
+  const inset = toFiniteNumber(params.keyboardInsetPx);
   const threshold =
-    toFiniteNumber(params.thresholdPx) ?? DEFAULT_KEYBOARD_INSET_THRESHOLD
-  if (inset == null) return false
-  return inset >= Math.max(32, Math.round(threshold))
-}
+    toFiniteNumber(params.thresholdPx) ?? DEFAULT_KEYBOARD_INSET_THRESHOLD;
+  if (inset == null) return false;
+  return inset >= Math.max(32, Math.round(threshold));
+};
 
 export const resolveMobileComposerViewportState = (params: {
-  layoutViewportHeight: number
-  visualViewportHeight: number
-  visualViewportOffsetTop?: number
-  thresholdPx?: number
+  layoutViewportHeight: number;
+  visualViewportHeight: number;
+  visualViewportOffsetTop?: number;
+  thresholdPx?: number;
 }): MobileComposerViewportState => {
-  const keyboardInsetPx = computeKeyboardInsetPx(params)
+  const keyboardInsetPx = computeKeyboardInsetPx(params);
   return {
     keyboardInsetPx,
     keyboardOpen: isKeyboardLikelyOpen({
       keyboardInsetPx,
-      thresholdPx: params.thresholdPx
-    })
-  }
-}
+      thresholdPx: params.thresholdPx,
+    }),
+  };
+};
 
 export const resolveStickyComposerTextareaMaxHeight = (params: {
-  viewportHeightPx: number
-  keyboardInsetPx?: number
-  isMobileViewport: boolean
-  defaultMaxHeightPx: number
+  viewportHeightPx: number;
+  keyboardInsetPx?: number;
+  isMobileViewport: boolean;
+  defaultMaxHeightPx: number;
 }): number => {
-  const viewportHeight = toFiniteNumber(params.viewportHeightPx)
-  const keyboardInsetPx = toFiniteNumber(params.keyboardInsetPx) ?? 0
-  const defaultMaxHeightPx = Math.max(
-    0,
-    Math.round(params.defaultMaxHeightPx)
-  )
+  const viewportHeight = toFiniteNumber(params.viewportHeightPx);
+  const keyboardInsetPx = toFiniteNumber(params.keyboardInsetPx) ?? 0;
+  const defaultMaxHeightPx = Math.max(0, Math.round(params.defaultMaxHeightPx));
 
   if (viewportHeight == null || viewportHeight <= 0) {
-    return defaultMaxHeightPx
+    return defaultMaxHeightPx;
   }
 
   const availableViewportHeight = Math.max(
     0,
     Math.round(
-      viewportHeight - (params.isMobileViewport ? keyboardInsetPx : 0)
-    )
-  )
-  const viewportRatio = params.isMobileViewport ? 0.22 : 0.33
-  const maxCap = params.isMobileViewport ? 220 : 320
-  const targetHeight = Math.round(availableViewportHeight * viewportRatio)
+      viewportHeight - (params.isMobileViewport ? keyboardInsetPx : 0),
+    ),
+  );
+  const viewportRatio = params.isMobileViewport ? 0.22 : 0.33;
+  const maxCap = params.isMobileViewport ? 220 : 320;
+  const targetHeight = Math.round(availableViewportHeight * viewportRatio);
 
   return Math.max(
     defaultMaxHeightPx,
-    Math.min(maxCap, Math.max(defaultMaxHeightPx, targetHeight))
-  )
-}
+    Math.min(maxCap, Math.max(defaultMaxHeightPx, targetHeight)),
+  );
+};
 
 export const resolveComposerBottomOffsetPx = (
-  metrics: ComposerDockLayoutMetrics | null | undefined
+  metrics: ComposerDockLayoutMetrics | null | undefined,
 ): number => {
   if (!metrics) {
-    return 0
+    return 0;
   }
 
   const occupiedHeightPx = Math.max(
     0,
-    Math.round(toFiniteNumber(metrics.occupiedHeightPx) ?? 0)
-  )
+    Math.round(toFiniteNumber(metrics.occupiedHeightPx) ?? 0),
+  );
   const keyboardInsetPx = Math.max(
     0,
-    Math.round(toFiniteNumber(metrics.keyboardInsetPx) ?? 0)
-  )
+    Math.round(toFiniteNumber(metrics.keyboardInsetPx) ?? 0),
+  );
 
-  return occupiedHeightPx + keyboardInsetPx
-}
+  return occupiedHeightPx + keyboardInsetPx;
+};

--- a/apps/packages/ui/src/components/Option/Playground/mobile-composer-layout.ts
+++ b/apps/packages/ui/src/components/Option/Playground/mobile-composer-layout.ts
@@ -77,10 +77,15 @@ export const resolveStickyComposerTextareaMaxHeight = (params: {
 }): number => {
   const viewportHeight = toFiniteNumber(params.viewportHeightPx);
   const keyboardInsetPx = toFiniteNumber(params.keyboardInsetPx) ?? 0;
-  const defaultMaxHeightPx = Math.max(0, Math.round(params.defaultMaxHeightPx));
+  const defaultMaxHeightPx = Math.max(
+    0,
+    Math.round(toFiniteNumber(params.defaultMaxHeightPx) ?? 0),
+  );
+  const maxCap = params.isMobileViewport ? 220 : 320;
+  const clampedDefaultMaxHeightPx = Math.min(maxCap, defaultMaxHeightPx);
 
   if (viewportHeight == null || viewportHeight <= 0) {
-    return defaultMaxHeightPx;
+    return clampedDefaultMaxHeightPx;
   }
 
   const availableViewportHeight = Math.max(
@@ -90,12 +95,11 @@ export const resolveStickyComposerTextareaMaxHeight = (params: {
     ),
   );
   const viewportRatio = params.isMobileViewport ? 0.22 : 0.33;
-  const maxCap = params.isMobileViewport ? 220 : 320;
   const targetHeight = Math.round(availableViewportHeight * viewportRatio);
 
   return Math.max(
-    defaultMaxHeightPx,
-    Math.min(maxCap, Math.max(defaultMaxHeightPx, targetHeight)),
+    clampedDefaultMaxHeightPx,
+    Math.min(maxCap, targetHeight),
   );
 };
 

--- a/apps/packages/ui/src/hooks/__tests__/useSmartScroll.dock-offset.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useSmartScroll.dock-offset.test.tsx
@@ -1,202 +1,210 @@
-import { act, renderHook } from "@testing-library/react"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { useSmartScroll } from "../useSmartScroll"
+import { useSmartScroll } from "../useSmartScroll";
 
 type DockAwareSmartScroll = (
   messages: Array<{ id: string }>,
   streaming: boolean,
   threshold: number,
   options?: {
-    bottomOffsetPx?: number
-  }
-) => ReturnType<typeof useSmartScroll>
+    bottomOffsetPx?: number;
+  },
+) => ReturnType<typeof useSmartScroll>;
 
 type ScrollContainerHandle = {
-  element: HTMLDivElement
-  get scrollTop(): number
-  set scrollTop(value: number)
-}
+  element: HTMLDivElement;
+  get scrollTop(): number;
+  set scrollTop(value: number);
+};
 
-const useSmartScrollWithDockOffset = useSmartScroll as unknown as DockAwareSmartScroll
+const useSmartScrollWithDockOffset =
+  useSmartScroll as unknown as DockAwareSmartScroll;
 
-const messages = [{ id: "m-1" }]
+const messages = [{ id: "m-1" }];
 
 const createScrollContainer = ({
   scrollHeight,
   clientHeight,
-  initialScrollTop
+  initialScrollTop,
 }: {
-  scrollHeight: number
-  clientHeight: number
-  initialScrollTop: number
+  scrollHeight: number;
+  clientHeight: number;
+  initialScrollTop: number;
 }): ScrollContainerHandle => {
-  const element = document.createElement("div") as HTMLDivElement
+  const element = document.createElement("div") as HTMLDivElement;
 
-  let top = initialScrollTop
+  let top = initialScrollTop;
   Object.defineProperty(element, "scrollHeight", {
     configurable: true,
-    get: () => scrollHeight
-  })
+    get: () => scrollHeight,
+  });
   Object.defineProperty(element, "clientHeight", {
     configurable: true,
-    get: () => clientHeight
-  })
+    get: () => clientHeight,
+  });
   Object.defineProperty(element, "scrollTop", {
     configurable: true,
     get: () => top,
     set: (value: number) => {
-      top = Number(value)
-    }
-  })
+      top = Number(value);
+    },
+  });
   Object.defineProperty(element, "scrollTo", {
     configurable: true,
     value: ({ top: nextTop }: { top: number }) => {
-      top = Number(nextTop)
-    }
-  })
+      top = Number(nextTop);
+    },
+  });
 
   return {
     element,
     get scrollTop() {
-      return top
+      return top;
     },
     set scrollTop(value: number) {
-      top = value
-    }
-  }
-}
+      top = value;
+    },
+  };
+};
 
 describe("useSmartScroll dock offset preservation", () => {
   let originalRequestAnimationFrame:
     | typeof window.requestAnimationFrame
-    | undefined
+    | undefined;
   let originalCancelAnimationFrame:
     | typeof window.cancelAnimationFrame
-    | undefined
+    | undefined;
 
   beforeEach(() => {
-    originalRequestAnimationFrame = window.requestAnimationFrame
-    originalCancelAnimationFrame = window.cancelAnimationFrame
+    originalRequestAnimationFrame = window.requestAnimationFrame;
+    originalCancelAnimationFrame = window.cancelAnimationFrame;
 
     const raf = (callback: FrameRequestCallback) => {
-      callback(0)
-      return 1
-    }
+      callback(0);
+      return 1;
+    };
 
-    ;(window as typeof window & { requestAnimationFrame?: typeof raf }).requestAnimationFrame =
-      raf
-    ;(
+    (
+      window as typeof window & { requestAnimationFrame?: typeof raf }
+    ).requestAnimationFrame = raf;
+    (
       globalThis as typeof globalThis & {
-        requestAnimationFrame?: typeof raf
+        requestAnimationFrame?: typeof raf;
       }
-    ).requestAnimationFrame = raf
-    ;(
-      window as typeof window & { cancelAnimationFrame?: (handle: number) => void }
-    ).cancelAnimationFrame = () => undefined
-    ;(
+    ).requestAnimationFrame = raf;
+    (
+      window as typeof window & {
+        cancelAnimationFrame?: (handle: number) => void;
+      }
+    ).cancelAnimationFrame = () => undefined;
+    (
       globalThis as typeof globalThis & {
-        cancelAnimationFrame?: (handle: number) => void
+        cancelAnimationFrame?: (handle: number) => void;
       }
-    ).cancelAnimationFrame = () => undefined
-  })
+    ).cancelAnimationFrame = () => undefined;
+  });
 
   afterEach(() => {
     if (originalRequestAnimationFrame) {
-      ;(
+      (
         window as typeof window & {
-          requestAnimationFrame?: typeof window.requestAnimationFrame
+          requestAnimationFrame?: typeof window.requestAnimationFrame;
         }
-      ).requestAnimationFrame = originalRequestAnimationFrame
-      ;(
+      ).requestAnimationFrame = originalRequestAnimationFrame;
+      (
         globalThis as typeof globalThis & {
-          requestAnimationFrame?: typeof globalThis.requestAnimationFrame
+          requestAnimationFrame?: typeof globalThis.requestAnimationFrame;
         }
-      ).requestAnimationFrame = originalRequestAnimationFrame
+      ).requestAnimationFrame = originalRequestAnimationFrame;
     } else {
       delete (
-        window as typeof window & { requestAnimationFrame?: typeof window.requestAnimationFrame }
-      ).requestAnimationFrame
+        window as typeof window & {
+          requestAnimationFrame?: typeof window.requestAnimationFrame;
+        }
+      ).requestAnimationFrame;
       delete (
         globalThis as typeof globalThis & {
-          requestAnimationFrame?: typeof globalThis.requestAnimationFrame
+          requestAnimationFrame?: typeof globalThis.requestAnimationFrame;
         }
-      ).requestAnimationFrame
+      ).requestAnimationFrame;
     }
 
     if (originalCancelAnimationFrame) {
-      ;(
+      (
         window as typeof window & {
-          cancelAnimationFrame?: typeof window.cancelAnimationFrame
+          cancelAnimationFrame?: typeof window.cancelAnimationFrame;
         }
-      ).cancelAnimationFrame = originalCancelAnimationFrame
-      ;(
+      ).cancelAnimationFrame = originalCancelAnimationFrame;
+      (
         globalThis as typeof globalThis & {
-          cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame
+          cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame;
         }
-      ).cancelAnimationFrame = originalCancelAnimationFrame
+      ).cancelAnimationFrame = originalCancelAnimationFrame;
     } else {
       delete (
-        window as typeof window & { cancelAnimationFrame?: typeof window.cancelAnimationFrame }
-      ).cancelAnimationFrame
+        window as typeof window & {
+          cancelAnimationFrame?: typeof window.cancelAnimationFrame;
+        }
+      ).cancelAnimationFrame;
       delete (
         globalThis as typeof globalThis & {
-          cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame
+          cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame;
         }
-      ).cancelAnimationFrame
+      ).cancelAnimationFrame;
     }
-  })
+  });
 
   it("keeps the latest message anchored when the reserved dock offset grows at bottom", () => {
     const container = createScrollContainer({
       scrollHeight: 2000,
       clientHeight: 600,
-      initialScrollTop: 1400
-    })
+      initialScrollTop: 1400,
+    });
 
     const { result, rerender } = renderHook(
       ({ bottomOffsetPx }) =>
         useSmartScrollWithDockOffset(messages, false, 120, { bottomOffsetPx }),
       {
-        initialProps: { bottomOffsetPx: 80 }
-      }
-    )
+        initialProps: { bottomOffsetPx: 80 },
+      },
+    );
 
     act(() => {
-      result.current.containerRef.current = container.element
-    })
+      result.current.containerRef.current = container.element;
+    });
 
     act(() => {
-      rerender({ bottomOffsetPx: 160 })
-    })
+      rerender({ bottomOffsetPx: 160 });
+    });
 
-    expect(container.scrollTop).toBe(1480)
-  })
+    expect(container.scrollTop).toBe(1480);
+  });
 
   it("restores the prior scroll position when the reserved dock offset grows while scrolled up", () => {
     const container = createScrollContainer({
       scrollHeight: 2000,
       clientHeight: 600,
-      initialScrollTop: 900
-    })
+      initialScrollTop: 900,
+    });
 
     const { result, rerender } = renderHook(
       ({ bottomOffsetPx }) =>
         useSmartScrollWithDockOffset(messages, false, 120, { bottomOffsetPx }),
       {
-        initialProps: { bottomOffsetPx: 80 }
-      }
-    )
+        initialProps: { bottomOffsetPx: 80 },
+      },
+    );
 
     act(() => {
-      result.current.containerRef.current = container.element
-    })
+      result.current.containerRef.current = container.element;
+    });
 
     act(() => {
-      container.scrollTop = 980
-      rerender({ bottomOffsetPx: 160 })
-    })
+      container.scrollTop = 980;
+      rerender({ bottomOffsetPx: 160 });
+    });
 
-    expect(container.scrollTop).toBe(900)
-  })
-})
+    expect(container.scrollTop).toBe(900);
+  });
+});

--- a/apps/packages/ui/src/hooks/__tests__/useSmartScroll.dock-offset.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useSmartScroll.dock-offset.test.tsx
@@ -181,7 +181,7 @@ describe("useSmartScroll dock offset preservation", () => {
     expect(container.scrollTop).toBe(1480);
   });
 
-  it("restores the prior scroll position when the reserved dock offset grows while scrolled up", () => {
+  it("preserves the current scroll position when the reserved dock offset grows while scrolled up", () => {
     const container = createScrollContainer({
       scrollHeight: 2000,
       clientHeight: 600,
@@ -205,6 +205,6 @@ describe("useSmartScroll dock offset preservation", () => {
       rerender({ bottomOffsetPx: 160 });
     });
 
-    expect(container.scrollTop).toBe(900);
+    expect(container.scrollTop).toBe(980);
   });
 });

--- a/apps/packages/ui/src/hooks/__tests__/useSmartScroll.dock-offset.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useSmartScroll.dock-offset.test.tsx
@@ -1,0 +1,202 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { useSmartScroll } from "../useSmartScroll"
+
+type DockAwareSmartScroll = (
+  messages: Array<{ id: string }>,
+  streaming: boolean,
+  threshold: number,
+  options?: {
+    bottomOffsetPx?: number
+  }
+) => ReturnType<typeof useSmartScroll>
+
+type ScrollContainerHandle = {
+  element: HTMLDivElement
+  get scrollTop(): number
+  set scrollTop(value: number)
+}
+
+const useSmartScrollWithDockOffset = useSmartScroll as unknown as DockAwareSmartScroll
+
+const messages = [{ id: "m-1" }]
+
+const createScrollContainer = ({
+  scrollHeight,
+  clientHeight,
+  initialScrollTop
+}: {
+  scrollHeight: number
+  clientHeight: number
+  initialScrollTop: number
+}): ScrollContainerHandle => {
+  const element = document.createElement("div") as HTMLDivElement
+
+  let top = initialScrollTop
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    get: () => scrollHeight
+  })
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    get: () => clientHeight
+  })
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    get: () => top,
+    set: (value: number) => {
+      top = Number(value)
+    }
+  })
+  Object.defineProperty(element, "scrollTo", {
+    configurable: true,
+    value: ({ top: nextTop }: { top: number }) => {
+      top = Number(nextTop)
+    }
+  })
+
+  return {
+    element,
+    get scrollTop() {
+      return top
+    },
+    set scrollTop(value: number) {
+      top = value
+    }
+  }
+}
+
+describe("useSmartScroll dock offset preservation", () => {
+  let originalRequestAnimationFrame:
+    | typeof window.requestAnimationFrame
+    | undefined
+  let originalCancelAnimationFrame:
+    | typeof window.cancelAnimationFrame
+    | undefined
+
+  beforeEach(() => {
+    originalRequestAnimationFrame = window.requestAnimationFrame
+    originalCancelAnimationFrame = window.cancelAnimationFrame
+
+    const raf = (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    }
+
+    ;(window as typeof window & { requestAnimationFrame?: typeof raf }).requestAnimationFrame =
+      raf
+    ;(
+      globalThis as typeof globalThis & {
+        requestAnimationFrame?: typeof raf
+      }
+    ).requestAnimationFrame = raf
+    ;(
+      window as typeof window & { cancelAnimationFrame?: (handle: number) => void }
+    ).cancelAnimationFrame = () => undefined
+    ;(
+      globalThis as typeof globalThis & {
+        cancelAnimationFrame?: (handle: number) => void
+      }
+    ).cancelAnimationFrame = () => undefined
+  })
+
+  afterEach(() => {
+    if (originalRequestAnimationFrame) {
+      ;(
+        window as typeof window & {
+          requestAnimationFrame?: typeof window.requestAnimationFrame
+        }
+      ).requestAnimationFrame = originalRequestAnimationFrame
+      ;(
+        globalThis as typeof globalThis & {
+          requestAnimationFrame?: typeof globalThis.requestAnimationFrame
+        }
+      ).requestAnimationFrame = originalRequestAnimationFrame
+    } else {
+      delete (
+        window as typeof window & { requestAnimationFrame?: typeof window.requestAnimationFrame }
+      ).requestAnimationFrame
+      delete (
+        globalThis as typeof globalThis & {
+          requestAnimationFrame?: typeof globalThis.requestAnimationFrame
+        }
+      ).requestAnimationFrame
+    }
+
+    if (originalCancelAnimationFrame) {
+      ;(
+        window as typeof window & {
+          cancelAnimationFrame?: typeof window.cancelAnimationFrame
+        }
+      ).cancelAnimationFrame = originalCancelAnimationFrame
+      ;(
+        globalThis as typeof globalThis & {
+          cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame
+        }
+      ).cancelAnimationFrame = originalCancelAnimationFrame
+    } else {
+      delete (
+        window as typeof window & { cancelAnimationFrame?: typeof window.cancelAnimationFrame }
+      ).cancelAnimationFrame
+      delete (
+        globalThis as typeof globalThis & {
+          cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame
+        }
+      ).cancelAnimationFrame
+    }
+  })
+
+  it("keeps the latest message anchored when the reserved dock offset grows at bottom", () => {
+    const container = createScrollContainer({
+      scrollHeight: 2000,
+      clientHeight: 600,
+      initialScrollTop: 1400
+    })
+
+    const { result, rerender } = renderHook(
+      ({ bottomOffsetPx }) =>
+        useSmartScrollWithDockOffset(messages, false, 120, { bottomOffsetPx }),
+      {
+        initialProps: { bottomOffsetPx: 80 }
+      }
+    )
+
+    act(() => {
+      result.current.containerRef.current = container.element
+    })
+
+    act(() => {
+      rerender({ bottomOffsetPx: 160 })
+    })
+
+    expect(container.scrollTop).toBe(1480)
+  })
+
+  it("restores the prior scroll position when the reserved dock offset grows while scrolled up", () => {
+    const container = createScrollContainer({
+      scrollHeight: 2000,
+      clientHeight: 600,
+      initialScrollTop: 900
+    })
+
+    const { result, rerender } = renderHook(
+      ({ bottomOffsetPx }) =>
+        useSmartScrollWithDockOffset(messages, false, 120, { bottomOffsetPx }),
+      {
+        initialProps: { bottomOffsetPx: 80 }
+      }
+    )
+
+    act(() => {
+      result.current.containerRef.current = container.element
+    })
+
+    act(() => {
+      container.scrollTop = 980
+      rerender({ bottomOffsetPx: 160 })
+    })
+
+    expect(container.scrollTop).toBe(900)
+  })
+})

--- a/apps/packages/ui/src/hooks/useSmartScroll.tsx
+++ b/apps/packages/ui/src/hooks/useSmartScroll.tsx
@@ -1,9 +1,14 @@
 import { useRef, useEffect, useState, useCallback, useMemo } from "react"
 
+type SmartScrollOptions = {
+  bottomOffsetPx?: number
+}
+
 export const useSmartScroll = (
   messages: any[],
   streaming: boolean,
-  threshold: number = 100 
+  threshold: number = 100,
+  options: SmartScrollOptions = {}
 ) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true)
@@ -11,13 +16,20 @@ export const useSmartScroll = (
   const lastScrollTop = useRef(0)
   const lastScrollHeight = useRef(0)
   const isScrollingProgrammatically = useRef(false)
+  const bottomOffsetPx = Math.max(0, Math.round(options.bottomOffsetPx ?? 0))
+  const bottomOffsetPxRef = useRef(bottomOffsetPx)
+  const previousBottomOffsetPxRef = useRef(bottomOffsetPx)
 
-  const isAtBottom = useCallback(() => {
+  useEffect(() => {
+    bottomOffsetPxRef.current = bottomOffsetPx
+  }, [bottomOffsetPx])
+
+  const isAtBottom = useCallback((offsetPx: number = bottomOffsetPxRef.current) => {
     const container = containerRef.current
     if (!container) return false
 
     const { scrollTop, scrollHeight, clientHeight } = container
-    return scrollHeight - scrollTop - clientHeight <= threshold
+    return scrollHeight - scrollTop - clientHeight - offsetPx <= threshold
   }, [threshold])
 
   const scrollToBottom = useCallback((smooth: boolean = false) => {
@@ -98,6 +110,24 @@ export const useSmartScroll = (
     }
   }, [messages, isAutoScrollEnabled, scrollToBottom, streaming, isAtBottom])
 
+  useEffect(() => {
+    const container = containerRef.current
+    const previousBottomOffsetPx = previousBottomOffsetPxRef.current
+    previousBottomOffsetPxRef.current = bottomOffsetPx
+
+    if (!container) return
+    const bottomOffsetDeltaPx = bottomOffsetPx - previousBottomOffsetPx
+    if (bottomOffsetDeltaPx === 0) return
+
+    const wasPinnedToBottom = isAtBottom(previousBottomOffsetPx)
+    const nextScrollTop = wasPinnedToBottom
+      ? container.scrollTop + bottomOffsetDeltaPx
+      : container.scrollTop - bottomOffsetDeltaPx
+
+    container.scrollTop = Math.max(0, nextScrollTop)
+    lastScrollTop.current = container.scrollTop
+  }, [bottomOffsetPx, isAtBottom])
+
   const autoScrollToBottom = useCallback(() => {
     setIsAutoScrollEnabled(true)
     scrollToBottom(true)
@@ -106,7 +136,7 @@ export const useSmartScroll = (
   const isAutoScrollToBottom = useMemo(
     () => isAutoScrollEnabled && isAtBottom(),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally re-evaluate when messages or streaming change
-    [isAutoScrollEnabled, messages, streaming]
+    [bottomOffsetPx, isAutoScrollEnabled, messages, streaming]
   )
 
   return {

--- a/apps/packages/ui/src/hooks/useSmartScroll.tsx
+++ b/apps/packages/ui/src/hooks/useSmartScroll.tsx
@@ -1,147 +1,150 @@
-import { useRef, useEffect, useState, useCallback, useMemo } from "react"
+import { useRef, useEffect, useState, useCallback, useMemo } from "react";
 
 type SmartScrollOptions = {
-  bottomOffsetPx?: number
-}
+  bottomOffsetPx?: number;
+};
 
 export const useSmartScroll = (
   messages: any[],
   streaming: boolean,
   threshold: number = 100,
-  options: SmartScrollOptions = {}
+  options: SmartScrollOptions = {},
 ) => {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true)
-  const scrollTimeout = useRef<NodeJS.Timeout | null>(null)
-  const lastScrollTop = useRef(0)
-  const lastScrollHeight = useRef(0)
-  const isScrollingProgrammatically = useRef(false)
-  const bottomOffsetPx = Math.max(0, Math.round(options.bottomOffsetPx ?? 0))
-  const bottomOffsetPxRef = useRef(bottomOffsetPx)
-  const previousBottomOffsetPxRef = useRef(bottomOffsetPx)
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true);
+  const scrollTimeout = useRef<NodeJS.Timeout | null>(null);
+  const lastScrollTop = useRef(0);
+  const lastScrollHeight = useRef(0);
+  const isScrollingProgrammatically = useRef(false);
+  const bottomOffsetPx = Math.max(0, Math.round(options.bottomOffsetPx ?? 0));
+  const bottomOffsetPxRef = useRef(bottomOffsetPx);
+  const previousBottomOffsetPxRef = useRef(bottomOffsetPx);
 
   useEffect(() => {
-    bottomOffsetPxRef.current = bottomOffsetPx
-  }, [bottomOffsetPx])
+    bottomOffsetPxRef.current = bottomOffsetPx;
+  }, [bottomOffsetPx]);
 
-  const isAtBottom = useCallback((offsetPx: number = bottomOffsetPxRef.current) => {
-    const container = containerRef.current
-    if (!container) return false
+  const isAtBottom = useCallback(
+    (offsetPx: number = bottomOffsetPxRef.current) => {
+      const container = containerRef.current;
+      if (!container) return false;
 
-    const { scrollTop, scrollHeight, clientHeight } = container
-    return scrollHeight - scrollTop - clientHeight - offsetPx <= threshold
-  }, [threshold])
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      return scrollHeight - scrollTop - clientHeight - offsetPx <= threshold;
+    },
+    [threshold],
+  );
 
   const scrollToBottom = useCallback((smooth: boolean = false) => {
-    const container = containerRef.current
-    if (!container) return
+    const container = containerRef.current;
+    if (!container) return;
 
-    isScrollingProgrammatically.current = true
+    isScrollingProgrammatically.current = true;
 
     container.scrollTo({
       top: container.scrollHeight,
-      behavior: smooth ? "smooth" : "auto"
-    })
+      behavior: smooth ? "smooth" : "auto",
+    });
 
     setTimeout(
       () => {
-        isScrollingProgrammatically.current = false
+        isScrollingProgrammatically.current = false;
       },
-      smooth ? 300 : 50
-    )
-  }, [])
+      smooth ? 300 : 50,
+    );
+  }, []);
 
   useEffect(() => {
-    const container = containerRef.current
-    if (!container) return
+    const container = containerRef.current;
+    if (!container) return;
 
     const handleScroll = () => {
-      if (isScrollingProgrammatically.current) return
+      if (isScrollingProgrammatically.current) return;
 
-      const { scrollTop, scrollHeight } = container
-      const isScrollingUp = scrollTop < lastScrollTop.current
+      const { scrollTop, scrollHeight } = container;
+      const isScrollingUp = scrollTop < lastScrollTop.current;
 
-      lastScrollTop.current = scrollTop
-      lastScrollHeight.current = scrollHeight
+      lastScrollTop.current = scrollTop;
+      lastScrollHeight.current = scrollHeight;
 
       if (isScrollingUp) {
-        setIsAutoScrollEnabled(false)
+        setIsAutoScrollEnabled(false);
       }
 
       if (scrollTimeout.current) {
-        clearTimeout(scrollTimeout.current)
+        clearTimeout(scrollTimeout.current);
       }
 
       scrollTimeout.current = setTimeout(() => {
         if (isAtBottom()) {
-          setIsAutoScrollEnabled(true)
+          setIsAutoScrollEnabled(true);
         }
-      }, 300)
-    }
+      }, 300);
+    };
 
-    container.addEventListener("scroll", handleScroll, { passive: true })
+    container.addEventListener("scroll", handleScroll, { passive: true });
 
     return () => {
-      container.removeEventListener("scroll", handleScroll)
+      container.removeEventListener("scroll", handleScroll);
       if (scrollTimeout.current) {
-        clearTimeout(scrollTimeout.current)
+        clearTimeout(scrollTimeout.current);
       }
-    }
-  }, [isAtBottom])
+    };
+  }, [isAtBottom]);
 
   useEffect(() => {
     if (streaming && isAutoScrollEnabled) {
       requestAnimationFrame(() => {
-        scrollToBottom(false)
-      })
+        scrollToBottom(false);
+      });
     }
-  }, [streaming, isAutoScrollEnabled, scrollToBottom])
+  }, [streaming, isAutoScrollEnabled, scrollToBottom]);
 
   useEffect(() => {
     if (messages.length === 0) {
-      setIsAutoScrollEnabled(true)
-      return
+      setIsAutoScrollEnabled(true);
+      return;
     }
 
     if (isAutoScrollEnabled && !isAtBottom()) {
       requestAnimationFrame(() => {
-        scrollToBottom(!streaming)
-      })
+        scrollToBottom(!streaming);
+      });
     }
-  }, [messages, isAutoScrollEnabled, scrollToBottom, streaming, isAtBottom])
+  }, [messages, isAutoScrollEnabled, scrollToBottom, streaming, isAtBottom]);
 
   useEffect(() => {
-    const container = containerRef.current
-    const previousBottomOffsetPx = previousBottomOffsetPxRef.current
-    previousBottomOffsetPxRef.current = bottomOffsetPx
+    const container = containerRef.current;
+    const previousBottomOffsetPx = previousBottomOffsetPxRef.current;
+    previousBottomOffsetPxRef.current = bottomOffsetPx;
 
-    if (!container) return
-    const bottomOffsetDeltaPx = bottomOffsetPx - previousBottomOffsetPx
-    if (bottomOffsetDeltaPx === 0) return
+    if (!container) return;
+    const bottomOffsetDeltaPx = bottomOffsetPx - previousBottomOffsetPx;
+    if (bottomOffsetDeltaPx === 0) return;
 
-    const wasPinnedToBottom = isAtBottom(previousBottomOffsetPx)
+    const wasPinnedToBottom = isAtBottom(previousBottomOffsetPx);
     const nextScrollTop = wasPinnedToBottom
       ? container.scrollTop + bottomOffsetDeltaPx
-      : container.scrollTop - bottomOffsetDeltaPx
+      : container.scrollTop - bottomOffsetDeltaPx;
 
-    container.scrollTop = Math.max(0, nextScrollTop)
-    lastScrollTop.current = container.scrollTop
-  }, [bottomOffsetPx, isAtBottom])
+    container.scrollTop = Math.max(0, nextScrollTop);
+    lastScrollTop.current = container.scrollTop;
+  }, [bottomOffsetPx, isAtBottom]);
 
   const autoScrollToBottom = useCallback(() => {
-    setIsAutoScrollEnabled(true)
-    scrollToBottom(true)
-  }, [scrollToBottom])
+    setIsAutoScrollEnabled(true);
+    scrollToBottom(true);
+  }, [scrollToBottom]);
 
   const isAutoScrollToBottom = useMemo(
     () => isAutoScrollEnabled && isAtBottom(),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally re-evaluate when messages or streaming change
-    [bottomOffsetPx, isAutoScrollEnabled, messages, streaming]
-  )
+    [bottomOffsetPx, isAutoScrollEnabled, messages, streaming],
+  );
 
   return {
     containerRef,
     isAutoScrollToBottom,
-    autoScrollToBottom
-  }
-}
+    autoScrollToBottom,
+  };
+};

--- a/apps/packages/ui/src/hooks/useSmartScroll.tsx
+++ b/apps/packages/ui/src/hooks/useSmartScroll.tsx
@@ -123,11 +123,10 @@ export const useSmartScroll = (
     if (bottomOffsetDeltaPx === 0) return;
 
     const wasPinnedToBottom = isAtBottom(previousBottomOffsetPx);
-    const nextScrollTop = wasPinnedToBottom
-      ? container.scrollTop + bottomOffsetDeltaPx
-      : container.scrollTop - bottomOffsetDeltaPx;
-
-    container.scrollTop = Math.max(0, nextScrollTop);
+    if (wasPinnedToBottom) {
+      const nextScrollTop = container.scrollTop + bottomOffsetDeltaPx;
+      container.scrollTop = Math.max(0, nextScrollTop);
+    }
     lastScrollTop.current = container.scrollTop;
   }, [bottomOffsetPx, isAtBottom]);
 

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import OptionLayout from '../../../components/layout/WebLayout';
 

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -64,6 +64,9 @@ const connectionState = vi.hoisted(() => ({
 }))
 
 const confirmDangerMock = vi.hoisted(() => vi.fn(async () => false))
+const storageState = vi.hoisted(() => ({
+  stickyChatInput: true
+}))
 
 vi.mock("antd", () => ({
   Drawer: ({
@@ -228,6 +231,15 @@ vi.mock("@/hooks/useSetting", () => ({
   useSetting: () => [""]
 }))
 
+vi.mock("@plasmohq/storage/hook", () => ({
+  useStorage: (key: string, defaultValue: unknown) => {
+    if (key === "stickyChatInput") {
+      return [storageState.stickyChatInput]
+    }
+    return [defaultValue]
+  }
+}))
+
 vi.mock("@/hooks/useServerOnline", () => ({
   useServerOnline: () => undefined
 }))
@@ -312,34 +324,12 @@ vi.mock("@/context/demo-mode", () => ({
 }))
 
 describe("WebLayout /chat scroll contract", () => {
-  const previousWindow = globalThis.window
-
   beforeEach(() => {
     vi.clearAllMocks()
     routerState.location.pathname = "/chat"
     routerState.location.search = ""
     routerState.location.hash = ""
-    ;(
-      globalThis as typeof globalThis & {
-        window?: {
-          localStorage: {
-            getItem: (key: string) => string | null
-          }
-        }
-      }
-    ).window = {
-      localStorage: {
-        getItem: (key: string) => (key === "stickyChatInput" ? "true" : null)
-      }
-    }
-  })
-
-  afterEach(() => {
-    ;(
-      globalThis as typeof globalThis & {
-        window?: typeof globalThis.window
-      }
-    ).window = previousWindow
+    storageState.stickyChatInput = true
   })
 
   it("marks the /chat route shell as transcript-owned when sticky chat input is active", () => {

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -1,0 +1,354 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import OptionLayout from "../../../components/layout/WebLayout"
+
+const routerState = vi.hoisted(() => ({
+  location: {
+    pathname: "/chat",
+    search: "",
+    hash: ""
+  },
+  navigate: vi.fn()
+}))
+
+const layoutUiState = vi.hoisted(() => ({
+  value: {
+    chatSidebarCollapsed: true,
+    setChatSidebarCollapsed: vi.fn()
+  }
+}))
+
+const routeTransitionState = vi.hoisted(() => ({
+  value: {
+    active: false,
+    pendingPath: null as string | null,
+    startedAt: null as number | null,
+    stop: vi.fn()
+  }
+}))
+
+const messageOptionState = vi.hoisted(() => ({
+  value: {
+    clearChat: vi.fn(),
+    useOCR: false,
+    chatMode: "chat",
+    setChatMode: vi.fn(),
+    webSearch: false,
+    setWebSearch: vi.fn()
+  }
+}))
+
+const optionStoreState = vi.hoisted(() => ({
+  value: {
+    historyId: null as string | null,
+    serverChatId: null as string | null
+  }
+}))
+
+const quickChatState = vi.hoisted(() => ({
+  value: {
+    isOpen: false,
+    setIsOpen: vi.fn()
+  }
+}))
+
+const connectionState = vi.hoisted(() => ({
+  value: {
+    checkOnce: vi.fn(async () => undefined),
+    phase: "connected",
+    isConnected: true,
+    isChecking: false
+  }
+}))
+
+const confirmDangerMock = vi.hoisted(() => vi.fn(async () => false))
+
+vi.mock("antd", () => ({
+  Drawer: ({
+    children,
+    open
+  }: {
+    children: React.ReactNode
+    open?: boolean
+  }) => (open ? <div data-testid="drawer">{children}</div> : null),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock("lucide-react", () => ({
+  EraserIcon: () => null,
+  XIcon: () => null
+}))
+
+vi.mock("@/components/Common/IconButton", () => ({
+  IconButton: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  )
+}))
+
+vi.mock("react-router-dom", () => ({
+  useLocation: () => routerState.location,
+  useNavigate: () => routerState.navigate
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallback?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof fallback === "string") return fallback
+      if (fallback && typeof fallback === "object" && fallback.defaultValue) {
+        return fallback.defaultValue
+      }
+      return key
+    }
+  })
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+    setQueryData: vi.fn(),
+    getQueryData: vi.fn()
+  })
+}))
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: <T,>(selector: T) => selector
+}))
+
+vi.mock("@/libs/class-name", () => ({
+  classNames: (...parts: Array<string | false | null | undefined>) =>
+    parts.filter(Boolean).join(" ")
+}))
+
+vi.mock("@/db/dexie/chat", () => ({
+  PageAssistDatabase: class {
+    async deleteAllChatHistory(): Promise<void> {}
+  }
+}))
+
+vi.mock("@/hooks/useMessageOption", () => ({
+  useMessageOption: () => messageOptionState.value
+}))
+
+vi.mock("@/hooks/keyboard/useKeyboardShortcuts", () => ({
+  useChatShortcuts: () => undefined,
+  useSidebarShortcuts: () => undefined,
+  useQuickChatShortcuts: () => undefined
+}))
+
+vi.mock("@/store/quick-chat", () => ({
+  useQuickChatStore: () => quickChatState.value
+}))
+
+vi.mock("@/store/option", () => ({
+  useStoreMessageOption: (
+    selector: (state: typeof optionStoreState.value) => unknown
+  ) => selector(optionStoreState.value)
+}))
+
+vi.mock("@/store/layout-ui", () => ({
+  useLayoutUiStore: (
+    selector: (state: typeof layoutUiState.value) => unknown
+  ) => selector(layoutUiState.value)
+}))
+
+vi.mock("@/store/route-transition", () => ({
+  useRouteTransitionStore: (
+    selector: (state: typeof routeTransitionState.value) => unknown
+  ) => selector(routeTransitionState.value)
+}))
+
+vi.mock("@/components/Common/QuickChatHelper", () => ({
+  QuickChatHelperButton: () => <div data-testid="quick-chat-helper" />
+}))
+
+vi.mock("@/components/Common/NotesDock", () => ({
+  NotesDockHost: () => <div data-testid="notes-dock-host" />
+}))
+
+vi.mock("@/components/Common/PersonaBuddy", () => ({
+  BuddyShellHost: () => <div data-testid="buddy-shell-host" />,
+  BuddyShellRenderContextProvider: ({
+    children
+  }: {
+    children: React.ReactNode
+  }) => <>{children}</>
+}))
+
+vi.mock("@/components/Common/Settings/CurrentChatModelSettings", () => ({
+  CurrentChatModelSettings: () => null
+}))
+
+vi.mock("@/components/Option/Sidebar", () => ({
+  Sidebar: () => null
+}))
+
+vi.mock("@/components/Layouts/Header", () => ({
+  Header: () => <div data-testid="header" />
+}))
+
+vi.mock("@/components/Layouts/QuickIngestButton", () => ({
+  QuickIngestModalHost: () => null
+}))
+
+vi.mock("@/hooks/useMigration", () => ({
+  useMigration: () => ({ isLoading: false })
+}))
+
+vi.mock("@/hooks/useStorageMigrations", () => ({
+  useStorageMigrations: () => undefined
+}))
+
+vi.mock("@/hooks/useLayoutEffectsOwner", () => ({
+  useLayoutEffectsOwner: () => false
+}))
+
+vi.mock("@/hooks/useFeatureFlags", () => ({
+  useChatSidebar: () => [false]
+}))
+
+vi.mock("@/hooks/useMediaQuery", () => ({
+  useMobile: () => false
+}))
+
+vi.mock("@/hooks/useSetting", () => ({
+  useSetting: () => [""]
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => undefined
+}))
+
+vi.mock("@/components/Common/ChatSidebar", () => ({
+  ChatSidebar: () => null
+}))
+
+vi.mock("@/components/Common/EventHosts", () => ({
+  EventOnlyHosts: () => null
+}))
+
+vi.mock("@/components/Common/PageAssistLoader", () => ({
+  PageAssistLoader: () => <div data-testid="page-assist-loader" />
+}))
+
+vi.mock("@/utils/settings-return", () => ({
+  setSettingsReturnTo: vi.fn()
+}))
+
+vi.mock("@/components/Common/Workflow", () => ({
+  WorkflowIntegrationHost: () => null
+}))
+
+vi.mock("@/routes/route-paths", () => ({
+  VIEWPORT_CONSTRAINED_PATHS: ["/chat"]
+}))
+
+vi.mock("@/services/settings/ui-settings", () => ({
+  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
+  HEADER_SHORTCUTS_EXPANDED_SETTING: "headerShortcutsExpanded"
+}))
+
+vi.mock("@/services/settings/registry", () => ({
+  setSetting: vi.fn(async () => undefined)
+}))
+
+vi.mock("@/services/request-events", () => ({
+  BACKEND_UNREACHABLE_EVENT: "tldw:backend-unreachable"
+}))
+
+vi.mock("@/components/Common/BackendRecoveryUiContext", () => ({
+  useBackendRecoveryUi: () => ({ fatalBackendRecoveryActive: false })
+}))
+
+vi.mock("@web/components/layout/BackendUnavailableModalGate", () => ({
+  BackendUnavailableModalGate: () => null
+}))
+
+vi.mock("@web/lib/api/notifications", () => ({
+  getUnreadCount: vi.fn(async () => ({ unread_count: 0 }))
+}))
+
+vi.mock("@/components/Common/CommandPalette", () => ({
+  CommandPalette: () => null
+}))
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useConnectionActions: () => ({ checkOnce: connectionState.value.checkOnce }),
+  useConnectionState: () => ({
+    phase: connectionState.value.phase,
+    isConnected: connectionState.value.isConnected
+  }),
+  useConnectionUxState: () => ({
+    isChecking: connectionState.value.isChecking
+  })
+}))
+
+vi.mock("@/types/connection", () => ({
+  ConnectionPhase: {
+    CONNECTED: "connected"
+  }
+}))
+
+vi.mock("@/components/Common/confirm-danger", () => ({
+  useConfirmDanger: () => confirmDangerMock
+}))
+
+vi.mock("@/context/demo-mode", () => ({
+  DemoModeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useDemoMode: () => ({ demoEnabled: false })
+}))
+
+describe("WebLayout /chat scroll contract", () => {
+  const previousWindow = globalThis.window
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routerState.location.pathname = "/chat"
+    routerState.location.search = ""
+    routerState.location.hash = ""
+    ;(
+      globalThis as typeof globalThis & {
+        window?: {
+          localStorage: {
+            getItem: (key: string) => string | null
+          }
+        }
+      }
+    ).window = {
+      localStorage: {
+        getItem: (key: string) => (key === "stickyChatInput" ? "true" : null)
+      }
+    }
+  })
+
+  afterEach(() => {
+    ;(
+      globalThis as typeof globalThis & {
+        window?: typeof globalThis.window
+      }
+    ).window = previousWindow
+  })
+
+  it("marks the /chat route shell as transcript-owned when sticky chat input is active", () => {
+    const html = renderToStaticMarkup(
+      <OptionLayout hideSidebar>
+        <div data-testid="chat-route-content">Chat route</div>
+      </OptionLayout>
+    )
+
+    expect(html).toContain('data-chat-scroll-owner="transcript"')
+  })
+})

--- a/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
+++ b/apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx
@@ -1,344 +1,329 @@
-import React from "react"
-import { renderToStaticMarkup } from "react-dom/server"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import OptionLayout from "../../../components/layout/WebLayout"
+import OptionLayout from '../../../components/layout/WebLayout';
 
 const routerState = vi.hoisted(() => ({
   location: {
-    pathname: "/chat",
-    search: "",
-    hash: ""
+    pathname: '/chat',
+    search: '',
+    hash: '',
   },
-  navigate: vi.fn()
-}))
+  navigate: vi.fn(),
+}));
 
 const layoutUiState = vi.hoisted(() => ({
   value: {
     chatSidebarCollapsed: true,
-    setChatSidebarCollapsed: vi.fn()
-  }
-}))
+    setChatSidebarCollapsed: vi.fn(),
+  },
+}));
 
 const routeTransitionState = vi.hoisted(() => ({
   value: {
     active: false,
     pendingPath: null as string | null,
     startedAt: null as number | null,
-    stop: vi.fn()
-  }
-}))
+    stop: vi.fn(),
+  },
+}));
 
 const messageOptionState = vi.hoisted(() => ({
   value: {
     clearChat: vi.fn(),
     useOCR: false,
-    chatMode: "chat",
+    chatMode: 'chat',
     setChatMode: vi.fn(),
     webSearch: false,
-    setWebSearch: vi.fn()
-  }
-}))
+    setWebSearch: vi.fn(),
+  },
+}));
 
 const optionStoreState = vi.hoisted(() => ({
   value: {
     historyId: null as string | null,
-    serverChatId: null as string | null
-  }
-}))
+    serverChatId: null as string | null,
+  },
+}));
 
 const quickChatState = vi.hoisted(() => ({
   value: {
     isOpen: false,
-    setIsOpen: vi.fn()
-  }
-}))
+    setIsOpen: vi.fn(),
+  },
+}));
 
 const connectionState = vi.hoisted(() => ({
   value: {
     checkOnce: vi.fn(async () => undefined),
-    phase: "connected",
+    phase: 'connected',
     isConnected: true,
-    isChecking: false
-  }
-}))
+    isChecking: false,
+  },
+}));
 
-const confirmDangerMock = vi.hoisted(() => vi.fn(async () => false))
+const confirmDangerMock = vi.hoisted(() => vi.fn(async () => false));
 const storageState = vi.hoisted(() => ({
-  stickyChatInput: true
-}))
+  stickyChatInput: true,
+}));
 
-vi.mock("antd", () => ({
-  Drawer: ({
-    children,
-    open
-  }: {
-    children: React.ReactNode
-    open?: boolean
-  }) => (open ? <div data-testid="drawer">{children}</div> : null),
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
-}))
+vi.mock('antd', () => ({
+  Drawer: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open ? <div data-testid="drawer">{children}</div> : null,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 
-vi.mock("lucide-react", () => ({
+vi.mock('lucide-react', () => ({
   EraserIcon: () => null,
-  XIcon: () => null
-}))
+  XIcon: () => null,
+}));
 
-vi.mock("@/components/Common/IconButton", () => ({
-  IconButton: ({
-    children,
-    ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+vi.mock('@/components/Common/IconButton', () => ({
+  IconButton: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button type="button" {...props}>
       {children}
     </button>
-  )
-}))
+  ),
+}));
 
-vi.mock("react-router-dom", () => ({
+vi.mock('react-router-dom', () => ({
   useLocation: () => routerState.location,
-  useNavigate: () => routerState.navigate
-}))
+  useNavigate: () => routerState.navigate,
+}));
 
-vi.mock("react-i18next", () => ({
+vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (
       key: string,
       fallback?:
         | string
         | {
-            defaultValue?: string
+            defaultValue?: string;
           }
     ) => {
-      if (typeof fallback === "string") return fallback
-      if (fallback && typeof fallback === "object" && fallback.defaultValue) {
-        return fallback.defaultValue
+      if (typeof fallback === 'string') return fallback;
+      if (fallback && typeof fallback === 'object' && fallback.defaultValue) {
+        return fallback.defaultValue;
       }
-      return key
-    }
-  })
-}))
+      return key;
+    },
+  }),
+}));
 
-vi.mock("@tanstack/react-query", () => ({
+vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({
     invalidateQueries: vi.fn(),
     setQueryData: vi.fn(),
-    getQueryData: vi.fn()
-  })
-}))
+    getQueryData: vi.fn(),
+  }),
+}));
 
-vi.mock("zustand/react/shallow", () => ({
-  useShallow: <T,>(selector: T) => selector
-}))
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: <T,>(selector: T) => selector,
+}));
 
-vi.mock("@/libs/class-name", () => ({
+vi.mock('@/libs/class-name', () => ({
   classNames: (...parts: Array<string | false | null | undefined>) =>
-    parts.filter(Boolean).join(" ")
-}))
+    parts.filter(Boolean).join(' '),
+}));
 
-vi.mock("@/db/dexie/chat", () => ({
+vi.mock('@/db/dexie/chat', () => ({
   PageAssistDatabase: class {
     async deleteAllChatHistory(): Promise<void> {}
-  }
-}))
+  },
+}));
 
-vi.mock("@/hooks/useMessageOption", () => ({
-  useMessageOption: () => messageOptionState.value
-}))
+vi.mock('@/hooks/useMessageOption', () => ({
+  useMessageOption: () => messageOptionState.value,
+}));
 
-vi.mock("@/hooks/keyboard/useKeyboardShortcuts", () => ({
+vi.mock('@/hooks/keyboard/useKeyboardShortcuts', () => ({
   useChatShortcuts: () => undefined,
   useSidebarShortcuts: () => undefined,
-  useQuickChatShortcuts: () => undefined
-}))
+  useQuickChatShortcuts: () => undefined,
+}));
 
-vi.mock("@/store/quick-chat", () => ({
-  useQuickChatStore: () => quickChatState.value
-}))
+vi.mock('@/store/quick-chat', () => ({
+  useQuickChatStore: () => quickChatState.value,
+}));
 
-vi.mock("@/store/option", () => ({
-  useStoreMessageOption: (
-    selector: (state: typeof optionStoreState.value) => unknown
-  ) => selector(optionStoreState.value)
-}))
+vi.mock('@/store/option', () => ({
+  useStoreMessageOption: (selector: (state: typeof optionStoreState.value) => unknown) =>
+    selector(optionStoreState.value),
+}));
 
-vi.mock("@/store/layout-ui", () => ({
-  useLayoutUiStore: (
-    selector: (state: typeof layoutUiState.value) => unknown
-  ) => selector(layoutUiState.value)
-}))
+vi.mock('@/store/layout-ui', () => ({
+  useLayoutUiStore: (selector: (state: typeof layoutUiState.value) => unknown) =>
+    selector(layoutUiState.value),
+}));
 
-vi.mock("@/store/route-transition", () => ({
-  useRouteTransitionStore: (
-    selector: (state: typeof routeTransitionState.value) => unknown
-  ) => selector(routeTransitionState.value)
-}))
+vi.mock('@/store/route-transition', () => ({
+  useRouteTransitionStore: (selector: (state: typeof routeTransitionState.value) => unknown) =>
+    selector(routeTransitionState.value),
+}));
 
-vi.mock("@/components/Common/QuickChatHelper", () => ({
-  QuickChatHelperButton: () => <div data-testid="quick-chat-helper" />
-}))
+vi.mock('@/components/Common/QuickChatHelper', () => ({
+  QuickChatHelperButton: () => <div data-testid="quick-chat-helper" />,
+}));
 
-vi.mock("@/components/Common/NotesDock", () => ({
-  NotesDockHost: () => <div data-testid="notes-dock-host" />
-}))
+vi.mock('@/components/Common/NotesDock', () => ({
+  NotesDockHost: () => <div data-testid="notes-dock-host" />,
+}));
 
-vi.mock("@/components/Common/PersonaBuddy", () => ({
+vi.mock('@/components/Common/PersonaBuddy', () => ({
   BuddyShellHost: () => <div data-testid="buddy-shell-host" />,
-  BuddyShellRenderContextProvider: ({
-    children
-  }: {
-    children: React.ReactNode
-  }) => <>{children}</>
-}))
+  BuddyShellRenderContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 
-vi.mock("@/components/Common/Settings/CurrentChatModelSettings", () => ({
-  CurrentChatModelSettings: () => null
-}))
+vi.mock('@/components/Common/Settings/CurrentChatModelSettings', () => ({
+  CurrentChatModelSettings: () => null,
+}));
 
-vi.mock("@/components/Option/Sidebar", () => ({
-  Sidebar: () => null
-}))
+vi.mock('@/components/Option/Sidebar', () => ({
+  Sidebar: () => null,
+}));
 
-vi.mock("@/components/Layouts/Header", () => ({
-  Header: () => <div data-testid="header" />
-}))
+vi.mock('@/components/Layouts/Header', () => ({
+  Header: () => <div data-testid="header" />,
+}));
 
-vi.mock("@/components/Layouts/QuickIngestButton", () => ({
-  QuickIngestModalHost: () => null
-}))
+vi.mock('@/components/Layouts/QuickIngestButton', () => ({
+  QuickIngestModalHost: () => null,
+}));
 
-vi.mock("@/hooks/useMigration", () => ({
-  useMigration: () => ({ isLoading: false })
-}))
+vi.mock('@/hooks/useMigration', () => ({
+  useMigration: () => ({ isLoading: false }),
+}));
 
-vi.mock("@/hooks/useStorageMigrations", () => ({
-  useStorageMigrations: () => undefined
-}))
+vi.mock('@/hooks/useStorageMigrations', () => ({
+  useStorageMigrations: () => undefined,
+}));
 
-vi.mock("@/hooks/useLayoutEffectsOwner", () => ({
-  useLayoutEffectsOwner: () => false
-}))
+vi.mock('@/hooks/useLayoutEffectsOwner', () => ({
+  useLayoutEffectsOwner: () => false,
+}));
 
-vi.mock("@/hooks/useFeatureFlags", () => ({
-  useChatSidebar: () => [false]
-}))
+vi.mock('@/hooks/useFeatureFlags', () => ({
+  useChatSidebar: () => [false],
+}));
 
-vi.mock("@/hooks/useMediaQuery", () => ({
-  useMobile: () => false
-}))
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useMobile: () => false,
+}));
 
-vi.mock("@/hooks/useSetting", () => ({
-  useSetting: () => [""]
-}))
+vi.mock('@/hooks/useSetting', () => ({
+  useSetting: () => [''],
+}));
 
-vi.mock("@plasmohq/storage/hook", () => ({
+vi.mock('@plasmohq/storage/hook', () => ({
   useStorage: (key: string, defaultValue: unknown) => {
-    if (key === "stickyChatInput") {
-      return [storageState.stickyChatInput]
+    if (key === 'stickyChatInput') {
+      return [storageState.stickyChatInput];
     }
-    return [defaultValue]
-  }
-}))
+    return [defaultValue];
+  },
+}));
 
-vi.mock("@/hooks/useServerOnline", () => ({
-  useServerOnline: () => undefined
-}))
+vi.mock('@/hooks/useServerOnline', () => ({
+  useServerOnline: () => undefined,
+}));
 
-vi.mock("@/components/Common/ChatSidebar", () => ({
-  ChatSidebar: () => null
-}))
+vi.mock('@/components/Common/ChatSidebar', () => ({
+  ChatSidebar: () => null,
+}));
 
-vi.mock("@/components/Common/EventHosts", () => ({
-  EventOnlyHosts: () => null
-}))
+vi.mock('@/components/Common/EventHosts', () => ({
+  EventOnlyHosts: () => null,
+}));
 
-vi.mock("@/components/Common/PageAssistLoader", () => ({
-  PageAssistLoader: () => <div data-testid="page-assist-loader" />
-}))
+vi.mock('@/components/Common/PageAssistLoader', () => ({
+  PageAssistLoader: () => <div data-testid="page-assist-loader" />,
+}));
 
-vi.mock("@/utils/settings-return", () => ({
-  setSettingsReturnTo: vi.fn()
-}))
+vi.mock('@/utils/settings-return', () => ({
+  setSettingsReturnTo: vi.fn(),
+}));
 
-vi.mock("@/components/Common/Workflow", () => ({
-  WorkflowIntegrationHost: () => null
-}))
+vi.mock('@/components/Common/Workflow', () => ({
+  WorkflowIntegrationHost: () => null,
+}));
 
-vi.mock("@/routes/route-paths", () => ({
-  VIEWPORT_CONSTRAINED_PATHS: ["/chat"]
-}))
+vi.mock('@/routes/route-paths', () => ({
+  VIEWPORT_CONSTRAINED_PATHS: ['/chat'],
+}));
 
-vi.mock("@/services/settings/ui-settings", () => ({
-  CHAT_BACKGROUND_IMAGE_SETTING: "chatBackgroundImage",
-  HEADER_SHORTCUTS_EXPANDED_SETTING: "headerShortcutsExpanded"
-}))
+vi.mock('@/services/settings/ui-settings', () => ({
+  CHAT_BACKGROUND_IMAGE_SETTING: 'chatBackgroundImage',
+  HEADER_SHORTCUTS_EXPANDED_SETTING: 'headerShortcutsExpanded',
+}));
 
-vi.mock("@/services/settings/registry", () => ({
-  setSetting: vi.fn(async () => undefined)
-}))
+vi.mock('@/services/settings/registry', () => ({
+  setSetting: vi.fn(async () => undefined),
+}));
 
-vi.mock("@/services/request-events", () => ({
-  BACKEND_UNREACHABLE_EVENT: "tldw:backend-unreachable"
-}))
+vi.mock('@/services/request-events', () => ({
+  BACKEND_UNREACHABLE_EVENT: 'tldw:backend-unreachable',
+}));
 
-vi.mock("@/components/Common/BackendRecoveryUiContext", () => ({
-  useBackendRecoveryUi: () => ({ fatalBackendRecoveryActive: false })
-}))
+vi.mock('@/components/Common/BackendRecoveryUiContext', () => ({
+  useBackendRecoveryUi: () => ({ fatalBackendRecoveryActive: false }),
+}));
 
-vi.mock("@web/components/layout/BackendUnavailableModalGate", () => ({
-  BackendUnavailableModalGate: () => null
-}))
+vi.mock('@web/components/layout/BackendUnavailableModalGate', () => ({
+  BackendUnavailableModalGate: () => null,
+}));
 
-vi.mock("@web/lib/api/notifications", () => ({
-  getUnreadCount: vi.fn(async () => ({ unread_count: 0 }))
-}))
+vi.mock('@web/lib/api/notifications', () => ({
+  getUnreadCount: vi.fn(async () => ({ unread_count: 0 })),
+}));
 
-vi.mock("@/components/Common/CommandPalette", () => ({
-  CommandPalette: () => null
-}))
+vi.mock('@/components/Common/CommandPalette', () => ({
+  CommandPalette: () => null,
+}));
 
-vi.mock("@/hooks/useConnectionState", () => ({
+vi.mock('@/hooks/useConnectionState', () => ({
   useConnectionActions: () => ({ checkOnce: connectionState.value.checkOnce }),
   useConnectionState: () => ({
     phase: connectionState.value.phase,
-    isConnected: connectionState.value.isConnected
+    isConnected: connectionState.value.isConnected,
   }),
   useConnectionUxState: () => ({
-    isChecking: connectionState.value.isChecking
-  })
-}))
+    isChecking: connectionState.value.isChecking,
+  }),
+}));
 
-vi.mock("@/types/connection", () => ({
+vi.mock('@/types/connection', () => ({
   ConnectionPhase: {
-    CONNECTED: "connected"
-  }
-}))
+    CONNECTED: 'connected',
+  },
+}));
 
-vi.mock("@/components/Common/confirm-danger", () => ({
-  useConfirmDanger: () => confirmDangerMock
-}))
+vi.mock('@/components/Common/confirm-danger', () => ({
+  useConfirmDanger: () => confirmDangerMock,
+}));
 
-vi.mock("@/context/demo-mode", () => ({
+vi.mock('@/context/demo-mode', () => ({
   DemoModeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useDemoMode: () => ({ demoEnabled: false })
-}))
+  useDemoMode: () => ({ demoEnabled: false }),
+}));
 
-describe("WebLayout /chat scroll contract", () => {
+describe('WebLayout /chat scroll contract', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    routerState.location.pathname = "/chat"
-    routerState.location.search = ""
-    routerState.location.hash = ""
-    storageState.stickyChatInput = true
-  })
+    vi.clearAllMocks();
+    routerState.location.pathname = '/chat';
+    routerState.location.search = '';
+    routerState.location.hash = '';
+    storageState.stickyChatInput = true;
+  });
 
-  it("marks the /chat route shell as transcript-owned when sticky chat input is active", () => {
+  it('marks the /chat route shell as transcript-owned when sticky chat input is active', () => {
     const html = renderToStaticMarkup(
       <OptionLayout hideSidebar>
         <div data-testid="chat-route-content">Chat route</div>
       </OptionLayout>
-    )
+    );
 
-    expect(html).toContain('data-chat-scroll-owner="transcript"')
-  })
-})
+    expect(html).toContain('data-chat-scroll-owner="transcript"');
+  });
+});

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -1,640 +1,607 @@
-import React, { lazy, Suspense, useState, useContext, useEffect, useCallback } from "react"
+import React, { lazy, Suspense, useState, useContext, useEffect, useCallback } from 'react';
 
-import { Drawer, Tooltip } from "antd"
-import { EraserIcon, XIcon } from "lucide-react"
-import { IconButton } from "@/components/Common/IconButton"
-import { useLocation, useNavigate } from "react-router-dom"
-import { useTranslation } from "react-i18next"
-import { useQueryClient } from "@tanstack/react-query"
-import { useShallow } from "zustand/react/shallow"
-import { useStorage } from "@plasmohq/storage/hook"
+import { Drawer, Tooltip } from 'antd';
+import { EraserIcon, XIcon } from 'lucide-react';
+import { IconButton } from '@/components/Common/IconButton';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { useShallow } from 'zustand/react/shallow';
+import { useStorage } from '@plasmohq/storage/hook';
 
-import { classNames } from "@/libs/class-name"
-import { PageAssistDatabase } from "@/db/dexie/chat"
-import { useMessageOption } from "@/hooks/useMessageOption"
+import { classNames } from '@/libs/class-name';
+import { PageAssistDatabase } from '@/db/dexie/chat';
+import { useMessageOption } from '@/hooks/useMessageOption';
 import {
   useChatShortcuts,
   useSidebarShortcuts,
-  useQuickChatShortcuts
-} from "@/hooks/keyboard/useKeyboardShortcuts"
-import { useQuickChatStore } from "@/store/quick-chat"
-import { useStoreMessageOption } from "@/store/option"
-import { useLayoutUiStore } from "@/store/layout-ui"
-import { useRouteTransitionStore } from "@/store/route-transition"
-import { QuickChatHelperButton } from "@/components/Common/QuickChatHelper"
-import { NotesDockHost } from "@/components/Common/NotesDock"
-import {
-  BuddyShellHost,
-  BuddyShellRenderContextProvider
-} from "@/components/Common/PersonaBuddy"
-import { CurrentChatModelSettings } from "@/components/Common/Settings/CurrentChatModelSettings"
-import { Sidebar } from "@/components/Option/Sidebar"
-import { Header } from "@/components/Layouts/Header"
-import { QuickIngestModalHost } from "@/components/Layouts/QuickIngestButton"
-import { useMigration } from "@/hooks/useMigration"
-import { useStorageMigrations } from "@/hooks/useStorageMigrations"
-import { useLayoutEffectsOwner } from "@/hooks/useLayoutEffectsOwner"
-import { useChatSidebar } from "@/hooks/useFeatureFlags"
-import { useMobile } from "@/hooks/useMediaQuery"
-import { useSetting } from "@/hooks/useSetting"
-import { useServerOnline } from "@/hooks/useServerOnline"
-import { ChatSidebar } from "@/components/Common/ChatSidebar"
-import { EventOnlyHosts } from "@/components/Common/EventHosts"
-import { PageAssistLoader } from "@/components/Common/PageAssistLoader"
-import { setSettingsReturnTo } from "@/utils/settings-return"
-import { WorkflowIntegrationHost } from "@/components/Common/Workflow"
-import {
-  VIEWPORT_CONSTRAINED_PATHS
-} from "@/routes/route-paths"
+  useQuickChatShortcuts,
+} from '@/hooks/keyboard/useKeyboardShortcuts';
+import { useQuickChatStore } from '@/store/quick-chat';
+import { useStoreMessageOption } from '@/store/option';
+import { useLayoutUiStore } from '@/store/layout-ui';
+import { useRouteTransitionStore } from '@/store/route-transition';
+import { QuickChatHelperButton } from '@/components/Common/QuickChatHelper';
+import { NotesDockHost } from '@/components/Common/NotesDock';
+import { BuddyShellHost, BuddyShellRenderContextProvider } from '@/components/Common/PersonaBuddy';
+import { CurrentChatModelSettings } from '@/components/Common/Settings/CurrentChatModelSettings';
+import { Sidebar } from '@/components/Option/Sidebar';
+import { Header } from '@/components/Layouts/Header';
+import { QuickIngestModalHost } from '@/components/Layouts/QuickIngestButton';
+import { useMigration } from '@/hooks/useMigration';
+import { useStorageMigrations } from '@/hooks/useStorageMigrations';
+import { useLayoutEffectsOwner } from '@/hooks/useLayoutEffectsOwner';
+import { useChatSidebar } from '@/hooks/useFeatureFlags';
+import { useMobile } from '@/hooks/useMediaQuery';
+import { useSetting } from '@/hooks/useSetting';
+import { useServerOnline } from '@/hooks/useServerOnline';
+import { ChatSidebar } from '@/components/Common/ChatSidebar';
+import { EventOnlyHosts } from '@/components/Common/EventHosts';
+import { PageAssistLoader } from '@/components/Common/PageAssistLoader';
+import { setSettingsReturnTo } from '@/utils/settings-return';
+import { WorkflowIntegrationHost } from '@/components/Common/Workflow';
+import { VIEWPORT_CONSTRAINED_PATHS } from '@/routes/route-paths';
 import {
   CHAT_BACKGROUND_IMAGE_SETTING,
-  HEADER_SHORTCUTS_EXPANDED_SETTING
-} from "@/services/settings/ui-settings"
-import { setSetting } from "@/services/settings/registry"
+  HEADER_SHORTCUTS_EXPANDED_SETTING,
+} from '@/services/settings/ui-settings';
+import { setSetting } from '@/services/settings/registry';
 import {
   BACKEND_UNREACHABLE_EVENT,
-  type BackendUnreachableDetail
-} from "@/services/request-events"
-import { useBackendRecoveryUi } from "@/components/Common/BackendRecoveryUiContext"
-import { BackendUnavailableModalGate } from "@web/components/layout/BackendUnavailableModalGate"
-import { getUnreadCount } from "@web/lib/api/notifications"
-import { CommandPalette } from "@/components/Common/CommandPalette"
+  type BackendUnreachableDetail,
+} from '@/services/request-events';
+import { useBackendRecoveryUi } from '@/components/Common/BackendRecoveryUiContext';
+import { BackendUnavailableModalGate } from '@web/components/layout/BackendUnavailableModalGate';
+import { getUnreadCount } from '@web/lib/api/notifications';
+import { CommandPalette } from '@/components/Common/CommandPalette';
 import {
   useConnectionActions,
   useConnectionState,
-  useConnectionUxState
-} from "@/hooks/useConnectionState"
-import { ConnectionPhase } from "@/types/connection"
+  useConnectionUxState,
+} from '@/hooks/useConnectionState';
+import { ConnectionPhase } from '@/types/connection';
 
 // Lazy-load Timeline to reduce initial bundle size (~1.2MB cytoscape)
 const TimelineModal = lazy(() =>
-  import("@/components/Timeline").then((m) => ({ default: m.TimelineModal }))
-)
+  import('@/components/Timeline').then((m) => ({ default: m.TimelineModal }))
+);
 
 const KeyboardShortcutsModal = lazy(() =>
-  import("@/components/Common/KeyboardShortcutsModal").then((m) => ({
-    default: m.KeyboardShortcutsModal
+  import('@/components/Common/KeyboardShortcutsModal').then((m) => ({
+    default: m.KeyboardShortcutsModal,
   }))
-)
-import { useConfirmDanger } from "@/components/Common/confirm-danger"
-import { DemoModeProvider, useDemoMode } from "@/context/demo-mode"
+);
+import { useConfirmDanger } from '@/components/Common/confirm-danger';
+import { DemoModeProvider, useDemoMode } from '@/context/demo-mode';
 
 type OptionLayoutProps = {
-  children: React.ReactNode
-  hideHeader?: boolean
-  hideSidebar?: boolean
-  allowNestedHideHeader?: boolean
-  allowNestedHideSidebar?: boolean
-}
+  children: React.ReactNode;
+  hideHeader?: boolean;
+  hideSidebar?: boolean;
+  allowNestedHideHeader?: boolean;
+  allowNestedHideSidebar?: boolean;
+};
 
-const SHORTCUT_LOADING_MIN_MS = 0
-const SHORTCUT_LOADING_MAX_MS = 2500
+const SHORTCUT_LOADING_MIN_MS = 0;
+const SHORTCUT_LOADING_MAX_MS = 2500;
 
 const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   children,
   hideHeader = false,
-  hideSidebar = false
+  hideSidebar = false,
 }) => {
-  const confirmDanger = useConfirmDanger()
-  const isLayoutEffectsOwner = useLayoutEffectsOwner({ prefer: true })
-  useStorageMigrations(isLayoutEffectsOwner)
-  const [sidebarOpen, setSidebarOpen] = useState(false)
-  const chatSidebarCollapsed = useLayoutUiStore(
-    (state) => state.chatSidebarCollapsed
-  )
-  const setChatSidebarCollapsed = useLayoutUiStore(
-    (state) => state.setChatSidebarCollapsed
-  )
-  const { t } = useTranslation(["option", "common", "settings"])
-  const navigate = useNavigate()
-  const [openModelSettings, setOpenModelSettings] = useState(false)
-  const { isLoading: migrationLoading } = useMigration()
-  const { demoEnabled } = useDemoMode()
-  const [showChatSidebar] = useChatSidebar()
-  const isMobileViewport = useMobile()
-  useServerOnline()
+  const confirmDanger = useConfirmDanger();
+  const isLayoutEffectsOwner = useLayoutEffectsOwner({ prefer: true });
+  useStorageMigrations(isLayoutEffectsOwner);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const chatSidebarCollapsed = useLayoutUiStore((state) => state.chatSidebarCollapsed);
+  const setChatSidebarCollapsed = useLayoutUiStore((state) => state.setChatSidebarCollapsed);
+  const { t } = useTranslation(['option', 'common', 'settings']);
+  const navigate = useNavigate();
+  const [openModelSettings, setOpenModelSettings] = useState(false);
+  const { isLoading: migrationLoading } = useMigration();
+  const { demoEnabled } = useDemoMode();
+  const [showChatSidebar] = useChatSidebar();
+  const isMobileViewport = useMobile();
+  useServerOnline();
 
   // Notification unread count for header bell
-  const [notificationCount, setNotificationCount] = useState(0)
+  const [notificationCount, setNotificationCount] = useState(0);
   useEffect(() => {
-    if (demoEnabled) return
-    let cancelled = false
+    if (demoEnabled) return;
+    let cancelled = false;
     const poll = () => {
       getUnreadCount()
-        .then((res) => { if (!cancelled) setNotificationCount(res?.unread_count ?? 0) })
-        .catch(() => {})
-    }
-    poll()
-    const id = setInterval(poll, 30_000)
-    return () => { cancelled = true; clearInterval(id) }
-  }, [demoEnabled])
-  const handleOpenNotifications = useCallback(() => navigate("/notifications"), [navigate])
-  const location = useLocation()
+        .then((res) => {
+          if (!cancelled) setNotificationCount(res?.unread_count ?? 0);
+        })
+        .catch(() => {});
+    };
+    poll();
+    const id = setInterval(poll, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [demoEnabled]);
+  const handleOpenNotifications = useCallback(() => navigate('/notifications'), [navigate]);
+  const location = useLocation();
   const { historyId, serverChatId } = useStoreMessageOption((state) => ({
     historyId: state.historyId,
-    serverChatId: state.serverChatId
-  }))
-  const mobileSidebarPathRef = React.useRef(location.pathname)
-  const { phase, isConnected } = useConnectionState()
-  const { checkOnce } = useConnectionActions()
-  const { isChecking } = useConnectionUxState()
-  const { fatalBackendRecoveryActive } = useBackendRecoveryUi()
+    serverChatId: state.serverChatId,
+  }));
+  const mobileSidebarPathRef = React.useRef(location.pathname);
+  const { phase, isConnected } = useConnectionState();
+  const { checkOnce } = useConnectionActions();
+  const { isChecking } = useConnectionUxState();
+  const { fatalBackendRecoveryActive } = useBackendRecoveryUi();
   const [backendUnavailableDetail, setBackendUnavailableDetail] =
-    useState<BackendUnreachableDetail | null>(null)
+    useState<BackendUnreachableDetail | null>(null);
   const suppressBackendUnavailableModal = React.useMemo(() => {
-    if (typeof window === "undefined") return false
+    if (typeof window === 'undefined') return false;
     try {
-      return window.localStorage.getItem("__tldw_test_bypass") === "true"
+      return window.localStorage.getItem('__tldw_test_bypass') === 'true';
     } catch {
-      return false
+      return false;
     }
-  }, [])
-  const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING)
-  const [stickyChatInput] = useStorage("stickyChatInput", false)
-  const isChatScreen = location.pathname === "/chat"
-  const isViewportConstrainedRoute = (VIEWPORT_CONSTRAINED_PATHS as readonly string[]).includes(location.pathname)
-  const stickyChatLayoutActive = isChatScreen && stickyChatInput
+  }, []);
+  const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING);
+  const [stickyChatInput] = useStorage('stickyChatInput', false);
+  const isChatScreen = location.pathname === '/chat';
+  const isViewportConstrainedRoute = (VIEWPORT_CONSTRAINED_PATHS as readonly string[]).includes(
+    location.pathname
+  );
+  const stickyChatLayoutActive = isChatScreen && stickyChatInput;
   const chatScreenBackgroundStyle =
     isChatScreen && chatBackgroundImage
       ? {
           backgroundImage: `url(${chatBackgroundImage})`,
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-          backgroundRepeat: "no-repeat"
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
         }
-      : undefined
-  const { clearChat, useOCR, chatMode, setChatMode, webSearch, setWebSearch } =
-    useMessageOption()
-  const queryClient = useQueryClient()
+      : undefined;
+  const { clearChat, useOCR, chatMode, setChatMode, webSearch, setWebSearch } = useMessageOption();
+  const queryClient = useQueryClient();
   const {
     active: shortcutLoading,
     pendingPath: shortcutPendingPath,
     startedAt: shortcutStartedAt,
-    stop: stopShortcutLoading
+    stop: stopShortcutLoading,
   } = useRouteTransitionStore(
     useShallow((state) => ({
       active: state.active,
       pendingPath: state.pendingPath,
       startedAt: state.startedAt,
-      stop: state.stop
+      stop: state.stop,
     }))
-  )
+  );
 
   React.useEffect(() => {
-    if (!isLayoutEffectsOwner) return
-    const path = `${location.pathname}${location.search}${location.hash}`
-    setSettingsReturnTo(path, { historyId, serverChatId })
+    if (!isLayoutEffectsOwner) return;
+    const path = `${location.pathname}${location.search}${location.hash}`;
+    setSettingsReturnTo(path, { historyId, serverChatId });
   }, [
     historyId,
     isLayoutEffectsOwner,
     location.hash,
     location.pathname,
     location.search,
-    serverChatId
-  ])
+    serverChatId,
+  ]);
 
   React.useEffect(() => {
-    setChatSidebarCollapsed(true)
+    setChatSidebarCollapsed(true);
     void setSetting(HEADER_SHORTCUTS_EXPANDED_SETTING, false).catch(() => {
       // ignore storage write failures
-    })
-  }, [location.pathname, setChatSidebarCollapsed])
+    });
+  }, [location.pathname, setChatSidebarCollapsed]);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") return
+    if (typeof window === 'undefined') return;
     const onBackendUnreachable = (event: Event) => {
-      if (suppressBackendUnavailableModal) return
-      const detail = (event as CustomEvent<BackendUnreachableDetail | undefined>)
-        ?.detail
-      if (!detail || typeof detail !== "object") return
-      setBackendUnavailableDetail(detail)
-      void checkOnce().catch(() => undefined)
-    }
+      if (suppressBackendUnavailableModal) return;
+      const detail = (event as CustomEvent<BackendUnreachableDetail | undefined>)?.detail;
+      if (!detail || typeof detail !== 'object') return;
+      setBackendUnavailableDetail(detail);
+      void checkOnce().catch(() => undefined);
+    };
 
-    window.addEventListener(
-      BACKEND_UNREACHABLE_EVENT,
-      onBackendUnreachable as EventListener
-    )
+    window.addEventListener(BACKEND_UNREACHABLE_EVENT, onBackendUnreachable as EventListener);
     return () => {
-      window.removeEventListener(
-        BACKEND_UNREACHABLE_EVENT,
-        onBackendUnreachable as EventListener
-      )
-    }
-  }, [checkOnce, suppressBackendUnavailableModal])
+      window.removeEventListener(BACKEND_UNREACHABLE_EVENT, onBackendUnreachable as EventListener);
+    };
+  }, [checkOnce, suppressBackendUnavailableModal]);
 
   React.useEffect(() => {
     if (isConnected && phase === ConnectionPhase.CONNECTED) {
-      setBackendUnavailableDetail(null)
+      setBackendUnavailableDetail(null);
     }
-  }, [isConnected, phase])
+  }, [isConnected, phase]);
 
   const closeBackendUnavailableModal = React.useCallback(() => {
-    setBackendUnavailableDetail(null)
-  }, [])
+    setBackendUnavailableDetail(null);
+  }, []);
 
   const openHealthDiagnostics = React.useCallback(() => {
-    setBackendUnavailableDetail(null)
-    navigate("/settings/health")
-  }, [navigate])
+    setBackendUnavailableDetail(null);
+    navigate('/settings/health');
+  }, [navigate]);
 
   const retryConnectionCheck = React.useCallback(() => {
-    void checkOnce().catch(() => undefined)
-  }, [checkOnce])
+    void checkOnce().catch(() => undefined);
+  }, [checkOnce]);
 
   // Create toggle function for sidebar
   const toggleSidebar = () => {
-    if (hideSidebar) return
+    if (hideSidebar) return;
     if (showChatSidebar && !hideHeader) {
       if (isMobileViewport) {
-        setSidebarOpen((prev) => !prev)
-        return
+        setSidebarOpen((prev) => !prev);
+        return;
       }
-      setChatSidebarCollapsed((prev) => !prev)
-      return
+      setChatSidebarCollapsed((prev) => !prev);
+      return;
     }
-    setSidebarOpen((prev) => !prev)
-  }
+    setSidebarOpen((prev) => !prev);
+  };
 
   React.useEffect(() => {
-    if (isMobileViewport && !showChatSidebar) return
+    if (isMobileViewport && !showChatSidebar) return;
     if (!isMobileViewport && sidebarOpen) {
-      setSidebarOpen(false)
+      setSidebarOpen(false);
     }
-  }, [isMobileViewport, showChatSidebar, sidebarOpen])
+  }, [isMobileViewport, showChatSidebar, sidebarOpen]);
 
   React.useEffect(() => {
     if (!isMobileViewport || !showChatSidebar) {
-      mobileSidebarPathRef.current = location.pathname
-      return
+      mobileSidebarPathRef.current = location.pathname;
+      return;
     }
     if (location.pathname !== mobileSidebarPathRef.current && sidebarOpen) {
-      setSidebarOpen(false)
+      setSidebarOpen(false);
     }
-    mobileSidebarPathRef.current = location.pathname
-  }, [isMobileViewport, showChatSidebar, sidebarOpen, location.pathname])
+    mobileSidebarPathRef.current = location.pathname;
+  }, [isMobileViewport, showChatSidebar, sidebarOpen, location.pathname]);
 
   const handleIngestPage = () => {
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(new CustomEvent("tldw:open-quick-ingest"))
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('tldw:open-quick-ingest'));
     }
-  }
+  };
 
   const commandPaletteProps = {
     onNewChat: clearChat,
-    onToggleRag: () => setChatMode(chatMode === "rag" ? "normal" : "rag"),
+    onToggleRag: () => setChatMode(chatMode === 'rag' ? 'normal' : 'rag'),
     onToggleWebSearch: () => setWebSearch(!webSearch),
     onIngestPage: handleIngestPage,
     onSwitchModel: () => setOpenModelSettings(true),
-    onToggleSidebar: toggleSidebar
-  }
+    onToggleSidebar: toggleSidebar,
+  };
 
   // Quick Chat Helper toggle
-  const { isOpen: quickChatOpen, setIsOpen: setQuickChatOpen } = useQuickChatStore()
+  const { isOpen: quickChatOpen, setIsOpen: setQuickChatOpen } = useQuickChatStore();
   const toggleQuickChat = () => {
-    setQuickChatOpen(!quickChatOpen)
-  }
+    setQuickChatOpen(!quickChatOpen);
+  };
 
   // Initialize shortcuts
-  useChatShortcuts(clearChat, true)
-  useSidebarShortcuts(toggleSidebar, true)
-  useQuickChatShortcuts(toggleQuickChat, true)
+  useChatShortcuts(clearChat, true);
+  useSidebarShortcuts(toggleSidebar, true);
+  useQuickChatShortcuts(toggleQuickChat, true);
 
   React.useEffect(() => {
-    if (!shortcutLoading) return
-    if (
-      shortcutPendingPath &&
-      shortcutPendingPath !== location.pathname
-    ) {
-      return
+    if (!shortcutLoading) return;
+    if (shortcutPendingPath && shortcutPendingPath !== location.pathname) {
+      return;
     }
-    const elapsed = shortcutStartedAt ? Date.now() - shortcutStartedAt : 0
-    const delay = Math.max(SHORTCUT_LOADING_MIN_MS - elapsed, 0)
+    const elapsed = shortcutStartedAt ? Date.now() - shortcutStartedAt : 0;
+    const delay = Math.max(SHORTCUT_LOADING_MIN_MS - elapsed, 0);
     if (delay <= 0) {
-      stopShortcutLoading()
-      return
+      stopShortcutLoading();
+      return;
     }
     const timeoutId = window.setTimeout(() => {
-      stopShortcutLoading()
-    }, delay)
-    return () => window.clearTimeout(timeoutId)
+      stopShortcutLoading();
+    }, delay);
+    return () => window.clearTimeout(timeoutId);
   }, [
     shortcutLoading,
     shortcutPendingPath,
     location.pathname,
     shortcutStartedAt,
-    stopShortcutLoading
-  ])
+    stopShortcutLoading,
+  ]);
 
   React.useEffect(() => {
-    if (!shortcutLoading) return
+    if (!shortcutLoading) return;
     const timeoutId = window.setTimeout(() => {
-      stopShortcutLoading()
-    }, SHORTCUT_LOADING_MAX_MS)
-    return () => window.clearTimeout(timeoutId)
-  }, [shortcutLoading, stopShortcutLoading])
-
-
+      stopShortcutLoading();
+    }, SHORTCUT_LOADING_MAX_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [shortcutLoading, stopShortcutLoading]);
 
   if (migrationLoading) {
     return (
       <div className="flex h-screen w-full items-center justify-center bg-bg ">
         <div className="text-center space-y-2">
-          <div className="text-base font-medium text-text ">
-            Migrating your chat history…
-          </div>
+          <div className="text-base font-medium text-text ">Migrating your chat history…</div>
           <div className="text-xs text-text-muted ">
             This runs once after an update and will reload the extension when finished.
           </div>
         </div>
       </div>
-    )
+    );
   }
 
   const renderShortcutOverlay = () => (
     <div className="pointer-events-none absolute inset-0 z-30 flex justify-center px-4 sm:px-6 lg:px-8">
       <div className="pointer-events-auto relative w-full max-w-6xl">
         <div className="absolute inset-0 rounded-2xl bg-bg/70 backdrop-blur-[1px]">
-          <PageAssistLoader
-            label="Loading..."
-            fullScreen={false}
-            autoFocus={false}
-          />
+          <PageAssistLoader label="Loading..." fullScreen={false} autoFocus={false} />
         </div>
       </div>
     </div>
-  )
+  );
 
   return (
     <BuddyShellRenderContextProvider>
       <div
         className={classNames(
-          "relative flex w-full",
-          isViewportConstrainedRoute ? "h-screen min-h-0" : "min-h-screen"
+          'relative flex w-full',
+          isViewportConstrainedRoute ? 'h-screen min-h-0' : 'min-h-screen'
         )}
         style={chatScreenBackgroundStyle}
       >
-      {/* Persistent ChatSidebar when feature flag enabled */}
-      {showChatSidebar && !hideHeader && !hideSidebar && !isMobileViewport && (
-        <ChatSidebar
-          collapsed={chatSidebarCollapsed}
-          onToggleCollapse={() => setChatSidebarCollapsed((prev) => !prev)}
-          className="sticky top-0 shrink-0 border-r border-border"
-        />
-      )}
-      <main
-        className={classNames(
-          "relative flex-1 flex flex-col",
-          hideHeader ? "bg-bg " : ""
+        {/* Persistent ChatSidebar when feature flag enabled */}
+        {showChatSidebar && !hideHeader && !hideSidebar && !isMobileViewport && (
+          <ChatSidebar
+            collapsed={chatSidebarCollapsed}
+            onToggleCollapse={() => setChatSidebarCollapsed((prev) => !prev)}
+            className="sticky top-0 shrink-0 border-r border-border"
+          />
         )}
-        data-demo-mode={demoEnabled ? "on" : "off"}>
-        {hideHeader ? (
-          <div className="relative flex min-h-screen flex-1 flex-col items-center justify-center px-4 py-10 sm:px-8 overflow-auto">
-            {children}
-            {shortcutLoading && renderShortcutOverlay()}
-          </div>
-        ) : isViewportConstrainedRoute ? (
-          <div
-            data-chat-scroll-owner={
-              stickyChatLayoutActive ? "transcript" : undefined
-            }
-            className={classNames(
-              "relative flex min-h-0 flex-1 flex-col",
-              stickyChatLayoutActive ? "overflow-hidden" : "overflow-y-auto"
-            )}
-          >
-            <div className="relative z-20 w-full shrink-0">
-              <Header
-                onToggleSidebar={hideSidebar ? undefined : toggleSidebar}
-                sidebarCollapsed={
-                  showChatSidebar && isMobileViewport
-                    ? !sidebarOpen
-                    : chatSidebarCollapsed
-                }
-                notificationCount={notificationCount}
-                onOpenNotifications={handleOpenNotifications}
-              />
-            </div>
-            <div className="relative flex min-h-0 flex-1 flex-col">
+        <main
+          className={classNames('relative flex-1 flex flex-col', hideHeader ? 'bg-bg ' : '')}
+          data-demo-mode={demoEnabled ? 'on' : 'off'}
+        >
+          {hideHeader ? (
+            <div className="relative flex min-h-screen flex-1 flex-col items-center justify-center px-4 py-10 sm:px-8 overflow-auto">
               {children}
               {shortcutLoading && renderShortcutOverlay()}
             </div>
-          </div>
-        ) : (
-          <div className="relative flex flex-col min-h-[135vh]">
-            <div className="relative z-20 w-full">
-              <Header
-                onToggleSidebar={hideSidebar ? undefined : toggleSidebar}
-                sidebarCollapsed={
-                  showChatSidebar && isMobileViewport
-                    ? !sidebarOpen
-                    : chatSidebarCollapsed
-                }
-                notificationCount={notificationCount}
-                onOpenNotifications={handleOpenNotifications}
-              />
-            </div>
-            <div className="relative flex min-h-0 flex-1 flex-col">
-              {children}
-              {shortcutLoading && renderShortcutOverlay()}
-            </div>
-          </div>
-        )}
-        {/* Mobile Drawer for ChatSidebar when the persistent sidebar is enabled */}
-        {!hideHeader && showChatSidebar && !hideSidebar && isMobileViewport && (
-          <Drawer
-            title={
-              <div className="flex items-center justify-between">
-                <span>{t("common:chatSidebar.title", "Chats")}</span>
-                <IconButton
-                  onClick={() => setSidebarOpen(false)}
-                  ariaLabel={t("common:close", { defaultValue: "Close" }) as string}
-                  title={t("common:close", { defaultValue: "Close" }) as string}
-                  className="h-10 w-10 sm:h-7 sm:w-7 sm:min-h-0 sm:min-w-0"
-                >
-                  <XIcon className="h-5 w-5 text-text-muted" />
-                </IconButton>
+          ) : isViewportConstrainedRoute ? (
+            <div
+              data-chat-scroll-owner={stickyChatLayoutActive ? 'transcript' : undefined}
+              className={classNames(
+                'relative flex min-h-0 flex-1 flex-col',
+                stickyChatLayoutActive ? 'overflow-hidden' : 'overflow-y-auto'
+              )}
+            >
+              <div className="relative z-20 w-full shrink-0">
+                <Header
+                  onToggleSidebar={hideSidebar ? undefined : toggleSidebar}
+                  sidebarCollapsed={
+                    showChatSidebar && isMobileViewport ? !sidebarOpen : chatSidebarCollapsed
+                  }
+                  notificationCount={notificationCount}
+                  onOpenNotifications={handleOpenNotifications}
+                />
               </div>
-            }
-            placement="left"
-            closeIcon={null}
-            onClose={() => setSidebarOpen(false)}
-            open={sidebarOpen}
-          >
-            <ChatSidebar
-              collapsed={false}
-              onToggleCollapse={() => setSidebarOpen(false)}
-            />
-          </Drawer>
-        )}
-        {/* Legacy Drawer sidebar - only shown when new ChatSidebar feature is disabled */}
-        {!hideHeader && !showChatSidebar && !hideSidebar && (
-          <Drawer
-            title={
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
+              <div className="relative flex min-h-0 flex-1 flex-col">
+                {children}
+                {shortcutLoading && renderShortcutOverlay()}
+              </div>
+            </div>
+          ) : (
+            <div className="relative flex flex-col min-h-[135vh]">
+              <div className="relative z-20 w-full">
+                <Header
+                  onToggleSidebar={hideSidebar ? undefined : toggleSidebar}
+                  sidebarCollapsed={
+                    showChatSidebar && isMobileViewport ? !sidebarOpen : chatSidebarCollapsed
+                  }
+                  notificationCount={notificationCount}
+                  onOpenNotifications={handleOpenNotifications}
+                />
+              </div>
+              <div className="relative flex min-h-0 flex-1 flex-col">
+                {children}
+                {shortcutLoading && renderShortcutOverlay()}
+              </div>
+            </div>
+          )}
+          {/* Mobile Drawer for ChatSidebar when the persistent sidebar is enabled */}
+          {!hideHeader && showChatSidebar && !hideSidebar && isMobileViewport && (
+            <Drawer
+              title={
+                <div className="flex items-center justify-between">
+                  <span>{t('common:chatSidebar.title', 'Chats')}</span>
                   <IconButton
                     onClick={() => setSidebarOpen(false)}
                     ariaLabel={t('common:close', { defaultValue: 'Close' }) as string}
                     title={t('common:close', { defaultValue: 'Close' }) as string}
-                    className="-ml-1 h-11 w-11 sm:h-7 sm:w-7 sm:min-w-0 sm:min-h-0">
-                    <XIcon className="h-5 w-5 text-text-muted " />
+                    className="h-10 w-10 sm:h-7 sm:w-7 sm:min-h-0 sm:min-w-0"
+                  >
+                    <XIcon className="h-5 w-5 text-text-muted" />
                   </IconButton>
-                  <span>{t("sidebarTitle")}</span>
                 </div>
-
-                <div className="flex items-center space-x-3">
-                  <Tooltip
-                    title={t(
-                      "settings:generalSettings.systemData.deleteChatHistory.label",
-                      { defaultValue: t("settings:generalSettings.system.deleteChatHistory.label") as string }
-                    )}
-                    placement="left">
+              }
+              placement="left"
+              closeIcon={null}
+              onClose={() => setSidebarOpen(false)}
+              open={sidebarOpen}
+            >
+              <ChatSidebar collapsed={false} onToggleCollapse={() => setSidebarOpen(false)} />
+            </Drawer>
+          )}
+          {/* Legacy Drawer sidebar - only shown when new ChatSidebar feature is disabled */}
+          {!hideHeader && !showChatSidebar && !hideSidebar && (
+            <Drawer
+              title={
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
                     <IconButton
-                      ariaLabel={t(
-                        "settings:generalSettings.systemData.deleteChatHistory.label",
-                        { defaultValue: t("settings:generalSettings.system.deleteChatHistory.label") as string }
-                      ) as string}
-                      onClick={async () => {
-                        const ok = await confirmDanger({
-                          title: t("common:confirmTitle", {
-                            defaultValue: "Please confirm"
-                          }),
-                          content: t(
-                            "settings:generalSettings.systemData.deleteChatHistory.confirm",
-                            {
-                              defaultValue: t(
-                                "settings:generalSettings.system.deleteChatHistory.confirm"
-                              ) as string
-                            }
-                          ),
-                          okText: t("common:delete", { defaultValue: "Delete" }),
-                          cancelText: t("common:cancel", { defaultValue: "Cancel" })
-                        })
-
-                        if (!ok) return
-
-                        const db = new PageAssistDatabase()
-                        await db.deleteAllChatHistory()
-                        await queryClient.invalidateQueries({
-                          queryKey: ["fetchChatHistory"]
-                        })
-                        clearChat()
-                      }}
-                      className="text-text-muted hover:text-text h-11 w-11 sm:h-7 sm:w-7 sm:min-w-0 sm:min-h-0">
-                      <EraserIcon className="size-5" />
+                      onClick={() => setSidebarOpen(false)}
+                      ariaLabel={t('common:close', { defaultValue: 'Close' }) as string}
+                      title={t('common:close', { defaultValue: 'Close' }) as string}
+                      className="-ml-1 h-11 w-11 sm:h-7 sm:w-7 sm:min-w-0 sm:min-h-0"
+                    >
+                      <XIcon className="h-5 w-5 text-text-muted " />
                     </IconButton>
-                  </Tooltip>
+                    <span>{t('sidebarTitle')}</span>
+                  </div>
+
+                  <div className="flex items-center space-x-3">
+                    <Tooltip
+                      title={t('settings:generalSettings.systemData.deleteChatHistory.label', {
+                        defaultValue: t(
+                          'settings:generalSettings.system.deleteChatHistory.label'
+                        ) as string,
+                      })}
+                      placement="left"
+                    >
+                      <IconButton
+                        ariaLabel={
+                          t('settings:generalSettings.systemData.deleteChatHistory.label', {
+                            defaultValue: t(
+                              'settings:generalSettings.system.deleteChatHistory.label'
+                            ) as string,
+                          }) as string
+                        }
+                        onClick={async () => {
+                          const ok = await confirmDanger({
+                            title: t('common:confirmTitle', {
+                              defaultValue: 'Please confirm',
+                            }),
+                            content: t(
+                              'settings:generalSettings.systemData.deleteChatHistory.confirm',
+                              {
+                                defaultValue: t(
+                                  'settings:generalSettings.system.deleteChatHistory.confirm'
+                                ) as string,
+                              }
+                            ),
+                            okText: t('common:delete', { defaultValue: 'Delete' }),
+                            cancelText: t('common:cancel', { defaultValue: 'Cancel' }),
+                          });
+
+                          if (!ok) return;
+
+                          const db = new PageAssistDatabase();
+                          await db.deleteAllChatHistory();
+                          await queryClient.invalidateQueries({
+                            queryKey: ['fetchChatHistory'],
+                          });
+                          clearChat();
+                        }}
+                        className="text-text-muted hover:text-text h-11 w-11 sm:h-7 sm:w-7 sm:min-w-0 sm:min-h-0"
+                      >
+                        <EraserIcon className="size-5" />
+                      </IconButton>
+                    </Tooltip>
+                  </div>
                 </div>
-              </div>
-            }
-            placement="left"
-            closeIcon={null}
-          onClose={() => setSidebarOpen(false)}
-          open={sidebarOpen}>
-          <Sidebar
-            isOpen={sidebarOpen}
-            onClose={() => setSidebarOpen(false)}
+              }
+              placement="left"
+              closeIcon={null}
+              onClose={() => setSidebarOpen(false)}
+              open={sidebarOpen}
+            >
+              <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+            </Drawer>
+          )}
+
+          {!hideHeader && (
+            <CurrentChatModelSettings
+              open={openModelSettings}
+              setOpen={setOpenModelSettings}
+              useDrawer
+              isOCREnabled={useOCR}
+            />
+          )}
+
+          {/* Quick Chat Helper floating button (legacy layout only) */}
+          {!hideHeader && !showChatSidebar && !hideSidebar && <QuickChatHelperButton />}
+
+          {/* Timeline Modal - lazy-loaded */}
+          {!hideHeader && (
+            <Suspense fallback={null}>
+              <TimelineModal />
+            </Suspense>
+          )}
+
+          {/* Command Palette - global keyboard shortcut ⌘K */}
+          {!hideHeader && <CommandPalette {...commandPaletteProps} />}
+
+          {/* Keyboard Shortcuts Help Modal - triggered by ? */}
+          {!hideHeader && (
+            <Suspense fallback={null}>
+              <KeyboardShortcutsModal />
+            </Suspense>
+          )}
+
+          {/* Quick Ingest Modal Host - listens for global open events */}
+          <QuickIngestModalHost />
+
+          {/* Notes Dock Host - floating notes panel */}
+          <NotesDockHost />
+
+          <BuddyShellHost root="web" />
+
+          {/* Ensure event-driven modals are available even when the header is hidden */}
+          {hideHeader && <EventOnlyHosts commandPaletteProps={commandPaletteProps} />}
+
+          {/* Workflow landing modal + active workflow overlay */}
+          <WorkflowIntegrationHost autoShowPaths={['/']} />
+
+          <BackendUnavailableModalGate
+            backendUnavailableDetail={backendUnavailableDetail}
+            fatalBackendRecoveryActive={fatalBackendRecoveryActive}
+            isChecking={isChecking}
+            onClose={closeBackendUnavailableModal}
+            onConsumeHiddenDetail={closeBackendUnavailableModal}
+            onOpenHealth={openHealthDiagnostics}
+            onRetry={retryConnectionCheck}
+            t={t}
           />
-        </Drawer>
-        )}
-
-        {!hideHeader && (
-          <CurrentChatModelSettings
-            open={openModelSettings}
-            setOpen={setOpenModelSettings}
-            useDrawer
-            isOCREnabled={useOCR}
-          />
-        )}
-
-        {/* Quick Chat Helper floating button (legacy layout only) */}
-        {!hideHeader && !showChatSidebar && !hideSidebar && (
-          <QuickChatHelperButton />
-        )}
-
-        {/* Timeline Modal - lazy-loaded */}
-        {!hideHeader && (
-          <Suspense fallback={null}>
-            <TimelineModal />
-          </Suspense>
-        )}
-
-        {/* Command Palette - global keyboard shortcut ⌘K */}
-        {!hideHeader && (
-          <CommandPalette
-            {...commandPaletteProps}
-          />
-        )}
-
-        {/* Keyboard Shortcuts Help Modal - triggered by ? */}
-        {!hideHeader && (
-          <Suspense fallback={null}>
-            <KeyboardShortcutsModal />
-          </Suspense>
-        )}
-
-        {/* Quick Ingest Modal Host - listens for global open events */}
-        <QuickIngestModalHost />
-
-        {/* Notes Dock Host - floating notes panel */}
-        <NotesDockHost />
-
-        <BuddyShellHost root="web" />
-
-        {/* Ensure event-driven modals are available even when the header is hidden */}
-        {hideHeader && <EventOnlyHosts commandPaletteProps={commandPaletteProps} />}
-
-        {/* Workflow landing modal + active workflow overlay */}
-        <WorkflowIntegrationHost autoShowPaths={["/"]} />
-
-        <BackendUnavailableModalGate
-          backendUnavailableDetail={backendUnavailableDetail}
-          fatalBackendRecoveryActive={fatalBackendRecoveryActive}
-          isChecking={isChecking}
-          onClose={closeBackendUnavailableModal}
-          onConsumeHiddenDetail={closeBackendUnavailableModal}
-          onOpenHealth={openHealthDiagnostics}
-          onRetry={retryConnectionCheck}
-          t={t}
-        />
-      </main>
-    </div>
+        </main>
+      </div>
     </BuddyShellRenderContextProvider>
-  )
-}
+  );
+};
 
 type LayoutShellOverrides = {
-  hideHeader?: boolean
-  hideSidebar?: boolean
-  sourcePath?: string
-}
+  hideHeader?: boolean;
+  hideSidebar?: boolean;
+  sourcePath?: string;
+};
 
 type LayoutShellContextValue = {
-  inShell: boolean
-  setOverrides?: (overrides: LayoutShellOverrides | null) => void
-}
+  inShell: boolean;
+  setOverrides?: (overrides: LayoutShellOverrides | null) => void;
+};
 
 type LayoutShellGlobal = {
-  mounted: boolean
-  ownerId?: string
-  setOverrides?: (overrides: LayoutShellOverrides | null) => void
-}
+  mounted: boolean;
+  ownerId?: string;
+  setOverrides?: (overrides: LayoutShellOverrides | null) => void;
+};
 
 const LayoutShellContext = React.createContext<LayoutShellContextValue>({
-  inShell: false
-})
+  inShell: false,
+});
 
 const getGlobalShell = (): LayoutShellGlobal | null => {
-  if (typeof globalThis === "undefined") return null
+  if (typeof globalThis === 'undefined') return null;
   const scope = globalThis as typeof globalThis & {
-    __tldwOptionShell?: LayoutShellGlobal
-  }
+    __tldwOptionShell?: LayoutShellGlobal;
+  };
   if (!scope.__tldwOptionShell) {
-    scope.__tldwOptionShell = { mounted: false }
+    scope.__tldwOptionShell = { mounted: false };
   }
-  return scope.__tldwOptionShell
-}
+  return scope.__tldwOptionShell;
+};
 
 /**
  * Component for when OptionLayout is nested inside an existing shell.
@@ -643,30 +610,30 @@ const getGlobalShell = (): LayoutShellGlobal | null => {
 function NestedLayoutContent({
   props,
   shell,
-  globalShell
+  globalShell,
 }: {
-  props: OptionLayoutProps
-  shell: LayoutShellContextValue
-  globalShell: LayoutShellGlobal | null
+  props: OptionLayoutProps;
+  shell: LayoutShellContextValue;
+  globalShell: LayoutShellGlobal | null;
 }) {
-  const location = useLocation()
+  const location = useLocation();
   const requestedOverrides = React.useMemo(() => {
-    const overrides: LayoutShellOverrides = {}
-    if (props.hideHeader) overrides.hideHeader = true
-    if (props.hideSidebar) overrides.hideSidebar = true
-    if (Object.keys(overrides).length === 0) return null
-    overrides.sourcePath = location.pathname
-    return overrides
-  }, [location.pathname, props.hideHeader, props.hideSidebar])
+    const overrides: LayoutShellOverrides = {};
+    if (props.hideHeader) overrides.hideHeader = true;
+    if (props.hideSidebar) overrides.hideSidebar = true;
+    if (Object.keys(overrides).length === 0) return null;
+    overrides.sourcePath = location.pathname;
+    return overrides;
+  }, [location.pathname, props.hideHeader, props.hideSidebar]);
 
   React.useEffect(() => {
-    const setOverrides = shell.setOverrides || globalShell?.setOverrides
-    if (!setOverrides || !requestedOverrides) return
-    setOverrides(requestedOverrides)
-    return () => setOverrides?.(null)
-  }, [globalShell?.setOverrides, requestedOverrides, shell.setOverrides])
+    const setOverrides = shell.setOverrides || globalShell?.setOverrides;
+    if (!setOverrides || !requestedOverrides) return;
+    setOverrides(requestedOverrides);
+    return () => setOverrides?.(null);
+  }, [globalShell?.setOverrides, requestedOverrides, shell.setOverrides]);
 
-  return <>{props.children}</>
+  return <>{props.children}</>;
 }
 
 /**
@@ -676,55 +643,47 @@ function NestedLayoutContent({
 function RootLayoutShell({
   props,
   globalShell,
-  ownerId
+  ownerId,
 }: {
-  props: OptionLayoutProps
-  globalShell: LayoutShellGlobal | null
-  ownerId: string
+  props: OptionLayoutProps;
+  globalShell: LayoutShellGlobal | null;
+  ownerId: string;
 }) {
-  const [overrides, setOverrides] = React.useState<LayoutShellOverrides | null>(
-    null
-  )
-  const location = useLocation()
-  const allowNestedHideHeader = props.allowNestedHideHeader !== false
-  const allowNestedHideSidebar = props.allowNestedHideSidebar !== false
-  const overridesMatch =
-    !overrides?.sourcePath || overrides.sourcePath === location.pathname
+  const [overrides, setOverrides] = React.useState<LayoutShellOverrides | null>(null);
+  const location = useLocation();
+  const allowNestedHideHeader = props.allowNestedHideHeader !== false;
+  const allowNestedHideSidebar = props.allowNestedHideSidebar !== false;
+  const overridesMatch = !overrides?.sourcePath || overrides.sourcePath === location.pathname;
   const effectiveHideHeader =
-    (allowNestedHideHeader && overridesMatch && overrides?.hideHeader) ||
-    props.hideHeader ||
-    false
+    (allowNestedHideHeader && overridesMatch && overrides?.hideHeader) || props.hideHeader || false;
   const effectiveHideSidebar =
     (allowNestedHideSidebar && overridesMatch && overrides?.hideSidebar) ||
     props.hideSidebar ||
-    false
+    false;
 
   if (globalShell) {
-    globalShell.mounted = true
-    globalShell.ownerId = ownerId
-    globalShell.setOverrides = setOverrides
+    globalShell.mounted = true;
+    globalShell.ownerId = ownerId;
+    globalShell.setOverrides = setOverrides;
   }
 
   React.useEffect(() => {
-    if (!globalShell) return
+    if (!globalShell) return;
     return () => {
-      if (
-        globalShell.setOverrides === setOverrides &&
-        globalShell.ownerId === ownerId
-      ) {
-        globalShell.setOverrides = undefined
-        globalShell.mounted = false
-        globalShell.ownerId = undefined
+      if (globalShell.setOverrides === setOverrides && globalShell.ownerId === ownerId) {
+        globalShell.setOverrides = undefined;
+        globalShell.mounted = false;
+        globalShell.ownerId = undefined;
       }
-    }
-  }, [globalShell, ownerId, setOverrides])
+    };
+  }, [globalShell, ownerId, setOverrides]);
 
   React.useEffect(() => {
-    if (!overrides?.sourcePath) return
+    if (!overrides?.sourcePath) return;
     if (overrides.sourcePath !== location.pathname) {
-      setOverrides(null)
+      setOverrides(null);
     }
-  }, [location.pathname, overrides?.sourcePath])
+  }, [location.pathname, overrides?.sourcePath]);
 
   return (
     <DemoModeProvider>
@@ -736,28 +695,22 @@ function RootLayoutShell({
         />
       </LayoutShellContext.Provider>
     </DemoModeProvider>
-  )
+  );
 }
 
 export default function OptionLayout(props: OptionLayoutProps) {
-  const shell = useContext(LayoutShellContext)
-  const globalShell = getGlobalShell()
-  const ownerId = React.useId()
+  const shell = useContext(LayoutShellContext);
+  const globalShell = getGlobalShell();
+  const ownerId = React.useId();
   const externalShell =
     Boolean(globalShell?.mounted) &&
-    (globalShell?.ownerId == null || globalShell.ownerId !== ownerId)
+    (globalShell?.ownerId == null || globalShell.ownerId !== ownerId);
 
   // Check if we're nested inside an existing shell
   if (shell.inShell || externalShell) {
-    return <NestedLayoutContent props={props} shell={shell} globalShell={globalShell} />
+    return <NestedLayoutContent props={props} shell={shell} globalShell={globalShell} />;
   }
 
   // We're the root shell
-  return (
-    <RootLayoutShell
-      props={props}
-      globalShell={globalShell}
-      ownerId={ownerId}
-    />
-  )
+  return <RootLayoutShell props={props} globalShell={globalShell} ownerId={ownerId} />;
 }

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -7,6 +7,7 @@ import { useLocation, useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { useQueryClient } from "@tanstack/react-query"
 import { useShallow } from "zustand/react/shallow"
+import { useStorage } from "@plasmohq/storage/hook"
 
 import { classNames } from "@/libs/class-name"
 import { PageAssistDatabase } from "@/db/dexie/chat"
@@ -88,19 +89,6 @@ type OptionLayoutProps = {
 
 const SHORTCUT_LOADING_MIN_MS = 0
 const SHORTCUT_LOADING_MAX_MS = 2500
-const STICKY_CHAT_INPUT_STORAGE_KEY = "stickyChatInput"
-
-const shouldUseTranscriptOwnedChatShell = (pathname: string): boolean => {
-  if (pathname !== "/chat" || typeof window === "undefined") {
-    return false
-  }
-
-  try {
-    return window.localStorage.getItem(STICKY_CHAT_INPUT_STORAGE_KEY) === "true"
-  } catch {
-    return false
-  }
-}
 
 const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   children,
@@ -162,11 +150,10 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
     }
   }, [])
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING)
+  const [stickyChatInput] = useStorage("stickyChatInput", false)
   const isChatScreen = location.pathname === "/chat"
   const isViewportConstrainedRoute = (VIEWPORT_CONSTRAINED_PATHS as readonly string[]).includes(location.pathname)
-  const stickyChatLayoutActive = shouldUseTranscriptOwnedChatShell(
-    location.pathname
-  )
+  const stickyChatLayoutActive = isChatScreen && stickyChatInput
   const chatScreenBackgroundStyle =
     isChatScreen && chatBackgroundImage
       ? {

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -88,6 +88,19 @@ type OptionLayoutProps = {
 
 const SHORTCUT_LOADING_MIN_MS = 0
 const SHORTCUT_LOADING_MAX_MS = 2500
+const STICKY_CHAT_INPUT_STORAGE_KEY = "stickyChatInput"
+
+const shouldUseTranscriptOwnedChatShell = (pathname: string): boolean => {
+  if (pathname !== "/chat" || typeof window === "undefined") {
+    return false
+  }
+
+  try {
+    return window.localStorage.getItem(STICKY_CHAT_INPUT_STORAGE_KEY) === "true"
+  } catch {
+    return false
+  }
+}
 
 const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   children,
@@ -151,6 +164,9 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   const [chatBackgroundImage] = useSetting(CHAT_BACKGROUND_IMAGE_SETTING)
   const isChatScreen = location.pathname === "/chat"
   const isViewportConstrainedRoute = (VIEWPORT_CONSTRAINED_PATHS as readonly string[]).includes(location.pathname)
+  const stickyChatLayoutActive = shouldUseTranscriptOwnedChatShell(
+    location.pathname
+  )
   const chatScreenBackgroundStyle =
     isChatScreen && chatBackgroundImage
       ? {
@@ -391,7 +407,15 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
             {shortcutLoading && renderShortcutOverlay()}
           </div>
         ) : isViewportConstrainedRoute ? (
-          <div className="relative flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <div
+            data-chat-scroll-owner={
+              stickyChatLayoutActive ? "transcript" : undefined
+            }
+            className={classNames(
+              "relative flex min-h-0 flex-1 flex-col",
+              stickyChatLayoutActive ? "overflow-hidden" : "overflow-y-auto"
+            )}
+          >
             <div className="relative z-20 w-full shrink-0">
               <Header
                 onToggleSidebar={hideSidebar ? undefined : toggleSidebar}

--- a/apps/tldw-frontend/components/layout/WebLayout.tsx
+++ b/apps/tldw-frontend/components/layout/WebLayout.tsx
@@ -126,10 +126,8 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
   }, [demoEnabled]);
   const handleOpenNotifications = useCallback(() => navigate('/notifications'), [navigate]);
   const location = useLocation();
-  const { historyId, serverChatId } = useStoreMessageOption((state) => ({
-    historyId: state.historyId,
-    serverChatId: state.serverChatId,
-  }));
+  const historyId = useStoreMessageOption((state) => state.historyId);
+  const serverChatId = useStoreMessageOption((state) => state.serverChatId);
   const mobileSidebarPathRef = React.useRef(location.pathname);
   const { phase, isConnected } = useConnectionState();
   const { checkOnce } = useConnectionActions();

--- a/apps/tldw-frontend/e2e/smoke/chat-sticky-composer.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/chat-sticky-composer.spec.ts
@@ -1,108 +1,110 @@
-import { expect, test, type Page } from "@playwright/test"
+import { expect, test, type Page } from '@playwright/test';
 
 const bypassChatGates = async (page: Page) => {
   await page.addInitScript(() => {
     try {
-      window.localStorage.setItem("assistant_setup_dismissed", "true")
-      window.localStorage.setItem("__tldw_test_bypass", "true")
-      window.localStorage.setItem("stickyChatInput", "true")
+      window.localStorage.setItem('assistant_setup_dismissed', 'true');
+      window.localStorage.setItem('__tldw_test_bypass', 'true');
+      window.localStorage.setItem('stickyChatInput', 'true');
     } catch {
       /* ignore */
     }
-  })
-}
+  });
+};
 
 const waitForStickyChat = async (page: Page) => {
-  await page.goto("/chat", { waitUntil: "domcontentloaded" })
-  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {})
-  await expect(page.getByTestId("playground-chat-composer-dock")).toBeVisible({
-    timeout: 30_000
-  })
-}
+  await page.goto('/chat', { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => {});
+  await expect(page.getByTestId('playground-chat-composer-dock')).toBeVisible({
+    timeout: 30_000,
+  });
+};
 
 const expectDockWithinViewport = async (page: Page) => {
-  const dockBox = await page.getByTestId("playground-chat-composer-dock").boundingBox()
-  expect(dockBox).not.toBeNull()
-  expect(dockBox!.y).toBeGreaterThanOrEqual(0)
-  expect(dockBox!.y + dockBox!.height).toBeLessThanOrEqual(page.viewportSize()!.height)
-}
+  const dockBox = await page.getByTestId('playground-chat-composer-dock').boundingBox();
+  expect(dockBox).not.toBeNull();
+  expect(dockBox!.y).toBeGreaterThanOrEqual(0);
+  expect(dockBox!.y + dockBox!.height).toBeLessThanOrEqual(page.viewportSize()!.height);
+};
 
-test.describe("chat sticky composer dock", () => {
-  test("desktop sticky /chat keeps the composer visible while the transcript scrolls", async ({
-    page
+test.describe('chat sticky composer dock', () => {
+  test('desktop sticky /chat keeps the composer visible while the transcript scrolls', async ({
+    page,
   }) => {
-    test.setTimeout(90_000)
-    await bypassChatGates(page)
-    await page.setViewportSize({ width: 1440, height: 960 })
-    await waitForStickyChat(page)
+    test.setTimeout(90_000);
+    await bypassChatGates(page);
+    await page.setViewportSize({ width: 1440, height: 960 });
+    await waitForStickyChat(page);
 
-    const transcript = page.getByTestId("playground-chat-transcript")
-    await expect(transcript).toBeVisible()
+    const transcript = page.getByTestId('playground-chat-transcript');
+    await expect(transcript).toBeVisible();
 
-    await expectDockWithinViewport(page)
-  })
+    await expectDockWithinViewport(page);
+  });
 
-  test("mobile-sized sticky /chat keeps the composer visible after focusing the input", async ({
-    page
+  test('mobile-sized sticky /chat keeps the composer visible after focusing the input', async ({
+    page,
   }) => {
-    test.setTimeout(90_000)
-    await bypassChatGates(page)
-    await page.setViewportSize({ width: 390, height: 844 })
-    await waitForStickyChat(page)
+    test.setTimeout(90_000);
+    await bypassChatGates(page);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForStickyChat(page);
 
-    const chatInput = page.getByTestId("chat-input")
-    await expect(chatInput).toBeVisible()
-    await chatInput.focus()
+    const chatInput = page.getByTestId('chat-input');
+    await expect(chatInput).toBeVisible();
+    await chatInput.focus();
 
-    await expectDockWithinViewport(page)
-  })
+    await expectDockWithinViewport(page);
+  });
 
-  test("desktop sticky /chat keeps the dock scoped to the chat column when artifacts are open", async ({
-    page
+  test('desktop sticky /chat keeps the dock scoped to the chat column when artifacts are open', async ({
+    page,
   }) => {
-    test.setTimeout(90_000)
-    await bypassChatGates(page)
-    await page.setViewportSize({ width: 1440, height: 960 })
-    await waitForStickyChat(page)
+    test.setTimeout(90_000);
+    await bypassChatGates(page);
+    await page.setViewportSize({ width: 1440, height: 960 });
+    await waitForStickyChat(page);
 
     await page.evaluate(() => {
-      const artifactsStore = (window as Window & {
-        __tldw_useArtifactsStore?: {
-          getState: () => {
-            openArtifact: (
-              artifact: {
-                id: string
-                title: string
-                content: string
-                kind: "code"
-                language?: string
-              },
-              options?: { auto?: boolean }
-            ) => void
-          }
+      const artifactsStore = (
+        window as Window & {
+          __tldw_useArtifactsStore?: {
+            getState: () => {
+              openArtifact: (
+                artifact: {
+                  id: string;
+                  title: string;
+                  content: string;
+                  kind: 'code';
+                  language?: string;
+                },
+                options?: { auto?: boolean }
+              ) => void;
+            };
+          };
         }
-      }).__tldw_useArtifactsStore
+      ).__tldw_useArtifactsStore;
 
       artifactsStore?.getState().openArtifact(
         {
-          id: "dock-smoke-artifact",
-          title: "Smoke artifact",
+          id: 'dock-smoke-artifact',
+          title: 'Smoke artifact',
           content: "console.log('dock')",
-          kind: "code",
-          language: "ts"
+          kind: 'code',
+          language: 'ts',
         },
         { auto: false }
-      )
-    })
+      );
+    });
 
-    const artifactsPanel = page.locator('[data-testid="artifacts-panel"]').first()
-    await expect(artifactsPanel).toBeVisible({ timeout: 30_000 })
-    await expectDockWithinViewport(page)
+    const artifactsPanel = page.locator('[data-testid="artifacts-panel"]').first();
+    await expect(artifactsPanel).toBeVisible({ timeout: 30_000 });
+    await expectDockWithinViewport(page);
 
-    const dockBox = await page.getByTestId("playground-chat-composer-dock").boundingBox()
-    const panelBox = await artifactsPanel.boundingBox()
-    expect(dockBox).not.toBeNull()
-    expect(panelBox).not.toBeNull()
-    expect(dockBox!.x + dockBox!.width).toBeLessThanOrEqual(panelBox!.x + 1)
-  })
-})
+    const dockBox = await page.getByTestId('playground-chat-composer-dock').boundingBox();
+    const panelBox = await artifactsPanel.boundingBox();
+    expect(dockBox).not.toBeNull();
+    expect(panelBox).not.toBeNull();
+    expect(dockBox!.x + dockBox!.width).toBeLessThanOrEqual(panelBox!.x + 1);
+  });
+});

--- a/apps/tldw-frontend/e2e/smoke/chat-sticky-composer.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/chat-sticky-composer.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test, type Page } from "@playwright/test"
+
+const bypassChatGates = async (page: Page) => {
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem("assistant_setup_dismissed", "true")
+      window.localStorage.setItem("__tldw_test_bypass", "true")
+      window.localStorage.setItem("stickyChatInput", "true")
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+const waitForStickyChat = async (page: Page) => {
+  await page.goto("/chat", { waitUntil: "domcontentloaded" })
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {})
+  await expect(page.getByTestId("playground-chat-composer-dock")).toBeVisible({
+    timeout: 30_000
+  })
+}
+
+const expectDockWithinViewport = async (page: Page) => {
+  const dockBox = await page.getByTestId("playground-chat-composer-dock").boundingBox()
+  expect(dockBox).not.toBeNull()
+  expect(dockBox!.y).toBeGreaterThanOrEqual(0)
+  expect(dockBox!.y + dockBox!.height).toBeLessThanOrEqual(page.viewportSize()!.height)
+}
+
+test.describe("chat sticky composer dock", () => {
+  test("desktop sticky /chat keeps the composer visible while the transcript scrolls", async ({
+    page
+  }) => {
+    test.setTimeout(90_000)
+    await bypassChatGates(page)
+    await page.setViewportSize({ width: 1440, height: 960 })
+    await waitForStickyChat(page)
+
+    const transcript = page.getByTestId("playground-chat-transcript")
+    await expect(transcript).toBeVisible()
+
+    await expectDockWithinViewport(page)
+  })
+
+  test("mobile-sized sticky /chat keeps the composer visible after focusing the input", async ({
+    page
+  }) => {
+    test.setTimeout(90_000)
+    await bypassChatGates(page)
+    await page.setViewportSize({ width: 390, height: 844 })
+    await waitForStickyChat(page)
+
+    const chatInput = page.getByTestId("chat-input")
+    await expect(chatInput).toBeVisible()
+    await chatInput.focus()
+
+    await expectDockWithinViewport(page)
+  })
+
+  test("desktop sticky /chat keeps the dock scoped to the chat column when artifacts are open", async ({
+    page
+  }) => {
+    test.setTimeout(90_000)
+    await bypassChatGates(page)
+    await page.setViewportSize({ width: 1440, height: 960 })
+    await waitForStickyChat(page)
+
+    await page.evaluate(() => {
+      const artifactsStore = (window as Window & {
+        __tldw_useArtifactsStore?: {
+          getState: () => {
+            openArtifact: (
+              artifact: {
+                id: string
+                title: string
+                content: string
+                kind: "code"
+                language?: string
+              },
+              options?: { auto?: boolean }
+            ) => void
+          }
+        }
+      }).__tldw_useArtifactsStore
+
+      artifactsStore?.getState().openArtifact(
+        {
+          id: "dock-smoke-artifact",
+          title: "Smoke artifact",
+          content: "console.log('dock')",
+          kind: "code",
+          language: "ts"
+        },
+        { auto: false }
+      )
+    })
+
+    const artifactsPanel = page.locator('[data-testid="artifacts-panel"]').first()
+    await expect(artifactsPanel).toBeVisible({ timeout: 30_000 })
+    await expectDockWithinViewport(page)
+
+    const dockBox = await page.getByTestId("playground-chat-composer-dock").boundingBox()
+    const panelBox = await artifactsPanel.boundingBox()
+    expect(dockBox).not.toBeNull()
+    expect(panelBox).not.toBeNull()
+    expect(dockBox!.x + dockBox!.width).toBeLessThanOrEqual(panelBox!.x + 1)
+  })
+})

--- a/apps/tldw-frontend/e2e/smoke/chat-sticky-composer.spec.ts
+++ b/apps/tldw-frontend/e2e/smoke/chat-sticky-composer.spec.ts
@@ -1,20 +1,41 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from '@playwright/test';
 
 const bypassChatGates = async (page: Page) => {
+  await page.route('**/api/v1/llm/models/metadata**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ models: [] }),
+    });
+  });
+  await page.route('**/api/v1/llm/providers**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ providers: [] }),
+    });
+  });
+
   await page.addInitScript(() => {
-    try {
-      window.localStorage.setItem('assistant_setup_dismissed', 'true');
-      window.localStorage.setItem('__tldw_test_bypass', 'true');
-      window.localStorage.setItem('stickyChatInput', 'true');
-    } catch {
-      /* ignore */
-    }
+    const authConfig = {
+      serverUrl: 'http://127.0.0.1:8000',
+      authMode: 'single-user',
+      apiKey: 'THIS-IS-A-SECURE-KEY-123-FAKE-KEY',
+    };
+
+    window.localStorage.setItem('assistant_setup_dismissed', 'true');
+    window.localStorage.setItem('__tldw_first_run_complete', 'true');
+    window.localStorage.setItem('__tldw_test_bypass', 'true');
+    window.localStorage.setItem('tldwConfig', JSON.stringify(authConfig));
+    window.localStorage.setItem('apiKey', authConfig.apiKey);
+    window.localStorage.setItem('authMode', authConfig.authMode);
+    window.localStorage.setItem('stickyChatInput', 'true');
+    window.localStorage.setItem('playgroundComposerOptionsExpanded', 'false');
   });
 };
 
 const waitForStickyChat = async (page: Page) => {
   await page.goto('/chat', { waitUntil: 'domcontentloaded' });
-  await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => {});
   await expect(page.getByTestId('playground-chat-composer-dock')).toBeVisible({
     timeout: 30_000,
   });
@@ -25,6 +46,36 @@ const expectDockWithinViewport = async (page: Page) => {
   expect(dockBox).not.toBeNull();
   expect(dockBox!.y).toBeGreaterThanOrEqual(0);
   expect(dockBox!.y + dockBox!.height).toBeLessThanOrEqual(page.viewportSize()!.height);
+};
+
+const scrollTranscriptToBottom = async (page: Page, transcript: Locator) => {
+  const dock = page.getByTestId('playground-chat-composer-dock');
+
+  await expect(transcript).toBeVisible();
+  const forceScrollTranscript = () =>
+    transcript.evaluate((el) => {
+      let filler = el.querySelector<HTMLElement>('[data-testid="sticky-chat-scroll-filler"]');
+      if (!filler) {
+        filler = document.createElement('div');
+        filler.setAttribute('data-testid', 'sticky-chat-scroll-filler');
+        filler.style.flex = '0 0 auto';
+        el.appendChild(filler);
+      }
+
+      filler.style.height = `${Math.max(1200, el.clientHeight * 2)}px`;
+      const maxScrollTop = el.scrollHeight - el.clientHeight;
+      if (maxScrollTop <= 0) {
+        return 0;
+      }
+
+      el.scrollTop = maxScrollTop;
+      return el.scrollTop;
+    });
+
+  await expect.poll(forceScrollTranscript).toBeGreaterThan(0);
+  await forceScrollTranscript();
+  await expect(dock).toBeVisible();
+  await expectDockWithinViewport(page);
 };
 
 test.describe('chat sticky composer dock', () => {
@@ -38,8 +89,7 @@ test.describe('chat sticky composer dock', () => {
 
     const transcript = page.getByTestId('playground-chat-transcript');
     await expect(transcript).toBeVisible();
-
-    await expectDockWithinViewport(page);
+    await scrollTranscriptToBottom(page, transcript);
   });
 
   test('mobile-sized sticky /chat keeps the composer visible after focusing the input', async ({

--- a/apps/tldw-frontend/vitest.config.ts
+++ b/apps/tldw-frontend/vitest.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
       '@': path.resolve(__dirname, '../packages/ui/src'),
       '~': path.resolve(__dirname, '../packages/ui/src'),
       '@web': path.resolve(__dirname, '.'),
+      '@plasmohq/storage/hook': path.resolve(
+        __dirname,
+        './extension/shims/plasmo-storage-hook.tsx'
+      ),
+      '@plasmohq/storage': path.resolve(__dirname, './extension/shims/plasmo-storage.ts'),
       'wxt/browser': path.resolve(__dirname, './extension/shims/wxt-browser.ts'),
       'react-router-dom': path.resolve(
         __dirname,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -3058,6 +3058,8 @@ def speech_to_text_parakeet(
         # Convert to segment format with sentence-level segmentation
         return create_segments_from_text(text, audio_duration, segmentation="sentence")
 
+    except STTTranscriptionError:
+        raise
     except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS as e:
         logging.error(f"Parakeet transcription failed: {e}")
         raise STTTranscriptionError(f"Parakeet transcription error: {str(e)}") from e

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_ONNX.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_ONNX.py
@@ -346,6 +346,7 @@ def _prepare_onnx_inputs(
     session: Any,
     features: np.ndarray,
     waveform: Optional[np.ndarray] = None,
+    signal_length: int | None = None,
 ) -> dict[str, np.ndarray]:
     """
     Build a best-effort ONNX input map from runtime input names.
@@ -357,6 +358,12 @@ def _prepare_onnx_inputs(
     inputs_meta = list(session.get_inputs() or [])
     input_names = [_onnx_input_name(inp) for inp in inputs_meta]
     prepared: dict[str, np.ndarray] = {}
+    explicit_signal_length: int | None = None
+    if signal_length is not None:
+        try:
+            explicit_signal_length = max(0, int(signal_length))
+        except (OverflowError, TypeError, ValueError):
+            explicit_signal_length = None
 
     signal_name: str | None = None
     signal_tensor = features
@@ -367,7 +374,11 @@ def _prepare_onnx_inputs(
             if _is_raw_waveform_input(input_meta):
                 signal_name = _onnx_input_name(input_meta)
                 signal_tensor = waveform.astype(np.float32, copy=False)
-                signal_length = int(signal_tensor.shape[-1])
+                signal_length = (
+                    explicit_signal_length
+                    if explicit_signal_length is not None
+                    else int(signal_tensor.shape[-1])
+                )
                 break
 
     if signal_name is None:
@@ -386,7 +397,11 @@ def _prepare_onnx_inputs(
             signal_name = name
             if waveform is not None and _onnx_input_rank(input_meta) == 2:
                 signal_tensor = waveform.astype(np.float32, copy=False)
-                signal_length = int(signal_tensor.shape[-1])
+                signal_length = (
+                    explicit_signal_length
+                    if explicit_signal_length is not None
+                    else int(signal_tensor.shape[-1])
+                )
             break
 
     if signal_name is not None:
@@ -701,7 +716,9 @@ def transcribe_chunked_onnx(
         end = min(start + chunk_samples, total_samples)
 
         # Extract chunk
-        chunk = audio_data[start:end]
+        raw_chunk = audio_data[start:end]
+        chunk_length = len(raw_chunk)
+        chunk = raw_chunk
 
         # Pad if needed
         if len(chunk) < chunk_samples:
@@ -719,7 +736,12 @@ def transcribe_chunked_onnx(
             waveform = _prepare_waveform_input(chunk)
 
             # Prepare inputs
-            inputs = _prepare_onnx_inputs(session, features, waveform=waveform)
+            inputs = _prepare_onnx_inputs(
+                session,
+                features,
+                waveform=waveform,
+                signal_length=chunk_length,
+            )
 
             # Run inference
             outputs = session.run(output_names, inputs)

--- a/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
+++ b/tldw_Server_API/tests/Audio/test_parakeet_onnx_failfast.py
@@ -89,19 +89,21 @@ def test_speech_to_text_parakeet_onnx_error_sentinel_fails_fast(monkeypatch, tmp
 
     import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Nemo as nemo_mod
 
+    sentinel = (
+        "[Error: Transcription failed: Required inputs (['waveforms_lens']) "
+        "are missing from input feed (['waveforms']).]"
+    )
     monkeypatch.setattr(
         nemo_mod,
         "transcribe_with_parakeet",
-        lambda *_args, **_kwargs: (
-            "[Error: Transcription failed: Required inputs (['waveforms_lens']) "
-            "are missing from input feed (['waveforms']).]"
-        ),
+        lambda *_args, **_kwargs: sentinel,
     )
 
-    with pytest.raises(atlib.STTTranscriptionError, match="waveforms_lens"):
+    with pytest.raises(atlib.STTTranscriptionError, match="waveforms_lens") as exc_info:
         atlib.speech_to_text_parakeet(
             str(audio_file),
             variant="onnx",
             selected_source_lang="en",
             vad_filter=False,
         )
+    assert str(exc_info.value) == sentinel  # nosec B101

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_onnx.py
@@ -276,7 +276,7 @@ class TestParakeetONNX:
         )
 
         sample_rate = 16000
-        audio_data = np.random.randn(sample_rate * 2).astype(np.float32)
+        audio_data = np.random.randn(sample_rate * 2 + sample_rate // 2).astype(np.float32)
         session = MagicMock()
         input_waveforms = MagicMock()
         input_waveforms.name = "waveforms"
@@ -309,8 +309,8 @@ class TestParakeetONNX:
             overlap_duration=0.0,
         )
 
-        assert result == "chunk ok chunk ok"
-        assert seen_lens == [sample_rate, sample_rate]
+        assert result == "chunk ok chunk ok chunk ok"  # nosec B101
+        assert seen_lens == [sample_rate, sample_rate, sample_rate // 2]  # nosec B101
 
     def test_preprocessing(self):
 


### PR DESCRIPTION
## Summary
- dock `/chat` composer to the viewport bottom when sticky input is enabled while keeping the transcript scrollable
- preserve bottom anchoring as the dock grows and cap sticky composer textarea growth by viewport and keyboard state
- add sticky layout, smart-scroll, and browser smoke coverage for desktop, mobile, and artifacts-open states

## Test Plan
- `bunx vitest run src/components/Option/Playground/__tests__/Playground.sticky-composer-layout.integration.test.tsx src/hooks/__tests__/useSmartScroll.dock-offset.test.tsx`
- `bunx vitest run apps/tldw-frontend/__tests__/components/layout/WebLayout.chat-scroll-contract.test.tsx`
- `bunx playwright test e2e/smoke/chat-sticky-composer.spec.ts --project=chromium`
- `source .venv/bin/activate && python -m bandit -r apps/packages/ui/src/components/Option/Playground apps/packages/ui/src/hooks apps/tldw-frontend/components/layout -f json -o /tmp/bandit_chat_composer_bottom_dock.json`

## Change summary
- Required before merge: please replace this note with your own explanation of what changed and why these implementation choices were made, per `Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md`.
