### PR TITLE
Require runtime-backed monitoring overlay identities

### DIFF
--- a/Docs/Product/Completed/Topic_Monitoring_Watchlists.md
+++ b/Docs/Product/Completed/Topic_Monitoring_Watchlists.md
@@ -118,6 +118,11 @@ Monitoring emits alerts without changing moderation behavior or endpoint results
 - `acknowledge` marks the runtime alert as read and records `acknowledged_at`.
 - `dismiss` marks the runtime alert as read and records `dismissed_at`.
 
+## Admin Overlay Identity Contract
+- Admin overlay mutation endpoints (`assign`, `snooze`, and `escalate`) only accept runtime-backed `alert:<id>` identities.
+- The referenced runtime alert row must exist in the monitoring alerts database before overlay state or history events are written.
+- Overlay-only identities such as `fingerprint:*` are not a public mutation contract; operators should create or locate the runtime alert first, then mutate its `alert:<id>` identity.
+
 ## Phase 2 (planned)
 - Delivery channels: email, webhook, Slack.
 - WebSocket push to WebUI for admins.

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_monitoring.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_monitoring.py
@@ -148,43 +148,45 @@ def _event_response_from_row(row: dict[str, Any]) -> AdminAlertEventResponse:
     )
 
 
-def _warn_if_overlay_identity_has_no_runtime_row(
+def _require_runtime_alert_identity(
     alert_identity: str,
     monitoring_db: TopicMonitoringDB,
-) -> None:
+) -> int:
+    """Validate that an admin overlay mutation targets an existing runtime alert."""
     if not alert_identity.startswith(_RUNTIME_ALERT_ID_PREFIX):
-        logger.info("monitoring admin overlay mutation for overlay-only identity {}", alert_identity)
-        return
+        raise HTTPException(status_code=422, detail="unsupported_alert_identity")
 
     raw_alert_id = alert_identity[len(_RUNTIME_ALERT_ID_PREFIX) :]
     try:
         alert_id = int(raw_alert_id)
     except ValueError:
-        logger.warning(
-            "monitoring admin overlay mutation uses malformed runtime alert identity {}",
-            alert_identity,
-        )
-        return
+        raise HTTPException(status_code=422, detail="malformed_alert_identity") from None
 
     if monitoring_db.get_alert(alert_id) is None:
-        logger.warning(
-            "monitoring admin overlay mutation references missing runtime alert {}",
-            alert_identity,
-        )
+        raise HTTPException(status_code=404, detail="unknown_alert")
+
+    return alert_id
 
 
-async def _emit_overlay_identity_diagnostic(alert_identity: str) -> None:
-    try:
-        monitoring_db = TopicMonitoringDB(_resolve_monitoring_alerts_db_path())
-        await asyncio.to_thread(
-            _warn_if_overlay_identity_has_no_runtime_row,
-            alert_identity,
-            monitoring_db,
-        )
-    except asyncio.CancelledError:
-        raise
-    except _MONITORING_NONCRITICAL_EXCEPTIONS:
-        logger.debug("monitoring overlay diagnostic skipped")
+async def _get_runtime_alerts_db() -> TopicMonitoringDB:
+    """Return the runtime monitoring alerts DB without blocking the event loop."""
+    return await asyncio.to_thread(
+        TopicMonitoringDB,
+        _resolve_monitoring_alerts_db_path(),
+    )
+
+
+async def _require_runtime_alert_identity_for_mutation(
+    alert_identity: str,
+    monitoring_db: TopicMonitoringDB,
+) -> str:
+    """Validate an overlay mutation target and return its canonical alert identity."""
+    alert_id = await asyncio.to_thread(
+        _require_runtime_alert_identity,
+        alert_identity,
+        monitoring_db,
+    )
+    return f"{_RUNTIME_ALERT_ID_PREFIX}{alert_id}"
 
 
 @router.on_event("startup")
@@ -297,15 +299,19 @@ async def assign_alert(
     payload: AdminAlertAssignRequest,
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
+    runtime_alerts_db: TopicMonitoringDB = Depends(_get_runtime_alerts_db),  # noqa: B008
 ) -> AdminAlertStateMutationResponse:
-    """Assign or unassign a monitoring alert in authoritative overlay state."""
+    """Assign or unassign a runtime-backed monitoring alert in authoritative overlay state."""
     try:
         if payload.assigned_to_user_id is not None:
             users_repo = await _get_users_repo()
             assignee = await users_repo.get_user_by_id(payload.assigned_to_user_id)
             if assignee is None:
                 raise HTTPException(status_code=404, detail="unknown_user")
-        await _emit_overlay_identity_diagnostic(alert_identity)
+        canonical_alert_identity = await _require_runtime_alert_identity_for_mutation(
+            alert_identity,
+            runtime_alerts_db,
+        )
         repo = await _get_monitoring_repo()
         actor_id = _principal_actor_id(principal)
         event_action = "assigned" if payload.assigned_to_user_id is not None else "unassigned"
@@ -313,12 +319,12 @@ async def assign_alert(
             "monitoring.alert.assign" if payload.assigned_to_user_id is not None else "monitoring.alert.unassign"
         )
         state = await repo.upsert_alert_state(
-            alert_identity=alert_identity,
+            alert_identity=canonical_alert_identity,
             assigned_to_user_id=payload.assigned_to_user_id,
             updated_by_user_id=actor_id,
         )
         await repo.append_alert_event(
-            alert_identity=alert_identity,
+            alert_identity=canonical_alert_identity,
             action=event_action,
             actor_user_id=actor_id,
             details_json=json.dumps({"assigned_to_user_id": payload.assigned_to_user_id}),
@@ -329,7 +335,7 @@ async def assign_alert(
             event_type="data.update",
             category="system",
             resource_type="monitoring_alert",
-            resource_id=alert_identity,
+            resource_id=canonical_alert_identity,
             action=audit_action,
             metadata={"assigned_to_user_id": payload.assigned_to_user_id},
         )
@@ -349,19 +355,23 @@ async def snooze_alert(
     payload: AdminAlertSnoozeRequest,
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
+    runtime_alerts_db: TopicMonitoringDB = Depends(_get_runtime_alerts_db),  # noqa: B008
 ) -> AdminAlertStateMutationResponse:
-    """Snooze a monitoring alert in authoritative overlay state."""
+    """Snooze a runtime-backed monitoring alert in authoritative overlay state."""
     try:
-        await _emit_overlay_identity_diagnostic(alert_identity)
+        canonical_alert_identity = await _require_runtime_alert_identity_for_mutation(
+            alert_identity,
+            runtime_alerts_db,
+        )
         repo = await _get_monitoring_repo()
         actor_id = _principal_actor_id(principal)
         state = await repo.upsert_alert_state(
-            alert_identity=alert_identity,
+            alert_identity=canonical_alert_identity,
             snoozed_until=payload.snoozed_until.isoformat(),
             updated_by_user_id=actor_id,
         )
         await repo.append_alert_event(
-            alert_identity=alert_identity,
+            alert_identity=canonical_alert_identity,
             action="snoozed",
             actor_user_id=actor_id,
             details_json=json.dumps({"snoozed_until": payload.snoozed_until.isoformat()}),
@@ -372,7 +382,7 @@ async def snooze_alert(
             event_type="data.update",
             category="system",
             resource_type="monitoring_alert",
-            resource_id=alert_identity,
+            resource_id=canonical_alert_identity,
             action="monitoring.alert.snooze",
             metadata={"snoozed_until": payload.snoozed_until.isoformat()},
         )
@@ -392,19 +402,23 @@ async def escalate_alert(
     payload: AdminAlertEscalateRequest,
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
+    runtime_alerts_db: TopicMonitoringDB = Depends(_get_runtime_alerts_db),  # noqa: B008
 ) -> AdminAlertStateMutationResponse:
-    """Escalate a monitoring alert in authoritative overlay state."""
+    """Escalate a runtime-backed monitoring alert in authoritative overlay state."""
     try:
-        await _emit_overlay_identity_diagnostic(alert_identity)
+        canonical_alert_identity = await _require_runtime_alert_identity_for_mutation(
+            alert_identity,
+            runtime_alerts_db,
+        )
         repo = await _get_monitoring_repo()
         actor_id = _principal_actor_id(principal)
         state = await repo.upsert_alert_state(
-            alert_identity=alert_identity,
+            alert_identity=canonical_alert_identity,
             escalated_severity=payload.severity,
             updated_by_user_id=actor_id,
         )
         await repo.append_alert_event(
-            alert_identity=alert_identity,
+            alert_identity=canonical_alert_identity,
             action="escalated",
             actor_user_id=actor_id,
             details_json=json.dumps({"severity": payload.severity}),
@@ -415,7 +429,7 @@ async def escalate_alert(
             event_type="data.update",
             category="system",
             resource_type="monitoring_alert",
-            resource_id=alert_identity,
+            resource_id=canonical_alert_identity,
             action="monitoring.alert.escalate",
             metadata={"severity": payload.severity},
         )

--- a/tldw_Server_API/app/core/Monitoring/README.md
+++ b/tldw_Server_API/app/core/Monitoring/README.md
@@ -79,5 +79,6 @@
   - Webhook/email sends are best‑effort and may be disabled in restricted environments; rely on JSONL for auditability.
   - Public alert mutation endpoints return the authoritative merged alert state in `{status, id, item}`.
   - `read` marks the runtime alert as read without setting `acknowledged_at`; `acknowledge` records `acknowledged_at`; `dismiss` records `dismissed_at`.
+  - Admin overlay mutation endpoints require runtime-backed `alert:<id>` identities; overlay-only identities are rejected before state or history events are written.
   - Large texts are truncated for scanning; test your rules with realistic snippets.
   - Regex complexity can impact performance; prefer literals or well‑scoped regexes.

--- a/tldw_Server_API/tests/Admin/test_admin_monitoring_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_monitoring_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import uuid
 
@@ -32,6 +33,32 @@ async def _seed_assignable_user() -> int:
     return int(user_id)
 
 
+def _seed_runtime_alert(alerts_db_path: str) -> int:
+    """Seed one runtime alert so admin overlay mutation tests target a real row."""
+    from tldw_Server_API.app.core.DB_Management.TopicMonitoring_DB import (
+        TopicAlert,
+        TopicMonitoringDB,
+    )
+
+    monitoring_db = TopicMonitoringDB(alerts_db_path)
+    return monitoring_db.insert_alert(
+        TopicAlert(
+            user_id="1",
+            scope_type="user",
+            scope_id="1",
+            source="watchlist",
+            watchlist_id="watch-1",
+            rule_id="rule-1",
+            rule_category="system",
+            rule_severity="warning",
+            pattern="CPU high",
+            text_snippet="CPU sustained at 92%",
+            metadata={"host": "api-1"},
+            created_at="2026-03-10T10:00:00Z",
+        )
+    )
+
+
 @pytest.mark.asyncio
 async def test_admin_monitoring_rules_and_actions(tmp_path) -> None:
     _setup_env(tmp_path)
@@ -42,6 +69,9 @@ async def test_admin_monitoring_rules_and_actions(tmp_path) -> None:
     from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 
     os.environ["MONITORING_ALERTS_DB"] = str(tmp_path / "monitoring_alerts.db")
+    alert_id = await asyncio.to_thread(_seed_runtime_alert, os.environ["MONITORING_ALERTS_DB"])
+    alert_identity = f"alert:{alert_id}"
+    noncanonical_alert_identity = f"alert:{str(alert_id).zfill(len(str(alert_id)) + 2)}"
 
     await reset_db_pool()
     reset_settings()
@@ -72,40 +102,48 @@ async def test_admin_monitoring_rules_and_actions(tmp_path) -> None:
         assert any(item["id"] == rule_id for item in list_rules_resp.json()["items"])
 
         assign_resp = client.post(
-            "/api/v1/admin/monitoring/alerts/alert:7/assign",
+            f"/api/v1/admin/monitoring/alerts/{noncanonical_alert_identity}/assign",
             json={"assigned_to_user_id": assignee_id},
         )
         assert assign_resp.status_code == 200, assign_resp.text
+        assert assign_resp.json()["item"]["alert_identity"] == alert_identity
         assert assign_resp.json()["item"]["assigned_to_user_id"] == assignee_id
 
         unassign_resp = client.post(
-            "/api/v1/admin/monitoring/alerts/alert:7/assign",
+            f"/api/v1/admin/monitoring/alerts/{noncanonical_alert_identity}/assign",
             json={"assigned_to_user_id": None},
         )
         assert unassign_resp.status_code == 200, unassign_resp.text
+        assert unassign_resp.json()["item"]["alert_identity"] == alert_identity
         assert unassign_resp.json()["item"]["assigned_to_user_id"] is None
 
         snooze_resp = client.post(
-            "/api/v1/admin/monitoring/alerts/alert:7/snooze",
+            f"/api/v1/admin/monitoring/alerts/{noncanonical_alert_identity}/snooze",
             json={"snoozed_until": "2026-03-10T11:00:00Z"},
         )
         assert snooze_resp.status_code == 200, snooze_resp.text
+        assert snooze_resp.json()["item"]["alert_identity"] == alert_identity
         assert snooze_resp.json()["item"]["snoozed_until"] == "2026-03-10T11:00:00Z"
 
         escalate_resp = client.post(
-            "/api/v1/admin/monitoring/alerts/alert:7/escalate",
+            f"/api/v1/admin/monitoring/alerts/{noncanonical_alert_identity}/escalate",
             json={"severity": "critical"},
         )
         assert escalate_resp.status_code == 200, escalate_resp.text
+        assert escalate_resp.json()["item"]["alert_identity"] == alert_identity
         assert escalate_resp.json()["item"]["escalated_severity"] == "critical"
 
         public_alerts_resp = client.get("/api/v1/monitoring/alerts")
         assert public_alerts_resp.status_code == 200, public_alerts_resp.text
-        assert all(item["alert_identity"] != "alert:7" for item in public_alerts_resp.json()["items"])
+        public_items = public_alerts_resp.json()["items"]
+        public_item = next(item for item in public_items if item["alert_identity"] == alert_identity)
+        assert public_item["assigned_to_user_id"] is None
+        assert public_item["snoozed_until"] == "2026-03-10T11:00:00+00:00"
+        assert public_item["escalated_severity"] == "critical"
 
         history_resp = client.get(
             "/api/v1/admin/monitoring/alerts/history",
-            params={"alert_identity": "alert:7"},
+            params={"alert_identity": alert_identity},
         )
         assert history_resp.status_code == 200, history_resp.text
         assert [item["action"] for item in history_resp.json()["items"][:4]] == [
@@ -114,6 +152,28 @@ async def test_admin_monitoring_rules_and_actions(tmp_path) -> None:
             "unassigned",
             "assigned",
         ]
+
+        snooze_payload = {"snoozed_until": "2026-03-10T11:00:00Z"}
+        overlay_only_resp = client.post(
+            "/api/v1/admin/monitoring/alerts/fingerprint:abc/snooze",
+            json=snooze_payload,
+        )
+        assert overlay_only_resp.status_code == 422, overlay_only_resp.text
+        assert overlay_only_resp.json()["detail"] == "unsupported_alert_identity"
+
+        malformed_resp = client.post(
+            "/api/v1/admin/monitoring/alerts/alert:not-an-int/snooze",
+            json=snooze_payload,
+        )
+        assert malformed_resp.status_code == 422, malformed_resp.text
+        assert malformed_resp.json()["detail"] == "malformed_alert_identity"
+
+        missing_runtime_resp = client.post(
+            "/api/v1/admin/monitoring/alerts/alert:404/snooze",
+            json=snooze_payload,
+        )
+        assert missing_runtime_resp.status_code == 404, missing_runtime_resp.text
+        assert missing_runtime_resp.json()["detail"] == "unknown_alert"
 
         delete_resp = client.delete(f"/api/v1/admin/monitoring/alert-rules/{rule_id}")
         assert delete_resp.status_code == 200, delete_resp.text

--- a/tldw_Server_API/tests/Admin/test_admin_monitoring_overlay_diagnostics.py
+++ b/tldw_Server_API/tests/Admin/test_admin_monitoring_overlay_diagnostics.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from tldw_Server_API.app.api.v1.endpoints.admin import admin_monitoring as admin_monitoring_mod
 
@@ -37,74 +38,50 @@ class _StubMonitoringDb:
         return self.row
 
 
-def test_warn_if_runtime_alert_identity_missing_logs_warning(monkeypatch) -> None:
+def test_require_runtime_alert_identity_rejects_missing_runtime_row() -> None:
     db = _StubMonitoringDb(row=None)
-    warnings: list[str] = []
-    monkeypatch.setattr(
-        admin_monitoring_mod.logger,
-        "warning",
-        lambda message, *args, **kwargs: warnings.append(str(message)),
-    )
 
-    admin_monitoring_mod._warn_if_overlay_identity_has_no_runtime_row("alert:77", db)
+    with pytest.raises(HTTPException) as exc_info:
+        admin_monitoring_mod._require_runtime_alert_identity("alert:77", db)
 
     assert db.lookups == [77]
-    assert any("missing runtime alert" in msg for msg in warnings)
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "unknown_alert"
 
 
-def test_warn_if_overlay_only_identity_logs_info_without_lookup(monkeypatch) -> None:
+def test_require_runtime_alert_identity_rejects_overlay_only_identity() -> None:
     db = _StubMonitoringDb(row=None)
-    infos: list[str] = []
-    monkeypatch.setattr(
-        admin_monitoring_mod.logger,
-        "info",
-        lambda message, *args, **kwargs: infos.append(str(message)),
-    )
 
-    admin_monitoring_mod._warn_if_overlay_identity_has_no_runtime_row("fingerprint:abc", db)
+    with pytest.raises(HTTPException) as exc_info:
+        admin_monitoring_mod._require_runtime_alert_identity("fingerprint:abc", db)
 
     assert db.lookups == []
-    assert any("overlay-only identity" in msg for msg in infos)
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "unsupported_alert_identity"
 
 
-def test_warn_if_malformed_runtime_alert_identity_logs_warning(monkeypatch) -> None:
+def test_require_runtime_alert_identity_rejects_malformed_runtime_identity() -> None:
     db = _StubMonitoringDb(row=None)
-    warnings: list[str] = []
-    monkeypatch.setattr(
-        admin_monitoring_mod.logger,
-        "warning",
-        lambda message, *args, **kwargs: warnings.append(str(message)),
-    )
 
-    admin_monitoring_mod._warn_if_overlay_identity_has_no_runtime_row("alert:not-an-int", db)
+    with pytest.raises(HTTPException) as exc_info:
+        admin_monitoring_mod._require_runtime_alert_identity("alert:not-an-int", db)
 
     assert db.lookups == []
-    assert any("malformed runtime alert identity" in msg for msg in warnings)
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "malformed_alert_identity"
 
 
 @pytest.mark.asyncio
-async def test_emit_overlay_identity_diagnostic_sanitizes_skip_log(monkeypatch) -> None:
-    debug_records: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+async def test_require_runtime_alert_identity_for_mutation_returns_canonical_identity() -> None:
+    db = _StubMonitoringDb(row={"id": 7})
 
-    def _raise_path_resolution() -> str:
-        raise RuntimeError("monitoring backend exploded at /private/monitoring.db")
-
-    monkeypatch.setattr(
-        admin_monitoring_mod,
-        "_resolve_monitoring_alerts_db_path",
-        _raise_path_resolution,
-    )
-    monkeypatch.setattr(
-        admin_monitoring_mod.logger,
-        "debug",
-        lambda message, *args, **kwargs: debug_records.append((str(message), args, kwargs)),
+    canonical_identity = await admin_monitoring_mod._require_runtime_alert_identity_for_mutation(
+        "alert:007",
+        db,
     )
 
-    await admin_monitoring_mod._emit_overlay_identity_diagnostic(
-        "alert:private-alert-id",
-    )
-
-    assert debug_records == [("monitoring overlay diagnostic skipped", (), {})]
+    assert canonical_identity == "alert:7"
+    assert db.lookups == [7]
 
 
 @pytest.mark.asyncio
@@ -243,7 +220,7 @@ async def test_assign_alert_sanitizes_backend_error_log(monkeypatch) -> None:
 
     class _Repo:
         async def upsert_alert_state(self, **kwargs):
-            assert kwargs["alert_identity"] == "alert:private-assign"
+            assert kwargs["alert_identity"] == "alert:7"
             assert kwargs["assigned_to_user_id"] == 123
             raise RuntimeError("monitoring assign failed at /private/admin-monitoring.db")
 
@@ -253,27 +230,24 @@ async def test_assign_alert_sanitizes_backend_error_log(monkeypatch) -> None:
     async def _fake_get_monitoring_repo():
         return _Repo()
 
-    async def _noop_overlay_diagnostic(alert_identity: str) -> None:
-        assert alert_identity == "alert:private-assign"
-
     logger_stub = _LoggerStub()
     monkeypatch.setattr(admin_monitoring_mod, "_get_users_repo", _fake_get_users_repo)
     monkeypatch.setattr(admin_monitoring_mod, "_get_monitoring_repo", _fake_get_monitoring_repo)
-    monkeypatch.setattr(admin_monitoring_mod, "_emit_overlay_identity_diagnostic", _noop_overlay_diagnostic)
     monkeypatch.setattr(admin_monitoring_mod, "logger", logger_stub)
 
     with pytest.raises(admin_monitoring_mod.HTTPException) as exc_info:
         await admin_monitoring_mod.assign_alert(
-            alert_identity="alert:private-assign",
+            alert_identity="alert:007",
             payload=AdminAlertAssignRequest(assigned_to_user_id=123),
             request=SimpleNamespace(),
             principal=SimpleNamespace(user_id=7),
+            runtime_alerts_db=_StubMonitoringDb(row={"id": 7}),
         )
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Failed to assign alert"
     assert logger_stub.errors == ["Failed to assign monitoring alert"]
-    assert "alert:private-assign" not in str(logger_stub.errors)
+    assert "alert:007" not in str(logger_stub.errors)
     assert "123" not in str(logger_stub.errors)
     assert "monitoring assign failed" not in str(logger_stub.errors)
     assert "/private/admin-monitoring.db" not in str(logger_stub.errors)
@@ -287,33 +261,30 @@ async def test_snooze_alert_sanitizes_backend_error_log(monkeypatch) -> None:
 
     class _Repo:
         async def upsert_alert_state(self, **kwargs):
-            assert kwargs["alert_identity"] == "alert:private-snooze"
+            assert kwargs["alert_identity"] == "alert:8"
             assert kwargs["snoozed_until"] == snoozed_until.isoformat()
             raise RuntimeError("monitoring snooze failed at /private/admin-monitoring.db")
 
     async def _fake_get_monitoring_repo():
         return _Repo()
 
-    async def _noop_overlay_diagnostic(alert_identity: str) -> None:
-        assert alert_identity == "alert:private-snooze"
-
     logger_stub = _LoggerStub()
     monkeypatch.setattr(admin_monitoring_mod, "_get_monitoring_repo", _fake_get_monitoring_repo)
-    monkeypatch.setattr(admin_monitoring_mod, "_emit_overlay_identity_diagnostic", _noop_overlay_diagnostic)
     monkeypatch.setattr(admin_monitoring_mod, "logger", logger_stub)
 
     with pytest.raises(admin_monitoring_mod.HTTPException) as exc_info:
         await admin_monitoring_mod.snooze_alert(
-            alert_identity="alert:private-snooze",
+            alert_identity="alert:008",
             payload=AdminAlertSnoozeRequest(snoozed_until=snoozed_until),
             request=SimpleNamespace(),
             principal=SimpleNamespace(user_id=7),
+            runtime_alerts_db=_StubMonitoringDb(row={"id": 8}),
         )
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Failed to snooze alert"
     assert logger_stub.errors == ["Failed to snooze monitoring alert"]
-    assert "alert:private-snooze" not in str(logger_stub.errors)
+    assert "alert:008" not in str(logger_stub.errors)
     assert snoozed_until.isoformat() not in str(logger_stub.errors)
     assert "monitoring snooze failed" not in str(logger_stub.errors)
     assert "/private/admin-monitoring.db" not in str(logger_stub.errors)
@@ -325,33 +296,39 @@ async def test_escalate_alert_sanitizes_backend_error_log(monkeypatch) -> None:
 
     class _Repo:
         async def upsert_alert_state(self, **kwargs):
-            assert kwargs["alert_identity"] == "alert:private-escalate"
+            assert kwargs["alert_identity"] == "alert:9"
             assert kwargs["escalated_severity"] == "critical"
             raise RuntimeError("monitoring escalate failed at /private/admin-monitoring.db")
 
     async def _fake_get_monitoring_repo():
         return _Repo()
 
-    async def _noop_overlay_diagnostic(alert_identity: str) -> None:
-        assert alert_identity == "alert:private-escalate"
-
     logger_stub = _LoggerStub()
     monkeypatch.setattr(admin_monitoring_mod, "_get_monitoring_repo", _fake_get_monitoring_repo)
-    monkeypatch.setattr(admin_monitoring_mod, "_emit_overlay_identity_diagnostic", _noop_overlay_diagnostic)
     monkeypatch.setattr(admin_monitoring_mod, "logger", logger_stub)
 
     with pytest.raises(admin_monitoring_mod.HTTPException) as exc_info:
         await admin_monitoring_mod.escalate_alert(
-            alert_identity="alert:private-escalate",
+            alert_identity="alert:009",
             payload=AdminAlertEscalateRequest(severity="critical"),
             request=SimpleNamespace(),
             principal=SimpleNamespace(user_id=7),
+            runtime_alerts_db=_StubMonitoringDb(row={"id": 9}),
         )
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Failed to escalate alert"
     assert logger_stub.errors == ["Failed to escalate monitoring alert"]
-    assert "alert:private-escalate" not in str(logger_stub.errors)
+    assert "alert:009" not in str(logger_stub.errors)
     assert "critical" not in str(logger_stub.errors)
     assert "monitoring escalate failed" not in str(logger_stub.errors)
     assert "/private/admin-monitoring.db" not in str(logger_stub.errors)
+
+
+def test_require_runtime_alert_identity_accepts_existing_runtime_row() -> None:
+    db = _StubMonitoringDb(row={"id": 77})
+
+    alert_id = admin_monitoring_mod._require_runtime_alert_identity("alert:77", db)
+
+    assert alert_id == 77
+    assert db.lookups == [77]


### PR DESCRIPTION
## Change summary

Admin monitoring overlay mutations now have an explicit runtime-backed identity contract. The public admin mutation endpoints for assign, snooze, and escalate only accept `alert:<id>` identities when that runtime alert row exists in the monitoring alerts database.

Unsupported overlay-only identities such as `fingerprint:*` are rejected with `422 unsupported_alert_identity`; malformed `alert:*` identities are rejected with `422 malformed_alert_identity`; missing runtime rows return `404 unknown_alert`. This keeps persisted overlay state aligned with the runtime alert list that public monitoring reads can actually merge and display.

Docs now state that overlay-only identities are not a public mutation contract. Tests seed a real runtime alert for successful admin overlay mutations, verify the public alert list receives the merged overlay state, and cover the rejection paths.

Closes #1027

## Verification

- Red step before implementation: focused admin tests failed because `_require_runtime_alert_identity` did not exist and the current API accepted non-runtime overlay writes.
- `python -m pytest tldw_Server_API/tests/Admin/test_admin_monitoring_api.py tldw_Server_API/tests/Admin/test_admin_monitoring_overlay_diagnostics.py -v` -> 5 passed.
- `python -m pytest tldw_Server_API/tests/Admin/test_monitoring_alerts_overlay_integration.py -v` -> 1 passed.
- `python -m pytest tldw_Server_API/tests/Admin/test_admin_monitoring_alerts_service.py tldw_Server_API/tests/Admin/test_admin_monitoring_repo.py -v` -> 6 passed.
- `python -m pytest tldw_Server_API/tests/Admin/test_admin_e2e_support_api.py::test_admin_e2e_reset_clears_monitoring_authority_state -v` -> 1 passed.
- `python -m pytest tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py -v` -> 1 passed.
- `git diff --check` and `git diff --cached --check` -> passed.
- `python -m compileall tldw_Server_API/app/api/v1/endpoints/admin/admin_monitoring.py` -> passed.
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/admin/admin_monitoring.py -f json -o /tmp/bandit_monitoring_overlay_identity.json` -> 0 findings.

Known unrelated verification note: running several full-app TestClient-heavy admin monitoring tests in one pytest process timed out in TestClient teardown after earlier tests had passed. The same integration test passed when run alone, and the timeout stack is in app startup/shutdown background infrastructure rather than this overlay identity validation path.

## Merge note

This is materially AI-authored. Per repo policy, a human-written Change summary is required before merge.
