### PR TITLE
refactor: centralize endpoint auth dependency imports

### DIFF
--- a/tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
@@ -53,6 +53,8 @@ from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
     authenticate_api_key_user,
     get_single_user_instance,
     get_request_user,
+    resolve_user_id_for_request as resolve_user_id_for_request,
+    User as User,
     verify_jwt_and_fetch_user,
 )
 from tldw_Server_API.app.core.DB_Management.scope_context import set_scope

--- a/tldw_Server_API/app/api/v1/endpoints/acp_permissions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/acp_permissions.py
@@ -10,11 +10,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-)
 from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
 
 router = APIRouter(prefix="/acp/permissions", tags=["acp-permissions"])

--- a/tldw_Server_API/app/api/v1/endpoints/acp_schedules.py
+++ b/tldw_Server_API/app/api/v1/endpoints/acp_schedules.py
@@ -14,11 +14,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from apscheduler.triggers.cron import CronTrigger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-)
 
 router = APIRouter(prefix="/acp/schedules", tags=["acp-schedules"])
 

--- a/tldw_Server_API/app/api/v1/endpoints/acp_triggers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/acp_triggers.py
@@ -13,11 +13,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-)
 
 router = APIRouter(prefix="/acp/triggers", tags=["acp-triggers"])
 

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -16,8 +16,8 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect, status
 from fastapi.responses import StreamingResponse
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
 from tldw_Server_API.app.api.v1.endpoints._in_memory_limits import SlidingWindowLimiter
 from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentInfo,
@@ -62,10 +62,6 @@ from tldw_Server_API.app.core.AuthNZ.ip_allowlist import is_single_user_ip_allow
 from tldw_Server_API.app.core.AuthNZ.jwt_service import get_jwt_service
 from tldw_Server_API.app.core.AuthNZ.session_manager import get_session_manager
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings as get_auth_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-)
 from tldw_Server_API.app.core.Streaming.streams import WebSocketStream
 from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime
 from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.checkpoint_consumer import CheckpointConsumer

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -13,9 +13,8 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
 from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
     CycleDependencyError,

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
@@ -10,8 +10,8 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from loguru import logger
 from starlette import status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
@@ -20,7 +20,6 @@ from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
     TTSHistoryListItem,
     TTSHistoryListResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter, log_histogram

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_jobs.py
@@ -22,15 +22,10 @@ except ImportError:  # pragma: no cover - fallback for older environments
 import contextlib
 
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, RequirePermission, RequireRole, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    RequireRole,
-    get_auth_principal,
-)
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_MAINTENANCE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.backends.base import (
     DatabaseError as BackendDatabaseError,
 )

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
@@ -18,8 +18,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket
 from fastapi.responses import JSONResponse
 from loguru import logger
 from starlette import status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import resolve_org_id_for_principal
 from tldw_Server_API.app.core.Resource_Governance import cost_units
 from tldw_Server_API.app.core.Billing.enforcement import (
@@ -68,7 +68,6 @@ from tldw_Server_API.app.core.Audio.streaming_service import (
 )
 from tldw_Server_API.app.core.AuthNZ.byok_runtime import resolve_byok_credentials
 from tldw_Server_API.app.core.AuthNZ.settings import is_multi_user_mode
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Chat.chat_service import perform_chat_api_call_async as chat_api_call_async
 from tldw_Server_API.app.core.Chat.chat_helpers import (
     get_or_create_character_context,

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py
@@ -7,8 +7,8 @@ import numpy as np
 import soundfile as sf
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse, Response
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, TokenScopeGuard
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
     AudioTokenizerDecodeRequest,
     AudioTokenizerEncodeRequest,
@@ -28,7 +28,6 @@ from tldw_Server_API.app.core.Audio.tokenizer_service import (
     _serialize_audio_output,
     _serialize_tokens,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Logging.log_context import ensure_request_id
 
 router = APIRouter(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -17,13 +17,8 @@ from fastapi.responses import JSONResponse, Response
 from loguru import logger
 import soundfile as sf
 from starlette import status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_db_transaction, get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    check_rate_limit,
-    get_auth_principal,
-    get_db_transaction,
-    TokenScopeGuard,
-)
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import get_billing_org_id, require_within_limit
 from tldw_Server_API.app.core.Resource_Governance import cost_units
 from tldw_Server_API.app.core.Billing.enforcement import (
@@ -46,7 +41,6 @@ from tldw_Server_API.app.core.Audio.error_payloads import _http_error_detail
 from tldw_Server_API.app.core.Audio.quota_helpers import EXPECTED_DB_EXC
 from tldw_Server_API.app.core.Audio.transcription_service import _map_openai_audio_model_to_whisper
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.stt_policy import (
     apply_transcript_text_policy,
     build_audio_retention_decision,

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_tts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_tts.py
@@ -11,8 +11,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from loguru import logger
 from starlette import status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
@@ -23,7 +23,6 @@ from tldw_Server_API.app.core.Audio.error_payloads import _http_error_detail
 from tldw_Server_API.app.core.Audio.tts_service import _raise_for_tts_error
 from tldw_Server_API.app.core.Audio.tts_service import _sanitize_speech_request
 from tldw_Server_API.app.core.AuthNZ.exceptions import QuotaExceededError, StorageError
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.Jobs.manager import JobManager

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -6,8 +6,8 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Path, Request
 from fastapi.responses import StreamingResponse
 from loguru import logger
 from starlette import status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, TokenScopeGuard
 from tldw_Server_API.app.api.v1.endpoints.audio.audio_tts import get_tts_service
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
     OpenAISpeechRequest,
@@ -15,7 +15,6 @@ from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
     VoiceEncodeResponse,
 )
 from tldw_Server_API.app.core.Audio.error_payloads import _http_error_detail
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Logging.log_context import ensure_request_id
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py
@@ -21,8 +21,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi.responses import PlainTextResponse
 from loguru import logger
 from starlette import status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.audiobook_schemas import (
@@ -52,7 +52,6 @@ from tldw_Server_API.app.core.Audiobooks.tag_parser import (
     build_chapters_from_markers,
     parse_tagged_text,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Chunking.strategies.ebook_chapters import EbookChapterChunkingStrategy
 from tldw_Server_API.app.core.config import get_config_value
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase

--- a/tldw_Server_API/app/api/v1/endpoints/audit.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audit.py
@@ -8,7 +8,7 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, get_auth_principal
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, RequirePermission, User
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventCategory,
     AuditEventType,
@@ -16,7 +16,6 @@ from tldw_Server_API.app.core.Audit.unified_audit_service import (
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_LOGS
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core import config as app_config
 from tldw_Server_API.app.core.testing import is_truthy
 

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -26,17 +26,7 @@ from pydantic import BaseModel, EmailStr, Field
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
     get_or_create_audit_service_for_user_id,
 )
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    check_auth_rate_limit,
-    get_auth_principal,
-    get_current_active_user,  # compat export used by integration tests
-    get_db_transaction,
-    get_jwt_service_dep,
-    get_password_service_dep,
-    get_rate_limiter_dep,
-    get_registration_service_dep,
-    get_session_manager_dep,
-)
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_auth_rate_limit, get_auth_principal, get_current_active_user, get_db_transaction, get_jwt_service_dep, get_password_service_dep, get_rate_limiter_dep, get_registration_service_dep, get_session_manager_dep, RateLimiter
 from tldw_Server_API.app.api.v1.API_Deps.federation_deps import (
     get_federation_provisioning_service_dep,
     get_identity_provider_repo_dep,
@@ -90,7 +80,6 @@ from tldw_Server_API.app.core.AuthNZ.jwt_service import JWTService
 from tldw_Server_API.app.core.AuthNZ.orgs_teams import list_memberships_for_user
 from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.rate_limiter import RateLimiter
 from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import IdentityProviderRepo
 from tldw_Server_API.app.core.AuthNZ.session_manager import SessionManager
 from tldw_Server_API.app.core.AuthNZ.settings import Settings, get_profile, get_settings

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -86,7 +86,7 @@ from tldw_Server_API.app.core.AuthNZ.byok_runtime import (
     record_byok_missing_credentials,
     resolve_byok_credentials,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
 # Character chat helpers
 from tldw_Server_API.app.core.Character_Chat.Character_Chat_Lib_facade import (

--- a/tldw_Server_API/app/api/v1/endpoints/character_memory.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_memory.py
@@ -28,7 +28,7 @@ from tldw_Server_API.app.api.v1.schemas.character_memory_schemas import (
     CharacterMemoryResponse,
     CharacterMemoryUpdate,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,

--- a/tldw_Server_API/app/api/v1/endpoints/character_messages.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_messages.py
@@ -25,7 +25,7 @@ from tldw_Server_API.app.api.v1.schemas.chat_session_schemas import (
     MessageResponse,
     MessageUpdate,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
 # Character chat helpers
 from tldw_Server_API.app.core.Character_Chat.Character_Chat_Lib_facade import (

--- a/tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py
@@ -178,7 +178,7 @@ from tldw_Server_API.app.api.v1.schemas.world_book_schemas import (
     WorldBookUpdate,
     WorldBookWithEntries,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Character_Chat.Character_Chat_Lib_facade import (
     create_new_character_from_data,
     delete_character_from_db,

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -51,11 +51,7 @@ from tldw_Server_API.app.core.AuthNZ.llm_provider_overrides import (
 # ---------------------------------------------------------------------------
 # Imports
 # ---------------------------------------------------------------------------
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-    resolve_user_id_for_request,
-)
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, resolve_user_id_for_request, TokenScopeGuard, User
 from tldw_Server_API.app.core.Utils.image_validation import (
     get_max_base64_bytes,
     validate_image_url,
@@ -211,12 +207,6 @@ _ORIGINAL_PERFORM_CHAT_API_CALL = perform_chat_api_call
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field, ValidationError
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    get_auth_principal,
-    rbac_rate_limit,
-    TokenScopeGuard,
-)
 from tldw_Server_API.app.api.v1.API_Deps.llm_routing_deps import (
     get_request_routing_decision_store,
 )

--- a/tldw_Server_API/app/api/v1/endpoints/chat_loop.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat_loop.py
@@ -13,7 +13,7 @@ from tldw_Server_API.app.api.v1.schemas.chat_loop_schemas import (
     ChatLoopStartRequest,
     ChatLoopStartResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Chat.chat_loop_store import InMemoryChatLoopStore
 
 router = APIRouter()

--- a/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
@@ -25,8 +25,8 @@ from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_
 from tldw_Server_API.app.core.Audit.unified_audit_service import AuditContext, AuditEventType
 from tldw_Server_API.app.core.Logging.log_context import ensure_request_id, ensure_traceparent, get_ps_logger
 from tldw_Server_API.app.core.Metrics.metrics_manager import increment_counter
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
 
-from ....core.AuthNZ.User_DB_Handling import User, get_request_user
 from ....core.Chatbooks.chatbook_models import ContentType, ExportJob, ExportStatus
 from ....core.Chatbooks.chatbook_service import ChatbookService
 from ....core.Chatbooks.chatbook_validators import ChatbookValidator
@@ -34,7 +34,6 @@ from ....core.Chatbooks.exceptions import JobError
 from ....core.Chatbooks.quota_manager import QuotaManager
 from ....core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from ....core.DB_Management.db_path_utils import DatabasePaths
-from ..API_Deps.auth_deps import rbac_rate_limit
 from ..API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user as get_chacha_db
 from ..schemas.chatbook_schemas import (
     CancelJobResponse,

--- a/tldw_Server_API/app/api/v1/endpoints/chunking.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chunking.py
@@ -60,7 +60,7 @@ from tldw_Server_API.app.core.AuthNZ.byok_runtime import (
     record_byok_missing_credentials,
     resolve_byok_credentials,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Chunking import Chunker
 from tldw_Server_API.app.core.Chunking.base import ChunkingMethod
 from tldw_Server_API.app.core.config import load_and_log_configs as load_server_configs

--- a/tldw_Server_API/app/api/v1/endpoints/chunking_templates.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chunking_templates.py
@@ -25,7 +25,7 @@ from tldw_Server_API.app.api.v1.schemas.chunking_templates_schemas import (
     TemplateValidationError,
     TemplateValidationResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Chunking.chunker import Chunker
 from tldw_Server_API.app.core.Chunking.regex_safety import check_pattern as _rx_check
 from tldw_Server_API.app.core.Chunking.regex_safety import compile_flags as _rx_flags

--- a/tldw_Server_API/app/api/v1/endpoints/claims.py
+++ b/tldw_Server_API/app/api/v1/endpoints/claims.py
@@ -2,12 +2,8 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import Response
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import AdminPrincipal, get_auth_principal, get_request_user, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    AdminPrincipal,
-    RequirePermission,
-    get_auth_principal,
-)
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.claims_schemas import (
     ClaimNotificationResponse,
@@ -40,7 +36,6 @@ from tldw_Server_API.app.api.v1.schemas.claims_schemas import (
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Claims_Extraction import claims_service
 from tldw_Server_API.app.core.Claims_Extraction.claims_rebuild_service import get_claims_rebuild_service
 

--- a/tldw_Server_API/app/api/v1/endpoints/collections_feeds.py
+++ b/tldw_Server_API/app/api/v1/endpoints/collections_feeds.py
@@ -17,7 +17,7 @@ from tldw_Server_API.app.api.v1.schemas.collections_feeds_schemas import (
     CollectionsFeedsListResponse,
     CollectionsFeedUpdateRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase
 from tldw_Server_API.app.core.Personalization import (
     record_watchlist_source_created,

--- a/tldw_Server_API/app/api/v1/endpoints/collections_websub.py
+++ b/tldw_Server_API/app/api/v1/endpoints/collections_websub.py
@@ -20,7 +20,7 @@ from tldw_Server_API.app.api.v1.schemas.collections_websub_schemas import (
     WebSubSubscriptionResponse,
     WebSubUnsubscribeResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase
 
 _WEBSUB_NONCRITICAL_EXCEPTIONS = (

--- a/tldw_Server_API/app/api/v1/endpoints/data_tables.py
+++ b/tldw_Server_API/app/api/v1/endpoints/data_tables.py
@@ -15,13 +15,8 @@ from uuid import UUID
 from cachetools import LRUCache
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    check_rate_limit,
-    get_auth_principal,
-    rbac_rate_limit,
-)
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.data_tables_schemas import (
@@ -56,7 +51,6 @@ from tldw_Server_API.app.core.AuthNZ.permissions import (
     MEDIA_UPDATE,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.DB_Management.media_db.errors import DatabaseError, InputError
 from tldw_Server_API.app.core.exceptions import (

--- a/tldw_Server_API/app/api/v1/endpoints/discord.py
+++ b/tldw_Server_API/app/api/v1/endpoints/discord.py
@@ -7,8 +7,8 @@ from urllib.parse import urlencode
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, RequireRole, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 from tldw_Server_API.app.api.v1.endpoints.discord_oauth_admin import (
     discord_admin_delete_installation_impl,
     discord_admin_get_policy_impl,
@@ -58,7 +58,6 @@ from tldw_Server_API.app.core.AuthNZ.repos import (
     get_workspace_provider_installations_repo as _get_workspace_provider_installations_repo_impl,
 )
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter
 
 router = APIRouter(prefix="/discord", tags=["discord"])

--- a/tldw_Server_API/app/api/v1/endpoints/discord_oauth_admin.py
+++ b/tldw_Server_API/app/api/v1/endpoints/discord_oauth_admin.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable
 
 from fastapi import HTTPException, status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User
 
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import key_hint_for_api_key
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -46,11 +46,7 @@ from prometheus_client import REGISTRY, Counter, Gauge, Histogram
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    RequireRole,
-    rbac_rate_limit,
-)
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, RequireRole, resolve_user_id_for_request, User
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
 
@@ -73,11 +69,6 @@ from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPri
 from tldw_Server_API.app.core.AuthNZ.settings import is_single_user_profile_mode
 
 # Authentication
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-    resolve_user_id_for_request,
-)
 
 # Configuration
 from tldw_Server_API.app.core.config import settings

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_auth.py
@@ -14,8 +14,8 @@ from typing import Any, Optional
 from fastapi import Depends, Header, HTTPException, Request, Response, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, User, verify_jwt_and_fetch_user
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep
 from tldw_Server_API.app.api.v1.API_Deps.v1_endpoint_deps import oauth2_scheme
 from tldw_Server_API.app.core.AuthNZ.exceptions import InvalidTokenError, TokenExpiredError
 from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
@@ -25,11 +25,6 @@ from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
 from tldw_Server_API.app.core.AuthNZ.jwt_service import get_jwt_service
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-    verify_jwt_and_fetch_user,
-)
 from tldw_Server_API.app.core.exceptions import InactiveUserError
 from tldw_Server_API.app.core.Evaluations.identity import (
     EvaluationIdentity,

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_benchmarks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_benchmarks.py
@@ -9,8 +9,8 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User
 
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.AuthNZ.permissions import EVALS_MANAGE, EVALS_READ
 from tldw_Server_API.app.core.Evaluations.benchmark_loaders import load_benchmark_dataset
 from tldw_Server_API.app.core.Evaluations.benchmark_registry import get_registry

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_crud.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_crud.py
@@ -8,11 +8,8 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    rbac_rate_limit,
-    TokenScopeGuard,
-)
 from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_auth import (
     check_evaluation_rate_limit,
     create_error_response,
@@ -32,7 +29,6 @@ from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import (
     UpdateEvaluationRequest,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import EVALS_MANAGE, EVALS_READ
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.Evaluations.audit_adapter import MandatoryAuditWriteError
 from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import (
     get_unified_evaluation_service_for_user,

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_datasets.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_datasets.py
@@ -21,7 +21,7 @@ from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import (
     DatasetListResponse,
     DatasetResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User
 from tldw_Server_API.app.core.AuthNZ.permissions import EVALS_MANAGE, EVALS_READ
 from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import (
     _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS,

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_embeddings_abtest.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_embeddings_abtest.py
@@ -9,8 +9,8 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_auth import (
     check_evaluation_rate_limit,
@@ -30,7 +30,6 @@ from tldw_Server_API.app.api.v1.schemas.embeddings_abtest_schemas import (
     EmbeddingsABTestStatusResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.Evaluations.audit_adapter import (
     log_evaluation_created,
     log_run_started,

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_rag_pipeline.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_rag_pipeline.py
@@ -7,8 +7,8 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
 from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_auth import (
     create_error_response,
     get_eval_request_user,
@@ -20,7 +20,6 @@ from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import (
     PipelinePresetListResponse,
     PipelinePresetResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import (
     get_unified_evaluation_service_for_user,
 )

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_recipes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_recipes.py
@@ -21,7 +21,7 @@ from tldw_Server_API.app.api.v1.schemas.evaluation_recipe_schemas import (
     RecipeRunCreateRequest,
     RecipeRunRecord,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User
 from tldw_Server_API.app.core.AuthNZ.permissions import EVALS_MANAGE, EVALS_READ
 from tldw_Server_API.app.core.Evaluations.recipe_runs_jobs import (
     enqueue_recipe_run,

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_synthetic.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_synthetic.py
@@ -19,7 +19,7 @@ from tldw_Server_API.app.api.v1.schemas.synthetic_eval_schemas import (
     SyntheticEvalReviewActionRecord,
     SyntheticEvalReviewRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User
 from tldw_Server_API.app.core.AuthNZ.permissions import EVALS_MANAGE, EVALS_READ
 from tldw_Server_API.app.core.Evaluations.synthetic_eval_service import (
     get_synthetic_eval_service_for_user,

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
@@ -14,8 +14,8 @@ from typing import Annotated, Any, Optional, Union
 from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Query, Request, Response, UploadFile, status
 from fastapi.routing import APIRoute
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, rbac_rate_limit, RequireRole, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, rbac_rate_limit
 
 # Import unified schemas
 from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import (
@@ -42,7 +42,6 @@ from tldw_Server_API.app.core.AuthNZ.byok_runtime import (
     record_byok_missing_credentials,
     resolve_byok_credentials,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.AuthNZ.permissions import EVALS_READ
 from tldw_Server_API.app.core.Chat.chat_service import resolve_provider_api_key
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
@@ -96,7 +95,6 @@ _wm_lock = None
 
 import contextlib
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 
 from .evaluations_auth import (

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_webhooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_webhooks.py
@@ -22,7 +22,7 @@ from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import (
     WebhookTestRequest,
     WebhookTestResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User
 from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import (
     get_unified_evaluation_service_for_user,
 )

--- a/tldw_Server_API/app/api/v1/endpoints/family_wizard.py
+++ b/tldw_Server_API/app/api/v1/endpoints/family_wizard.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_registration_service_dep, get_request_user, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_registration_service_dep
 from tldw_Server_API.app.api.v1.API_Deps.guardian_deps import (
     get_guardian_db_for_user,
     get_guardian_db_for_user_id,
@@ -36,7 +36,6 @@ from tldw_Server_API.app.api.v1.schemas.family_wizard_schemas import (
     RelationshipDraftResponse,
 )
 from tldw_Server_API.app.api.v1.schemas.guardian_schemas import DetailResponse
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.Guardian_DB import GuardianDB
 from tldw_Server_API.app.core.Moderation.family_wizard_materializer import (
     materialize_pending_plans_for_relationship,

--- a/tldw_Server_API/app/api/v1/endpoints/feedback.py
+++ b/tldw_Server_API/app/api/v1/endpoints/feedback.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.feedback_schemas import (
@@ -19,7 +19,6 @@ from tldw_Server_API.app.api.v1.schemas.feedback_schemas import (
     FeedbackRecord,
     FeedbackUpdateRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
 from tldw_Server_API.app.core.RAG.rag_service.analytics_system import UnifiedFeedbackSystem, UserFeedbackStore
 

--- a/tldw_Server_API/app/api/v1/endpoints/files.py
+++ b/tldw_Server_API/app/api/v1/endpoints/files.py
@@ -22,7 +22,7 @@ from tldw_Server_API.app.api.v1.schemas.file_artifacts_schemas import (
     ReferenceImageListItem,
     ReferenceImageListResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.exceptions import FileArtifactsError, file_artifacts_http_status

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_owner, get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, User
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import DEFAULT_LLM_PROVIDER
@@ -61,7 +61,6 @@ from tldw_Server_API.app.api.v1.schemas.study_packs import (
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import FLASHCARDS_ADMIN
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.config import loaded_config_data
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,

--- a/tldw_Server_API/app/api/v1/endpoints/guardian_controls.py
+++ b/tldw_Server_API/app/api/v1/endpoints/guardian_controls.py
@@ -42,7 +42,7 @@ from tldw_Server_API.app.api.v1.schemas.guardian_schemas import (
     SupervisionAuditList,
     SupervisionAuditResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.Guardian_DB import GuardianDB
 from tldw_Server_API.app.core.Moderation.family_wizard_materializer import (
     materialize_pending_plans_for_relationship,

--- a/tldw_Server_API/app/api/v1/endpoints/ingestion_sources.py
+++ b/tldw_Server_API/app/api/v1/endpoints/ingestion_sources.py
@@ -19,8 +19,7 @@ from tldw_Server_API.app.api.v1.schemas.ingestion_sources import (
     IngestionSourceResponse,
     IngestionSourceSyncTriggerResponse,
 )
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, User
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths

--- a/tldw_Server_API/app/api/v1/endpoints/integrations_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/integrations_control_plane.py
@@ -5,8 +5,8 @@ from typing import Any
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, RequireRole, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, get_auth_principal
 from tldw_Server_API.app.api.v1.endpoints.discord_oauth_admin import discord_oauth_start_impl
 from tldw_Server_API.app.api.v1.endpoints.discord_support import (
     _decrypt_discord_payload,
@@ -66,7 +66,6 @@ from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
     TelegramLinkedActorListResponse,
     TelegramLinkedActorRevokeResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.repos import get_workspace_provider_installations_repo

--- a/tldw_Server_API/app/api/v1/endpoints/items.py
+++ b/tldw_Server_API/app/api/v1/endpoints/items.py
@@ -16,7 +16,7 @@ from tldw_Server_API.app.api.v1.schemas.items_schemas import (
     ItemsListResponse,
 )
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.Collections_DB import ContentItemRow
 from tldw_Server_API.app.core.DB_Management.media_db.api import search_media
 from tldw_Server_API.app.core.DB_Management.media_db.errors import (

--- a/tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py
+++ b/tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py
@@ -29,7 +29,7 @@ from tldw_Server_API.app.api.v1.schemas.kanban_schemas import (
     WorkflowTransitionsListResponse,
     WorkflowTransitionRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.Kanban_DB import (
     ConflictError,
     InputError,

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -9,9 +9,8 @@ from typing import Any, Optional
 # Thid-party Libraries
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, RequireRole, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, check_rate_limit
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Local_LLM.LlamaCpp_Handler import LlamaCppHandler
 
 #

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -20,12 +20,8 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, R
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from loguru import logger
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_db_transaction, RequirePermission, verify_jwt_and_fetch_user
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    get_auth_principal,
-    get_db_transaction,
-)
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import ToolCatalogResponse
 from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
 from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
@@ -42,7 +38,6 @@ from tldw_Server_API.app.core.AuthNZ.settings import (
     get_settings,
     is_single_user_profile_mode,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import verify_jwt_and_fetch_user
 from tldw_Server_API.app.core.feature_flags import is_mcp_hub_policy_enforcement_enabled
 from tldw_Server_API.app.core.MCP_unified import MCPRequest, MCPResponse, get_config, get_mcp_server
 from tldw_Server_API.app.core.MCP_unified.auth import UserRole

--- a/tldw_Server_API/app/api/v1/endpoints/media/__init__.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/__init__.py
@@ -54,7 +54,7 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import get_usage_e
 from tldw_Server_API.app.api.v1.API_Deps.validations_deps import (
     file_validator_instance,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user
 TemplateClassifier = _optional_import_attr(
     "tldw_Server_API.app.core.Chunking.templates",
     "TemplateClassifier",

--- a/tldw_Server_API/app/api/v1/endpoints/media/add.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/add.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Request, UploadFile
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -16,7 +16,6 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
 )
 from tldw_Server_API.app.api.v1.schemas.media_request_models import AddMediaForm
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Ingestion_Media_Processing.persistence import (
     add_media_persist,
 )

--- a/tldw_Server_API/app/api/v1/endpoints/media/document_annotations.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/document_annotations.py
@@ -19,7 +19,7 @@ from tldw_Server_API.app.api.v1.schemas.document_annotations import (
     AnnotationSyncResponse,
     AnnotationUpdate,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
 router = APIRouter(tags=["Document Workspace"])
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/document_figures.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/document_figures.py
@@ -14,7 +14,7 @@ from tldw_Server_API.app.api.v1.schemas.document_figures import (
     DocumentFiguresResponse,
     Figure,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Storage import get_storage_backend
 from tldw_Server_API.app.core.Storage.storage_interface import StorageError
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/document_insights.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/document_insights.py
@@ -9,8 +9,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import DEFAULT_LLM_PROVIDER
 from tldw_Server_API.app.api.v1.schemas.document_insights import (
@@ -23,7 +23,6 @@ from tldw_Server_API.app.api.v1.utils.cache import (
     cache_response,
     get_cached_response,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Chat.Chat_Deps import ChatConfigurationError
 from tldw_Server_API.app.core.Chat.chat_helpers import extract_response_content
 from tldw_Server_API.app.core.Chat.chat_service import resolve_provider_api_key

--- a/tldw_Server_API/app/api/v1/endpoints/media/document_outline.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/document_outline.py
@@ -13,7 +13,7 @@ from tldw_Server_API.app.api.v1.schemas.document_outline import (
     DocumentOutlineResponse,
     OutlineEntry,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Storage import get_storage_backend
 from tldw_Server_API.app.core.Storage.storage_interface import StorageError
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/document_references.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/document_references.py
@@ -12,8 +12,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.document_references import (
     DocumentReferencesResponse,
@@ -24,7 +24,6 @@ from tldw_Server_API.app.api.v1.utils.cache import (
     get_cache_client,
     get_cached_response,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.media_db.api import (
     get_latest_transcription,
 )

--- a/tldw_Server_API/app/api/v1/endpoints/media/file.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/file.py
@@ -11,7 +11,7 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Storage import get_storage_backend
 from tldw_Server_API.app.core.Storage.storage_interface import StorageError
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
@@ -17,13 +17,8 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    check_rate_limit,
-    get_auth_principal,
-    rbac_rate_limit,
-)
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -32,7 +27,6 @@ from tldw_Server_API.app.api.v1.API_Deps.validations_deps import file_validator_
 from tldw_Server_API.app.api.v1.schemas.media_request_models import AddMediaForm
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Ingestion_Media_Processing.input_sourcing import (
     TempDirManager,
     save_uploaded_files,

--- a/tldw_Server_API/app/api/v1/endpoints/media/item.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/item.py
@@ -5,8 +5,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, Response, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     MediaKeywordsUpdateRequest,
@@ -23,7 +23,6 @@ from tldw_Server_API.app.api.v1.utils.rag_cache import (
     invalidate_rag_caches,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_DELETE, MEDIA_UPDATE
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.media_db.api import (
     fetch_keywords_for_media,
     get_full_media_details_rich,

--- a/tldw_Server_API/app/api/v1/endpoints/media/listing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/listing.py
@@ -14,8 +14,8 @@ from fastapi import (
     status,
 )
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import (
     get_media_db_for_user,
     try_get_media_db_for_user,
@@ -28,7 +28,6 @@ from tldw_Server_API.app.api.v1.schemas.media_response_models import (
 from tldw_Server_API.app.api.v1.utils.cache import generate_etag, is_not_modified
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_DELETE
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.DB_Management.media_db.api import (
     fetch_keywords_for_media_batch,

--- a/tldw_Server_API/app/api/v1/endpoints/media/navigation.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/navigation.py
@@ -11,8 +11,8 @@ from typing import Any, Protocol
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.endpoints.media.document_outline import (
     MAX_OUTLINE_FILE_SIZE,
@@ -32,7 +32,6 @@ from tldw_Server_API.app.api.v1.schemas.media_navigation_schemas import (
     MediaNavigationTarget,
 )
 from tldw_Server_API.app.api.v1.utils.cache import cache_response, get_cached_response
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.media_db.api import (
     get_document_version,
     get_latest_transcription,

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
@@ -15,11 +15,8 @@ from fastapi import (
 )
 from loguru import logger
 from starlette.responses import JSONResponse
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    rbac_rate_limit,
-)
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import propagate_billing_headers, require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -37,7 +34,6 @@ from tldw_Server_API.app.api.v1.schemas.media_request_models import ProcessVideo
 from tldw_Server_API.app.core.AuthNZ.permissions import (
     MEDIA_CREATE,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Ingestion_Media_Processing.chunking_options import (
     apply_chunking_template_if_any,
     prepare_chunking_options_dict,

--- a/tldw_Server_API/app/api/v1/endpoints/media/reading_progress.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/reading_progress.py
@@ -16,7 +16,7 @@ from tldw_Server_API.app.api.v1.schemas.reading_progress import (
     ReadingProgressUpdate,
     ViewMode,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
 router = APIRouter(tags=["Document Workspace"])
 

--- a/tldw_Server_API/app/api/v1/endpoints/media/reprocess.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/reprocess.py
@@ -6,8 +6,8 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.endpoints import media_embeddings as embeddings_endpoint
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ReprocessMediaRequest
@@ -15,7 +15,6 @@ from tldw_Server_API.app.api.v1.schemas.media_response_models import ReprocessMe
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.utils.rag_cache import invalidate_rag_caches
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_UPDATE
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Chunking import improved_chunking_process
 from tldw_Server_API.app.core.Chunking.chunker import Chunker
 from tldw_Server_API.app.core.Chunking.templates import TemplateClassifier

--- a/tldw_Server_API/app/api/v1/endpoints/media/versions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/versions.py
@@ -30,10 +30,7 @@ from tldw_Server_API.app.api.v1.schemas.media_response_models import (
     VersionDetailResponse,
 )
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-)
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.media_db.api import (
     check_media_exists,
     get_document_version,

--- a/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media_embeddings.py
@@ -14,17 +14,12 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi import status as http_status
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, resolve_user_id_for_request, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit
 
 # Local imports
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.utils.rag_cache import invalidate_rag_caches
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-    resolve_user_id_for_request,
-)
 from tldw_Server_API.app.core.Chunking.base import ChunkerConfig
 from tldw_Server_API.app.core.Chunking.chunker import Chunker
 from tldw_Server_API.app.core.config import settings

--- a/tldw_Server_API/app/api/v1/endpoints/meetings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/meetings.py
@@ -11,7 +11,7 @@ from tldw_Server_API.app.api.v1.API_Deps.Meetings_DB_Deps import (
     get_meetings_db_for_user,
     get_meetings_db_for_websocket,
 )
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, User
 from tldw_Server_API.app.api.v1.schemas.meetings_schemas import (
     MeetingArtifactCreate,
     MeetingArtifactResponse,
@@ -28,7 +28,6 @@ from tldw_Server_API.app.api.v1.schemas.meetings_schemas import (
     MeetingTemplateResponse,
     MeetingTemplateScope,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.Meetings_DB import MeetingsDatabase
 from tldw_Server_API.app.core.Meetings.artifact_service import MeetingArtifactService
 from tldw_Server_API.app.core.Meetings.events_service import MeetingEventsService

--- a/tldw_Server_API/app/api/v1/endpoints/messages.py
+++ b/tldw_Server_API/app/api/v1/endpoints/messages.py
@@ -10,8 +10,8 @@ from typing import Any
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Request, status
 from loguru import logger
 from starlette.responses import JSONResponse, StreamingResponse
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
 from tldw_Server_API.app.api.v1.schemas.anthropic_messages import (
     AnthropicCountTokensRequest,
     AnthropicMessagesRequest,
@@ -26,7 +26,6 @@ from tldw_Server_API.app.core.AuthNZ.llm_provider_overrides import (
     get_override_credentials,
     validate_provider_override,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Chat.chat_service import (
     perform_chat_api_call_async,
     resolve_provider_and_model,

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -29,8 +29,8 @@ from fastapi import (
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, rbac_rate_limit
 
 # Dependency to get user-specific ChaChaNotes_DB instance
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import (
@@ -90,8 +90,6 @@ from tldw_Server_API.app.api.v1.schemas.notes_moodboards import (
     MoodboardResponse,
     MoodboardUpdate,
 )
-from tldw_Server_API.app.core.AuthNZ.rate_limiter import RateLimiter
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.config import settings as core_settings
 
 #

--- a/tldw_Server_API/app/api/v1/endpoints/notes_graph.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes_graph.py
@@ -3,12 +3,8 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    rbac_rate_limit,
-    TokenScopeGuard,
-)
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.notes_graph import (
@@ -18,7 +14,6 @@ from tldw_Server_API.app.api.v1.schemas.notes_graph import (
     NoteLinkCreate,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import NOTES_GRAPH_READ, NOTES_GRAPH_WRITE
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,

--- a/tldw_Server_API/app/api/v1/endpoints/outputs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/outputs.py
@@ -24,11 +24,7 @@ from tldw_Server_API.app.api.v1.schemas.outputs_schemas import (
     OutputListResponse,
     OutputUpdateRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-    resolve_user_id_for_request,
-)
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, resolve_user_id_for_request, User
 from tldw_Server_API.app.core.DB_Management.backends.base import DatabaseError
 from tldw_Server_API.app.core.exceptions import InvalidStoragePathError
 from tldw_Server_API.app.services.outputs_service import (

--- a/tldw_Server_API/app/api/v1/endpoints/outputs_templates.py
+++ b/tldw_Server_API/app/api/v1/endpoints/outputs_templates.py
@@ -27,7 +27,7 @@ from tldw_Server_API.app.api.v1.schemas.outputs_templates_schemas import (
     TemplatePreviewResponse,
 )
 from tldw_Server_API.app.core.DB_Management.media_db.api import search_media
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.services.outputs_service import (
     build_items_context_from_content_items,
     render_output_template,

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -21,8 +21,8 @@ from urllib.parse import urljoin
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, WebSocket, WebSocketDisconnect, status
 from loguru import logger
 from starlette.requests import Request as StarletteRequest
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, User, verify_jwt_and_fetch_user
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaBuddyResponse,
@@ -90,7 +90,6 @@ from tldw_Server_API.app.core.AuthNZ.exceptions import DatabaseError, InvalidTok
 from tldw_Server_API.app.core.AuthNZ.ip_allowlist import resolve_client_ip
 from tldw_Server_API.app.core.AuthNZ.jwt_service import get_jwt_service
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user, verify_jwt_and_fetch_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,

--- a/tldw_Server_API/app/api/v1/endpoints/prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompts.py
@@ -18,7 +18,7 @@ from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_f
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas import prompt_schemas as schemas
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings as get_auth_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.config import settings
 from tldw_Server_API.app.core.DB_Management.Prompts_DB import (
     ConflictError,

--- a/tldw_Server_API/app/api/v1/endpoints/quizzes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/quizzes.py
@@ -34,7 +34,7 @@ from tldw_Server_API.app.api.v1.schemas.flashcards import (
     StudyAssistantRespondRequest,
     StudyAssistantRespondResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -17,14 +17,8 @@ from uuid import uuid4
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, status
 from fastapi.responses import StreamingResponse
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    check_rate_limit,
-    get_auth_principal,
-    rbac_rate_limit,
-    TokenScopeGuard,
-)
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 
@@ -41,7 +35,6 @@ from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import (
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_READ
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.RAG.rag_service.agentic_chunker import (

--- a/tldw_Server_API/app/api/v1/endpoints/reading.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading.py
@@ -15,8 +15,8 @@ try:
     import bleach  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency fallback
     bleach = None
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
@@ -55,7 +55,6 @@ from tldw_Server_API.app.api.v1.schemas.reading_schemas import (
     ReadingTTSRequest,
     ReadingUpdateRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Collections.reading_import_jobs import (
     MAX_READING_IMPORT_BYTES,
     READING_IMPORT_DOMAIN,

--- a/tldw_Server_API/app/api/v1/endpoints/reading_highlights.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading_highlights.py
@@ -24,7 +24,7 @@ from tldw_Server_API.app.api.v1.schemas.reading_highlights_schemas import (
     HighlightCreateRequest,
     HighlightUpdateRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Collections.utils import (
     build_highlight_context,
     find_highlight_span,

--- a/tldw_Server_API/app/api/v1/endpoints/research.py
+++ b/tldw_Server_API/app/api/v1/endpoints/research.py
@@ -31,7 +31,7 @@ from tldw_Server_API.app.api.v1.schemas.websearch_schemas import (
     WebSearchRawResponse,
     WebSearchRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user  # For User dependency
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Chat.Chat_Deps import ChatConfigurationError
 from tldw_Server_API.app.core.DB_Management.media_db.api import get_media_repository
 from tldw_Server_API.app.core.DB_Management.media_db.api import managed_media_database

--- a/tldw_Server_API/app/api/v1/endpoints/research_runs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/research_runs.py
@@ -17,7 +17,7 @@ from tldw_Server_API.app.api.v1.schemas.research_runs_schemas import (
     ResearchRunListItemResponse,
     ResearchRunResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.Research.streaming import (
     diff_stream_events,
     initial_stream_events,

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -28,8 +28,8 @@ from fastapi import (
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.routing import APIRoute
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, RequireRole, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminMacOSDiagnosticsResponse,
@@ -68,7 +68,6 @@ from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
 from tldw_Server_API.app.core.AuthNZ.ip_allowlist import is_single_user_ip_allowed, resolve_client_ip
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.Metrics import increment_counter, observe_histogram
 from tldw_Server_API.app.core.Sandbox.models import RunSpec, SessionSpec

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.schemas.reminders_schemas import (
     ReminderTaskCreateRequest,
     ReminderTaskUpdateRequest,
@@ -12,7 +12,6 @@ from tldw_Server_API.app.api.v1.schemas.scheduled_tasks_control_plane_schemas im
     ScheduledTaskDeleteResponse,
     ScheduledTaskListResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.permissions import TASKS_CONTROL, TASKS_READ
 from tldw_Server_API.app.services.scheduled_tasks_control_plane_service import ScheduledTasksControlPlaneService
 

--- a/tldw_Server_API/app/api/v1/endpoints/scheduler_workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduler_workflows.py
@@ -6,15 +6,10 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, RequirePermission, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    get_auth_principal,
-    TokenScopeGuard,
-)
 from tldw_Server_API.app.core.AuthNZ.permissions import WORKFLOWS_ADMIN
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Scheduler import get_global_scheduler
 from tldw_Server_API.app.services.workflows_scheduler import (
     build_schedule_payload,

--- a/tldw_Server_API/app/api/v1/endpoints/self_monitoring.py
+++ b/tldw_Server_API/app/api/v1/endpoints/self_monitoring.py
@@ -43,7 +43,7 @@ from tldw_Server_API.app.api.v1.schemas.guardian_schemas import (
     SelfMonitoringRuleResponse,
     SelfMonitoringRuleUpdate,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.Guardian_DB import GuardianDB
 from tldw_Server_API.app.core.Monitoring.self_monitoring_service import (
     CRISIS_DISCLAIMER,

--- a/tldw_Server_API/app/api/v1/endpoints/sharing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sharing.py
@@ -16,9 +16,8 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
 
-from ....core.AuthNZ.User_DB_Handling import User, get_request_user
-from ..API_Deps.auth_deps import rbac_rate_limit
 from ..schemas.sharing_schemas import (
     AdminShareListResponse,
     AuditEventResponse,

--- a/tldw_Server_API/app/api/v1/endpoints/slack.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slack.py
@@ -9,8 +9,8 @@ from urllib.parse import parse_qs, urlencode
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, RequireRole, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 from tldw_Server_API.app.api.v1.endpoints.slack_oauth_admin import (
     slack_admin_delete_installation_impl,
     slack_admin_get_policy_impl,
@@ -63,7 +63,6 @@ from tldw_Server_API.app.core.AuthNZ.repos import (
     get_workspace_provider_installations_repo as _get_workspace_provider_installations_repo_impl,
 )
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter
 
 router = APIRouter(prefix="/slack", tags=["slack"])

--- a/tldw_Server_API/app/api/v1/endpoints/slack_oauth_admin.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slack_oauth_admin.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable
 
 from fastapi import HTTPException, status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User
 
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import key_hint_for_api_key
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -18,8 +18,8 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, R
 from fastapi.encoders import jsonable_encoder
 from loguru import logger
 from pydantic import ValidationError
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user, get_chacha_db_for_user_id
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
@@ -58,7 +58,6 @@ from tldw_Server_API.app.api.v1.schemas.slides_schemas import (
     VisualStyleResponse,
 )
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.permissions import MEDIA_CREATE, MEDIA_DELETE, MEDIA_READ, MEDIA_UPDATE
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase

--- a/tldw_Server_API/app/api/v1/endpoints/storage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage.py
@@ -14,8 +14,8 @@ from pathlib import Path as PathlibPath
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     BulkDeleteRequest,
     BulkDeleteResponse,
@@ -48,7 +48,6 @@ from tldw_Server_API.app.core.AuthNZ.exceptions import (
     UserNotFoundError,
 )
 from tldw_Server_API.app.core.AuthNZ.repos.generated_files_repo import FILE_CATEGORY_VOICE_CLONE
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.services.storage_quota_service import get_storage_service

--- a/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/study_suggestions.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, User
 from tldw_Server_API.app.api.v1.schemas.study_suggestions import (
     SuggestionActionRequest,
     SuggestionActionResponse,
@@ -23,7 +23,6 @@ from tldw_Server_API.app.api.v1.schemas.study_suggestions import (
     SuggestionSnapshotResponse,
     SuggestionStatusResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from tldw_Server_API.app.core.Jobs.manager import JobManager

--- a/tldw_Server_API/app/api/v1/endpoints/sync.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sync.py
@@ -30,7 +30,7 @@ from tldw_Server_API.app.api.v1.schemas.sync_server_models import (
     SyncLogEntry,
 )
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
 #
 # DB Mgmt

--- a/tldw_Server_API/app/api/v1/endpoints/text2sql.py
+++ b/tldw_Server_API/app/api/v1/endpoints/text2sql.py
@@ -6,14 +6,8 @@ import asyncio
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, rbac_rate_limit, RequirePermission, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    check_rate_limit,
-    get_request_user,
-    rbac_rate_limit,
-    TokenScopeGuard,
-)
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.text2sql_schemas import (
@@ -24,7 +18,6 @@ from tldw_Server_API.app.core.AuthNZ.permissions import (
     SQL_READ,
     SQL_TARGET_ANY,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
 from tldw_Server_API.app.core.Text2SQL.executor import SqliteReadOnlyExecutor
 from tldw_Server_API.app.core.Text2SQL.service import Text2SQLCoreService

--- a/tldw_Server_API/app/api/v1/endpoints/tools.py
+++ b/tldw_Server_API/app/api/v1/endpoints/tools.py
@@ -4,15 +4,14 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, RequirePermission, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission
 from tldw_Server_API.app.api.v1.schemas.tools import (
     ExecuteToolRequest,
     ExecuteToolResult,
     ToolInfo,
     ToolListResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Tools.tool_executor import ToolExecutionError, ToolExecutor
 
 router = APIRouter()

--- a/tldw_Server_API/app/api/v1/endpoints/translate.py
+++ b/tldw_Server_API/app/api/v1/endpoints/translate.py
@@ -10,7 +10,7 @@ from tldw_Server_API.app.api.v1.schemas.translate_schemas import (
     TranslateRequest,
     TranslateResponse,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.config import load_and_log_configs
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze
 

--- a/tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
@@ -17,21 +17,11 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, RequireRole, resolve_user_id_for_request, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    RequirePermission,
-    RequireRole,
-    get_auth_principal,
-    rbac_rate_limit,
-)
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-    resolve_user_id_for_request,
-)
 from tldw_Server_API.app.core.Chunking.base import ChunkerConfig, ChunkingMethod
 from tldw_Server_API.app.core.Chunking.chunker import Chunker
 from tldw_Server_API.app.core.config import settings

--- a/tldw_Server_API/app/api/v1/endpoints/voice_assistant.py
+++ b/tldw_Server_API/app/api/v1/endpoints/voice_assistant.py
@@ -59,7 +59,7 @@ from tldw_Server_API.app.api.v1.schemas.voice_assistant_schemas import (
     WSWorkflowCompleteMessage,
     WSWorkflowProgressMessage,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSError
 from tldw_Server_API.app.core.TTS.tts_request_resolution import (

--- a/tldw_Server_API/app/api/v1/endpoints/watchlist_alert_rules.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlist_alert_rules.py
@@ -13,8 +13,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Watchlists.alert_rules import (
     ALERT_CONDITION_TYPE_VALUES,

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -42,8 +42,8 @@ from fastapi import (
 from fastapi.responses import HTMLResponse, PlainTextResponse, Response
 from loguru import logger
 from starlette.responses import FileResponse
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, resolve_user_id_for_request, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Watchlists_DB_Deps import get_watchlists_db_for_user
@@ -54,11 +54,6 @@ from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
     resolve_client_ip,
 )
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-    resolve_user_id_for_request,
-)
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.DB_Management.scope_context import get_scope as _get_scope
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase

--- a/tldw_Server_API/app/api/v1/endpoints/web_clipper.py
+++ b/tldw_Server_API/app/api/v1/endpoints/web_clipper.py
@@ -6,8 +6,8 @@ import asyncio
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.schemas.web_clipper_schemas import (
     WebClipperEnrichmentPayload,
@@ -17,8 +17,6 @@ from tldw_Server_API.app.api.v1.schemas.web_clipper_schemas import (
     WebClipperStatusResponse,
 )
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
-from tldw_Server_API.app.core.AuthNZ.rate_limiter import RateLimiter
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,

--- a/tldw_Server_API/app/api/v1/endpoints/web_scraping.py
+++ b/tldw_Server_API/app/api/v1/endpoints/web_scraping.py
@@ -8,8 +8,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Metrics import get_metrics_registry
 from tldw_Server_API.app.core.Security.url_validation import assert_url_safe
 from tldw_Server_API.app.services.enhanced_web_scraping_service import get_web_scraping_service

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -30,8 +30,8 @@ from fastapi import (
 from fastapi.responses import FileResponse, StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field, ValidationError
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, RequirePermission, RequireRole, resolve_user_id_for_request, TokenScopeGuard, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, RequireRole, TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.api.v1.schemas.workflows import (
     AdhocRunRequest,
@@ -62,11 +62,6 @@ from tldw_Server_API.app.core.AuthNZ.permissions import (
     WORKFLOWS_RUNS_READ,
 )
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import (
-    User,
-    get_request_user,
-    resolve_user_id_for_request,
-)
 from tldw_Server_API.app.core.DB_Management.backends.base import BackendType
 from tldw_Server_API.app.core.DB_Management.DB_Manager import (
     create_workflows_database,

--- a/tldw_Server_API/app/api/v1/endpoints/workspaces.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workspaces.py
@@ -28,7 +28,7 @@ from tldw_Server_API.app.api.v1.endpoints.workspaces_rate_limit_policy import (
     WORKSPACES_READ_RATE_LIMIT,
     WORKSPACES_WRITE_RATE_LIMIT,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, User
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,

--- a/tldw_Server_API/app/api/v1/endpoints/writing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/writing.py
@@ -13,8 +13,8 @@ from typing import Any, NoReturn
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.endpoints.llm_providers import get_configured_providers_async
 from tldw_Server_API.app.api.v1.schemas.writing_schemas import (
@@ -65,8 +65,6 @@ from tldw_Server_API.app.api.v1.schemas.writing_schemas import (
     WritingWordcloudWord,
 )
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
-from tldw_Server_API.app.core.AuthNZ.rate_limiter import RateLimiter
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,

--- a/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
@@ -6,11 +6,8 @@ from typing import Any, Literal, NoReturn
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from loguru import logger
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    get_rate_limiter_dep,
-    rbac_rate_limit,
-)
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.schemas.writing_manuscript_schemas import (
     ChapterSummary,
@@ -70,8 +67,6 @@ from tldw_Server_API.app.api.v1.schemas.writing_manuscript_schemas import (
     WORLD_INFO_KINDS,
 )
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
-from tldw_Server_API.app.core.AuthNZ.rate_limiter import RateLimiter
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Chat.chat_service import is_model_known_for_provider
 from tldw_Server_API.app.core.Chat.provider_manager import get_provider_manager
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (

--- a/tldw_Server_API/tests/lint/test_endpoint_auth_deps_import_boundary.py
+++ b/tldw_Server_API/tests/lint/test_endpoint_auth_deps_import_boundary.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ENDPOINTS_ROOT = REPO_ROOT / "tldw_Server_API" / "app" / "api" / "v1" / "endpoints"
+AUTH_DEPS_PATH = (
+    REPO_ROOT / "tldw_Server_API" / "app" / "api" / "v1" / "API_Deps" / "auth_deps.py"
+)
+
+BANNED_ENDPOINT_IMPORTS = {
+    "tldw_Server_API.app.core.AuthNZ.User_DB_Handling": None,
+    "core.AuthNZ.User_DB_Handling": None,
+    "tldw_Server_API.app.core.AuthNZ.rate_limiter": {"RateLimiter"},
+    "core.AuthNZ.rate_limiter": {"RateLimiter"},
+}
+
+REQUIRED_AUTH_DEPS_EXPORTS = {
+    "RateLimiter",
+    "User",
+    "get_rate_limiter_dep",
+    "get_request_user",
+    "rbac_rate_limit",
+    "resolve_user_id_for_request",
+    "verify_jwt_and_fetch_user",
+}
+
+
+def _is_banned_import_module(imported_module: str) -> bool:
+    return any(
+        imported_module == banned_module or imported_module.startswith(f"{banned_module}.")
+        for banned_module in BANNED_ENDPOINT_IMPORTS
+    )
+
+
+def _auth_dependency_import_offenders(module: ast.Module, rel_path: str) -> list[str]:
+    offenders: list[str] = []
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_banned_import_module(alias.name):
+                    imported_module = (
+                        f"{alias.name} as {alias.asname}" if alias.asname else alias.name
+                    )
+                    offenders.append(
+                        f"{rel_path}:{node.lineno}: import module {imported_module}"
+                    )
+            continue
+
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        if node.module not in BANNED_ENDPOINT_IMPORTS:
+            continue
+
+        banned_names = BANNED_ENDPOINT_IMPORTS[node.module]
+        if banned_names is None:
+            imported_banned_names = sorted(alias.name for alias in node.names)
+        else:
+            imported_banned_names = sorted(
+                alias.name for alias in node.names if alias.name in banned_names
+            )
+        if imported_banned_names:
+            offenders.append(
+                f"{rel_path}:{node.lineno}: import "
+                f"{', '.join(imported_banned_names)} from {node.module}"
+            )
+    return offenders
+
+
+def _direct_auth_dependency_imports() -> list[str]:
+    offenders: list[str] = []
+    for py_file in sorted(ENDPOINTS_ROOT.rglob("*.py")):
+        rel_path = py_file.relative_to(REPO_ROOT).as_posix()
+        module = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        offenders.extend(_auth_dependency_import_offenders(module, rel_path))
+    return offenders
+
+
+def test_endpoint_auth_dependency_scan_flags_direct_module_imports():
+    module = ast.parse(
+        "\n".join(
+            [
+                "import tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+                "import tldw_Server_API.app.core.AuthNZ.rate_limiter as rate_limiter",
+                "import tldw_Server_API.app.core.AuthNZ.User_DB_Handling.extra",
+            ]
+        )
+    )
+
+    assert _auth_dependency_import_offenders(module, "sample.py") == [  # nosec B101
+        "sample.py:1: import module tldw_Server_API.app.core.AuthNZ.User_DB_Handling",
+        "sample.py:2: import module tldw_Server_API.app.core.AuthNZ.rate_limiter as rate_limiter",
+        "sample.py:3: import module tldw_Server_API.app.core.AuthNZ.User_DB_Handling.extra",
+    ]
+
+
+def test_endpoint_auth_dependency_symbols_come_from_auth_deps():
+    offenders = _direct_auth_dependency_imports()
+
+    assert offenders == [], (  # nosec B101
+        "Endpoint files should import common auth dependency symbols "
+        "from tldw_Server_API.app.api.v1.API_Deps.auth_deps instead of core.AuthNZ.\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_auth_deps_reexports_common_endpoint_auth_symbols():
+    module = ast.parse(AUTH_DEPS_PATH.read_text(encoding="utf-8"), filename=str(AUTH_DEPS_PATH))
+    exported_names: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                exported_names.add(alias.asname or alias.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            exported_names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    exported_names.add(target.id)
+
+    missing = sorted(REQUIRED_AUTH_DEPS_EXPORTS - exported_names)
+
+    assert missing == [], (  # nosec B101
+        "auth_deps.py must re-export common endpoint auth dependency symbols: "
+        + ", ".join(missing)
+    )


### PR DESCRIPTION
## Change summary

Maintainer action required before merge: replace this section with a human-written change summary that explains what changed and why these implementation choices were made.

## What changed

- Resolves #1016.
- Re-exported common endpoint auth dependency symbols from `API_Deps.auth_deps`, including `User` and `resolve_user_id_for_request`.
- Updated endpoint modules to import `User`, `get_request_user`, `verify_jwt_and_fetch_user`, `resolve_user_id_for_request`, and `RateLimiter` through `auth_deps` instead of the lower-level `core.AuthNZ.User_DB_Handling` / `rate_limiter` modules.
- Added a lint-style regression test that prevents endpoint files from reintroducing direct imports from those lower-level modules.

## Verification

- `python -m pytest tldw_Server_API/tests/lint/test_endpoint_auth_deps_import_boundary.py tldw_Server_API/tests/unit/test_schema_imports.py -v` -> 16 passed
- `python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_auth_deps_hardening.py tldw_Server_API/tests/AuthNZ/unit/test_auth_deps_precedence.py -v` -> 23 passed
- `python -m compileall -q tldw_Server_API/app/api/v1/API_Deps/auth_deps.py tldw_Server_API/app/api/v1/endpoints tldw_Server_API/tests/lint/test_endpoint_auth_deps_import_boundary.py`
- `git diff --check`
- F401 baseline comparison against `origin/dev`: 0 new findings, 2 pre-existing findings removed
- Bandit baseline comparison against `origin/dev`: 0 new findings

## Notes

- A raw F401 scan over all touched endpoint files still reports pre-existing unused imports already present on `origin/dev`; this branch does not introduce new F401 findings.
- A raw Bandit scan over the broad touched endpoint scope still reports pre-existing findings already present on `origin/dev`; this branch does not introduce new Bandit findings.
