### PR TITLE
Phase 3.4: standardize auth dependency factories

### DIFF
--- a/Docs/AuthNZ/AUTHNZ_PERMISSION_MATRIX.md
+++ b/Docs/AuthNZ/AUTHNZ_PERMISSION_MATRIX.md
@@ -82,9 +82,9 @@ For new FastAPI endpoints, use the unified `AuthPrincipal` dependency stack from
 ```python
 from fastapi import APIRouter, Depends
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    RequireRole,
     get_auth_principal,
-    require_permissions,
-    require_roles,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 
@@ -94,14 +94,14 @@ router = APIRouter()
 async def secure(principal: AuthPrincipal = Depends(get_auth_principal)):
     return {"principal_id": principal.principal_id, "roles": principal.roles}
 
-@router.post("/media/{media_id}", dependencies=[Depends(require_permissions("media.update"))])
+@router.post("/media/{media_id}", dependencies=[Depends(RequirePermission("media.update"))])
 async def update_media(
     media_id: int,
     principal: AuthPrincipal = Depends(get_auth_principal),
 ):
     return {"ok": True, "media_id": media_id, "by": principal.principal_id}
 
-@router.get("/admin/dashboard", dependencies=[Depends(require_roles("admin"))])
+@router.get("/admin/dashboard", dependencies=[Depends(RequireRole("admin"))])
 async def admin_dashboard(
     principal: AuthPrincipal = Depends(get_auth_principal),
 ):
@@ -110,7 +110,7 @@ async def admin_dashboard(
 
 ### Legacy Permission Decorators (Historical)
 
-Earlier versions exposed decorator-style FastAPI helpers (`PermissionChecker`, `RoleChecker`, `AnyPermissionChecker`, `AllPermissionsChecker`) from `permissions.py`. These have been removed in favor of the claim-first dependency pattern; new and existing routes should rely on `get_auth_principal` together with `require_permissions` / `require_roles` instead.
+Earlier versions exposed decorator-style FastAPI helpers (`PermissionChecker`, `RoleChecker`, `AnyPermissionChecker`, `AllPermissionsChecker`) from `permissions.py`. These have been removed in favor of the claim-first dependency pattern; new and existing routes should rely on `get_auth_principal` together with `RequirePermission` / `RequireRole` instead.
 
 ### Using Permission Functions
 

--- a/Docs/AuthNZ/AUTHNZ_USAGE_EXAMPLES.md
+++ b/Docs/AuthNZ/AUTHNZ_USAGE_EXAMPLES.md
@@ -138,9 +138,9 @@ New endpoints should use the unified `AuthPrincipal` / dependency stack. This ke
 ```python
 from fastapi import APIRouter, Depends
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    RequireRole,
     get_auth_principal,
-    require_permissions,
-    require_roles,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 
@@ -159,7 +159,7 @@ async def get_me(principal: AuthPrincipal = Depends(get_auth_principal)):
 # Require a specific permission
 @router.post(
     "/api/v1/media/{media_id}",
-    dependencies=[Depends(require_permissions("media.update"))],
+    dependencies=[Depends(RequirePermission("media.update"))],
 )
 async def update_media(
     media_id: int,
@@ -170,7 +170,7 @@ async def update_media(
 # Require admin role
 @router.delete(
     "/api/v1/admin/user/{user_id}",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def delete_user(
     user_id: int,
@@ -183,7 +183,7 @@ async def delete_user(
 
 ### Legacy Permission Decorators (Historical Only)
 
-Earlier versions exposed decorator-style FastAPI helpers (`PermissionChecker`, `RoleChecker`, `AnyPermissionChecker`, `AllPermissionsChecker`) from `permissions.py`. These have been removed in favor of the claim-first dependency pattern shown above; new and existing endpoints should use `get_auth_principal` with `require_permissions` / `require_roles` instead.
+Earlier versions exposed decorator-style FastAPI helpers (`PermissionChecker`, `RoleChecker`, `AnyPermissionChecker`, `AllPermissionsChecker`) from `permissions.py`. These have been removed in favor of the claim-first dependency pattern shown above; new and existing endpoints should use `get_auth_principal` with `RequirePermission` / `RequireRole` instead.
 
 ### Using in Non-FastAPI Code
 

--- a/Docs/Code_Documentation/Guides/Audit_Module_Code_Guide.md
+++ b/Docs/Code_Documentation/Guides/Audit_Module_Code_Guide.md
@@ -258,7 +258,7 @@ async with audit_operation(service, AuditEventType.DATA_READ, ctx,
   otherwise clean audit service boundary before the strict `flush(raise_on_failure=True)` call.
 - PII not redacting: verify patterns and `AUDIT_PII_*` settings; confirm fields are strings or in `metadata`.
 - Slow queries: verify indexes were created (service creates on init); filter narrowing with indexed fields (`timestamp`, `context_*`, `event_type`, `category`).
-- Admin requirement: export/count endpoints enforce admin via claim-first dependencies (`require_roles("admin")` / `require_permissions(...)`); override those deps in tests accordingly.
+- Admin requirement: export/count endpoints enforce admin via claim-first dependencies (`RequireRole("admin")` / `RequirePermission(...)`); override those deps in tests accordingly.
 
 ## Security Notes
 

--- a/Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md
+++ b/Docs/Code_Documentation/Guides/AuthNZ_Code_Guide.md
@@ -26,7 +26,7 @@ See also: `tldw_Server_API/app/core/AuthNZ/README.md` and `Docs/Code_Documentati
 
 ## New endpoints checklist (AuthNZ + RG)
 
-- Always authenticate via `get_auth_principal` and enforce authorization with `require_permissions(...)` / `require_roles(...)` (and `require_service_principal()` for service-only routes). `require_admin`/`require_role` API-dependency shims are removed; avoid raw `request.state.user_id` checks or ad-hoc `is_single_user_mode()` branches for access control.
+- Always authenticate via `get_auth_principal` and enforce authorization with `RequirePermission(...)` / `RequireRole(...)` (and `require_service_principal()` for service-only routes). `require_admin`/`require_role` API-dependency shims are removed; avoid raw `request.state.user_id` checks or ad-hoc `is_single_user_mode()` branches for access control.
 - For latency/cost-sensitive or user-facing endpoints (chat, audio, embeddings, evaluations, MCP, workflows, tools, media ingestion, etc.), verify whether they should be governed by Resource Governor:
   - If yes, ensure there is a policy entry (`resource_governor_policies.yaml` or DB-backed `rg_policies`) and a `route_map` entry mapping the endpoint’s path/tag to an appropriate policy id.
   - Confirm tests exercise the RG-enforced behavior where limits are important (429/Retry-After headers, tokens/streams limits, etc.).
@@ -50,7 +50,7 @@ See also: `tldw_Server_API/app/core/AuthNZ/README.md` and `Docs/Code_Documentati
 
 Admin role semantics (claims-first):
 - The `admin` role claim is interpreted consistently across profiles: a principal with `roles=["admin", ...]` is treated as having both admin- and user-level access regardless of `AUTH_MODE`/`PROFILE`.
-- Helpers such as `check_role`, `require_roles("admin")`, and `require_permissions(...)` rely on claims (`principal.roles`, `principal.permissions`, `principal.is_admin`) rather than re-reading mode, so new endpoints should always gate admin/control surfaces through these claim-first dependencies instead of adding new mode checks.
+- Helpers such as `check_role`, `RequireRole("admin")`, and `RequirePermission(...)` rely on claims (`principal.roles`, `principal.permissions`, `principal.is_admin`) rather than re-reading mode, so new endpoints should always gate admin/control surfaces through these claim-first dependencies instead of adding new mode checks.
 
 Recommended combinations (v0.1):
 - Local single-user desktop: `AUTH_MODE=single_user`, `PROFILE=local-single-user` (default SQLite users DB).
@@ -77,9 +77,9 @@ Recommended combinations (v0.1):
 - Virtual keys (JWT) are short-lived scoped tokens minted by authenticated users for automation/integrations. Validation works in both modes when JWT is configured. In single-user mode the JWT service derives a surrogate secret from `SINGLE_USER_API_KEY`, so bearer JWTs can be validated; API keys remain the simplest option when operating single-user.
 
 Note on single-user JWTs:
-- In single-user mode, `get_current_user` does not accept arbitrary JWTs; it only accepts `SINGLE_USER_API_KEY` via `X-API-KEY` or as Bearer (see `tldw_Server_API.app.api.v1.API_Deps.auth_deps.get_current_user`). Virtual JWTs can still be verified and scoped via `require_token_scope`, but they do not authenticate a user in single-user mode.
+- In single-user mode, `get_current_user` does not accept arbitrary JWTs; it only accepts `SINGLE_USER_API_KEY` via `X-API-KEY` or as Bearer (see `tldw_Server_API.app.api.v1.API_Deps.auth_deps.get_current_user`). Virtual JWTs can still be verified and scoped via `TokenScopeGuard`, but they do not authenticate a user in single-user mode.
 
-JWT virtual keys support additional constraints via claims (enforced with `auth_deps.require_token_scope`, not in `get_current_user`):
+JWT virtual keys support additional constraints via claims (enforced with `auth_deps.TokenScopeGuard`, not in `get_current_user`):
 - `allowed_endpoints`: list of endpoint codes (e.g., `chat.completions`)
 - `allowed_methods`: HTTP methods allowlist (e.g., `["POST"]`)
 - `allowed_paths`: path prefixes allowlist (e.g., `["/api/v1/chat/"]`)
@@ -97,13 +97,13 @@ JWT virtual keys support additional constraints via claims (enforced with `auth_
 
 - Virtual JWTs (short-lived tokens)
   - Minted with `JWTService.create_virtual_access_token(...)`; not stored server-side.
-  - Authenticate with Bearer; claim-level enforcement is applied via `auth_deps.require_token_scope` (allowed_endpoints/methods/paths, quotas via `count_as` + `max_calls`/`max_runs`, optional `schedule_id`).
+  - Authenticate with Bearer; claim-level enforcement is applied via `auth_deps.TokenScopeGuard` (allowed_endpoints/methods/paths, quotas via `count_as` + `max_calls`/`max_runs`, optional `schedule_id`).
   - Work in both modes (single-user derives a surrogate secret; multi-user uses configured JWT secrets/keys).
   - Best for ephemeral, scoped automation (e.g., scheduled workflows) where rotation and narrow scope are required.
 
 ## Using Dependencies in Endpoints
 
-Prefer the shared dependencies from `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`.
+Prefer the shared dependencies from `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`. Endpoint code should import the PascalCase factories (`RequirePermission`, `RequireRole`, and `TokenScopeGuard`); the lowercase names remain implementation/backcompat factories and are covered directly by AuthNZ unit tests.
 
 Typical patterns:
 
@@ -113,7 +113,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_current_user,           # Resolves single-user, API-key, or JWT
     get_current_active_user,    # Adds active status check
     check_rate_limit,           # Diagnostics-only ingress compatibility helper
-    require_permissions,        # Claim-first permission gate (preferred)
+    RequirePermission,          # Claim-first permission gate
 )
 
 router = APIRouter(prefix="/example", tags=["examples"])
@@ -124,7 +124,7 @@ async def protected_route(user=Depends(get_current_user)):
 
 @router.post(
     "/write",
-    dependencies=[Depends(require_permissions("media.update"))],
+    dependencies=[Depends(RequirePermission("media.update"))],
 )
 async def write_route(user=Depends(get_current_active_user)):
     return {"ok": True}
@@ -135,17 +135,17 @@ async def limited_route(user=Depends(get_current_user)):
 ```
 
 Scoped token/key enforcement:
-- Use `require_token_scope(scope, endpoint_id=..., count_as=...)` to enforce virtual-key constraints on a route. It validates JWT claims when a bearer is present and applies equivalent metadata-based checks when only `X-API-KEY` is provided (allowed endpoints/methods/paths and optional per-key quotas).
+- Use `TokenScopeGuard(scope, endpoint_id=..., count_as=...)` to enforce virtual-key constraints on a route. It validates JWT claims when a bearer is present and applies equivalent metadata-based checks when only `X-API-KEY` is provided (allowed endpoints/methods/paths and optional per-key quotas).
  - This dependency is additive and does not replace `get_current_user`; use both when a route must authenticate and enforce scoped constraints.
 
 Example (scoped automation endpoint):
 ```python
 from fastapi import Depends
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    get_current_user, require_token_scope
+    get_current_user, TokenScopeGuard
 )
 
-@router.post("/workflows/run", dependencies=[Depends(require_token_scope(
+@router.post("/workflows/run", dependencies=[Depends(TokenScopeGuard(
     scope="workflows",
     endpoint_id="workflows.run",
     count_as="run",
@@ -170,8 +170,8 @@ from fastapi import Depends
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_optional_current_user,
     get_auth_principal,
-    require_permissions,
-    require_roles,
+    RequirePermission,
+    RequireRole,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 
@@ -182,11 +182,11 @@ async def maybe_auth(user=Depends(get_optional_current_user)):
     return {"hello": "anonymous"}
 
 @router.get("/admin-only")
-async def admin_only(principal: AuthPrincipal = Depends(require_roles("admin"))):
+async def admin_only(principal: AuthPrincipal = Depends(RequireRole("admin"))):
     return {"ok": True, "as": "admin", "id": principal.user_id}
 
 @router.get("/media-read")
-async def media_read(principal: AuthPrincipal = Depends(require_permissions("media.read"))):
+async def media_read(principal: AuthPrincipal = Depends(RequirePermission("media.read"))):
     return {"ok": True, "id": principal.user_id}
 ```
 
@@ -208,7 +208,7 @@ Key calls you’ll see in endpoints/services:
 - Keys support: expiry, usage counts, IP allowlists, rate limits, audit log, and optional LLM usage budgets and allowlists.
 - `auth_deps.get_current_user` can authenticate via `X-API-KEY` when no Bearer token is present.
 - Virtual keys: use `POST /api/v1/auth/virtual-key` or programmatically via `JWTService.create_virtual_access_token(...)`.
-  - Virtual keys are enforced via scoped claims (e.g., `scope`, allowed endpoints/methods/paths) with helpers in `auth_deps.require_token_scope` and budget checks in `llm_budget_guard.py`.
+  - Virtual keys are enforced via scoped claims (e.g., `scope`, allowed endpoints/methods/paths) with helpers in `auth_deps.TokenScopeGuard` and budget checks in `llm_budget_guard.py`.
 
 Example: create and validate an API key
 ```python
@@ -229,7 +229,7 @@ Notes:
 - Org/team context: DI attaches `request.state.user_id`, plus memberships from `orgs_teams.list_memberships_for_user` and a content scope token via `scope_context.set_scope` for downstream DB access.
 - **Modern pattern (preferred)**: use claim-first dependencies from `auth_deps`:
   - `get_auth_principal` → returns `AuthPrincipal` with `roles`/`permissions` claims.
-  - `require_permissions("perm")` / `require_roles("role")` → enforce claims and return the principal.
+  - `RequirePermission("perm")` / `RequireRole("role")` → enforce claims and return the principal.
   - `require_service_principal()` → enforces `principal.kind == "service"` for internal-only/service endpoints.
   - Representative usage exists on media, RAG, notes graph, evaluations CRUD endpoints, sandbox admin views, and selected workflows surfaces.
   - `get_org_policy_from_principal` → resolves an organization policy in a **principal-first** way for org-scoped features (for example, connectors/admin policy and sources):
@@ -244,20 +244,20 @@ Notes:
   - `get_current_user`:
     - Returns a user-shaped dict when credentials are valid.
     - Raises **401 Unauthorized** for missing/invalid credentials with detail containing `"Authentication required"` and `WWW-Authenticate: Bearer`.
-  - `require_permissions` / `require_roles`:
+  - `RequirePermission` / `RequireRole`:
     - Propagate **401** from `get_auth_principal` when no principal can be resolved.
     - Raise **403 Forbidden** when a principal is present but lacks required claims:
-      - `require_permissions` → `detail="Permission denied. Required: <perm-list>"`.
-      - `require_roles` → `detail="Access denied. Required role(s): <role-list>"`.
+      - `RequirePermission` → `detail="Permission denied. Required: <perm-list>"`.
+      - `RequireRole` → `detail="Access denied. Required role(s): <role-list>"`.
     - These 403 payload shapes are treated as part of the public surface for claim-first/admin routes.
   - `require_service_principal`:
     - Depends on `get_auth_principal` for authentication (401 on missing/invalid credentials).
     - Raises **403 Forbidden** with `detail="Service principal required"` when a non-service principal calls a service-only route.
     - Returns the underlying `AuthPrincipal` unchanged when `principal.kind == "service"`.
 - **Removed legacy helpers (historical only)**:
-  - Earlier versions exposed FastAPI dependencies `PermissionChecker`, `RoleChecker`, `AnyPermissionChecker`, and `AllPermissionsChecker` from `permissions.py`. These have now been removed; endpoints must use `get_auth_principal` together with `require_permissions` / `require_roles` instead.
+  - Earlier versions exposed FastAPI dependencies `PermissionChecker`, `RoleChecker`, `AnyPermissionChecker`, and `AllPermissionsChecker` from `permissions.py`. These have now been removed; endpoints must use `get_auth_principal` together with `RequirePermission` / `RequireRole` instead.
   - Existing admin and control surfaces that once used these helpers (media add, tools execute, workflows runs/events/artifacts/control/DLQ, sandbox admin) have been migrated to claim-first dependencies. Tests such as `test_media_add_permissions_claims.py`, `test_tools_permissions_claims.py`, `test_workflows_runs_permissions_claims.py`, `test_workflows_artifacts_permissions_claims.py`, `test_workflows_webhook_dlq_permissions_claims.py`, `test_workflows_control_permissions_claims.py`, and `test_sandbox_admin_permissions_claims.py` lock in the new behavior and ensure the claim-first dependencies are the true authorization gates.
-  - Heavy evaluations admin paths use claim-first checks via `enforce_heavy_evaluations_admin(AuthPrincipal)` together with `require_roles("admin")` / `require_permissions(...)` on top of `get_auth_principal`.
+  - Heavy evaluations admin paths use claim-first checks via `enforce_heavy_evaluations_admin(AuthPrincipal)` together with `RequireRole("admin")` / `RequirePermission(...)` on top of `get_auth_principal`.
   - A repository layer exists for AuthNZ and MUST be used instead of ad-hoc SQL for core tables:
     - `AuthnzUsersRepo` (`app/core/AuthNZ/repos/users_repo.py`) wraps `UsersDB` for user lookups; exercised against both SQLite and Postgres in AuthNZ tests.
     - `AuthnzApiKeysRepo` (`app/core/AuthNZ/repos/api_keys_repo.py`) centralizes `api_keys` read/write paths and is used by `APIKeyManager` and single-user bootstrap.
@@ -279,13 +279,13 @@ Tests:
     - `AuthnzRateLimitsRepo` (`app/core/AuthNZ/repos/rate_limits_repo.py`) encapsulates all DB-backed rate-limiter tables (`rate_limits`, `failed_attempts`, `account_lockouts`) and is used by `rate_limiter.RateLimiter` for counters, lockouts, and cleanup.
   - New AuthNZ code should **not** add fresh backend-specific SQL for these tables; prefer adding small, task-focused methods to the appropriate repo and calling them from business logic.
   - New code MUST NOT introduce fresh `is_single_user_mode()` branches in endpoint/business logic. Mode/profile checks are confined to a small number of coordination points (bootstrap, DB selection, and legacy compatibility helpers); authorization should flow through `AuthPrincipal` + claim-first dependencies instead.
-  - New code **must not** reintroduce FastAPI dependency helpers that bypass `get_auth_principal` or duplicate `require_permissions` / `require_roles`. Authorization for endpoints should always flow through claim-first dependencies.
+  - New code **must not** reintroduce FastAPI dependency helpers that bypass `get_auth_principal` or duplicate `RequirePermission` / `RequireRole`. Authorization for endpoints should always flow through claim-first dependencies.
   - AuthNZ-facing documentation (usage examples, API integration guides) should treat this guide as canonical and mirror its claim-first patterns. When decorator-style helpers appear in historical examples (including the removed `*Checker` classes), they should be clearly labeled as legacy and not used for new code.
 
 References:
 - `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#get_auth_principal`
-- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#require_permissions`
-- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#require_roles`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#RequirePermission`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#RequireRole`
 
 ## How to Secure a New Endpoint (Checklist)
 
@@ -301,9 +301,9 @@ When adding a new FastAPI endpoint that needs AuthNZ and guardrails:
 2. **Define and apply permissions/roles**
    - Add or reuse a permission constant in `tldw_Server_API/app/core/AuthNZ/permissions.py`.
    - Gate the route with claim-first dependencies on the router or endpoint:
-     - `dependencies=[Depends(require_permissions(MY_PERMISSION))]`
-     - and/or `dependencies=[Depends(require_roles("admin"))]`.
-   - Do **not** introduce mode-based gates or legacy admin shims; always build on `get_auth_principal` + `require_permissions` / `require_roles`.
+     - `dependencies=[Depends(RequirePermission(MY_PERMISSION))]`
+     - and/or `dependencies=[Depends(RequireRole("admin"))]`.
+   - Do **not** introduce mode-based gates or legacy admin shims; always build on `get_auth_principal` + `RequirePermission` / `RequireRole`.
 
 3. **Wire ResourceGovernor / rate limits if needed**
    - For rate-limited endpoints, reuse shared helpers instead of new per-module limiters:
@@ -401,8 +401,8 @@ async def tight_user(user=Depends(get_current_user)):
 ## Expected Roles/Permissions for Resource-Governor Admin
 
 - Resource-Governor admin and diagnostics endpoints under `/api/v1/resource-governor/*` are treated as AuthNZ admin surfaces and MUST:
-  - Use claim-first dependencies: `principal: AuthPrincipal = Depends(get_auth_principal)` and `dependencies=[Depends(require_roles("admin"))]` on the route.
-  - Rely on `require_roles("admin")` (admin role or `principal.is_admin`) as the gate; do not add new `is_single_user_mode()` / mode-specific bypasses in handlers.
+  - Use claim-first dependencies: `principal: AuthPrincipal = Depends(get_auth_principal)` and `dependencies=[Depends(RequireRole("admin"))]` on the route.
+  - Rely on `RequireRole("admin")` (admin role or `principal.is_admin`) as the gate; do not add new `is_single_user_mode()` / mode-specific bypasses in handlers.
   - Keep 401/403 semantics aligned with other admin endpoints (401 for missing/invalid credentials, 403 for insufficient roles), as enforced by:
     - `tldw_Server_API/tests/AuthNZ_Unit/test_resource_governor_permissions_claims.py`
     - `tldw_Server_API/tests/Resource_Governance/test_rg_capabilities_endpoint.py`
@@ -473,9 +473,9 @@ async def secure(user=Depends(get_current_user)):
 2) Require a permission (claim-first)
 ```python
 from fastapi import Depends
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_current_user, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, get_current_user
 
-@router.post("/media/update", dependencies=[Depends(require_permissions("media.update"))])
+@router.post("/media/update", dependencies=[Depends(RequirePermission("media.update"))])
 async def update_media(user=Depends(get_current_user)):
     ...
 ```
@@ -518,7 +518,7 @@ async def mint_vk(user=Depends(get_current_user)):
 
 - Add new permissions in `permissions.py` and seed mapping in RBAC migrations/seeders.
 - New admin surfaces belong under `.../endpoints/admin/` (router + shared helpers) or a feature-specific `admin_<feature>.py` module and should be guarded using claim-first dependencies:
-  - Prefer `principal: AuthPrincipal = Depends(get_auth_principal)` together with `dependencies=[Depends(require_roles("admin"))]` (and `require_permissions(...)` where appropriate).
+  - Prefer `principal: AuthPrincipal = Depends(get_auth_principal)` together with `dependencies=[Depends(RequireRole("admin"))]` (and `RequirePermission(...)` where appropriate).
 - For new guardrails, prefer middleware with settings gating, and expose DI helpers to keep endpoints simple.
 - Keep both SQLite and Postgres code paths working; use `DatabasePool` helpers to normalize placeholders across backends when needed.
 

--- a/Docs/Code_Documentation/Guides/Evaluations_Code_Guide.md
+++ b/Docs/Code_Documentation/Guides/Evaluations_Code_Guide.md
@@ -132,7 +132,7 @@ results = await rag_eval.evaluate(
 - PDF path: `POST /ocr-pdf` (multipart) runs OCR (backend selectable) then computes metrics against provided ground truths; tune via form fields (dpi, lang, mode, min chars).
 
 **Auth, Limits, and Error Handling**
-- Auth modes handled in `evaluations_auth.verify_api_key`; admin gating is claim-first (`get_auth_principal` + `require_roles("admin")` / heavy-admin claim checks).
+- Auth modes handled in `evaluations_auth.verify_api_key`; admin gating is claim-first (`get_auth_principal` + `RequireRole("admin")` / heavy-admin claim checks).
 - Path limiter (`check_evaluation_rate_limit`) + per‑user `UserRateLimiter` estimate tokens and enforce daily/cost quotas; usage headers are applied by helpers.
 - Errors are normalized via `create_error_response` and `sanitize_error_message` for consistent API error shapes.
 

--- a/Docs/Deployment/Operations/MCP_Rate_Limits_Tuning.md
+++ b/Docs/Deployment/Operations/MCP_Rate_Limits_Tuning.md
@@ -60,7 +60,7 @@ Sample YAML (checked in):
 
 ## Security Notes
 
-- Keep the Prometheus endpoint gated by `require_permissions("system.logs")` / admin-style principals. Do not expose it unauthenticated; use credentials or an ingress/auth proxy for Prometheus scraping on internal networks.
+- Keep the Prometheus endpoint gated by `RequirePermission("system.logs")` / admin-style principals. Do not expose it unauthenticated; use credentials or an ingress/auth proxy for Prometheus scraping on internal networks.
 
 ## References
 

--- a/Docs/Product/Graphing-Notes-PRD.md
+++ b/Docs/Product/Graphing-Notes-PRD.md
@@ -281,7 +281,7 @@ Config keys (env → config.txt → defaults):
 - Rate limits should follow existing `rbac_rate_limit(...)` mechanism across endpoints.
 
 Token scopes:
-- When a JWT is presented, require the `notes` scope; when no token is present (single-user mode), proceed with RBAC checks only. Implementation follows `require_token_scope("notes", require_if_present=True)`.
+- When a JWT is presented, require the `notes` scope; when no token is present (single-user mode), proceed with RBAC checks only. Implementation follows `TokenScopeGuard("notes", require_if_present=True)`.
 
 ## 13. Performance and Caching
 

--- a/Docs/Published/Code_Documentation/Guides/Audit_Module_Code_Guide.md
+++ b/Docs/Published/Code_Documentation/Guides/Audit_Module_Code_Guide.md
@@ -225,7 +225,7 @@ async with audit_operation(service, AuditEventType.DATA_READ, ctx,
 - Missing events: ensure `await flush()` is called before shutdown; prefer DI and `await stop()` on app shutdown.
 - PII not redacting: verify patterns and `AUDIT_PII_*` settings; confirm fields are strings or in `metadata`.
 - Slow queries: verify indexes were created (service creates on init); filter narrowing with indexed fields (`timestamp`, `context_*`, `event_type`, `category`).
-- Admin requirement: export/count endpoints enforce admin via claim-first dependencies (`require_roles("admin")` / `require_permissions(...)`); override those deps in tests accordingly.
+- Admin requirement: export/count endpoints enforce admin via claim-first dependencies (`RequireRole("admin")` / `RequirePermission(...)`); override those deps in tests accordingly.
 
 ## Security Notes
 

--- a/Docs/Published/Code_Documentation/Guides/AuthNZ_Code_Guide.md
+++ b/Docs/Published/Code_Documentation/Guides/AuthNZ_Code_Guide.md
@@ -26,7 +26,7 @@ See also: `tldw_Server_API/app/core/AuthNZ/README.md` and `Docs/Code_Documentati
 
 ## New endpoints checklist (AuthNZ + RG)
 
-- Always authenticate via `get_auth_principal` and enforce authorization with `require_permissions(...)` / `require_roles(...)` (and `require_service_principal()` for service-only routes). `require_admin`/`require_role` API-dependency shims are removed; avoid raw `request.state.user_id` checks or ad-hoc `is_single_user_mode()` branches for access control.
+- Always authenticate via `get_auth_principal` and enforce authorization with `RequirePermission(...)` / `RequireRole(...)` (and `require_service_principal()` for service-only routes). `require_admin`/`require_role` API-dependency shims are removed; avoid raw `request.state.user_id` checks or ad-hoc `is_single_user_mode()` branches for access control.
 - For latency/cost-sensitive or user-facing endpoints (chat, audio, embeddings, evaluations, MCP, workflows, tools, media ingestion, etc.), verify whether they should be governed by Resource Governor:
   - If yes, ensure there is a policy entry (`resource_governor_policies.yaml` or DB-backed `rg_policies`) and a `route_map` entry mapping the endpoint’s path/tag to an appropriate policy id.
   - Confirm tests exercise the RG-enforced behavior where limits are important (429/Retry-After headers, tokens/streams limits, etc.).
@@ -50,7 +50,7 @@ See also: `tldw_Server_API/app/core/AuthNZ/README.md` and `Docs/Code_Documentati
 
 Admin role semantics (claims-first):
 - The `admin` role claim is interpreted consistently across profiles: a principal with `roles=["admin", ...]` is treated as having both admin- and user-level access regardless of `AUTH_MODE`/`PROFILE`.
-- Helpers such as `check_role`, `require_roles("admin")`, and `require_permissions(...)` rely on claims (`principal.roles`, `principal.permissions`, `principal.is_admin`) rather than re-reading mode, so new endpoints should always gate admin/control surfaces through these claim-first dependencies instead of adding new mode checks.
+- Helpers such as `check_role`, `RequireRole("admin")`, and `RequirePermission(...)` rely on claims (`principal.roles`, `principal.permissions`, `principal.is_admin`) rather than re-reading mode, so new endpoints should always gate admin/control surfaces through these claim-first dependencies instead of adding new mode checks.
 
 Recommended combinations (v0.1):
 - Local single-user desktop: `AUTH_MODE=single_user`, `PROFILE=local-single-user` (default SQLite users DB).
@@ -77,9 +77,9 @@ Recommended combinations (v0.1):
 - Virtual keys (JWT) are short-lived scoped tokens minted by authenticated users for automation/integrations. Validation works in both modes when JWT is configured. In single-user mode the JWT service derives a surrogate secret from `SINGLE_USER_API_KEY`, so bearer JWTs can be validated; API keys remain the simplest option when operating single-user.
 
 Note on single-user JWTs:
-- In single-user mode, `get_current_user` does not accept arbitrary JWTs; it only accepts `SINGLE_USER_API_KEY` via `X-API-KEY` or as Bearer (see `tldw_Server_API.app.api.v1.API_Deps.auth_deps.get_current_user`). Virtual JWTs can still be verified and scoped via `require_token_scope`, but they do not authenticate a user in single-user mode.
+- In single-user mode, `get_current_user` does not accept arbitrary JWTs; it only accepts `SINGLE_USER_API_KEY` via `X-API-KEY` or as Bearer (see `tldw_Server_API.app.api.v1.API_Deps.auth_deps.get_current_user`). Virtual JWTs can still be verified and scoped via `TokenScopeGuard`, but they do not authenticate a user in single-user mode.
 
-JWT virtual keys support additional constraints via claims (enforced with `auth_deps.require_token_scope`, not in `get_current_user`):
+JWT virtual keys support additional constraints via claims (enforced with `auth_deps.TokenScopeGuard`, not in `get_current_user`):
 - `allowed_endpoints`: list of endpoint codes (e.g., `chat.completions`)
 - `allowed_methods`: HTTP methods allowlist (e.g., `["POST"]`)
 - `allowed_paths`: path prefixes allowlist (e.g., `["/api/v1/chat/"]`)
@@ -97,13 +97,13 @@ JWT virtual keys support additional constraints via claims (enforced with `auth_
 
 - Virtual JWTs (short-lived tokens)
   - Minted with `JWTService.create_virtual_access_token(...)`; not stored server-side.
-  - Authenticate with Bearer; claim-level enforcement is applied via `auth_deps.require_token_scope` (allowed_endpoints/methods/paths, quotas via `count_as` + `max_calls`/`max_runs`, optional `schedule_id`).
+  - Authenticate with Bearer; claim-level enforcement is applied via `auth_deps.TokenScopeGuard` (allowed_endpoints/methods/paths, quotas via `count_as` + `max_calls`/`max_runs`, optional `schedule_id`).
   - Work in both modes (single-user derives a surrogate secret; multi-user uses configured JWT secrets/keys).
   - Best for ephemeral, scoped automation (e.g., scheduled workflows) where rotation and narrow scope are required.
 
 ## Using Dependencies in Endpoints
 
-Prefer the shared dependencies from `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`.
+Prefer the shared dependencies from `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py`. Endpoint code should import the PascalCase factories (`RequirePermission`, `RequireRole`, and `TokenScopeGuard`); the lowercase names remain implementation/backcompat factories and are covered directly by AuthNZ unit tests.
 
 Typical patterns:
 
@@ -113,7 +113,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_current_user,           # Resolves single-user, API-key, or JWT
     get_current_active_user,    # Adds active status check
     check_rate_limit,           # Diagnostics-only ingress compatibility helper
-    require_permissions,        # Claim-first permission gate (preferred)
+    RequirePermission,          # Claim-first permission gate
 )
 
 router = APIRouter(prefix="/example", tags=["examples"])
@@ -124,7 +124,7 @@ async def protected_route(user=Depends(get_current_user)):
 
 @router.post(
     "/write",
-    dependencies=[Depends(require_permissions("media.update"))],
+    dependencies=[Depends(RequirePermission("media.update"))],
 )
 async def write_route(user=Depends(get_current_active_user)):
     return {"ok": True}
@@ -135,17 +135,17 @@ async def limited_route(user=Depends(get_current_user)):
 ```
 
 Scoped token/key enforcement:
-- Use `require_token_scope(scope, endpoint_id=..., count_as=...)` to enforce virtual-key constraints on a route. It validates JWT claims when a bearer is present and applies equivalent metadata-based checks when only `X-API-KEY` is provided (allowed endpoints/methods/paths and optional per-key quotas).
+- Use `TokenScopeGuard(scope, endpoint_id=..., count_as=...)` to enforce virtual-key constraints on a route. It validates JWT claims when a bearer is present and applies equivalent metadata-based checks when only `X-API-KEY` is provided (allowed endpoints/methods/paths and optional per-key quotas).
  - This dependency is additive and does not replace `get_current_user`; use both when a route must authenticate and enforce scoped constraints.
 
 Example (scoped automation endpoint):
 ```python
 from fastapi import Depends
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    get_current_user, require_token_scope
+    get_current_user, TokenScopeGuard
 )
 
-@router.post("/workflows/run", dependencies=[Depends(require_token_scope(
+@router.post("/workflows/run", dependencies=[Depends(TokenScopeGuard(
     scope="workflows",
     endpoint_id="workflows.run",
     count_as="run",
@@ -170,8 +170,8 @@ from fastapi import Depends
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_optional_current_user,
     get_auth_principal,
-    require_permissions,
-    require_roles,
+    RequirePermission,
+    RequireRole,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 
@@ -182,11 +182,11 @@ async def maybe_auth(user=Depends(get_optional_current_user)):
     return {"hello": "anonymous"}
 
 @router.get("/admin-only")
-async def admin_only(principal: AuthPrincipal = Depends(require_roles("admin"))):
+async def admin_only(principal: AuthPrincipal = Depends(RequireRole("admin"))):
     return {"ok": True, "as": "admin", "id": principal.user_id}
 
 @router.get("/media-read")
-async def media_read(principal: AuthPrincipal = Depends(require_permissions("media.read"))):
+async def media_read(principal: AuthPrincipal = Depends(RequirePermission("media.read"))):
     return {"ok": True, "id": principal.user_id}
 ```
 
@@ -208,7 +208,7 @@ Key calls you’ll see in endpoints/services:
 - Keys support: expiry, usage counts, IP allowlists, rate limits, audit log, and optional LLM usage budgets and allowlists.
 - `auth_deps.get_current_user` can authenticate via `X-API-KEY` when no Bearer token is present.
 - Virtual keys: use `POST /api/v1/auth/virtual-key` or programmatically via `JWTService.create_virtual_access_token(...)`.
-  - Virtual keys are enforced via scoped claims (e.g., `scope`, allowed endpoints/methods/paths) with helpers in `auth_deps.require_token_scope` and budget checks in `llm_budget_guard.py`.
+  - Virtual keys are enforced via scoped claims (e.g., `scope`, allowed endpoints/methods/paths) with helpers in `auth_deps.TokenScopeGuard` and budget checks in `llm_budget_guard.py`.
 
 Example: create and validate an API key
 ```python
@@ -229,7 +229,7 @@ Notes:
 - Org/team context: DI attaches `request.state.user_id`, plus memberships from `orgs_teams.list_memberships_for_user` and a content scope token via `scope_context.set_scope` for downstream DB access.
 - **Modern pattern (preferred)**: use claim-first dependencies from `auth_deps`:
   - `get_auth_principal` → returns `AuthPrincipal` with `roles`/`permissions` claims.
-  - `require_permissions("perm")` / `require_roles("role")` → enforce claims and return the principal.
+  - `RequirePermission("perm")` / `RequireRole("role")` → enforce claims and return the principal.
   - `require_service_principal()` → enforces `principal.kind == "service"` for internal-only/service endpoints.
   - Representative usage exists on media, RAG, notes graph, evaluations CRUD endpoints, sandbox admin views, and selected workflows surfaces.
   - `get_org_policy_from_principal` → resolves an organization policy in a **principal-first** way for org-scoped features (for example, connectors/admin policy and sources):
@@ -244,20 +244,20 @@ Notes:
   - `get_current_user`:
     - Returns a user-shaped dict when credentials are valid.
     - Raises **401 Unauthorized** for missing/invalid credentials with detail containing `"Authentication required"` and `WWW-Authenticate: Bearer`.
-  - `require_permissions` / `require_roles`:
+  - `RequirePermission` / `RequireRole`:
     - Propagate **401** from `get_auth_principal` when no principal can be resolved.
     - Raise **403 Forbidden** when a principal is present but lacks required claims:
-      - `require_permissions` → `detail="Permission denied. Required: <perm-list>"`.
-      - `require_roles` → `detail="Access denied. Required role(s): <role-list>"`.
+      - `RequirePermission` → `detail="Permission denied. Required: <perm-list>"`.
+      - `RequireRole` → `detail="Access denied. Required role(s): <role-list>"`.
     - These 403 payload shapes are treated as part of the public surface for claim-first/admin routes.
   - `require_service_principal`:
     - Depends on `get_auth_principal` for authentication (401 on missing/invalid credentials).
     - Raises **403 Forbidden** with `detail="Service principal required"` when a non-service principal calls a service-only route.
     - Returns the underlying `AuthPrincipal` unchanged when `principal.kind == "service"`.
 - **Removed legacy helpers (historical only)**:
-  - Earlier versions exposed FastAPI dependencies `PermissionChecker`, `RoleChecker`, `AnyPermissionChecker`, and `AllPermissionsChecker` from `permissions.py`. These have now been removed; endpoints must use `get_auth_principal` together with `require_permissions` / `require_roles` instead.
+  - Earlier versions exposed FastAPI dependencies `PermissionChecker`, `RoleChecker`, `AnyPermissionChecker`, and `AllPermissionsChecker` from `permissions.py`. These have now been removed; endpoints must use `get_auth_principal` together with `RequirePermission` / `RequireRole` instead.
   - Existing admin and control surfaces that once used these helpers (media add, tools execute, workflows runs/events/artifacts/control/DLQ, sandbox admin) have been migrated to claim-first dependencies. Tests such as `test_media_add_permissions_claims.py`, `test_tools_permissions_claims.py`, `test_workflows_runs_permissions_claims.py`, `test_workflows_artifacts_permissions_claims.py`, `test_workflows_webhook_dlq_permissions_claims.py`, `test_workflows_control_permissions_claims.py`, and `test_sandbox_admin_permissions_claims.py` lock in the new behavior and ensure the claim-first dependencies are the true authorization gates.
-  - Heavy evaluations admin paths use claim-first checks via `enforce_heavy_evaluations_admin(AuthPrincipal)` together with `require_roles("admin")` / `require_permissions(...)` on top of `get_auth_principal`.
+  - Heavy evaluations admin paths use claim-first checks via `enforce_heavy_evaluations_admin(AuthPrincipal)` together with `RequireRole("admin")` / `RequirePermission(...)` on top of `get_auth_principal`.
   - A repository layer exists for AuthNZ and MUST be used instead of ad-hoc SQL for core tables:
     - `AuthnzUsersRepo` (`app/core/AuthNZ/repos/users_repo.py`) wraps `UsersDB` for user lookups; exercised against both SQLite and Postgres in AuthNZ tests.
     - `AuthnzApiKeysRepo` (`app/core/AuthNZ/repos/api_keys_repo.py`) centralizes `api_keys` read/write paths and is used by `APIKeyManager` and single-user bootstrap.
@@ -279,13 +279,13 @@ Tests:
     - `AuthnzRateLimitsRepo` (`app/core/AuthNZ/repos/rate_limits_repo.py`) encapsulates all DB-backed rate-limiter tables (`rate_limits`, `failed_attempts`, `account_lockouts`) and is used by `rate_limiter.RateLimiter` for counters, lockouts, and cleanup.
   - New AuthNZ code should **not** add fresh backend-specific SQL for these tables; prefer adding small, task-focused methods to the appropriate repo and calling them from business logic.
   - New code MUST NOT introduce fresh `is_single_user_mode()` branches in endpoint/business logic. Mode/profile checks are confined to a small number of coordination points (bootstrap, DB selection, and legacy compatibility helpers); authorization should flow through `AuthPrincipal` + claim-first dependencies instead.
-  - New code **must not** reintroduce FastAPI dependency helpers that bypass `get_auth_principal` or duplicate `require_permissions` / `require_roles`. Authorization for endpoints should always flow through claim-first dependencies.
+  - New code **must not** reintroduce FastAPI dependency helpers that bypass `get_auth_principal` or duplicate `RequirePermission` / `RequireRole`. Authorization for endpoints should always flow through claim-first dependencies.
   - AuthNZ-facing documentation (usage examples, API integration guides) should treat this guide as canonical and mirror its claim-first patterns. When decorator-style helpers appear in historical examples (including the removed `*Checker` classes), they should be clearly labeled as legacy and not used for new code.
 
 References:
 - `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#get_auth_principal`
-- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#require_permissions`
-- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#require_roles`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#RequirePermission`
+- `tldw_Server_API/app/api/v1/API_Deps/auth_deps.py#RequireRole`
 
 ## How to Secure a New Endpoint (Checklist)
 
@@ -301,9 +301,9 @@ When adding a new FastAPI endpoint that needs AuthNZ and guardrails:
 2. **Define and apply permissions/roles**
    - Add or reuse a permission constant in `tldw_Server_API/app/core/AuthNZ/permissions.py`.
    - Gate the route with claim-first dependencies on the router or endpoint:
-     - `dependencies=[Depends(require_permissions(MY_PERMISSION))]`
-     - and/or `dependencies=[Depends(require_roles("admin"))]`.
-   - Do **not** introduce mode-based gates or legacy admin shims; always build on `get_auth_principal` + `require_permissions` / `require_roles`.
+     - `dependencies=[Depends(RequirePermission(MY_PERMISSION))]`
+     - and/or `dependencies=[Depends(RequireRole("admin"))]`.
+   - Do **not** introduce mode-based gates or legacy admin shims; always build on `get_auth_principal` + `RequirePermission` / `RequireRole`.
 
 3. **Wire ResourceGovernor / rate limits if needed**
    - For rate-limited endpoints, reuse shared helpers instead of new per-module limiters:
@@ -401,8 +401,8 @@ async def tight_user(user=Depends(get_current_user)):
 ## Expected Roles/Permissions for Resource-Governor Admin
 
 - Resource-Governor admin and diagnostics endpoints under `/api/v1/resource-governor/*` are treated as AuthNZ admin surfaces and MUST:
-  - Use claim-first dependencies: `principal: AuthPrincipal = Depends(get_auth_principal)` and `dependencies=[Depends(require_roles("admin"))]` on the route.
-  - Rely on `require_roles("admin")` (admin role or `principal.is_admin`) as the gate; do not add new `is_single_user_mode()` / mode-specific bypasses in handlers.
+  - Use claim-first dependencies: `principal: AuthPrincipal = Depends(get_auth_principal)` and `dependencies=[Depends(RequireRole("admin"))]` on the route.
+  - Rely on `RequireRole("admin")` (admin role or `principal.is_admin`) as the gate; do not add new `is_single_user_mode()` / mode-specific bypasses in handlers.
   - Keep 401/403 semantics aligned with other admin endpoints (401 for missing/invalid credentials, 403 for insufficient roles), as enforced by:
     - `tldw_Server_API/tests/AuthNZ_Unit/test_resource_governor_permissions_claims.py`
     - `tldw_Server_API/tests/Resource_Governance/test_rg_capabilities_endpoint.py`
@@ -473,9 +473,9 @@ async def secure(user=Depends(get_current_user)):
 2) Require a permission (claim-first)
 ```python
 from fastapi import Depends
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_current_user, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, get_current_user
 
-@router.post("/media/update", dependencies=[Depends(require_permissions("media.update"))])
+@router.post("/media/update", dependencies=[Depends(RequirePermission("media.update"))])
 async def update_media(user=Depends(get_current_user)):
     ...
 ```
@@ -518,7 +518,7 @@ async def mint_vk(user=Depends(get_current_user)):
 
 - Add new permissions in `permissions.py` and seed mapping in RBAC migrations/seeders.
 - New admin surfaces belong under `.../endpoints/admin/` (router + shared helpers) or a feature-specific `admin_<feature>.py` module and should be guarded using claim-first dependencies:
-  - Prefer `principal: AuthPrincipal = Depends(get_auth_principal)` together with `dependencies=[Depends(require_roles("admin"))]` (and `require_permissions(...)` where appropriate).
+  - Prefer `principal: AuthPrincipal = Depends(get_auth_principal)` together with `dependencies=[Depends(RequireRole("admin"))]` (and `RequirePermission(...)` where appropriate).
 - For new guardrails, prefer middleware with settings gating, and expose DI helpers to keep endpoints simple.
 - Keep both SQLite and Postgres code paths working; use `DatabasePool` helpers to normalize placeholders across backends when needed.
 

--- a/Docs/Published/Code_Documentation/Guides/Evaluations_Code_Guide.md
+++ b/Docs/Published/Code_Documentation/Guides/Evaluations_Code_Guide.md
@@ -132,7 +132,7 @@ results = await rag_eval.evaluate(
 - PDF path: `POST /ocr-pdf` (multipart) runs OCR (backend selectable) then computes metrics against provided ground truths; tune via form fields (dpi, lang, mode, min chars).
 
 **Auth, Limits, and Error Handling**
-- Auth modes handled in `evaluations_auth.verify_api_key`; admin gating is claim-first (`get_auth_principal` + `require_roles("admin")` / heavy-admin claim checks).
+- Auth modes handled in `evaluations_auth.verify_api_key`; admin gating is claim-first (`get_auth_principal` + `RequireRole("admin")` / heavy-admin claim checks).
 - Path limiter (`check_evaluation_rate_limit`) + per‑user `UserRateLimiter` estimate tokens and enforce daily/cost quotas; usage headers are applied by helpers.
 - Errors are normalized via `create_error_response` and `sanitize_error_message` for consistent API error shapes.
 

--- a/Docs/Published/Deployment/Operations/MCP_Rate_Limits_Tuning.md
+++ b/Docs/Published/Deployment/Operations/MCP_Rate_Limits_Tuning.md
@@ -60,7 +60,7 @@ Sample YAML (checked in):
 
 ## Security Notes
 
-- Keep the Prometheus endpoint gated by `require_permissions("system.logs")` / admin-style principals. Do not expose it unauthenticated; use credentials or an ingress/auth proxy for Prometheus scraping on internal networks.
+- Keep the Prometheus endpoint gated by `RequirePermission("system.logs")` / admin-style principals. Do not expose it unauthenticated; use credentials or an ingress/auth proxy for Prometheus scraping on internal networks.
 
 ## References
 

--- a/Docs/Published/User_Guides/Server/Usage_Module.md
+++ b/Docs/Published/User_Guides/Server/Usage_Module.md
@@ -88,7 +88,7 @@ Indexes are created on usage tables for performance:
 - Leave `USAGE_LOG_ENABLED=true` in dev/staging to get insights; tune exclusions as needed.
 - In production, set sensible retention to keep DB size in check.
 - Keep pricing overrides current for accurate cost tracking.
-- Ensure admin endpoints are restricted with claim-first admin dependencies (`require_roles("admin")` and/or `require_permissions(...)`).
+- Ensure admin endpoints are restricted with claim-first admin dependencies (`RequireRole("admin")` and/or `RequirePermission(...)`).
 
 ## Troubleshooting
 

--- a/Docs/User_Guides/Server/Usage_Module.md
+++ b/Docs/User_Guides/Server/Usage_Module.md
@@ -88,7 +88,7 @@ Indexes are created on usage tables for performance:
 - Leave `USAGE_LOG_ENABLED=true` in dev/staging to get insights; tune exclusions as needed.
 - In production, set sensible retention to keep DB size in check.
 - Keep pricing overrides current for accurate cost tracking.
-- Ensure admin endpoints are restricted with claim-first admin dependencies (`require_roles("admin")` and/or `require_permissions(...)`).
+- Ensure admin endpoints are restricted with claim-first admin dependencies (`RequireRole("admin")` and/or `RequirePermission(...)`).
 
 ## Troubleshooting
 

--- a/tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
@@ -738,7 +738,11 @@ async def get_current_user(
     x_api_key: Optional[str] = Header(None, alias="X-API-KEY")
 ) -> dict[str, Any]:
     """
-    Resolve and return the current authenticated user.
+    Legacy compatibility shim that resolves and returns a user dictionary.
+
+    New or migrated route code should prefer ``CurrentPrincipal`` /
+    ``get_auth_principal`` unless the endpoint still requires dictionary-shaped
+    user data for backwards compatibility.
 
     Supports Bearer JWT authentication and API keys via `X-API-KEY` or
     Authorization Bearer (non-JWT tokens). If an upstream dependency already
@@ -1560,7 +1564,10 @@ async def get_current_active_user(
     current_user: dict[str, Any] = Depends(get_current_user)
 ) -> dict[str, Any]:
     """
-    Get current active user (verified and not locked)
+    Legacy compatibility shim that returns an active user dictionary.
+
+    New or migrated route code should prefer ``CurrentPrincipal`` /
+    ``get_auth_principal`` unless dictionary-shaped user data is still needed.
 
     Args:
         current_user: Current authenticated user

--- a/tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
@@ -10,7 +10,7 @@ import time
 from collections import deque
 from collections.abc import AsyncGenerator, Awaitable, Mapping
 from datetime import datetime, timezone
-from typing import Any, Callable, Optional
+from typing import Annotated, Any, Callable, Optional
 from weakref import WeakKeyDictionary
 
 #
@@ -2500,6 +2500,36 @@ def require_token_scope(
         )
 
     return _checker
+
+
+#######################################################################################################################
+#
+# Phase 3.4 Standard Auth Dependency Surface
+
+CurrentPrincipal = Annotated[AuthPrincipal, Depends(get_auth_principal)]
+"""Route dependency alias that resolves and returns the current AuthPrincipal."""
+
+CurrentUserDict = Annotated[dict[str, Any], Depends(get_current_active_user)]
+"""Legacy route dependency alias for endpoints that still require user dictionaries."""
+
+_require_admin_principal = require_roles("admin")
+AdminPrincipal = Annotated[AuthPrincipal, Depends(_require_admin_principal)]
+"""Route dependency alias that returns an AuthPrincipal after admin role checks."""
+
+ServicePrincipal = Annotated[AuthPrincipal, Depends(require_service_principal)]
+"""Route dependency alias that returns an AuthPrincipal after service-principal checks."""
+
+RequireRole = require_roles
+"""Standard role-guard factory; returns an AuthPrincipal on success."""
+
+RequirePermission = require_permissions
+"""Standard permission-guard factory; returns an AuthPrincipal on success."""
+
+RequireApiKeyScope = require_api_key_scope
+"""Standard API-key-scope guard factory; returns an AuthPrincipal on success."""
+
+TokenScopeGuard = require_token_scope
+"""Standard token-scope guard factory for dependency lists; returns None on success."""
 #
 # End of auth_deps.py
 #######################################################################################################################

--- a/tldw_Server_API/app/api/v1/endpoints/admin/__init__.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 from tldw_Server_API.app.core.AuthNZ.alerting import (
     get_security_alert_dispatcher as _core_get_security_alert_dispatcher,
 )
@@ -107,7 +107,7 @@ _authnz_migration_lock = asyncio.Lock()
 router = APIRouter(
     prefix="/admin",
     tags=["admin"],
-    dependencies=[Depends(require_roles("admin"))],  # All endpoints require admin role
+    dependencies=[Depends(RequireRole("admin"))],  # All endpoints require admin role
     responses={403: {"description": "Not authorized"}},
 )
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
@@ -8,9 +8,9 @@ from typing import Annotated, Any, Literal, Protocol
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequireRole,
     check_rate_limit,
     get_auth_principal,
-    require_roles,
 )
 from tldw_Server_API.app.api.v1.schemas.user_keys import (
     AdminUserKeysResponse,
@@ -94,7 +94,7 @@ def get_byok_validation_job_enqueuer() -> Callable[[dict[str, Any]], Awaitable[s
 @router.get(
     "/keys/users/{user_id}",
     response_model=AdminUserKeysResponse,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_list_user_byok_keys(
     user_id: int,
@@ -108,7 +108,7 @@ async def admin_list_user_byok_keys(
     "/keys/users/{user_id}/{provider}",
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_revoke_user_byok_key(
     user_id: int,
@@ -123,7 +123,7 @@ async def admin_revoke_user_byok_key(
 @router.post(
     "/keys/shared",
     response_model=SharedProviderKeyResponse,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_upsert_shared_byok_key(
     payload: SharedProviderKeyUpsertRequest,
@@ -136,7 +136,7 @@ async def admin_upsert_shared_byok_key(
 @router.post(
     "/keys/shared/test",
     response_model=SharedProviderKeyTestResponse,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_test_shared_byok_key(
     payload: SharedProviderKeyTestRequest,
@@ -149,7 +149,7 @@ async def admin_test_shared_byok_key(
 @router.get(
     "/keys/shared",
     response_model=SharedProviderKeysResponse,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_list_shared_byok_keys(
     principal: AuthPrincipal = Depends(get_auth_principal),
@@ -170,7 +170,7 @@ async def admin_list_shared_byok_keys(
     "/keys/shared/{scope_type}/{scope_id}/{provider}",
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_delete_shared_byok_key(
     scope_type: Literal["org", "team"],
@@ -186,7 +186,7 @@ async def admin_delete_shared_byok_key(
 @router.post(
     "/byok/validation-runs",
     response_model=ByokValidationRunItem,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_create_byok_validation_run(
     payload: ByokValidationRunCreateRequest,
@@ -224,7 +224,7 @@ async def admin_create_byok_validation_run(
 @router.get(
     "/byok/validation-runs",
     response_model=ByokValidationRunListResponse,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_list_byok_validation_runs(
     limit: int = Query(50, ge=1, le=200),
@@ -245,7 +245,7 @@ async def admin_list_byok_validation_runs(
 @router.get(
     "/byok/validation-runs/{run_id}",
     response_model=ByokValidationRunItem,
-    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+    dependencies=[Depends(RequireRole("admin")), Depends(check_rate_limit)],
 )
 async def admin_get_byok_validation_run(
     run_id: str,

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_circuit_breakers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_circuit_breakers.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 
 from fastapi import APIRouter, Depends
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     AdminCircuitBreakerListFilters,
     AdminCircuitBreakerListResponse,
@@ -86,7 +86,7 @@ def _build_status_row(
 @router.get(
     "/circuit-breakers",
     response_model=AdminCircuitBreakerListResponse,
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def list_unified_circuit_breakers(
     filters: AdminCircuitBreakerListFilters = Depends(),

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_personalization.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_personalization.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Query
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequireRole,
     check_rate_limit,
-    require_roles,
 )
 from tldw_Server_API.app.services import admin_personalization_service
 
@@ -13,7 +13,7 @@ router = APIRouter()
 @router.post(
     "/personalization/consolidate",
     response_model=dict,
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def trigger_personalization_consolidation(
     user_id: str | None = Query(None, description="User ID to consolidate; defaults to single-user id"),
@@ -34,7 +34,7 @@ async def trigger_personalization_consolidation(
 @router.get(
     "/personalization/status",
     response_model=dict,
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def get_personalization_status() -> dict:
     """Return personalization consolidation status (admin scope)."""

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_tools.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_tools.py
@@ -7,8 +7,8 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequireRole,
     get_db_transaction,
-    require_roles,
 )
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     ToolCatalogCreateRequest,
@@ -32,7 +32,7 @@ router = APIRouter()
         "Filters: Optional `org_id` and/or `team_id` parameters restrict results to a given scope.\n"
         "Without filters, returns all catalogs."
     ),
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def list_tool_catalogs(
     org_id: int | None = Query(None),
@@ -67,7 +67,7 @@ async def list_tool_catalogs(
         "Scope: Set `org_id` for org-owned, `team_id` for team-owned, or neither for global.\n"
         "Name must be unique per (name, org_id, team_id)."
     ),
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def create_tool_catalog(
     payload: ToolCatalogCreateRequest,
@@ -110,7 +110,7 @@ async def create_tool_catalog(
         "RBAC: Admin-only.\n\n"
         "Scope: Works for any catalog (global/org/team)."
     ),
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def delete_tool_catalog(
     catalog_id: int,
@@ -134,8 +134,11 @@ async def delete_tool_catalog(
     "/mcp/tool_catalogs/{catalog_id}/entries",
     response_model=list[ToolCatalogEntryResponse],
     summary="List catalog entries (admin)",
-    description=("List tools included in the specified catalog.\n\n" "RBAC: Admin-only."),
-    dependencies=[Depends(require_roles("admin"))],
+    description=(
+        "List tools included in the specified catalog.\n\n"
+        "RBAC: Admin-only."
+    ),
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def list_tool_catalog_entries(
     catalog_id: int,
@@ -167,8 +170,11 @@ async def list_tool_catalog_entries(
     response_model=ToolCatalogEntryResponse,
     status_code=201,
     summary="Add tool to catalog (admin)",
-    description=("Add a tool entry to the catalog. Idempotent per (catalog_id, tool_name).\n\n" "RBAC: Admin-only."),
-    dependencies=[Depends(require_roles("admin"))],
+    description=(
+        "Add a tool entry to the catalog. Idempotent per (catalog_id, tool_name).\n\n"
+        "RBAC: Admin-only."
+    ),
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def add_tool_catalog_entry(
     catalog_id: int,
@@ -197,7 +203,7 @@ async def add_tool_catalog_entry(
     description=(
         "Remove a tool entry from the catalog. Returns 200 whether or not the entry existed.\n\n" "RBAC: Admin-only."
     ),
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def delete_tool_catalog_entry(
     catalog_id: int,

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket
 from fastapi.responses import StreamingResponse
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
 from tldw_Server_API.app.api.v1.endpoints._in_memory_limits import SlidingWindowLimiter
 from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentInfo,
@@ -1379,7 +1379,7 @@ def _check_agent_availability(agent_type: str) -> dict[str, Any]:
 @router.get(
     "/health",
     response_model=ACPHealthResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.health"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.health"))],
 )
 async def acp_health(
     user: User = Depends(get_request_user),
@@ -1477,7 +1477,7 @@ async def acp_health(
 
 @router.get(
     "/setup-guide",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.setup_guide"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.setup_guide"))],
 )
 async def acp_setup_guide(
     agent_type: str | None = Query(default=None, description="Filter to a specific agent type"),
@@ -1673,7 +1673,7 @@ async def _get_available_agents() -> tuple[list[ACPAgentInfo], str]:
 @router.get(
     "/agents",
     response_model=ACPAgentListResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.agents.list"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.agents.list"))],
 )
 async def acp_list_agents(
     user: User = Depends(get_request_user),
@@ -1693,7 +1693,7 @@ async def acp_list_agents(
 @router.post(
     "/agents/register",
     response_model=ACPAgentRegistrationResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.agents.register"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.agents.register"))],
 )
 async def acp_register_agent(
     request: ACPAgentRegisterRequest,
@@ -1730,7 +1730,7 @@ async def acp_register_agent(
 @router.delete(
     "/agents/{agent_type}",
     response_model=ACPAgentRegistrationResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.agents.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.agents.manage"))],
 )
 async def acp_deregister_agent(
     agent_type: str,
@@ -1755,7 +1755,7 @@ async def acp_deregister_agent(
 @router.put(
     "/agents/{agent_type}",
     response_model=ACPAgentRegistrationResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.agents.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.agents.manage"))],
 )
 async def acp_update_agent(
     agent_type: str,
@@ -1782,7 +1782,7 @@ async def acp_update_agent(
 @router.get(
     "/agents/health",
     response_model=ACPAgentHealthResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.agents.health"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.agents.health"))],
 )
 async def acp_agents_health(
     user: User = Depends(get_request_user),
@@ -1832,7 +1832,7 @@ def _generate_session_name(cwd: str) -> str:
 @router.post(
     "/sessions/new",
     response_model=ACPSessionNewResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_new(
     payload: ACPSessionNewRequest,
@@ -2014,7 +2014,7 @@ async def acp_session_new(
 @router.post(
     "/sessions/prompt",
     response_model=ACPSessionPromptResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_prompt(
     payload: ACPSessionPromptRequest,
@@ -2086,7 +2086,7 @@ async def acp_session_prompt(
 
 @router.post(
     "/sessions/cancel",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_cancel(
     payload: ACPSessionCancelRequest,
@@ -2119,7 +2119,7 @@ async def acp_session_cancel(
 
 @router.post(
     "/sessions/close",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_close(
     payload: ACPSessionCloseRequest,
@@ -2182,7 +2182,7 @@ async def acp_session_close(
 
 @router.post(
     "/sessions/{session_id}/teardown",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_teardown(
     session_id: str,
@@ -2231,7 +2231,7 @@ async def acp_session_teardown(
 
 @router.get(
     "/sessions/{session_id}/reconciliation",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_reconciliation(
     session_id: str,
@@ -2250,7 +2250,7 @@ async def acp_session_reconciliation(
 
 @router.post(
     "/sessions/{session_id}/reconcile",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_reconcile(
     session_id: str,
@@ -2303,7 +2303,7 @@ async def acp_session_reconcile(
 @router.get(
     "/sessions/{session_id}/updates",
     response_model=ACPSessionUpdatesResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_updates(
     session_id: str,
@@ -2331,7 +2331,7 @@ async def acp_session_updates(
 @router.get(
     "/sessions",
     response_model=ACPSessionListResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_list_sessions(
     status_filter: str | None = Query(default=None, alias="status"),
@@ -2363,7 +2363,7 @@ async def acp_list_sessions(
 @router.get(
     "/sessions/{session_id}/detail",
     response_model=ACPSessionDetailResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_detail(
     session_id: str,
@@ -2387,7 +2387,7 @@ async def acp_session_detail(
 @router.get(
     "/sessions/{session_id}/usage",
     response_model=ACPSessionUsageResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_usage(
     session_id: str,
@@ -2424,7 +2424,7 @@ async def acp_session_usage(
 
 @router.get(
     "/sessions/{session_id}/events",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_events(
     session_id: str,
@@ -2484,7 +2484,7 @@ async def acp_session_events(
 
 @router.get(
     "/sessions/{session_id}/events/stream",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_events_stream(
     request: Request,
@@ -2549,7 +2549,7 @@ async def acp_session_events_stream(
 
 @router.get(
     "/sessions/{session_id}/artifacts",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_artifacts(
     session_id: str,
@@ -2594,7 +2594,7 @@ async def acp_session_artifacts(
 
 @router.get(
     "/sessions/{session_id}/diagnostics",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_diagnostics(
     session_id: str,
@@ -2626,7 +2626,7 @@ async def acp_session_diagnostics(
 
 @router.get(
     "/sessions/{session_id}/audit",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_audit(
     session_id: str,
@@ -2652,7 +2652,7 @@ async def acp_session_audit(
 @router.post(
     "/sessions/{session_id}/fork",
     response_model=ACPSessionForkResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_fork(
     session_id: str,
@@ -2743,7 +2743,7 @@ async def acp_session_fork(
 @router.post(
     "/sessions/prompt-async",
     response_model=ACPAsyncPromptResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.prompt_async"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.prompt_async"))],
 )
 async def acp_prompt_async(
     body: ACPAsyncPromptRequest,
@@ -2789,7 +2789,7 @@ async def acp_prompt_async(
 @router.get(
     "/tasks/{task_id}",
     response_model=ACPTaskStatusResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.tasks.status"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.tasks.status"))],
 )
 async def acp_task_status(
     task_id: str,
@@ -2845,7 +2845,7 @@ async def acp_task_status(
 
 @router.get(
     "/runs",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.runs.list"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.runs.list"))],
 )
 async def list_acp_runs(
     user: User = Depends(get_request_user),
@@ -2872,7 +2872,7 @@ async def list_acp_runs(
 
 @router.get(
     "/runs/aggregate",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.runs.aggregate"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.runs.aggregate"))],
 )
 async def aggregate_acp_runs(
     user: User = Depends(get_request_user),
@@ -2940,7 +2940,7 @@ async def _ensure_checkpoint_consumer(session_id: str) -> CheckpointConsumer:
 @router.post(
     "/sessions/{session_id}/rollback",
     response_model=ACPRollbackResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_rollback(
     session_id: str,
@@ -3047,7 +3047,7 @@ async def acp_session_rollback(
 @router.get(
     "/sessions/{session_id}/checkpoints",
     response_model=ACPCheckpointListResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.manage"))],
 )
 async def acp_session_checkpoints(
     session_id: str,

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
 from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
@@ -285,7 +285,7 @@ class ReviewRequest(BaseModel):
     "/workspaces",
     response_model=ACPWorkspaceResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
 )
 async def create_workspace(
     payload: ACPWorkspaceCreateRequest,
@@ -314,7 +314,7 @@ async def create_workspace(
 @router.get(
     "/workspaces",
     response_model=list[ACPWorkspaceResponse],
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
 )
 async def list_workspaces(
     workspace_type: str | None = Query(default=None, description="Filter by type"),
@@ -333,7 +333,7 @@ async def list_workspaces(
 @router.get(
     "/workspaces/{workspace_id}",
     response_model=ACPWorkspaceResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
 )
 async def get_workspace(
     workspace_id: int,
@@ -357,7 +357,7 @@ async def get_workspace(
 @router.put(
     "/workspaces/{workspace_id}",
     response_model=ACPWorkspaceResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
 )
 async def update_workspace(
     workspace_id: int,
@@ -383,7 +383,7 @@ async def update_workspace(
 
 @router.delete(
     "/workspaces/{workspace_id}",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
 )
 async def delete_workspace(
     workspace_id: int,
@@ -404,7 +404,7 @@ async def delete_workspace(
 
 @router.get(
     "/workspaces/{workspace_id}/health",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
 )
 async def check_workspace_health(
     workspace_id: int,
@@ -436,7 +436,7 @@ async def check_workspace_health(
 
 @router.post(
     "/workspaces/health/refresh-all",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
 )
 async def refresh_all_workspace_health(
     user: User = Depends(get_request_user),
@@ -457,7 +457,7 @@ async def refresh_all_workspace_health(
 
 @router.get(
     "/workspaces/{workspace_id}/mcp-servers",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.read"))],
 )
 async def list_workspace_mcp_servers(
     workspace_id: int,
@@ -475,7 +475,7 @@ async def list_workspace_mcp_servers(
 @router.post(
     "/workspaces/{workspace_id}/mcp-servers",
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
 )
 async def create_workspace_mcp_server(
     workspace_id: int,
@@ -504,7 +504,7 @@ async def create_workspace_mcp_server(
 
 @router.delete(
     "/workspaces/{workspace_id}/mcp-servers/{server_id}",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
 )
 async def delete_workspace_mcp_server(
     workspace_id: int,
@@ -532,7 +532,7 @@ async def delete_workspace_mcp_server(
 
 @router.post(
     "/workspaces/discover",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.workspaces.manage"))],
 )
 async def discover_workspaces(
     payload: WorkspaceDiscoverRequest,
@@ -576,7 +576,7 @@ async def discover_workspaces(
     "/projects",
     response_model=ProjectResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))],
 )
 async def create_project(
     payload: ProjectCreateRequest,
@@ -599,7 +599,7 @@ async def create_project(
 @router.get(
     "/projects",
     response_model=list[ProjectResponse],
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))],
 )
 async def list_projects(
     workspace_id: int | None = Query(default=None, description="Filter by workspace ID (omit for all)"),
@@ -636,7 +636,7 @@ async def list_projects(
 @router.get(
     "/projects/{project_id}",
     response_model=ProjectResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))],
 )
 async def get_project(
     project_id: int,
@@ -659,7 +659,7 @@ async def get_project(
 
 @router.delete(
     "/projects/{project_id}",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))],
 )
 async def delete_project(
     project_id: int,
@@ -683,7 +683,7 @@ async def delete_project(
     "/projects/{project_id}/tasks",
     response_model=TaskResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
 )
 async def create_task(
     project_id: int,
@@ -722,7 +722,7 @@ async def create_task(
 @router.get(
     "/projects/{project_id}/tasks",
     response_model=list[TaskResponse],
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))],
 )
 async def list_tasks(
     project_id: int,
@@ -747,7 +747,7 @@ async def list_tasks(
 @router.get(
     "/tasks/{task_id}",
     response_model=TaskResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))],
 )
 async def get_task(
     task_id: int,
@@ -771,7 +771,7 @@ async def get_task(
 
 @router.post(
     "/tasks/{task_id}/run",
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
 )
 async def dispatch_run(
     task_id: int,
@@ -942,7 +942,7 @@ async def dispatch_run(
 @router.post(
     "/tasks/{task_id}/review",
     response_model=TaskResponse,
-    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+    dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
 )
 async def submit_review(
     task_id: int,

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from loguru import logger
 from starlette import status
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
@@ -107,7 +107,7 @@ def _parse_json_field(raw: Any) -> Any:
     summary="List TTS history entries.",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),
     ],
     response_model=TTSHistoryListResponse,
 )
@@ -285,7 +285,7 @@ async def list_tts_history(
     summary="Get TTS history entry details.",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),
     ],
     response_model=TTSHistoryDetailResponse,
 )
@@ -354,7 +354,7 @@ async def get_tts_history_entry(
     summary="Update TTS history entry fields.",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),
     ],
 )
 async def update_tts_history_entry(
@@ -381,7 +381,7 @@ async def update_tts_history_entry(
     summary="Delete a TTS history entry (soft delete).",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),
     ],
 )
 async def delete_tts_history_entry(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_jobs.py
@@ -24,9 +24,9 @@ import contextlib
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    RequireRole,
     get_auth_principal,
-    require_permissions,
-    require_roles,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_MAINTENANCE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
@@ -58,8 +58,8 @@ _job_manager_lock = threading.Lock()
 _ADMIN_CLAIM_PERMISSIONS = frozenset({"*", "system.configure"})
 
 _ADMIN_DEPS = [
-    Depends(require_roles("admin")),
-    Depends(require_permissions(SYSTEM_MAINTENANCE)),
+    Depends(RequireRole("admin")),
+    Depends(RequirePermission(SYSTEM_MAINTENANCE)),
 ]
 
 _AUDIO_JOBS_NONCRITICAL_EXCEPTIONS = (

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_streaming.py
@@ -19,7 +19,7 @@ from fastapi.responses import JSONResponse
 from loguru import logger
 from starlette import status
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import resolve_org_id_for_principal
 from tldw_Server_API.app.core.Resource_Governance import cost_units
 from tldw_Server_API.app.core.Billing.enforcement import (
@@ -759,7 +759,7 @@ async def _finish_job(user_id: int):
     summary="Non-streaming Speech-to-Speech chat (STT → LLM → TTS)",
     dependencies=[
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "any",
                 require_if_present=True,
                 endpoint_id="audio.chat",

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py
@@ -8,7 +8,7 @@ import soundfile as sf
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse, Response
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, TokenScopeGuard
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
     AudioTokenizerDecodeRequest,
     AudioTokenizerEncodeRequest,
@@ -64,7 +64,7 @@ def _audio_shim_attr(name: str):
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "audio.tokenizer",
                 require_if_present=True,
                 endpoint_id="audio.tokenizer.encode",
@@ -80,7 +80,8 @@ async def encode_audio_tokenizer(
     request_id = ensure_request_id(request)
     settings = _audio_shim_attr("_get_qwen3_tokenizer_settings")()
     tokenizer_model = settings["tokenizer_model"]
-    token_format = "list"
+    # Response format label, not a credential.
+    token_format = "list"  # nosec B105
     sample_rate_hint: Optional[int] = None
 
     content_type = (request.headers.get("content-type") or "").lower()
@@ -182,7 +183,7 @@ async def encode_audio_tokenizer(
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "audio.tokenizer",
                 require_if_present=True,
                 endpoint_id="audio.tokenizer.decode",

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -22,7 +22,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     check_rate_limit,
     get_auth_principal,
     get_db_transaction,
-    require_token_scope,
+    TokenScopeGuard,
 )
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import get_billing_org_id, require_within_limit
 from tldw_Server_API.app.core.Resource_Governance import cost_units
@@ -441,7 +441,7 @@ def _dictation_error_detail(
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope("any", require_if_present=True, endpoint_id="audio.transcriptions", count_as="call")
+            TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.transcriptions", count_as="call")
         ),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),
         # Pessimistic pre-check: verifies at least 1 minute of transcription
@@ -1344,7 +1344,7 @@ async def create_transcription(
     },
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.translations", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.translations", count_as="call")),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),
         # Pessimistic pre-check: verifies at least 1 minute of transcription
         # quota remains.  Actual duration is unknown until after processing,

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_tts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_tts.py
@@ -12,7 +12,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from loguru import logger
 from starlette import status
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import try_get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     UsageEventLogger,
@@ -173,7 +173,7 @@ def _tts_history_error_message(exc: Exception) -> str:
     summary="Submit a long-form TTS job",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
     ],
 )
 async def create_speech_job(
@@ -222,7 +222,7 @@ async def create_speech_job(
     summary="List artifacts for a TTS job",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
     ],
 )
 async def get_speech_job_artifacts(
@@ -262,7 +262,7 @@ async def get_tts_service() -> TTSServiceV2:
     summary="Generates audio from text input.",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
     ],
     responses={
         200: {
@@ -786,7 +786,7 @@ async def create_speech(
     summary="Returns alignment metadata for a TTS request.",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
     ],
     responses={
         200: {

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -7,7 +7,7 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 from starlette import status
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, TokenScopeGuard
 from tldw_Server_API.app.api.v1.endpoints.audio.audio_tts import get_tts_service
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
     OpenAISpeechRequest,
@@ -43,7 +43,7 @@ VOICE_COUNTER_TYPE = "voice_call"
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "any",
                 require_if_present=True,
                 endpoint_id=VOICE_SCOPE_UPLOAD,
@@ -119,7 +119,7 @@ async def upload_voice(
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "any",
                 require_if_present=True,
                 endpoint_id=VOICE_SCOPE_ENCODE,
@@ -167,7 +167,7 @@ async def encode_voice_reference(
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "any",
                 require_if_present=True,
                 endpoint_id=VOICE_SCOPE_LIST,
@@ -201,7 +201,7 @@ async def list_voices(request: Request, current_user: User = Depends(get_request
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "any",
                 require_if_present=True,
                 endpoint_id=VOICE_SCOPE_GET,
@@ -242,7 +242,7 @@ async def get_voice_details(
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "any",
                 require_if_present=True,
                 endpoint_id=VOICE_SCOPE_DELETE,
@@ -285,7 +285,7 @@ async def delete_voice(
     dependencies=[
         Depends(check_rate_limit),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "any",
                 require_if_present=True,
                 endpoint_id=VOICE_SCOPE_PREVIEW,

--- a/tldw_Server_API/app/api/v1/endpoints/audit.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audit.py
@@ -8,7 +8,7 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, get_auth_principal
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventCategory,
     AuditEventType,
@@ -195,7 +195,7 @@ def _sanitize_filename(name: str, default_name: str) -> str:
 @router.get(
     "/audit/export",
     summary="Export audit events (JSON/JSONL/CSV)",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def export_audit_events(
     format: str = Query("json"),
@@ -345,7 +345,7 @@ async def export_audit_events(
 @router.get(
     "/audit/count",
     summary="Count audit events for pagination",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def count_audit_events(
     start_time: str | None = Query(None, description="ISO8601 start timestamp"),

--- a/tldw_Server_API/app/api/v1/endpoints/billing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/billing.py
@@ -12,8 +12,8 @@ from fastapi import APIRouter, Depends, Query
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequireRole,
     get_auth_principal,
-    require_roles,
 )
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
@@ -23,7 +23,7 @@ from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import AuthnzOrgsTeam
 router = APIRouter(
     prefix="/billing",
     tags=["billing"],
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -212,9 +212,9 @@ from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field, ValidationError
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     get_auth_principal,
     rbac_rate_limit,
-    require_permissions,
     require_token_scope,
 )
 from tldw_Server_API.app.api.v1.API_Deps.llm_routing_deps import (
@@ -4448,7 +4448,7 @@ async def create_chat_completion(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.queue.status")),
-        Depends(require_permissions(SYSTEM_LOGS)),
+        Depends(RequirePermission(SYSTEM_LOGS)),
     ],
 )
 async def get_chat_queue_status():
@@ -4473,7 +4473,7 @@ async def get_chat_queue_status():
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.queue.activity")),
-        Depends(require_permissions(SYSTEM_LOGS)),
+        Depends(RequirePermission(SYSTEM_LOGS)),
     ],
 )
 async def get_chat_queue_activity(

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -215,7 +215,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     RequirePermission,
     get_auth_principal,
     rbac_rate_limit,
-    require_token_scope,
+    TokenScopeGuard,
 )
 from tldw_Server_API.app.api.v1.API_Deps.llm_routing_deps import (
     get_request_routing_decision_store,
@@ -1526,7 +1526,7 @@ async def _maybe_rg_shadow_chat_decision(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.commands.list")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.commands.list")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.commands.list")),
     ],
 )
 async def list_chat_commands(
@@ -1630,7 +1630,7 @@ async def list_chat_commands(
     },
     dependencies=[
         Depends(rbac_rate_limit("chat.dictionaries.validate")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.dictionaries.validate")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.dictionaries.validate")),
         Depends(get_request_user),
     ],
 )
@@ -2260,7 +2260,7 @@ async def _persist_system_message_if_needed(
     },
     dependencies=[
         Depends(rbac_rate_limit("chat.create")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.completions", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.completions", count_as="call")),
         Depends(get_auth_principal),  # Establish AuthPrincipal/AuthContext early for guardrails
         Depends(enforce_llm_budget),  # Hard budget stop before handler runs
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),  # Billing: daily API call limit
@@ -5012,7 +5012,7 @@ class SharedConversationResolveResponse(BaseModel):
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.knowledge.save")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.knowledge.save")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.knowledge.save")),
     ],
 )
 async def save_chat_knowledge(
@@ -5109,7 +5109,7 @@ async def save_chat_knowledge(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.list")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.list")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.list")),
     ],
 )
 @conversations_alias_router.get(
@@ -5119,7 +5119,7 @@ async def save_chat_knowledge(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.list")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.list")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.list")),
     ],
     include_in_schema=False,
 )
@@ -5306,7 +5306,7 @@ async def list_chat_conversations(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.list")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.list")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.list")),
     ],
 )
 @conversations_alias_router.get(
@@ -5316,7 +5316,7 @@ async def list_chat_conversations(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.list")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.list")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.list")),
     ],
     include_in_schema=False,
 )
@@ -5371,7 +5371,7 @@ async def get_chat_conversation(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.update")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.update")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.update")),
     ],
 )
 @conversations_alias_router.patch(
@@ -5381,7 +5381,7 @@ async def get_chat_conversation(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.update")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.update")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.update")),
     ],
     include_in_schema=False,
 )
@@ -5488,7 +5488,7 @@ async def update_chat_conversation(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.tree")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.tree")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.tree")),
     ],
 )
 @conversations_alias_router.get(
@@ -5498,7 +5498,7 @@ async def update_chat_conversation(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.tree")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.tree")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.tree")),
     ],
     include_in_schema=False,
 )
@@ -5680,7 +5680,7 @@ async def get_conversation_tree(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.share_links")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
     ],
 )
 @conversations_alias_router.post(
@@ -5690,7 +5690,7 @@ async def get_conversation_tree(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.share_links")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
     ],
     include_in_schema=False,
 )
@@ -5753,7 +5753,7 @@ async def create_conversation_share_link(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.share_links")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
     ],
 )
 @conversations_alias_router.get(
@@ -5763,7 +5763,7 @@ async def create_conversation_share_link(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.share_links")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
     ],
     include_in_schema=False,
 )
@@ -5828,7 +5828,7 @@ async def list_conversation_share_links(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.share_links")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
     ],
 )
 @conversations_alias_router.delete(
@@ -5838,7 +5838,7 @@ async def list_conversation_share_links(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.share_links")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.share_links")),
     ],
     include_in_schema=False,
 )
@@ -5954,7 +5954,7 @@ async def resolve_conversation_share_token(
     tags=["chat"],
     dependencies=[
         Depends(rbac_rate_limit("chat.analytics")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.analytics")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.analytics")),
     ],
 )
 async def get_chat_analytics(
@@ -6095,7 +6095,7 @@ class ConversationCitationsResponse(BaseModel):
     tags=["chat", "rag"],
     dependencies=[
         Depends(rbac_rate_limit("chat.messages.rag_context")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.messages.rag_context")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.messages.rag_context")),
     ],
 )
 async def persist_rag_context(
@@ -6151,7 +6151,7 @@ async def persist_rag_context(
     tags=["chat", "rag"],
     dependencies=[
         Depends(rbac_rate_limit("chat.messages.rag_context")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.messages.rag_context")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.messages.rag_context")),
     ],
 )
 async def get_rag_context(
@@ -6195,7 +6195,7 @@ async def get_rag_context(
     tags=["chat", "rag"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.messages")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.messages")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.messages")),
     ],
 )
 async def get_messages_with_rag_context(
@@ -6246,7 +6246,7 @@ async def get_messages_with_rag_context(
     tags=["chat", "rag"],
     dependencies=[
         Depends(rbac_rate_limit("chat.conversations.citations")),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="chat.conversations.citations")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="chat.conversations.citations")),
     ],
 )
 async def get_conversation_citations(

--- a/tldw_Server_API/app/api/v1/endpoints/chat_workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat_workflows.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 
-from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission
 from tldw_Server_API.app.api.v1.API_Deps.chat_workflows_deps import (
     get_chat_workflows_db,
     get_chat_workflows_user,
@@ -395,7 +395,7 @@ async def _build_run_response(
     "/templates",
     response_model=ChatWorkflowTemplateResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_WRITE))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_WRITE))],
 )
 async def create_template(
     payload: ChatWorkflowTemplateCreate,
@@ -424,7 +424,7 @@ async def create_template(
 @router.get(
     "/templates",
     response_model=list[ChatWorkflowTemplateResponse],
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_READ))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_READ))],
 )
 async def list_templates(
     user_context: dict[str, Any] = Depends(_get_user_context),
@@ -451,7 +451,7 @@ async def list_templates(
 @router.get(
     "/templates/{template_id}",
     response_model=ChatWorkflowTemplateResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_READ))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_READ))],
 )
 async def get_template(
     template_id: int,
@@ -469,7 +469,7 @@ async def get_template(
 @router.put(
     "/templates/{template_id}",
     response_model=ChatWorkflowTemplateResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_WRITE))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_WRITE))],
 )
 async def update_template(
     template_id: int,
@@ -513,7 +513,7 @@ async def update_template(
 @router.delete(
     "/templates/{template_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_WRITE))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_WRITE))],
 )
 async def delete_template(
     template_id: int,
@@ -532,7 +532,7 @@ async def delete_template(
 @router.post(
     "/generate-draft",
     response_model=GenerateDraftResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_WRITE))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_WRITE))],
 )
 async def generate_draft(
     payload: GenerateDraftRequest,
@@ -553,7 +553,7 @@ async def generate_draft(
 @router.post(
     "/runs",
     response_model=ChatWorkflowRunResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_RUN))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_RUN))],
 )
 async def start_run(
     payload: StartRunRequest,
@@ -597,7 +597,7 @@ async def start_run(
 @router.get(
     "/runs/{run_id}",
     response_model=ChatWorkflowRunResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_READ))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_READ))],
 )
 async def get_run(
     run_id: str,
@@ -616,7 +616,7 @@ async def get_run(
 @router.get(
     "/runs/{run_id}/transcript",
     response_model=ChatWorkflowTranscriptResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_READ))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_READ))],
 )
 async def get_run_transcript(
     run_id: str,
@@ -642,7 +642,7 @@ async def get_run_transcript(
 @router.post(
     "/runs/{run_id}/answer",
     response_model=ChatWorkflowRunResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_RUN))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_RUN))],
 )
 async def answer_run_step(
     run_id: str,
@@ -679,7 +679,7 @@ async def answer_run_step(
 @router.post(
     "/runs/{run_id}/rounds/{round_index}/respond",
     response_model=ChatWorkflowRunResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_RUN))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_RUN))],
 )
 async def respond_to_run_round(
     run_id: str,
@@ -717,7 +717,7 @@ async def respond_to_run_round(
 @router.post(
     "/runs/{run_id}/cancel",
     response_model=ChatWorkflowRunResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_RUN))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_RUN))],
 )
 async def cancel_run(
     run_id: str,
@@ -755,7 +755,7 @@ async def cancel_run(
 @router.post(
     "/runs/{run_id}/continue-chat",
     response_model=ContinueChatResponse,
-    dependencies=[Depends(auth_deps.require_permissions(CHAT_WORKFLOWS_RUN))],
+    dependencies=[Depends(RequirePermission(CHAT_WORKFLOWS_RUN))],
 )
 async def continue_chat(
     run_id: str,

--- a/tldw_Server_API/app/api/v1/endpoints/claims.py
+++ b/tldw_Server_API/app/api/v1/endpoints/claims.py
@@ -4,9 +4,9 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import Response
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    AdminPrincipal,
+    RequirePermission,
     get_auth_principal,
-    require_permissions,
-    require_roles,
 )
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.claims_schemas import (
@@ -48,9 +48,7 @@ router = APIRouter(prefix="/claims", tags=["claims"])
 
 
 @router.get("/status")
-def claims_rebuild_status(
-    _principal: AuthPrincipal = Depends(require_roles("admin")),  # noqa: B008
-) -> dict[str, Any]:
+def claims_rebuild_status(_principal: AdminPrincipal) -> dict[str, Any]:
     """Return statistics about the claims rebuild worker. Admin only."""
     return claims_service.claims_rebuild_status(
         rebuild_service=get_claims_rebuild_service(),
@@ -191,7 +189,7 @@ def evaluate_watchlist_notifications(
 
 @router.get("/settings", response_model=ClaimsSettingsResponse)
 def get_claims_settings(
-    _principal: AuthPrincipal = Depends(require_roles("admin")),  # noqa: B008
+    _principal: AdminPrincipal,
 ) -> ClaimsSettingsResponse:
     """Return current claims settings."""
     return claims_service.get_claims_settings(_principal)
@@ -200,8 +198,8 @@ def get_claims_settings(
 @router.put("/settings", response_model=ClaimsSettingsResponse)
 def update_claims_settings(
     payload: ClaimsSettingsUpdate,
-    principal: AuthPrincipal = Depends(require_roles("admin")),  # noqa: B008
-    _perm: AuthPrincipal = Depends(require_permissions(SYSTEM_CONFIGURE)),  # noqa: B008
+    principal: AdminPrincipal,
+    _perm: AuthPrincipal = Depends(RequirePermission(SYSTEM_CONFIGURE)),  # noqa: B008
 ) -> ClaimsSettingsResponse:
     """Update claims settings (optionally persisted)."""
     return claims_service.update_claims_settings(

--- a/tldw_Server_API/app/api/v1/endpoints/config_admin.py
+++ b/tldw_Server_API/app/api/v1/endpoints/config_admin.py
@@ -12,7 +12,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, check_rate_limit
 from tldw_Server_API.app.api.v1.schemas.config_schemas import (
     ConfigValue,
     EffectiveConfigResponse,
@@ -36,7 +36,7 @@ from tldw_Server_API.app.core.TTS.tts_config import get_tts_config_manager
 router = APIRouter(
     prefix="/admin/config",
     tags=["admin", "config"],
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 
 _SENSITIVE_KEY_PATTERN = re.compile(

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -13,11 +13,11 @@ from loguru import logger
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_500_INTERNAL_SERVER_ERROR
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    RequireRole,
     get_auth_principal,
     get_db_transaction,
     get_org_policy_from_principal,
-    require_permissions,
-    require_roles,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.api.v1.schemas.connectors import (
@@ -1146,8 +1146,8 @@ async def get_job_status(job_id: int) -> dict[str, Any]:
     response_model=ConnectorPolicy,
     dependencies=[
         Depends(get_auth_principal),
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
     ],
 )
 async def get_org_policy(
@@ -1179,8 +1179,8 @@ async def get_org_policy(
     response_model=ConnectorPolicy,
     dependencies=[
         Depends(get_auth_principal),
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
     ],
 )
 async def upsert_org_policy(

--- a/tldw_Server_API/app/api/v1/endpoints/data_tables.py
+++ b/tldw_Server_API/app/api/v1/endpoints/data_tables.py
@@ -17,10 +17,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response,
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     check_rate_limit,
     get_auth_principal,
     rbac_rate_limit,
-    require_permissions,
 )
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
@@ -435,7 +435,7 @@ def _build_table_detail_response(
     response_model=Union[DataTableGenerateResponse, DataTableDetailResponse],
     summary="Submit a data table generation job",
     dependencies=[
-        Depends(require_permissions(MEDIA_CREATE)),
+        Depends(RequirePermission(MEDIA_CREATE)),
         Depends(rbac_rate_limit("data_tables.generate")),
     ],
 )
@@ -595,7 +595,7 @@ async def generate_data_table(
     response_model=DataTablesListResponse,
     summary="List data tables",
     dependencies=[
-        Depends(require_permissions(MEDIA_READ)),
+        Depends(RequirePermission(MEDIA_READ)),
         Depends(rbac_rate_limit("data_tables.list")),
     ],
 )
@@ -678,7 +678,7 @@ async def list_data_tables(
     "/{table_uuid}",
     response_model=DataTableDetailResponse,
     summary="Get a data table by UUID",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(check_rate_limit)],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(check_rate_limit)],
 )
 async def get_data_table(
     table_uuid: str,
@@ -720,7 +720,7 @@ async def get_data_table(
     response_model=DataTableExportResponse,
     summary="Export a data table",
     dependencies=[
-        Depends(require_permissions(MEDIA_READ)),
+        Depends(RequirePermission(MEDIA_READ)),
         Depends(rbac_rate_limit("data_tables.export")),
     ],
 )
@@ -846,7 +846,7 @@ async def export_data_table(
     response_model=DataTableDetailResponse,
     summary="Update data table content",
     dependencies=[
-        Depends(require_permissions(MEDIA_UPDATE)),
+        Depends(RequirePermission(MEDIA_UPDATE)),
         Depends(rbac_rate_limit("data_tables.update_content")),
     ],
 )
@@ -983,7 +983,7 @@ async def update_data_table_content(
     response_model=DataTableSummary,
     summary="Update data table metadata",
     dependencies=[
-        Depends(require_permissions(MEDIA_UPDATE)),
+        Depends(RequirePermission(MEDIA_UPDATE)),
         Depends(rbac_rate_limit("data_tables.update")),
     ],
 )
@@ -1028,7 +1028,7 @@ async def update_data_table(
     response_model=DataTableDeleteResponse,
     summary="Delete a data table",
     dependencies=[
-        Depends(require_permissions(MEDIA_DELETE)),
+        Depends(RequirePermission(MEDIA_DELETE)),
         Depends(rbac_rate_limit("data_tables.delete")),
     ],
 )
@@ -1062,7 +1062,7 @@ async def delete_data_table(
     response_model=Union[DataTableGenerateResponse, DataTableDetailResponse],
     summary="Regenerate a data table from stored sources",
     dependencies=[
-        Depends(require_permissions(MEDIA_UPDATE)),
+        Depends(RequirePermission(MEDIA_UPDATE)),
         Depends(rbac_rate_limit("data_tables.regenerate")),
     ],
 )
@@ -1211,7 +1211,7 @@ async def regenerate_data_table(
     response_model=DataTableJobStatus,
     summary="Get data table job status",
     dependencies=[
-        Depends(require_permissions(MEDIA_READ)),
+        Depends(RequirePermission(MEDIA_READ)),
         Depends(rbac_rate_limit("data_tables.jobs.get")),
     ],
 )
@@ -1253,7 +1253,7 @@ async def get_data_table_job(
     response_model=DataTableJobCancelResponse,
     summary="Cancel a data table job",
     dependencies=[
-        Depends(require_permissions(MEDIA_UPDATE)),
+        Depends(RequirePermission(MEDIA_UPDATE)),
         Depends(rbac_rate_limit("data_tables.jobs.cancel")),
     ],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/discord.py
+++ b/tldw_Server_API/app/api/v1/endpoints/discord.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 from tldw_Server_API.app.api.v1.endpoints.discord_oauth_admin import (
     discord_admin_delete_installation_impl,
     discord_admin_get_policy_impl,
@@ -47,6 +47,7 @@ from tldw_Server_API.app.api.v1.endpoints.discord_support import (
     _parse_discord_interaction_command,
     _public_installation_record,
     _rate_limit_key,
+    _reset_discord_state_for_tests,
     _resolve_discord_actor_id,
     _safe_int,
     _set_discord_policy,
@@ -424,7 +425,7 @@ async def discord_oauth_callback(
 
 @router.get(
     "/admin/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def discord_admin_get_policy(
     guild_id: str | None = Query(default=None),
@@ -438,7 +439,7 @@ async def discord_admin_get_policy(
 
 @router.put(
     "/admin/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def discord_admin_set_policy(
     payload: dict[str, Any] | None = None,
@@ -451,7 +452,7 @@ async def discord_admin_set_policy(
     )
 
 
-@router.get("/admin/installations", dependencies=[Depends(require_roles("admin"))])
+@router.get("/admin/installations", dependencies=[Depends(RequireRole("admin"))])
 async def discord_admin_list_installations(
     user: User = Depends(get_request_user),
 ):
@@ -464,7 +465,7 @@ async def discord_admin_list_installations(
     )
 
 
-@router.delete("/admin/installations/{guild_id}", dependencies=[Depends(require_roles("admin"))])
+@router.delete("/admin/installations/{guild_id}", dependencies=[Depends(RequireRole("admin"))])
 async def discord_admin_delete_installation(
     request: Request,
     guild_id: str,
@@ -483,7 +484,7 @@ async def discord_admin_delete_installation(
     )
 
 
-@router.put("/admin/installations/{guild_id}", dependencies=[Depends(require_roles("admin"))])
+@router.put("/admin/installations/{guild_id}", dependencies=[Depends(RequireRole("admin"))])
 async def discord_admin_set_installation_state(
     request: Request,
     guild_id: str,

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -47,9 +47,9 @@ from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    RequireRole,
     rbac_rate_limit,
-    require_permissions,
-    require_roles,
 )
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -1304,7 +1304,7 @@ class CompactorRunResponse(BaseModel):
     "/embeddings/compactor/run",
     response_model=CompactorRunResponse,
     summary="Run a one-shot vector compaction for a user (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def run_compactor_once(
     req: CompactorRunRequest,
@@ -3226,8 +3226,8 @@ class PriorityBumpRequest(BaseModel):
     "/embeddings/job/priority/bump",
     summary="Override/bump job priority for routing into priority queues (best-effort)",
     dependencies=[
-        Depends(require_roles("admin")),
-        Depends(require_permissions(EMBEDDINGS_ADMIN)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(EMBEDDINGS_ADMIN)),
     ],
 )
 async def bump_job_priority(
@@ -3300,7 +3300,7 @@ class CollectionStatsResponse(BaseModel):
 @router.post(
     "/embeddings/models/warmup",
     summary="Warmup (preload) an embedding model (admin)",
-    dependencies=[Depends(require_roles("admin")), Depends(require_permissions(SYSTEM_CONFIGURE))],
+    dependencies=[Depends(RequireRole("admin")), Depends(RequirePermission(SYSTEM_CONFIGURE))],
 )
 async def warmup_model(
     payload: ModelActionRequest,
@@ -3332,7 +3332,7 @@ async def warmup_model(
 @router.post(
     "/embeddings/models/download",
     summary="Download/prepare a model (admin)",
-    dependencies=[Depends(require_roles("admin")), Depends(require_permissions(SYSTEM_CONFIGURE))],
+    dependencies=[Depends(RequireRole("admin")), Depends(RequirePermission(SYSTEM_CONFIGURE))],
 )
 async def download_model(
     payload: ModelActionRequest,
@@ -3364,7 +3364,7 @@ async def download_model(
 @router.delete(
     "/embeddings/cache",
     summary="Clear embedding cache (admin only)",
-    dependencies=[Depends(require_roles("admin")), Depends(require_permissions(SYSTEM_CONFIGURE))],
+    dependencies=[Depends(RequireRole("admin")), Depends(RequirePermission(SYSTEM_CONFIGURE))],
 )
 async def clear_cache(
     current_user: User = Depends(get_request_user),
@@ -3599,7 +3599,7 @@ async def health_check():
 @router.get(
     "/embeddings/circuit-breakers",
     summary="Get circuit breaker status (admin only)",
-    dependencies=[Depends(require_roles("admin")), Depends(require_permissions(SYSTEM_CONFIGURE))],
+    dependencies=[Depends(RequireRole("admin")), Depends(RequirePermission(SYSTEM_CONFIGURE))],
 )
 async def get_circuit_breakers(
     _current_user: User = Depends(get_request_user),
@@ -3611,7 +3611,7 @@ async def get_circuit_breakers(
 @router.post(
     "/embeddings/circuit-breakers/{provider}/reset",
     summary="Reset circuit breaker (admin only)",
-    dependencies=[Depends(require_roles("admin")), Depends(require_permissions(SYSTEM_CONFIGURE))],
+    dependencies=[Depends(RequireRole("admin")), Depends(RequirePermission(SYSTEM_CONFIGURE))],
 )
 async def reset_circuit_breaker(
     provider: str,
@@ -3645,7 +3645,7 @@ async def reset_circuit_breaker(
 @router.get(
     "/embeddings/metrics",
     summary="Get service metrics (admin only)",
-    dependencies=[Depends(require_roles("admin")), Depends(require_permissions(SYSTEM_CONFIGURE))],
+    dependencies=[Depends(RequireRole("admin")), Depends(RequirePermission(SYSTEM_CONFIGURE))],
 )
 async def get_metrics(
     request: Request,
@@ -3758,7 +3758,7 @@ def _redact_obj(obj: Any, depth: int = 0) -> Any:
 @router.get(
     "/embeddings/dlq",
     summary="List DLQ items for a stage (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def list_dlq_items(
     stage: str = Query("embedding", description="Stage: chunking|embedding|storage|content"),
@@ -3841,7 +3841,7 @@ class DLQRequeueRequest(BaseModel):
 @router.post(
     "/embeddings/dlq/requeue",
     summary="Requeue a DLQ item to its live stream (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def requeue_dlq_item(
     req: DLQRequeueRequest,
@@ -3939,7 +3939,7 @@ class DLQRequeueBulkRequest(BaseModel):
 @router.post(
     "/embeddings/dlq/requeue/bulk",
     summary="Bulk requeue DLQ items to live stream (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def requeue_dlq_bulk(
     req: DLQRequeueBulkRequest,
@@ -4038,7 +4038,7 @@ async def requeue_dlq_bulk(
 @router.get(
     "/embeddings/dlq/stats",
     summary="DLQ and queue depths (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def get_dlq_stats(
     current_user: User = Depends(get_request_user),
@@ -4115,7 +4115,7 @@ def _dlq_state_key(stream: str, entry_id: str) -> str:
 @router.post(
     "/embeddings/dlq/state",
     summary="Set DLQ quarantine state (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def set_dlq_state(req: DLQStateSetRequest, current_user: User = Depends(get_request_user)):
     client = await _get_redis_client()
@@ -4180,7 +4180,7 @@ def _stage_key(stage: str, suffix: str) -> str:
 @router.get(
     "/embeddings/stage/status",
     summary="Get per-stage pause/drain flags (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def get_stage_status(current_user: User = Depends(get_request_user)):
     client = await _get_redis_client()
@@ -4201,7 +4201,7 @@ async def get_stage_status(current_user: User = Depends(get_request_user)):
 @router.post(
     "/embeddings/stage/control",
     summary="Pause/Resume/Drain a stage (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def control_stage(req: StageControlRequest, current_user: User = Depends(get_request_user)):
     client = await _get_redis_client()
@@ -4259,7 +4259,7 @@ def _skip_key(job_id: str) -> str:
 @router.post(
     "/embeddings/job/skip",
     summary="Mark a job_id as skipped (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def mark_job_skipped(req: JobSkipRequest, current_user: User = Depends(get_request_user)):
     client = await _get_redis_client()
@@ -4292,7 +4292,7 @@ async def mark_job_skipped(req: JobSkipRequest, current_user: User = Depends(get
 @router.get(
     "/embeddings/job/skip/status",
     summary="Check if a job_id is marked as skipped (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def get_job_skip_status(job_id: str = Query(..., description="Job ID to check"), current_user: User = Depends(get_request_user)):
     client = await _get_redis_client()
@@ -4319,7 +4319,7 @@ class LedgerEntry(BaseModel):
 @router.get(
     "/embeddings/ledger/status",
     summary="Inspect ledger entries by idempotency_key/dedupe_key (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def get_ledger_status(
     idempotency_key: str | None = Query(default=None),
@@ -4406,7 +4406,7 @@ class ReembedScheduleResponse(BaseModel):
     "/embeddings/reembed/schedule",
     response_model=ReembedScheduleResponse,
     summary="Schedule a re-embed expansion job (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def schedule_reembed(
     req: ReembedScheduleRequest,
@@ -4637,7 +4637,7 @@ async def _sse_orchestrator_stream(client: aioredis.Redis):
 @router.get(
     "/embeddings/orchestrator/events",
     summary="SSE: embeddings orchestrator live summary (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def orchestrator_events(_current_user: User = Depends(get_request_user)):
     # Admin/embeddings-admin gate is enforced via AuthNZ permissions; _current_user is used for audit context.
@@ -4727,7 +4727,7 @@ async def orchestrator_events(_current_user: User = Depends(get_request_user)):
 @router.get(
     "/embeddings/orchestrator/summary",
     summary="Orchestrator summary for polling (admin only)",
-    dependencies=[Depends(require_permissions(EMBEDDINGS_ADMIN))],
+    dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def orchestrator_summary(current_user: User = Depends(get_request_user)):
     """Return a snapshot identical to the SSE payload.

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_crud.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_crud.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     rbac_rate_limit,
-    require_token_scope,
+    TokenScopeGuard,
 )
 from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_auth import (
     check_evaluation_rate_limit,
@@ -280,7 +280,7 @@ async def delete_evaluation(
     dependencies=[
         Depends(require_eval_permissions(EVALS_MANAGE)),
         Depends(check_evaluation_rate_limit),
-        Depends(require_token_scope(
+        Depends(TokenScopeGuard(
             "workflows",
             require_if_present=True,
             require_schedule_match=False,

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_embeddings_abtest.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_embeddings_abtest.py
@@ -10,7 +10,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_auth import (
     check_evaluation_rate_limit,
@@ -104,7 +104,7 @@ def _abtest_status_response(test_id: str, row: dict[str, object] | None) -> Embe
 @abtest_router.post(
     "/embeddings/abtest",
     response_model=EmbeddingsABTestCreateResponse,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="evals.embeddings_abtest.create"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="evals.embeddings_abtest.create"))],
 )
 async def create_embeddings_abtest(
     payload: EmbeddingsABTestCreateRequest,
@@ -177,7 +177,7 @@ async def run_embeddings_abtest(
     payload: EmbeddingsABTestRunRequest,
     user_ctx: str = Depends(verify_api_key),
     _: None = Depends(check_evaluation_rate_limit),
-    __: None = Depends(require_token_scope("workflows", require_if_present=True, require_schedule_match=False, allow_admin_bypass=True, endpoint_id="evals.embeddings_abtest.run", count_as="run")),
+    __: None = Depends(TokenScopeGuard("workflows", require_if_present=True, require_schedule_match=False, allow_admin_bypass=True, endpoint_id="evals.embeddings_abtest.run", count_as="run")),
     media_db = Depends(get_media_db_for_user),
     principal: AuthPrincipal = Depends(get_auth_principal),  # noqa: B008
     current_user: User = Depends(get_eval_request_user),  # noqa: B008

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_rag_pipeline.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_rag_pipeline.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
 from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_auth import (
     create_error_response,
     get_eval_request_user,
@@ -54,7 +54,7 @@ _PIPELINE_CLEANUP_ITEM_EXCEPTIONS = (
 @pipeline_router.post(
     "/rag/pipeline/presets",
     response_model=PipelinePresetResponse,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.preset.create"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.preset.create"))],
 )
 async def create_or_update_pipeline_preset(
     preset: PipelinePresetCreate,
@@ -97,7 +97,7 @@ async def create_or_update_pipeline_preset(
 @pipeline_router.get(
     "/rag/pipeline/presets",
     response_model=PipelinePresetListResponse,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.preset.list"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.preset.list"))],
 )
 async def list_pipeline_presets(
     limit: int = Query(50, ge=1, le=200),
@@ -143,7 +143,7 @@ async def list_pipeline_presets(
 @pipeline_router.get(
     "/rag/pipeline/presets/{name}",
     response_model=PipelinePresetResponse,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.preset.get"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.preset.get"))],
 )
 async def get_pipeline_preset(
     name: str,
@@ -194,7 +194,7 @@ async def get_pipeline_preset(
     "/rag/pipeline/presets/{name}",
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.preset.delete"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.preset.delete"))],
 )
 async def delete_pipeline_preset(
     name: str,
@@ -228,7 +228,7 @@ async def delete_pipeline_preset(
 @pipeline_router.post(
     "/rag/pipeline/cleanup",
     response_model=PipelineCleanupResponse,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.cleanup"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="evals.rag_pipeline.cleanup"))],
 )
 async def cleanup_ephemeral_collections(
     current_user: User = Depends(get_eval_request_user),

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Query
 from fastapi.routing import APIRoute
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, rbac_rate_limit
 
 # Import unified schemas
 from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import (
@@ -536,7 +536,7 @@ async def delete_embeddings_abtest(
 @router.get(
     "/embeddings/abtest/{test_id}/export",
     dependencies=[
-        Depends(require_roles("admin")),
+        Depends(RequireRole("admin")),
         Depends(rbac_rate_limit("evals.abtest.export")),
     ],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/integrations_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/integrations_control_plane.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, get_auth_principal
 from tldw_Server_API.app.api.v1.endpoints.discord_oauth_admin import discord_oauth_start_impl
 from tldw_Server_API.app.api.v1.endpoints.discord_support import (
     _decrypt_discord_payload,
@@ -533,7 +533,7 @@ async def delete_personal_integration(
     )
 
 
-@router.get("/workspace", dependencies=[Depends(require_roles("admin"))], response_model=IntegrationOverviewResponse)
+@router.get("/workspace", dependencies=[Depends(RequireRole("admin"))], response_model=IntegrationOverviewResponse)
 async def list_workspace_integrations(
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
@@ -550,7 +550,7 @@ async def list_workspace_integrations(
 
 @router.get(
     "/workspace/slack/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=SlackWorkspacePolicyResponse,
 )
 async def get_workspace_slack_policy(
@@ -564,7 +564,7 @@ async def get_workspace_slack_policy(
 
 @router.put(
     "/workspace/slack/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=SlackWorkspacePolicyResponse,
 )
 async def put_workspace_slack_policy(
@@ -579,7 +579,7 @@ async def put_workspace_slack_policy(
 
 @router.get(
     "/workspace/discord/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=DiscordWorkspacePolicyResponse,
 )
 async def get_workspace_discord_policy(
@@ -593,7 +593,7 @@ async def get_workspace_discord_policy(
 
 @router.put(
     "/workspace/discord/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=DiscordWorkspacePolicyResponse,
 )
 async def put_workspace_discord_policy(
@@ -608,7 +608,7 @@ async def put_workspace_discord_policy(
 
 @router.get(
     "/workspace/telegram/bot",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=TelegramBotConfigResponse,
 )
 async def get_workspace_telegram_bot(
@@ -620,7 +620,7 @@ async def get_workspace_telegram_bot(
 
 @router.put(
     "/workspace/telegram/bot",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=TelegramBotConfigResponse,
 )
 async def put_workspace_telegram_bot(
@@ -631,7 +631,7 @@ async def put_workspace_telegram_bot(
     return await telegram_admin_put_bot_impl(principal=principal, payload=payload, request=request)
 
 
-@router.post("/workspace/telegram/pairing-code", dependencies=[Depends(require_roles("admin"))])
+@router.post("/workspace/telegram/pairing-code", dependencies=[Depends(RequireRole("admin"))])
 async def create_workspace_telegram_pairing_code(
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
@@ -641,7 +641,7 @@ async def create_workspace_telegram_pairing_code(
 
 @router.get(
     "/workspace/telegram/linked-actors",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=TelegramLinkedActorListResponse,
 )
 async def list_workspace_telegram_linked_actors(
@@ -653,7 +653,7 @@ async def list_workspace_telegram_linked_actors(
 
 @router.delete(
     "/workspace/telegram/linked-actors/{actor_id}",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=TelegramLinkedActorRevokeResponse,
 )
 async def revoke_workspace_telegram_linked_actor(

--- a/tldw_Server_API/app/api/v1/endpoints/jobs_admin.py
+++ b/tldw_Server_API/app/api/v1/endpoints/jobs_admin.py
@@ -22,8 +22,8 @@ from fastapi.responses import StreamingResponse
 
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequireRole,
     get_auth_principal,
-    require_roles,
 )
 from tldw_Server_API.app.core.Audit.unified_audit_service import AuditContext, AuditEventType
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
@@ -57,7 +57,7 @@ _JOBS_ADMIN_NONCRITICAL_EXCEPTIONS = (
 )
 
 router = APIRouter(
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 
 
@@ -151,7 +151,7 @@ def _enforce_domain_scope_unified(
     Unified domain-scoped RBAC enforcement for jobs admin endpoints.
 
     All jobs-admin endpoints in this module use this helper alongside the
-    router-level require_roles(\"admin\") guard. It always derives the
+    router-level RequireRole(\"admin\") guard. It always derives the
     admin_user from the AuthPrincipal so callers can reuse the same user
     mapping for downstream operations (e.g., Postgres RLS). When
     JOBS_DOMAIN_RBAC_PRINCIPAL is enabled, enforcement is driven from the

--- a/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llamacpp.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, check_rate_limit
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Local_LLM.LlamaCpp_Handler import LlamaCppHandler
 
@@ -98,7 +98,7 @@ def _log_sanitized_manager_error(llm_manager: LLMInferenceManager, message: str)
 @router.post(
     "/llamacpp/start_server",
     summary="Start or Swap Llama.cpp Server Model",
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def start_llamacpp_server_endpoint(
     model_filename: str = Body(
@@ -138,7 +138,7 @@ async def start_llamacpp_server_endpoint(
 @router.post(
     "/llamacpp/stop_server",
     summary="Stop Llama.cpp Server",
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def stop_llamacpp_server_endpoint(llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager)):
     try:
@@ -162,7 +162,7 @@ async def stop_llamacpp_server_endpoint(llm_manager: LLMInferenceManager = Depen
 @router.get(
     "/llamacpp/status",
     summary="Get Llama.cpp Server Status",
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def get_llamacpp_status_endpoint(llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager)):
     try:
@@ -186,7 +186,7 @@ async def get_llamacpp_status_endpoint(llm_manager: LLMInferenceManager = Depend
 @router.get(
     "/llamacpp/metrics",
     summary="Get Llama.cpp Metrics",
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def get_llamacpp_metrics_endpoint(llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager)):
     try:
@@ -225,7 +225,7 @@ async def get_llamafile_metrics_endpoint(llm_manager: LLMInferenceManager = Depe
 @router.get(
     "/llamacpp/models",
     summary="List available Llama.cpp models",
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def list_llamacpp_models_endpoint(llm_manager: LLMInferenceManager = Depends(_resolve_llm_manager)):
     try:

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -22,9 +22,9 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     get_auth_principal,
     get_db_transaction,
-    require_permissions,
 )
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import ToolCatalogResponse
 from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
@@ -938,7 +938,7 @@ async def get_server_status(
 
 @router.get("/metrics", response_model=ServerMetricsResponse)
 async def get_server_metrics(
-    _principal: AuthPrincipal = Depends(require_permissions(SYSTEM_LOGS)),
+    _principal: AuthPrincipal = Depends(RequirePermission(SYSTEM_LOGS)),
     _guard: None = Depends(enforce_http_security),
 ):
     """
@@ -961,14 +961,14 @@ async def get_server_metrics(
 
 @router.get("/metrics/prometheus")
 async def get_prometheus_metrics(
-    _principal: AuthPrincipal = Depends(require_permissions(SYSTEM_LOGS)),
+    _principal: AuthPrincipal = Depends(RequirePermission(SYSTEM_LOGS)),
     _guard: None = Depends(enforce_http_security),
 ):
     """
     Prometheus scrape endpoint for MCP metrics.
 
     Security: Requires an authenticated principal with the `system.logs`
-    permission (or admin-style claims via require_permissions). External
+    permission (or admin-style claims via the standard permission dependency). External
     ingress or Prometheus-side configuration should be used to handle any
     additional network-level access controls.
     """
@@ -1298,7 +1298,7 @@ async def list_modules(
 @router.get("/modules/health")
 async def get_modules_health(
     http_request: Request,
-    principal: AuthPrincipal = Depends(require_permissions(SYSTEM_LOGS)),
+    principal: AuthPrincipal = Depends(RequirePermission(SYSTEM_LOGS)),
     _guard: None = Depends(enforce_http_security),
 ):
     """

--- a/tldw_Server_API/app/api/v1/endpoints/media/add.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/add.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Request, UploadFile
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
@@ -28,7 +28,7 @@ router = APIRouter()
     "/add",
     # Status code is determined dynamically based on per-item results.
     dependencies=[
-        Depends(require_permissions(MEDIA_CREATE)),
+        Depends(RequirePermission(MEDIA_CREATE)),
         Depends(rbac_rate_limit("media.create")),
         Depends(guard_storage_quota),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
@@ -19,10 +19,10 @@ from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     check_rate_limit,
     get_auth_principal,
     rbac_rate_limit,
-    require_permissions,
 )
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
@@ -409,7 +409,7 @@ def _resolve_batch_or_session_id(
     summary="Submit async media ingestion jobs (one job per item)",
     tags=["Media Ingestion Jobs"],
     dependencies=[
-        Depends(require_permissions(MEDIA_CREATE)),
+        Depends(RequirePermission(MEDIA_CREATE)),
         Depends(rbac_rate_limit("media.create")),
         Depends(guard_storage_quota),
         # Pessimistic pre-check: verifies at least 1 MB of storage quota

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_web_content.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_token_scope
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.backpressure import (
     guard_backpressure_and_quota,
 )
@@ -30,7 +30,7 @@ router = APIRouter()
     dependencies=[
         Depends(guard_backpressure_and_quota),
         Depends(
-            require_token_scope(
+            TokenScopeGuard(
                 "any",
                 require_if_present=True,
                 endpoint_id="media.ingest",

--- a/tldw_Server_API/app/api/v1/endpoints/media/item.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/item.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Request, Response, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.media_request_models import (
     MediaKeywordsUpdateRequest,
@@ -164,7 +164,7 @@ async def get_media_item(
         status.HTTP_409_CONFLICT: {"description": "Media could not be moved to trash"},
     },
     dependencies=[
-        Depends(require_permissions(MEDIA_DELETE)),
+        Depends(RequirePermission(MEDIA_DELETE)),
         Depends(rbac_rate_limit("media.delete")),
     ],
 )
@@ -236,7 +236,7 @@ async def delete_media_item(
         status.HTTP_409_CONFLICT: {"description": "Media could not be restored from trash"},
     },
     dependencies=[
-        Depends(require_permissions(MEDIA_DELETE)),
+        Depends(RequirePermission(MEDIA_DELETE)),
         Depends(rbac_rate_limit("media.delete")),
     ],
 )
@@ -329,7 +329,7 @@ async def restore_media_item(
         status.HTTP_409_CONFLICT: {"description": "Media is not in trash"},
     },
     dependencies=[
-        Depends(require_permissions(MEDIA_DELETE)),
+        Depends(RequirePermission(MEDIA_DELETE)),
         Depends(rbac_rate_limit("media.delete")),
     ],
 )
@@ -674,7 +674,7 @@ async def update_media_item(
     response_model=MediaKeywordsResponse,
     summary="Update media keywords (add/remove/set)",
     dependencies=[
-        Depends(require_permissions(MEDIA_UPDATE)),
+        Depends(RequirePermission(MEDIA_UPDATE)),
         Depends(rbac_rate_limit("media.update")),
     ],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/media/listing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/listing.py
@@ -15,7 +15,7 @@ from fastapi import (
 )
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import (
     get_media_db_for_user,
     try_get_media_db_for_user,
@@ -508,7 +508,7 @@ async def list_media_trash_endpoint(
     "/trash/empty",
     summary="Empty media trash",
     dependencies=[
-        Depends(require_permissions(MEDIA_DELETE)),
+        Depends(RequirePermission(MEDIA_DELETE)),
         Depends(rbac_rate_limit("media.delete")),
     ],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
@@ -17,8 +17,8 @@ from loguru import logger
 from starlette.responses import JSONResponse
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     rbac_rate_limit,
-    require_permissions,
 )
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import propagate_billing_headers, require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
@@ -63,7 +63,7 @@ router = APIRouter()
     summary="Transcribe / chunk / analyse videos and return the full artefacts (no DB write)",
     tags=["Media Processing (No DB)"],
     dependencies=[
-        Depends(require_permissions(MEDIA_CREATE)),
+        Depends(RequirePermission(MEDIA_CREATE)),
         Depends(rbac_rate_limit("media.create")),
         Depends(guard_storage_quota),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_web_scraping.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.core.Billing.enforcement import LimitCategory
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
@@ -48,7 +48,7 @@ def _resolve_process_web_scraping_task() -> WebScrapingTask:
 @router.post(
     "/process-web-scraping",
     dependencies=[
-        Depends(require_permissions(MEDIA_CREATE)),
+        Depends(RequirePermission(MEDIA_CREATE)),
         Depends(rbac_rate_limit("media.create")),
         Depends(require_within_limit(LimitCategory.STORAGE_MB, 1)),
         Depends(require_within_limit(LimitCategory.API_CALLS_DAY, 1)),

--- a/tldw_Server_API/app/api/v1/endpoints/media/reprocess.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/reprocess.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.endpoints import media_embeddings as embeddings_endpoint
 from tldw_Server_API.app.api.v1.schemas.media_request_models import ReprocessMediaRequest
@@ -188,7 +188,7 @@ async def _generate_embeddings(
 @router.post(
     "/{media_id:int}/reprocess",
     dependencies=[
-        Depends(require_permissions(MEDIA_UPDATE)),
+        Depends(RequirePermission(MEDIA_UPDATE)),
         Depends(rbac_rate_limit("media.update")),
     ],
     status_code=status.HTTP_200_OK,

--- a/tldw_Server_API/app/api/v1/endpoints/metrics.py
+++ b/tldw_Server_API/app/api/v1/endpoints/metrics.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 import tldw_Server_API.app.core.Chat.chat_metrics as chat_metrics
 from tldw_Server_API.app.core.Chat.chat_metrics import get_chat_metrics
 from tldw_Server_API.app.core.Metrics.metrics_manager import get_metrics_registry
@@ -246,7 +246,7 @@ async def get_chat_metrics_endpoint() -> dict[str, Any]:
     "/metrics/reset",
     summary="Reset registry metrics (admin only)",
     response_model=dict[str, str],
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def reset_metrics() -> dict[str, str]:
     """

--- a/tldw_Server_API/app/api/v1/endpoints/mlx.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mlx.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Body, Depends, HTTPException
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, check_rate_limit
 from tldw_Server_API.app.api.v1.schemas.mlx import MLXLoadRequest, MLXUnloadRequest
 from tldw_Server_API.app.core.Chat.Chat_Deps import ChatBadRequestError, ChatProviderError
 from tldw_Server_API.app.core.LLM_Calls.providers.mlx_provider import (
@@ -45,7 +45,7 @@ def _normalize_model_path(value: Any) -> str | None:
 @router.post(
     "/llm/providers/mlx/load",
     summary="Load or swap the active MLX model",
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def load_mlx_model(
     payload: MLXLoadRequest = Body(default_factory=MLXLoadRequest),
@@ -71,7 +71,7 @@ async def load_mlx_model(
 @router.post(
     "/llm/providers/mlx/unload",
     summary="Unload the active MLX model",
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def unload_mlx_model(
     payload: MLXUnloadRequest = Body(default_factory=MLXUnloadRequest),
@@ -89,7 +89,7 @@ async def unload_mlx_model(
 @router.get(
     "/llm/providers/mlx/status",
     summary="Get MLX provider status",
-    dependencies=[Depends(check_rate_limit), Depends(require_roles("admin"))],
+    dependencies=[Depends(check_rate_limit), Depends(RequireRole("admin"))],
 )
 async def get_mlx_status(
     registry: MLXSessionRegistry = Depends(_resolve_mlx_registry),

--- a/tldw_Server_API/app/api/v1/endpoints/moderation.py
+++ b/tldw_Server_API/app/api/v1/endpoints/moderation.py
@@ -10,8 +10,8 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, 
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
-    require_permissions,
-    require_roles,
+    RequirePermission,
+    RequireRole,
 )
 from tldw_Server_API.app.api.v1.schemas.moderation_schemas import (
     BlocklistAppendRequest,
@@ -40,8 +40,8 @@ from tldw_Server_API.app.core.Moderation.supervised_policy import (
 
 router = APIRouter(
     dependencies=[
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
     ]
 )
 

--- a/tldw_Server_API/app/api/v1/endpoints/monitoring.py
+++ b/tldw_Server_API/app/api/v1/endpoints/monitoring.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, get_auth_principal
 from tldw_Server_API.app.api.v1.schemas.monitoring_schemas import (
     AlertItem,
     AlertsListResponse,
@@ -51,7 +51,7 @@ _TOPIC_MONITORING_DB: TopicMonitoringDB | None = None
 
 # All monitoring routes require SYSTEM_LOGS permission via this dependency.
 router = APIRouter(
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/notes_graph.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes_graph.py
@@ -5,8 +5,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     rbac_rate_limit,
-    require_permissions,
     require_token_scope,
 )
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
@@ -102,7 +102,7 @@ async def get_notes_graph(
     current_user: User = Depends(get_request_user),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("notes.graph.read")),
-    __: None = Depends(require_permissions(NOTES_GRAPH_READ)),
+    __: None = Depends(RequirePermission(NOTES_GRAPH_READ)),
     ___: None = Depends(require_token_scope("notes", require_if_present=True, endpoint_id="notes.graph.read")),
 ):
     """Return a bounded subgraph of notes, tags, and sources."""
@@ -166,7 +166,7 @@ async def get_note_neighbors(
     current_user: User = Depends(get_request_user),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("notes.graph.read")),
-    __: None = Depends(require_permissions(NOTES_GRAPH_READ)),
+    __: None = Depends(RequirePermission(NOTES_GRAPH_READ)),
     ___: None = Depends(require_token_scope("notes", require_if_present=True, endpoint_id="notes.graph.read")),
 ):
     """Return a radius=1 ego network for the given note."""
@@ -245,7 +245,7 @@ async def create_manual_link(
     current_user: User = Depends(get_request_user),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("notes.graph.write")),
-    __: None = Depends(require_permissions(NOTES_GRAPH_WRITE)),
+    __: None = Depends(RequirePermission(NOTES_GRAPH_WRITE)),
     ___: None = Depends(require_token_scope("notes", require_if_present=True, endpoint_id="notes.graph.write")),
 ) -> dict[str, Any]:
     """
@@ -305,7 +305,7 @@ async def delete_manual_link(
     current_user: User = Depends(get_request_user),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("notes.graph.write")),
-    __: None = Depends(require_permissions(NOTES_GRAPH_WRITE)),
+    __: None = Depends(RequirePermission(NOTES_GRAPH_WRITE)),
     ___: None = Depends(require_token_scope("notes", require_if_present=True, endpoint_id="notes.graph.write")),
 ) -> dict[str, Any]:
     """

--- a/tldw_Server_API/app/api/v1/endpoints/notes_graph.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes_graph.py
@@ -7,7 +7,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     RequirePermission,
     rbac_rate_limit,
-    require_token_scope,
+    TokenScopeGuard,
 )
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
@@ -103,7 +103,7 @@ async def get_notes_graph(
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("notes.graph.read")),
     __: None = Depends(RequirePermission(NOTES_GRAPH_READ)),
-    ___: None = Depends(require_token_scope("notes", require_if_present=True, endpoint_id="notes.graph.read")),
+    ___: None = Depends(TokenScopeGuard("notes", require_if_present=True, endpoint_id="notes.graph.read")),
 ):
     """Return a bounded subgraph of notes, tags, and sources."""
     if not NOTES_GRAPH_ENABLED():
@@ -167,7 +167,7 @@ async def get_note_neighbors(
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("notes.graph.read")),
     __: None = Depends(RequirePermission(NOTES_GRAPH_READ)),
-    ___: None = Depends(require_token_scope("notes", require_if_present=True, endpoint_id="notes.graph.read")),
+    ___: None = Depends(TokenScopeGuard("notes", require_if_present=True, endpoint_id="notes.graph.read")),
 ):
     """Return a radius=1 ego network for the given note."""
     if not NOTES_GRAPH_ENABLED():
@@ -246,7 +246,7 @@ async def create_manual_link(
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("notes.graph.write")),
     __: None = Depends(RequirePermission(NOTES_GRAPH_WRITE)),
-    ___: None = Depends(require_token_scope("notes", require_if_present=True, endpoint_id="notes.graph.write")),
+    ___: None = Depends(TokenScopeGuard("notes", require_if_present=True, endpoint_id="notes.graph.write")),
 ) -> dict[str, Any]:
     """
     Create a manual link in the user's ChaChaNotes DB. Populates created_by.
@@ -306,7 +306,7 @@ async def delete_manual_link(
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
     _: None = Depends(rbac_rate_limit("notes.graph.write")),
     __: None = Depends(RequirePermission(NOTES_GRAPH_WRITE)),
-    ___: None = Depends(require_token_scope("notes", require_if_present=True, endpoint_id="notes.graph.write")),
+    ___: None = Depends(TokenScopeGuard("notes", require_if_present=True, endpoint_id="notes.graph.write")),
 ) -> dict[str, Any]:
     """
     Delete a manual link by id for the current user.

--- a/tldw_Server_API/app/api/v1/endpoints/notifications.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notifications.py
@@ -12,7 +12,7 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.schemas.reminders_schemas import (
     NotificationCancelSnoozeResponse,
     NotificationDismissResponse,
@@ -159,7 +159,7 @@ async def list_notifications(
     include_archived: bool = Query(False),
     only_snoozed: bool = Query(False),
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_READ)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_READ)),  # noqa: B008
 ) -> NotificationsListResponse:
     """List notifications for the authenticated user."""
 
@@ -193,7 +193,7 @@ async def list_notifications(
 )
 async def unread_count(
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_READ)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_READ)),  # noqa: B008
 ) -> NotificationsUnreadCountResponse:
     """Return unread notification count for the authenticated user."""
 
@@ -208,7 +208,7 @@ async def unread_count(
 async def mark_read(
     payload: NotificationsMarkReadRequest,
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_CONTROL)),  # noqa: B008
 ) -> NotificationsMarkReadResponse:
     """Mark one or more notifications as read."""
 
@@ -224,7 +224,7 @@ async def mark_read(
 async def dismiss_notification(
     notification_id: int = Path(..., ge=1),
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_CONTROL)),  # noqa: B008
 ) -> NotificationDismissResponse:
     """Dismiss a notification from the active inbox view."""
 
@@ -240,7 +240,7 @@ async def snooze_notification(
     payload: NotificationSnoozeRequest,
     notification_id: int = Path(..., ge=1),
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_CONTROL)),  # noqa: B008
 ) -> NotificationSnoozeResponse:
     """Create a one-time reminder derived from an existing notification."""
 
@@ -266,7 +266,7 @@ async def snooze_notification(
 async def cancel_notification_snooze(
     notification_id: int = Path(..., ge=1),
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_CONTROL)),  # noqa: B008
 ) -> NotificationCancelSnoozeResponse:
     """Cancel any active snooze reminder derived from an existing notification."""
 
@@ -292,7 +292,7 @@ async def cancel_notification_snooze(
 )
 async def get_preferences(
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_READ)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_READ)),  # noqa: B008
 ) -> NotificationPreferencesResponse:
     """Fetch notification preference flags for the current user."""
 
@@ -314,7 +314,7 @@ async def get_preferences(
 async def patch_preferences(
     payload: NotificationPreferencesUpdateRequest,
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_CONTROL)),  # noqa: B008
 ) -> NotificationPreferencesResponse:
     """Update notification preference flags for the current user."""
 
@@ -340,7 +340,7 @@ async def stream_notifications(
     after: int = Query(0, ge=0),
     last_event_id: str | None = Header(None, alias="Last-Event-ID"),
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(NOTIFICATIONS_READ)),  # noqa: B008
+    _principal=Depends(RequirePermission(NOTIFICATIONS_READ)),  # noqa: B008
 ) -> StreamingResponse:
     """Stream live notification events via Server-Sent Events."""
 

--- a/tldw_Server_API/app/api/v1/endpoints/rag_health.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_health.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_LOGS
 
 # Import RAG components
@@ -194,7 +194,7 @@ async def readiness_check() -> dict[str, Any]:
 @router.get(
     "/cache/stats",
     summary="Get cache statistics",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def get_cache_statistics() -> dict[str, Any]:
     """
@@ -243,7 +243,7 @@ async def get_cache_statistics() -> dict[str, Any]:
 @router.post(
     "/cache/clear",
     summary="Clear cache",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def clear_cache() -> dict[str, str]:
     """
@@ -273,7 +273,7 @@ async def clear_cache() -> dict[str, str]:
 @router.get(
     "/cache/warm",
     summary="Get cache warming status",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def get_cache_warming_status() -> dict[str, Any]:
     """Get status of cache warming operations."""
@@ -305,7 +305,7 @@ async def get_cache_warming_status() -> dict[str, Any]:
 @router.get(
     "/metrics/summary",
     summary="Get metrics summary",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def get_metrics_summary() -> dict[str, Any]:
     """Get summary of RAG pipeline metrics."""
@@ -344,7 +344,7 @@ async def get_metrics_summary() -> dict[str, Any]:
 @router.get(
     "/costs/summary",
     summary="Get cost tracking summary",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def get_cost_summary() -> dict[str, Any]:
     """Get summary of LLM API costs."""
@@ -390,7 +390,7 @@ async def get_cost_summary() -> dict[str, Any]:
 @router.get(
     "/batch/jobs",
     summary="Get batch job statuses",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def get_batch_jobs() -> dict[str, Any]:
     """Get status of all batch processing jobs."""
@@ -429,7 +429,7 @@ async def get_batch_jobs() -> dict[str, Any]:
 @router.post(
     "/quality-gate",
     summary="Run quality gate evaluation",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def quality_gate_endpoint(
     metrics: dict[str, float],
@@ -463,7 +463,7 @@ async def quality_gate_endpoint(
 @router.post(
     "/baseline/save",
     summary="Save metric baseline",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def save_baseline_endpoint(
     metrics: dict[str, float],
@@ -506,7 +506,7 @@ async def save_baseline_endpoint(
 @router.get(
     "/regression/check",
     summary="Check for metric regression",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def check_regression_endpoint(
     baseline_id: str = "latest",
@@ -555,7 +555,7 @@ async def check_regression_endpoint(
 @router.post(
     "/regression/check",
     summary="Check for metric regression with current values",
-    dependencies=[Depends(require_permissions(SYSTEM_LOGS))],
+    dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )
 async def check_regression_post_endpoint(
     current_metrics: dict[str, float],

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -19,10 +19,10 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     check_rate_limit,
     get_auth_principal,
     rbac_rate_limit,
-    require_permissions,
     require_token_scope,
 )
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
@@ -1013,7 +1013,7 @@ async def list_vlm_backends():
     dependencies=[
         Depends(check_rate_limit),
         Depends(rbac_rate_limit("rag.search")),
-        Depends(require_permissions(MEDIA_READ)),
+        Depends(RequirePermission(MEDIA_READ)),
         Depends(require_token_scope("any", require_if_present=True, endpoint_id="rag.search", count_as="call")),
         Depends(require_within_limit(LimitCategory.RAG_QUERIES_DAY, 1)),
     ]
@@ -1242,7 +1242,7 @@ async def rag_implicit_feedback(
     response_description="Batch processing results",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_permissions(MEDIA_READ)),
+        Depends(RequirePermission(MEDIA_READ)),
     ]
 )
 async def unified_batch_endpoint(
@@ -1443,7 +1443,7 @@ async def unified_batch_endpoint(
     response_description="Search results",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_permissions(MEDIA_READ)),
+        Depends(RequirePermission(MEDIA_READ)),
         Depends(require_within_limit(LimitCategory.RAG_QUERIES_DAY, 1)),
     ]
 )
@@ -1536,7 +1536,7 @@ async def simple_search_endpoint(
     description="Resume a batch RAG operation from a checkpoint.",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_permissions(MEDIA_READ)),
+        Depends(RequirePermission(MEDIA_READ)),
     ],
 )
 async def resume_batch_endpoint(
@@ -1733,7 +1733,7 @@ async def resume_batch_endpoint(
     description="Stream generated answer chunks with optional incremental claim overlay events (NDJSON)",
     dependencies=[
         Depends(check_rate_limit),
-        Depends(require_permissions(MEDIA_READ)),
+        Depends(RequirePermission(MEDIA_READ)),
         Depends(require_within_limit(LimitCategory.RAG_QUERIES_DAY, 1)),
     ]
 )
@@ -1819,7 +1819,7 @@ async def unified_search_stream_endpoint(
     - Performance analysis
     """,
     response_description="Full search results with analysis",
-    dependencies=[Depends(check_rate_limit), Depends(require_permissions(MEDIA_READ))]
+    dependencies=[Depends(check_rate_limit), Depends(RequirePermission(MEDIA_READ))]
 )
 async def advanced_search_endpoint(
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -23,7 +23,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     check_rate_limit,
     get_auth_principal,
     rbac_rate_limit,
-    require_token_scope,
+    TokenScopeGuard,
 )
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
@@ -1014,7 +1014,7 @@ async def list_vlm_backends():
         Depends(check_rate_limit),
         Depends(rbac_rate_limit("rag.search")),
         Depends(RequirePermission(MEDIA_READ)),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="rag.search", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="rag.search", count_as="call")),
         Depends(require_within_limit(LimitCategory.RAG_QUERIES_DAY, 1)),
     ]
 )

--- a/tldw_Server_API/app/api/v1/endpoints/reminders.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reminders.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.schemas.reminders_schemas import (
     ReminderTaskCreateRequest,
     ReminderTaskDeleteResponse,
@@ -80,7 +80,7 @@ def _row_to_response(row: ReminderTaskRow) -> ReminderTaskResponse:
 async def create_task(
     payload: ReminderTaskCreateRequest,
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(TASKS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
 ) -> ReminderTaskResponse:
     task_id = db.create_reminder_task(
         title=payload.title,
@@ -107,7 +107,7 @@ async def create_task(
 )
 async def list_tasks(
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(TASKS_READ)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
 ) -> ReminderTaskListResponse:
     rows = db.list_reminder_tasks()
     return ReminderTaskListResponse(items=[_row_to_response(row) for row in rows], total=len(rows))
@@ -121,7 +121,7 @@ async def list_tasks(
 async def get_task(
     task_id: str = Path(..., min_length=1),
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(TASKS_READ)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
 ) -> ReminderTaskResponse:
     try:
         return _row_to_response(db.get_reminder_task(task_id))
@@ -138,7 +138,7 @@ async def update_task(
     payload: ReminderTaskUpdateRequest,
     task_id: str = Path(..., min_length=1),
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(TASKS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
 ) -> ReminderTaskResponse:
     patch = payload.model_dump(exclude_unset=True)
     try:
@@ -160,7 +160,7 @@ async def update_task(
 async def delete_task(
     task_id: str = Path(..., min_length=1),
     db: CollectionsDatabase = Depends(get_collections_db_for_user),
-    _principal=Depends(require_permissions(TASKS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
 ) -> ReminderTaskDeleteResponse:
     existing_task = None
     try:

--- a/tldw_Server_API/app/api/v1/endpoints/resource_governor.py
+++ b/tldw_Server_API/app/api/v1/endpoints/resource_governor.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Body, Depends, Path, Query
 from fastapi.responses import JSONResponse
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 from tldw_Server_API.app.main import app as _app
 
 router = APIRouter()
@@ -70,7 +70,7 @@ def _get_or_init_governor() -> Any | None:
 
 @router.get(
     "/resource-governor/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def get_resource_governor_policy(
     include: str | None = Query(None, description="Include extra data: 'ids' or 'full'"),
@@ -195,7 +195,7 @@ async def get_resource_governor_policy(
         return JSONResponse({"status": "error", "error": "internal server error"}, status_code=500)
 
 
-# --- Policy admin endpoints (gated by require_roles('admin')) ---
+# --- Policy admin endpoints (gated by RequireRole('admin')) ---
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.core.Resource_Governance.policy_admin import (
@@ -211,7 +211,7 @@ class PolicyUpsertRequest(BaseModel):
 
 @router.put(
     "/resource-governor/policy/{policy_id}",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def upsert_policy(
     policy_id: str = Path(..., description="Policy identifier, e.g., 'chat.default'"),
@@ -274,7 +274,7 @@ async def upsert_policy(
 
 @router.delete(
     "/resource-governor/policy/{policy_id}",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def delete_policy(
     policy_id: str = Path(..., description="Policy identifier"),
@@ -337,7 +337,7 @@ async def delete_policy(
 
 @router.get(
     "/resource-governor/policies",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def list_policies():
     try:
@@ -351,7 +351,7 @@ async def list_policies():
 
 @router.get(
     "/resource-governor/policy/{policy_id}",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def get_policy(policy_id: str = Path(..., description="Policy identifier")):
     try:
@@ -368,7 +368,7 @@ async def get_policy(policy_id: str = Path(..., description="Policy identifier")
 # --- Diagnostics (admin) ---
 @router.get(
     "/resource-governor/diag/peek",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def rg_diag_peek(
     entity: str = Query(..., description="Entity key, e.g., 'user:123'"),
@@ -397,7 +397,7 @@ async def rg_diag_peek(
 
 @router.get(
     "/resource-governor/diag/query",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def rg_diag_query(
     entity: str = Query(..., description="Entity key, e.g., 'user:123'"),
@@ -418,7 +418,7 @@ async def rg_diag_query(
 
 @router.get(
     "/resource-governor/diag/media-budget",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def rg_diag_media_budget(
     user_id: int = Query(..., ge=1, description="User id to inspect, e.g., 123"),
@@ -545,7 +545,7 @@ async def rg_diag_media_budget(
 
 @router.get(
     "/resource-governor/diag/capabilities",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def rg_diag_capabilities():
     """Tiny capability probe to report whether Lua or fallback paths are in use."""
@@ -570,7 +570,7 @@ async def rg_diag_capabilities():
 
 @router.get(
     "/diag/coverage",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     summary="Resource Governor endpoint coverage audit",
 )
 async def rg_coverage_audit():

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -2244,7 +2244,7 @@ async def admin_macos_diagnostics(
 )
 async def admin_repair_macos_reconciliation(
     request: SandboxAdminMacOSReconciliationRepairRequest = Body(default_factory=SandboxAdminMacOSReconciliationRepairRequest),
-    _principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    _principal: AuthPrincipal = Depends(RequireRole("admin")),
     _current_user: User = Depends(get_request_user),
 ) -> SandboxAdminMacOSReconciliationRepairResponse:
     try:

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -29,7 +29,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.routing import APIRoute
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminMacOSDiagnosticsResponse,
@@ -2229,7 +2229,7 @@ async def stream_run_logs(websocket: WebSocket, run_id: str) -> None:
     summary="Admin: macOS sandbox diagnostics",
 )
 async def admin_macos_diagnostics(
-    _principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    _principal: AuthPrincipal = Depends(RequireRole("admin")),
     _current_user: User = Depends(get_request_user),
 ) -> SandboxAdminMacOSDiagnosticsResponse:
     """Return detailed macOS sandbox diagnostics for admin troubleshooting."""
@@ -2268,7 +2268,7 @@ async def admin_list_runs(
     limit: int = Query(50, ge=1, le=1000),
     offset: int = Query(0, ge=0),
     sort: str | None = Query("desc", pattern="^(asc|desc)$"),
-    principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    principal: AuthPrincipal = Depends(RequireRole("admin")),
     current_user: User = Depends(get_request_user),
 ) -> SandboxAdminRunListResponse:
     items_raw = _service._orch.list_runs(  # type: ignore[attr-defined]
@@ -2323,7 +2323,7 @@ async def admin_list_runs(
 )
 async def admin_get_run_details(
     run_id: str = Path(..., min_length=1),
-    principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    principal: AuthPrincipal = Depends(RequireRole("admin")),
     current_user: User = Depends(get_request_user),
 ) -> SandboxAdminRunDetails:
     st = _service.get_run(run_id)
@@ -2423,7 +2423,7 @@ async def admin_list_idempotency(
     limit: int = Query(50, ge=1, le=1000),
     offset: int = Query(0, ge=0),
     sort: str | None = Query("desc", pattern="^(asc|desc)$"),
-    principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    principal: AuthPrincipal = Depends(RequireRole("admin")),
     current_user: User = Depends(get_request_user),
 ) -> SandboxAdminIdempotencyListResponse:
     items_raw = _service._orch._store.list_idempotency(  # type: ignore[attr-defined]
@@ -2469,7 +2469,7 @@ async def admin_usage(
     limit: int = Query(50, ge=1, le=1000),
     offset: int = Query(0, ge=0),
     sort: str | None = Query("desc", pattern="^(asc|desc)$"),
-    principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    principal: AuthPrincipal = Depends(RequireRole("admin")),
     current_user: User = Depends(get_request_user),
 ) -> SandboxAdminUsageResponse:
     items_raw = _service._orch._store.list_usage(  # type: ignore[attr-defined]

--- a/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduled_tasks_control_plane.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.schemas.reminders_schemas import (
     ReminderTaskCreateRequest,
     ReminderTaskUpdateRequest,
@@ -30,7 +30,7 @@ def get_scheduled_tasks_control_plane_service() -> ScheduledTasksControlPlaneSer
 )
 async def list_scheduled_tasks(
     current_user: User = Depends(get_request_user),
-    _principal=Depends(require_permissions(TASKS_READ)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
     service: ScheduledTasksControlPlaneService = Depends(get_scheduled_tasks_control_plane_service),
 ) -> ScheduledTaskListResponse:
     return await service.list_tasks(user_id=int(current_user.id))
@@ -44,7 +44,7 @@ async def list_scheduled_tasks(
 async def get_scheduled_task(
     task_id: str = Path(..., min_length=1),
     current_user: User = Depends(get_request_user),
-    _principal=Depends(require_permissions(TASKS_READ)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_READ)),  # noqa: B008
     service: ScheduledTasksControlPlaneService = Depends(get_scheduled_tasks_control_plane_service),
 ) -> ScheduledTask:
     try:
@@ -62,7 +62,7 @@ async def get_scheduled_task(
 async def create_scheduled_task_reminder(
     payload: ReminderTaskCreateRequest,
     current_user: User = Depends(get_request_user),
-    _principal=Depends(require_permissions(TASKS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
     service: ScheduledTasksControlPlaneService = Depends(get_scheduled_tasks_control_plane_service),
 ) -> ScheduledTask:
     return await service.create_reminder(user_id=int(current_user.id), payload=payload)
@@ -77,7 +77,7 @@ async def update_scheduled_task_reminder(
     payload: ReminderTaskUpdateRequest,
     task_id: str = Path(..., min_length=1),
     current_user: User = Depends(get_request_user),
-    _principal=Depends(require_permissions(TASKS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
     service: ScheduledTasksControlPlaneService = Depends(get_scheduled_tasks_control_plane_service),
 ) -> ScheduledTask:
     try:
@@ -94,7 +94,7 @@ async def update_scheduled_task_reminder(
 async def delete_scheduled_task_reminder(
     task_id: str = Path(..., min_length=1),
     current_user: User = Depends(get_request_user),
-    _principal=Depends(require_permissions(TASKS_CONTROL)),  # noqa: B008
+    _principal=Depends(RequirePermission(TASKS_CONTROL)),  # noqa: B008
     service: ScheduledTasksControlPlaneService = Depends(get_scheduled_tasks_control_plane_service),
 ) -> ScheduledTaskDeleteResponse:
     return await service.delete_reminder(user_id=int(current_user.id), task_id=task_id)

--- a/tldw_Server_API/app/api/v1/endpoints/scheduler_workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduler_workflows.py
@@ -8,8 +8,8 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     get_auth_principal,
-    require_permissions,
     require_token_scope,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import WORKFLOWS_ADMIN
@@ -29,7 +29,7 @@ _ADMIN_RESCAN_SCOPE_DEP = require_token_scope(
     require_if_present=True,
     endpoint_id="scheduler.workflows.admin_rescan",
 )
-_ADMIN_RESCAN_PERMISSIONS_DEP = require_permissions(WORKFLOWS_ADMIN)
+_ADMIN_RESCAN_PERMISSIONS_DEP = RequirePermission(WORKFLOWS_ADMIN)
 
 
 class ScheduleCreateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/endpoints/scheduler_workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/scheduler_workflows.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     RequirePermission,
     get_auth_principal,
-    require_token_scope,
+    TokenScopeGuard,
 )
 from tldw_Server_API.app.core.AuthNZ.permissions import WORKFLOWS_ADMIN
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
@@ -24,7 +24,7 @@ from tldw_Server_API.app.services.workflows_scheduler import (
 
 router = APIRouter(prefix="/api/v1/scheduler/workflows", tags=["scheduler", "workflows"])
 
-_ADMIN_RESCAN_SCOPE_DEP = require_token_scope(
+_ADMIN_RESCAN_SCOPE_DEP = TokenScopeGuard(
     "workflows",
     require_if_present=True,
     endpoint_id="scheduler.workflows.admin_rescan",
@@ -130,7 +130,7 @@ def _is_scheduler_admin_user(current_user: User) -> bool:
     "",
     response_model=dict[str, str],
     status_code=201,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="scheduler.workflows.create"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="scheduler.workflows.create"))],
 )
 async def create_schedule(
     body: ScheduleCreateRequest,
@@ -194,7 +194,7 @@ async def admin_rescan(
 @router.get(
     "",
     response_model=list[ScheduleResponse],
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="scheduler.workflows.list"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="scheduler.workflows.list"))],
 )
 async def list_schedules(
     owner: str | None = Query(None, description="Admin-only: filter by owner user_id"),
@@ -248,7 +248,7 @@ async def list_schedules(
 @router.get(
     "/{schedule_id}",
     response_model=ScheduleResponse,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="scheduler.workflows.get"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="scheduler.workflows.get"))],
 )
 async def get_schedule(
     schedule_id: str,
@@ -309,7 +309,7 @@ async def get_schedule(
 @router.patch(
     "/{schedule_id}",
     response_model=dict[str, bool],
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="scheduler.workflows.update"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="scheduler.workflows.update"))],
 )
 async def update_schedule(
     schedule_id: str,
@@ -354,7 +354,7 @@ async def update_schedule(
 @router.delete(
     "/{schedule_id}",
     response_model=dict[str, bool],
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="scheduler.workflows.delete"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="scheduler.workflows.delete"))],
 )
 async def delete_schedule(
     schedule_id: str,
@@ -374,7 +374,7 @@ async def delete_schedule(
 @router.post(
     "/{schedule_id}/run-now",
     response_model=dict[str, str],
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, require_schedule_match=True, schedule_path_param="schedule_id", allow_admin_bypass=True, endpoint_id="scheduler.workflows.run_now", count_as="run"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, require_schedule_match=True, schedule_path_param="schedule_id", allow_admin_bypass=True, endpoint_id="scheduler.workflows.run_now", count_as="run"))],
 )
 async def run_now(
     schedule_id: str,
@@ -411,7 +411,7 @@ class DryRunRequest(BaseModel):
 @router.post(
     "/dry-run",
     response_model=dict[str, Any],
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="scheduler.workflows.dry_run"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="scheduler.workflows.dry_run"))],
 )
 async def dry_run_schedule(body: DryRunRequest, current_user: User = Depends(get_request_user)):
     """Validate cron/timezone and return next run time and echo inputs.

--- a/tldw_Server_API/app/api/v1/endpoints/setup.py
+++ b/tldw_Server_API/app/api/v1/endpoints/setup.py
@@ -16,10 +16,10 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    RequireRole,
     get_auth_principal,
     get_db_transaction,
-    require_permissions,
-    require_roles,
 )
 from tldw_Server_API.app.api.v1.API_Deps.setup_deps import (
     require_local_setup_access,
@@ -173,8 +173,8 @@ async def require_admin_and_system_configure(
     - Other principals must hold the ``admin`` role and the SYSTEM_CONFIGURE
       permission to pass.
     """
-    role_checker = require_roles("admin")
-    perm_checker = require_permissions(SYSTEM_CONFIGURE)
+    role_checker = RequireRole("admin")
+    perm_checker = RequirePermission(SYSTEM_CONFIGURE)
 
     principal = await role_checker(principal)
     principal = await perm_checker(principal)

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -29,6 +29,7 @@ from fastapi.responses import Response
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import CurrentPrincipal
 
 # Local Imports
 from tldw_Server_API.app.api.v1.schemas.skills_schemas import (
@@ -42,7 +43,6 @@ from tldw_Server_API.app.api.v1.schemas.skills_schemas import (
     SkillSummary,
     SkillUpdate,
 )
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Skills.exceptions import (
@@ -58,19 +58,19 @@ router = APIRouter()
 
 
 async def get_skills_service(
-    current_user: User = Depends(get_request_user),
+    principal: CurrentPrincipal,
     chacha_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> SkillsService:
     """
     FastAPI dependency to get the SkillsService instance for the identified user.
     """
-    if not current_user or not isinstance(current_user.id, int):
+    if not isinstance(principal.user_id, int):
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="User identification failed for Skills service.",
         )
 
-    user_id = current_user.id
+    user_id = principal.user_id
     user_base_dir = DatabasePaths.get_user_base_directory(user_id)
 
     return SkillsService(user_id=user_id, base_path=user_base_dir, db=chacha_db)
@@ -432,8 +432,8 @@ async def export_skill(
 async def execute_skill(
     skill_name: str,
     request: SkillExecuteRequest,
+    principal: CurrentPrincipal,
     service: SkillsService = Depends(get_skills_service),
-    current_user: User = Depends(get_request_user),
 ):
     """
     Execute a skill with optional arguments.
@@ -446,7 +446,7 @@ async def execute_skill(
 
         executor = SkillExecutor()
         ctx = None
-        if current_user and getattr(current_user, "id", None) is not None:
+        if isinstance(principal.user_id, int):
             # Populate full RequestContext for fork mode support
             try:
                 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import DEFAULT_LLM_PROVIDER
@@ -459,7 +459,7 @@ async def execute_skill(
             except Exception:
                 app_config = None
             ctx = RequestContext(
-                user_id=current_user.id,
+                user_id=principal.user_id,
                 default_provider=default_provider,
                 app_config=app_config,
                 client_id=getattr(service.db, "client_id", None) if getattr(service, "db", None) else None,

--- a/tldw_Server_API/app/api/v1/endpoints/slack.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slack.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole
 from tldw_Server_API.app.api.v1.endpoints.slack_oauth_admin import (
     slack_admin_delete_installation_impl,
     slack_admin_get_policy_impl,
@@ -49,6 +49,7 @@ from tldw_Server_API.app.api.v1.endpoints.slack_support import (
     _public_installation_record,
     _rate_limit_key_for_commands,
     _rate_limit_key_for_events,
+    _reset_slack_state_for_tests,
     _resolve_slack_actor_id,
     _safe_int,
     _set_slack_policy,
@@ -513,7 +514,7 @@ async def slack_oauth_callback(
 
 @router.get(
     "/admin/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def slack_admin_get_policy(
     team_id: str | None = Query(default=None),
@@ -527,7 +528,7 @@ async def slack_admin_get_policy(
 
 @router.put(
     "/admin/policy",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
 )
 async def slack_admin_set_policy(
     payload: dict[str, Any] | None = None,
@@ -540,7 +541,7 @@ async def slack_admin_set_policy(
     )
 
 
-@router.get("/admin/installations", dependencies=[Depends(require_roles("admin"))])
+@router.get("/admin/installations", dependencies=[Depends(RequireRole("admin"))])
 async def slack_admin_list_installations(
     user: User = Depends(get_request_user),
 ):
@@ -553,7 +554,7 @@ async def slack_admin_list_installations(
     )
 
 
-@router.delete("/admin/installations/{team_id}", dependencies=[Depends(require_roles("admin"))])
+@router.delete("/admin/installations/{team_id}", dependencies=[Depends(RequireRole("admin"))])
 async def slack_admin_delete_installation(
     request: Request,
     team_id: str,
@@ -572,7 +573,7 @@ async def slack_admin_delete_installation(
     )
 
 
-@router.put("/admin/installations/{team_id}", dependencies=[Depends(require_roles("admin"))])
+@router.put("/admin/installations/{team_id}", dependencies=[Depends(RequireRole("admin"))])
 async def slack_admin_set_installation_state(
     request: Request,
     team_id: str,

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -19,7 +19,7 @@ from fastapi.encoders import jsonable_encoder
 from loguru import logger
 from pydantic import ValidationError
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, rbac_rate_limit
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user, get_chacha_db_for_user_id
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
@@ -1139,7 +1139,7 @@ def _generate_presentation(
     response_model=PresentationResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create a presentation",
-    dependencies=[Depends(require_permissions(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.create"))],
+    dependencies=[Depends(RequirePermission(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.create"))],
 )
 async def create_presentation(
     request: PresentationCreateRequest,
@@ -1199,7 +1199,7 @@ async def create_presentation(
     "/presentations",
     response_model=PresentationListResponse,
     summary="List presentations",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.list"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.list"))],
 )
 async def list_presentations(
     limit: int = Query(50, ge=1, le=200),
@@ -1228,7 +1228,7 @@ async def list_presentations(
     "/presentations/search",
     response_model=PresentationSearchResponse,
     summary="Search presentations",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.search"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.search"))],
 )
 async def search_presentations(
     q: str = Query(..., min_length=1),
@@ -1250,7 +1250,7 @@ async def search_presentations(
     "/presentations/{presentation_id}",
     response_model=PresentationResponse,
     summary="Get presentation",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.get"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.get"))],
 )
 async def get_presentation(
     presentation_id: str,
@@ -1271,7 +1271,7 @@ async def get_presentation(
     "/presentations/{presentation_id}",
     response_model=PresentationResponse,
     summary="Update presentation",
-    dependencies=[Depends(require_permissions(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.update"))],
+    dependencies=[Depends(RequirePermission(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.update"))],
 )
 async def update_presentation(
     presentation_id: str,
@@ -1341,7 +1341,7 @@ async def update_presentation(
     "/presentations/{presentation_id}",
     response_model=PresentationResponse,
     summary="Patch presentation",
-    dependencies=[Depends(require_permissions(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.update"))],
+    dependencies=[Depends(RequirePermission(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.update"))],
 )
 async def patch_presentation(
     presentation_id: str,
@@ -1447,7 +1447,7 @@ async def patch_presentation(
     "/presentations/{presentation_id}/reorder",
     response_model=PresentationResponse,
     summary="Reorder slides in a presentation",
-    dependencies=[Depends(require_permissions(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.update"))],
+    dependencies=[Depends(RequirePermission(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.update"))],
 )
 async def reorder_presentation(
     presentation_id: str,
@@ -1501,7 +1501,7 @@ async def reorder_presentation(
     "/presentations/{presentation_id}",
     response_model=PresentationResponse,
     summary="Soft delete presentation",
-    dependencies=[Depends(require_permissions(MEDIA_DELETE)), Depends(rbac_rate_limit("slides.delete"))],
+    dependencies=[Depends(RequirePermission(MEDIA_DELETE)), Depends(rbac_rate_limit("slides.delete"))],
 )
 async def delete_presentation(
     presentation_id: str,
@@ -1527,7 +1527,7 @@ async def delete_presentation(
     "/presentations/{presentation_id}/restore",
     response_model=PresentationResponse,
     summary="Restore soft-deleted presentation",
-    dependencies=[Depends(require_permissions(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.restore"))],
+    dependencies=[Depends(RequirePermission(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.restore"))],
 )
 async def restore_presentation(
     presentation_id: str,
@@ -1553,7 +1553,7 @@ async def restore_presentation(
     "/templates",
     response_model=SlidesTemplateListResponse,
     summary="List slide templates",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.templates.list"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.templates.list"))],
 )
 async def list_templates() -> SlidesTemplateListResponse:
     try:
@@ -1567,7 +1567,7 @@ async def list_templates() -> SlidesTemplateListResponse:
     "/templates/{template_id}",
     response_model=SlidesTemplateResponse,
     summary="Get slide template",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.templates.get"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.templates.get"))],
 )
 async def get_template(template_id: str) -> SlidesTemplateResponse:
     try:
@@ -1583,7 +1583,7 @@ async def get_template(template_id: str) -> SlidesTemplateResponse:
     "/styles",
     response_model=VisualStyleListResponse,
     summary="List visual styles",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.styles.list"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.styles.list"))],
 )
 async def list_visual_styles(
     limit: int = Query(50, ge=1, le=500),
@@ -1617,7 +1617,7 @@ async def list_visual_styles(
     "/styles/{style_id}",
     response_model=VisualStyleResponse,
     summary="Get visual style",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.styles.get"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.styles.get"))],
 )
 async def get_visual_style(
     style_id: str,
@@ -1631,7 +1631,7 @@ async def get_visual_style(
     response_model=VisualStyleResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create visual style",
-    dependencies=[Depends(require_permissions(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.styles.create"))],
+    dependencies=[Depends(RequirePermission(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.styles.create"))],
 )
 async def create_visual_style(
     request: VisualStyleCreateRequest,
@@ -1658,7 +1658,7 @@ async def create_visual_style(
     "/styles/{style_id}",
     response_model=VisualStyleResponse,
     summary="Patch visual style",
-    dependencies=[Depends(require_permissions(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.styles.update"))],
+    dependencies=[Depends(RequirePermission(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.styles.update"))],
 )
 async def patch_visual_style(
     style_id: str,
@@ -1749,7 +1749,7 @@ async def patch_visual_style(
     "/styles/{style_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Delete visual style",
-    dependencies=[Depends(require_permissions(MEDIA_DELETE)), Depends(rbac_rate_limit("slides.styles.delete"))],
+    dependencies=[Depends(RequirePermission(MEDIA_DELETE)), Depends(rbac_rate_limit("slides.styles.delete"))],
 )
 async def delete_visual_style(
     style_id: str,
@@ -1773,7 +1773,7 @@ async def delete_visual_style(
     "/presentations/{presentation_id}/versions",
     response_model=PresentationVersionListResponse,
     summary="List presentation versions",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.versions.list"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.versions.list"))],
 )
 async def list_presentation_versions(
     presentation_id: str,
@@ -1804,7 +1804,7 @@ async def list_presentation_versions(
     "/presentations/{presentation_id}/versions/{version}",
     response_model=PresentationResponse,
     summary="Get presentation version",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.versions.get"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.versions.get"))],
 )
 async def get_presentation_version(
     presentation_id: str,
@@ -1823,7 +1823,7 @@ async def get_presentation_version(
     "/presentations/{presentation_id}/versions/{version}/restore",
     response_model=PresentationResponse,
     summary="Restore presentation to a previous version",
-    dependencies=[Depends(require_permissions(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.versions.restore"))],
+    dependencies=[Depends(RequirePermission(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.versions.restore"))],
 )
 async def restore_presentation_version(
     presentation_id: str,
@@ -1894,7 +1894,7 @@ async def restore_presentation_version(
     response_model=PresentationRenderJobResponse,
     status_code=status.HTTP_202_ACCEPTED,
     summary="Submit a presentation render job",
-    dependencies=[Depends(require_permissions(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.render.submit"))],
+    dependencies=[Depends(RequirePermission(MEDIA_UPDATE)), Depends(rbac_rate_limit("slides.render.submit"))],
 )
 async def submit_presentation_render_job(
     presentation_id: str,
@@ -1947,7 +1947,7 @@ async def submit_presentation_render_job(
     "/render-jobs/{job_id}",
     response_model=PresentationRenderJobStatusResponse,
     summary="Get presentation render job status",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.render.status"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.render.status"))],
 )
 async def get_presentation_render_job_status(
     job_id: int,
@@ -1987,7 +1987,7 @@ async def get_presentation_render_job_status(
     "/presentations/{presentation_id}/render-artifacts",
     response_model=PresentationRenderArtifactListResponse,
     summary="List presentation render artifacts",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.render.artifacts"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.render.artifacts"))],
 )
 async def list_presentation_render_artifacts(
     presentation_id: str,
@@ -2033,7 +2033,7 @@ async def list_presentation_render_artifacts(
     "/generate",
     response_model=PresentationResponse,
     summary="Generate slides from prompt",
-    dependencies=[Depends(require_permissions(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
+    dependencies=[Depends(RequirePermission(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
 )
 async def generate_from_prompt(
     request: GenerateFromPromptRequest,
@@ -2058,7 +2058,7 @@ async def generate_from_prompt(
     "/generate/from-chat",
     response_model=PresentationResponse,
     summary="Generate slides from chat conversation",
-    dependencies=[Depends(require_permissions(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
+    dependencies=[Depends(RequirePermission(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
 )
 async def generate_from_chat(
     request: GenerateFromChatRequest,
@@ -2093,7 +2093,7 @@ async def generate_from_chat(
     "/generate/from-media",
     response_model=PresentationResponse,
     summary="Generate slides from media transcript",
-    dependencies=[Depends(require_permissions(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
+    dependencies=[Depends(RequirePermission(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
 )
 async def generate_from_media(
     request: GenerateFromMediaRequest,
@@ -2136,7 +2136,7 @@ async def generate_from_media(
     "/generate/from-notes",
     response_model=PresentationResponse,
     summary="Generate slides from notes",
-    dependencies=[Depends(require_permissions(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
+    dependencies=[Depends(RequirePermission(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
 )
 async def generate_from_notes(
     request: GenerateFromNotesRequest,
@@ -2176,7 +2176,7 @@ async def generate_from_notes(
     "/generate/from-rag",
     response_model=PresentationResponse,
     summary="Generate slides from RAG results",
-    dependencies=[Depends(require_permissions(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
+    dependencies=[Depends(RequirePermission(MEDIA_CREATE)), Depends(rbac_rate_limit("slides.generate"))],
 )
 async def generate_from_rag(
     request: GenerateFromRagRequest,
@@ -2218,7 +2218,7 @@ async def generate_from_rag(
 @router.get(
     "/presentations/{presentation_id}/export",
     summary="Export presentation",
-    dependencies=[Depends(require_permissions(MEDIA_READ)), Depends(rbac_rate_limit("slides.export"))],
+    dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.export"))],
 )
 async def export_presentation(
     presentation_id: str,

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Request
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequireRole,
     check_rate_limit,
     get_auth_principal,
-    require_roles,
 )
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     telegram_admin_get_bot_impl,
@@ -29,7 +29,7 @@ from tldw_Server_API.app.services.telegram_execution_identity_service import (
 router = APIRouter(prefix="/telegram", tags=["telegram"])
 
 
-@router.put("/admin/bot", dependencies=[Depends(require_roles("admin"))], response_model=TelegramBotConfigResponse)
+@router.put("/admin/bot", dependencies=[Depends(RequireRole("admin"))], response_model=TelegramBotConfigResponse)
 async def telegram_admin_put_bot(
     request: Request,
     payload: TelegramBotConfigUpdate,
@@ -38,7 +38,7 @@ async def telegram_admin_put_bot(
     return await telegram_admin_put_bot_impl(principal=principal, payload=payload, request=request)
 
 
-@router.get("/admin/bot", dependencies=[Depends(require_roles("admin"))], response_model=TelegramBotConfigResponse)
+@router.get("/admin/bot", dependencies=[Depends(RequireRole("admin"))], response_model=TelegramBotConfigResponse)
 async def telegram_admin_get_bot(
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
@@ -46,7 +46,7 @@ async def telegram_admin_get_bot(
     return await telegram_admin_get_bot_impl(principal=principal, request=request)
 
 
-@router.post("/admin/link/start", dependencies=[Depends(require_roles("admin"))])
+@router.post("/admin/link/start", dependencies=[Depends(RequireRole("admin"))])
 async def telegram_admin_start_link(
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
@@ -54,7 +54,7 @@ async def telegram_admin_start_link(
     return await telegram_admin_start_link_impl(principal=principal, request=request)
 
 
-@router.get("/admin/links", dependencies=[Depends(require_roles("admin"))], response_model=TelegramLinkedActorListResponse)
+@router.get("/admin/links", dependencies=[Depends(RequireRole("admin"))], response_model=TelegramLinkedActorListResponse)
 async def telegram_admin_list_links(
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
@@ -64,7 +64,7 @@ async def telegram_admin_list_links(
 
 @router.delete(
     "/admin/links/{link_id}",
-    dependencies=[Depends(require_roles("admin"))],
+    dependencies=[Depends(RequireRole("admin"))],
     response_model=TelegramLinkedActorRevokeResponse,
 )
 async def telegram_admin_revoke_link(

--- a/tldw_Server_API/app/api/v1/endpoints/text2sql.py
+++ b/tldw_Server_API/app/api/v1/endpoints/text2sql.py
@@ -12,7 +12,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     check_rate_limit,
     get_request_user,
     rbac_rate_limit,
-    require_token_scope,
+    TokenScopeGuard,
 )
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
@@ -99,7 +99,7 @@ def _connector_acl_allows(current_user: User, target_id: str) -> bool:
         Depends(check_rate_limit),
         Depends(rbac_rate_limit("text2sql.query")),
         Depends(RequirePermission(SQL_READ)),
-        Depends(require_token_scope("any", require_if_present=True, endpoint_id="text2sql.query", count_as="call")),
+        Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="text2sql.query", count_as="call")),
         Depends(require_within_limit(LimitCategory.RAG_QUERIES_DAY, 1)),
     ],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/text2sql.py
+++ b/tldw_Server_API/app/api/v1/endpoints/text2sql.py
@@ -8,10 +8,10 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
     check_rate_limit,
     get_request_user,
     rbac_rate_limit,
-    require_permissions,
     require_token_scope,
 )
 from tldw_Server_API.app.api.v1.API_Deps.billing_deps import require_within_limit
@@ -98,7 +98,7 @@ def _connector_acl_allows(current_user: User, target_id: str) -> bool:
     dependencies=[
         Depends(check_rate_limit),
         Depends(rbac_rate_limit("text2sql.query")),
-        Depends(require_permissions(SQL_READ)),
+        Depends(RequirePermission(SQL_READ)),
         Depends(require_token_scope("any", require_if_present=True, endpoint_id="text2sql.query", count_as="call")),
         Depends(require_within_limit(LimitCategory.RAG_QUERIES_DAY, 1)),
     ],

--- a/tldw_Server_API/app/api/v1/endpoints/tools.py
+++ b/tldw_Server_API/app/api/v1/endpoints/tools.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission
 from tldw_Server_API.app.api.v1.schemas.tools import (
     ExecuteToolRequest,
     ExecuteToolResult,
@@ -68,7 +68,7 @@ async def list_tools_endpoint(current_user: User = Depends(get_request_user)) ->
     response_model=ExecuteToolResult,
     summary="Execute a tool via the server",
     dependencies=[
-        Depends(auth_deps.require_permissions("tools.execute:*")),
+        Depends(RequirePermission("tools.execute:*")),
     ],
 )
 async def execute_tool_endpoint(

--- a/tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vector_stores_openai.py
@@ -19,10 +19,10 @@ from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    RequirePermission,
+    RequireRole,
     get_auth_principal,
     rbac_rate_limit,
-    require_permissions,
-    require_roles,
 )
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
@@ -511,8 +511,8 @@ async def list_vector_stores(
 @router.get(
     "/vector_stores/admin/users",
     dependencies=[
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
         Depends(RBAC_VECTOR_ADMIN),
     ],
 )
@@ -978,8 +978,8 @@ class HNSWEfSearchRequest(BaseModel):
 @router.get(
     "/vector_stores/{store_id}/admin/index_info",
     dependencies=[
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
         Depends(RBAC_VECTOR_ADMIN),
     ],
 )
@@ -1005,8 +1005,8 @@ async def get_index_info(
 @router.post(
     "/vector_stores/admin/hnsw_ef_search",
     dependencies=[
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
         Depends(RBAC_VECTOR_ADMIN),
     ],
 )
@@ -1034,8 +1034,8 @@ class RebuildIndexRequest(BaseModel):
 @router.post(
     "/vector_stores/{store_id}/admin/rebuild_index",
     dependencies=[
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
         Depends(RBAC_VECTOR_ADMIN),
     ],
 )
@@ -1070,8 +1070,8 @@ class DeleteByFilterRequest(BaseModel):
 @router.post(
     "/vector_stores/{store_id}/admin/delete_by_filter",
     dependencies=[
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
         Depends(RBAC_VECTOR_ADMIN),
     ],
 )
@@ -1128,8 +1128,8 @@ async def delete_by_filter(
 @router.get(
     "/vector_stores/admin/health",
     dependencies=[
-        Depends(require_roles("admin")),
-        Depends(require_permissions(SYSTEM_CONFIGURE)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(SYSTEM_CONFIGURE)),
         Depends(RBAC_VECTOR_ADMIN),
     ],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -31,7 +31,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field, ValidationError
 
-from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, RequireRole, TokenScopeGuard
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.api.v1.schemas.workflows import (
     AdhocRunRequest,
@@ -1568,7 +1568,7 @@ async def list_definitions(
 @router.post(
     "/preflight",
     response_model=WorkflowPreflightResponse,
-    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+    dependencies=[Depends(RequirePermission(WORKFLOWS_RUNS_READ))],
 )
 async def preflight_definition(
     body: WorkflowPreflightRequest,
@@ -1728,8 +1728,8 @@ class VirtualKeyRequest(BaseModel):
     "/auth/virtual-key",
     summary="Mint a short-lived JWT for workflows (multi-user)",
     dependencies=[
-        Depends(auth_deps.require_roles("admin")),
-        Depends(auth_deps.require_permissions(WORKFLOWS_ADMIN)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(WORKFLOWS_ADMIN)),
     ],
 )
 async def workflows_virtual_key(
@@ -1786,13 +1786,11 @@ async def workflows_virtual_key(
 
 import contextlib
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_token_scope
-
 
 @router.post(
     "/{workflow_id}/run",
     response_model=WorkflowRunResponse,
-    dependencies=[Depends(require_token_scope("workflows", require_if_present=True, endpoint_id="workflows.run_saved", count_as="run"))],
+    dependencies=[Depends(TokenScopeGuard("workflows", require_if_present=True, endpoint_id="workflows.run_saved", count_as="run"))],
 )
 async def run_saved(
     workflow_id: int,
@@ -2026,7 +2024,7 @@ async def run_saved(
     "/runs",
     response_model=WorkflowRunListResponse,
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
     openapi_extra={
         "x-codeSamples": [
@@ -2259,7 +2257,7 @@ async def run_adhoc(
     db: WorkflowsDatabase = Depends(_get_db),
     audit_service=Depends(get_audit_service_for_user),
     _token_scope: None = Depends(
-        auth_deps.require_token_scope(
+        TokenScopeGuard(
             "workflows",
             require_if_present=True,
             endpoint_id="workflows.run_adhoc",
@@ -2395,7 +2393,7 @@ async def run_adhoc(
     "/runs/{run_id}",
     response_model=WorkflowRunResponse,
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
 )
 async def get_run(
@@ -2486,7 +2484,7 @@ async def get_run(
             }
         ]
     },
-    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+    dependencies=[Depends(RequirePermission(WORKFLOWS_RUNS_READ))],
 )
 async def get_run_events(
     run_id: str,
@@ -2581,7 +2579,7 @@ async def get_run_events(
 @router.get(
     "/runs/{run_id}/webhooks/deliveries",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
 )
 async def get_run_webhook_deliveries(
@@ -2619,8 +2617,8 @@ async def get_run_webhook_deliveries(
         # Permission-first gate so failures clearly attribute the missing
         # workflows.runs.control permission in error details, even when the
         # principal also lacks the admin role.
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_CONTROL)),
-        Depends(auth_deps.require_roles("admin")),
+        Depends(RequirePermission(WORKFLOWS_RUNS_CONTROL)),
+        Depends(RequireRole("admin")),
     ],
 )
 async def list_webhook_dlq(
@@ -2658,8 +2656,8 @@ async def list_webhook_dlq(
 @router.post(
     "/webhooks/dlq/{dlq_id}/replay",
     dependencies=[
-        Depends(auth_deps.require_roles("admin")),
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_CONTROL)),
+        Depends(RequireRole("admin")),
+        Depends(RequirePermission(WORKFLOWS_RUNS_CONTROL)),
     ],
 )
 async def replay_webhook_dlq(
@@ -2946,7 +2944,7 @@ def _resolve_artifact_file_path(
 @router.get(
     "/runs/{run_id}/artifacts",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
 )
 async def get_run_artifacts(
@@ -2984,7 +2982,7 @@ async def get_run_artifacts(
 @router.get(
     "/runs/{run_id}/artifacts/manifest",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
 )
 async def get_run_artifacts_manifest(
@@ -3064,7 +3062,7 @@ class VerifyBatchRequest(BaseModel):
 @router.post(
     "/runs/{run_id}/artifacts/verify-batch",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
 )
 async def verify_artifacts_batch(
@@ -3145,7 +3143,7 @@ async def verify_artifacts_batch(
 @router.get(
     "/artifacts/{artifact_id}/download",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
 )
 async def download_artifact(
@@ -3329,7 +3327,7 @@ async def download_artifact(
 @router.get(
     "/runs/{run_id}/artifacts/download",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
 )
 async def download_run_artifacts_zip(
@@ -3459,7 +3457,7 @@ async def get_chunker_options():
 @router.get(
     "/runs/{run_id}/investigation",
     response_model=WorkflowRunInvestigationResponse,
-    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+    dependencies=[Depends(RequirePermission(WORKFLOWS_RUNS_READ))],
 )
 async def get_run_investigation(
     run_id: str,
@@ -3480,7 +3478,7 @@ async def get_run_investigation(
 @router.get(
     "/runs/{run_id}/steps",
     response_model=WorkflowRunStepsResponse,
-    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+    dependencies=[Depends(RequirePermission(WORKFLOWS_RUNS_READ))],
 )
 async def get_run_steps(
     run_id: str,
@@ -3501,7 +3499,7 @@ async def get_run_steps(
 @router.get(
     "/runs/{run_id}/steps/{step_id}/attempts",
     response_model=WorkflowStepAttemptsResponse,
-    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+    dependencies=[Depends(RequirePermission(WORKFLOWS_RUNS_READ))],
 )
 async def get_step_attempts(
     run_id: str,
@@ -3524,7 +3522,7 @@ async def get_step_attempts(
 @router.post(
     "/runs/{run_id}/{action}",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_CONTROL)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_CONTROL)),
     ],
 )
 async def control_run(
@@ -4191,7 +4189,7 @@ async def get_workflow_template_legacy(name: str) -> dict[str, Any]:
 @router.get(
     "/config",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_ADMIN)),
+        Depends(RequirePermission(WORKFLOWS_ADMIN)),
     ],
 )
 async def get_workflows_config(
@@ -4254,7 +4252,7 @@ async def get_workflows_config(
 @router.post(
     "/runs/{run_id}/retry",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_CONTROL)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_CONTROL)),
     ],
 )
 async def retry_run(
@@ -4284,7 +4282,7 @@ async def retry_run(
 @router.get(
     "/{workflow_id}",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
 )
 async def get_definition(
@@ -4330,7 +4328,7 @@ class HumanReviewPayload(BaseModel):
 @router.post(
     "/runs/{run_id}/steps/{step_id}/approve",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_CONTROL)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_CONTROL)),
     ],
 )
 async def approve_step(
@@ -4397,7 +4395,7 @@ async def approve_step(
 @router.post(
     "/runs/{run_id}/steps/{step_id}/reject",
     dependencies=[
-        Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_CONTROL)),
+        Depends(RequirePermission(WORKFLOWS_RUNS_CONTROL)),
     ],
 )
 async def reject_step(

--- a/tldw_Server_API/app/core/AuthNZ/README.md
+++ b/tldw_Server_API/app/core/AuthNZ/README.md
@@ -83,7 +83,7 @@ Note: This README follows the project-wide template to help contributors quickly
 - Error Handling & Security:
   - Custom exceptions in `exceptions.py`; consistent HTTP errors from endpoints.
   - Input validation in `input_validation.py`; CSRF middleware for WebUI flows.
-- Admin routes should be protected via claim-first dependencies (`get_auth_principal` + `require_roles("admin")` / `require_permissions(...)`); legacy `require_admin`/`require_role` shims in API deps are retired.
+- Admin routes should be protected via claim-first dependencies (`get_auth_principal` + `RequireRole("admin")` / `RequirePermission(...)`); legacy `require_admin`/`require_role` shims in API deps are retired.
 
 ## 3. Developer-Related/Relevant Information for Contributors
 
@@ -95,7 +95,7 @@ Note: This README follows the project-wide template to help contributors quickly
   - Keys/budgets: `api_key_manager.py`, `virtual_keys.py`, `quotas.py`.
   - Ops/monitoring: `monitoring.py`, `alerting.py`, `scheduler.py`.
 - Extension Points:
-  - Add endpoints under `app/api/v1/endpoints/` and use dependencies from `API_Deps/auth_deps.py` (`get_auth_principal`, `require_roles`, `require_permissions`, `check_rate_limit`).
+  - Add endpoints under `app/api/v1/endpoints/` and use dependencies from `API_Deps/auth_deps.py` (`get_auth_principal`, `RequireRole`, `RequirePermission`, `TokenScopeGuard`, `check_rate_limit`).
   - Extend roles/permissions using RBAC tables; seed updates go into `migrations.py` seeding section.
   - Add budgets or allowlists by extending `virtual_keys.py`/`api_key_manager.py` and updating schema + tests.
   - Add periodic tasks in `scheduler.py` (e.g., cleanup of expired tokens/lockouts).

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -399,11 +399,7 @@ def _decorate_collections_public_operations(cls: type["CollectionsDatabase"]) ->
     for name, attribute in list(vars(cls).items()):
         if name.startswith("_") or name in {"ensure_schema", "transaction"}:
             continue
-        if isinstance(attribute, type):
-            continue
-        if isinstance(attribute, (classmethod, staticmethod, property)):
-            continue
-        if isinstance(attribute, type):
+        if isinstance(attribute, (classmethod, staticmethod, property, type)):
             continue
         if not callable(attribute):
             continue

--- a/tldw_Server_API/app/core/Evaluations/README.md
+++ b/tldw_Server_API/app/core/Evaluations/README.md
@@ -71,7 +71,7 @@ The Evaluations module provides a unified, API- and CLI-driven system for model 
 
 - Configuration & AuthNZ
   - Rate limits: `evaluations_auth.check_evaluation_rate_limit`; per-user limits + `GET /rate-limits`
-  - RBAC: `rbac_rate_limit`, `require_token_scope` on sensitive endpoints; admin checks for A/B runs and cleanup
+  - RBAC: `rbac_rate_limit`, `TokenScopeGuard` on sensitive endpoints; admin checks for A/B runs and cleanup
   - Canonical identity: route and Jobs code should derive one `EvaluationIdentity` via `get_evaluation_identity()` / `evaluations_identity_from_user()` and then use:
     - `user_scope` for per-user service binding and DB path selection
     - `created_by` for ownership filters and idempotency rows

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/README.md
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/README.md
@@ -72,7 +72,7 @@ The ingestion and media processing hub for video, audio, PDF, EPUB, documents (t
 - Error Handling:
   - Functions collect non‑fatal issues in `warnings`; fatal errors set `status='Error'` with `error` details. Endpoint maps exceptions to HTTP status with consistent messages.
 - Security:
-  - Media ingestion endpoints enforce claim-first `require_permissions(MEDIA_CREATE)` + `rbac_rate_limit('media.create')`; API keys/JWTs required. Never accept client‑supplied provider API keys; providers are resolved server‑side.
+  - Media ingestion endpoints enforce claim-first `RequirePermission(MEDIA_CREATE)` + `rbac_rate_limit('media.create')`; API keys/JWTs required. Never accept client‑supplied provider API keys; providers are resolved server‑side.
 
 
 ## 3. Developer‑Related/Relevant Information for Contributors

--- a/tldw_Server_API/app/core/Jobs/README.md
+++ b/tldw_Server_API/app/core/Jobs/README.md
@@ -51,7 +51,7 @@
   - `JOBS_UPDATE_GAUGES_ON_PRUNE` — refresh gauges after prune when fully scoped.
 
 - Security
-  - Admin endpoints use claim-first authorization (`get_auth_principal` + `require_roles("admin")` / `require_permissions(...)`). For Postgres, RLS is set per-user and per-domain before mutating rows.
+  - Admin endpoints use claim-first authorization (`get_auth_principal` + `RequireRole("admin")` / `RequirePermission(...)`). For Postgres, RLS is set per-user and per-domain before mutating rows.
 
 ## 3. Developer-Related/Relevant Information for Contributors
 

--- a/tldw_Server_API/app/core/MCP_unified/README.md
+++ b/tldw_Server_API/app/core/MCP_unified/README.md
@@ -552,7 +552,7 @@ Scrape MCP metrics at `GET /api/v1/mcp/metrics/prometheus` (text exposition form
    - `mcp_idempotency_hits_total{module,tool}` - protocol-level idempotency cache hits
    - `mcp_idempotency_misses_total{module,tool}` - protocol-level idempotency cache misses
 
-Security: The Prometheus endpoint is gated by `require_permissions(SYSTEM_LOGS)` on `AuthPrincipal` (admin-style principals also pass). Unauthenticated scraping is not supported; use credentials or an auth proxy for Prometheus.
+Security: The Prometheus endpoint is gated by `RequirePermission(SYSTEM_LOGS)` on `AuthPrincipal` (admin-style principals also pass). Unauthenticated scraping is not supported; use credentials or an auth proxy for Prometheus.
 
 ### Health Checks
 - `/api/v1/mcp/health` - Overall health

--- a/tldw_Server_API/app/core/Monitoring/README.md
+++ b/tldw_Server_API/app/core/Monitoring/README.md
@@ -57,7 +57,7 @@
 - Error Handling & Safety
   - Rule compilation is guarded; invalid rules are skipped with warnings.
   - Alert metadata is JSON‑encoded/decoded with fallback on parse failures.
-  - Admin endpoints use claim-first authorization (`get_auth_principal` + `require_roles("admin")` / `require_permissions(...)`) and validate inputs.
+  - Admin endpoints use claim-first authorization (`get_auth_principal` + `RequireRole("admin")` / `RequirePermission(...)`) and validate inputs.
 
 ## 3. Developer-Related/Relevant Information for Contributors
 

--- a/tldw_Server_API/app/core/RateLimiting/README.md
+++ b/tldw_Server_API/app/core/RateLimiting/README.md
@@ -7,7 +7,7 @@
   - RG middleware enforces request caps using route_map (path + tag matching).
   - Ingress rate limiting is enforced exclusively by RG (no legacy ingress decorators).
   - RBAC rate-limit selector (logs strictest user/role limits for a resource; enforcement path stubbed).
-  - Token scope dependency (`require_token_scope`) with usage counting hints (`count_as="call"|"run"`).
+  - Token scope dependency (`TokenScopeGuard`) with usage counting hints (`count_as="call"|"run"`).
 - Inputs/Outputs:
   - Input: HTTP requests (and contextual user/role data).
   - Output: Allow or HTTP 429 with `Retry-After` header (where applicable).
@@ -40,7 +40,7 @@
 ## 3. Developer-Related/Relevant Information for Contributors
 
 - Folder Structure
-  - `app/api/v1/API_Deps/auth_deps.py` — `rbac_rate_limit` and `require_token_scope` dependencies.
+  - `app/api/v1/API_Deps/auth_deps.py` — `rbac_rate_limit` and `TokenScopeGuard` dependencies.
 - Extension Points
 - Use RG policy entries + route_map for new endpoints. For resource-scoped behavior, add `Depends(rbac_rate_limit("<resource>"))`.
   - To enable true RBAC enforcement, extend `enforce_rbac_rate_limit` to check counters and raise 429 based on selected limits.

--- a/tldw_Server_API/app/core/RateLimiting/README.md
+++ b/tldw_Server_API/app/core/RateLimiting/README.md
@@ -25,7 +25,7 @@
 - Architecture & Data Flow
   - RG middleware + route_map: tldw_Server_API/app/core/Resource_Governance/middleware_simple.py
   - RBAC selector: `rbac_rate_limit(resource)` returns a dependency that logs selected limits from `rbac_user_rate_limits` and `rbac_role_rate_limits` but does not enforce yet: tldw_Server_API/app/api/v1/API_Deps/auth_deps.py:994
-  - Token-scope enforcement: `require_token_scope(scope, ..., endpoint_id=..., count_as=...)` injects scoped virtual-key checks and emits usage hints: tldw_Server_API/app/api/v1/API_Deps/auth_deps.py:1040
+  - Token-scope enforcement: `TokenScopeGuard(scope, ..., endpoint_id=..., count_as=...)` injects scoped virtual-key checks and emits usage hints: tldw_Server_API/app/api/v1/API_Deps/auth_deps.py:1040
 
 - Configuration
   - Testing bypass: `RG_ENABLED` defaults off in tests; set `RG_ENABLED=1` to enforce in CI.

--- a/tldw_Server_API/app/core/Resource_Governance/README.md
+++ b/tldw_Server_API/app/core/Resource_Governance/README.md
@@ -8,7 +8,7 @@ Centralized rate limiting and concurrency control with policy-based configuratio
 
 ## New endpoints checklist (RG-aware design)
 
-- When adding new API endpoints, first wire authentication/authorization via `get_auth_principal` together with `require_permissions(...)` / `require_roles(...)` (and `require_service_principal()` for service-only routes). Authorization should be claim-first; do not gate new behavior on `AUTH_MODE` or `is_single_user_mode()` / `is_multi_user_mode()` checks.
+- When adding new API endpoints, first wire authentication/authorization via `get_auth_principal` together with `RequirePermission(...)` / `RequireRole(...)` (and `require_service_principal()` for service-only routes). Authorization should be claim-first; do not gate new behavior on `AUTH_MODE` or `is_single_user_mode()` / `is_multi_user_mode()` checks.
 - For endpoints that are latency/cost-sensitive or user-facing (chat, audio, embeddings, evaluations, MCP, workflows, tools, media ingestion, etc.), decide whether they should be governed by Resource Governor:
   - If yes, add or reuse a policy in the RG policy store (`resource_governor_policies.yaml` or DB-backed `rg_policies`) and ensure there is a corresponding `route_map` entry keyed by path/tag (for example `/api/v1/chat/* → chat.default`).
   - Where feasible, add or extend tests so RG-enforced behavior is covered at the HTTP level (200/429 behavior, `Retry-After` and `X-RateLimit-*` headers, and token/stream caps).

--- a/tldw_Server_API/app/core/TTS/README.md
+++ b/tldw_Server_API/app/core/TTS/README.md
@@ -61,7 +61,7 @@ Provider support snapshot (indicative): OpenAI (cloud), ElevenLabs (cloud, cloni
 - Error Handling:
   - Rich exception taxonomy in `tts_exceptions.py` with retry classification; circuit breaker integration; optional streaming of errors as audio.
 - Security:
-  - Endpoints use `require_token_scope` and per-route rate limits; inputs validated and sanitized; uploads validated for type/size/path.
+  - Endpoints use `TokenScopeGuard` and per-route rate limits; inputs validated and sanitized; uploads validated for type/size/path.
 - Metrics:
   - Registered counters/histograms (e.g., `tts_requests_total`, `tts_request_duration_seconds`, `tts_fallback_attempts`, text length/audio size metrics) via Metrics registry.
 

--- a/tldw_Server_API/app/core/Workflows/README.md
+++ b/tldw_Server_API/app/core/Workflows/README.md
@@ -52,7 +52,7 @@ Related Schemas
   - Endpoints: `/api/v1/scheduler/workflows` provide CRUD + dry-run + run-now.
   - Presence gating, concurrency mode (skip vs queue), jitter, misfire/coalesce, next‑run persistence handled in service.
 - Security & RBAC
-  - Endpoint gates: claim-first dependencies (`require_permissions(...)`) plus token scope (`require_token_scope("workflows", ...)`) on scheduler routes; per‑user scoping for definitions/runs.
+  - Endpoint gates: claim-first dependencies (`RequirePermission(...)`) plus token scope (`TokenScopeGuard("workflows", ...)`) on scheduler routes; per‑user scoping for definitions/runs.
   - Optional minting of short‑lived virtual keys for scheduled runs (env‑gated) in `workflows_scheduler`.
 - Configuration
   - `WORKFLOWS_SCHEDULER_ENABLED`, `WORKFLOWS_SCHEDULER_TZ`, `WORKFLOWS_SCHEDULER_RESCAN_SEC`, `WORKFLOWS_SCHEDULER_DATABASE_URL`, `WORKFLOWS_SCHEDULER_SQLITE_PATH`.

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -553,6 +553,13 @@ def test_sandbox_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(sandbox, "auth_deps")
 
 
+def test_slides_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import slides
+
+    assert slides.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(slides, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -417,6 +417,13 @@ def test_audit_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(audit, "require_permissions")
 
 
+def test_scheduled_tasks_control_plane_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import scheduled_tasks_control_plane
+
+    assert scheduled_tasks_control_plane.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(scheduled_tasks_control_plane, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -494,6 +494,13 @@ def test_media_leaf_routers_use_standard_permission_factory_alias(module_name: s
     assert not hasattr(module, "require_permissions")
 
 
+def test_notes_graph_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import notes_graph
+
+    assert notes_graph.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(notes_graph, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -367,6 +367,13 @@ def test_admin_personalization_router_uses_standard_role_factory_alias() -> None
     assert not hasattr(admin_personalization, "require_roles")
 
 
+def test_admin_byok_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_byok
+
+    assert admin_byok.RequireRole is auth_deps.RequireRole
+    assert not hasattr(admin_byok, "require_roles")
+
+
 def test_admin_package_router_uses_standard_role_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import admin
 

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -18,6 +19,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     TokenScopeGuard,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 
 
 pytestmark = pytest.mark.unit
@@ -124,6 +126,30 @@ def _build_app(principal: AuthPrincipal) -> FastAPI:
     return app
 
 
+def _build_real_principal_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/current-principal")
+    async def current_principal(request: Request, principal: CurrentPrincipal):
+        auth_ctx = getattr(request.state, "auth", None)
+        state_principal = getattr(auth_ctx, "principal", None)
+        cached_user = getattr(request.state, "_auth_user", None)
+        return {
+            "kind": principal.kind,
+            "user_id": principal.user_id,
+            "api_key_id": principal.api_key_id,
+            "roles": principal.roles,
+            "permissions": principal.permissions,
+            "state_principal_id": getattr(state_principal, "principal_id", None),
+            "principal_id": principal.principal_id,
+            "cached_user_id": getattr(cached_user, "id", None),
+            "state_user_id": getattr(request.state, "user_id", None),
+            "state_api_key_id": getattr(request.state, "api_key_id", None),
+        }
+
+    return app
+
+
 def test_current_principal_alias_returns_principal_and_preserves_request_state() -> None:
     app = _build_app(
         _principal(roles=["user"], permissions=["media.read"], subject="user:42"),
@@ -197,3 +223,98 @@ def test_factory_aliases_are_documented_existing_factories() -> None:
     assert RequirePermission is auth_deps.require_permissions
     assert RequireApiKeyScope is auth_deps.require_api_key_scope
     assert TokenScopeGuard is auth_deps.require_token_scope
+
+
+def test_current_principal_alias_preserves_missing_credentials_401() -> None:
+    response = TestClient(_build_real_principal_app()).get("/current-principal")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated (provide Bearer token or X-API-KEY)"
+    assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+
+def test_current_principal_alias_populates_state_for_multi_user_jwt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ import User_DB_Handling as udh
+    from tldw_Server_API.app.core.AuthNZ import auth_principal_resolver as resolver
+
+    async def fake_verify_jwt_and_fetch_user(request: Request, token: str) -> User:
+        assert token == "jwt.header.signature"
+        request.state.user_id = 17
+        request.state.org_ids = [3]
+        request.state.team_ids = [5]
+        return User(
+            id=17,
+            username="jwt-user",
+            roles=["editor"],
+            permissions=["skills.read"],
+        )
+
+    monkeypatch.setattr(
+        resolver,
+        "get_settings",
+        lambda: SimpleNamespace(AUTH_MODE="multi_user", PII_REDACT_LOGS=False),
+    )
+    monkeypatch.setattr(udh, "verify_jwt_and_fetch_user", fake_verify_jwt_and_fetch_user)
+
+    response = TestClient(_build_real_principal_app()).get(
+        "/current-principal",
+        headers={"Authorization": "Bearer jwt.header.signature"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["kind"] == "user"
+    assert payload["user_id"] == 17
+    assert payload["api_key_id"] is None
+    assert set(payload["roles"]) == {"editor", "user"}
+    assert payload["permissions"] == ["skills.read"]
+    assert payload["principal_id"] == payload["state_principal_id"]
+    assert payload["cached_user_id"] == 17
+    assert payload["state_user_id"] == 17
+    assert payload["state_api_key_id"] is None
+
+
+def test_current_principal_alias_populates_state_for_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ import User_DB_Handling as udh
+    from tldw_Server_API.app.core.AuthNZ import auth_principal_resolver as resolver
+
+    async def fake_authenticate_api_key_user(request: Request, api_key: str) -> User:
+        assert api_key == "test-api-key"
+        request.state.user_id = 33
+        request.state.api_key_id = 123
+        request.state.org_ids = [7]
+        request.state.team_ids = [11]
+        return User(
+            id=33,
+            username="api-key-user",
+            roles=["automation"],
+            permissions=["skills.read", "skills.write"],
+        )
+
+    monkeypatch.setattr(
+        resolver,
+        "get_settings",
+        lambda: SimpleNamespace(AUTH_MODE="multi_user", PII_REDACT_LOGS=False),
+    )
+    monkeypatch.setattr(udh, "authenticate_api_key_user", fake_authenticate_api_key_user)
+
+    response = TestClient(_build_real_principal_app()).get(
+        "/current-principal",
+        headers={"X-API-KEY": "test-api-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["kind"] == "api_key"
+    assert payload["user_id"] == 33
+    assert payload["api_key_id"] == 123
+    assert set(payload["roles"]) == {"automation", "user"}
+    assert payload["permissions"] == ["skills.read", "skills.write"]
+    assert payload["principal_id"] == payload["state_principal_id"]
+    assert payload["cached_user_id"] == 33
+    assert payload["state_user_id"] == 33
+    assert payload["state_api_key_id"] == 123

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -311,6 +311,13 @@ def test_discord_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(discord, "require_roles")
 
 
+def test_integrations_control_plane_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import integrations_control_plane
+
+    assert integrations_control_plane.RequireRole is auth_deps.RequireRole
+    assert not hasattr(integrations_control_plane, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -70,6 +70,8 @@ async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
     request.state.api_key_id = principal.api_key_id
     request.state.org_ids = list(principal.org_ids)
     request.state.team_ids = list(principal.team_ids)
+    if hasattr(request.app.state, "api_key_scope"):
+        request.state._api_key_scope = request.app.state.api_key_scope
     return principal
 
 
@@ -122,6 +124,12 @@ def _build_app(principal: AuthPrincipal) -> FastAPI:
         principal: AuthPrincipal = Depends(RequirePermission("media.read", "skills.read")),
     ):
         return {"permissions": principal.permissions}
+
+    @app.get("/api-key-scope")
+    async def api_key_scope(
+        principal: AuthPrincipal = Depends(RequireApiKeyScope("write")),
+    ):
+        return {"kind": principal.kind, "api_key_id": principal.api_key_id}
 
     return app
 
@@ -225,6 +233,27 @@ def test_factory_aliases_are_documented_existing_factories() -> None:
     assert RequirePermission is auth_deps.require_permissions
     assert RequireApiKeyScope is auth_deps.require_api_key_scope
     assert TokenScopeGuard is auth_deps.require_token_scope
+
+
+def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
+    jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
+        "/api-key-scope",
+    )
+
+    api_key_app = _build_app(_principal(kind="api_key", api_key_id=123))
+    api_key_app.state.api_key_scope = "write"
+    api_key_response = TestClient(api_key_app).get("/api-key-scope")
+
+    limited_key_app = _build_app(_principal(kind="api_key", api_key_id=456))
+    limited_key_app.state.api_key_scope = "read"
+    limited_key_response = TestClient(limited_key_app).get("/api-key-scope")
+
+    assert jwt_response.status_code == 200
+    assert jwt_response.json() == {"kind": "user", "api_key_id": None}
+    assert api_key_response.status_code == 200
+    assert api_key_response.json() == {"kind": "api_key", "api_key_id": 123}
+    assert limited_key_response.status_code == 403
+    assert "API key lacks required scope" in limited_key_response.json()["detail"]
 
 
 def test_current_principal_alias_preserves_missing_credentials_401() -> None:

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -382,6 +382,13 @@ def test_setup_router_uses_standard_auth_factory_aliases() -> None:
     assert not hasattr(setup, "require_permissions")
 
 
+def test_admin_circuit_breakers_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_circuit_breakers
+
+    assert admin_circuit_breakers.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(admin_circuit_breakers, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -337,6 +337,26 @@ def test_audio_jobs_router_uses_standard_admin_dependency_aliases() -> None:
     assert not hasattr(audio_jobs, "require_permissions")
 
 
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "audio_history",
+        "audio_streaming",
+        "audio_tokenizer",
+        "audio_transcriptions",
+        "audio_tts",
+        "audio_voices",
+    ],
+)
+def test_audio_leaf_routers_use_standard_token_scope_alias(module_name: str) -> None:
+    module = importlib.import_module(
+        f"tldw_Server_API.app.api.v1.endpoints.audio.{module_name}",
+    )
+
+    assert module.TokenScopeGuard is auth_deps.TokenScopeGuard
+    assert not hasattr(module, "require_token_scope")
+
+
 def test_connectors_router_uses_standard_admin_dependency_aliases() -> None:
     from tldw_Server_API.app.api.v1.endpoints import connectors
 

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -539,6 +539,13 @@ def test_data_tables_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(data_tables, "require_permissions")
 
 
+def test_chat_workflows_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import chat_workflows
+
+    assert chat_workflows.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(chat_workflows, "auth_deps")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -336,6 +336,15 @@ def test_audio_jobs_router_uses_standard_admin_dependency_aliases() -> None:
     assert not hasattr(audio_jobs, "require_permissions")
 
 
+def test_connectors_router_uses_standard_admin_dependency_aliases() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import connectors
+
+    assert connectors.RequireRole is auth_deps.RequireRole
+    assert connectors.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(connectors, "require_roles")
+    assert not hasattr(connectors, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -563,7 +563,9 @@ def test_chat_router_uses_standard_permission_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import chat
 
     assert chat.RequirePermission is auth_deps.RequirePermission
+    assert chat.TokenScopeGuard is auth_deps.TokenScopeGuard
     assert not hasattr(chat, "require_permissions")
+    assert not hasattr(chat, "require_token_scope")
 
 
 def test_agent_orchestration_router_uses_standard_token_scope_alias() -> None:

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -352,6 +352,13 @@ def test_evaluations_unified_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(evaluations_unified, "require_roles")
 
 
+def test_admin_tools_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_tools
+
+    assert admin_tools.RequireRole is auth_deps.RequireRole
+    assert not hasattr(admin_tools, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -304,6 +304,13 @@ def test_slack_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(slack, "require_roles")
 
 
+def test_discord_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import discord
+
+    assert discord.RequireRole is auth_deps.RequireRole
+    assert not hasattr(discord, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -367,6 +367,13 @@ def test_admin_personalization_router_uses_standard_role_factory_alias() -> None
     assert not hasattr(admin_personalization, "require_roles")
 
 
+def test_admin_package_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import admin
+
+    assert admin.RequireRole is auth_deps.RequireRole
+    assert not hasattr(admin, "require_roles")
+
+
 def test_resource_governor_router_uses_standard_role_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import resource_governor
 

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -560,6 +560,15 @@ def test_slides_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(slides, "require_permissions")
 
 
+def test_workflows_router_uses_standard_auth_factory_aliases() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import workflows
+
+    assert workflows.RequireRole is auth_deps.RequireRole
+    assert workflows.RequirePermission is auth_deps.RequirePermission
+    assert workflows.TokenScopeGuard is auth_deps.TokenScopeGuard
+    assert not hasattr(workflows, "auth_deps")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -573,6 +573,13 @@ def test_agent_orchestration_router_uses_standard_token_scope_alias() -> None:
     assert not hasattr(agent_orchestration, "require_token_scope")
 
 
+def test_agent_client_protocol_router_uses_standard_token_scope_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import agent_client_protocol
+
+    assert agent_client_protocol.TokenScopeGuard is auth_deps.TokenScopeGuard
+    assert not hasattr(agent_client_protocol, "require_token_scope")
+
+
 def test_vector_stores_router_uses_standard_auth_factory_aliases() -> None:
     from tldw_Server_API.app.api.v1.endpoints import vector_stores_openai
 

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -459,6 +459,13 @@ def test_scheduler_workflows_router_uses_standard_permission_factory_alias() -> 
     assert not hasattr(scheduler_workflows, "require_permissions")
 
 
+def test_tools_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import tools
+
+    assert tools.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(tools, "auth_deps")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -290,6 +290,13 @@ def test_metrics_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(metrics, "require_roles")
 
 
+def test_telegram_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import telegram
+
+    assert telegram.RequireRole is auth_deps.RequireRole
+    assert not hasattr(telegram, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -408,7 +408,9 @@ def test_text2sql_router_uses_standard_permission_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import text2sql
 
     assert text2sql.RequirePermission is auth_deps.RequirePermission
+    assert text2sql.TokenScopeGuard is auth_deps.TokenScopeGuard
     assert not hasattr(text2sql, "require_permissions")
+    assert not hasattr(text2sql, "require_token_scope")
 
 
 def test_rag_health_router_uses_standard_permission_factory_alias() -> None:
@@ -471,7 +473,9 @@ def test_scheduler_workflows_router_uses_standard_permission_factory_alias() -> 
     from tldw_Server_API.app.api.v1.endpoints import scheduler_workflows
 
     assert scheduler_workflows.RequirePermission is auth_deps.RequirePermission
+    assert scheduler_workflows.TokenScopeGuard is auth_deps.TokenScopeGuard
     assert not hasattr(scheduler_workflows, "require_permissions")
+    assert not hasattr(scheduler_workflows, "require_token_scope")
 
 
 def test_tools_router_uses_standard_permission_factory_alias() -> None:
@@ -506,7 +510,9 @@ def test_notes_graph_router_uses_standard_permission_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import notes_graph
 
     assert notes_graph.RequirePermission is auth_deps.RequirePermission
+    assert notes_graph.TokenScopeGuard is auth_deps.TokenScopeGuard
     assert not hasattr(notes_graph, "require_permissions")
+    assert not hasattr(notes_graph, "require_token_scope")
 
 
 def test_chat_router_uses_standard_permission_factory_alias() -> None:
@@ -538,7 +544,9 @@ def test_rag_unified_router_uses_standard_permission_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import rag_unified
 
     assert rag_unified.RequirePermission is auth_deps.RequirePermission
+    assert rag_unified.TokenScopeGuard is auth_deps.TokenScopeGuard
     assert not hasattr(rag_unified, "require_permissions")
+    assert not hasattr(rag_unified, "require_token_scope")
 
 
 def test_data_tables_router_uses_standard_permission_factory_alias() -> None:

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -138,6 +138,8 @@ def _build_real_principal_app() -> FastAPI:
             "kind": principal.kind,
             "user_id": principal.user_id,
             "api_key_id": principal.api_key_id,
+            "subject": principal.subject,
+            "token_type": principal.token_type,
             "roles": principal.roles,
             "permissions": principal.permissions,
             "state_principal_id": getattr(state_principal, "principal_id", None),
@@ -231,6 +233,39 @@ def test_current_principal_alias_preserves_missing_credentials_401() -> None:
     assert response.status_code == 401
     assert response.json()["detail"] == "Not authenticated (provide Bearer token or X-API-KEY)"
     assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+
+def test_current_principal_alias_populates_state_for_single_user_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.settings import get_settings, reset_settings
+
+    with monkeypatch.context() as env:
+        env.setenv("AUTH_MODE", "single_user")
+        env.setenv("SINGLE_USER_API_KEY", "phase34-single-user-key")
+        reset_settings()
+        settings = get_settings()
+
+        response = TestClient(_build_real_principal_app()).get(
+            "/current-principal",
+            headers={"X-API-KEY": "phase34-single-user-key"},
+        )
+
+    reset_settings()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["kind"] == "user"
+    assert payload["user_id"] == settings.SINGLE_USER_FIXED_ID
+    assert payload["api_key_id"] is None
+    assert payload["subject"] == "single_user"
+    assert payload["token_type"] == "api_key"
+    assert "admin" in payload["roles"]
+    assert payload["permissions"]
+    assert payload["principal_id"] == payload["state_principal_id"]
+    assert payload["cached_user_id"] == settings.SINGLE_USER_FIXED_ID
+    assert payload["state_user_id"] == settings.SINGLE_USER_FIXED_ID
+    assert payload["state_api_key_id"] is None
 
 
 def test_current_principal_alias_populates_state_for_multi_user_jwt(

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -353,6 +353,23 @@ def test_evaluations_unified_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(evaluations_unified, "require_roles")
 
 
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "evaluations_crud",
+        "evaluations_embeddings_abtest",
+        "evaluations_rag_pipeline",
+    ],
+)
+def test_evaluations_leaf_routers_use_standard_token_scope_alias(module_name: str) -> None:
+    module = importlib.import_module(
+        f"tldw_Server_API.app.api.v1.endpoints.evaluations.{module_name}",
+    )
+
+    assert module.TokenScopeGuard is auth_deps.TokenScopeGuard
+    assert not hasattr(module, "require_token_scope")
+
+
 def test_admin_tools_router_uses_standard_role_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints.admin import admin_tools
 
@@ -504,6 +521,13 @@ def test_media_leaf_routers_use_standard_permission_factory_alias(module_name: s
 
     assert module.RequirePermission is auth_deps.RequirePermission
     assert not hasattr(module, "require_permissions")
+
+
+def test_media_ingest_web_content_router_uses_standard_token_scope_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.media import ingest_web_content
+
+    assert ingest_web_content.TokenScopeGuard is auth_deps.TokenScopeGuard
+    assert not hasattr(ingest_web_content, "require_token_scope")
 
 
 def test_notes_graph_router_uses_standard_permission_factory_alias() -> None:

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -410,6 +410,13 @@ def test_monitoring_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(monitoring, "require_permissions")
 
 
+def test_audit_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import audit
+
+    assert audit.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(audit, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Any
 
@@ -24,6 +25,16 @@ from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
 
 
 pytestmark = pytest.mark.unit
+
+
+def _public_names(module: object) -> set[str]:
+    return {name for name in dir(module) if not name.startswith("_")}
+
+
+def _cached_user_id(cached_user: object) -> Any:
+    if isinstance(cached_user, Mapping):
+        return cached_user.get("id")
+    return getattr(cached_user, "id", None)
 
 
 def _principal(
@@ -153,7 +164,7 @@ def _build_real_principal_app() -> FastAPI:
             "permissions": principal.permissions,
             "state_principal_id": getattr(state_principal, "principal_id", None),
             "principal_id": principal.principal_id,
-            "cached_user_id": getattr(cached_user, "id", None),
+            "cached_user_id": _cached_user_id(cached_user),
             "state_user_id": getattr(request.state, "user_id", None),
             "state_api_key_id": getattr(request.state, "api_key_id", None),
         }
@@ -519,7 +530,9 @@ def test_tools_router_uses_standard_permission_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import tools
 
     assert tools.RequirePermission is auth_deps.RequirePermission
-    assert not hasattr(tools, "auth_deps")
+    assert callable(tools.RequirePermission("tools.execute:*"))
+    assert "auth_deps" not in _public_names(tools)
+    assert not hasattr(tools, "require_permissions")
 
 
 @pytest.mark.parametrize(
@@ -620,14 +633,18 @@ def test_chat_workflows_router_uses_standard_permission_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import chat_workflows
 
     assert chat_workflows.RequirePermission is auth_deps.RequirePermission
-    assert not hasattr(chat_workflows, "auth_deps")
+    assert callable(chat_workflows.RequirePermission("chat.workflows.read"))
+    assert "auth_deps" not in _public_names(chat_workflows)
+    assert not hasattr(chat_workflows, "require_permissions")
 
 
 def test_sandbox_router_uses_standard_role_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import sandbox
 
     assert sandbox.RequireRole is auth_deps.RequireRole
-    assert not hasattr(sandbox, "auth_deps")
+    assert callable(sandbox.RequireRole("admin"))
+    assert "auth_deps" not in _public_names(sandbox)
+    assert not hasattr(sandbox, "require_roles")
 
 
 def test_slides_router_uses_standard_permission_factory_alias() -> None:
@@ -643,7 +660,13 @@ def test_workflows_router_uses_standard_auth_factory_aliases() -> None:
     assert workflows.RequireRole is auth_deps.RequireRole
     assert workflows.RequirePermission is auth_deps.RequirePermission
     assert workflows.TokenScopeGuard is auth_deps.TokenScopeGuard
-    assert not hasattr(workflows, "auth_deps")
+    assert callable(workflows.RequireRole("admin"))
+    assert callable(workflows.RequirePermission("workflows.runs.read"))
+    assert callable(workflows.TokenScopeGuard("workflows.runs.read"))
+    assert "auth_deps" not in _public_names(workflows)
+    assert not hasattr(workflows, "require_roles")
+    assert not hasattr(workflows, "require_permissions")
+    assert not hasattr(workflows, "require_token_scope")
 
 
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -396,6 +396,13 @@ def test_text2sql_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(text2sql, "require_permissions")
 
 
+def test_rag_health_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import rag_health
+
+    assert rag_health.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(rag_health, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -452,6 +452,13 @@ def test_billing_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(billing, "require_roles")
 
 
+def test_scheduler_workflows_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import scheduler_workflows
+
+    assert scheduler_workflows.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(scheduler_workflows, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -525,6 +525,15 @@ def test_vector_stores_router_uses_standard_auth_factory_aliases() -> None:
     assert not hasattr(vector_stores_openai, "require_permissions")
 
 
+def test_embeddings_v5_router_uses_standard_auth_factory_aliases() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced
+
+    assert embeddings_v5_production_enhanced.RequireRole is auth_deps.RequireRole
+    assert embeddings_v5_production_enhanced.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(embeddings_v5_production_enhanced, "require_roles")
+    assert not hasattr(embeddings_v5_production_enhanced, "require_permissions")
+
+
 def test_rag_unified_router_uses_standard_permission_factory_alias() -> None:
     from tldw_Server_API.app.api.v1.endpoints import rag_unified
 

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -327,6 +327,15 @@ def test_claims_router_uses_standard_admin_principal_alias() -> None:
     assert not hasattr(claims, "require_permissions")
 
 
+def test_audio_jobs_router_uses_standard_admin_dependency_aliases() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.audio import audio_jobs
+
+    assert audio_jobs.RequireRole is auth_deps.RequireRole
+    assert audio_jobs.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(audio_jobs, "require_roles")
+    assert not hasattr(audio_jobs, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -373,6 +373,15 @@ def test_resource_governor_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(resource_governor, "require_roles")
 
 
+def test_setup_router_uses_standard_auth_factory_aliases() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import setup
+
+    assert setup.RequireRole is auth_deps.RequireRole
+    assert setup.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(setup, "require_roles")
+    assert not hasattr(setup, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -283,6 +283,13 @@ def test_config_admin_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(config_admin, "require_roles")
 
 
+def test_metrics_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import metrics
+
+    assert metrics.RequireRole is auth_deps.RequireRole
+    assert not hasattr(metrics, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -546,6 +546,13 @@ def test_chat_workflows_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(chat_workflows, "auth_deps")
 
 
+def test_sandbox_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox
+
+    assert sandbox.RequireRole is auth_deps.RequireRole
+    assert not hasattr(sandbox, "auth_deps")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -424,6 +424,13 @@ def test_scheduled_tasks_control_plane_router_uses_standard_permission_factory_a
     assert not hasattr(scheduled_tasks_control_plane, "require_permissions")
 
 
+def test_reminders_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import reminders
+
+    assert reminders.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(reminders, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -431,6 +431,13 @@ def test_reminders_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(reminders, "require_permissions")
 
 
+def test_notifications_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import notifications
+
+    assert notifications.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(notifications, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -345,6 +345,13 @@ def test_connectors_router_uses_standard_admin_dependency_aliases() -> None:
     assert not hasattr(connectors, "require_permissions")
 
 
+def test_evaluations_unified_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.evaluations import evaluations_unified
+
+    assert evaluations_unified.RequireRole is auth_deps.RequireRole
+    assert not hasattr(evaluations_unified, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -438,6 +438,13 @@ def test_notifications_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(notifications, "require_permissions")
 
 
+def test_mcp_unified_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import mcp_unified_endpoint
+
+    assert mcp_unified_endpoint.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(mcp_unified_endpoint, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -483,6 +483,7 @@ def test_tools_router_uses_standard_permission_factory_alias() -> None:
         "process_videos",
         "reprocess",
         "ingest_jobs",
+        "item",
     ],
 )
 def test_media_leaf_routers_use_standard_permission_factory_alias(module_name: str) -> None:

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from types import SimpleNamespace
 from typing import Any
 
@@ -464,6 +465,26 @@ def test_tools_router_uses_standard_permission_factory_alias() -> None:
 
     assert tools.RequirePermission is auth_deps.RequirePermission
     assert not hasattr(tools, "auth_deps")
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "add",
+        "listing",
+        "process_web_scraping",
+        "process_videos",
+        "reprocess",
+        "ingest_jobs",
+    ],
+)
+def test_media_leaf_routers_use_standard_permission_factory_alias(module_name: str) -> None:
+    module = importlib.import_module(
+        f"tldw_Server_API.app.api.v1.endpoints.media.{module_name}",
+    )
+
+    assert module.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(module, "require_permissions")
 
 
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -502,6 +502,13 @@ def test_notes_graph_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(notes_graph, "require_permissions")
 
 
+def test_chat_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import chat
+
+    assert chat.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(chat, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -445,6 +445,13 @@ def test_mcp_unified_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(mcp_unified_endpoint, "require_permissions")
 
 
+def test_billing_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import billing
+
+    assert billing.RequireRole is auth_deps.RequireRole
+    assert not hasattr(billing, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -276,6 +276,13 @@ def test_factory_aliases_are_documented_existing_factories() -> None:
     assert TokenScopeGuard is auth_deps.require_token_scope
 
 
+def test_config_admin_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import config_admin
+
+    assert config_admin.RequireRole is auth_deps.RequireRole
+    assert not hasattr(config_admin, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -318,6 +318,15 @@ def test_integrations_control_plane_router_uses_standard_role_factory_alias() ->
     assert not hasattr(integrations_control_plane, "require_roles")
 
 
+def test_claims_router_uses_standard_admin_principal_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import claims
+
+    assert claims.AdminPrincipal is auth_deps.AdminPrincipal
+    assert claims.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(claims, "require_roles")
+    assert not hasattr(claims, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -509,6 +509,15 @@ def test_chat_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(chat, "require_permissions")
 
 
+def test_vector_stores_router_uses_standard_auth_factory_aliases() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import vector_stores_openai
+
+    assert vector_stores_openai.RequireRole is auth_deps.RequireRole
+    assert vector_stores_openai.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(vector_stores_openai, "require_roles")
+    assert not hasattr(vector_stores_openai, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -403,6 +403,13 @@ def test_rag_health_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(rag_health, "require_permissions")
 
 
+def test_monitoring_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import monitoring
+
+    assert monitoring.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(monitoring, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -525,6 +525,13 @@ def test_vector_stores_router_uses_standard_auth_factory_aliases() -> None:
     assert not hasattr(vector_stores_openai, "require_permissions")
 
 
+def test_rag_unified_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import rag_unified
+
+    assert rag_unified.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(rag_unified, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -160,6 +160,47 @@ def _build_real_principal_app() -> FastAPI:
     return app
 
 
+class _FakeJwtService:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def decode_access_token(self, token: str) -> dict[str, Any]:
+        assert token == "jwt.header.signature"
+        return dict(self.payload)
+
+
+class _FakeSessionManager:
+    async def is_token_blacklisted(self, token: str, jti: str | None = None) -> bool:
+        assert token == "jwt.header.signature"
+        return False
+
+
+def _build_token_scope_app(payload: dict[str, Any]) -> FastAPI:
+    app = FastAPI()
+
+    async def fake_jwt_service() -> _FakeJwtService:
+        return _FakeJwtService(payload)
+
+    async def fake_db_pool() -> object:
+        return object()
+
+    app.dependency_overrides[auth_deps.get_jwt_service_dep] = fake_jwt_service
+    app.dependency_overrides[auth_deps.get_db_pool] = fake_db_pool
+
+    @app.get("/token-scope")
+    async def token_scope(
+        request: Request,
+        _: None = Depends(TokenScopeGuard("skills.run", allow_admin_bypass=False)),
+    ):
+        return {
+            "scope_enforced": getattr(request.state, "_token_scope_enforced", None),
+            "scope_claim": getattr(request.state, "_token_scope_claim", None),
+            "scope_required": getattr(request.state, "_token_scope_required", None),
+        }
+
+    return app
+
+
 def test_current_principal_alias_returns_principal_and_preserves_request_state() -> None:
     app = _build_app(
         _principal(roles=["user"], permissions=["media.read"], subject="user:42"),
@@ -254,6 +295,45 @@ def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> 
     assert api_key_response.json() == {"kind": "api_key", "api_key_id": 123}
     assert limited_key_response.status_code == 403
     assert "API key lacks required scope" in limited_key_response.json()["detail"]
+
+
+def test_token_scope_guard_alias_preserves_scoped_jwt_success_and_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ import session_manager
+
+    async def fake_session_manager() -> _FakeSessionManager:
+        return _FakeSessionManager()
+
+    monkeypatch.setattr(session_manager, "get_session_manager", fake_session_manager)
+
+    scoped_response = TestClient(
+        _build_token_scope_app({"scope": "skills.run", "jti": "token-1"}),
+    ).get(
+        "/token-scope",
+        headers={"Authorization": "Bearer jwt.header.signature"},
+    )
+    invalid_scope_response = TestClient(
+        _build_token_scope_app({"scope": "wrong.scope", "jti": "token-2"}),
+    ).get(
+        "/token-scope",
+        headers={"Authorization": "Bearer jwt.header.signature"},
+    )
+    missing_credentials_response = TestClient(
+        _build_token_scope_app({"scope": "skills.run", "jti": "token-3"}),
+    ).get("/token-scope")
+
+    assert scoped_response.status_code == 200
+    assert scoped_response.json() == {
+        "scope_enforced": True,
+        "scope_claim": "skills.run",
+        "scope_required": "skills.run",
+    }
+    assert invalid_scope_response.status_code == 403
+    assert invalid_scope_response.json()["detail"] == "Forbidden: invalid token scope"
+    assert missing_credentials_response.status_code == 401
+    assert missing_credentials_response.json()["detail"] == "Authentication required"
+    assert missing_credentials_response.headers.get("WWW-Authenticate") == "Bearer"
 
 
 def test_current_principal_alias_preserves_missing_credentials_401() -> None:

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -359,6 +359,13 @@ def test_admin_tools_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(admin_tools, "require_roles")
 
 
+def test_admin_personalization_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_personalization
+
+    assert admin_personalization.RequireRole is auth_deps.RequireRole
+    assert not hasattr(admin_personalization, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -532,6 +532,13 @@ def test_rag_unified_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(rag_unified, "require_permissions")
 
 
+def test_data_tables_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import data_tables
+
+    assert data_tables.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(data_tables, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -389,6 +389,13 @@ def test_admin_circuit_breakers_router_uses_standard_permission_factory_alias() 
     assert not hasattr(admin_circuit_breakers, "require_permissions")
 
 
+def test_text2sql_router_uses_standard_permission_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import text2sql
+
+    assert text2sql.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(text2sql, "require_permissions")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -566,6 +566,13 @@ def test_chat_router_uses_standard_permission_factory_alias() -> None:
     assert not hasattr(chat, "require_permissions")
 
 
+def test_agent_orchestration_router_uses_standard_token_scope_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import agent_orchestration
+
+    assert agent_orchestration.TokenScopeGuard is auth_deps.TokenScopeGuard
+    assert not hasattr(agent_orchestration, "require_token_scope")
+
+
 def test_vector_stores_router_uses_standard_auth_factory_aliases() -> None:
     from tldw_Server_API.app.api.v1.endpoints import vector_stores_openai
 

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -366,6 +366,13 @@ def test_admin_personalization_router_uses_standard_role_factory_alias() -> None
     assert not hasattr(admin_personalization, "require_roles")
 
 
+def test_resource_governor_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import resource_governor
+
+    assert resource_governor.RequireRole is auth_deps.RequireRole
+    assert not hasattr(resource_governor, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    AdminPrincipal,
+    CurrentPrincipal,
+    CurrentUserDict,
+    RequireApiKeyScope,
+    RequirePermission,
+    RequireRole,
+    ServicePrincipal,
+    TokenScopeGuard,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+
+
+pytestmark = pytest.mark.unit
+
+
+def _principal(
+    *,
+    kind: str = "user",
+    user_id: int | None = 42,
+    api_key_id: int | None = None,
+    roles: list[str] | None = None,
+    permissions: list[str] | None = None,
+    subject: str | None = None,
+    token_type: str | None = "access",
+    is_admin: bool = False,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind=kind,
+        user_id=user_id,
+        api_key_id=api_key_id,
+        username="phase34-user" if kind == "user" else None,
+        subject=subject,
+        token_type=token_type,
+        roles=list(roles or []),
+        permissions=list(permissions or []),
+        is_admin=is_admin,
+        org_ids=[7] if kind == "user" else [],
+        team_ids=[11] if kind == "user" else [],
+    )
+
+
+async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
+    principal = request.app.state.principal
+    request.state.auth = AuthContext(
+        principal=principal,
+        ip="127.0.0.1",
+        user_agent="phase34-test",
+        request_id="phase34-request",
+    )
+    request.state._auth_user = {
+        "id": principal.user_id,
+        "roles": list(principal.roles),
+        "permissions": list(principal.permissions),
+        "is_active": True,
+        "is_verified": True,
+    }
+    request.state.user_id = principal.user_id
+    request.state.api_key_id = principal.api_key_id
+    request.state.org_ids = list(principal.org_ids)
+    request.state.team_ids = list(principal.team_ids)
+    return principal
+
+
+async def _fake_current_active_user() -> dict[str, Any]:
+    return {
+        "id": 99,
+        "roles": ["legacy"],
+        "permissions": ["legacy.read"],
+        "is_active": True,
+        "is_verified": True,
+    }
+
+
+def _build_app(principal: AuthPrincipal) -> FastAPI:
+    app = FastAPI()
+    app.state.principal = principal
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[auth_deps.get_current_active_user] = _fake_current_active_user
+
+    @app.get("/current-principal")
+    async def current_principal(request: Request, principal: CurrentPrincipal):
+        ctx = request.state.auth
+        return {
+            "principal_id": principal.principal_id,
+            "state_principal_id": ctx.principal.principal_id,
+            "user_id": principal.user_id,
+            "state_user_id": request.state.user_id,
+            "org_ids": request.state.org_ids,
+            "team_ids": request.state.team_ids,
+        }
+
+    @app.get("/current-user-dict")
+    async def current_user_dict(user: CurrentUserDict):
+        return user
+
+    @app.get("/admin")
+    async def admin(principal: AdminPrincipal):
+        return {"principal_id": principal.principal_id}
+
+    @app.get("/service")
+    async def service(principal: ServicePrincipal):
+        return {"principal_id": principal.principal_id, "kind": principal.kind}
+
+    @app.get("/role")
+    async def role(principal: AuthPrincipal = Depends(RequireRole("editor", "admin"))):
+        return {"roles": principal.roles}
+
+    @app.get("/permission")
+    async def permission(
+        principal: AuthPrincipal = Depends(RequirePermission("media.read", "skills.read")),
+    ):
+        return {"permissions": principal.permissions}
+
+    return app
+
+
+def test_current_principal_alias_returns_principal_and_preserves_request_state() -> None:
+    app = _build_app(
+        _principal(roles=["user"], permissions=["media.read"], subject="user:42"),
+    )
+
+    response = TestClient(app).get("/current-principal")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "principal_id": _principal(subject="user:42").principal_id,
+        "state_principal_id": _principal(subject="user:42").principal_id,
+        "user_id": 42,
+        "state_user_id": 42,
+        "org_ids": [7],
+        "team_ids": [11],
+    }
+
+
+def test_current_user_dict_alias_honors_legacy_active_user_override() -> None:
+    response = TestClient(_build_app(_principal())).get("/current-user-dict")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": 99,
+        "roles": ["legacy"],
+        "permissions": ["legacy.read"],
+        "is_active": True,
+        "is_verified": True,
+    }
+
+
+def test_admin_principal_alias_preserves_admin_role_gate() -> None:
+    admin_response = TestClient(
+        _build_app(_principal(roles=["admin"], is_admin=True)),
+    ).get("/admin")
+    user_response = TestClient(
+        _build_app(_principal(roles=["user"], permissions=[])),
+    ).get("/admin")
+
+    assert admin_response.status_code == 200
+    assert user_response.status_code == 403
+
+
+def test_service_principal_alias_preserves_service_gate() -> None:
+    service_response = TestClient(
+        _build_app(_principal(kind="service", user_id=None, subject="service:worker")),
+    ).get("/service")
+    user_response = TestClient(_build_app(_principal(kind="user"))).get("/service")
+
+    assert service_response.status_code == 200
+    assert service_response.json()["kind"] == "service"
+    assert user_response.status_code == 403
+
+
+def test_role_and_permission_factory_aliases_preserve_existing_semantics() -> None:
+    role_response = TestClient(_build_app(_principal(roles=["editor"]))).get("/role")
+    permission_response = TestClient(
+        _build_app(_principal(permissions=["media.read", "skills.read"])),
+    ).get("/permission")
+    missing_permission_response = TestClient(
+        _build_app(_principal(permissions=["media.read"])),
+    ).get("/permission")
+
+    assert role_response.status_code == 200
+    assert permission_response.status_code == 200
+    assert missing_permission_response.status_code == 403
+
+
+def test_factory_aliases_are_documented_existing_factories() -> None:
+    assert RequireRole is auth_deps.require_roles
+    assert RequirePermission is auth_deps.require_permissions
+    assert RequireApiKeyScope is auth_deps.require_api_key_scope
+    assert TokenScopeGuard is auth_deps.require_token_scope

--- a/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
+++ b/tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py
@@ -297,6 +297,13 @@ def test_telegram_router_uses_standard_role_factory_alias() -> None:
     assert not hasattr(telegram, "require_roles")
 
 
+def test_slack_router_uses_standard_role_factory_alias() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import slack
+
+    assert slack.RequireRole is auth_deps.RequireRole
+    assert not hasattr(slack, "require_roles")
+
+
 def test_api_key_scope_factory_alias_preserves_jwt_bypass_and_scope_checks() -> None:
     jwt_response = TestClient(_build_app(_principal(kind="user", api_key_id=None))).get(
         "/api-key-scope",

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_moderation_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_moderation_permissions_claims.py
@@ -81,6 +81,13 @@ def _build_app(
     return app
 
 
+def test_moderation_router_uses_standard_auth_factory_aliases() -> None:
+    assert moderation_mod.RequireRole is auth_deps.RequireRole
+    assert moderation_mod.RequirePermission is auth_deps.RequirePermission
+    assert not hasattr(moderation_mod, "require_roles")
+    assert not hasattr(moderation_mod, "require_permissions")
+
+
 @pytest.mark.asyncio
 async def test_moderation_users_401_when_principal_unavailable():
     app = _build_app(principal=None, fail_with_401=True)

--- a/tldw_Server_API/tests/Jobs/test_jobs_admin_test_mode_truthiness.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_admin_test_mode_truthiness.py
@@ -75,6 +75,11 @@ def _build_app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     return app
 
 
+def test_jobs_admin_router_uses_standard_role_factory_alias() -> None:
+    assert jobs_mod.RequireRole is auth_deps.RequireRole
+    assert not hasattr(jobs_mod, "require_roles")
+
+
 def test_prune_skips_confirm_when_tldw_test_mode_is_y(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEST_MODE", "0")
     monkeypatch.setenv("TLDW_TEST_MODE", "y")

--- a/tldw_Server_API/tests/LLM_Local/test_llamacpp_management_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_llamacpp_management_api.py
@@ -180,6 +180,12 @@ def _make_app_with_manager(manager) -> FastAPI:  # noqa: ANN001
 
 
 @pytest.mark.unit
+def test_llamacpp_management_uses_standard_role_factory_alias():
+    assert lp.RequireRole is auth_deps.RequireRole
+    assert not hasattr(lp, "require_roles")
+
+
+@pytest.mark.unit
 def test_llamacpp_start_server_happy_path():
     app = _make_app_with_manager(_ManagedStub())
 

--- a/tldw_Server_API/tests/LLM_Local/test_mlx_management_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_mlx_management_api.py
@@ -109,6 +109,12 @@ def _make_app_with_registry(registry: _RegistryStub) -> FastAPI:
 
 
 @pytest.mark.unit
+def test_mlx_management_uses_standard_role_factory_alias():
+    assert mlx_ep.RequireRole is auth_deps.RequireRole
+    assert not hasattr(mlx_ep, "require_roles")
+
+
+@pytest.mark.unit
 def test_mlx_load_uses_default_model_path_and_adds_backend(monkeypatch):
     registry = _RegistryStub(load_result={"active": True, "model": "stub-model"})
     monkeypatch.setattr(mlx_ep, "_default_settings", lambda: {"model_path": "stub-model"})

--- a/tldw_Server_API/tests/LLM_Local/test_mlx_management_api.py
+++ b/tldw_Server_API/tests/LLM_Local/test_mlx_management_api.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import pytest
 from fastapi import FastAPI
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from starlette.requests import Request
 
@@ -108,10 +110,48 @@ def _make_app_with_registry(registry: _RegistryStub) -> FastAPI:
     return app
 
 
+def _route_for_path(path: str) -> APIRoute:
+    matches = [
+        route
+        for route in mlx_ep.router.routes
+        if isinstance(route, APIRoute) and route.path == path
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _role_guard_dependencies(route: APIRoute) -> list[Callable[..., Any]]:
+    expected_checker_code = auth_deps.RequireRole("admin").__code__
+    return [
+        dependency.dependency
+        for dependency in route.dependencies
+        if getattr(dependency.dependency, "__code__", None) is expected_checker_code
+    ]
+
+
+def _dependency_requires_roles(dependency: Callable[..., Any], roles: list[str]) -> bool:
+    closure_values = [
+        cell.cell_contents
+        for cell in getattr(dependency, "__closure__", None) or ()
+    ]
+    return roles in closure_values
+
+
 @pytest.mark.unit
-def test_mlx_management_uses_standard_role_factory_alias():
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/llm/providers/mlx/load",
+        "/llm/providers/mlx/unload",
+        "/llm/providers/mlx/status",
+    ],
+)
+def test_mlx_management_uses_standard_role_factory_alias(path: str) -> None:
     assert mlx_ep.RequireRole is auth_deps.RequireRole
     assert not hasattr(mlx_ep, "require_roles")
+    role_guards = _role_guard_dependencies(_route_for_path(path))
+    assert len(role_guards) == 1
+    assert _dependency_requires_roles(role_guards[0], ["admin"])
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -124,6 +124,32 @@ def principal_client(tmp_path, monkeypatch):
         chacha_db.close_connection()
 
 
+@pytest.fixture()
+def auth_path_client(tmp_path, monkeypatch):
+    """Provide a TestClient that leaves get_auth_principal on the real auth path."""
+    from tldw_Server_API.app.main import app as fastapi_app
+
+    user_base = tmp_path / "user_databases" / str(TEST_USER_ID)
+    user_base.mkdir(parents=True)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path / "user_databases"))
+
+    db_path = user_base / "ChaChaNotes.db"
+    chacha_db = CharactersRAGDB(db_path=db_path, client_id="auth_path_test_client")
+
+    def override_chacha_db():
+        return chacha_db
+
+    monkeypatch.setattr(DatabasePaths, "get_user_base_directory", staticmethod(lambda uid: user_base))
+    fastapi_app.dependency_overrides[get_chacha_db_for_user] = override_chacha_db
+
+    try:
+        with TestClient(fastapi_app) as c:
+            yield c
+    finally:
+        fastapi_app.dependency_overrides.clear()
+        chacha_db.close_connection()
+
+
 SAMPLE_SKILL = """---
 name: test-skill
 description: A test skill for API integration
@@ -157,6 +183,105 @@ class TestListSkills:
 
     def test_list_skills_uses_current_principal_alias(self, principal_client):
         r = principal_client.get(f"{SKILLS_PREFIX}/")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["skills"] == []
+        assert data["total"] == 0
+
+    def test_list_skills_current_principal_accepts_single_user_api_key(
+        self,
+        auth_path_client,
+        monkeypatch,
+    ):
+        from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+        with monkeypatch.context() as env:
+            env.setenv("AUTH_MODE", "single_user")
+            env.setenv("SINGLE_USER_API_KEY", "phase34-skills-single-user-key")
+            reset_settings()
+
+            r = auth_path_client.get(
+                f"{SKILLS_PREFIX}/",
+                headers={"X-API-KEY": "phase34-skills-single-user-key"},
+            )
+
+        reset_settings()
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["skills"] == []
+        assert data["total"] == 0
+
+    def test_list_skills_current_principal_accepts_jwt(
+        self,
+        auth_path_client,
+        monkeypatch,
+    ):
+        from tldw_Server_API.app.core.AuthNZ import User_DB_Handling as udh
+        from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+        async def fake_verify_jwt_and_fetch_user(request: Request, token: str) -> User:
+            assert token == "jwt.header.signature"
+            request.state.user_id = TEST_USER_ID
+            request.state.org_ids = []
+            request.state.team_ids = []
+            return User(
+                id=TEST_USER_ID,
+                username="skills-jwt-user",
+                roles=["user"],
+                permissions=["skills.read"],
+            )
+
+        monkeypatch.setattr(udh, "verify_jwt_and_fetch_user", fake_verify_jwt_and_fetch_user)
+
+        with monkeypatch.context() as env:
+            env.setenv("AUTH_MODE", "multi_user")
+            reset_settings()
+            r = auth_path_client.get(
+                f"{SKILLS_PREFIX}/",
+                headers={"Authorization": "Bearer jwt.header.signature"},
+            )
+
+        reset_settings()
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["skills"] == []
+        assert data["total"] == 0
+
+    def test_list_skills_current_principal_accepts_api_key(
+        self,
+        auth_path_client,
+        monkeypatch,
+    ):
+        from tldw_Server_API.app.core.AuthNZ import User_DB_Handling as udh
+        from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+        async def fake_authenticate_api_key_user(request: Request, api_key: str) -> User:
+            assert api_key == "phase34-skills-api-key"
+            request.state.user_id = TEST_USER_ID
+            request.state.api_key_id = 321
+            request.state.org_ids = []
+            request.state.team_ids = []
+            return User(
+                id=TEST_USER_ID,
+                username="skills-api-key-user",
+                roles=["automation"],
+                permissions=["skills.read"],
+            )
+
+        monkeypatch.setattr(udh, "authenticate_api_key_user", fake_authenticate_api_key_user)
+
+        with monkeypatch.context() as env:
+            env.setenv("AUTH_MODE", "multi_user")
+            reset_settings()
+            r = auth_path_client.get(
+                f"{SKILLS_PREFIX}/",
+                headers={"X-API-KEY": "phase34-skills-api-key"},
+            )
+
+        reset_settings()
+
         assert r.status_code == 200, r.text
         data = r.json()
         assert data["skills"] == []

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -6,6 +6,7 @@
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -39,7 +40,7 @@ TEST_USER_ID = 999
 
 
 @pytest.fixture()
-def client(tmp_path, monkeypatch):
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """Provide a TestClient with mocked auth and isolated user database."""
     from tldw_Server_API.app.main import app as fastapi_app
 
@@ -50,10 +51,10 @@ def client(tmp_path, monkeypatch):
     db_path = user_base / "ChaChaNotes.db"
     chacha_db = CharactersRAGDB(db_path=db_path, client_id="test_client")
 
-    async def override_user():
+    async def override_user() -> User:
         return User(id=TEST_USER_ID, username="skills-test-user", email=None, is_active=True)
 
-    def override_chacha_db():
+    def override_chacha_db() -> CharactersRAGDB:
         return chacha_db
 
     # Monkeypatch DatabasePaths so SkillsService gets our temp dir
@@ -71,7 +72,7 @@ def client(tmp_path, monkeypatch):
 
 
 @pytest.fixture()
-def principal_client(tmp_path, monkeypatch):
+def principal_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """Provide a TestClient that authenticates skills routes through AuthPrincipal only."""
     from tldw_Server_API.app.main import app as fastapi_app
 
@@ -108,7 +109,7 @@ def principal_client(tmp_path, monkeypatch):
         request.state.team_ids = list(principal.team_ids)
         return principal
 
-    def override_chacha_db():
+    def override_chacha_db() -> CharactersRAGDB:
         return chacha_db
 
     monkeypatch.setattr(DatabasePaths, "get_user_base_directory", staticmethod(lambda uid: user_base))
@@ -125,7 +126,7 @@ def principal_client(tmp_path, monkeypatch):
 
 
 @pytest.fixture()
-def auth_path_client(tmp_path, monkeypatch):
+def auth_path_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """Provide a TestClient that leaves get_auth_principal on the real auth path."""
     from tldw_Server_API.app.main import app as fastapi_app
 
@@ -136,7 +137,7 @@ def auth_path_client(tmp_path, monkeypatch):
     db_path = user_base / "ChaChaNotes.db"
     chacha_db = CharactersRAGDB(db_path=db_path, client_id="auth_path_test_client")
 
-    def override_chacha_db():
+    def override_chacha_db() -> CharactersRAGDB:
         return chacha_db
 
     monkeypatch.setattr(DatabasePaths, "get_user_base_directory", staticmethod(lambda uid: user_base))

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -6,8 +6,10 @@
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
+from types import SimpleNamespace
 
 import pytest
+from fastapi import Request
 from fastapi.testclient import TestClient
 
 # Keep module-level app import lightweight for this suite.
@@ -22,7 +24,9 @@ _routes_disable.update({"media", "audio", "audio-websocket"})
 os.environ["ROUTES_DISABLE"] = ",".join(sorted(_routes_disable))
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Skills.exceptions import SkillsError
@@ -66,6 +70,60 @@ def client(tmp_path, monkeypatch):
         chacha_db.close_connection()
 
 
+@pytest.fixture()
+def principal_client(tmp_path, monkeypatch):
+    """Provide a TestClient that authenticates skills routes through AuthPrincipal only."""
+    from tldw_Server_API.app.main import app as fastapi_app
+
+    user_base = tmp_path / "user_databases" / str(TEST_USER_ID)
+    user_base.mkdir(parents=True)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path / "user_databases"))
+
+    db_path = user_base / "ChaChaNotes.db"
+    chacha_db = CharactersRAGDB(db_path=db_path, client_id="principal_test_client")
+
+    principal = AuthPrincipal(
+        kind="user",
+        user_id=TEST_USER_ID,
+        username="skills-principal-user",
+        roles=["user"],
+        permissions=["skills.read", "skills.write"],
+        subject=f"user:{TEST_USER_ID}",
+        token_type="access",
+    )
+
+    async def override_principal(request: Request) -> AuthPrincipal:
+        request.state.auth = AuthContext(principal=principal)
+        request.state._auth_user = {
+            "id": principal.user_id,
+            "username": principal.username,
+            "roles": list(principal.roles),
+            "permissions": list(principal.permissions),
+            "is_active": True,
+            "is_verified": True,
+        }
+        request.state.user_id = principal.user_id
+        request.state.api_key_id = principal.api_key_id
+        request.state.org_ids = list(principal.org_ids)
+        request.state.team_ids = list(principal.team_ids)
+        return principal
+
+    def override_chacha_db():
+        return chacha_db
+
+    monkeypatch.setattr(DatabasePaths, "get_user_base_directory", staticmethod(lambda uid: user_base))
+
+    fastapi_app.dependency_overrides[auth_deps.get_auth_principal] = override_principal
+    fastapi_app.dependency_overrides[get_chacha_db_for_user] = override_chacha_db
+
+    try:
+        with TestClient(fastapi_app) as c:
+            yield c
+    finally:
+        fastapi_app.dependency_overrides.clear()
+        chacha_db.close_connection()
+
+
 SAMPLE_SKILL = """---
 name: test-skill
 description: A test skill for API integration
@@ -92,6 +150,13 @@ def _capture_skills_endpoint_errors() -> Iterator[list[str]]:
 class TestListSkills:
     def test_list_skills_empty(self, client):
         r = client.get(f"{SKILLS_PREFIX}/")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["skills"] == []
+        assert data["total"] == 0
+
+    def test_list_skills_uses_current_principal_alias(self, principal_client):
+        r = principal_client.get(f"{SKILLS_PREFIX}/")
         assert r.status_code == 200, r.text
         data = r.json()
         assert data["skills"] == []
@@ -559,6 +624,42 @@ class TestExecuteSkill:
         assert "Error executing skill" in joined
         assert "skills backend exploded" not in joined
         assert "/private/" not in joined
+
+    def test_execute_skill_request_context_uses_current_principal_alias(
+        self,
+        principal_client,
+        monkeypatch,
+    ):
+        create_resp = principal_client.post(
+            f"{SKILLS_PREFIX}/",
+            json={"name": "principal-exec-skill", "content": "Do: $ARGUMENTS"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        observed = {}
+
+        async def fake_execute(self, *, skill_data, arguments, context):
+            observed["user_id"] = context.user_id if context else None
+            return SimpleNamespace(
+                skill_name=skill_data["name"],
+                rendered_prompt=f"rendered {arguments}",
+                allowed_tools=[],
+                model_override=None,
+                execution_mode="inline",
+                fork_output=None,
+            )
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.api.v1.endpoints.skills.SkillExecutor.execute",
+            fake_execute,
+        )
+
+        r = principal_client.post(
+            f"{SKILLS_PREFIX}/principal-exec-skill/execute",
+            json={"args": "principal args"},
+        )
+
+        assert r.status_code == 200, r.text
+        assert observed["user_id"] == TEST_USER_ID
 
 
 class TestContextPayload:


### PR DESCRIPTION
## Summary
- Standardizes endpoint-facing AuthNZ dependency factory usage on `RequireRole`, `RequirePermission`, and `TokenScopeGuard`.
- Keeps lowercase factory implementations/backcompat aliases in `auth_deps.py` while removing direct endpoint imports/uses.
- Updates AuthNZ/module docs so new endpoint guidance matches the standardized pattern.

## Test Plan
- `python -m pytest tldw_Server_API/tests/AuthNZ/test_auth_dependency_contract.py -q`
- `python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -q`
- `python -m pytest tldw_Server_API/tests/Slack/test_slack_webhook_foundation.py tldw_Server_API/tests/Slack/test_slack_command_routing.py tldw_Server_API/tests/Slack/test_slack_oauth_lifecycle.py tldw_Server_API/tests/Slack/test_slack_policy_hardening.py tldw_Server_API/tests/Integrations/test_slack_endpoint_sanitizers.py -q`
- `python -m pytest tldw_Server_API/tests/Discord/test_discord_policy_hardening.py tldw_Server_API/tests/Discord/test_discord_interaction_foundation.py tldw_Server_API/tests/Discord/test_discord_command_routing.py tldw_Server_API/tests/Discord/test_discord_oauth_lifecycle.py tldw_Server_API/tests/Integrations/test_discord_endpoint_sanitizers.py -q`
- `python -m pytest tldw_Server_API/tests/Admin/test_admin_tools_endpoint.py -q`
- `python -m pytest tldw_Server_API/tests/Notifications/test_reminders_api.py -q`
- `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py tldw_Server_API/tests/Agent_Client_Protocol/test_checkpoint_rollback.py -q`
- `python -m bandit` on changed Python source scope, output: `/tmp/bandit_phase3_4_changed_sources.json`

## Merge Gate
- This PR is materially AI-authored. Per repository policy, a human-written `Change summary` explaining what changed and why is required before merge.

Closes #1116
