### PR TITLE
Clarify monitoring permission boundary

### DIFF
--- a/Docs/Product/Completed/Topic_Monitoring_Watchlists.md
+++ b/Docs/Product/Completed/Topic_Monitoring_Watchlists.md
@@ -7,7 +7,7 @@ Goal: Provide a configurable, privacy-respecting content monitoring feature that
 - Scopes: global (all users), per-user; basic support for per-team and per-org when caller provides membership.
 - Integration points: chat input and output; ingestion; notes (create/update/bulk); RAG search (unified/simple/advanced). Hooks emit alerts but NEVER block content.
 - Alert storage and retrieval API with mark-as-read.
-- Admin endpoints to manage watchlists and list alerts.
+- Operational endpoints to manage watchlists and list alerts, gated by monitoring permissions.
 
 ## Non-Goals (Phase 1)
 - Email/SMS/Slack/webhook delivery (planned in Phase 2).
@@ -65,14 +65,19 @@ Goal: Provide a configurable, privacy-respecting content monitoring feature that
 - Config (optional): `tldw_Server_API/Config_Files/monitoring_watchlists.json`
 
 ## API Endpoints (Phase 1)
-- `GET  /api/v1/monitoring/watchlists`        list watchlists (admin)
-- `POST /api/v1/monitoring/watchlists`        create/update watchlist (admin)
-- `DELETE /api/v1/monitoring/watchlists/{id}` delete watchlist (admin)
-- `GET  /api/v1/monitoring/alerts`            list alerts (admin; filters: user_id, since, unread)
-- `POST /api/v1/monitoring/alerts/{id}/read`  mark alert as read (admin)
-- `POST /api/v1/monitoring/alerts/{id}/acknowledge` acknowledge alert (admin)
-- `DELETE /api/v1/monitoring/alerts/{id}` dismiss alert (admin)
-- `POST /api/v1/monitoring/reload`            reload config file (admin)
+- `GET  /api/v1/monitoring/watchlists`        list watchlists (requires `system.logs`)
+- `POST /api/v1/monitoring/watchlists`        create/update watchlist (requires `system.logs`)
+- `DELETE /api/v1/monitoring/watchlists/{id}` delete watchlist (requires `system.logs`)
+- `GET  /api/v1/monitoring/alerts`            list alerts (requires `system.logs`; filters: user_id, since, unread)
+- `POST /api/v1/monitoring/alerts/{id}/read`  mark alert as read (requires `system.logs`)
+- `POST /api/v1/monitoring/alerts/{id}/acknowledge` acknowledge alert (requires `system.logs`)
+- `DELETE /api/v1/monitoring/alerts/{id}` dismiss alert (requires `system.logs`)
+- `POST /api/v1/monitoring/reload`            reload config file (requires `system.logs`)
+
+## Permission Model
+- `/api/v1/monitoring/*` routes require `system.logs`. These are operational monitoring routes under the non-`/admin` prefix, not anonymous or end-user public routes. Admin-role principals also pass through the shared AuthNZ admin bypass.
+- `/api/v1/admin/monitoring/*` routes inherit the admin role gate from the `/api/v1/admin` router. They are the control-plane surface for shared alert rules, overlay mutations, and alert history.
+- There is no unauthenticated public monitoring surface. Public monitoring means non-`/admin` prefix, not anonymous access.
 
 ## Reload Semantics (Phase 1)
 - Default mode is `upsert` only. No deletes or disables unless explicitly requested.
@@ -98,7 +103,7 @@ Monitoring emits alerts without changing moderation behavior or endpoint results
 - If a chunk is deduped, skip alert creation; otherwise store the similarity metrics in `metadata`.
 
 ## Security & Privacy
-- Admin-only APIs. Extend to org/team leads later.
+- Monitoring APIs are AuthNZ claim-gated. Extend to org/team leads later.
 - Opt-in via config or explicit creation of watchlists.
 - Store minimal snippets (e.g., first 200 chars around the match).
 - Local-first by default; webhook/email delivery is attempted only when operators configure those channels.

--- a/tldw_Server_API/app/core/Monitoring/README.md
+++ b/tldw_Server_API/app/core/Monitoring/README.md
@@ -2,11 +2,11 @@
 
 ## 1. Descriptive of Current Feature Set
 
-- Purpose: Topic Monitoring and lightweight notifications for watchlist‑based text scanning, plus admin APIs to manage watchlists and view alerts. (Metrics/tracing are covered in the Metrics module.)
+- Purpose: Topic Monitoring and lightweight notifications for watchlist‑based text scanning, plus operational APIs to manage watchlists and view alerts. (Metrics/tracing are covered in the Metrics module.)
 - Capabilities:
   - Topic Monitoring Service: scans text against configured watchlists; creates alerts; de‑duplicates within a time window; supports `global`/`user`/`team`/`org` scopes.
   - Notification Service (Phase 1): local‑first JSONL sink; optional webhook/email stubs with retries; severity threshold.
-  - Admin endpoints to CRUD watchlists, list/mark alerts, and inspect/update notification settings.
+  - Operational monitoring endpoints to CRUD watchlists, list/mark alerts, and inspect/update notification settings.
 - Inputs/Outputs:
   - Input: free‑text strings from various sources (chat input/output, ingestion summaries, notes, RAG results).
   - Output: persisted `topic_alerts` rows and JSONL notification records; optional webhook/email sends.
@@ -59,6 +59,11 @@
   - Alert metadata is JSON‑encoded/decoded with fallback on parse failures.
   - Admin endpoints use claim-first authorization (`get_auth_principal` + `RequireRole("admin")` / `RequirePermission(...)`) and validate inputs.
 
+- Permission Model
+  - `/api/v1/monitoring/*` routes require `system.logs`. These routes expose operational watchlist, alert, and notification APIs under the non-`/admin` prefix.
+  - `/api/v1/admin/monitoring/*` routes inherit the admin role gate from the parent admin router. Use this surface for shared alert-rule administration, overlay mutations, and alert history.
+  - Public monitoring means non-`/admin` prefix, not anonymous access. There is no unauthenticated public monitoring surface.
+
 ## 3. Developer-Related/Relevant Information for Contributors
 
 - Folder Structure
@@ -74,7 +79,9 @@
   - Metrics JSON/Prometheus shape (observability): tldw_Server_API/tests/Monitoring/test_metrics_endpoints.py:1
 - Local Dev Tips
   - Enable notifications locally with `MONITORING_NOTIFY_ENABLED=true` and set `MONITORING_NOTIFY_FILE` to a temp path to inspect JSONL.
-  - Use the admin APIs to manage watchlists; reload via `/api/v1/monitoring/reload` after file edits.
+  - Use `/api/v1/monitoring/*` APIs to manage watchlists, alerts, and notification settings with a principal that has the `system.logs` permission.
+  - Use `/api/v1/admin/monitoring/*` only for shared admin-only alert rules, overlay mutations, and alert history.
+  - In local AuthNZ tests, grant `SYSTEM_LOGS` from `tldw_Server_API.app.core.AuthNZ.permissions`; reload via `/api/v1/monitoring/reload` after file edits.
 - Pitfalls & Gotchas
   - Webhook/email sends are best‑effort and may be disabled in restricted environments; rely on JSONL for auditability.
   - Public alert mutation endpoints return the authoritative merged alert state in `{status, id, item}`.

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints import admin as admin_mod
 from tldw_Server_API.app.api.v1.endpoints import monitoring as monitoring_mod
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_LOGS
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
@@ -42,6 +43,18 @@ def _build_app_with_overrides(
 
     monitoring_mod.get_topic_monitoring_service = _fake_get_topic_monitoring_service  # type: ignore[assignment]
 
+    return app
+
+
+def _build_admin_app_with_overrides(principal: AuthPrincipal) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_mod.router, prefix="/api/v1")
+
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:  # type: ignore[override]
+        del request
+        return principal
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
     return app
 
 
@@ -109,3 +122,53 @@ async def test_monitoring_watchlists_200_for_admin_principal():
     assert resp.status_code == 200
     body = resp.json()
     assert body.get("watchlists") == []
+
+
+@pytest.mark.asyncio
+async def test_monitoring_watchlists_200_for_system_logs_principal():
+    principal = _make_principal(
+        is_admin=False,
+        roles=["user"],
+        permissions=[SYSTEM_LOGS],
+    )
+    app = _build_app_with_overrides(principal=principal)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/monitoring/watchlists")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("watchlists") == []
+
+
+@pytest.mark.asyncio
+async def test_monitoring_notification_settings_403_when_missing_system_logs_permission():
+    principal = _make_principal(
+        is_admin=False,
+        roles=["user"],
+        permissions=[],
+    )
+    app = _build_app_with_overrides(principal=principal)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/monitoring/notifications/settings")
+
+    assert resp.status_code == 403
+    detail = resp.json().get("detail", "")
+    assert SYSTEM_LOGS in detail
+
+
+@pytest.mark.asyncio
+async def test_admin_monitoring_routes_reject_system_logs_without_admin_role():
+    principal = _make_principal(
+        is_admin=False,
+        roles=["user"],
+        permissions=[SYSTEM_LOGS],
+    )
+    app = _build_admin_app_with_overrides(principal)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/admin/monitoring/alert-rules")
+
+    assert resp.status_code == 403
+    assert "Required role" in resp.json().get("detail", "")

--- a/tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py
+++ b/tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py
@@ -16,9 +16,33 @@ def test_monitoring_docs_describe_current_notification_contract() -> None:
     assert "generic notifications use the jsonl sink plus optional webhook dispatch" in lowered_product
     assert "mutation responses include the authoritative merged alert state" in lowered_product
     assert "`read` marks the runtime alert as read without setting `acknowledged_at`" in lowered_product
+    assert (
+        "`/api/v1/monitoring/*` routes require `system.logs`"
+        in lowered_product
+    )
+    assert (
+        "`/api/v1/admin/monitoring/*` routes inherit the admin role gate"
+        in lowered_product
+    )
+    assert (
+        "there is no unauthenticated public monitoring surface"
+        in lowered_product
+    )
 
     lowered_readme = readme_doc.lower()
     assert "generic notifications only use the jsonl sink plus optional webhook dispatch" in lowered_readme
     assert "`flush_digest()` currently clears buffered items and returns the count only" in lowered_readme
     assert "public alert mutation endpoints return the authoritative merged alert state" in lowered_readme
     assert "`acknowledge` records `acknowledged_at`" in lowered_readme
+    assert (
+        "`/api/v1/monitoring/*` routes require `system.logs`"
+        in lowered_readme
+    )
+    assert (
+        "`/api/v1/admin/monitoring/*` routes inherit the admin role gate"
+        in lowered_readme
+    )
+    assert (
+        "public monitoring means non-`/admin` prefix, not anonymous access"
+        in lowered_readme
+    )


### PR DESCRIPTION
## Change summary

- Documents the intended monitoring permission model: non-admin-prefix monitoring routes require `system.logs`, admin monitoring routes inherit the admin role gate, and there is no anonymous monitoring surface.
- Updates monitoring docs to stop describing the `/api/v1/monitoring/*` routes as admin-only when the actual gate is `system.logs`.
- Adds AuthNZ and docs-contract tests that pin the public/admin monitoring route boundary.

## Verification

- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py -v` -> 7 passed
- `git diff --check` -> passed
- `python -m compileall tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py` -> passed
- `python -m bandit -ll -r tldw_Server_API/tests/AuthNZ_Unit/test_monitoring_permissions_claims.py tldw_Server_API/tests/Monitoring/test_monitoring_docs_contract.py -f json -o /tmp/bandit_monitoring_permissions_1028_medium_high.json` -> passed, no medium/high findings

Full Bandit on the touched test files reports LOW test-file patterns only (B101 asserts and the existing AuthPrincipal token_type="access" B106 heuristic).

Closes #1028