### PR TITLE
Return merged monitoring alert mutation state

### DIFF
--- a/Docs/Product/Completed/Topic_Monitoring_Watchlists.md
+++ b/Docs/Product/Completed/Topic_Monitoring_Watchlists.md
@@ -70,6 +70,8 @@ Goal: Provide a configurable, privacy-respecting content monitoring feature that
 - `DELETE /api/v1/monitoring/watchlists/{id}` delete watchlist (admin)
 - `GET  /api/v1/monitoring/alerts`            list alerts (admin; filters: user_id, since, unread)
 - `POST /api/v1/monitoring/alerts/{id}/read`  mark alert as read (admin)
+- `POST /api/v1/monitoring/alerts/{id}/acknowledge` acknowledge alert (admin)
+- `DELETE /api/v1/monitoring/alerts/{id}` dismiss alert (admin)
 - `POST /api/v1/monitoring/reload`            reload config file (admin)
 
 ## Reload Semantics (Phase 1)
@@ -111,9 +113,10 @@ Monitoring emits alerts without changing moderation behavior or endpoint results
   - `MONITORING_NOTIFY_WEBHOOK_URL`, `MONITORING_NOTIFY_EMAIL_TO`, `MONITORING_NOTIFY_SMTP_HOST`, `MONITORING_NOTIFY_EMAIL_FROM`
 
 ## Alert Lifecycle
-- `POST /api/v1/monitoring/alerts/{id}/read` and `POST /api/v1/monitoring/alerts/{id}/acknowledge` currently return the same minimal `{status, id}` acknowledgement.
-- `DELETE /api/v1/monitoring/alerts/{id}` returns the same minimal acknowledgement after dismissing the alert.
-- Re-list alerts for authoritative merged state after any mutation.
+- Mutation responses include the authoritative merged alert state as `{status, id, item}`.
+- `read` marks the runtime alert as read without setting `acknowledged_at`.
+- `acknowledge` marks the runtime alert as read and records `acknowledged_at`.
+- `dismiss` marks the runtime alert as read and records `dismissed_at`.
 
 ## Phase 2 (planned)
 - Delivery channels: email, webhook, Slack.

--- a/tldw_Server_API/app/api/v1/endpoints/monitoring.py
+++ b/tldw_Server_API/app/api/v1/endpoints/monitoring.py
@@ -150,6 +150,65 @@ def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _decode_alert_metadata(row: dict[str, object]) -> dict[str, object]:
+    """Return an alert row copy with runtime DB metadata normalized for AlertItem.
+
+    TopicMonitoringDB alert rows expose metadata as SQLite JSON text, a decoded
+    mapping, or an empty/null value depending on the source path. AlertItem
+    accepts a mapping or None, so this helper preserves the original row and
+    normalizes only the metadata field before response construction.
+    """
+    normalized = dict(row)
+    meta = normalized.get("metadata")
+    if isinstance(meta, str) and meta:
+        try:
+            parsed = json.loads(meta)
+        except (TypeError, json.JSONDecodeError) as e:
+            logger.debug(
+                "monitoring: failed to parse alert metadata JSON: {}",
+                e,
+            )
+            normalized["metadata"] = {"raw": meta}
+        else:
+            if parsed is None:
+                normalized["metadata"] = None
+            else:
+                normalized["metadata"] = parsed if isinstance(parsed, dict) else {"value": parsed}
+    elif meta == "":
+        normalized["metadata"] = None
+    return normalized
+
+
+async def _build_alert_mutation_response(
+    *,
+    alert_id: int,
+    db: TopicMonitoringDB,
+    repo: AuthnzAdminMonitoringRepo,
+) -> MarkReadResponse:
+    """Build the mutation response with the authoritative merged alert state.
+
+    The public read, acknowledge, and dismiss endpoints mutate overlay state,
+    then return the runtime alert row merged with the matching admin overlay row
+    so clients do not need to re-list alerts to see the updated state.
+    """
+    raw_alert = await asyncio.to_thread(db.get_alert, alert_id)
+    if raw_alert is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Alert not found")
+
+    normalized_alert = _decode_alert_metadata(raw_alert)
+    alert_identity = build_alert_identity(normalized_alert)
+    overlay_rows = await repo.list_alert_states([alert_identity])
+    merged_row = merge_runtime_alert_with_overlay(
+        normalized_alert,
+        overlay_rows[0] if overlay_rows else None,
+    )
+    return MarkReadResponse(
+        status="ok",
+        id=alert_id,
+        item=AlertItem(**merged_row),
+    )
+
+
 async def _emit_admin_audit_event(
     request: Request,
     principal: AuthPrincipal,
@@ -300,20 +359,10 @@ async def list_alerts(
     }
     items: list[AlertItem] = []
     for r in rows:
-        # metadata column may be JSON string
-        meta = r.get("metadata")
-        if isinstance(meta, str) and meta:
-            try:
-                r["metadata"] = json.loads(meta)
-            except (TypeError, json.JSONDecodeError) as e:
-                logger.debug(
-                    "monitoring: failed to parse alert metadata JSON: {}",
-                    e,
-                )
-                r["metadata"] = {"raw": meta}
-        alert_identity = build_alert_identity(r)
+        normalized_row = _decode_alert_metadata(r)
+        alert_identity = build_alert_identity(normalized_row)
         merged_row = merge_runtime_alert_with_overlay(
-            r,
+            normalized_row,
             overlay_by_identity.get(alert_identity),
         )
         items.append(AlertItem(**merged_row))
@@ -333,6 +382,45 @@ async def mark_alert_read(
     db: TopicMonitoringDB = Depends(get_topic_monitoring_db),  # noqa: B008
 ) -> MarkReadResponse:
     """Mark a single alert as read by ID."""
+
+    ok = await asyncio.to_thread(db.mark_read, alert_id)
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Alert not found")
+
+    alert_identity = f"alert:{alert_id}"
+    actor_id = _principal_actor_id(principal)
+    read_at = _utcnow_iso()
+    repo = await _get_monitoring_repo()
+    await repo.append_alert_event(
+        alert_identity=alert_identity,
+        action="read",
+        actor_user_id=actor_id,
+        details_json=json.dumps({"alert_id": alert_id}),
+        created_at=read_at,
+    )
+    await _emit_admin_audit_event(
+        request,
+        principal,
+        action="monitoring.alert.read",
+        resource_id=alert_identity,
+        metadata={"alert_id": alert_id},
+    )
+    return await _build_alert_mutation_response(alert_id=alert_id, db=db, repo=repo)
+
+
+@router.post(
+    "/monitoring/alerts/{alert_id}/acknowledge",
+    response_model=MarkReadResponse,
+    tags=["monitoring"],
+    summary="Acknowledge an alert",
+)
+async def acknowledge_alert(
+    alert_id: int,
+    request: Request,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    db: TopicMonitoringDB = Depends(get_topic_monitoring_db),  # noqa: B008
+) -> MarkReadResponse:
+    """Acknowledge a monitoring alert using the authoritative overlay state."""
 
     ok = await asyncio.to_thread(db.mark_read, alert_id)
     if not ok:
@@ -361,29 +449,7 @@ async def mark_alert_read(
         resource_id=alert_identity,
         metadata={"alert_id": alert_id},
     )
-    return MarkReadResponse(status="ok", id=alert_id)
-
-
-@router.post(
-    "/monitoring/alerts/{alert_id}/acknowledge",
-    response_model=MarkReadResponse,
-    tags=["monitoring"],
-    summary="Acknowledge an alert",
-)
-async def acknowledge_alert(
-    alert_id: int,
-    request: Request,
-    principal: AuthPrincipal = Depends(get_auth_principal),
-    db: TopicMonitoringDB = Depends(get_topic_monitoring_db),  # noqa: B008
-) -> MarkReadResponse:
-    """Acknowledge a monitoring alert using the authoritative overlay state."""
-
-    return await mark_alert_read(
-        alert_id=alert_id,
-        request=request,
-        principal=principal,
-        db=db,
-    )
+    return await _build_alert_mutation_response(alert_id=alert_id, db=db, repo=repo)
 
 
 @router.delete(
@@ -427,7 +493,7 @@ async def dismiss_alert(
         resource_id=alert_identity,
         metadata={"alert_id": alert_id},
     )
-    return MarkReadResponse(status="ok", id=alert_id)
+    return await _build_alert_mutation_response(alert_id=alert_id, db=db, repo=repo)
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/schemas/monitoring_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/monitoring_schemas.py
@@ -77,9 +77,10 @@ class AlertsListResponse(BaseModel):
 
 class MarkReadResponse(BaseModel):
     status: str = Field(
-        description="Minimal mutation acknowledgement only; re-list alerts for authoritative merged state."
+        description="Mutation succeeded; item contains the authoritative merged state after the mutation."
     )
     id: int = Field(description="Runtime alert row id for the mutated monitoring alert")
+    item: AlertItem = Field(description="Authoritative merged alert state after the mutation")
 
 
 class NotificationSettings(BaseModel):

--- a/tldw_Server_API/app/core/Monitoring/README.md
+++ b/tldw_Server_API/app/core/Monitoring/README.md
@@ -77,6 +77,7 @@
   - Use the admin APIs to manage watchlists; reload via `/api/v1/monitoring/reload` after file edits.
 - Pitfalls & Gotchas
   - Webhook/email sends are best‑effort and may be disabled in restricted environments; rely on JSONL for auditability.
-  - Public alert mutation endpoints return minimal acknowledgements; re-list alerts for authoritative merged state.
+  - Public alert mutation endpoints return the authoritative merged alert state in `{status, id, item}`.
+  - `read` marks the runtime alert as read without setting `acknowledged_at`; `acknowledge` records `acknowledged_at`; `dismiss` records `dismissed_at`.
   - Large texts are truncated for scanning; test your rules with realistic snippets.
   - Regex complexity can impact performance; prefer literals or well‑scoped regexes.

--- a/tldw_Server_API/tests/Admin/test_monitoring_alerts_overlay_integration.py
+++ b/tldw_Server_API/tests/Admin/test_monitoring_alerts_overlay_integration.py
@@ -90,15 +90,39 @@ async def test_monitoring_alerts_include_backend_overlay_and_authoritative_actio
 
         read_resp = client.post(f"/api/v1/monitoring/alerts/{alert_id}/read")
         assert read_resp.status_code == 200, read_resp.text
-        assert read_resp.json() == {"status": "ok", "id": alert_id}
+        read_payload = read_resp.json()
+        assert read_payload["status"] == "ok"
+        assert read_payload["id"] == alert_id
+        assert read_payload["item"]["id"] == alert_id
+        assert read_payload["item"]["alert_identity"] == f"alert:{alert_id}"
+        assert read_payload["item"]["is_read"] is True
+        assert read_payload["item"]["read_at"] is not None
+        assert read_payload["item"]["acknowledged_at"] is None
+        assert read_payload["item"]["assigned_to_user_id"] == 1
+        assert read_payload["item"]["snoozed_until"] == "2026-03-10T11:00:00Z"
+        assert read_payload["item"]["escalated_severity"] == "critical"
 
         acknowledge_resp = client.post(f"/api/v1/monitoring/alerts/{alert_id}/acknowledge")
         assert acknowledge_resp.status_code == 200, acknowledge_resp.text
-        assert acknowledge_resp.json() == {"status": "ok", "id": alert_id}
+        acknowledge_payload = acknowledge_resp.json()
+        assert acknowledge_payload["status"] == "ok"
+        assert acknowledge_payload["id"] == alert_id
+        assert acknowledge_payload["item"]["id"] == alert_id
+        assert acknowledge_payload["item"]["alert_identity"] == f"alert:{alert_id}"
+        assert acknowledge_payload["item"]["is_read"] is True
+        assert acknowledge_payload["item"]["acknowledged_at"] is not None
+        assert acknowledge_payload["item"]["assigned_to_user_id"] == 1
 
         dismiss_resp = client.delete(f"/api/v1/monitoring/alerts/{alert_id}")
         assert dismiss_resp.status_code == 200, dismiss_resp.text
-        assert dismiss_resp.json() == {"status": "ok", "id": alert_id}
+        dismiss_payload = dismiss_resp.json()
+        assert dismiss_payload["status"] == "ok"
+        assert dismiss_payload["id"] == alert_id
+        assert dismiss_payload["item"]["id"] == alert_id
+        assert dismiss_payload["item"]["alert_identity"] == f"alert:{alert_id}"
+        assert dismiss_payload["item"]["is_read"] is True
+        assert dismiss_payload["item"]["acknowledged_at"] is not None
+        assert dismiss_payload["item"]["dismissed_at"] is not None
 
         refreshed_resp = client.get("/api/v1/monitoring/alerts")
         assert refreshed_resp.status_code == 200, refreshed_resp.text
@@ -114,5 +138,6 @@ async def test_monitoring_alerts_include_backend_overlay_and_authoritative_actio
         )
         assert history_resp.status_code == 200, history_resp.text
         actions = [item["action"] for item in history_resp.json()["items"]]
+        assert "read" in actions
         assert "acknowledged" in actions
         assert "dismissed" in actions

--- a/tldw_Server_API/tests/Monitoring/test_monitoring_alert_metadata.py
+++ b/tldw_Server_API/tests/Monitoring/test_monitoring_alert_metadata.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints.monitoring import _decode_alert_metadata
+
+
+@pytest.mark.parametrize(
+    ("raw_metadata", "expected_metadata"),
+    [
+        ("", None),
+        ("null", None),
+        ('{"host": "api-1"}', {"host": "api-1"}),
+        ('["tag-a", "tag-b"]', {"value": ["tag-a", "tag-b"]}),
+        ("not-json", {"raw": "not-json"}),
+    ],
+)
+def test_decode_alert_metadata_normalizes_runtime_database_values(
+    raw_metadata: object,
+    expected_metadata: object,
+) -> None:
+    decoded = _decode_alert_metadata({"id": 1, "metadata": raw_metadata})
+
+    assert decoded["metadata"] == expected_metadata  # nosec B101

--- a/tldw_Server_API/tests/Monitoring/test_monitoring_contract_schema.py
+++ b/tldw_Server_API/tests/Monitoring/test_monitoring_contract_schema.py
@@ -5,13 +5,14 @@ from tldw_Server_API.app.api.v1.schemas.monitoring_schemas import MarkReadRespon
 
 def test_mark_read_response_schema_describes_minimal_mutation_contract() -> None:
     schema = MarkReadResponse.model_json_schema()
-    assert set(schema["properties"]) == {"status", "id"}
-    assert set(schema["required"]) == {"status", "id"}
+    assert set(schema["properties"]) == {"status", "id", "item"}
+    assert set(schema["required"]) == {"status", "id", "item"}
 
     status_description = schema["properties"]["status"]["description"].lower()
     id_description = schema["properties"]["id"]["description"].lower()
+    item_description = schema["properties"]["item"]["description"].lower()
 
-    assert "minimal mutation acknowledgement" in status_description
-    assert "re-list alerts" in status_description
+    assert "mutation succeeded" in status_description
     assert "authoritative merged state" in status_description
     assert "runtime alert row id" in id_description
+    assert "authoritative merged alert state" in item_description

--- a/tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py
+++ b/tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py
@@ -14,9 +14,11 @@ def test_monitoring_docs_describe_current_notification_contract() -> None:
     lowered_product = product_doc.lower()
     assert "best-effort webhook/email attempts" in lowered_product
     assert "generic notifications use the jsonl sink plus optional webhook dispatch" in lowered_product
-    assert "re-list alerts for authoritative merged state" in lowered_product
+    assert "mutation responses include the authoritative merged alert state" in lowered_product
+    assert "`read` marks the runtime alert as read without setting `acknowledged_at`" in lowered_product
 
     lowered_readme = readme_doc.lower()
     assert "generic notifications only use the jsonl sink plus optional webhook dispatch" in lowered_readme
     assert "`flush_digest()` currently clears buffered items and returns the count only" in lowered_readme
-    assert "re-list alerts for authoritative merged state" in lowered_readme
+    assert "public alert mutation endpoints return the authoritative merged alert state" in lowered_readme
+    assert "`acknowledge` records `acknowledged_at`" in lowered_readme


### PR DESCRIPTION
## Change summary

Public monitoring alert mutation endpoints now return the authoritative merged alert state in the mutation response, so clients no longer need to perform an immediate re-list to see backend overlay fields after a read, acknowledge, or dismiss action.

This keeps runtime alert state and admin overlay state distinct:

- `read` marks the runtime alert as read and records a `read` history/audit action without setting `acknowledged_at`.
- `acknowledge` marks the alert read, records `acknowledged_at`, and records an `acknowledged` action.
- `dismiss` marks the alert read, records `dismissed_at`, and records a `dismissed` action.

Docs and schema-contract tests were updated to describe the new `{status, id, item}` response contract.

Closes #1030

## Verification

- Red step before implementation: targeted mutation/schema tests failed because responses lacked `item`.
- `python -m pytest tldw_Server_API/tests/Admin/test_monitoring_alerts_overlay_integration.py tldw_Server_API/tests/Monitoring/test_monitoring_contract_schema.py tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py -v` -> 3 passed.
- `python -m pytest tldw_Server_API/tests/Admin/test_admin_monitoring_alerts_service.py tldw_Server_API/tests/Admin/test_admin_monitoring_api.py tldw_Server_API/tests/Admin/test_admin_monitoring_overlay_diagnostics.py tldw_Server_API/tests/Monitoring/test_monitoring_contract_schema.py tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py -v` -> 13 passed.
- `git diff --check` -> passed.
- `python -m compileall tldw_Server_API/app/api/v1/endpoints/monitoring.py tldw_Server_API/app/api/v1/schemas/monitoring_schemas.py` -> passed.
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/monitoring.py tldw_Server_API/app/api/v1/schemas/monitoring_schemas.py -f json -o /tmp/bandit_monitoring_alert_mutation.json` -> 0 findings.

Known unrelated verification note: including `tldw_Server_API/tests/Admin/test_admin_split_openapi_contract.py` in the broader adjacent batch timed out while exiting `TestClient(app)` during app startup/shutdown cleanup. The timeout stack points at background startup services/threads, not at this monitoring alert mutation contract.

## Merge note

This is materially AI-authored. Per repo policy, a human-written Change summary is required before merge.
