### PR TITLE
Harden vz_linux lifecycle recovery

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -9,7 +9,7 @@ These notes cover the current macOS runtime scaffolding for the sandbox subsyste
 - `seatbelt`
 
 This is not yet a guide for shipping the full macOS runtime roadmap. The current implementation exposes runtime identities, policy admission, discovery metadata, helper/image-store contracts, and one real VM-backed path:
-- `vz_linux` now supports helper-backed ephemeral execution plus session VM reuse.
+- `vz_linux` supports helper-backed boot, guest command execution, ephemeral execution, and session VM reuse on prepared Apple silicon macOS hosts.
 - `vz_macos` remains scaffold-only.
 - `seatbelt` has a real trusted-workflow subprocess path on compatible macOS hosts.
 
@@ -59,7 +59,8 @@ other scaffold-only paths:
 - `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY=1`
 
 `vz_linux` uses helper-backed truth outside `TEST_MODE` and exposes a real
-execution path only when the helper and template are both validated.
+boot and guest execution path only when the helper and template are both
+validated.
 `vz_macos` still stays scaffold-only and exposes `real_execution_not_implemented`
 in preflight/discovery unless its fake execution flags are enabled.
 
@@ -74,8 +75,9 @@ The repo now contains:
 - a first-party Swift helper daemon subproject in `tools/macos-vz-helper/`
 - a first guest-protocol bridge in `tools/tldw-agent/` for guest-mode `tldw-agent`
 
-What is still incomplete is the actual `Virtualization.framework` boot path and
-the real vsock transport binding. The protocol and daemon surfaces are now in-repo.
+The `vz_linux` helper-backed boot and guest execution path is real when host,
+helper, guest agent, and canonical bundle or compatibility template validation
+all pass. `vz_macos` remains scaffold-only.
 
 ## Template Preparation Flow
 
@@ -98,7 +100,7 @@ Its current role is narrow:
 Expected operator flow:
 
 1. Prepare a sealed template image per runtime family.
-2. Register the template or canonical bundle in the sandbox image store.
+2. Register the canonical bundle, or a weaker compatibility template, in the sandbox image store.
 3. Create run-scoped clone manifests from that template.
 4. Hand clone metadata to the native helper for VM boot.
 5. Destroy the run-scoped clone state after completion.
@@ -175,6 +177,19 @@ that payload stays summarized and does not expose helper/template internals.
 
 ACP sandbox session creation now performs runtime preflight validation before calling the sandbox service, and converts failures into `ACPResponseError` instead of leaking raw sandbox exceptions.
 
+## Reconciliation And Repair
+
+`/api/v1/sandbox/admin/macos-diagnostics` is read-only. Its reconciliation block
+compares persisted VZ session-control rows with helper live VM state and reports
+healthy, stale, unhealthy, active, and orphan facts without changing either side.
+
+`POST /api/v1/sandbox/admin/macos-reconciliation/repair` is the explicit
+admin-only repair endpoint. Repair defaults to dry-run, skips active sessions,
+and can delete stale or unhealthy inactive persisted session-control rows when
+requested. It does not terminate orphan helper VMs yet; orphan termination
+remains deferred and manual. Helper unavailable or protocol mismatch conditions
+fail closed and block mutating repair.
+
 ## Current Limits
 
 - `vz_linux` real guest command execution is available behind helper/template readiness on Apple silicon macOS hosts
@@ -187,6 +202,8 @@ ACP sandbox session creation now performs runtime preflight validation before ca
 - No APFS clone execution path yet
 - No allowlist networking for the new macOS runtimes
 - No `vz_macos` warm-session VM reuse yet
+- No launchd or managed helper lifecycle yet
+- No automatic orphan VM termination during diagnostics or repair yet
 
 Current diagnostics are mixed-mode:
 

--- a/Docs/superpowers/plans/2026-04-27-vz-linux-lifecycle-recovery-hardening-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-27-vz-linux-lifecycle-recovery-hardening-implementation-plan.md
@@ -52,7 +52,7 @@
 - Create: `tldw_Server_API/app/core/Sandbox/vz_reconciliation.py`
 - Create: `tldw_Server_API/tests/sandbox/test_vz_reconciliation.py`
 
-- [ ] **Step 1: Write failing tests for reconciliation categories**
+- [x] **Step 1: Write failing tests for reconciliation categories**
 
 Create `tldw_Server_API/tests/sandbox/test_vz_reconciliation.py` with fake orchestrator/helper classes.
 
@@ -106,7 +106,7 @@ def test_reconciliation_marks_active_stale_sessions_as_skipped():
     assert any(item["status"] == "skipped_active_session" for item in report["items"])
 ```
 
-- [ ] **Step 2: Run tests and verify they fail**
+- [x] **Step 2: Run tests and verify they fail**
 
 Run:
 
@@ -116,7 +116,7 @@ source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test
 
 Expected: fail with import error for `vz_reconciliation` or missing `collect_vz_reconciliation`.
 
-- [ ] **Step 3: Implement `vz_reconciliation.py`**
+- [x] **Step 3: Implement `vz_reconciliation.py`**
 
 Implement a side-effect-free module:
 
@@ -174,7 +174,7 @@ Implementation rules:
 - Sort all ID lists for deterministic tests.
 - Include per-item dictionaries with `status`, `session_id`, `vm_id`, `state`, `healthy`, and `reason` where available.
 
-- [ ] **Step 4: Run Task 1 tests**
+- [x] **Step 4: Run Task 1 tests**
 
 Run:
 
@@ -184,7 +184,7 @@ source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test
 
 Expected: all Task 1 tests pass.
 
-- [ ] **Step 5: Commit Task 1**
+- [x] **Step 5: Commit Task 1**
 
 ```bash
 git add tldw_Server_API/app/core/Sandbox/vz_reconciliation.py tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
@@ -199,7 +199,7 @@ git commit -m "feat(sandbox): add vz reconciliation report"
 - Modify: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
 - Modify: `tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py`
 
-- [ ] **Step 1: Write failing diagnostics/schema tests**
+- [x] **Step 1: Write failing diagnostics/schema tests**
 
 Update `test_collect_macos_diagnostics_reports_reconciliation_mismatches` to assert additive fields:
 
@@ -231,7 +231,7 @@ Update schema tests so `SandboxAdminMacOSDiagnosticsResponse` accepts:
 - `skipped_active_session_ids`
 - `items`
 
-- [ ] **Step 2: Run tests and verify they fail**
+- [x] **Step 2: Run tests and verify they fail**
 
 Run:
 
@@ -244,7 +244,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: fail on missing fields or uncaught protocol mismatch.
 
-- [ ] **Step 3: Update Pydantic schemas**
+- [x] **Step 3: Update Pydantic schemas**
 
 In `sandbox_schemas.py`, add:
 
@@ -267,7 +267,7 @@ skipped_active_session_ids: list[str] = Field(default_factory=list)
 items: list[SandboxAdminMacOSReconciliationItem] = Field(default_factory=list)
 ```
 
-- [ ] **Step 4: Update diagnostics implementation**
+- [x] **Step 4: Update diagnostics implementation**
 
 In `macos_diagnostics.py`:
 
@@ -283,7 +283,7 @@ return collect_vz_reconciliation(orchestrator)
 
 Keep diagnostics read-only.
 
-- [ ] **Step 5: Run diagnostics tests**
+- [x] **Step 5: Run diagnostics tests**
 
 Run:
 
@@ -297,7 +297,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: all pass.
 
-- [ ] **Step 6: Commit Task 2**
+- [x] **Step 6: Commit Task 2**
 
 ```bash
 git add \
@@ -316,7 +316,7 @@ git commit -m "feat(sandbox): surface vz reconciliation diagnostics"
 - Modify: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
 - Create: `tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py`
 
-- [ ] **Step 1: Write failing service/API tests**
+- [x] **Step 1: Write failing service/API tests**
 
 Create `test_admin_macos_reconciliation_repair.py`.
 
@@ -354,7 +354,7 @@ Service-level tests should instantiate `SandboxService`, monkeypatch `collect_vz
 - active session item is skipped
 - helper unavailable/protocol mismatch with `dry_run=False` raises a service error that endpoint maps to 503
 
-- [ ] **Step 2: Run tests and verify they fail**
+- [x] **Step 2: Run tests and verify they fail**
 
 Run:
 
@@ -364,7 +364,7 @@ source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test
 
 Expected: fail because schemas/service/endpoint do not exist.
 
-- [ ] **Step 3: Add schemas**
+- [x] **Step 3: Add schemas**
 
 In `sandbox_schemas.py`, add request and response models near admin diagnostics:
 
@@ -401,7 +401,7 @@ class SandboxAdminMacOSReconciliationRepairResponse(BaseModel):
     reasons: list[str] = Field(default_factory=list)
 ```
 
-- [ ] **Step 4: Add service repair method**
+- [x] **Step 4: Add service repair method**
 
 In `service.py`:
 
@@ -442,7 +442,7 @@ Rules:
 
 Do not terminate orphaned VMs.
 
-- [ ] **Step 5: Add endpoint**
+- [x] **Step 5: Add endpoint**
 
 In `endpoints/sandbox.py`:
 
@@ -468,7 +468,7 @@ async def admin_repair_macos_reconciliation(
     return SandboxAdminMacOSReconciliationRepairResponse.model_validate(payload)
 ```
 
-- [ ] **Step 6: Run repair tests**
+- [x] **Step 6: Run repair tests**
 
 Run:
 
@@ -481,7 +481,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: all pass.
 
-- [ ] **Step 7: Commit Task 3**
+- [x] **Step 7: Commit Task 3**
 
 ```bash
 git add \
@@ -498,7 +498,7 @@ git commit -m "feat(sandbox): add explicit vz reconciliation repair"
 - Modify: `tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
 - Modify: `tldw_Server_API/tests/sandbox/test_vz_linux_runner.py`
 
-- [ ] **Step 1: Write failing runner tests**
+- [x] **Step 1: Write failing runner tests**
 
 Add tests:
 
@@ -530,7 +530,7 @@ def test_vz_linux_session_reuse_protocol_mismatch_does_not_delete_control(...):
     ...
 ```
 
-- [ ] **Step 2: Run tests and verify current behavior**
+- [x] **Step 2: Run tests and verify current behavior**
 
 Run:
 
@@ -540,7 +540,7 @@ source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test
 
 Expected: tests may already pass for deletion behavior but may fail on explicit protocol-mismatch message if not imported/caught clearly. Keep them as regression coverage either way.
 
-- [ ] **Step 3: Make runner intent explicit**
+- [x] **Step 3: Make runner intent explicit**
 
 In `vz_linux_runner.py`:
 
@@ -555,7 +555,7 @@ The behavior must stay:
 - helper unavailable exception: fail without deleting
 - protocol mismatch exception: fail without deleting
 
-- [ ] **Step 4: Run runner tests**
+- [x] **Step 4: Run runner tests**
 
 Run:
 
@@ -565,7 +565,7 @@ source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test
 
 Expected: all pass.
 
-- [ ] **Step 5: Commit Task 4**
+- [x] **Step 5: Commit Task 4**
 
 ```bash
 git add tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -579,7 +579,7 @@ git commit -m "fix(sandbox): fail closed on vz session helper mismatch"
 - Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
 - Optionally modify: `tools/macos-vz-helper/README.md`
 
-- [ ] **Step 1: Update stale current-state language**
+- [x] **Step 1: Update stale current-state language**
 
 Remove or replace claims that:
 
@@ -593,7 +593,7 @@ Replace with:
 - guest `tldw-agent` connects over vsock
 - operator smoke validates ephemeral execution and same-session reuse
 
-- [ ] **Step 2: Document reconciliation split**
+- [x] **Step 2: Document reconciliation split**
 
 Add documentation that:
 
@@ -603,7 +603,7 @@ Add documentation that:
 - dry-run is default
 - orphan VM termination is report-only until helper VM metadata is richer
 
-- [ ] **Step 3: Run doc grep checks**
+- [x] **Step 3: Run doc grep checks**
 
 Run:
 
@@ -614,7 +614,7 @@ rg -n "boot path.*incomplete|vsock.*incomplete|real vsock transport binding.*inc
 
 Expected: no stale incomplete claims remain, except if explicitly described as historical context.
 
-- [ ] **Step 4: Commit Task 5**
+- [x] **Step 4: Commit Task 5**
 
 ```bash
 git add \
@@ -631,7 +631,7 @@ If `tools/macos-vz-helper/README.md` was not changed, omit it from `git add`.
 **Files:**
 - No source changes unless verification finds issues.
 
-- [ ] **Step 1: Run focused sandbox tests**
+- [x] **Step 1: Run focused sandbox tests**
 
 Run:
 
@@ -649,7 +649,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: all pass.
 
-- [ ] **Step 2: Run helper-client regression tests**
+- [x] **Step 2: Run helper-client regression tests**
 
 Run:
 
@@ -661,7 +661,7 @@ source .venv/bin/activate && python -m pytest \
 
 Expected: all pass.
 
-- [ ] **Step 3: Run Bandit on touched code**
+- [x] **Step 3: Run Bandit on touched code**
 
 Run:
 
@@ -677,7 +677,7 @@ source .venv/bin/activate && python -m bandit \
 
 Expected: no new high/medium findings in touched code. If Bandit is not installed, install/use the project dev environment only after approval if needed.
 
-- [ ] **Step 4: Run formatting/whitespace checks**
+- [x] **Step 4: Run formatting/whitespace checks**
 
 Run:
 
@@ -687,7 +687,7 @@ git diff --check
 
 Expected: no output.
 
-- [ ] **Step 5: Review final diff**
+- [x] **Step 5: Review final diff**
 
 Run:
 
@@ -705,7 +705,7 @@ Check:
 - helper unavailable/protocol mismatch does not delete metadata
 - docs match current real VZ/vsock state
 
-- [ ] **Step 6: Final commit if needed**
+- [x] **Step 6: Final commit if needed**
 
 If verification fixes were needed:
 

--- a/Docs/superpowers/plans/2026-04-27-vz-linux-lifecycle-recovery-hardening-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-27-vz-linux-lifecycle-recovery-hardening-implementation-plan.md
@@ -1,0 +1,729 @@
+# vz_linux Lifecycle Recovery Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `vz_linux` lifecycle recovery deterministic by separating read-only reconciliation from explicit admin repair, classifying helper compatibility failures, and refreshing stale operator docs.
+
+**Architecture:** Add a focused Python reconciliation module that consumes helper-owned VM truth and Python-owned session-control metadata. Wire diagnostics to the read-only report, add a separate admin repair operation for safe stale-row deletion, keep orphan VM termination deferred, and tighten runner/helper error classification without expanding helper ownership.
+
+**Tech Stack:** Python 3, FastAPI, Pydantic, pytest, Loguru, existing macOS Virtualization helper protocol client.
+
+---
+
+## Source References
+
+- Spec: `Docs/superpowers/specs/2026-04-27-vz-linux-lifecycle-recovery-hardening-design.md`
+- Doctrine: `Docs/Sandbox/sandbox-architecture-doctrine.md`
+- Current diagnostics: `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+- Current helper client: `tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py`
+- Current runner: `tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
+- Current admin endpoint: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+- Current API schemas: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+
+## File Structure
+
+- Create `tldw_Server_API/app/core/Sandbox/vz_reconciliation.py`
+  - One responsibility: build read-only reconciliation reports and repair plans from persisted VZ session-control rows plus helper VM state.
+- Create `tldw_Server_API/tests/sandbox/test_vz_reconciliation.py`
+  - Unit coverage for reconciliation categories and helper/protocol failure classification.
+- Modify `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+  - Delegate reconciliation to the new module and classify helper protocol mismatch consistently.
+- Modify `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+  - Add additive reconciliation detail fields and repair request/response models.
+- Modify `tldw_Server_API/app/core/Sandbox/service.py`
+  - Add explicit admin repair service method; keep diagnostics read-only.
+- Modify `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+  - Add admin-only repair endpoint and error mapping.
+- Modify `tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
+  - Make helper unavailable/protocol mismatch paths explicit during session reuse.
+- Modify tests:
+  - `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+  - `tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py`
+  - `tldw_Server_API/tests/sandbox/test_vz_linux_runner.py`
+  - Create `tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py`
+- Modify docs:
+  - `tldw_Server_API/app/core/Sandbox/README.md`
+  - `Docs/Sandbox/macos-runtime-operator-notes.md`
+  - Optionally `tools/macos-vz-helper/README.md`
+
+## Task 1: Add Read-Only VZ Reconciliation Module
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Sandbox/vz_reconciliation.py`
+- Create: `tldw_Server_API/tests/sandbox/test_vz_reconciliation.py`
+
+- [ ] **Step 1: Write failing tests for reconciliation categories**
+
+Create `tldw_Server_API/tests/sandbox/test_vz_reconciliation.py` with fake orchestrator/helper classes.
+
+Test cases:
+
+```python
+def test_reconciliation_reports_healthy_stale_unhealthy_and_orphaned_vms():
+    # persisted:
+    # sess-live -> vm-live healthy
+    # sess-stale -> vm-missing
+    # sess-unhealthy -> vm-unhealthy live but healthy=False
+    # live helper also has vm-orphan
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator(...),
+        helper_client=_FakeHelper(...),
+    )
+
+    assert report["computed"] is True
+    assert report["persisted_sessions"] == 3
+    assert report["live_vms"] == 3
+    assert report["healthy_session_ids"] == ["sess-live"]
+    assert report["stale_session_ids"] == ["sess-stale"]
+    assert report["unhealthy_session_ids"] == ["sess-unhealthy"]
+    assert report["orphaned_vm_ids"] == ["vm-orphan"]
+    assert {item["status"] for item in report["items"]} >= {
+        "healthy",
+        "stale_session",
+        "unhealthy_vm",
+        "orphaned_vm",
+    }
+```
+
+Also add tests:
+
+```python
+def test_reconciliation_classifies_helper_unavailable():
+    ...
+    assert report["computed"] is False
+    assert "macos_virtualization_helper_unavailable" in report["reasons"]
+
+
+def test_reconciliation_classifies_protocol_mismatch():
+    ...
+    assert report["computed"] is False
+    assert "macos_virtualization_helper_protocol_mismatch" in report["reasons"]
+
+
+def test_reconciliation_marks_active_stale_sessions_as_skipped():
+    report = collect_vz_reconciliation(..., active_session_checker=lambda sid: sid == "sess-active")
+    assert report["skipped_active_session_ids"] == ["sess-active"]
+    assert any(item["status"] == "skipped_active_session" for item in report["items"])
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_vz_reconciliation.py -v
+```
+
+Expected: fail with import error for `vz_reconciliation` or missing `collect_vz_reconciliation`.
+
+- [ ] **Step 3: Implement `vz_reconciliation.py`**
+
+Implement a side-effect-free module:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from loguru import logger
+
+from .macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperClient,
+    MacOSVirtualizationHelperProtocolError,
+    MacOSVirtualizationHelperUnavailable,
+)
+
+REASON_HELPER_UNAVAILABLE = "macos_virtualization_helper_unavailable"
+REASON_PROTOCOL_MISMATCH = "macos_virtualization_helper_protocol_mismatch"
+REASON_RECONCILIATION_UNAVAILABLE = "vz_reconciliation_unavailable"
+
+
+def collect_vz_reconciliation(
+    orchestrator: Any | None,
+    *,
+    helper_client: Any | None = None,
+    active_session_checker: Callable[[str], bool] | None = None,
+) -> dict[str, object]:
+    ...
+```
+
+Output shape must preserve existing fields:
+
+```python
+{
+    "computed": False,
+    "persisted_sessions": 0,
+    "live_vms": 0,
+    "healthy_session_ids": [],
+    "stale_session_ids": [],
+    "unhealthy_session_ids": [],
+    "skipped_active_session_ids": [],
+    "orphaned_vm_ids": [],
+    "items": [],
+    "reasons": [],
+}
+```
+
+Implementation rules:
+
+- Return `computed=False` if `orchestrator` is missing or lacks `list_vz_session_controls`.
+- Catch `MacOSVirtualizationHelperUnavailable` and return reason `macos_virtualization_helper_unavailable`.
+- Catch `MacOSVirtualizationHelperProtocolError` and return reason `macos_virtualization_helper_protocol_mismatch`.
+- Do not call delete/terminate APIs.
+- Sort all ID lists for deterministic tests.
+- Include per-item dictionaries with `status`, `session_id`, `vm_id`, `state`, `healthy`, and `reason` where available.
+
+- [ ] **Step 4: Run Task 1 tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_vz_reconciliation.py -v
+```
+
+Expected: all Task 1 tests pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/vz_reconciliation.py tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
+git commit -m "feat(sandbox): add vz reconciliation report"
+```
+
+## Task 2: Wire Diagnostics To Reconciliation Truth
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py`
+
+- [ ] **Step 1: Write failing diagnostics/schema tests**
+
+Update `test_collect_macos_diagnostics_reports_reconciliation_mismatches` to assert additive fields:
+
+```python
+assert data["reconciliation"]["healthy_session_ids"] == ["sess-live"]
+assert data["reconciliation"]["stale_session_ids"] == ["sess-stale"]
+assert data["reconciliation"]["items"]
+```
+
+Add a protocol mismatch test:
+
+```python
+def test_collect_macos_diagnostics_classifies_helper_protocol_mismatch(monkeypatch):
+    class _FakeHelper:
+        def ping(self):
+            raise MacOSVirtualizationHelperProtocolError("macos_virtualization_helper_protocol_mismatch")
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _FakeHelper)
+
+    data = diagnostics_module.collect_macos_diagnostics()
+
+    assert "macos_virtualization_helper_protocol_mismatch" in data["helper"]["reasons"]
+```
+
+Update schema tests so `SandboxAdminMacOSDiagnosticsResponse` accepts:
+
+- `healthy_session_ids`
+- `unhealthy_session_ids`
+- `skipped_active_session_ids`
+- `items`
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/sandbox/test_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py \
+  -v
+```
+
+Expected: fail on missing fields or uncaught protocol mismatch.
+
+- [ ] **Step 3: Update Pydantic schemas**
+
+In `sandbox_schemas.py`, add:
+
+```python
+class SandboxAdminMacOSReconciliationItem(BaseModel):
+    status: str
+    session_id: str | None = None
+    vm_id: str | None = None
+    state: str | None = None
+    healthy: bool | None = None
+    reason: str | None = None
+```
+
+Extend `SandboxAdminMacOSReconciliationDiagnostics` additively:
+
+```python
+healthy_session_ids: list[str] = Field(default_factory=list)
+unhealthy_session_ids: list[str] = Field(default_factory=list)
+skipped_active_session_ids: list[str] = Field(default_factory=list)
+items: list[SandboxAdminMacOSReconciliationItem] = Field(default_factory=list)
+```
+
+- [ ] **Step 4: Update diagnostics implementation**
+
+In `macos_diagnostics.py`:
+
+- Import `MacOSVirtualizationHelperProtocolError`.
+- Import `collect_vz_reconciliation`.
+- Catch protocol mismatch in `probe_helper()` and append `macos_virtualization_helper_protocol_mismatch`.
+- Catch protocol mismatch in `_vz_linux_template_status()` and append the same reason.
+- Replace `probe_reconciliation()` internals with:
+
+```python
+return collect_vz_reconciliation(orchestrator)
+```
+
+Keep diagnostics read-only.
+
+- [ ] **Step 5: Run diagnostics tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/sandbox/test_vz_reconciliation.py \
+  tldw_Server_API/tests/sandbox/test_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py \
+  -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add \
+  tldw_Server_API/app/core/Sandbox/macos_diagnostics.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  tldw_Server_API/tests/sandbox/test_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+git commit -m "feat(sandbox): surface vz reconciliation diagnostics"
+```
+
+## Task 3: Add Explicit Admin Repair Operation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+- Create: `tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py`
+
+- [ ] **Step 1: Write failing service/API tests**
+
+Create `test_admin_macos_reconciliation_repair.py`.
+
+Endpoint tests should follow `test_admin_macos_diagnostics.py` app override style.
+
+Required tests:
+
+```python
+def test_admin_reconciliation_repair_defaults_to_dry_run(monkeypatch):
+    fake_service = SimpleNamespace(
+        repair_macos_reconciliation=lambda **kwargs: {
+            "dry_run": kwargs["dry_run"],
+            "helper": {"ready": True, "protocol_version": "1", "helper_version": "0.1.0"},
+            "summary": {...},
+            "actions": [{"type": "delete_session_control", "status": "planned"}],
+            "reasons": [],
+        }
+    )
+    ...
+    resp = client.post("/api/v1/sandbox/admin/macos-reconciliation/repair", json={})
+    assert resp.status_code == 200
+    assert resp.json()["dry_run"] is True
+```
+
+Also test:
+
+- `dry_run=false` passes through and can return `status="deleted"`.
+- `terminate_orphaned_vms=true` returns HTTP 400 with `orphan_termination_not_supported`.
+- non-admin cannot access endpoint.
+
+Service-level tests should instantiate `SandboxService`, monkeypatch `collect_vz_reconciliation` imported in service, and verify:
+
+- stale row dry-run plans deletion but does not call `delete_vz_session_control`
+- stale row with `dry_run=False` calls `delete_vz_session_control`
+- active session item is skipped
+- helper unavailable/protocol mismatch with `dry_run=False` raises a service error that endpoint maps to 503
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py -v
+```
+
+Expected: fail because schemas/service/endpoint do not exist.
+
+- [ ] **Step 3: Add schemas**
+
+In `sandbox_schemas.py`, add request and response models near admin diagnostics:
+
+```python
+class SandboxAdminMacOSReconciliationRepairRequest(BaseModel):
+    delete_stale_session_controls: bool = True
+    delete_unhealthy_session_controls: bool = True
+    terminate_orphaned_vms: bool = False
+    dry_run: bool = True
+
+
+class SandboxAdminMacOSReconciliationRepairAction(BaseModel):
+    type: str
+    session_id: str | None = None
+    vm_id: str | None = None
+    status: str
+    reason: str | None = None
+
+
+class SandboxAdminMacOSReconciliationRepairSummary(BaseModel):
+    stale_session_controls: int = 0
+    unhealthy_session_controls: int = 0
+    deleted_session_controls: int = 0
+    skipped_active_sessions: int = 0
+    orphaned_vms: int = 0
+    terminated_orphaned_vms: int = 0
+
+
+class SandboxAdminMacOSReconciliationRepairResponse(BaseModel):
+    dry_run: bool
+    helper: dict[str, object] = Field(default_factory=dict)
+    summary: SandboxAdminMacOSReconciliationRepairSummary
+    actions: list[SandboxAdminMacOSReconciliationRepairAction] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+```
+
+- [ ] **Step 4: Add service repair method**
+
+In `service.py`:
+
+- Import `collect_vz_reconciliation`.
+- Add small exception class:
+
+```python
+class SandboxReconciliationRepairError(RuntimeError):
+    def __init__(self, reason: str, status_code: int = 503) -> None:
+        self.reason = reason
+        self.status_code = int(status_code)
+        super().__init__(reason)
+```
+
+- Add method:
+
+```python
+def repair_macos_reconciliation(
+    self,
+    *,
+    delete_stale_session_controls: bool = True,
+    delete_unhealthy_session_controls: bool = True,
+    terminate_orphaned_vms: bool = False,
+    dry_run: bool = True,
+) -> dict[str, object]:
+    ...
+```
+
+Rules:
+
+- If `terminate_orphaned_vms` is true, raise `SandboxReconciliationRepairError("orphan_termination_not_supported", 400)`.
+- Build report using `collect_vz_reconciliation(self._orch, active_session_checker=lambda sid: self._active_session_run_count(sid) > 0)`.
+- If report has `macos_virtualization_helper_unavailable` or `macos_virtualization_helper_protocol_mismatch` and `dry_run=False`, raise 503.
+- Plan delete actions only for `stale_session` and `unhealthy_vm` items, based on request flags.
+- Skip any item with active session status.
+- If not dry-run, call `self._orch.delete_vz_session_control(session_id)`.
+- Log each planned/deleted/skipped action with Loguru.
+
+Do not terminate orphaned VMs.
+
+- [ ] **Step 5: Add endpoint**
+
+In `endpoints/sandbox.py`:
+
+- Import the new request/response schemas.
+- Import `SandboxReconciliationRepairError`.
+- Add:
+
+```python
+@router.post(
+    "/admin/macos-reconciliation/repair",
+    response_model=SandboxAdminMacOSReconciliationRepairResponse,
+    summary="Admin: repair macOS sandbox reconciliation state",
+)
+async def admin_repair_macos_reconciliation(
+    request: SandboxAdminMacOSReconciliationRepairRequest = Body(default_factory=SandboxAdminMacOSReconciliationRepairRequest),
+    _principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    _current_user: User = Depends(get_request_user),
+) -> SandboxAdminMacOSReconciliationRepairResponse:
+    try:
+        payload = _service.repair_macos_reconciliation(**request.model_dump())
+    except SandboxReconciliationRepairError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.reason) from exc
+    return SandboxAdminMacOSReconciliationRepairResponse.model_validate(payload)
+```
+
+- [ ] **Step 6: Run repair tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py \
+  -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/sandbox.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+git commit -m "feat(sandbox): add explicit vz reconciliation repair"
+```
+
+## Task 4: Tighten Session Reuse Failure Classification
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_vz_linux_runner.py`
+
+- [ ] **Step 1: Write failing runner tests**
+
+Add tests:
+
+```python
+def test_vz_linux_session_reuse_helper_unavailable_does_not_delete_control(monkeypatch, tmp_path):
+    deleted = []
+    class _Store:
+        def get_vz_session_control(self, session_id): ...
+        def delete_vz_session_control(self, session_id):
+            deleted.append(session_id)
+
+    class _FakeHelper:
+        def get_vm_status(self, vm_id):
+            raise MacOSVirtualizationHelperUnavailable("macos_virtualization_helper_unavailable")
+
+    status = VZLinuxRunner(session_control_store=_Store()).start_run(...)
+    assert status.phase == RunPhase.failed
+    assert "macos_virtualization_helper_unavailable" in status.message
+    assert deleted == []
+```
+
+And:
+
+```python
+def test_vz_linux_session_reuse_protocol_mismatch_does_not_delete_control(...):
+    class _FakeHelper:
+        def get_vm_status(self, vm_id):
+            raise MacOSVirtualizationHelperProtocolError("macos_virtualization_helper_protocol_mismatch")
+    ...
+```
+
+- [ ] **Step 2: Run tests and verify current behavior**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -v
+```
+
+Expected: tests may already pass for deletion behavior but may fail on explicit protocol-mismatch message if not imported/caught clearly. Keep them as regression coverage either way.
+
+- [ ] **Step 3: Make runner intent explicit**
+
+In `vz_linux_runner.py`:
+
+- Import `MacOSVirtualizationHelperProtocolError`.
+- Include it in the runner noncritical exception tuple if needed.
+- Around `helper.get_vm_status(candidate_vm_id)`, do not catch helper unavailable/protocol mismatch and do not call `_delete_session_control` in those cases.
+- Ensure final failure message contains the underlying helper reason.
+
+The behavior must stay:
+
+- missing/unhealthy status object: delete row and recreate
+- helper unavailable exception: fail without deleting
+- protocol mismatch exception: fail without deleting
+
+- [ ] **Step 4: Run runner tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+git commit -m "fix(sandbox): fail closed on vz session helper mismatch"
+```
+
+## Task 5: Refresh macOS Sandbox Runtime Docs
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Optionally modify: `tools/macos-vz-helper/README.md`
+
+- [ ] **Step 1: Update stale current-state language**
+
+Remove or replace claims that:
+
+- actual `Virtualization.framework` boot driver is incomplete
+- real vsock binding is incomplete
+
+Replace with:
+
+- real `vz_linux` execution uses the Swift helper `VirtualizationLinuxBootDriver`
+- helper owns vsock session management
+- guest `tldw-agent` connects over vsock
+- operator smoke validates ephemeral execution and same-session reuse
+
+- [ ] **Step 2: Document reconciliation split**
+
+Add documentation that:
+
+- diagnostics are read-only
+- `GET /api/v1/sandbox/admin/macos-diagnostics` reports reconciliation outcomes
+- `POST /api/v1/sandbox/admin/macos-reconciliation/repair` is the explicit repair path
+- dry-run is default
+- orphan VM termination is report-only until helper VM metadata is richer
+
+- [ ] **Step 3: Run doc grep checks**
+
+Run:
+
+```bash
+rg -n "boot path.*incomplete|vsock.*incomplete|real vsock transport binding.*incomplete|Virtualization.framework.*incomplete" \
+  tldw_Server_API/app/core/Sandbox/README.md Docs/Sandbox/macos-runtime-operator-notes.md tools/macos-vz-helper/README.md
+```
+
+Expected: no stale incomplete claims remain, except if explicitly described as historical context.
+
+- [ ] **Step 4: Commit Task 5**
+
+```bash
+git add \
+  tldw_Server_API/app/core/Sandbox/README.md \
+  Docs/Sandbox/macos-runtime-operator-notes.md \
+  tools/macos-vz-helper/README.md
+git commit -m "docs(sandbox): refresh vz linux lifecycle recovery notes"
+```
+
+If `tools/macos-vz-helper/README.md` was not changed, omit it from `git add`.
+
+## Task 6: Full Verification And Security Pass
+
+**Files:**
+- No source changes unless verification finds issues.
+
+- [ ] **Step 1: Run focused sandbox tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/sandbox/test_vz_reconciliation.py \
+  tldw_Server_API/tests/sandbox/test_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_runner.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_session_cleanup.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py \
+  -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run helper-client regression tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py \
+  -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run Bandit on touched code**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit \
+  -r \
+  tldw_Server_API/app/core/Sandbox \
+  tldw_Server_API/app/api/v1/endpoints/sandbox.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  -f json \
+  -o /tmp/bandit_vz_lifecycle_recovery.json
+```
+
+Expected: no new high/medium findings in touched code. If Bandit is not installed, install/use the project dev environment only after approval if needed.
+
+- [ ] **Step 4: Run formatting/whitespace checks**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Review final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat dev...HEAD
+git diff dev...HEAD -- tldw_Server_API/app/core/Sandbox tldw_Server_API/app/api/v1 Docs/Sandbox tldw_Server_API/app/core/Sandbox/README.md tools/macos-vz-helper/README.md
+```
+
+Check:
+
+- diagnostics path is read-only
+- repair endpoint is admin-only
+- orphan VM termination is rejected
+- helper unavailable/protocol mismatch does not delete metadata
+- docs match current real VZ/vsock state
+
+- [ ] **Step 6: Final commit if needed**
+
+If verification fixes were needed:
+
+```bash
+git add <changed-files>
+git commit -m "test(sandbox): verify vz lifecycle recovery hardening"
+```
+
+If no changes were needed, do not create an empty commit.
+
+## Completion Criteria
+
+- Reconciliation report is reusable outside diagnostics.
+- Diagnostics remain read-only.
+- Explicit admin repair exists and defaults to dry-run.
+- Repair deletes only stale/unhealthy session-control rows, only when requested, and skips active sessions.
+- Orphan VM termination is rejected/report-only.
+- Helper unavailable and protocol mismatch are explicit fail-closed states.
+- Runner tests prove helper unavailable/protocol mismatch do not delete session metadata.
+- Docs no longer claim real VZ boot/vsock are incomplete.
+- Focused tests and Bandit pass or any inability to run them is documented before PR creation.

--- a/Docs/superpowers/specs/2026-04-27-vz-linux-lifecycle-recovery-hardening-design.md
+++ b/Docs/superpowers/specs/2026-04-27-vz-linux-lifecycle-recovery-hardening-design.md
@@ -1,0 +1,342 @@
+# vz_linux Lifecycle And Recovery Hardening Design
+
+**Date:** 2026-04-27
+**Status:** Approved for implementation planning
+**Scope:** `tldw_Server_API/app/core/Sandbox/`, sandbox admin API schemas/endpoints, macOS sandbox docs, and helper protocol compatibility handling
+
+## Summary
+
+This design hardens the `vz_linux` runtime lifecycle after the real execution, vsock transport, operator smoke, and image-store foundations have landed.
+
+The next slice should make session reuse and helper failure behavior deterministic before expanding into APFS clone provisioning, launchd installation, hosted Apple Silicon CI, or `vz_macos` execution.
+
+The PR should add:
+
+- a read-only reconciliation report for persisted `sandbox_vz_sessions` versus live helper VM facts
+- an explicit admin repair path for stale persisted session-control rows
+- fail-closed helper protocol compatibility handling
+- clearer session-reuse behavior for helper unavailable, protocol mismatch, missing VM, and unhealthy VM cases
+- updated docs that reflect the current real VZ boot and real vsock implementation
+
+## Source Documents
+
+This design follows the durable sandbox doctrine:
+
+- `Docs/Sandbox/sandbox-architecture-doctrine.md`
+- `Docs/Plans/2026-03-10-vz-linux-helper-stability-design.md`
+- `Docs/Plans/2026-03-10-vz-linux-real-execution-design.md`
+- `Docs/Plans/2026-03-11-vz-linux-vsock-transport-design.md`
+- `Docs/Design/2026-04-27-vz-linux-operator-image-store-design.md`
+- `Docs/Sandbox/macos-runtime-operator-notes.md`
+- `tldw_Server_API/app/core/Sandbox/README.md`
+
+The active doctrine requires:
+
+- Python owns policy, sessions, runs, artifacts, queueing, and API behavior.
+- The native helper owns live runtime availability, VM state, guest transport health, and reconciliation facts.
+- Diagnostics must reuse runtime truth.
+- Session reuse must check live health before trusting persisted metadata.
+- Cleanup must tolerate already-gone runtime state.
+
+## Current State
+
+`vz_linux` now has a real helper-backed execution path on prepared Apple silicon macOS hosts:
+
+- Python talks to the helper over a Unix socket through `MacOSVirtualizationHelperClient`.
+- The Swift helper owns `Virtualization.framework` boot, VM registry state, vsock session management, and guest exec bridging.
+- The guest-side `tldw-agent` connects over vsock and serves structured exec requests.
+- `VZLinuxRunner` supports ephemeral execution and same-session VM reuse.
+- `SandboxImageStore` has a filesystem-backed manifest path.
+- `run-host-e2e-smoke.sh` exercises helper build/sign/start, template validation, ephemeral execution, same-session reuse, and shutdown.
+
+The remaining lifecycle gaps are:
+
+- Reconciliation is currently a diagnostics helper shape, not a reusable lifecycle service concept.
+- Existing diagnostics report stale persisted rows and orphaned helper VMs, but do not expose enough structured outcome categories for operator action.
+- There is no explicit admin repair operation for stale persisted session-control rows.
+- Helper protocol mismatch is raised by the client, but diagnostics and runtime lifecycle handling do not consistently classify it as a compatibility failure.
+- Orphaned helper VM termination is unsafe with the current helper metadata, because `list_vms()` does not expose `run_id`, `session_id`, `runtime`, creation time, or ownership.
+- Two docs still incorrectly say the VZ boot driver and real vsock binding are incomplete.
+
+## Goals
+
+1. Make persisted `vz_linux` session-control metadata recoverable after helper restarts, API restarts, helper crashes, and stale rows.
+2. Keep diagnostics read-only and safe to call repeatedly.
+3. Add an explicit admin repair path for stale persisted session rows.
+4. Treat helper protocol mismatch as a fail-closed compatibility state with clear diagnostics.
+5. Avoid terminating helper VMs that Python cannot prove it owns.
+6. Preserve the Python/helper ownership boundary.
+7. Update docs so future runtime plans start from current reality.
+
+## Non-Goals
+
+1. Full launchd install/uninstall support.
+2. Managed helper auto-upgrade.
+3. APFS clone-backed provisioning.
+4. Apple Silicon host-gated GitHub Actions runner wiring.
+5. `vz_macos` real execution.
+6. Allowlist networking.
+7. Orphan VM termination without extending helper VM metadata.
+8. Making the helper a persistence layer for sandbox sessions.
+
+## Recommended Approach
+
+Implement Python-side lifecycle and recovery hardening first.
+
+This is the pragmatic next step because it uses the helper truth that already exists, keeps the PR reviewable, and reduces the risk of future provisioning work compounding lifecycle ambiguity.
+
+Alternatives considered:
+
+- Full launchd/service management now. This has higher operator value, but it is too broad before the recovery semantics are stable.
+- Minimal stale-row deletion only. This is safer, but leaves helper compatibility, diagnostics clarity, and documentation drift unresolved.
+- APFS cloning next. This improves speed, but it does not address stale session state or helper crash behavior.
+
+## Architecture
+
+### Read-Only Reconciliation
+
+Add a reusable reconciliation report function under the sandbox core. It should compare:
+
+- persisted rows from `SandboxOrchestrator.list_vz_session_controls()`
+- live helper VM records from `MacOSVirtualizationHelperClient.list_vms()`
+- active queued, starting, or running session work from the sandbox service/orchestrator
+
+The report should be machine-readable and include outcome categories:
+
+- `healthy`: persisted session has a live, healthy helper VM
+- `stale_session`: persisted session references a missing live VM
+- `unhealthy_vm`: persisted session references a live VM that is not healthy
+- `orphaned_vm`: helper reports a VM not referenced by persisted session controls
+- `skipped_active_session`: row is stale or unhealthy but repair must skip because the session has active work
+- `helper_unavailable`: helper cannot be reached
+- `protocol_mismatch`: helper responded with an incompatible protocol version
+- `reconciliation_unavailable`: local store/orchestrator support is unavailable
+
+Diagnostics should call this report path and return the report. Diagnostics must not delete rows or terminate VMs.
+
+### Explicit Repair
+
+Add an admin-only repair operation that applies a conservative subset of the reconciliation report.
+
+Repair should:
+
+- require helper reachability
+- require protocol compatibility
+- delete stale persisted session-control rows only when the session has no active queued, starting, or running runs
+- delete unhealthy persisted session-control rows only when the helper confirms the VM is not healthy and the session has no active runs
+- skip active sessions and report them as skipped
+- never terminate orphaned VMs in this PR
+- tolerate rows already deleted by concurrent cleanup
+- return a structured repair summary
+
+Repair should not try to make the helper state authoritative for product sessions. It only repairs Python-owned session-control metadata that is provably stale against helper-owned runtime truth.
+
+### Orphan VM Policy
+
+Orphan VMs should remain report-only in this slice.
+
+The current helper `list_vms()` response does not expose enough ownership metadata to safely distinguish:
+
+- an active ephemeral run VM
+- a VM created by another local process
+- a VM from a previous helper lifecycle
+- a legitimate session VM that Python has not persisted yet because of a race
+
+Future orphan termination should first extend helper VM metadata to include at least `run_id`, `session_id`, `runtime`, `created_at`, `session_mode`, and possibly workspace/template identifiers.
+
+### Helper Compatibility
+
+Centralize helper compatibility classification.
+
+The Python client already rejects mismatched protocol versions. This slice should make that failure consistently visible as `protocol_mismatch` in diagnostics and reconciliation instead of collapsing it into generic helper unavailability.
+
+Runtime behavior should fail closed:
+
+- no fallback to fake execution
+- no deletion of persisted metadata when the helper is unavailable
+- no deletion of persisted metadata when the helper protocol is incompatible
+- explicit remediation in diagnostics to update the helper or Python client together
+
+### Session Reuse
+
+`VZLinuxRunner` already checks `get_vm_status()` before reusing a persisted VM. This slice should tighten the outcomes:
+
+- healthy VM: reuse
+- missing VM: delete stale row and create a fresh VM for the session run
+- unhealthy VM: delete stale row and create a fresh VM for the session run
+- helper unavailable: fail the run clearly without deleting metadata
+- protocol mismatch: fail the run clearly without deleting metadata
+
+This keeps reuse optimistic only after the helper confirms live health.
+
+### Startup Behavior
+
+Startup should remain non-destructive.
+
+The service may compute and log a reconciliation report during startup if a helper is configured, but it should not mutate session metadata or terminate VMs automatically. Operators should use the explicit repair path after reviewing diagnostics.
+
+This avoids surprising cleanup on hosts where the helper starts after the API service or where a protocol mismatch is temporarily caused by deployment ordering.
+
+## API Shape
+
+The existing endpoint remains read-only:
+
+```text
+GET /api/v1/sandbox/admin/macos-diagnostics
+```
+
+It should keep returning host, helper, template, runtime, and reconciliation data.
+
+Add a new admin endpoint for explicit repair:
+
+```text
+POST /api/v1/sandbox/admin/macos-reconciliation/repair
+```
+
+Recommended request shape:
+
+```json
+{
+  "delete_stale_session_controls": true,
+  "delete_unhealthy_session_controls": true,
+  "terminate_orphaned_vms": false,
+  "dry_run": true
+}
+```
+
+Rules:
+
+- `dry_run` should default to `true`.
+- `terminate_orphaned_vms=true` should be rejected in this PR with `orphan_termination_not_supported`.
+- actual mutation requires `dry_run=false`.
+- admin role is required.
+
+Recommended response shape:
+
+```json
+{
+  "dry_run": true,
+  "helper": {
+    "ready": true,
+    "protocol_version": "1",
+    "helper_version": "0.1.0"
+  },
+  "summary": {
+    "stale_session_controls": 1,
+    "unhealthy_session_controls": 0,
+    "deleted_session_controls": 0,
+    "skipped_active_sessions": 0,
+    "orphaned_vms": 1,
+    "terminated_orphaned_vms": 0
+  },
+  "actions": [
+    {
+      "type": "delete_session_control",
+      "session_id": "session-1",
+      "vm_id": "vm-missing",
+      "status": "planned",
+      "reason": "stale_session"
+    }
+  ],
+  "reasons": []
+}
+```
+
+## Error Handling
+
+Use explicit reason strings:
+
+- `macos_virtualization_helper_unavailable`
+- `macos_virtualization_helper_protocol_mismatch`
+- `vz_reconciliation_unavailable`
+- `vz_session_active_runs_present`
+- `orphan_termination_not_supported`
+- `vz_session_control_delete_failed`
+
+Read-only diagnostics should report failures as data and still return HTTP 200 when possible.
+
+The mutating repair endpoint should use 4xx only for invalid requests or unsupported options, and 503 for helper unavailable or protocol mismatch when mutation was requested.
+
+## Observability And Audit
+
+Emit structured logs for:
+
+- reconciliation report computed
+- stale session row detected
+- unhealthy session row detected
+- active session skipped
+- repair dry-run planned
+- session-control row deleted
+- repair failure
+
+The repair endpoint should also emit an admin/audit event if the existing audit pattern for sandbox admin endpoints supports it. If there is no straightforward existing audit hook in this endpoint cluster, structured Loguru events are the minimum for this PR, and audit integration can follow separately.
+
+## Testing Strategy
+
+### Unit Tests
+
+- reconciliation reports healthy persisted sessions
+- reconciliation reports stale persisted sessions
+- reconciliation reports unhealthy persisted sessions
+- reconciliation reports orphaned helper VMs without planning termination
+- helper unavailable leaves `computed=false` or an explicit helper-unavailable reason
+- protocol mismatch is classified distinctly
+- active sessions are marked `skipped_active_session`
+
+### Service/API Tests
+
+- diagnostics endpoint remains read-only
+- repair endpoint defaults to dry-run
+- repair endpoint deletes stale rows only with `dry_run=false`
+- repair endpoint skips sessions with active runs
+- repair endpoint rejects orphan termination
+- repair endpoint is admin-only
+
+### Runner Tests
+
+- session reuse fails closed on helper unavailable without deleting control metadata
+- session reuse fails closed on protocol mismatch without deleting control metadata
+- missing or unhealthy session VM causes the control row to be deleted and a new VM to be created
+
+### Host-Gated Tests
+
+No new host-gated VZ test is required for the first lifecycle hardening PR. Existing smoke coverage remains:
+
+- helper daemon host-gated smoke
+- real `vz_linux` host E2E smoke with ephemeral execution and same-session reuse
+
+## Documentation Updates
+
+Update:
+
+- `tldw_Server_API/app/core/Sandbox/README.md`
+- `Docs/Sandbox/macos-runtime-operator-notes.md`
+- optionally `tools/macos-vz-helper/README.md`
+
+Required doc corrections:
+
+- remove stale claims that real `Virtualization.framework` boot and real vsock binding are incomplete
+- describe diagnostics as read-only
+- describe explicit reconciliation repair
+- clarify that orphan VM termination is deferred pending richer helper metadata
+- keep launchd, auto-upgrade, APFS clone execution, and host-gated CI listed as future work
+
+## Design Review Notes
+
+The initial design was tightened in four ways before implementation planning:
+
+1. Diagnostics must remain non-mutating.
+2. Orphan VM termination must be deferred because helper VM records lack ownership metadata.
+3. Repair must skip sessions with active queued, starting, or running work.
+4. Helper unavailability and protocol mismatch must not delete persisted metadata.
+
+These constraints prevent the recovery work from creating a more dangerous cleanup path than the stale state it is meant to repair.
+
+## Open Follow-Up Work
+
+- Add helper VM metadata for safe orphan ownership decisions.
+- Add launchd install/uninstall and managed helper lifecycle commands.
+- Add helper auto-upgrade/version compatibility policy.
+- Add APFS clone-backed provisioning behind the stable image-store/helper contract.
+- Add Apple Silicon host-gated CI/nightly workflow.
+- Add stricter network policy enforcement once a provable allowlist mechanism exists.

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -33,6 +33,8 @@ from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminMacOSDiagnosticsResponse,
+    SandboxAdminMacOSReconciliationRepairRequest,
+    SandboxAdminMacOSReconciliationRepairResponse,
     ArtifactListResponse,
     CancelResponse,
     SandboxAdminIdempotencyItem,
@@ -78,7 +80,7 @@ from tldw_Server_API.app.core.Sandbox.orchestrator import (
     SessionActiveRunsConflict,
 )
 from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
-from tldw_Server_API.app.core.Sandbox.service import SandboxService
+from tldw_Server_API.app.core.Sandbox.service import SandboxReconciliationRepairError, SandboxService
 from tldw_Server_API.app.core.Sandbox.streams import get_hub
 from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
 from tldw_Server_API.app.core.testing import (
@@ -2233,6 +2235,24 @@ async def admin_macos_diagnostics(
     """Return detailed macOS sandbox diagnostics for admin troubleshooting."""
 
     return SandboxAdminMacOSDiagnosticsResponse.model_validate(_service.macos_diagnostics())
+
+
+@router.post(
+    "/admin/macos-reconciliation/repair",
+    response_model=SandboxAdminMacOSReconciliationRepairResponse,
+    summary="Admin: repair macOS sandbox reconciliation state",
+)
+async def admin_repair_macos_reconciliation(
+    request: SandboxAdminMacOSReconciliationRepairRequest = Body(default_factory=SandboxAdminMacOSReconciliationRepairRequest),
+    _principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    _current_user: User = Depends(get_request_user),
+) -> SandboxAdminMacOSReconciliationRepairResponse:
+    try:
+        payload = _service.repair_macos_reconciliation(**request.model_dump())
+    except SandboxReconciliationRepairError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.reason) from exc
+    return SandboxAdminMacOSReconciliationRepairResponse.model_validate(payload)
+
 
 @router.get(
     "/admin/runs",

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -2248,7 +2248,7 @@ async def admin_repair_macos_reconciliation(
     _current_user: User = Depends(get_request_user),
 ) -> SandboxAdminMacOSReconciliationRepairResponse:
     try:
-        payload = _service.repair_macos_reconciliation(**request.model_dump())
+        payload = await asyncio.to_thread(_service.repair_macos_reconciliation, **request.model_dump())
     except SandboxReconciliationRepairError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.reason) from exc
     return SandboxAdminMacOSReconciliationRepairResponse.model_validate(payload)

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -313,14 +313,27 @@ class SandboxAdminMacOSRuntimeDiagnostics(BaseModel):
     remediation: str | None = None
 
 
+class SandboxAdminMacOSReconciliationItem(BaseModel):
+    status: str
+    session_id: str | None = None
+    vm_id: str | None = None
+    state: str | None = None
+    healthy: bool | None = None
+    reason: str | None = None
+
+
 class SandboxAdminMacOSReconciliationDiagnostics(BaseModel):
     """Admin-facing comparison between persisted VZ session state and live helper VMs."""
 
     computed: bool
     persisted_sessions: int
     live_vms: int
+    healthy_session_ids: list[str] = Field(default_factory=list)
     stale_session_ids: list[str] = Field(default_factory=list)
+    unhealthy_session_ids: list[str] = Field(default_factory=list)
+    skipped_active_session_ids: list[str] = Field(default_factory=list)
     orphaned_vm_ids: list[str] = Field(default_factory=list)
+    items: list[SandboxAdminMacOSReconciliationItem] = Field(default_factory=list)
     reasons: list[str] = Field(default_factory=list)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -347,6 +347,38 @@ class SandboxAdminMacOSDiagnosticsResponse(BaseModel):
     reconciliation: SandboxAdminMacOSReconciliationDiagnostics | None = None
 
 
+class SandboxAdminMacOSReconciliationRepairRequest(BaseModel):
+    delete_stale_session_controls: bool = True
+    delete_unhealthy_session_controls: bool = True
+    terminate_orphaned_vms: bool = False
+    dry_run: bool = True
+
+
+class SandboxAdminMacOSReconciliationRepairAction(BaseModel):
+    type: str
+    session_id: str | None = None
+    vm_id: str | None = None
+    status: str
+    reason: str | None = None
+
+
+class SandboxAdminMacOSReconciliationRepairSummary(BaseModel):
+    stale_session_controls: int = 0
+    unhealthy_session_controls: int = 0
+    deleted_session_controls: int = 0
+    skipped_active_sessions: int = 0
+    orphaned_vms: int = 0
+    terminated_orphaned_vms: int = 0
+
+
+class SandboxAdminMacOSReconciliationRepairResponse(BaseModel):
+    dry_run: bool
+    helper: dict[str, object] = Field(default_factory=dict)
+    summary: SandboxAdminMacOSReconciliationRepairSummary
+    actions: list[SandboxAdminMacOSReconciliationRepairAction] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+
+
 # Snapshot/Clone Schemas
 class SnapshotCreateResponse(BaseModel):
     """Response when creating a session snapshot."""

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -22,7 +22,7 @@
 - `docker`: general-purpose default runtime with existing interactive support.
 - `firecracker`: VM-oriented Linux isolation path.
 - `lima`: strict macOS-host VM path with explicit deny-all readiness checks.
-- `vz_linux`: Apple `Virtualization.framework` Linux guest runtime on Apple silicon macOS hosts, with real helper-backed ephemeral execution and session VM reuse.
+- `vz_linux`: Apple `Virtualization.framework` Linux guest runtime on prepared Apple silicon macOS hosts, with real helper-backed boot, guest command execution, and session VM reuse when helper/template readiness passes.
 - `vz_macos`: Apple `Virtualization.framework` macOS guest scaffold on Apple silicon macOS hosts.
 - `seatbelt`: host-local process isolation runtime for conservative trusted macOS workflows, compatibility-gated by deprecated `sandbox-exec`.
 
@@ -57,15 +57,18 @@ Trust-level rules:
 Current limitations:
 
 - `vz_macos` real `Virtualization.framework` execution is not implemented yet.
-- `vz_linux` requires helper/template readiness and reports `execution_mode=real` when the helper-backed path is available.
+- `vz_linux` requires helper/template readiness and reports `execution_mode=real` when the helper-backed boot and guest execution path is available.
 - `vz_macos` still requires helper/template readiness plus `*_FAKE_EXEC=1`; otherwise discovery reports `real_execution_not_implemented`.
 - Strict allowlist networking is not implemented for `vz_linux`, `vz_macos`, or `seatbelt`.
 - `seatbelt` discovery may be `available=True` while `strict_deny_all_supported=False`; deny-all is a best-effort host policy claim, not a VM-grade guarantee.
 - `seatbelt` control files and isolated `HOME`/temp dirs live outside the writable workspace and are removed after each run.
 - `seatbelt` real execution still depends on deprecated `sandbox-exec` and may be blocked by an enclosing sandbox even on macOS hosts.
 - `vz_linux` supports session VM reuse through persisted VZ session-control metadata; `vz_macos` does not.
-- `vz_linux` admin diagnostics now include reconciliation data comparing persisted VZ session-control rows against live helper VM state.
-- the helper daemon and guest protocol are now real at the socket/stream level, but the actual `Virtualization.framework` boot driver and vsock transport binding are still incomplete.
+- `vz_linux` admin diagnostics include reconciliation data comparing persisted VZ session-control rows against live helper VM state.
+- `vz_linux` repair is explicit and admin-only through `POST /api/v1/sandbox/admin/macos-reconciliation/repair`; diagnostics do not mutate state.
+- `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and does not terminate orphan helper VMs yet.
+- Helper unavailable or protocol mismatch conditions fail closed and block mutating repair.
+- Orphan VM termination and launchd/managed helper lifecycle are future work, not automatic repair behavior.
 - helper-backed template validation now distinguishes canonical bundles from
   raw-disk compatibility mode through `boot_mode` and `validation_strength`.
 - `SandboxImageStore` persists template manifests under
@@ -87,13 +90,18 @@ Current limitations:
   - `/api/v1/sandbox/health`
   - `/api/v1/sandbox/runtimes`
   - `/api/v1/sandbox/admin/macos-diagnostics`
+  - `POST /api/v1/sandbox/admin/macos-reconciliation/repair`
   - `/api/v1/sandbox/runs`
 
 `/api/v1/sandbox/runtimes` is the summarized discovery surface used by clients and ACP.
 `/api/v1/sandbox/admin/macos-diagnostics` is an admin-only diagnostics surface for
 operator troubleshooting and exposes helper/template readiness details that are not
 included in the public discovery payload, plus reconciliation data for persisted
-`vz_linux` session-control rows versus live helper VM state.
+`vz_linux` session-control rows versus live helper VM state. It is read-only.
+`POST /api/v1/sandbox/admin/macos-reconciliation/repair` is the separate
+admin-only repair surface. Repair defaults to dry-run, skips active sessions,
+can delete stale or unhealthy inactive persisted session-control rows when
+requested, and currently leaves orphan helper VMs running for manual handling.
 
 Selected configuration knobs:
 

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -46,6 +46,8 @@ def _remediation_for_reasons(reasons: list[str]) -> str | None:
         return "Run this runtime on an Apple silicon macOS host."
     if "macos_virtualization_helper_unavailable" in reasons:
         return "Install or start the macOS virtualization helper service."
+    if "macos_virtualization_helper_protocol_mismatch" in reasons:
+        return "Update the macOS virtualization helper and Python client to compatible protocol versions."
     if "macos_helper_missing" in reasons:
         return "Configure the macOS virtualization helper and mark it ready."
     if _VZ_LINUX_TEMPLATE_MISSING_REASON in reasons or _VZ_MACOS_TEMPLATE_MISSING_REASON in reasons:

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -112,7 +112,13 @@ def probe_helper() -> dict[str, object]:
     except MacOSVirtualizationHelperProtocolError:
         reasons.append("macos_virtualization_helper_protocol_mismatch")
 
-    if not ready and "macos_virtualization_helper_unavailable" not in reasons:
+    if not ready and not any(
+        reason in reasons
+        for reason in (
+            "macos_virtualization_helper_unavailable",
+            "macos_virtualization_helper_protocol_mismatch",
+        )
+    ):
         reasons.append("macos_helper_missing")
 
     return {

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -11,11 +11,13 @@ from tldw_Server_API.app.core.testing import is_truthy
 
 from .macos_virtualization.helper_client import (
     MacOSVirtualizationHelperClient,
+    MacOSVirtualizationHelperProtocolError,
     MacOSVirtualizationHelperUnavailable,
 )
 from .models import RuntimeType
 from .runtime_capabilities import RuntimePreflightResult, collect_runtime_preflights
 from .runners.vz_common import vz_host_facts
+from .vz_reconciliation import collect_vz_reconciliation
 
 _VZ_LINUX_TEMPLATE_MISSING_REASON = "vz_linux_template_missing"
 _VZ_MACOS_TEMPLATE_MISSING_REASON = "macos_template_missing"
@@ -105,6 +107,8 @@ def probe_helper() -> dict[str, object]:
         helper_version = str(ping.helper_version or "").strip() or None
     except MacOSVirtualizationHelperUnavailable as exc:
         reasons.append(str(exc) or "macos_virtualization_helper_unavailable")
+    except MacOSVirtualizationHelperProtocolError:
+        reasons.append("macos_virtualization_helper_protocol_mismatch")
 
     if not ready and "macos_virtualization_helper_unavailable" not in reasons:
         reasons.append("macos_helper_missing")
@@ -173,6 +177,8 @@ def _vz_linux_template_status() -> dict[str, object]:
         reasons.extend(helper_reasons)
     except MacOSVirtualizationHelperUnavailable as exc:
         reasons.append(str(exc) or "macos_virtualization_helper_unavailable")
+    except MacOSVirtualizationHelperProtocolError:
+        reasons.append("macos_virtualization_helper_protocol_mismatch")
 
     if not ready and not reasons:
         reasons.append(_VZ_LINUX_TEMPLATE_MISSING_REASON)
@@ -226,52 +232,7 @@ def probe_runtime_statuses(
 def probe_reconciliation(orchestrator: Any | None = None) -> dict[str, object]:
     """Compare persisted VZ session rows with live helper VM state when available."""
 
-    summary: dict[str, object] = {
-        "computed": False,
-        "persisted_sessions": 0,
-        "live_vms": 0,
-        "stale_session_ids": [],
-        "orphaned_vm_ids": [],
-        "reasons": [],
-    }
-    if orchestrator is None:
-        return summary
-
-    lister = getattr(orchestrator, "list_vz_session_controls", None)
-    if not callable(lister):
-        summary["reasons"] = ["vz_session_listing_unavailable"]
-        return summary
-
-    persisted_rows = [dict(row) for row in lister() or [] if isinstance(row, dict)]
-    summary["persisted_sessions"] = len(persisted_rows)
-
-    try:
-        live = MacOSVirtualizationHelperClient().list_vms()
-    except MacOSVirtualizationHelperUnavailable as exc:
-        summary["reasons"] = [str(exc) or "macos_virtualization_helper_unavailable"]
-        return summary
-
-    live_vm_ids = {
-        str(vm.vm_id).strip()
-        for vm in list(live.vms or [])
-        if str(getattr(vm, "vm_id", "")).strip()
-    }
-    persisted_vm_by_session = {
-        str(row.get("id") or "").strip(): str(row.get("vm_id") or "").strip()
-        for row in persisted_rows
-        if str(row.get("id") or "").strip() and str(row.get("vm_id") or "").strip()
-    }
-    persisted_vm_ids = {vm_id for vm_id in persisted_vm_by_session.values() if vm_id}
-
-    summary["computed"] = True
-    summary["live_vms"] = len(live_vm_ids)
-    summary["stale_session_ids"] = sorted(
-        session_id
-        for session_id, vm_id in persisted_vm_by_session.items()
-        if vm_id not in live_vm_ids
-    )
-    summary["orphaned_vm_ids"] = sorted(vm_id for vm_id in live_vm_ids if vm_id not in persisted_vm_ids)
-    return summary
+    return collect_vz_reconciliation(orchestrator)
 
 
 def collect_macos_diagnostics(orchestrator: Any | None = None) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -67,10 +67,15 @@ class VZLinuxRunner(VZBaseRunner):
                         "network_policy": str(network_policy or "deny_all").strip().lower() or "deny_all",
                     }
                 )
-            except MacOSVirtualizationHelperUnavailable as exc:
+            except (MacOSVirtualizationHelperUnavailable, MacOSVirtualizationHelperProtocolError) as exc:
+                default_reason = (
+                    "macos_virtualization_helper_protocol_mismatch"
+                    if isinstance(exc, MacOSVirtualizationHelperProtocolError)
+                    else "macos_virtualization_helper_unavailable"
+                )
                 helper_result = {
                     "available": False,
-                    "reasons": [str(exc) or "macos_virtualization_helper_unavailable"],
+                    "reasons": [str(exc) or default_reason],
                     "execution_mode": "none",
                 }
             helper_reasons = [str(reason) for reason in helper_result.get("reasons", []) if str(reason).strip()]

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from ..macos_virtualization.helper_client import (
     MacOSVirtualizationHelperClient,
+    MacOSVirtualizationHelperProtocolError,
     MacOSVirtualizationHelperUnavailable,
 )
 from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
@@ -275,7 +276,11 @@ class VZLinuxRunner(VZBaseRunner):
                 and str(session_control.get("vm_id") or "").strip()
             ):
                 candidate_vm_id = str(session_control.get("vm_id") or "").strip()
-                status = helper.get_vm_status(candidate_vm_id)
+                try:
+                    status = helper.get_vm_status(candidate_vm_id)
+                except (MacOSVirtualizationHelperUnavailable, MacOSVirtualizationHelperProtocolError):
+                    # Host truth is unavailable or untrusted; explicit admin repair owns row cleanup.
+                    raise
                 if bool(status.healthy):
                     vm_id = candidate_vm_id
                     template_ref = str(session_control.get("template_id") or "").strip() or spec.base_image

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -1083,9 +1083,11 @@ class SandboxService:
 
             action_status = "planned"
             if not dry_run:
-                self._orch.delete_vz_session_control(session_id)
-                summary["deleted_session_controls"] += 1
-                action_status = "deleted"
+                if self._orch.delete_vz_session_control(session_id):
+                    summary["deleted_session_controls"] += 1
+                    action_status = "deleted"
+                else:
+                    action_status = "missing"
 
             action = {
                 "type": "delete_session_control",

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -55,6 +55,7 @@ from .runners.worktree_runner import WorktreeRunner, worktree_available
 from .snapshots import SnapshotManager
 from .store import get_store_mode
 from .streams import get_hub
+from .vz_reconciliation import collect_vz_reconciliation
 
 _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -90,6 +91,13 @@ except Exception:
 
 _SANDBOX_WORKSPACE_FALLBACK_LOCKS: dict[str, threading.Lock] = {}
 _SANDBOX_WORKSPACE_FALLBACK_LOCKS_GUARD = threading.Lock()
+
+
+class SandboxReconciliationRepairError(RuntimeError):
+    def __init__(self, reason: str, status_code: int = 503) -> None:
+        self.reason = reason
+        self.status_code = int(status_code)
+        super().__init__(reason)
 
 
 def _get_sandbox_workspace_thread_lock(lock_path: str) -> threading.Lock:
@@ -994,6 +1002,108 @@ class SandboxService:
 
     def macos_diagnostics(self) -> dict[str, object]:
         return collect_macos_diagnostics(self._orch)
+
+    def repair_macos_reconciliation(
+        self,
+        *,
+        delete_stale_session_controls: bool = True,
+        delete_unhealthy_session_controls: bool = True,
+        terminate_orphaned_vms: bool = False,
+        dry_run: bool = True,
+    ) -> dict[str, object]:
+        if terminate_orphaned_vms:
+            raise SandboxReconciliationRepairError("orphan_termination_not_supported", 400)
+
+        report = collect_vz_reconciliation(
+            self._orch,
+            active_session_checker=lambda sid: self._active_session_run_count(sid) > 0,
+        )
+        reasons = [str(reason) for reason in list(report.get("reasons") or [])]
+        blocking_reasons = {
+            "macos_virtualization_helper_unavailable",
+            "macos_virtualization_helper_protocol_mismatch",
+        }
+        if not dry_run:
+            for reason in reasons:
+                if reason in blocking_reasons:
+                    raise SandboxReconciliationRepairError(reason, 503)
+
+        report_items = [item for item in list(report.get("items") or []) if isinstance(item, dict)]
+        stale_items = [item for item in report_items if str(item.get("status") or "").strip() == "stale_session"]
+        unhealthy_items = [item for item in report_items if str(item.get("status") or "").strip() == "unhealthy_vm"]
+        skipped_items = [item for item in report_items if str(item.get("status") or "").strip() == "skipped_active_session"]
+        orphaned_items = [item for item in report_items if str(item.get("status") or "").strip() == "orphaned_vm"]
+        actions: list[dict[str, object]] = []
+        summary: dict[str, int] = {
+            "stale_session_controls": max(len(list(report.get("stale_session_ids") or [])), len(stale_items)),
+            "unhealthy_session_controls": max(len(list(report.get("unhealthy_session_ids") or [])), len(unhealthy_items)),
+            "deleted_session_controls": 0,
+            "skipped_active_sessions": max(len(list(report.get("skipped_active_session_ids") or [])), len(skipped_items)),
+            "orphaned_vms": max(len(list(report.get("orphaned_vm_ids") or [])), len(orphaned_items)),
+            "terminated_orphaned_vms": 0,
+        }
+
+        for item in report_items:
+            status = str(item.get("status") or "").strip()
+            session_id = str(item.get("session_id") or "").strip()
+            vm_id = str(item.get("vm_id") or "").strip()
+            reason = str(item.get("reason") or "").strip()
+
+            if status == "skipped_active_session":
+                action = {
+                    "type": "delete_session_control",
+                    "session_id": session_id or None,
+                    "vm_id": vm_id or None,
+                    "status": "skipped",
+                    "reason": reason or "active_session",
+                }
+                logger.info("Skipping VZ reconciliation repair action: {}", action)
+                actions.append(action)
+                continue
+
+            should_delete = (
+                (status == "stale_session" and delete_stale_session_controls)
+                or (status == "unhealthy_vm" and delete_unhealthy_session_controls)
+            )
+            if not should_delete or not session_id:
+                continue
+
+            if self._active_session_run_count(session_id) > 0:
+                summary["skipped_active_sessions"] += 1
+                action = {
+                    "type": "delete_session_control",
+                    "session_id": session_id,
+                    "vm_id": vm_id or None,
+                    "status": "skipped",
+                    "reason": "active_session",
+                }
+                logger.info("Skipping VZ reconciliation repair action: {}", action)
+                actions.append(action)
+                continue
+
+            action_status = "planned"
+            if not dry_run:
+                self._orch.delete_vz_session_control(session_id)
+                summary["deleted_session_controls"] += 1
+                action_status = "deleted"
+
+            action = {
+                "type": "delete_session_control",
+                "session_id": session_id,
+                "vm_id": vm_id or None,
+                "status": action_status,
+                "reason": reason or None,
+            }
+            logger.info("VZ reconciliation repair action: {}", action)
+            actions.append(action)
+
+        return {
+            "dry_run": bool(dry_run),
+            "helper": {},
+            "summary": summary,
+            "actions": actions,
+            "reasons": reasons,
+        }
 
     def _audit_run_completion(self, *, user_id: str | int | None, run_id: str, status: RunStatus, spec_version: str, session_id: str | None) -> None:
         """Log a completion audit event in a fire-and-forget manner."""

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -41,7 +41,7 @@ from .macos_virtualization.helper_client import (
     MacOSVirtualizationHelperClient,
     MacOSVirtualizationHelperFailure,
 )
-from .macos_diagnostics import collect_macos_diagnostics
+from .macos_diagnostics import collect_macos_diagnostics, probe_helper
 from .orchestrator import SandboxOrchestrator, SessionActiveRunsConflict
 from .policy import SandboxPolicy, SandboxPolicyConfig, compute_policy_hash
 from .runtime_capabilities import RuntimePreflightResult, collect_runtime_preflights
@@ -1014,6 +1014,7 @@ class SandboxService:
         if terminate_orphaned_vms:
             raise SandboxReconciliationRepairError("orphan_termination_not_supported", 400)
 
+        helper_status = probe_helper()
         report = collect_vz_reconciliation(
             self._orch,
             active_session_checker=lambda sid: self._active_session_run_count(sid) > 0,
@@ -1035,11 +1036,11 @@ class SandboxService:
         orphaned_items = [item for item in report_items if str(item.get("status") or "").strip() == "orphaned_vm"]
         actions: list[dict[str, object]] = []
         summary: dict[str, int] = {
-            "stale_session_controls": max(len(list(report.get("stale_session_ids") or [])), len(stale_items)),
-            "unhealthy_session_controls": max(len(list(report.get("unhealthy_session_ids") or [])), len(unhealthy_items)),
+            "stale_session_controls": len(stale_items),
+            "unhealthy_session_controls": len(unhealthy_items),
             "deleted_session_controls": 0,
-            "skipped_active_sessions": max(len(list(report.get("skipped_active_session_ids") or [])), len(skipped_items)),
-            "orphaned_vms": max(len(list(report.get("orphaned_vm_ids") or [])), len(orphaned_items)),
+            "skipped_active_sessions": len(skipped_items),
+            "orphaned_vms": len(orphaned_items),
             "terminated_orphaned_vms": 0,
         }
 
@@ -1083,7 +1084,12 @@ class SandboxService:
 
             action_status = "planned"
             if not dry_run:
-                if self._orch.delete_vz_session_control(session_id):
+                try:
+                    deleted = bool(self._orch.delete_vz_session_control(session_id))
+                except Exception as exc:
+                    logger.exception("VZ reconciliation repair delete failed for session_id={}", session_id)
+                    raise SandboxReconciliationRepairError("vz_session_control_delete_failed", 503) from exc
+                if deleted:
                     summary["deleted_session_controls"] += 1
                     action_status = "deleted"
                 else:
@@ -1101,7 +1107,7 @@ class SandboxService:
 
         return {
             "dry_run": bool(dry_run),
-            "helper": {},
+            "helper": helper_status,
             "summary": summary,
             "actions": actions,
             "reasons": reasons,

--- a/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
+++ b/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from loguru import logger
+
+from .macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperClient,
+    MacOSVirtualizationHelperProtocolError,
+    MacOSVirtualizationHelperUnavailable,
+)
+
+REASON_HELPER_UNAVAILABLE = "macos_virtualization_helper_unavailable"
+REASON_PROTOCOL_MISMATCH = "macos_virtualization_helper_protocol_mismatch"
+REASON_RECONCILIATION_UNAVAILABLE = "vz_reconciliation_unavailable"
+
+
+def _empty_report() -> dict[str, object]:
+    return {
+        "computed": False,
+        "persisted_sessions": 0,
+        "live_vms": 0,
+        "healthy_session_ids": [],
+        "stale_session_ids": [],
+        "unhealthy_session_ids": [],
+        "skipped_active_session_ids": [],
+        "orphaned_vm_ids": [],
+        "items": [],
+        "reasons": [],
+    }
+
+
+def _clean_id(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _append_item(
+    items: list[dict[str, object]],
+    *,
+    status: str,
+    session_id: str | None = None,
+    vm_id: str | None = None,
+    state: str | None = None,
+    healthy: bool | None = None,
+    reason: str | None = None,
+) -> None:
+    item: dict[str, object] = {"status": status}
+    if session_id:
+        item["session_id"] = session_id
+    if vm_id:
+        item["vm_id"] = vm_id
+    if state:
+        item["state"] = state
+    if healthy is not None:
+        item["healthy"] = bool(healthy)
+    if reason:
+        item["reason"] = reason
+    items.append(item)
+
+
+def _sort_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    return sorted(
+        items,
+        key=lambda item: (
+            str(item.get("status") or ""),
+            str(item.get("session_id") or ""),
+            str(item.get("vm_id") or ""),
+        ),
+    )
+
+
+def collect_vz_reconciliation(
+    orchestrator: Any | None,
+    *,
+    helper_client: Any | None = None,
+    active_session_checker: Callable[[str], bool] | None = None,
+) -> dict[str, object]:
+    """Compare persisted VZ session-control rows with live helper VM state.
+
+    This collector is intentionally read-only: it only lists persisted rows and
+    live VMs, then reports mismatches for later explicit repair paths.
+    """
+
+    report = _empty_report()
+    if orchestrator is None:
+        report["reasons"] = [REASON_RECONCILIATION_UNAVAILABLE]
+        return report
+
+    lister = getattr(orchestrator, "list_vz_session_controls", None)
+    if not callable(lister):
+        report["reasons"] = [REASON_RECONCILIATION_UNAVAILABLE]
+        return report
+
+    try:
+        persisted_rows = [dict(row) for row in lister() or [] if isinstance(row, dict)]
+    except Exception as exc:
+        logger.debug("Unable to list VZ session controls for reconciliation: {}", exc)
+        report["reasons"] = [REASON_RECONCILIATION_UNAVAILABLE]
+        return report
+
+    report["persisted_sessions"] = len(persisted_rows)
+
+    client = helper_client if helper_client is not None else MacOSVirtualizationHelperClient()
+    try:
+        live = client.list_vms()
+    except MacOSVirtualizationHelperUnavailable:
+        report["reasons"] = [REASON_HELPER_UNAVAILABLE]
+        return report
+    except MacOSVirtualizationHelperProtocolError:
+        report["reasons"] = [REASON_PROTOCOL_MISMATCH]
+        return report
+    except Exception as exc:
+        logger.debug("Unable to collect VZ helper VM list for reconciliation: {}", exc)
+        report["reasons"] = [REASON_RECONCILIATION_UNAVAILABLE]
+        return report
+
+    live_vm_by_id = {
+        vm_id: vm
+        for vm in list(getattr(live, "vms", None) or [])
+        if (vm_id := _clean_id(getattr(vm, "vm_id", "")))
+    }
+    persisted_vm_by_session = {
+        session_id: vm_id
+        for row in persisted_rows
+        if (session_id := _clean_id(row.get("id"))) and (vm_id := _clean_id(row.get("vm_id")))
+    }
+    persisted_vm_ids = set(persisted_vm_by_session.values())
+
+    healthy_session_ids: list[str] = []
+    stale_session_ids: list[str] = []
+    unhealthy_session_ids: list[str] = []
+    skipped_active_session_ids: list[str] = []
+    orphaned_vm_ids: list[str] = []
+    items: list[dict[str, object]] = []
+
+    for session_id, vm_id in persisted_vm_by_session.items():
+        vm = live_vm_by_id.get(vm_id)
+        if vm is None:
+            if active_session_checker is not None and active_session_checker(session_id):
+                skipped_active_session_ids.append(session_id)
+                _append_item(
+                    items,
+                    status="skipped_active_session",
+                    session_id=session_id,
+                    vm_id=vm_id,
+                    reason="active_session",
+                )
+                continue
+            stale_session_ids.append(session_id)
+            _append_item(
+                items,
+                status="stale_session",
+                session_id=session_id,
+                vm_id=vm_id,
+                reason="vm_missing",
+            )
+            continue
+
+        state = _clean_id(getattr(vm, "state", ""))
+        healthy = bool(getattr(vm, "healthy", False))
+        if healthy:
+            healthy_session_ids.append(session_id)
+            _append_item(
+                items,
+                status="healthy",
+                session_id=session_id,
+                vm_id=vm_id,
+                state=state,
+                healthy=healthy,
+            )
+            continue
+
+        unhealthy_session_ids.append(session_id)
+        _append_item(
+            items,
+            status="unhealthy_vm",
+            session_id=session_id,
+            vm_id=vm_id,
+            state=state,
+            healthy=healthy,
+            reason="vm_unhealthy",
+        )
+
+    for vm_id, vm in live_vm_by_id.items():
+        if vm_id in persisted_vm_ids:
+            continue
+        orphaned_vm_ids.append(vm_id)
+        _append_item(
+            items,
+            status="orphaned_vm",
+            vm_id=vm_id,
+            state=_clean_id(getattr(vm, "state", "")),
+            healthy=bool(getattr(vm, "healthy", False)),
+            reason="session_missing",
+        )
+
+    report["computed"] = True
+    report["live_vms"] = len(live_vm_by_id)
+    report["healthy_session_ids"] = sorted(healthy_session_ids)
+    report["stale_session_ids"] = sorted(stale_session_ids)
+    report["unhealthy_session_ids"] = sorted(unhealthy_session_ids)
+    report["skipped_active_session_ids"] = sorted(skipped_active_session_ids)
+    report["orphaned_vm_ids"] = sorted(orphaned_vm_ids)
+    report["items"] = _sort_items(items)
+    return report

--- a/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
+++ b/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
@@ -135,9 +135,10 @@ def collect_vz_reconciliation(
     items: list[dict[str, object]] = []
 
     for session_id, vm_id in persisted_vm_by_session.items():
+        is_active_session = active_session_checker is not None and active_session_checker(session_id)
         vm = live_vm_by_id.get(vm_id)
         if vm is None:
-            if active_session_checker is not None and active_session_checker(session_id):
+            if is_active_session:
                 skipped_active_session_ids.append(session_id)
                 _append_item(
                     items,
@@ -168,6 +169,19 @@ def collect_vz_reconciliation(
                 vm_id=vm_id,
                 state=state,
                 healthy=healthy,
+            )
+            continue
+
+        if is_active_session:
+            skipped_active_session_ids.append(session_id)
+            _append_item(
+                items,
+                status="skipped_active_session",
+                session_id=session_id,
+                vm_id=vm_id,
+                state=state,
+                healthy=healthy,
+                reason="active_session",
             )
             continue
 

--- a/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
+++ b/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
@@ -7,12 +7,14 @@ from loguru import logger
 
 from .macos_virtualization.helper_client import (
     MacOSVirtualizationHelperClient,
+    MacOSVirtualizationHelperFailure,
     MacOSVirtualizationHelperProtocolError,
     MacOSVirtualizationHelperUnavailable,
 )
 
 REASON_HELPER_UNAVAILABLE = "macos_virtualization_helper_unavailable"
 REASON_PROTOCOL_MISMATCH = "macos_virtualization_helper_protocol_mismatch"
+REASON_HELPER_FAILURE = "macos_virtualization_helper_failure"
 REASON_RECONCILIATION_UNAVAILABLE = "vz_reconciliation_unavailable"
 
 
@@ -109,6 +111,10 @@ def collect_vz_reconciliation(
         return report
     except MacOSVirtualizationHelperProtocolError:
         report["reasons"] = [REASON_PROTOCOL_MISMATCH]
+        return report
+    except MacOSVirtualizationHelperFailure as exc:
+        logger.debug("VZ helper returned failure for reconciliation: {}", exc.error_code)
+        report["reasons"] = [REASON_HELPER_FAILURE]
         return report
     except Exception as exc:
         logger.debug("Unable to collect VZ helper VM list for reconciliation: {}", exc)

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -102,8 +102,12 @@ def _diagnostics_payload() -> dict:
             "computed": False,
             "persisted_sessions": 0,
             "live_vms": 0,
+            "healthy_session_ids": [],
             "stale_session_ids": [],
+            "unhealthy_session_ids": [],
+            "skipped_active_session_ids": [],
             "orphaned_vm_ids": [],
+            "items": [],
             "reasons": ["macos_virtualization_helper_unavailable"],
         }
     }
@@ -125,6 +129,10 @@ def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None
     assert body["runtimes"]["vz_linux"]["execution_mode"] == "none"
     assert body["helper"]["protocol_version"] is None
     assert body["reconciliation"]["computed"] is False
+    assert body["reconciliation"]["healthy_session_ids"] == []
+    assert body["reconciliation"]["unhealthy_session_ids"] == []
+    assert body["reconciliation"]["skipped_active_session_ids"] == []
+    assert body["reconciliation"]["items"] == []
 
 
 def test_admin_macos_diagnostics_allows_real_vz_linux_execution_mode(monkeypatch) -> None:
@@ -144,6 +152,16 @@ def test_admin_macos_diagnostics_allows_real_vz_linux_execution_mode(monkeypatch
     payload["reconciliation"]["computed"] = True
     payload["reconciliation"]["persisted_sessions"] = 1
     payload["reconciliation"]["live_vms"] = 1
+    payload["reconciliation"]["healthy_session_ids"] = ["sess-live"]
+    payload["reconciliation"]["items"] = [
+        {
+            "status": "healthy",
+            "session_id": "sess-live",
+            "vm_id": "vm-live",
+            "state": "running",
+            "healthy": True,
+        }
+    ]
     payload["reconciliation"]["reasons"] = []
 
     fake_service = SimpleNamespace(macos_diagnostics=lambda: payload)
@@ -161,3 +179,5 @@ def test_admin_macos_diagnostics_allows_real_vz_linux_execution_mode(monkeypatch
     assert body["helper"]["protocol_version"] == "1"
     assert body["helper"]["helper_version"] == "0.1.0"
     assert body["reconciliation"]["computed"] is True
+    assert body["reconciliation"]["healthy_session_ids"] == ["sess-live"]
+    assert body["reconciliation"]["items"][0]["status"] == "healthy"

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
@@ -147,6 +147,33 @@ def test_admin_reconciliation_repair_dry_run_false_passes_through(monkeypatch) -
     assert resp.json()["actions"][0]["status"] == "deleted"
 
 
+def test_admin_reconciliation_repair_runs_service_in_thread(monkeypatch) -> None:
+    to_thread_calls: list[dict[str, object]] = []
+
+    async def _fake_to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append({"func": func, "args": args, "kwargs": dict(kwargs)})
+        return func(*args, **kwargs)
+
+    fake_service = SimpleNamespace(
+        repair_macos_reconciliation=lambda **kwargs: _repair_payload(
+            dry_run=kwargs["dry_run"],
+            action_status="planned",
+        )
+    )
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+    monkeypatch.setattr(sandbox_mod.asyncio, "to_thread", _fake_to_thread)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=True))
+
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/sandbox/admin/macos-reconciliation/repair", json={})
+
+    assert resp.status_code == 200
+    assert to_thread_calls
+    assert to_thread_calls[0]["func"] == fake_service.repair_macos_reconciliation
+    assert to_thread_calls[0]["kwargs"]["dry_run"] is True
+
+
 def test_admin_reconciliation_repair_rejects_orphan_termination(monkeypatch) -> None:
     def _repair(**kwargs) -> dict[str, object]:
         raise service_mod.SandboxReconciliationRepairError("orphan_termination_not_supported", 400)
@@ -202,6 +229,12 @@ def test_repair_stale_row_dry_run_plans_delete_without_mutation(monkeypatch) -> 
     monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
     monkeypatch.setattr(
         service_mod,
+        "probe_helper",
+        lambda: {"ready": True, "protocol_version": "1", "helper_version": "0.1.0"},
+        raising=True,
+    )
+    monkeypatch.setattr(
+        service_mod,
         "collect_vz_reconciliation",
         lambda *args, **kwargs: _reconciliation_report(
             items=[
@@ -220,6 +253,7 @@ def test_repair_stale_row_dry_run_plans_delete_without_mutation(monkeypatch) -> 
 
     assert deleted_session_ids == []
     assert result["dry_run"] is True
+    assert result["helper"] == {"ready": True, "protocol_version": "1", "helper_version": "0.1.0"}
     assert result["summary"]["stale_session_controls"] == 1
     assert result["summary"]["deleted_session_controls"] == 0
     assert result["actions"] == [
@@ -392,6 +426,36 @@ def test_repair_delete_false_reports_missing_without_incrementing_deleted(monkey
             "reason": "vm_missing",
         }
     ]
+
+
+def test_repair_delete_exception_maps_to_structured_error(monkeypatch) -> None:
+    def _delete_vz_session_control(session_id: str) -> bool:
+        raise RuntimeError("database locked")
+
+    orch = SimpleNamespace(delete_vz_session_control=_delete_vz_session_control)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "stale_session",
+                    "session_id": "sess-stale",
+                    "vm_id": "vm-missing",
+                    "reason": "vm_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    with pytest.raises(service_mod.SandboxReconciliationRepairError) as exc_info:
+        service.repair_macos_reconciliation(dry_run=False)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.reason == "vz_session_control_delete_failed"
 
 
 def test_repair_active_session_item_is_skipped(monkeypatch) -> None:

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints import sandbox as sandbox_mod
+from tldw_Server_API.app.core.AuthNZ.permissions import ROLE_ADMIN
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.Sandbox import service as service_mod
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def _make_principal(
+    *,
+    is_admin: bool,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        api_key_id=None,
+        subject=None,
+        token_type="access",
+        jti=None,
+        roles=[ROLE_ADMIN] if is_admin else ["user"],
+        permissions=[],
+        is_admin=is_admin,
+        org_ids=[],
+        team_ids=[],
+    )
+
+
+def _build_app_with_overrides(principal: AuthPrincipal) -> FastAPI:
+    app = FastAPI()
+    app.include_router(sandbox_mod.router, prefix="/api/v1")
+
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:  # type: ignore[override]
+        request.state.auth = AuthContext(
+            principal=principal,
+            ip=(request.client.host if getattr(request, "client", None) else None),
+            user_agent=(request.headers.get("User-Agent") if getattr(request, "headers", None) else None),
+            request_id=(request.headers.get("X-Request-ID") if getattr(request, "headers", None) else None),
+        )
+        return principal
+
+    async def _fake_get_request_user() -> SimpleNamespace:
+        return SimpleNamespace(
+            id=1,
+            username="sandbox-admin",
+            is_active=True,
+            roles=list(principal.roles),
+            permissions=list(principal.permissions),
+            is_admin=principal.is_admin,
+            tenant_id="default",
+        )
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[sandbox_mod.get_request_user] = _fake_get_request_user
+    return app
+
+
+def _repair_payload(*, dry_run: bool, action_status: str) -> dict[str, object]:
+    return {
+        "dry_run": dry_run,
+        "helper": {"ready": True, "protocol_version": "1", "helper_version": "0.1.0"},
+        "summary": {
+            "stale_session_controls": 1,
+            "unhealthy_session_controls": 0,
+            "deleted_session_controls": 0 if dry_run else 1,
+            "skipped_active_sessions": 0,
+            "orphaned_vms": 0,
+            "terminated_orphaned_vms": 0,
+        },
+        "actions": [{"type": "delete_session_control", "session_id": "sess-stale", "status": action_status}],
+        "reasons": [],
+    }
+
+
+def _reconciliation_report(
+    *,
+    items: list[dict[str, object]] | None = None,
+    reasons: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "computed": not bool(reasons),
+        "persisted_sessions": 0,
+        "live_vms": 0,
+        "healthy_session_ids": [],
+        "stale_session_ids": [],
+        "unhealthy_session_ids": [],
+        "skipped_active_session_ids": [],
+        "orphaned_vm_ids": [],
+        "items": list(items or []),
+        "reasons": list(reasons or []),
+    }
+
+
+def _service_with_orchestrator(orch: SimpleNamespace) -> SandboxService:
+    service = SandboxService(enable_background_tasks=False)
+    service._orch = orch
+    return service
+
+
+def test_admin_reconciliation_repair_defaults_to_dry_run(monkeypatch) -> None:
+    fake_service = SimpleNamespace(
+        repair_macos_reconciliation=lambda **kwargs: _repair_payload(
+            dry_run=kwargs["dry_run"],
+            action_status="planned",
+        )
+    )
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=True))
+
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/sandbox/admin/macos-reconciliation/repair", json={})
+
+    assert resp.status_code == 200
+    assert resp.json()["dry_run"] is True
+    assert resp.json()["actions"][0]["status"] == "planned"
+
+
+def test_admin_reconciliation_repair_dry_run_false_passes_through(monkeypatch) -> None:
+    seen_kwargs: dict[str, object] = {}
+
+    def _repair(**kwargs) -> dict[str, object]:
+        seen_kwargs.update(kwargs)
+        return _repair_payload(dry_run=kwargs["dry_run"], action_status="deleted")
+
+    monkeypatch.setattr(sandbox_mod, "_service", SimpleNamespace(repair_macos_reconciliation=_repair), raising=True)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=True))
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/sandbox/admin/macos-reconciliation/repair",
+            json={"dry_run": False},
+        )
+
+    assert resp.status_code == 200
+    assert seen_kwargs["dry_run"] is False
+    assert resp.json()["dry_run"] is False
+    assert resp.json()["actions"][0]["status"] == "deleted"
+
+
+def test_admin_reconciliation_repair_rejects_orphan_termination(monkeypatch) -> None:
+    def _repair(**kwargs) -> dict[str, object]:
+        raise service_mod.SandboxReconciliationRepairError("orphan_termination_not_supported", 400)
+
+    monkeypatch.setattr(sandbox_mod, "_service", SimpleNamespace(repair_macos_reconciliation=_repair), raising=True)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=True))
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/sandbox/admin/macos-reconciliation/repair",
+            json={"terminate_orphaned_vms": True},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "orphan_termination_not_supported"
+
+
+def test_admin_reconciliation_repair_maps_service_unavailable_error(monkeypatch) -> None:
+    def _repair(**kwargs) -> dict[str, object]:
+        raise service_mod.SandboxReconciliationRepairError("macos_virtualization_helper_unavailable", 503)
+
+    monkeypatch.setattr(sandbox_mod, "_service", SimpleNamespace(repair_macos_reconciliation=_repair), raising=True)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=True))
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/sandbox/admin/macos-reconciliation/repair",
+            json={"dry_run": False},
+        )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "macos_virtualization_helper_unavailable"
+
+
+def test_admin_reconciliation_repair_requires_admin(monkeypatch) -> None:
+    fake_service = SimpleNamespace(repair_macos_reconciliation=lambda **kwargs: _repair_payload(dry_run=True, action_status="planned"))
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=False))
+
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/sandbox/admin/macos-reconciliation/repair", json={})
+
+    assert resp.status_code == 403
+
+
+def test_repair_stale_row_dry_run_plans_delete_without_mutation(monkeypatch) -> None:
+    deleted_session_ids: list[str] = []
+    orch = SimpleNamespace(delete_vz_session_control=deleted_session_ids.append)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "stale_session",
+                    "session_id": "sess-stale",
+                    "vm_id": "vm-missing",
+                    "reason": "vm_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation()
+
+    assert deleted_session_ids == []
+    assert result["dry_run"] is True
+    assert result["summary"]["stale_session_controls"] == 1
+    assert result["summary"]["deleted_session_controls"] == 0
+    assert result["actions"] == [
+        {
+            "type": "delete_session_control",
+            "session_id": "sess-stale",
+            "vm_id": "vm-missing",
+            "status": "planned",
+            "reason": "vm_missing",
+        }
+    ]
+
+
+def test_repair_stale_row_delete_calls_orchestrator(monkeypatch) -> None:
+    deleted_session_ids: list[str] = []
+    orch = SimpleNamespace(delete_vz_session_control=deleted_session_ids.append)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "stale_session",
+                    "session_id": "sess-stale",
+                    "vm_id": "vm-missing",
+                    "reason": "vm_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(dry_run=False)
+
+    assert deleted_session_ids == ["sess-stale"]
+    assert result["summary"]["deleted_session_controls"] == 1
+    assert result["actions"][0]["status"] == "deleted"
+
+
+def test_repair_active_session_item_is_skipped(monkeypatch) -> None:
+    deleted_session_ids: list[str] = []
+    orch = SimpleNamespace(delete_vz_session_control=deleted_session_ids.append)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 1)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "skipped_active_session",
+                    "session_id": "sess-active",
+                    "vm_id": "vm-missing",
+                    "reason": "active_session",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(dry_run=False)
+
+    assert deleted_session_ids == []
+    assert result["summary"]["skipped_active_sessions"] == 1
+    assert result["actions"][0]["status"] == "skipped"
+    assert result["actions"][0]["reason"] == "active_session"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "macos_virtualization_helper_unavailable",
+        "macos_virtualization_helper_protocol_mismatch",
+    ],
+)
+def test_repair_helper_unavailable_or_protocol_mismatch_raises_for_mutating_run(monkeypatch, reason: str) -> None:
+    deleted_session_ids: list[str] = []
+    orch = SimpleNamespace(delete_vz_session_control=deleted_session_ids.append)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(reasons=[reason]),
+        raising=True,
+    )
+
+    with pytest.raises(service_mod.SandboxReconciliationRepairError) as exc_info:
+        service.repair_macos_reconciliation(dry_run=False)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.reason == reason
+    assert deleted_session_ids == []

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
@@ -235,7 +235,12 @@ def test_repair_stale_row_dry_run_plans_delete_without_mutation(monkeypatch) -> 
 
 def test_repair_stale_row_delete_calls_orchestrator(monkeypatch) -> None:
     deleted_session_ids: list[str] = []
-    orch = SimpleNamespace(delete_vz_session_control=deleted_session_ids.append)
+
+    def _delete_vz_session_control(session_id: str) -> bool:
+        deleted_session_ids.append(session_id)
+        return True
+
+    orch = SimpleNamespace(delete_vz_session_control=_delete_vz_session_control)
     service = _service_with_orchestrator(orch)
     monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
     monkeypatch.setattr(
@@ -259,6 +264,134 @@ def test_repair_stale_row_delete_calls_orchestrator(monkeypatch) -> None:
     assert deleted_session_ids == ["sess-stale"]
     assert result["summary"]["deleted_session_controls"] == 1
     assert result["actions"][0]["status"] == "deleted"
+
+
+def test_repair_unhealthy_row_delete_calls_orchestrator(monkeypatch) -> None:
+    deleted_session_ids: list[str] = []
+
+    def _delete_vz_session_control(session_id: str) -> bool:
+        deleted_session_ids.append(session_id)
+        return True
+
+    orch = SimpleNamespace(delete_vz_session_control=_delete_vz_session_control)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "unhealthy_vm",
+                    "session_id": "sess-unhealthy",
+                    "vm_id": "vm-unhealthy",
+                    "reason": "vm_unhealthy",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(dry_run=False)
+
+    assert deleted_session_ids == ["sess-unhealthy"]
+    assert result["summary"]["unhealthy_session_controls"] == 1
+    assert result["summary"]["deleted_session_controls"] == 1
+    assert result["actions"] == [
+        {
+            "type": "delete_session_control",
+            "session_id": "sess-unhealthy",
+            "vm_id": "vm-unhealthy",
+            "status": "deleted",
+            "reason": "vm_unhealthy",
+        }
+    ]
+
+
+def test_repair_disabled_delete_flags_suppress_actions_and_mutation(monkeypatch) -> None:
+    deleted_session_ids: list[str] = []
+
+    def _delete_vz_session_control(session_id: str) -> bool:
+        deleted_session_ids.append(session_id)
+        return True
+
+    orch = SimpleNamespace(delete_vz_session_control=_delete_vz_session_control)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "stale_session",
+                    "session_id": "sess-stale",
+                    "vm_id": "vm-missing",
+                    "reason": "vm_missing",
+                },
+                {
+                    "status": "unhealthy_vm",
+                    "session_id": "sess-unhealthy",
+                    "vm_id": "vm-unhealthy",
+                    "reason": "vm_unhealthy",
+                },
+            ]
+        ),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(
+        delete_stale_session_controls=False,
+        delete_unhealthy_session_controls=False,
+        dry_run=False,
+    )
+
+    assert deleted_session_ids == []
+    assert result["summary"]["stale_session_controls"] == 1
+    assert result["summary"]["unhealthy_session_controls"] == 1
+    assert result["summary"]["deleted_session_controls"] == 0
+    assert result["actions"] == []
+
+
+def test_repair_delete_false_reports_missing_without_incrementing_deleted(monkeypatch) -> None:
+    deleted_session_ids: list[str] = []
+
+    def _delete_vz_session_control(session_id: str) -> bool:
+        deleted_session_ids.append(session_id)
+        return False
+
+    orch = SimpleNamespace(delete_vz_session_control=_delete_vz_session_control)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "stale_session",
+                    "session_id": "sess-stale",
+                    "vm_id": "vm-missing",
+                    "reason": "vm_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(dry_run=False)
+
+    assert deleted_session_ids == ["sess-stale"]
+    assert result["summary"]["deleted_session_controls"] == 0
+    assert result["actions"] == [
+        {
+            "type": "delete_session_control",
+            "session_id": "sess-stale",
+            "vm_id": "vm-missing",
+            "status": "missing",
+            "reason": "vm_missing",
+        }
+    ]
 
 
 def test_repair_active_session_item_is_skipped(monkeypatch) -> None:

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -343,6 +343,7 @@ def test_collect_macos_diagnostics_classifies_helper_protocol_mismatch(monkeypat
     data = diagnostics_module.collect_macos_diagnostics()
 
     assert "macos_virtualization_helper_protocol_mismatch" in data["helper"]["reasons"]
+    assert "macos_helper_missing" not in data["helper"]["reasons"]
     assert (
         diagnostics_module._remediation_for_reasons(["macos_virtualization_helper_protocol_mismatch"])
         == "Update the macOS virtualization helper and Python client to compatible protocol versions."

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import tldw_Server_API.app.core.Sandbox.macos_diagnostics as diagnostics_module
+import tldw_Server_API.app.core.Sandbox.vz_reconciliation as reconciliation_module
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType
 from tldw_Server_API.app.core.Sandbox.macos_virtualization.models import (
     HelperPingReply,
     HelperVMListReply,
     HelperVMStatusReply,
+)
+from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperProtocolError,
 )
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimePreflightResult
 
@@ -65,8 +69,20 @@ def _sample_diagnostics_payload() -> dict:
             "computed": True,
             "persisted_sessions": 1,
             "live_vms": 1,
+            "healthy_session_ids": ["sess-live"],
             "stale_session_ids": [],
+            "unhealthy_session_ids": [],
+            "skipped_active_session_ids": [],
             "orphaned_vm_ids": [],
+            "items": [
+                {
+                    "status": "healthy",
+                    "session_id": "sess-live",
+                    "vm_id": "vm-live",
+                    "state": "running",
+                    "healthy": True,
+                }
+            ],
             "reasons": [],
         },
     }
@@ -313,6 +329,20 @@ def test_admin_schema_accepts_macos_diagnostics_payload() -> None:
     assert model.runtimes["vz_linux"].execution_mode == "fake"
     assert model.reconciliation is not None
     assert model.reconciliation.computed is True
+    assert model.reconciliation.healthy_session_ids == ["sess-live"]
+    assert model.reconciliation.items
+
+
+def test_collect_macos_diagnostics_classifies_helper_protocol_mismatch(monkeypatch) -> None:
+    class _FakeHelper:
+        def ping(self):
+            raise MacOSVirtualizationHelperProtocolError("macos_virtualization_helper_protocol_mismatch")
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _FakeHelper)
+
+    data = diagnostics_module.collect_macos_diagnostics()
+
+    assert "macos_virtualization_helper_protocol_mismatch" in data["helper"]["reasons"]
 
 
 def test_collect_macos_diagnostics_reports_reconciliation_mismatches(monkeypatch) -> None:
@@ -360,6 +390,7 @@ def test_collect_macos_diagnostics_reports_reconciliation_mismatches(monkeypatch
             ]
 
     monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _FakeHelper)
+    monkeypatch.setattr(reconciliation_module, "MacOSVirtualizationHelperClient", _FakeHelper)
     monkeypatch.setattr(
         diagnostics_module,
         "collect_runtime_preflights",
@@ -391,5 +422,7 @@ def test_collect_macos_diagnostics_reports_reconciliation_mismatches(monkeypatch
     assert data["reconciliation"]["computed"] is True
     assert data["reconciliation"]["persisted_sessions"] == 2
     assert data["reconciliation"]["live_vms"] == 1
+    assert data["reconciliation"]["healthy_session_ids"] == ["sess-live"]
     assert data["reconciliation"]["stale_session_ids"] == ["sess-stale"]
+    assert data["reconciliation"]["items"]
     assert data["reconciliation"]["orphaned_vm_ids"] == []

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -345,6 +345,55 @@ def test_collect_macos_diagnostics_classifies_helper_protocol_mismatch(monkeypat
     assert "macos_virtualization_helper_protocol_mismatch" in data["helper"]["reasons"]
 
 
+def test_collect_macos_diagnostics_classifies_template_protocol_mismatch(monkeypatch) -> None:
+    _patch_macos_host(monkeypatch)
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE", "/tmp/vz-linux.img")
+
+    class _FakeHelper:
+        def ping(self):
+            return HelperPingReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                status="ok",
+                details={"transport": "unix"},
+            )
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            raise MacOSVirtualizationHelperProtocolError("macos_virtualization_helper_protocol_mismatch")
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _FakeHelper)
+    monkeypatch.setattr(
+        diagnostics_module,
+        "collect_runtime_preflights",
+        lambda network_policy="deny_all": {
+            RuntimeType.vz_linux: RuntimePreflightResult(
+                runtime=RuntimeType.vz_linux,
+                available=False,
+                reasons=["macos_virtualization_helper_protocol_mismatch"],
+                execution_mode="none",
+            ),
+            RuntimeType.vz_macos: RuntimePreflightResult(
+                runtime=RuntimeType.vz_macos,
+                available=False,
+                reasons=["macos_virtualization_helper_unavailable"],
+                execution_mode="none",
+            ),
+            RuntimeType.seatbelt: RuntimePreflightResult(
+                runtime=RuntimeType.seatbelt,
+                available=False,
+                reasons=["seatbelt_unavailable"],
+                execution_mode="none",
+                supported_trust_levels=["trusted"],
+            ),
+        },
+    )
+
+    data = diagnostics_module.collect_macos_diagnostics()
+
+    assert "macos_virtualization_helper_protocol_mismatch" in data["templates"]["vz_linux"]["reasons"]
+
+
 def test_collect_macos_diagnostics_reports_reconciliation_mismatches(monkeypatch) -> None:
     _patch_macos_host(monkeypatch)
     monkeypatch.delenv("TEST_MODE", raising=False)

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -343,6 +343,10 @@ def test_collect_macos_diagnostics_classifies_helper_protocol_mismatch(monkeypat
     data = diagnostics_module.collect_macos_diagnostics()
 
     assert "macos_virtualization_helper_protocol_mismatch" in data["helper"]["reasons"]
+    assert (
+        diagnostics_module._remediation_for_reasons(["macos_virtualization_helper_protocol_mismatch"])
+        == "Update the macOS virtualization helper and Python client to compatible protocol versions."
+    )
 
 
 def test_collect_macos_diagnostics_classifies_template_protocol_mismatch(monkeypatch) -> None:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -7,6 +7,10 @@ from tldw_Server_API.app.core.Sandbox.macos_virtualization.models import (
     HelperVMReply,
     HelperVMStatusReply,
 )
+from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperProtocolError,
+    MacOSVirtualizationHelperUnavailable,
+)
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
 from tldw_Server_API.app.core.Sandbox.streams import get_hub
 from tldw_Server_API.app.core.Sandbox.runners.vz_linux_runner import VZLinuxRunner
@@ -220,6 +224,98 @@ def test_vz_linux_session_run_reuses_only_healthy_vm(monkeypatch, tmp_path) -> N
     assert status.phase == RunPhase.completed
     assert status.exit_code == 0
     assert calls == ["get_vm_status", "exec_guest"]
+
+
+def test_vz_linux_session_reuse_helper_unavailable_does_not_delete_control(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    deleted: list[str] = []
+
+    class _Store:
+        def get_vz_session_control(self, session_id: str) -> dict[str, object]:
+            assert session_id == "sess-helper-unavailable"
+            return {
+                "runtime": "vz_linux",
+                "vm_id": "vm-candidate",
+                "template_id": "vz_linux:existing",
+                "workspace_mount": str(tmp_path),
+                "agent_ready": True,
+            }
+
+        def delete_vz_session_control(self, session_id: str) -> bool:
+            deleted.append(session_id)
+            return True
+
+    class _FakeHelper:
+        def get_vm_status(self, vm_id: str) -> HelperVMStatusReply:
+            assert vm_id == "vm-candidate"
+            raise MacOSVirtualizationHelperUnavailable("macos_virtualization_helper_unavailable")
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            raise AssertionError(f"validate_template should not run when helper status is unavailable: {request}")
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    status = VZLinuxRunner(session_control_store=_Store()).start_run(
+        run_id="vz-run-helper-unavailable",
+        spec=RunSpec(
+            session_id="sess-helper-unavailable",
+            runtime=RuntimeType.vz_linux,
+            base_image="ubuntu-24.04",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+        ),
+        session_workspace=str(tmp_path),
+    )
+
+    assert status.phase == RunPhase.failed
+    assert "macos_virtualization_helper_unavailable" in status.message
+    assert deleted == []
+
+
+def test_vz_linux_session_reuse_protocol_mismatch_does_not_delete_control(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    deleted: list[str] = []
+
+    class _Store:
+        def get_vz_session_control(self, session_id: str) -> dict[str, object]:
+            assert session_id == "sess-protocol-mismatch"
+            return {
+                "runtime": "vz_linux",
+                "vm_id": "vm-candidate",
+                "template_id": "vz_linux:existing",
+                "workspace_mount": str(tmp_path),
+                "agent_ready": True,
+            }
+
+        def delete_vz_session_control(self, session_id: str) -> bool:
+            deleted.append(session_id)
+            return True
+
+    class _FakeHelper:
+        def get_vm_status(self, vm_id: str) -> HelperVMStatusReply:
+            assert vm_id == "vm-candidate"
+            raise MacOSVirtualizationHelperProtocolError("macos_virtualization_helper_protocol_mismatch")
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            raise AssertionError(f"validate_template should not run on helper protocol mismatch: {request}")
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    status = VZLinuxRunner(session_control_store=_Store()).start_run(
+        run_id="vz-run-protocol-mismatch",
+        spec=RunSpec(
+            session_id="sess-protocol-mismatch",
+            runtime=RuntimeType.vz_linux,
+            base_image="ubuntu-24.04",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+        ),
+        session_workspace=str(tmp_path),
+    )
+
+    assert status.phase == RunPhase.failed
+    assert "macos_virtualization_helper_protocol_mismatch" in status.message
+    assert deleted == []
 
 
 def test_vz_linux_session_run_recreates_unhealthy_vm(monkeypatch, tmp_path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -67,6 +67,25 @@ def test_vz_linux_preflight_requires_execution_readiness(monkeypatch) -> None:
     assert calls == [{"runtime": "vz_linux", "network_policy": "deny_all"}]
 
 
+def test_vz_linux_preflight_classifies_protocol_mismatch(monkeypatch) -> None:
+    monkeypatch.setattr(vz_common.sys, "platform", "darwin")
+    monkeypatch.setattr(vz_common.platform, "machine", lambda: "arm64")
+    monkeypatch.delenv("TEST_MODE", raising=False)
+
+    class _FakeHelper:
+        def validate_vz_linux_host(self, request: dict[str, object]) -> dict[str, object]:
+            raise MacOSVirtualizationHelperProtocolError("macos_virtualization_helper_protocol_mismatch")
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    result = VZLinuxRunner().preflight(network_policy="deny_all")
+
+    assert result.available is False
+    assert result.reasons == ["macos_virtualization_helper_protocol_mismatch"]
+    assert result.execution_mode == "none"
+    assert result.enforcement_ready == {"deny_all": False, "allowlist": False}
+
+
 def test_vz_linux_start_run_executes_real_ephemeral_vm_command(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
     calls: list[tuple[str, dict[str, object]]] = []

--- a/tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperFailure,
     MacOSVirtualizationHelperProtocolError,
     MacOSVirtualizationHelperUnavailable,
 )
@@ -58,6 +59,11 @@ class _UnavailableHelper:
 class _ProtocolMismatchHelper:
     def list_vms(self) -> HelperVMListReply:
         raise MacOSVirtualizationHelperProtocolError("helper protocol mismatch")
+
+
+class _FailureHelper:
+    def list_vms(self) -> HelperVMListReply:
+        raise MacOSVirtualizationHelperFailure("helper_internal_error", "list failed")
 
 
 def _vm(vm_id: str, *, state: str = "running", healthy: bool = True) -> HelperVMStatusReply:
@@ -125,6 +131,16 @@ def test_reconciliation_classifies_protocol_mismatch():
 
     assert report["computed"] is False
     assert "macos_virtualization_helper_protocol_mismatch" in report["reasons"]
+
+
+def test_reconciliation_classifies_helper_failure():
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator([{"id": "sess-live", "vm_id": "vm-live"}]),
+        helper_client=_FailureHelper(),
+    )
+
+    assert report["computed"] is False
+    assert report["reasons"] == ["macos_virtualization_helper_failure"]
 
 
 def test_reconciliation_marks_active_stale_sessions_as_skipped():

--- a/tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
@@ -19,6 +19,15 @@ class _FakeOrchestrator:
         return list(self._rows)
 
 
+class _NoListerOrchestrator:
+    pass
+
+
+class _RaisingOrchestrator:
+    def list_vz_session_controls(self) -> list[dict[str, object]]:
+        raise RuntimeError("store unavailable")
+
+
 class _FakeHelper:
     def __init__(self, vms: list[HelperVMStatusReply]) -> None:
         self._vms = vms
@@ -134,3 +143,93 @@ def test_reconciliation_marks_active_stale_sessions_as_skipped():
     assert report["skipped_active_session_ids"] == ["sess-active"]
     assert report["stale_session_ids"] == ["sess-stale"]
     assert any(item["status"] == "skipped_active_session" for item in report["items"])
+
+
+def test_reconciliation_marks_active_unhealthy_sessions_as_skipped():
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator(
+            [
+                {"id": "sess-active", "vm_id": "vm-unhealthy"},
+                {"id": "sess-unhealthy", "vm_id": "vm-also-unhealthy"},
+            ]
+        ),
+        helper_client=_FakeHelper(
+            [
+                _vm("vm-unhealthy", state="running", healthy=False),
+                _vm("vm-also-unhealthy", state="running", healthy=False),
+            ]
+        ),
+        active_session_checker=lambda sid: sid == "sess-active",
+    )
+
+    assert report["computed"] is True
+    assert report["skipped_active_session_ids"] == ["sess-active"]
+    assert report["unhealthy_session_ids"] == ["sess-unhealthy"]
+    assert any(item["status"] == "skipped_active_session" for item in report["items"])
+    assert not any(
+        item["status"] == "unhealthy_vm" and item.get("session_id") == "sess-active"
+        for item in report["items"]
+    )
+
+
+def test_reconciliation_unavailable_without_orchestrator():
+    report = collect_vz_reconciliation(orchestrator=None, helper_client=_FakeHelper([]))
+
+    assert report == {
+        "computed": False,
+        "persisted_sessions": 0,
+        "live_vms": 0,
+        "healthy_session_ids": [],
+        "stale_session_ids": [],
+        "unhealthy_session_ids": [],
+        "skipped_active_session_ids": [],
+        "orphaned_vm_ids": [],
+        "items": [],
+        "reasons": ["vz_reconciliation_unavailable"],
+    }
+
+
+def test_reconciliation_unavailable_when_lister_missing_or_raising():
+    for orchestrator in (_NoListerOrchestrator(), _RaisingOrchestrator()):
+        report = collect_vz_reconciliation(orchestrator=orchestrator, helper_client=_FakeHelper([]))
+
+        assert report["computed"] is False
+        assert report["reasons"] == ["vz_reconciliation_unavailable"]
+
+
+def test_reconciliation_orders_id_lists_and_items_deterministically():
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator(
+            [
+                {"id": "sess-stale-b", "vm_id": "vm-missing-b"},
+                {"id": "sess-unhealthy-b", "vm_id": "vm-unhealthy-b"},
+                {"id": "sess-stale-a", "vm_id": "vm-missing-a"},
+                {"id": "sess-healthy-b", "vm_id": "vm-healthy-b"},
+                {"id": "sess-unhealthy-a", "vm_id": "vm-unhealthy-a"},
+                {"id": "sess-healthy-a", "vm_id": "vm-healthy-a"},
+            ]
+        ),
+        helper_client=_FakeHelper(
+            [
+                _vm("vm-orphan-b", healthy=True),
+                _vm("vm-unhealthy-b", healthy=False),
+                _vm("vm-healthy-b", healthy=True),
+                _vm("vm-unhealthy-a", healthy=False),
+                _vm("vm-orphan-a", healthy=True),
+                _vm("vm-healthy-a", healthy=True),
+            ]
+        ),
+    )
+
+    assert report["healthy_session_ids"] == ["sess-healthy-a", "sess-healthy-b"]
+    assert report["stale_session_ids"] == ["sess-stale-a", "sess-stale-b"]
+    assert report["unhealthy_session_ids"] == ["sess-unhealthy-a", "sess-unhealthy-b"]
+    assert report["orphaned_vm_ids"] == ["vm-orphan-a", "vm-orphan-b"]
+    assert report["items"] == sorted(
+        report["items"],
+        key=lambda item: (
+            str(item.get("status") or ""),
+            str(item.get("session_id") or ""),
+            str(item.get("vm_id") or ""),
+        ),
+    )

--- a/tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperProtocolError,
+    MacOSVirtualizationHelperUnavailable,
+)
+from tldw_Server_API.app.core.Sandbox.macos_virtualization.models import (
+    HelperVMListReply,
+    HelperVMStatusReply,
+)
+from tldw_Server_API.app.core.Sandbox.vz_reconciliation import collect_vz_reconciliation
+
+
+class _FakeOrchestrator:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def list_vz_session_controls(self) -> list[dict[str, object]]:
+        return list(self._rows)
+
+
+class _FakeHelper:
+    def __init__(self, vms: list[HelperVMStatusReply]) -> None:
+        self._vms = vms
+        self.terminated_vm_ids: list[str] = []
+        self.deleted_vm_ids: list[str] = []
+
+    def list_vms(self) -> HelperVMListReply:
+        return HelperVMListReply(
+            protocol_version="1",
+            helper_version="0.1.0",
+            vms=list(self._vms),
+        )
+
+    def terminate_vm(self, vm_id: str) -> bool:
+        self.terminated_vm_ids.append(vm_id)
+        return True
+
+    def delete_vm(self, vm_id: str) -> bool:
+        self.deleted_vm_ids.append(vm_id)
+        return True
+
+
+class _UnavailableHelper:
+    def list_vms(self) -> HelperVMListReply:
+        raise MacOSVirtualizationHelperUnavailable("helper socket missing")
+
+
+class _ProtocolMismatchHelper:
+    def list_vms(self) -> HelperVMListReply:
+        raise MacOSVirtualizationHelperProtocolError("helper protocol mismatch")
+
+
+def _vm(vm_id: str, *, state: str = "running", healthy: bool = True) -> HelperVMStatusReply:
+    return HelperVMStatusReply(
+        protocol_version="1",
+        helper_version="0.1.0",
+        vm_id=vm_id,
+        state=state,
+        healthy=healthy,
+    )
+
+
+def test_reconciliation_reports_healthy_stale_unhealthy_and_orphaned_vms():
+    helper = _FakeHelper(
+        [
+            _vm("vm-live", state="running", healthy=True),
+            _vm("vm-unhealthy", state="running", healthy=False),
+            _vm("vm-orphan", state="running", healthy=True),
+        ]
+    )
+
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator(
+            [
+                {"id": "sess-live", "vm_id": "vm-live"},
+                {"id": "sess-stale", "vm_id": "vm-missing"},
+                {"id": "sess-unhealthy", "vm_id": "vm-unhealthy"},
+            ]
+        ),
+        helper_client=helper,
+    )
+
+    assert report["computed"] is True
+    assert report["persisted_sessions"] == 3
+    assert report["live_vms"] == 3
+    assert report["healthy_session_ids"] == ["sess-live"]
+    assert report["stale_session_ids"] == ["sess-stale"]
+    assert report["unhealthy_session_ids"] == ["sess-unhealthy"]
+    assert report["orphaned_vm_ids"] == ["vm-orphan"]
+    assert {item["status"] for item in report["items"]} >= {
+        "healthy",
+        "stale_session",
+        "unhealthy_vm",
+        "orphaned_vm",
+    }
+    assert helper.terminated_vm_ids == []
+    assert helper.deleted_vm_ids == []
+
+
+def test_reconciliation_classifies_helper_unavailable():
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator([{"id": "sess-live", "vm_id": "vm-live"}]),
+        helper_client=_UnavailableHelper(),
+    )
+
+    assert report["computed"] is False
+    assert "macos_virtualization_helper_unavailable" in report["reasons"]
+
+
+def test_reconciliation_classifies_protocol_mismatch():
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator([{"id": "sess-live", "vm_id": "vm-live"}]),
+        helper_client=_ProtocolMismatchHelper(),
+    )
+
+    assert report["computed"] is False
+    assert "macos_virtualization_helper_protocol_mismatch" in report["reasons"]
+
+
+def test_reconciliation_marks_active_stale_sessions_as_skipped():
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator(
+            [
+                {"id": "sess-active", "vm_id": "vm-missing"},
+                {"id": "sess-stale", "vm_id": "vm-also-missing"},
+            ]
+        ),
+        helper_client=_FakeHelper([]),
+        active_session_checker=lambda sid: sid == "sess-active",
+    )
+
+    assert report["computed"] is True
+    assert report["skipped_active_session_ids"] == ["sess-active"]
+    assert report["stale_session_ids"] == ["sess-stale"]
+    assert any(item["status"] == "skipped_active_session" for item in report["items"])

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -1,6 +1,6 @@
 # macOS VZ Helper
 
-This directory is the planned home for the first-party native macOS helper used by the
+This directory contains the first-party native macOS helper used by the
 `vz_linux` sandbox runtime.
 
 ## Scope
@@ -20,7 +20,9 @@ The first helper slice is not a generic macOS sandbox backend:
 - no `vz_macos` support yet
 - no `seatbelt` support here
 - no second persistence layer for sandbox sessions
-- no APFS clone manager in the first transport slice
+- no APFS clone execution path yet
+- no launchd or managed helper lifecycle yet
+- no automatic orphan VM termination during admin repair yet
 
 Python remains authoritative for sandbox admission, session identity, artifacts, and ACP
 integration. The helper only owns runtime VM facts and control-plane operations.


### PR DESCRIPTION
## Summary
- Add read-only VZ reconciliation that compares persisted session-control rows with helper live VM state.
- Add explicit admin repair for stale/unhealthy inactive VZ session metadata, with dry-run default, active-session skips, helper/protocol fail-closed behavior, and no orphan VM termination.
- Update vz_linux diagnostics, session reuse failure classification, and macOS sandbox docs for the current real helper-backed execution path.

## Test Plan
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_vz_reconciliation.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_session_cleanup.py tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py -v
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit tldw_Server_API/app/core/Sandbox/vz_reconciliation.py tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_vz_lifecycle_touched_after_review.json
- [x] git diff --check
- [x] Final code review subagent approved after protocol-mismatch preflight fix

## Merge Gate
- [ ] Human-authored Change summary to be added by requester before merge.