### PR TITLE
fix(prompts): wire per-prompt sync retry

### DIFF
--- a/apps/packages/ui/src/components/Option/Prompt/PromptListTable.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptListTable.tsx
@@ -30,6 +30,8 @@ type PromptListTableV1Props = {
   onEdit?: (id: string) => void
   onToggleFavorite?: (id: string, nextFavorite: boolean) => void
   onOpenConflictResolution?: (id: string) => void
+  canRetrySync?: (row: PromptRowVM) => boolean
+  onRetrySync?: (id: string) => void
   renderActions?: (row: PromptRowVM) => React.ReactNode
   renderTitleMeta?: (row: PromptRowVM) => React.ReactNode
   favoriteButtonTestId?: (row: PromptRowVM) => string
@@ -110,6 +112,8 @@ export const PromptListTable: React.FC<PromptListTableProps> = (props) => {
     onEdit,
     onToggleFavorite,
     onOpenConflictResolution,
+    canRetrySync,
+    onRetrySync,
     renderActions,
     renderTitleMeta,
     favoriteButtonTestId,
@@ -139,6 +143,8 @@ export const PromptListTable: React.FC<PromptListTableProps> = (props) => {
         onEdit: (row) => onEdit?.(row.id),
         onOpenConflictResolution: (row) =>
           onOpenConflictResolution?.(row.id),
+        canRetrySync,
+        onRetrySync: (row) => onRetrySync?.(row.id),
         renderActions,
         renderTitleMeta,
         favoriteButtonTestId,
@@ -151,8 +157,10 @@ export const PromptListTable: React.FC<PromptListTableProps> = (props) => {
       formatRelativeTime,
       isOnline,
       isCompactViewport,
+      canRetrySync,
       onEdit,
       onOpenConflictResolution,
+      onRetrySync,
       onToggleFavorite,
       query.sort.key,
       query.sort.order,

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptBody.search-pagination.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptBody.search-pagination.test.tsx
@@ -362,12 +362,33 @@ vi.mock("../PromptActionsMenu", () => ({
       >
         view history
       </button>
+      {props?.onRetrySync && (
+        <button
+          type="button"
+          data-testid={`mock-retry-sync-${props?.promptId || "unknown"}`}
+          onClick={() => props.onRetrySync()}
+        >
+          retry sync
+        </button>
+      )}
     </div>
   )
 }))
 
 vi.mock("../SyncStatusBadge", () => ({
-  SyncStatusBadge: () => <span data-testid="mock-sync-status-badge" />
+  SyncStatusBadge: (props: any) => (
+    <span data-testid="mock-sync-status-badge">
+      {props?.onRetry && (
+        <button
+          type="button"
+          data-testid="mock-sync-status-retry"
+          onClick={() => props.onRetry()}
+        >
+          retry status
+        </button>
+      )}
+    </span>
+  )
 }))
 
 vi.mock("../ConflictResolutionModal", () => ({
@@ -1191,6 +1212,118 @@ describe("PromptBody server search and pagination", () => {
     await waitFor(() => {
       expect(screen.getByTestId("table-selected-count")).toHaveTextContent("1")
     })
+  })
+
+  it("wires per-prompt retry from pending sync badges and row actions", async () => {
+    state.prompts = [
+      {
+        id: "pending-retry",
+        name: "Pending Retry Prompt",
+        title: "Pending Retry Prompt",
+        content: "Needs sync retry",
+        is_system: false,
+        createdAt: 100,
+        updatedAt: 150,
+        serverId: 201,
+        studioProjectId: 77,
+        syncStatus: "pending",
+        sourceSystem: "workspace"
+      }
+    ]
+    mocks.getAllPrompts.mockResolvedValue(state.prompts)
+    mocks.pushToStudio.mockResolvedValue({ success: true, syncStatus: "synced" })
+
+    renderPromptBody()
+    await waitFor(() => {
+      expect(screen.getByTestId("table-row-count")).toHaveTextContent("1")
+    })
+
+    fireEvent.click(screen.getByTestId("mock-sync-status-retry"))
+
+    await waitFor(() => {
+      expect(mocks.pushToStudio).toHaveBeenCalledWith("pending-retry", 77)
+    })
+    await waitFor(() => {
+      expect(screen.queryByTestId("prompts-batch-sync-status")).not.toBeInTheDocument()
+    })
+
+    mocks.pushToStudio.mockClear()
+    fireEvent.click(screen.getByTestId("mock-retry-sync-pending-retry"))
+
+    await waitFor(() => {
+      expect(mocks.pushToStudio).toHaveBeenCalledWith("pending-retry", 77)
+    })
+  })
+
+  it("does not start overlapping per-prompt retry runs", async () => {
+    state.prompts = [
+      {
+        id: "pending-retry",
+        name: "Pending Retry Prompt",
+        title: "Pending Retry Prompt",
+        content: "Needs sync retry",
+        is_system: false,
+        createdAt: 100,
+        updatedAt: 150,
+        serverId: 201,
+        studioProjectId: 77,
+        syncStatus: "pending",
+        sourceSystem: "workspace"
+      }
+    ]
+    mocks.getAllPrompts.mockResolvedValue(state.prompts)
+    let resolvePush: (() => void) | undefined
+    mocks.pushToStudio.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePush = () => resolve({ success: true, syncStatus: "synced" })
+        })
+    )
+
+    renderPromptBody()
+    await waitFor(() => {
+      expect(screen.getByTestId("table-row-count")).toHaveTextContent("1")
+    })
+
+    const retryButton = screen.getByTestId("mock-sync-status-retry")
+    fireEvent.click(retryButton)
+    fireEvent.click(retryButton)
+
+    await waitFor(() => {
+      expect(mocks.pushToStudio).toHaveBeenCalledTimes(1)
+    })
+
+    resolvePush?.()
+    await waitFor(() => {
+      expect(screen.queryByTestId("prompts-batch-sync-status")).not.toBeInTheDocument()
+    })
+  })
+
+  it("does not expose per-prompt retry for pending copilot prompts", async () => {
+    state.prompts = [
+      {
+        id: "copilot-pending",
+        name: "Copilot Pending Prompt",
+        title: "Copilot Pending Prompt",
+        content: "Managed prompt",
+        is_system: false,
+        createdAt: 100,
+        updatedAt: 150,
+        serverId: 301,
+        studioProjectId: 77,
+        syncStatus: "pending",
+        sourceSystem: "copilot"
+      }
+    ]
+    mocks.getAllPrompts.mockResolvedValue(state.prompts)
+
+    renderPromptBody()
+    await waitFor(() => {
+      expect(screen.getByTestId("table-row-count")).toHaveTextContent("1")
+    })
+
+    expect(screen.queryByTestId("mock-sync-status-retry")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("mock-retry-sync-copilot-pending")).not.toBeInTheDocument()
   })
 
   it("preserves use-in-chat modal behavior and navigates with both prompt parts", async () => {

--- a/apps/packages/ui/src/components/Option/Prompt/hooks/usePromptSync.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/hooks/usePromptSync.tsx
@@ -63,6 +63,7 @@ export function usePromptSync(deps: UsePromptSyncDeps) {
     INITIAL_BATCH_SYNC_STATE
   )
   const batchSyncCancelRef = useRef(false)
+  const batchSyncRunningRef = useRef(false)
 
   const syncPromptAfterLocalSave = React.useCallback(async (localId: string) => {
     try {
@@ -317,161 +318,166 @@ export function usePromptSync(deps: UsePromptSyncDeps) {
 
   const runBatchSync = React.useCallback(
     async (retryTasks?: SyncBatchTask[]) => {
-      if (!isOnline) return
+      if (!isOnline || batchSyncRunningRef.current) return
 
-      const plan = retryTasks
-        ? {
-            tasks: retryTasks,
-            skippedConflicts: 0,
-            skippedCopilotPending: 0
-          }
-        : buildSyncBatchPlan(await getAllPromptsWithSyncStatus())
+      batchSyncRunningRef.current = true
+      try {
+        const plan = retryTasks
+          ? {
+              tasks: retryTasks,
+              skippedConflicts: 0,
+              skippedCopilotPending: 0
+            }
+          : buildSyncBatchPlan(await getAllPromptsWithSyncStatus())
 
-      if (plan.tasks.length === 0) {
-        const description = plan.skippedConflicts > 0
-          ? t("managePrompts.sync.batchNoActionableWithConflicts", {
-              defaultValue:
-                "No prompts are ready for batch sync. {{count}} prompt(s) require manual conflict resolution.",
-              count: plan.skippedConflicts
-            })
-          : t("managePrompts.sync.batchNoActionable", {
-              defaultValue: "No prompts currently need syncing."
-            })
-        notification.info({
-          message: t("managePrompts.sync.batchNothingToSync", {
-            defaultValue: "Nothing to sync"
-          }),
-          description
-        })
-        return
-      }
-
-      batchSyncCancelRef.current = false
-      setBatchSyncState({
-        running: true,
-        completed: 0,
-        total: plan.tasks.length,
-        succeeded: 0,
-        failed: [],
-        skippedConflicts: plan.skippedConflicts,
-        skippedCopilotPending: plan.skippedCopilotPending,
-        cancelled: false
-      })
-
-      let completed = 0
-      let succeeded = 0
-      const failed: BatchSyncFailure[] = []
-
-      for (const task of plan.tasks) {
-        if (batchSyncCancelRef.current) {
-          setBatchSyncState({
-            running: false,
-            completed,
-            total: plan.tasks.length,
-            succeeded,
-            failed: [...failed],
-            skippedConflicts: plan.skippedConflicts,
-            skippedCopilotPending: plan.skippedCopilotPending,
-            cancelled: true
-          })
-          notification.warning({
-            message: t("managePrompts.sync.batchCancelled", {
-              defaultValue: "Batch sync cancelled"
+        if (plan.tasks.length === 0) {
+          const description = plan.skippedConflicts > 0
+            ? t("managePrompts.sync.batchNoActionableWithConflicts", {
+                defaultValue:
+                  "No prompts are ready for batch sync. {{count}} prompt(s) require manual conflict resolution.",
+                count: plan.skippedConflicts
+              })
+            : t("managePrompts.sync.batchNoActionable", {
+                defaultValue: "No prompts currently need syncing."
+              })
+          notification.info({
+            message: t("managePrompts.sync.batchNothingToSync", {
+              defaultValue: "Nothing to sync"
             }),
-            description: t("managePrompts.sync.batchCancelledDesc", {
-              defaultValue:
-                "Synced {{completed}} of {{total}} prompts before cancellation.",
-              completed,
-              total: plan.tasks.length
-            })
+            description
           })
-          await queryClient.invalidateQueries({ queryKey: ["fetchAllPrompts"] })
           return
         }
 
-        try {
-          const result =
-            task.direction === "pull"
-              ? await pullFromStudio(task.serverId!, task.promptId)
-              : task.serverId
-                ? await pushToStudio(task.promptId, task.preferredProjectId || 1)
-                : await autoSyncPrompt(task.promptId, task.preferredProjectId)
+        batchSyncCancelRef.current = false
+        setBatchSyncState({
+          running: true,
+          completed: 0,
+          total: plan.tasks.length,
+          succeeded: 0,
+          failed: [],
+          skippedConflicts: plan.skippedConflicts,
+          skippedCopilotPending: plan.skippedCopilotPending,
+          cancelled: false
+        })
 
-          if (result.success) {
-            succeeded += 1
-          } else {
+        let completed = 0
+        let succeeded = 0
+        const failed: BatchSyncFailure[] = []
+
+        for (const task of plan.tasks) {
+          if (batchSyncCancelRef.current) {
+            setBatchSyncState({
+              running: false,
+              completed,
+              total: plan.tasks.length,
+              succeeded,
+              failed: [...failed],
+              skippedConflicts: plan.skippedConflicts,
+              skippedCopilotPending: plan.skippedCopilotPending,
+              cancelled: true
+            })
+            notification.warning({
+              message: t("managePrompts.sync.batchCancelled", {
+                defaultValue: "Batch sync cancelled"
+              }),
+              description: t("managePrompts.sync.batchCancelledDesc", {
+                defaultValue:
+                  "Synced {{completed}} of {{total}} prompts before cancellation.",
+                completed,
+                total: plan.tasks.length
+              })
+            })
+            await queryClient.invalidateQueries({ queryKey: ["fetchAllPrompts"] })
+            return
+          }
+
+          try {
+            const result =
+              task.direction === "pull"
+                ? await pullFromStudio(task.serverId!, task.promptId)
+                : task.serverId
+                  ? await pushToStudio(task.promptId, task.preferredProjectId || 1)
+                  : await autoSyncPrompt(task.promptId, task.preferredProjectId)
+
+            if (result.success) {
+              succeeded += 1
+            } else {
+              failed.push({
+                task,
+                error:
+                  result.error ||
+                  t("managePrompts.notification.someError", {
+                    defaultValue: "Something went wrong."
+                  })
+              })
+            }
+          } catch (error: any) {
             failed.push({
               task,
               error:
-                result.error ||
+                error?.message ||
                 t("managePrompts.notification.someError", {
                   defaultValue: "Something went wrong."
                 })
             })
           }
-        } catch (error: any) {
-          failed.push({
-            task,
-            error:
-              error?.message ||
-              t("managePrompts.notification.someError", {
-                defaultValue: "Something went wrong."
-              })
-          })
+
+          completed += 1
+          setBatchSyncState((prev) => ({
+            ...prev,
+            completed,
+            succeeded,
+            failed: [...failed]
+          }))
         }
 
-        completed += 1
-        setBatchSyncState((prev) => ({
-          ...prev,
+        await queryClient.invalidateQueries({ queryKey: ["fetchAllPrompts"] })
+
+        setBatchSyncState({
+          running: false,
           completed,
+          total: plan.tasks.length,
           succeeded,
-          failed: [...failed]
-        }))
-      }
-
-      await queryClient.invalidateQueries({ queryKey: ["fetchAllPrompts"] })
-
-      setBatchSyncState({
-        running: false,
-        completed,
-        total: plan.tasks.length,
-        succeeded,
-        failed: [...failed],
-        skippedConflicts: plan.skippedConflicts,
-        skippedCopilotPending: plan.skippedCopilotPending,
-        cancelled: false
-      })
-
-      if (failed.length > 0) {
-        notification.warning({
-          message: t("managePrompts.sync.batchPartialFailure", {
-            defaultValue: "Sync completed with issues"
-          }),
-          description: t("managePrompts.sync.batchPartialFailureDesc", {
-            defaultValue:
-              "Synced {{succeeded}} of {{total}} prompts. {{failed}} failed.",
-            succeeded,
-            total: plan.tasks.length,
-            failed: failed.length
-          })
+          failed: [...failed],
+          skippedConflicts: plan.skippedConflicts,
+          skippedCopilotPending: plan.skippedCopilotPending,
+          cancelled: false
         })
-      } else {
-        const extra = plan.skippedConflicts > 0
-          ? t("managePrompts.sync.batchConflictReminder", {
+
+        if (failed.length > 0) {
+          notification.warning({
+            message: t("managePrompts.sync.batchPartialFailure", {
+              defaultValue: "Sync completed with issues"
+            }),
+            description: t("managePrompts.sync.batchPartialFailureDesc", {
               defaultValue:
-                " {{count}} conflict prompt(s) still need manual resolution.",
-              count: plan.skippedConflicts
+                "Synced {{succeeded}} of {{total}} prompts. {{failed}} failed.",
+              succeeded,
+              total: plan.tasks.length,
+              failed: failed.length
             })
-          : ""
-        notification.success({
-          message: t("managePrompts.sync.batchSuccess", {
-            defaultValue: "Batch sync complete"
-          }),
-          description: `${t("managePrompts.sync.batchSuccessDesc", {
-            defaultValue: "Synced {{count}} prompt(s).",
-            count: succeeded
-          })}${extra}`
-        })
+          })
+        } else {
+          const extra = plan.skippedConflicts > 0
+            ? t("managePrompts.sync.batchConflictReminder", {
+                defaultValue:
+                  " {{count}} conflict prompt(s) still need manual resolution.",
+                count: plan.skippedConflicts
+              })
+            : ""
+          notification.success({
+            message: t("managePrompts.sync.batchSuccess", {
+              defaultValue: "Batch sync complete"
+            }),
+            description: `${t("managePrompts.sync.batchSuccessDesc", {
+              defaultValue: "Synced {{count}} prompt(s).",
+              count: succeeded
+            })}${extra}`
+          })
+        }
+      } finally {
+        batchSyncRunningRef.current = false
       }
     },
     [isOnline, queryClient, t]

--- a/apps/packages/ui/src/components/Option/Prompt/index.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/index.tsx
@@ -56,6 +56,10 @@ import {
 import {
   type TagMatchMode
 } from "./custom-prompts-utils"
+import {
+  buildSyncBatchPlan,
+  type SyncBatchTask
+} from "./sync-batch-utils"
 // filterCopilotPrompts moved to usePromptInteractions hook
 import {
   filterTrashPromptsByName,
@@ -1004,6 +1008,61 @@ export const PromptBody = () => {
     [currentPage, resultsPerPage]
   )
 
+  const buildPromptRetryTaskById = React.useCallback(
+    (id: string): SyncBatchTask | null => {
+      if (!isOnline) return null
+
+      const promptRecord = getPromptRecordById(id)
+      if (!promptRecord || promptRecord.syncStatus !== "pending") return null
+
+      const plan = buildSyncBatchPlan([
+        {
+          prompt: {
+            id: String(promptRecord.id || id),
+            name: promptRecord.name,
+            title: promptRecord.title,
+            syncStatus: promptRecord.syncStatus,
+            sourceSystem: promptRecord.sourceSystem,
+            serverId: promptRecord.serverId,
+            studioProjectId: promptRecord.studioProjectId
+          },
+          syncStatus: promptRecord.syncStatus
+        }
+      ])
+
+      return plan.tasks[0] || null
+    },
+    [getPromptRecordById, isOnline]
+  )
+
+  const canRetryPromptSync = React.useCallback(
+    (row: PromptRowVM) => {
+      if (sync.batchSyncState.running) return false
+      if (row.syncStatus !== "pending" || row.sourceSystem === "copilot") {
+        return false
+      }
+      return buildPromptRetryTaskById(row.id) !== null
+    },
+    [buildPromptRetryTaskById, sync.batchSyncState.running]
+  )
+
+  const handleRetryPromptSyncById = React.useCallback(
+    (id: string) => {
+      if (sync.batchSyncState.running) return
+      const task = buildPromptRetryTaskById(id)
+      if (!task) return
+      void sync.runBatchSync([task])
+    },
+    [buildPromptRetryTaskById, sync.batchSyncState.running, sync.runBatchSync]
+  )
+
+  const handleRetryPromptSync = React.useCallback(
+    (row: PromptRowVM) => {
+      handleRetryPromptSyncById(row.id)
+    },
+    [handleRetryPromptSyncById]
+  )
+
   const renderCustomPromptTitleMeta = React.useCallback(
     (row: PromptRowVM) => {
       if (!isCompactViewport) return null
@@ -1033,13 +1092,26 @@ export const PromptBody = () => {
                     ? () => sync.openConflictResolution(row.id)
                     : undefined
                 }
+                onRetry={
+                  canRetryPromptSync(row)
+                    ? () => handleRetryPromptSync(row)
+                    : undefined
+                }
               />
             </span>
           </Tooltip>
         </div>
       )
     },
-    [formatRelativePromptTime, isCompactViewport, isOnline, sync.openConflictResolution, t]
+    [
+      canRetryPromptSync,
+      formatRelativePromptTime,
+      handleRetryPromptSync,
+      isCompactViewport,
+      isOnline,
+      sync.openConflictResolution,
+      t
+    ]
   )
 
   const renderCustomPromptActions = React.useCallback(
@@ -1120,6 +1192,13 @@ export const PromptBody = () => {
                 }
               : undefined
           }
+          onRetrySync={
+            canRetryPromptSync(row)
+              ? () => {
+                  handleRetryPromptSync(row)
+                }
+              : undefined
+          }
         />
       )
     },
@@ -1131,7 +1210,9 @@ export const PromptBody = () => {
       handleUsePromptInChat,
       isFireFoxPrivateMode,
       isOnline,
-      sync
+      sync,
+      canRetryPromptSync,
+      handleRetryPromptSync
     ]
   )
 
@@ -1848,6 +1929,8 @@ export const PromptBody = () => {
             onEdit={editor.handleEditPromptById}
             onToggleFavorite={editor.handleTogglePromptFavorite}
             onOpenConflictResolution={sync.openConflictResolution}
+            canRetrySync={canRetryPromptSync}
+            onRetrySync={handleRetryPromptSyncById}
             renderActions={renderCustomPromptActions}
             renderTitleMeta={renderCustomPromptTitleMeta}
             favoriteButtonTestId={(row) => `prompt-favorite-${row.id}`}

--- a/apps/packages/ui/src/components/Option/Prompt/prompt-table-columns.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/prompt-table-columns.tsx
@@ -29,6 +29,8 @@ export type PromptTableColumnOptions = {
   onToggleFavorite?: (row: PromptRowVM, nextFavorite: boolean) => void
   onEdit?: (row: PromptRowVM) => void
   onOpenConflictResolution?: (row: PromptRowVM) => void
+  canRetrySync?: (row: PromptRowVM) => boolean
+  onRetrySync?: (row: PromptRowVM) => void
   renderActions?: (row: PromptRowVM) => React.ReactNode
   renderTitleMeta?: (row: PromptRowVM) => React.ReactNode
   favoriteButtonTestId?: (row: PromptRowVM) => string
@@ -118,6 +120,8 @@ export const buildPromptTableColumns = (
     onToggleFavorite,
     onEdit,
     onOpenConflictResolution,
+    canRetrySync,
+    onRetrySync,
     renderActions,
     renderTitleMeta,
     favoriteButtonTestId,
@@ -275,6 +279,13 @@ export const buildPromptTableColumns = (
                     onClick={
                       record.syncStatus === "conflict"
                         ? () => onOpenConflictResolution?.(record)
+                        : undefined
+                    }
+                    onRetry={
+                      isOnline &&
+                      onRetrySync &&
+                      (canRetrySync?.(record) ?? false)
+                        ? () => onRetrySync(record)
                         : undefined
                     }
                   />


### PR DESCRIPTION
## Change summary
- Wired pending prompt rows to the existing per-prompt retry affordances on SyncStatusBadge and PromptActionsMenu.
- Reused the existing batch-sync execution path for a single-row retry so error handling, notifications, and skipped Copilot-pending behavior stay aligned with toolbar retry behavior.
- Added a PromptBody integration test that exercises retry from both the sync badge and row actions menu.

## Verification
- ./node_modules/.bin/vitest run src/components/Option/Prompt/__tests__/PromptBody.search-pagination.test.tsx -t "wires per-prompt retry"
- ./node_modules/.bin/vitest run src/components/Option/Prompt/__tests__/PromptBody.search-pagination.test.tsx src/components/Option/Prompt/__tests__/SyncStatusBadge.test.tsx src/components/Option/Prompt/__tests__/PromptActionsMenu.test.tsx src/components/Option/Prompt/__tests__/prompt-table-columns.visual-alignment.test.tsx
- git diff --cached --check

Bandit not run: TS/UI-only change.