### PR TITLE
feat(prompts): surface filter presets

### DIFF
--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptBody.search-pagination.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptBody.search-pagination.test.tsx
@@ -12,6 +12,11 @@ const state = vi.hoisted(() => ({
   prompts: [] as any[]
 }))
 
+const FILTER_PRESETS_STORAGE_KEY = "tldw-prompt-filter-presets-v1"
+const FILTER_PRESET_HINT_DISMISSED_KEY =
+  "tldw-prompt-hint-dismissed-filter-presets"
+const FILTER_PRESET_HINT_SHOWN_KEY = "tldw-prompt-hint-shown-filter-presets"
+
 const promptStudioStore = vi.hoisted(() => ({
   setActiveSubTab: vi.fn(),
   setSelectedProjectId: vi.fn(),
@@ -436,6 +441,7 @@ describe("PromptBody server search and pagination", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     window.sessionStorage.clear()
+    window.localStorage.clear()
     mocks.navigate.mockReset()
     mocks.setSelectedQuickPrompt.mockReset()
     mocks.setSelectedSystemPrompt.mockReset()
@@ -703,6 +709,235 @@ describe("PromptBody server search and pagination", () => {
     })
     expect(getVisibleRowNames()).toEqual(["Beta Prompt"])
     expect(mocks.searchPromptsServer).not.toHaveBeenCalled()
+  })
+
+  it("saves the current custom filters from the toolbar", async () => {
+    renderPromptBody()
+
+    await screen.findByTestId("prompts-table")
+    fireEvent.click(screen.getByTestId("prompts-filter-preset-save-toolbar"))
+    fireEvent.change(screen.getByTestId("prompts-filter-preset-toolbar-name"), {
+      target: { value: "Working set" }
+    })
+    fireEvent.click(screen.getByTestId("prompts-filter-preset-toolbar-confirm"))
+
+    const saved = JSON.parse(
+      window.localStorage.getItem(FILTER_PRESETS_STORAGE_KEY) || "[]"
+    )
+    expect(saved).toHaveLength(1)
+    expect(saved[0]).toMatchObject({
+      name: "Working set",
+      typeFilter: "all",
+      syncFilter: "all",
+      usageFilter: "all",
+      tagFilter: [],
+      tagMatchMode: "any",
+      savedView: "all"
+    })
+    expect(screen.getByTestId("prompts-filter-preset-chips")).toHaveTextContent(
+      "Working set"
+    )
+  })
+
+  it("rejects duplicate toolbar filter preset names", async () => {
+    const warningSpy = vi.spyOn(notification, "warning")
+    window.localStorage.setItem(
+      FILTER_PRESETS_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "working-set",
+          name: "Working set",
+          typeFilter: "all",
+          syncFilter: "all",
+          usageFilter: "all",
+          tagFilter: [],
+          tagMatchMode: "any",
+          savedView: "all"
+        }
+      ])
+    )
+
+    renderPromptBody()
+
+    await screen.findByTestId("prompts-filter-preset-chip-working-set")
+    fireEvent.click(screen.getByTestId("prompts-filter-preset-save-toolbar"))
+
+    const nameInput = screen.getByTestId("prompts-filter-preset-toolbar-name")
+    await waitFor(() => {
+      expect(nameInput).toHaveFocus()
+    })
+    expect(nameInput).toHaveAttribute("maxlength", "50")
+
+    fireEvent.change(nameInput, { target: { value: " working SET " } })
+    fireEvent.click(screen.getByTestId("prompts-filter-preset-toolbar-confirm"))
+
+    await waitFor(() => {
+      expect(warningSpy).toHaveBeenCalled()
+    })
+    const latestWarning = warningSpy.mock.calls.at(-1)?.[0] as
+      | { message?: string }
+      | undefined
+    expect(latestWarning?.message).toBe("A preset with this name already exists.")
+
+    const saved = JSON.parse(
+      window.localStorage.getItem(FILTER_PRESETS_STORAGE_KEY) || "[]"
+    )
+    expect(saved).toHaveLength(1)
+    expect(saved[0]).toMatchObject({ id: "working-set", name: "Working set" })
+  })
+
+  it("loads saved filter presets from quick chips above the prompt table", async () => {
+    state.prompts = [
+      {
+        id: "system-unused",
+        name: "System Unused",
+        title: "System Unused",
+        content: "system",
+        is_system: true,
+        createdAt: 100,
+        usageCount: 0,
+        keywords: []
+      },
+      {
+        id: "system-used",
+        name: "System Used",
+        title: "System Used",
+        content: "system used",
+        is_system: true,
+        createdAt: 90,
+        usageCount: 3,
+        keywords: []
+      },
+      {
+        id: "quick-unused",
+        name: "Quick Unused",
+        title: "Quick Unused",
+        content: "quick",
+        is_system: false,
+        createdAt: 80,
+        usageCount: 0,
+        keywords: []
+      }
+    ]
+    mocks.getAllPrompts.mockResolvedValue(state.prompts)
+    window.localStorage.setItem(
+      FILTER_PRESETS_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "unused-system",
+          name: "Unused systems",
+          typeFilter: "system",
+          syncFilter: "all",
+          usageFilter: "unused",
+          tagFilter: [],
+          tagMatchMode: "any",
+          savedView: "all"
+        }
+      ])
+    )
+
+    renderPromptBody()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("table-row-count")).toHaveTextContent("3")
+    })
+    fireEvent.click(screen.getByTestId("prompts-filter-preset-chip-unused-system"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("table-row-count")).toHaveTextContent("1")
+    })
+    expect(getVisibleRowNames()).toEqual(["System Unused"])
+  })
+
+  it("resets pagination when a preset narrows the local result set", async () => {
+    state.isOnline = false
+    state.prompts = [
+      ...Array.from({ length: 20 }, (_, index) => ({
+        id: `used-${index + 1}`,
+        name: `Used Prompt ${index + 1}`,
+        title: `Used Prompt ${index + 1}`,
+        content: `used content ${index + 1}`,
+        is_system: false,
+        createdAt: 1_000 - index,
+        usageCount: index + 1,
+        keywords: []
+      })),
+      {
+        id: "unused-only",
+        name: "Unused Only",
+        title: "Unused Only",
+        content: "unused content",
+        is_system: false,
+        createdAt: 1,
+        usageCount: 0,
+        keywords: []
+      }
+    ]
+    mocks.getAllPrompts.mockResolvedValue(state.prompts)
+    window.localStorage.setItem(
+      FILTER_PRESETS_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "used-only",
+          name: "Used only",
+          typeFilter: "all",
+          syncFilter: "all",
+          usageFilter: "used",
+          tagFilter: [],
+          tagMatchMode: "any",
+          savedView: "all"
+        }
+      ])
+    )
+
+    renderPromptBody()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("table-row-count")).toHaveTextContent("20")
+    })
+    fireEvent.click(screen.getByTestId("table-next-page"))
+    await waitFor(() => {
+      expect(screen.getByTestId("table-row-count")).toHaveTextContent("1")
+    })
+    expect(getVisibleRowNames()).toEqual(["Unused Only"])
+
+    fireEvent.click(screen.getByTestId("prompts-filter-preset-chip-used-only"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("table-row-count")).toHaveTextContent("20")
+    })
+    expect(getVisibleRowNames()[0]).toBe("Used Prompt 1")
+  })
+
+  it("shows the filter preset hint after repeated filter changes", async () => {
+    const { unmount } = renderPromptBody()
+
+    await screen.findByTestId("prompts-table")
+    fireEvent.click(screen.getByTestId("facet-type-system"))
+    fireEvent.click(screen.getByTestId("facet-sync-local"))
+    fireEvent.click(screen.getByTestId("smart-collection-favorites"))
+
+    expect(await screen.findByTestId("hint-filter-presets")).toHaveTextContent(
+      "Save this filter combination as a preset to reuse it later."
+    )
+    await waitFor(() => {
+      expect(window.localStorage.getItem(FILTER_PRESET_HINT_SHOWN_KEY)).toBe("1")
+      expect(window.localStorage.getItem(FILTER_PRESET_HINT_DISMISSED_KEY)).toBe(
+        "true"
+      )
+    })
+
+    unmount()
+    renderPromptBody()
+
+    await screen.findByTestId("prompts-table")
+    fireEvent.click(screen.getByTestId("facet-type-system"))
+    fireEvent.click(screen.getByTestId("facet-sync-local"))
+    fireEvent.click(screen.getByTestId("smart-collection-favorites"))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("hint-filter-presets")).not.toBeInTheDocument()
+    })
   })
 
   it("applies title sort override and persists sort state in session storage", async () => {

--- a/apps/packages/ui/src/components/Option/Prompt/index.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/index.tsx
@@ -14,7 +14,7 @@ import {
   Pagination,
   type InputRef
 } from "antd"
-import { Computer, Zap, Star, StarOff, UploadCloud, Download, Trash2, Pen, Undo2, AlertTriangle, Layers, Cloud, Clipboard, Copy, Keyboard, FolderPlus, Play, LayoutGrid, List } from "lucide-react"
+import { Computer, Zap, Star, StarOff, UploadCloud, Download, Trash2, Pen, Undo2, AlertTriangle, Layers, Cloud, Clipboard, Copy, Keyboard, FolderPlus, Play, LayoutGrid, List, Bookmark, BookmarkPlus, X } from "lucide-react"
 import { PromptActionsMenu } from "./PromptActionsMenu"
 import { SyncStatusBadge } from "./SyncStatusBadge"
 import { PromptBulkActionBar } from "./PromptBulkActionBar"
@@ -233,6 +233,10 @@ export const PromptBody = () => {
   const [tagFilter, setTagFilter] = useState<string[]>([])
   const [tagMatchMode, setTagMatchMode] = useState<TagMatchMode>("any")
   const [syncFilter, setSyncFilter] = useState<string>("all")
+  const [filterPresetSaving, setFilterPresetSaving] = useState(false)
+  const [filterPresetName, setFilterPresetName] = useState("")
+  const [filterChangeCount, setFilterChangeCount] = useState(0)
+  const filterSignatureInitializedRef = useRef(false)
   const [currentPage, setCurrentPage] = useState(1)
   const [resultsPerPage, setResultsPerPage] = useState(20)
   const [tableDensity, setTableDensity] = useState<PromptTableDensity>(() =>
@@ -401,7 +405,38 @@ export const PromptBody = () => {
 
   useEffect(() => {
     setCurrentPage(1)
-  }, [normalizedSearchText, projectFilter, typeFilter, collections.collectionFilter, tagFilter, tagMatchMode])
+  }, [
+    normalizedSearchText,
+    projectFilter,
+    typeFilter,
+    syncFilter,
+    usageFilter,
+    savedView,
+    collections.collectionFilter,
+    tagFilter,
+    tagMatchMode,
+  ])
+
+  const filterSignature = React.useMemo(
+    () =>
+      JSON.stringify({
+        typeFilter,
+        syncFilter,
+        usageFilter,
+        tagFilter,
+        tagMatchMode,
+        savedView
+      }),
+    [typeFilter, syncFilter, usageFilter, tagFilter, tagMatchMode, savedView]
+  )
+
+  useEffect(() => {
+    if (!filterSignatureInitializedRef.current) {
+      filterSignatureInitializedRef.current = true
+      return
+    }
+    setFilterChangeCount((count) => Math.min(3, count + 1))
+  }, [filterSignature])
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -849,24 +884,55 @@ export const PromptBody = () => {
   }
 
   const handleLoadFilterPreset = React.useCallback((preset: FilterPreset) => {
+    setCurrentPage(1)
     setTypeFilter(preset.typeFilter as any)
     setSyncFilter(preset.syncFilter as any)
+    setUsageFilter(preset.usageFilter || "all")
     setTagFilter(preset.tagFilter)
     setTagMatchMode(preset.tagMatchMode)
     setSavedView(preset.savedView)
   }, [])
 
+  const buildCurrentFilterPreset = React.useCallback(
+    () => ({
+      typeFilter,
+      syncFilter,
+      usageFilter,
+      tagFilter: [...tagFilter],
+      tagMatchMode,
+      savedView,
+    }),
+    [typeFilter, syncFilter, usageFilter, tagFilter, tagMatchMode, savedView]
+  )
+
   const handleSaveFilterPreset = React.useCallback(
     (name: string) => {
-      saveFilterPreset(name, {
-        typeFilter,
-        syncFilter,
-        tagFilter,
-        tagMatchMode,
-        savedView,
-      })
+      saveFilterPreset(name, buildCurrentFilterPreset())
     },
-    [typeFilter, syncFilter, tagFilter, tagMatchMode, savedView, saveFilterPreset]
+    [buildCurrentFilterPreset, saveFilterPreset]
+  )
+
+  const handleToolbarFilterPresetSave = React.useCallback(
+    () => {
+      const trimmed = filterPresetName.trim()
+      if (!trimmed) return
+      if (
+        filterPresets.some((preset) => preset.name.toLowerCase() === trimmed.toLowerCase())
+      ) {
+        notification.warning({
+          message: t("managePrompts.filterPresets.duplicateName", {
+            defaultValue: "A preset with this name already exists."
+          })
+        })
+        return
+      }
+      handleSaveFilterPreset(trimmed)
+      setFilterPresetName("")
+      setFilterPresetSaving(false)
+      markHintShown("filter-presets")
+      dismissHint("filter-presets")
+    },
+    [dismissHint, filterPresetName, filterPresets, handleSaveFilterPreset, markHintShown, t]
   )
 
   const handleCustomPromptTableQueryChange = React.useCallback(
@@ -1551,9 +1617,99 @@ export const PromptBody = () => {
                   />
                 </div>
               )}
+              {selectedSegment === "custom" && (
+                <div
+                  className="w-full sm:w-auto"
+                  data-testid="prompts-filter-preset-toolbar"
+                >
+                  {filterPresetSaving ? (
+                    <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+                      <Input
+                        autoFocus
+                        value={filterPresetName}
+                        onChange={(event) => setFilterPresetName(event.target.value)}
+                        onPressEnter={handleToolbarFilterPresetSave}
+                        placeholder={t("managePrompts.filterPresets.namePlaceholder", {
+                          defaultValue: "Preset name"
+                        })}
+                        aria-label={t("managePrompts.filterPresets.nameLabel", {
+                          defaultValue: "Filter preset name"
+                        })}
+                        data-testid="prompts-filter-preset-toolbar-name"
+                        style={{ width: isCompactViewport ? "100%" : 160 }}
+                        maxLength={50}
+                      />
+                      <button
+                        type="button"
+                        onClick={handleToolbarFilterPresetSave}
+                        disabled={!filterPresetName.trim()}
+                        data-testid="prompts-filter-preset-toolbar-confirm"
+                        className="inline-flex min-h-8 items-center gap-1.5 rounded-md border border-primary/40 px-2 py-1.5 text-sm font-medium text-primary hover:bg-primary/10 disabled:opacity-50"
+                      >
+                        <BookmarkPlus className="size-4" aria-hidden="true" />
+                        {t("common:save", { defaultValue: "Save" })}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setFilterPresetSaving(false)
+                          setFilterPresetName("")
+                        }}
+                        aria-label={t("common:cancel", { defaultValue: "Cancel" })}
+                        data-testid="prompts-filter-preset-toolbar-cancel"
+                        className="inline-flex min-h-8 min-w-8 items-center justify-center rounded-md border border-border text-text-muted hover:bg-surface2 hover:text-text"
+                      >
+                        <X className="size-4" aria-hidden="true" />
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setFilterPresetSaving(true)}
+                      data-testid="prompts-filter-preset-save-toolbar"
+                      className="inline-flex min-h-8 w-full items-center justify-center gap-1.5 rounded-md border border-border px-2 py-1.5 text-sm font-medium text-text hover:bg-surface2 sm:w-auto"
+                    >
+                      <BookmarkPlus className="size-4" aria-hidden="true" />
+                      {t("managePrompts.filterPresets.saveFilters", {
+                        defaultValue: "Save filters"
+                      })}
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
           </PromptListToolbar>
         </div>
+
+        {filterPresets.length > 0 && (
+          <div
+            className="mb-3 flex flex-wrap items-center gap-2"
+            data-testid="prompts-filter-preset-chips"
+          >
+            <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+              {t("managePrompts.filterPresets.quickLabel", {
+                defaultValue: "Filter presets"
+              })}
+            </span>
+            {filterPresets.slice(0, 5).map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={() => handleLoadFilterPreset(preset)}
+                className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-border bg-bg px-2.5 py-1 text-sm text-text-muted hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
+                data-testid={`prompts-filter-preset-chip-${preset.id}`}
+              >
+                <Bookmark className="size-3.5" aria-hidden="true" />
+                {preset.name}
+              </button>
+            ))}
+            {filterPresets.length > 5 && (
+              <span className="text-xs text-text-muted">
+                +{filterPresets.length - 5}
+              </span>
+            )}
+          </div>
+        )}
 
         {customPromptsLoading && <Skeleton paragraph={{ rows: 8 }} />}
 
@@ -1616,6 +1772,21 @@ export const PromptBody = () => {
             <ContextualHint
               id="keyboard-shortcuts"
               message="Press Enter to preview, E to edit, or ? for all keyboard shortcuts."
+              visible={true}
+              onDismiss={dismissHint}
+              onShown={markHintShown}
+            />
+          </Suspense>
+        )}
+
+        {filterChangeCount >= 3 && shouldShowHint("filter-presets") && (
+          <Suspense fallback={null}>
+            <ContextualHint
+              id="filter-presets"
+              message={t("managePrompts.filterPresets.hint", {
+                defaultValue:
+                  "Save this filter combination as a preset to reuse it later."
+              })}
               visible={true}
               onDismiss={dismissHint}
               onShown={markHintShown}

--- a/apps/packages/ui/src/components/Option/Prompt/useContextualHints.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/useContextualHints.ts
@@ -10,7 +10,14 @@ export type HintId =
 
 const STORAGE_PREFIX = "tldw-prompt-hint-dismissed-"
 const MAX_SHOWS = 3
+const MAX_SHOWS_BY_HINT: Partial<Record<HintId, number>> = {
+  "filter-presets": 1,
+}
 const SHOW_COUNT_PREFIX = "tldw-prompt-hint-shown-"
+
+function getMaxShows(id: HintId): number {
+  return MAX_SHOWS_BY_HINT[id] ?? MAX_SHOWS
+}
 
 function isDismissed(id: HintId): boolean {
   try {
@@ -59,7 +66,7 @@ export function useContextualHints() {
     ]
     const set = new Set<HintId>()
     for (const id of allIds) {
-      if (isDismissed(id) || getShowCount(id) >= MAX_SHOWS) {
+      if (isDismissed(id) || getShowCount(id) >= getMaxShows(id)) {
         set.add(id)
       }
     }
@@ -80,12 +87,16 @@ export function useContextualHints() {
 
   const markShown = useCallback(
     (id: HintId) => {
+      const maxShows = getMaxShows(id)
       incrementShowCount(id)
-      if (getShowCount(id) >= MAX_SHOWS) {
-        dismiss(id)
+      if (getShowCount(id) >= maxShows) {
+        dismissHint(id)
+        if (maxShows > 1) {
+          setDismissed((prev) => new Set(prev).add(id))
+        }
       }
     },
-    [dismiss]
+    []
   )
 
   return { shouldShow, dismiss, markShown }


### PR DESCRIPTION
## Change summary
- Promotes Custom prompt filter presets into the main toolbar with an inline Save filters flow, so users can discover and save filter combinations without relying on the sidebar.
- Adds quick preset chips above the prompt table and makes preset load/save round-trip the usage filter as part of the filter contract.
- Shows the existing contextual-hint component after repeated filter changes to point users at reusable filter presets.

## Verification
- ./node_modules/.bin/vitest run src/components/Option/Prompt/__tests__/PromptBody.search-pagination.test.tsx -t "filters from the toolbar|preset|repeated filter"
- ./node_modules/.bin/vitest run src/components/Option/Prompt/__tests__/PromptBody.search-pagination.test.tsx src/components/Option/Prompt/__tests__/useFilterPresets.test.tsx
- git diff --cached --check
- Bandit: not applicable, TypeScript/UI-only change.

Closes #1047