### PR TITLE
Phase 3.1: add response envelope contract helpers

### DIFF
--- a/apps/packages/ui/src/services/__tests__/response-envelope.test.ts
+++ b/apps/packages/ui/src/services/__tests__/response-envelope.test.ts
@@ -29,6 +29,16 @@ describe("response envelope helpers", () => {
     expect(unwrapApiResponseEnvelope(payload)).toBeNull()
   })
 
+  it("detects metadata-only canonical envelopes", () => {
+    const payload = {
+      success: true,
+      metadata: { request_id: "req-2" }
+    }
+
+    expect(isApiResponseEnvelope(payload)).toBe(true)
+    expect(unwrapApiResponseEnvelope(payload)).toBeNull()
+  })
+
   it("leaves legacy success-shaped endpoint payloads unchanged", () => {
     const payload = {
       success: true,
@@ -48,5 +58,24 @@ describe("response envelope helpers", () => {
     expect(isApiResponseEnvelope(payload)).toBe(false)
     expect(unwrapApiResponseEnvelope(payload)).toBe(payload)
     expect(unwrapApiResponseData(payload)).toEqual({ id: 9, name: "Existing response" })
+  })
+
+  it("returns null for transitional error-only wrappers", () => {
+    const payload = {
+      error: "Failed to load"
+    }
+
+    expect(isApiResponseEnvelope(payload)).toBe(false)
+    expect(unwrapApiResponseData<number>(payload)).toBeNull()
+  })
+
+  it("does not unwrap domain objects that happen to contain data", () => {
+    const payload = {
+      id: "domain-object",
+      data: "domain field"
+    }
+
+    expect(isApiResponseEnvelope(payload)).toBe(false)
+    expect(unwrapApiResponseData(payload)).toBe(payload)
   })
 })

--- a/apps/packages/ui/src/services/__tests__/response-envelope.test.ts
+++ b/apps/packages/ui/src/services/__tests__/response-envelope.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isApiResponseEnvelope,
+  unwrapApiResponseData,
+  unwrapApiResponseEnvelope
+} from "@/services/response-envelope"
+
+describe("response envelope helpers", () => {
+  it("unwraps canonical success envelopes", () => {
+    const payload = {
+      success: true,
+      data: { id: 7, name: "Demo" },
+      metadata: { request_id: "req-1" }
+    }
+
+    expect(isApiResponseEnvelope(payload)).toBe(true)
+    expect(unwrapApiResponseEnvelope(payload)).toEqual({ id: 7, name: "Demo" })
+  })
+
+  it("returns null for canonical error envelopes without data", () => {
+    const payload = {
+      success: false,
+      error: "Failed to load",
+      error_code: "LOAD_FAILED"
+    }
+
+    expect(isApiResponseEnvelope(payload)).toBe(true)
+    expect(unwrapApiResponseEnvelope(payload)).toBeNull()
+  })
+
+  it("leaves legacy success-shaped endpoint payloads unchanged", () => {
+    const payload = {
+      success: true,
+      file_id: "generated-file",
+      hard_delete: false
+    }
+
+    expect(isApiResponseEnvelope(payload)).toBe(false)
+    expect(unwrapApiResponseEnvelope(payload)).toBe(payload)
+  })
+
+  it("unwraps transitional data wrappers without requiring endpoint payload changes", () => {
+    const payload = {
+      data: { id: 9, name: "Existing response" }
+    }
+
+    expect(isApiResponseEnvelope(payload)).toBe(false)
+    expect(unwrapApiResponseEnvelope(payload)).toBe(payload)
+    expect(unwrapApiResponseData(payload)).toEqual({ id: 9, name: "Existing response" })
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/response-envelope.test.ts
+++ b/apps/packages/ui/src/services/__tests__/response-envelope.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, expectTypeOf, it } from "vitest"
 
 import {
   isApiResponseEnvelope,
   unwrapApiResponseData,
-  unwrapApiResponseEnvelope
+  unwrapApiResponseEnvelope,
+  type ApiResponseEnvelope
 } from "@/services/response-envelope"
 
 describe("response envelope helpers", () => {
@@ -48,6 +49,19 @@ describe("response envelope helpers", () => {
 
     expect(isApiResponseEnvelope(payload)).toBe(false)
     expect(unwrapApiResponseEnvelope(payload)).toBe(payload)
+  })
+
+  it("types union inputs without leaking the envelope shape", () => {
+    type Payload = { id: number }
+    const payload: ApiResponseEnvelope<Payload> | Payload | null | undefined =
+      Math.random() > 0.5 ? { success: true, data: { id: 3 } } : { id: 4 }
+    const legacyPayload = { success: true, file_id: "generated-file" }
+
+    const unwrapped = unwrapApiResponseEnvelope(payload)
+    const unwrappedLegacy = unwrapApiResponseEnvelope(legacyPayload)
+
+    expectTypeOf(unwrapped).toEqualTypeOf<Payload | null | undefined>()
+    expectTypeOf(unwrappedLegacy).toEqualTypeOf<typeof legacyPayload>()
   })
 
   it("unwraps transitional data wrappers without requiring endpoint payload changes", () => {

--- a/apps/packages/ui/src/services/prompt-studio.ts
+++ b/apps/packages/ui/src/services/prompt-studio.ts
@@ -1,5 +1,6 @@
 import { apiSend } from "@/services/api-send"
 import { appendPathQuery, toAllowedPath } from "@/services/tldw/path-utils"
+import type { ApiResponseEnvelope } from "@/services/response-envelope"
 
 // Prompt Studio client – aligns with tldw_server prompt_studio endpoints.
 
@@ -10,13 +11,7 @@ export type PaginationMeta = {
   total_pages?: number
 }
 
-export type StandardResponse<T> = {
-  success: boolean
-  data?: T
-  error?: string
-  error_code?: string
-  metadata?: Record<string, any>
-}
+export type StandardResponse<T> = ApiResponseEnvelope<T>
 
 export type ListResponse<T> = StandardResponse<T[]> & {
   metadata?: PaginationMeta

--- a/apps/packages/ui/src/services/prompt-sync.ts
+++ b/apps/packages/ui/src/services/prompt-sync.ts
@@ -28,6 +28,7 @@ import {
   StandardResponse
 } from '@/services/prompt-studio'
 import type { ApiSendResponse } from '@/services/api-send'
+import { unwrapApiResponseData } from '@/services/response-envelope'
 import {
   getPromptStudioDefaults,
   setPromptStudioDefaults
@@ -84,11 +85,7 @@ const isValidProjectId = (value: unknown): value is number =>
 const unwrapResponseData = <T>(
   response: ApiSendResponse<StandardResponse<T>> | ApiSendResponse<T>
 ): T | null => {
-  const outer = response?.data
-  if (outer && typeof outer === 'object' && 'data' in outer) {
-    return (outer as StandardResponse<T>).data ?? null
-  }
-  return (outer as T) ?? null
+  return unwrapApiResponseData<T>(response?.data) ?? null
 }
 
 const toText = (value: unknown): string => (typeof value === 'string' ? value : '')

--- a/apps/packages/ui/src/services/response-envelope.ts
+++ b/apps/packages/ui/src/services/response-envelope.ts
@@ -1,0 +1,62 @@
+export type ApiEnvelopeMetadata = Record<string, unknown>
+
+export type ApiResponseEnvelope<T> = {
+  success: boolean
+  data?: T | null
+  error?: string | null
+  error_code?: string | null
+  metadata?: ApiEnvelopeMetadata | null
+}
+
+export type ApiResponseDataWrapper<T> = {
+  data?: T | null
+  error?: string | null
+  error_code?: string | null
+  metadata?: ApiEnvelopeMetadata | null
+}
+
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value)
+
+export const isApiResponseEnvelope = (
+  value: unknown
+): value is ApiResponseEnvelope<unknown> => {
+  if (!isRecord(value) || typeof value.success !== "boolean") {
+    return false
+  }
+  return hasOwn(value, "data") || hasOwn(value, "error") || hasOwn(value, "error_code")
+}
+
+export function unwrapApiResponseEnvelope<T>(value: ApiResponseEnvelope<T>): T | null
+export function unwrapApiResponseEnvelope<T>(value: T): T
+export function unwrapApiResponseEnvelope(value: null): null
+export function unwrapApiResponseEnvelope(value: undefined): undefined
+export function unwrapApiResponseEnvelope<T>(
+  value: ApiResponseEnvelope<T> | T | null | undefined
+): T | null | undefined {
+  if (isApiResponseEnvelope(value)) {
+    return (value as ApiResponseEnvelope<T>).data ?? null
+  }
+  return value as T | null | undefined
+}
+
+export function unwrapApiResponseData<T>(
+  value: ApiResponseEnvelope<T> | ApiResponseDataWrapper<T>
+): T | null
+export function unwrapApiResponseData<T>(value: T): T
+export function unwrapApiResponseData(value: null): null
+export function unwrapApiResponseData(value: undefined): undefined
+export function unwrapApiResponseData<T>(
+  value: ApiResponseEnvelope<T> | ApiResponseDataWrapper<T> | T | null | undefined
+): T | null | undefined {
+  if (isApiResponseEnvelope(value)) {
+    return (value as ApiResponseEnvelope<T>).data ?? null
+  }
+  if (isRecord(value) && hasOwn(value, "data")) {
+    return (value as ApiResponseDataWrapper<T>).data ?? null
+  }
+  return value as T | null | undefined
+}

--- a/apps/packages/ui/src/services/response-envelope.ts
+++ b/apps/packages/ui/src/services/response-envelope.ts
@@ -38,6 +38,10 @@ const isApiResponseDataWrapper = (
   hasEnvelopeKey(value) &&
   hasOnlyEnvelopeKeys(value)
 
+/**
+ * Detects the canonical opt-in API response envelope without treating legacy
+ * success-shaped payloads as envelopes.
+ */
 export const isApiResponseEnvelope = (
   value: unknown
 ): value is ApiResponseEnvelope<unknown> => {
@@ -47,6 +51,9 @@ export const isApiResponseEnvelope = (
   return hasEnvelopeKey(value)
 }
 
+/**
+ * Unwraps canonical response envelopes while preserving non-envelope payloads.
+ */
 export function unwrapApiResponseEnvelope<T>(value: ApiResponseEnvelope<T>): T | null
 export function unwrapApiResponseEnvelope<T>(value: T): T
 export function unwrapApiResponseEnvelope(value: null): null
@@ -60,6 +67,9 @@ export function unwrapApiResponseEnvelope<T>(
   return value as T | null | undefined
 }
 
+/**
+ * Unwraps canonical envelopes and transitional response-body data wrappers.
+ */
 export function unwrapApiResponseData<T>(
   value: ApiResponseEnvelope<T> | ApiResponseDataWrapper<T>
 ): T | null

--- a/apps/packages/ui/src/services/response-envelope.ts
+++ b/apps/packages/ui/src/services/response-envelope.ts
@@ -21,13 +21,30 @@ const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value)
 
+const envelopeKeys = ["data", "error", "error_code", "metadata"] as const
+const envelopeKeySet = new Set<string>(envelopeKeys)
+
+const hasEnvelopeKey = (value: Record<string, unknown>): boolean =>
+  envelopeKeys.some((key) => hasOwn(value, key))
+
+const hasOnlyEnvelopeKeys = (value: Record<string, unknown>): boolean =>
+  Object.keys(value).every((key) => envelopeKeySet.has(key))
+
+const isApiResponseDataWrapper = (
+  value: unknown
+): value is ApiResponseDataWrapper<unknown> =>
+  isRecord(value) &&
+  !hasOwn(value, "success") &&
+  hasEnvelopeKey(value) &&
+  hasOnlyEnvelopeKeys(value)
+
 export const isApiResponseEnvelope = (
   value: unknown
 ): value is ApiResponseEnvelope<unknown> => {
   if (!isRecord(value) || typeof value.success !== "boolean") {
     return false
   }
-  return hasOwn(value, "data") || hasOwn(value, "error") || hasOwn(value, "error_code")
+  return hasEnvelopeKey(value)
 }
 
 export function unwrapApiResponseEnvelope<T>(value: ApiResponseEnvelope<T>): T | null
@@ -55,7 +72,7 @@ export function unwrapApiResponseData<T>(
   if (isApiResponseEnvelope(value)) {
     return (value as ApiResponseEnvelope<T>).data ?? null
   }
-  if (isRecord(value) && hasOwn(value, "data")) {
+  if (isApiResponseDataWrapper(value)) {
     return (value as ApiResponseDataWrapper<T>).data ?? null
   }
   return value as T | null | undefined

--- a/apps/packages/ui/src/services/response-envelope.ts
+++ b/apps/packages/ui/src/services/response-envelope.ts
@@ -15,21 +15,26 @@ export type ApiResponseDataWrapper<T> = {
   metadata?: ApiEnvelopeMetadata | null
 }
 
+/** Checks object-owned keys without matching prototype properties. */
 const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
   Object.prototype.hasOwnProperty.call(value, key)
 
+/** Narrows unknown values to plain response-like records. */
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value)
 
 const envelopeKeys = ["data", "error", "error_code", "metadata"] as const
 const envelopeKeySet = new Set<string>(envelopeKeys)
 
+/** Detects at least one canonical envelope payload key. */
 const hasEnvelopeKey = (value: Record<string, unknown>): boolean =>
   envelopeKeys.some((key) => hasOwn(value, key))
 
+/** Ensures transitional wrappers do not hide unrelated domain fields. */
 const hasOnlyEnvelopeKeys = (value: Record<string, unknown>): boolean =>
   Object.keys(value).every((key) => envelopeKeySet.has(key))
 
+/** Detects legacy data-wrapper responses that are safe to unwrap generically. */
 const isApiResponseDataWrapper = (
   value: unknown
 ): value is ApiResponseDataWrapper<unknown> =>

--- a/apps/packages/ui/src/services/response-envelope.ts
+++ b/apps/packages/ui/src/services/response-envelope.ts
@@ -60,6 +60,9 @@ export const isApiResponseEnvelope = (
  * Unwraps canonical response envelopes while preserving non-envelope payloads.
  */
 export function unwrapApiResponseEnvelope<T>(value: ApiResponseEnvelope<T>): T | null
+export function unwrapApiResponseEnvelope<T>(
+  value: ApiResponseEnvelope<T> | T | null | undefined
+): T | null | undefined
 export function unwrapApiResponseEnvelope<T>(value: T): T
 export function unwrapApiResponseEnvelope(value: null): null
 export function unwrapApiResponseEnvelope(value: undefined): undefined

--- a/tldw_Server_API/app/api/v1/schemas/response_envelope.py
+++ b/tldw_Server_API/app/api/v1/schemas/response_envelope.py
@@ -1,0 +1,28 @@
+"""Shared API response-envelope schemas.
+
+These models define the canonical envelope shape for new or migrated API
+responses. Existing endpoint payloads are intentionally unchanged until a route
+opts into the envelope contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel
+
+
+T = TypeVar("T")
+
+
+class ResponseEnvelope(BaseModel, Generic[T]):
+    """Canonical response envelope for successful and failed API responses."""
+
+    success: bool
+    data: T | None = None
+    error: str | None = None
+    error_code: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+__all__ = ["ResponseEnvelope"]

--- a/tldw_Server_API/app/api/v1/utils/response_envelope.py
+++ b/tldw_Server_API/app/api/v1/utils/response_envelope.py
@@ -10,7 +10,7 @@ from tldw_Server_API.app.api.v1.schemas.response_envelope import ResponseEnvelop
 
 T = TypeVar("T")
 
-_ENVELOPE_PAYLOAD_KEYS = frozenset(("data", "error", "error_code"))
+_ENVELOPE_PAYLOAD_KEYS = frozenset(("data", "error", "error_code", "metadata"))
 
 
 def envelope_success(
@@ -46,7 +46,7 @@ def is_response_envelope(value: object) -> bool:
     """Return true only for canonical envelope-shaped mappings.
 
     Several legacy endpoints return domain payloads with a top-level
-    ``success`` flag. Requiring at least one canonical envelope payload key
+    ``success`` flag. Requiring at least one canonical envelope contract key
     avoids misclassifying those legacy shapes before migration.
     """
 

--- a/tldw_Server_API/app/api/v1/utils/response_envelope.py
+++ b/tldw_Server_API/app/api/v1/utils/response_envelope.py
@@ -1,0 +1,65 @@
+"""Helpers for constructing and detecting API response envelopes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from tldw_Server_API.app.api.v1.schemas.response_envelope import ResponseEnvelope
+
+
+T = TypeVar("T")
+
+_ENVELOPE_PAYLOAD_KEYS = frozenset(("data", "error", "error_code"))
+
+
+def envelope_success(
+    data: T | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> ResponseEnvelope[T]:
+    """Build a successful response envelope without changing route semantics."""
+
+    return ResponseEnvelope[T](
+        success=True,
+        data=data,
+        metadata=metadata,
+    )
+
+
+def envelope_error(
+    error: str,
+    *,
+    error_code: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> ResponseEnvelope[None]:
+    """Build an error response envelope for routes that opt into the contract."""
+
+    return ResponseEnvelope[None](
+        success=False,
+        error=error,
+        error_code=error_code,
+        metadata=metadata,
+    )
+
+
+def is_response_envelope(value: object) -> bool:
+    """Return true only for canonical envelope-shaped mappings.
+
+    Several legacy endpoints return domain payloads with a top-level
+    ``success`` flag. Requiring at least one canonical envelope payload key
+    avoids misclassifying those legacy shapes before migration.
+    """
+
+    if not isinstance(value, Mapping):
+        return False
+    if not isinstance(value.get("success"), bool):
+        return False
+    return any(key in value for key in _ENVELOPE_PAYLOAD_KEYS)
+
+
+__all__ = [
+    "ResponseEnvelope",
+    "envelope_error",
+    "envelope_success",
+    "is_response_envelope",
+]

--- a/tldw_Server_API/tests/Utils/test_response_envelope.py
+++ b/tldw_Server_API/tests/Utils/test_response_envelope.py
@@ -46,6 +46,7 @@ def test_error_envelope_serializes_standard_contract() -> None:
 def test_is_response_envelope_accepts_only_wrapped_payloads() -> None:
     assert is_response_envelope({"success": True, "data": {"id": 1}})
     assert is_response_envelope({"success": False, "error": "Nope"})
+    assert is_response_envelope({"success": True, "metadata": {"request_id": "req-3"}})
 
     assert not is_response_envelope({"success": True, "file_id": "generated-file"})
     assert not is_response_envelope({"data": {"id": 1}})

--- a/tldw_Server_API/tests/Utils/test_response_envelope.py
+++ b/tldw_Server_API/tests/Utils/test_response_envelope.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from tldw_Server_API.app.api.v1.schemas.response_envelope import ResponseEnvelope
+from tldw_Server_API.app.api.v1.utils.response_envelope import (
+    envelope_error,
+    envelope_success,
+    is_response_envelope,
+)
+
+
+class Payload(BaseModel):
+    value: str
+
+
+def test_success_envelope_serializes_standard_contract() -> None:
+    response = envelope_success(Payload(value="ok"), metadata={"request_id": "req-1"})
+
+    assert isinstance(response, ResponseEnvelope)
+    assert response.model_dump(mode="json") == {
+        "success": True,
+        "data": {"value": "ok"},
+        "error": None,
+        "error_code": None,
+        "metadata": {"request_id": "req-1"},
+    }
+
+
+def test_error_envelope_serializes_standard_contract() -> None:
+    response = envelope_error(
+        "Failed to load resource",
+        error_code="RESOURCE_LOAD_FAILED",
+        metadata={"request_id": "req-2"},
+    )
+
+    assert response.model_dump(mode="json") == {
+        "success": False,
+        "data": None,
+        "error": "Failed to load resource",
+        "error_code": "RESOURCE_LOAD_FAILED",
+        "metadata": {"request_id": "req-2"},
+    }
+
+
+def test_is_response_envelope_accepts_only_wrapped_payloads() -> None:
+    assert is_response_envelope({"success": True, "data": {"id": 1}})
+    assert is_response_envelope({"success": False, "error": "Nope"})
+
+    assert not is_response_envelope({"success": True, "file_id": "generated-file"})
+    assert not is_response_envelope({"data": {"id": 1}})
+    assert not is_response_envelope(None)


### PR DESCRIPTION
## Summary

- What changed:
  - Added backend `ResponseEnvelope` schema plus helper builders/detection for future opt-in response-envelope migrations.
  - Added shared frontend envelope/data unwrap typing and reused it in Prompt Studio prompt sync without changing endpoint payloads.
  - Addressed review feedback for metadata-only envelope detection and safer transitional data-wrapper unwrapping.
- Why:
  - This gives Phase 3.1 a shared contract layer before any endpoint response payload migration, reducing frontend/API compatibility risk.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [ ] Docs updated (if behavior, routes, or config changed) — N/A, no endpoint behavior, routes, or config changed

Commands run:

- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/Utils/test_response_envelope.py tldw_Server_API/tests/Utils/test_api_v1_utils.py`
- [x] `./node_modules/.bin/vitest run src/services/__tests__/response-envelope.test.ts src/services/__tests__/prompt-sync.auto-sync.test.ts src/services/__tests__/prompt-sync.structured-prompts.test.ts`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/schemas/response_envelope.py tldw_Server_API/app/api/v1/utils/response_envelope.py -f json -o /tmp/bandit_phase3_1_response_envelope.json`
- [x] `git diff --check`

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes — N/A, no user-facing UI route behavior changed
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (or failures documented) — N/A, no user-facing UI route behavior changed
- [x] No listed AntD deprecations in console output: `Drawer.width`, `Space.direction`, `Alert.message`, `List` — N/A, no AntD/UI components changed
- [x] No `Maximum update depth exceeded` warnings on audited routes — N/A, no React components changed
- [x] No unresolved `{{...}}` placeholders on audited routes — N/A, no user-facing copy changed
- [x] WebUI/extension parity validated for shared UI fixes — shared service tests cover the changed unwrap behavior
- [x] For Flashcards UI changes: tabs remain `Study` / `Manage` / `Transfer` and secondary create CTAs route through manager create-entry path — N/A
- [x] For Flashcards drawer changes: use `FLASHCARDS_DRAWER_WIDTH_PX` and keep footer action order `Cancel -> secondary -> primary` — N/A
- [x] For Flashcards help/copy/import UX changes: update `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md` and keep in-app help links pointed at guide section anchors — N/A

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:a11y` passes locally — N/A, no Watchlists UI changed
- [x] If Watchlists UI behavior changed: keyboard-only path still works for Overview -> Feeds -> Monitors -> Activity -> Articles -> Reports — N/A
- [x] If Watchlists UI behavior changed: list/table labels and live-region copy remain localized (no new hardcoded assistive text) — N/A
- [x] If Watchlists UI behavior changed: monitor/feed active state is not color-only (explicit text or icon signal is present) — N/A
- [x] If Watchlists UI behavior changed: known assistive-tech constraints reviewed in `Docs/Plans/WATCHLISTS_ASSISTIVE_TECH_AUDIT_2026_02_24.md` — N/A

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] If Watchlists UI behavior changed: `cd apps/packages/ui && bun run test:watchlists:scale` passes locally — N/A, no Watchlists UI changed
- [x] If Watchlists polling/notifications behavior changed: no duplicate terminal notifications during in-flight polling overlap — N/A
- [x] If Watchlists Activity polling changed: auto-refresh is gated to active + visible Activity context (no background tab polling churn) — N/A
- [x] If Watchlists batch triage behavior changed: partial-failure retry path remains available and updates only failed IDs — N/A
- [x] If Watchlists scale behavior changed: constraints/mitigations reviewed in `Docs/Plans/WATCHLISTS_SCALE_READINESS_RUNBOOK_2026_02_24.md` — N/A

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR. It only adds shared helpers/types/tests and does not change endpoint payloads.

## Issue

Updates #1116.

## Merge note

Per the repo AI-generated PR policy, a human maintainer should add or replace the final `Change summary` before merge.
