### PR TITLE
Phase 3.2: standardize offset pagination pilots

### DIFF
--- a/Docs/superpowers/plans/2026-04-30-phase3-2-pagination-medium-tranche-plan.md
+++ b/Docs/superpowers/plans/2026-04-30-phase3-2-pagination-medium-tranche-plan.md
@@ -1,0 +1,237 @@
+# Phase 3.2 Pagination Medium Tranche Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add shared pagination helpers and migrate the `skills` plus `slides` offset pilots to expose canonical nested pagination metadata without breaking current request or response shapes.
+
+**Architecture:** Introduce a shared offset-pagination schema/helper layer first, then adopt it in two low-risk route families. Preserve existing query params and top-level pagination fields during the compatibility window while teaching only the touched frontend callers to accept canonical nested `pagination`.
+
+**Tech Stack:** FastAPI `Query`, Pydantic, pytest, Bandit, TypeScript UI service/client code, Vitest
+
+---
+
+### Task 1: Shared Pagination Contract
+
+**Files:**
+- Create: `tldw_Server_API/app/api/v1/schemas/pagination.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py`
+- Test: `tldw_Server_API/tests/Utils/test_pagination_contract.py`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Add tests for:
+- canonical `limit`/`offset`
+- `page` + `per_page`
+- `page` + `results_per_page`
+- canonical values winning over aliases
+- `has_more` and `next_offset`
+- RFC5988 `Link` headers generated from normalized offset inputs
+
+- [ ] **Step 2: Run focused helper tests to verify red**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_pagination_contract.py -q
+```
+
+- [ ] **Step 3: Add minimal shared schemas and helpers**
+
+Implement:
+- `OffsetPaginationMeta`
+- internal normalized request structure for offset pagination
+- normalization helper that accepts `limit`, `offset`, `page`, `per_page`, `results_per_page`
+- metadata builder
+- Link header builder that reuses normalized values
+
+- [ ] **Step 4: Run helper tests to verify green**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Utils/test_pagination_contract.py -q
+```
+
+- [ ] **Step 5: Commit shared pagination helper layer**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/pagination.py tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py tldw_Server_API/tests/Utils/test_pagination_contract.py
+git commit -m "Phase 3.2: add shared offset pagination helpers"
+```
+
+### Task 2: Skills Backend Pilot
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/skills.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/skills_schemas.py`
+- Test: `tldw_Server_API/tests/Skills/integration/test_skills_api.py`
+
+- [ ] **Step 1: Add failing skills pagination tests**
+
+Cover:
+- canonical nested `pagination`
+- legacy top-level `count`, `total`, `limit`, `offset` still present
+- legacy requests still work
+- `page`/`per_page` compatibility alias accepted if adopted in this tranche
+
+- [ ] **Step 2: Run focused skills tests to verify red**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "list_skills and pagination" -q
+```
+
+- [ ] **Step 3: Adopt shared pagination helper in skills list**
+
+Keep:
+- existing `limit` / `offset`
+- existing top-level fields
+
+Add:
+- canonical nested `pagination`
+
+- [ ] **Step 4: Run focused skills tests to verify green**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Skills/integration/test_skills_api.py -k "list_skills and pagination" -q
+```
+
+- [ ] **Step 5: Commit the skills backend pilot**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/skills.py tldw_Server_API/app/api/v1/schemas/skills_schemas.py tldw_Server_API/tests/Skills/integration/test_skills_api.py
+git commit -m "Phase 3.2: add canonical skills pagination metadata"
+```
+
+### Task 3: Slides Backend Pilot
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/slides.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/slides_schemas.py`
+- Test: `tldw_Server_API/tests/Slides/test_slides_api.py`
+
+- [ ] **Step 1: Add failing slides pagination tests**
+
+Cover:
+- `/slides/presentations`
+- `/slides/presentations/search`
+- `/slides/styles`
+- `/slides/presentations/{presentation_id}/versions`
+
+Assertions:
+- canonical nested `pagination`
+- existing top-level `total` or `total_count`, `limit`, `offset` still present
+
+- [ ] **Step 2: Run focused slides tests to verify red**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_slides_api.py -k "pagination or styles_list" -q
+```
+
+- [ ] **Step 3: Adopt shared pagination helper in slides offset endpoints**
+
+Keep each route’s current top-level fields for compatibility.
+
+- [ ] **Step 4: Run focused slides tests to verify green**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_slides_api.py -k "pagination or styles_list" -q
+```
+
+- [ ] **Step 5: Commit the slides backend pilot**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/slides.py tldw_Server_API/app/api/v1/schemas/slides_schemas.py tldw_Server_API/tests/Slides/test_slides_api.py
+git commit -m "Phase 3.2: add canonical slides pagination metadata"
+```
+
+### Task 4: Frontend Compatibility Updates
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+- Modify: `apps/packages/ui/src/components/Option/Skills/__tests__/Manager.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/PresentationStudio/*` if direct parser tests live there
+- Add or modify: focused Vitest tests for `listVisualStyles()` and skills list parsing
+
+- [ ] **Step 1: Add failing frontend compatibility tests**
+
+Cover:
+- legacy top-level skills pagination shape
+- canonical nested `pagination` skills shape
+- legacy slides `total_count`
+- canonical slides `pagination.total`
+
+- [ ] **Step 2: Run focused Vitest to verify red**
+
+Run:
+```bash
+cd apps/packages/ui && bunx vitest run <focused-skills-and-slides-tests>
+```
+
+- [ ] **Step 3: Update parsers without broad client churn**
+
+Only touched callers should learn:
+- `pagination.total`
+- `pagination.limit`
+- `pagination.offset`
+- `pagination.has_more`
+- `pagination.next_offset`
+
+- [ ] **Step 4: Run focused Vitest to verify green**
+
+Run:
+```bash
+cd apps/packages/ui && bunx vitest run <focused-skills-and-slides-tests>
+```
+
+- [ ] **Step 5: Commit frontend compatibility updates**
+
+```bash
+git add apps/packages/ui/src/services/tldw/TldwApiClient.ts apps/packages/ui/src/components/Option/Skills apps/packages/ui/src/components/Option/PresentationStudio
+git commit -m "Phase 3.2: teach skills and slides clients canonical pagination"
+```
+
+### Task 5: Final Verification And PR Prep
+
+**Files:**
+- Verify touched files only
+
+- [ ] **Step 1: Run backend verification**
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Utils/test_pagination_contract.py \
+  tldw_Server_API/tests/Skills/integration/test_skills_api.py \
+  tldw_Server_API/tests/Slides/test_slides_api.py -q
+```
+
+- [ ] **Step 2: Run frontend verification**
+
+```bash
+cd apps/packages/ui && bunx vitest run <focused-skills-and-slides-tests>
+```
+
+- [ ] **Step 3: Run Bandit on touched Python files**
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/api/v1/schemas/pagination.py \
+  tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py \
+  tldw_Server_API/app/api/v1/endpoints/skills.py \
+  tldw_Server_API/app/api/v1/endpoints/slides.py \
+  -f json -o /tmp/bandit_phase3_2_medium_tranche.json
+```
+
+- [ ] **Step 4: Run git hygiene**
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+- [ ] **Step 5: Push the branch and refresh tracker state**
+
+```bash
+git push --force-with-lease origin worktree-phase3.2-pagination-standardization
+```

--- a/Docs/superpowers/specs/2026-04-30-startup-warning-framework-design.md
+++ b/Docs/superpowers/specs/2026-04-30-startup-warning-framework-design.md
@@ -1,7 +1,7 @@
 # Startup Warning Framework Design
 
-**Date:** 2026-04-30  
-**Status:** Draft for review  
+**Date:** 2026-04-30
+**Status:** Draft for review
 **Scope:** `tldw_Server_API/app/services/`, admin API schemas/endpoints, sandbox diagnostics integration, and startup/lifespan wiring
 
 ## Summary

--- a/IMPLEMENTATION_PLAN_phase3_2_eval_list_count_pagination.md
+++ b/IMPLEMENTATION_PLAN_phase3_2_eval_list_count_pagination.md
@@ -1,0 +1,17 @@
+## Stage 1: Red Tests
+**Goal**: Add focused failing coverage for evaluation dataset list and synthetic queue canonical pagination.
+**Success Criteria**: New/updated tests fail because canonical `pagination` and true totals are not yet present.
+**Tests**: `python -m pytest tldw_Server_API/tests/Evaluations/test_evaluations_unified.py -k "list_datasets" -q`, `python -m pytest tldw_Server_API/tests/Evaluations/integration/test_synthetic_eval_api.py -k "queue" -q`, `python -m pytest tldw_Server_API/tests/Evaluations/test_synthetic_eval_service.py -k "true_queue_total" -q`
+**Status**: Complete
+
+## Stage 2: Narrow Count Seams And Response Wiring
+**Goal**: Add explicit count seams for dataset listing and synthetic draft queue, then wire canonical nested pagination into the two list responses.
+**Success Criteria**: Route responses preserve legacy fields and add correct `pagination`.
+**Tests**: Stage 1 tests plus touched evaluation route/service files.
+**Status**: Complete
+
+## Stage 3: Verification And Commit
+**Goal**: Run focused/full touched tests, Bandit, and local hygiene, then commit the tranche.
+**Success Criteria**: All touched tests green, Bandit clean, worktree clean except intended changes, local commit created.
+**Tests**: targeted pytest selections, full touched eval files, `git diff --check`, Bandit on touched scope.
+**Status**: Complete

--- a/apps/packages/ui/src/services/__tests__/data-tables-pagination.test.ts
+++ b/apps/packages/ui/src/services/__tests__/data-tables-pagination.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { mapApiListToUi } from "@/services/tldw/data-tables"
+
+describe("data tables pagination compatibility", () => {
+  it("falls back to canonical pagination.total when legacy total is absent", () => {
+    const mapped = mapApiListToUi({
+      tables: [
+        {
+          uuid: "table-1",
+          name: "Table 1",
+          prompt: "Prompt",
+          status: "ready",
+          row_count: 3,
+          column_count: 2,
+          source_count: 1,
+          created_at: "2026-04-29T00:00:00Z",
+          updated_at: "2026-04-29T00:00:00Z",
+        },
+      ],
+      count: 1,
+      limit: 20,
+      offset: 0,
+      pagination: {
+        mode: "offset",
+        limit: 20,
+        offset: 0,
+        total: 7,
+        has_more: true,
+        next_offset: 20,
+      },
+    })
+
+    expect(mapped.tables).toHaveLength(1)
+    expect(mapped.total).toBe(7)
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/tldw-api-client.presentations-normalization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-api-client.presentations-normalization.test.ts
@@ -64,4 +64,61 @@ describe("TldwApiClient presentations normalization", () => {
     expect(styles[0]?.best_for).toEqual(["systems explanation", "architecture walkthrough"])
     expect(styles[0]?.artifact_preferences).toEqual(["timeline", "comparison_matrix"])
   })
+
+  it("uses canonical pagination.total when total_count is absent", async () => {
+    const client: TldwApiClientCore = {
+      ensureConfigForRequest: vi.fn(async () => ({})),
+      request: vi
+        .fn()
+        .mockResolvedValueOnce({
+          styles: [
+            {
+              id: "page-1-style",
+              name: "Page 1",
+              scope: "builtin",
+              generation_rules: {},
+              artifact_preferences: [],
+              appearance_defaults: {},
+              fallback_policy: {}
+            }
+          ],
+          pagination: {
+            mode: "offset",
+            limit: 1,
+            offset: 0,
+            total: 2,
+            has_more: true,
+            next_offset: 1
+          }
+        })
+        .mockResolvedValueOnce({
+          styles: [
+            {
+              id: "page-2-style",
+              name: "Page 2",
+              scope: "user",
+              generation_rules: {},
+              artifact_preferences: [],
+              appearance_defaults: {},
+              fallback_policy: {}
+            }
+          ],
+          pagination: {
+            mode: "offset",
+            limit: 1,
+            offset: 1,
+            total: 2,
+            has_more: false,
+            next_offset: null
+          }
+        }),
+      resolveApiPath: vi.fn(),
+      fillPathParams: vi.fn()
+    }
+
+    const styles = await presentationsMethods.listVisualStyles.call(client)
+
+    expect(styles.map((style) => style.id)).toEqual(["page-1-style", "page-2-style"])
+    expect(client.request).toHaveBeenCalledTimes(2)
+  })
 })

--- a/apps/packages/ui/src/services/tldw/data-tables.ts
+++ b/apps/packages/ui/src/services/tldw/data-tables.ts
@@ -66,6 +66,14 @@ export type ApiDataTablesListResponse = {
   total?: number
   limit?: number
   offset?: number
+  pagination?: {
+    mode?: string
+    limit?: number
+    offset?: number
+    total?: number | null
+    has_more?: boolean
+    next_offset?: number | null
+  }
 }
 
 export type ApiDataTableGenerateResponse = {
@@ -126,7 +134,7 @@ export const mapApiListToUi = (
   const tables = tablesList.map(mapApiSummaryToUi)
   const total = Array.isArray(response)
     ? tables.length
-    : response.total ?? response.count ?? tables.length
+    : response.total ?? response.pagination?.total ?? response.count ?? tables.length
   return { tables, total }
 }
 

--- a/apps/packages/ui/src/services/tldw/domains/presentations.ts
+++ b/apps/packages/ui/src/services/tldw/domains/presentations.ts
@@ -46,6 +46,22 @@ const toFiniteNumber = (value: unknown, fallback = 0): number => {
   return fallback
 }
 
+const extractOffsetPaginationTotal = (value: unknown): number | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null
+  }
+  const record = value as Record<string, unknown>
+  if (typeof record.total_count === "number" && Number.isFinite(record.total_count)) {
+    return record.total_count
+  }
+  const pagination = record.pagination
+  if (!pagination || typeof pagination !== "object" || Array.isArray(pagination)) {
+    return null
+  }
+  const total = (pagination as Record<string, unknown>).total
+  return typeof total === "number" && Number.isFinite(total) ? total : null
+}
+
 const normalizeVisualStyleSnapshot = (
   value: unknown
 ): PresentationVisualStyleSnapshot | null => {
@@ -210,10 +226,7 @@ export const presentationsMethods = {
       const styles = Array.isArray(payload?.styles) ? payload.styles : []
       allStyles.push(...styles.map((style: unknown) => normalizeVisualStyleRecord(style)))
 
-      const totalCount =
-        typeof payload?.total_count === "number" && Number.isFinite(payload.total_count)
-          ? payload.total_count
-          : allStyles.length
+      const totalCount = extractOffsetPaginationTotal(payload) ?? allStyles.length
       if (allStyles.length >= totalCount || styles.length === 0) {
         return allStyles
       }

--- a/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
+++ b/apps/packages/ui/src/services/tldw/domains/workspace-api.ts
@@ -14,6 +14,33 @@ export interface TldwApiClientCore {
   buildQuery(params?: Record<string, any>): string
 }
 
+type OffsetPaginationMeta = {
+  mode: "offset"
+  limit: number
+  offset: number
+  total?: number | null
+  has_more: boolean
+  next_offset?: number | null
+}
+
+type SkillSummary = {
+  name: string
+  description?: string | null
+  argument_hint?: string | null
+  user_invocable: boolean
+  disable_model_invocation: boolean
+  context: "inline" | "fork"
+}
+
+type SkillsListPayload = {
+  skills: SkillSummary[]
+  count: number
+  total: number
+  limit: number
+  offset: number
+  pagination?: OffsetPaginationMeta
+}
+
 export const workspaceApiMethods = {
   // ── Skills API ──
 
@@ -23,13 +50,13 @@ export const workspaceApiMethods = {
       limit?: number
       offset?: number
     }
-  ): Promise<any> {
+  ): Promise<SkillsListPayload> {
     const query = buildQuery(params)
     const base = await this.resolveApiPath("skills.list", [
       "/api/v1/skills",
       "/api/v1/skills/"
     ])
-    return await bgRequest<any>({
+    return await bgRequest<SkillsListPayload>({
       path: appendPathQuery(base, query),
       method: "GET"
     })

--- a/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
+++ b/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
@@ -12,7 +12,11 @@ import urllib.parse as _u
 from tldw_Server_API.app.api.v1.schemas.pagination import (
     CursorPaginationMeta,
     OffsetPaginationMeta,
-    PagePaginationMeta,
+)
+from tldw_Server_API.app.api.v1.utils.pagination import (
+    build_cursor_pagination_meta,
+    build_offset_pagination_meta,
+    build_page_pagination_meta,
 )
 
 
@@ -94,75 +98,6 @@ def build_link_header(
                 links.append(f"<{hrefl}>; rel=\"last\"")
 
     return ", ".join(links) if links else None
-
-
-def build_offset_pagination_meta(
-    *,
-    limit: int,
-    offset: int,
-    total: int | None = None,
-    count: int | None = None,
-    has_more: bool | None = None,
-) -> OffsetPaginationMeta:
-    """Build canonical offset pagination metadata from route-local values."""
-    normalized_count = max(count or 0, 0)
-
-    if has_more is None:
-        if total is not None:
-            has_more = offset + normalized_count < total
-        else:
-            has_more = normalized_count >= limit
-
-    next_offset = offset + limit if has_more else None
-
-    return OffsetPaginationMeta(
-        limit=limit,
-        offset=offset,
-        total=total,
-        has_more=has_more,
-        next_offset=next_offset,
-    )
-
-
-def build_cursor_pagination_meta(
-    *,
-    limit: int,
-    cursor: str | None = None,
-    next_cursor: str | None = None,
-    has_more: bool | None = None,
-) -> CursorPaginationMeta:
-    """Build canonical cursor pagination metadata from route-local values."""
-    normalized_has_more = bool(next_cursor) if has_more is None else bool(has_more)
-    return CursorPaginationMeta(
-        limit=limit,
-        cursor=cursor,
-        next_cursor=next_cursor,
-        has_more=normalized_has_more,
-    )
-
-
-def build_page_pagination_meta(
-    *,
-    page: int,
-    per_page: int,
-    total: int | None = None,
-    total_pages: int | None = None,
-    has_more: bool | None = None,
-) -> PagePaginationMeta:
-    """Build canonical page-based pagination metadata from route-local values."""
-    normalized_total_pages = int(total_pages) if total_pages is not None else None
-    normalized_has_more = (
-        bool(normalized_total_pages and int(page) < normalized_total_pages)
-        if has_more is None
-        else bool(has_more)
-    )
-    return PagePaginationMeta(
-        page=int(page),
-        per_page=int(per_page),
-        total=int(total) if total is not None else None,
-        total_pages=normalized_total_pages,
-        has_more=normalized_has_more,
-    )
 
 
 def build_pagination_link_header(

--- a/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
+++ b/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
@@ -1,12 +1,11 @@
-from __future__ import annotations
-
 """
 Reusable helpers for building RFC5988 Link headers for paginated endpoints.
 
-This module is intentionally lightweight and dependency-free, so it can be
-used across endpoints (e.g., runs, events, future artifacts listings).
+This module centralizes pagination metadata and Link header construction for
+API endpoints while keeping dependencies limited to shared pagination schemas.
 """
 
+from __future__ import annotations
 
 import urllib.parse as _u
 

--- a/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
+++ b/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
@@ -110,17 +110,17 @@ def build_offset_pagination_meta(
 
     if has_more is None:
         if total is not None:
-            has_more = int(offset) + normalized_count < int(total)
+            has_more = offset + normalized_count < total
         else:
-            has_more = normalized_count >= int(limit)
+            has_more = normalized_count >= limit
 
-    next_offset = int(offset) + int(limit) if has_more else None
+    next_offset = offset + limit if has_more else None
 
     return OffsetPaginationMeta(
-        limit=int(limit),
-        offset=int(offset),
-        total=int(total) if total is not None else None,
-        has_more=bool(has_more),
+        limit=limit,
+        offset=offset,
+        total=total,
+        has_more=has_more,
         next_offset=next_offset,
     )
 
@@ -135,7 +135,7 @@ def build_cursor_pagination_meta(
     """Build canonical cursor pagination metadata from route-local values."""
     normalized_has_more = bool(next_cursor) if has_more is None else bool(has_more)
     return CursorPaginationMeta(
-        limit=int(limit),
+        limit=limit,
         cursor=cursor,
         next_cursor=next_cursor,
         has_more=normalized_has_more,

--- a/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
+++ b/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
@@ -10,6 +10,11 @@ used across endpoints (e.g., runs, events, future artifacts listings).
 
 import urllib.parse as _u
 
+from tldw_Server_API.app.api.v1.schemas.pagination import (
+    CursorPaginationMeta,
+    OffsetPaginationMeta,
+)
+
 
 def build_link_header(
     base_path: str,
@@ -91,4 +96,82 @@ def build_link_header(
     return ", ".join(links) if links else None
 
 
-__all__ = ["build_link_header"]
+def build_offset_pagination_meta(
+    *,
+    limit: int,
+    offset: int,
+    total: int | None = None,
+    count: int | None = None,
+    has_more: bool | None = None,
+) -> OffsetPaginationMeta:
+    """Build canonical offset pagination metadata from route-local values."""
+    normalized_count = max(count or 0, 0)
+
+    if has_more is None:
+        if total is not None:
+            has_more = int(offset) + normalized_count < int(total)
+        else:
+            has_more = normalized_count >= int(limit)
+
+    next_offset = int(offset) + int(limit) if has_more else None
+
+    return OffsetPaginationMeta(
+        limit=int(limit),
+        offset=int(offset),
+        total=int(total) if total is not None else None,
+        has_more=bool(has_more),
+        next_offset=next_offset,
+    )
+
+
+def build_cursor_pagination_meta(
+    *,
+    limit: int,
+    cursor: str | None = None,
+    next_cursor: str | None = None,
+    has_more: bool | None = None,
+) -> CursorPaginationMeta:
+    """Build canonical cursor pagination metadata from route-local values."""
+    normalized_has_more = bool(next_cursor) if has_more is None else bool(has_more)
+    return CursorPaginationMeta(
+        limit=int(limit),
+        cursor=cursor,
+        next_cursor=next_cursor,
+        has_more=normalized_has_more,
+    )
+
+
+def build_pagination_link_header(
+    base_path: str,
+    common_params: list[tuple[str, str]] | None = None,
+    *,
+    pagination: OffsetPaginationMeta | CursorPaginationMeta,
+    cursor_param: str = "cursor",
+    include_first_last: bool = True,
+) -> str | None:
+    """Build an RFC5988 Link header from canonical pagination metadata."""
+    if isinstance(pagination, OffsetPaginationMeta):
+        return build_link_header(
+            base_path=base_path,
+            common_params=common_params,
+            limit=pagination.limit,
+            offset=pagination.offset,
+            has_more=pagination.has_more,
+            include_first_last=include_first_last,
+        )
+
+    return build_link_header(
+        base_path=base_path,
+        common_params=common_params,
+        next_cursor=pagination.next_cursor,
+        limit=pagination.limit,
+        cursor_param=cursor_param,
+    )
+
+
+__all__ = [
+    "build_cursor_pagination_meta",
+    "build_link_header",
+    "build_offset_pagination_meta",
+    "build_pagination_link_header",
+]

--- a/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
+++ b/tldw_Server_API/app/api/v1/endpoints/_pagination_utils.py
@@ -13,6 +13,7 @@ import urllib.parse as _u
 from tldw_Server_API.app.api.v1.schemas.pagination import (
     CursorPaginationMeta,
     OffsetPaginationMeta,
+    PagePaginationMeta,
 )
 
 
@@ -141,6 +142,30 @@ def build_cursor_pagination_meta(
     )
 
 
+def build_page_pagination_meta(
+    *,
+    page: int,
+    per_page: int,
+    total: int | None = None,
+    total_pages: int | None = None,
+    has_more: bool | None = None,
+) -> PagePaginationMeta:
+    """Build canonical page-based pagination metadata from route-local values."""
+    normalized_total_pages = int(total_pages) if total_pages is not None else None
+    normalized_has_more = (
+        bool(normalized_total_pages and int(page) < normalized_total_pages)
+        if has_more is None
+        else bool(has_more)
+    )
+    return PagePaginationMeta(
+        page=int(page),
+        per_page=int(per_page),
+        total=int(total) if total is not None else None,
+        total_pages=normalized_total_pages,
+        has_more=normalized_has_more,
+    )
+
+
 def build_pagination_link_header(
     base_path: str,
     common_params: list[tuple[str, str]] | None = None,
@@ -172,6 +197,7 @@ def build_pagination_link_header(
 __all__ = [
     "build_cursor_pagination_meta",
     "build_link_header",
+    "build_page_pagination_meta",
     "build_offset_pagination_meta",
     "build_pagination_link_header",
 ]

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_acp_agents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_acp_agents.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentConfigCreate,
     ACPAgentConfigListResponse,
@@ -75,7 +76,16 @@ async def admin_list_acp_sessions(
         ))
         for rec in records
     ]
-    return ACPSessionListResponse(sessions=sessions, total=total)
+    return ACPSessionListResponse(
+        sessions=sessions,
+        total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(sessions),
+        ),
+    )
 
 
 @router.get("/acp/sessions/{session_id}/usage", response_model=ACPSessionUsageResponse)

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_bundle_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_bundle_ops.py
@@ -12,6 +12,9 @@ from fastapi.responses import FileResponse
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
+    build_offset_pagination_meta,
+)
 from tldw_Server_API.app.api.v1.schemas.bundle_schemas import (
     BundleCreateRequest,
     BundleCreateResponse,
@@ -249,6 +252,12 @@ async def list_bundles(
             total=total,
             limit=limit,
             offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(items),
+            ),
         )
     except BundleError as exc:
         raise _handle_bundle_error(exc) from exc

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
@@ -12,6 +12,9 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     check_rate_limit,
     get_auth_principal,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
+    build_offset_pagination_meta,
+)
 from tldw_Server_API.app.api.v1.schemas.user_keys import (
     AdminUserKeysResponse,
     ByokValidationRunCreateRequest,
@@ -239,6 +242,12 @@ async def admin_list_byok_validation_runs(
         total=total,
         limit=limit,
         offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(items),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -7,6 +7,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
+    build_offset_pagination_meta,
+)
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     BackupCreateRequest,
     BackupCreateResponse,
@@ -252,7 +255,18 @@ async def list_backups(
             )
             for item in items
         ]
-        return BackupListResponse(items=payload, total=total, limit=limit, offset=offset)
+        return BackupListResponse(
+            items=payload,
+            total=total,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                offset=offset,
+                limit=limit,
+                count=len(payload),
+            ),
+        )
     except HTTPException:
         raise
     except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -390,7 +390,18 @@ async def list_backup_schedules(
         )
         items = service.filter_visible_items(items, principal=principal)
         payload = [_serialize_backup_schedule_item(item) for item in items]
-        return BackupScheduleListResponse(items=payload, total=total, limit=limit, offset=offset)
+        return BackupScheduleListResponse(
+            items=payload,
+            total=total,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(payload),
+            ),
+        )
     except HTTPException:
         raise
     except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -726,6 +726,12 @@ async def list_data_subject_requests(
             total=total,
             limit=limit,
             offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(items),
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_ops.py
@@ -571,6 +571,12 @@ async def list_incidents(
         total=total,
         limit=limit,
         offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(items),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_ops.py
@@ -899,9 +899,16 @@ async def list_webhooks(
     """List all configured webhooks (secrets redacted)."""
     _require_platform_admin(principal)
     items = svc_list_webhooks()
+    limit = len(items)
     return WebhookListResponse(
         items=[WebhookItem(**item) for item in items],
         total=len(items),
+        pagination=build_offset_pagination_meta(
+            total=len(items),
+            limit=limit,
+            offset=0,
+            count=len(items),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_ops.py
@@ -11,6 +11,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
+    build_offset_pagination_meta,
+)
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     FeatureFlagItem,
     FeatureFlagsResponse,
@@ -409,6 +412,12 @@ async def list_maintenance_rotation_runs(
         total=payload["total"],
         limit=payload["limit"],
         offset=payload["offset"],
+        pagination=build_offset_pagination_meta(
+            total=payload["total"],
+            limit=payload["limit"],
+            offset=payload["offset"],
+            count=len(payload["items"]),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_storage_quotas.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_storage_quotas.py
@@ -10,8 +10,10 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, status
 from loguru import logger
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.storage_quotas_repo import (
     AuthnzStorageQuotasRepo,
@@ -74,6 +76,17 @@ class StorageQuotaSummaryResponse(BaseModel):
 
     total_quotas: int
     items: list[dict[str, Any]]
+    pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        if self.has_more is None:
+            self.has_more = self.pagination.has_more
+        if self.next_offset is None:
+            self.next_offset = self.pagination.next_offset
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +233,7 @@ async def get_storage_quota_summary(
         return StorageQuotaSummaryResponse(
             total_quotas=len(items),
             items=items,
+            pagination=build_offset_pagination_meta(limit=limit, offset=offset, count=len(items)),
         )
     except _NONCRITICAL_EXCEPTIONS as exc:
         logger.warning("Failed to get storage quota summary")

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_password_service_dep,
     get_registration_service_dep,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     AdminMfaRequirementRequest,
     AdminMfaRequirementResponse,
@@ -158,6 +159,12 @@ async def list_users(
             page=page,
             limit=limit,
             pages=(total + limit - 1) // limit if limit else 0,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=(page - 1) * limit,
+                count=len(users),
+            ),
         )
     except HTTPException as e:
         try:

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_webhooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_webhooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Query
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     AdminWebhookCreateRequest,
     AdminWebhookDeleteResponse,
@@ -67,6 +68,14 @@ async def list_webhooks(
             for r in items
         ],
         total=total,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(items),
+        ),
     )
 
 
@@ -173,4 +182,12 @@ async def list_webhook_deliveries(
             for e in items
         ],
         total=total,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(items),
+        ),
     )

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -19,6 +19,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, TokenScopeGuard, User
 
 from tldw_Server_API.app.api.v1.endpoints._in_memory_limits import SlidingWindowLimiter
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentInfo,
     ACPAgentListResponse,
@@ -2353,7 +2354,16 @@ async def acp_list_sessions(
         ))
         for rec in records
     ]
-    return ACPSessionListResponse(sessions=sessions, total=total)
+    return ACPSessionListResponse(
+        sessions=sessions,
+        total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(sessions),
+        ),
+    )
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
@@ -13,6 +13,7 @@ from starlette import status
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_request_user, TokenScopeGuard, User
 
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_cursor_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import (
     TTSHistoryDetailResponse,
@@ -239,6 +240,7 @@ async def list_tts_history(
         except _TTS_HISTORY_NONCRITICAL_EXCEPTIONS:
             logger.debug("TTS history: failed to build next cursor")
             next_cursor = None
+            has_more = False
 
     total = None
     if include_total:
@@ -276,6 +278,12 @@ async def list_tts_history(
         limit=limit,
         offset=offset,
         next_cursor=next_cursor,
+        pagination=build_cursor_pagination_meta(
+            limit=limit,
+            cursor=cursor,
+            next_cursor=next_cursor,
+            has_more=has_more,
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
@@ -237,10 +237,17 @@ async def list_tts_history(
         last_row = rows[-1]
         try:
             next_cursor = _encode_cursor(last_row.get("created_at"), int(last_row.get("id")))
-        except _TTS_HISTORY_NONCRITICAL_EXCEPTIONS:
-            logger.debug("TTS history: failed to build next cursor")
-            next_cursor = None
-            has_more = False
+        except _TTS_HISTORY_NONCRITICAL_EXCEPTIONS as exc:
+            logger.error(
+                "TTS history: failed to build next cursor for id={} created_at={}",
+                last_row.get("id"),
+                last_row.get("created_at"),
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to list TTS history",
+            ) from exc
 
     total = None
     if include_total:

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py
@@ -25,6 +25,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_
 
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.audiobook_schemas import (
     AlignmentPayload,
     ArtifactInfo,
@@ -734,11 +735,23 @@ async def list_audiobook_projects(
 ) -> AudiobookProjectListResponse:
     try:
         rows = collections_db.list_audiobook_projects(limit=limit, offset=offset)
+        total = collections_db.count_audiobook_projects()
     except Exception as exc:
         logger.exception("Failed to list audiobook projects")
         raise HTTPException(status_code=500, detail="audiobook_project_list_failed") from exc
     projects = [_project_row_to_info(row) for row in rows]
-    return AudiobookProjectListResponse(projects=projects)
+    return AudiobookProjectListResponse(
+        projects=projects,
+        total=total,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(projects),
+        ),
+    )
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audiobooks.py
@@ -901,11 +901,14 @@ async def create_voice_profile(
     dependencies=[Depends(check_rate_limit)],
 )
 async def list_voice_profiles(
+    limit: int = Query(100, ge=1, le=200, description="Maximum number of voice profiles to return"),
+    offset: int = Query(0, ge=0, description="Number of voice profiles to skip"),
     _current_user: User = Depends(get_request_user),
     collections_db: CollectionsDatabase = Depends(get_collections_db_for_user),
 ) -> VoiceProfileListResponse:
     try:
-        rows = collections_db.list_voice_profiles()
+        rows = collections_db.list_voice_profiles(limit=limit, offset=offset)
+        total = collections_db.count_voice_profiles()
     except Exception as exc:
         logger.exception("Failed to list audiobook voice profiles")
         raise HTTPException(status_code=500, detail="voice_profile_list_failed") from exc
@@ -926,7 +929,18 @@ async def list_voice_profiles(
                 chapter_overrides=overrides,
             )
         )
-    return VoiceProfileListResponse(profiles=profiles)
+    return VoiceProfileListResponse(
+        profiles=profiles,
+        total=total,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(profiles),
+        ),
+    )
 
 
 @router.delete(

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -76,6 +76,7 @@ from tldw_Server_API.app.api.v1.schemas.chat_session_schemas import (
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import (
     DEFAULT_LLM_PROVIDER,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.utils.deprecation import build_deprecation_headers
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.core.AuthNZ.llm_provider_overrides import (
@@ -5596,7 +5597,13 @@ async def list_chat_sessions(
             chats=chats,
             total=total_count,
             limit=limit,
-            offset=offset
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total_count,
+                limit=limit,
+                offset=offset,
+                count=len(chats),
+            ),
         )
 
     except HTTPException:

--- a/tldw_Server_API/app/api/v1/endpoints/character_memory.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_memory.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.character_memory_schemas import (
     CharacterMemoryArchiveRequest,
@@ -185,7 +186,18 @@ async def list_character_memories(
     except (InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to list character memories") from exc
     memories = [_row_to_response(r, character_id) for r in rows]
-    return CharacterMemoryListResponse(memories=memories, total=total_count)
+    return CharacterMemoryListResponse(
+        memories=memories,
+        total=total_count,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total_count,
+            limit=limit,
+            offset=offset,
+            count=len(memories),
+        ),
+    )
 
 
 @router.post(

--- a/tldw_Server_API/app/api/v1/endpoints/character_messages.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_messages.py
@@ -1026,6 +1026,7 @@ async def search_messages(
     chat_id: str = Path(..., description="Chat session ID"),
     query: str = Query(..., description="Search query", min_length=1, max_length=MAX_SEARCH_QUERY_LENGTH),
     limit: int = Query(50, ge=1, le=200, description="Maximum results"),
+    offset: int = Query(0, ge=0, description="Offset for search pagination"),
     scope_type: Literal["global", "workspace"] | None = Query(None, description="Conversation scope type"),
     workspace_id: str | None = Query(None, description="Workspace ID when scope_type='workspace'"),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
@@ -1038,6 +1039,7 @@ async def search_messages(
         chat_id: Chat session ID
         query: Search query string
         limit: Maximum number of results
+        offset: Offset for search pagination
         db: Database instance
         current_user: Authenticated user
 
@@ -1068,22 +1070,26 @@ async def search_messages(
             query,
             character_name_for_placeholders=character_name,
             user_name_for_placeholders=user_name,
-            limit=limit,
+            limit=limit + 1,
+            offset=offset,
         )
 
         if not results:
             results = []
+        has_more = len(results) > limit
+        page_results = results[:limit]
 
         return MessageListResponse(
-            messages=[_convert_db_message_to_response(msg) for msg in results],
-            total=len(results),
+            messages=[_convert_db_message_to_response(msg) for msg in page_results],
+            total=len(page_results),
             limit=limit,
-            offset=0,
+            offset=offset,
             pagination=build_offset_pagination_meta(
-                total=len(results),
+                total=None,
                 limit=limit,
-                offset=0,
-                count=len(results),
+                offset=offset,
+                count=len(page_results),
+                has_more=has_more,
             ),
         )
 

--- a/tldw_Server_API/app/api/v1/endpoints/character_messages.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_messages.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 
 # Database and authentication dependencies
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 
 # Schemas
@@ -659,7 +660,13 @@ async def get_chat_messages(
                 messages=built_messages,
                 total=total_count,
                 limit=limit,
-                offset=offset
+                offset=offset,
+                pagination=build_offset_pagination_meta(
+                    total=total_count,
+                    limit=limit,
+                    offset=offset,
+                    count=len(built_messages),
+                ),
             )
 
             # Add character context as additional field
@@ -722,7 +729,13 @@ async def get_chat_messages(
             messages=built_messages,
             total=total_count,
             limit=limit,
-            offset=offset
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total_count,
+                limit=limit,
+                offset=offset,
+                count=len(built_messages),
+            ),
         )
 
     except HTTPException:
@@ -1065,7 +1078,13 @@ async def search_messages(
             messages=[_convert_db_message_to_response(msg) for msg in results],
             total=len(results),
             limit=limit,
-            offset=0
+            offset=0,
+            pagination=build_offset_pagination_meta(
+                total=len(results),
+                limit=limit,
+                offset=0,
+                count=len(results),
+            ),
         )
 
     except HTTPException:

--- a/tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py
@@ -20,6 +20,7 @@ from loguru import logger
 from starlette import status
 
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 
 # Constants for file upload validation
 MAX_CHARACTER_FILE_SIZE = 10 * 1024 * 1024  # 10MB max file size
@@ -995,7 +996,13 @@ async def query_characters(
             total=total,
             page=page,
             page_size=page_size,
-            has_more=(offset + len(items)) < total
+            has_more=(offset + len(items)) < total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                offset=offset,
+                limit=page_size,
+                count=len(items),
+            ),
         )
     except CharactersRAGDBError as e:
         logger.error(f"DB error querying characters: {e}", exc_info=True)

--- a/tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat_dictionaries.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.chat_dictionary_schemas import (
     BulkEntryOperation,
@@ -1270,6 +1271,12 @@ async def list_dictionary_activity(
             total=total,
             limit=limit,
             offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                offset=offset,
+                limit=limit,
+                count=len(events),
+            ),
         )
     except HTTPException:
         raise
@@ -1321,6 +1328,12 @@ async def list_dictionary_versions(
             total=total,
             limit=limit,
             offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                offset=offset,
+                limit=limit,
+                count=len(versions),
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/chat_grammars.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat_grammars.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.chat_grammar_schemas import (
     ChatGrammarCreate,
@@ -100,6 +101,12 @@ async def list_chat_grammars(
     return ChatGrammarListResponse(
         items=[_grammar_to_response(grammar) for grammar in grammars],
         total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(grammars),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
@@ -34,6 +34,7 @@ from ....core.Chatbooks.exceptions import JobError
 from ....core.Chatbooks.quota_manager import QuotaManager
 from ....core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from ....core.DB_Management.db_path_utils import DatabasePaths
+from ._pagination_utils import build_offset_pagination_meta
 from ..API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user as get_chacha_db
 from ..schemas.chatbook_schemas import (
     CancelJobResponse,
@@ -940,7 +941,16 @@ async def list_export_jobs(
                 )
             )
 
-        return ListExportJobsResponse(jobs=job_responses, total=total)
+        return ListExportJobsResponse(
+            jobs=job_responses,
+            total=total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(job_responses),
+            ),
+        )
 
     except HTTPException:
         raise
@@ -1055,7 +1065,16 @@ async def list_import_jobs(
                 )
             )
 
-        return ListImportJobsResponse(jobs=job_responses, total=total)
+        return ListImportJobsResponse(
+            jobs=job_responses,
+            total=total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(job_responses),
+            ),
+        )
 
     except _CHATBOOKS_NONCRITICAL_EXCEPTIONS:
         logger.error("Failed to list chatbook import jobs")

--- a/tldw_Server_API/app/api/v1/endpoints/companion.py
+++ b/tldw_Server_API/app/api/v1/endpoints/companion.py
@@ -17,6 +17,7 @@ from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
     get_personalization_db_for_user,
     get_usage_event_logger,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.companion import (
     CompanionActivityCreate,
     CompanionActivityDetail,
@@ -277,7 +278,18 @@ async def list_companion_activity(
         offset,
     )
     await asyncio.to_thread(log.log_event, "companion.activity.view", metadata={"count": len(items)})
-    return CompanionActivityListResponse(items=items, total=total, limit=limit, offset=offset)
+    return CompanionActivityListResponse(
+        items=items,
+        total=total,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/data_tables.py
+++ b/tldw_Server_API/app/api/v1/endpoints/data_tables.py
@@ -411,6 +411,8 @@ def _build_table_detail_response(
             for row in db.list_data_table_sources(table_id, owner_user_id=owner_user_id)
         ]
         source_count = len(sources)
+    total_rows = int(table_row.get("row_count") or 0)
+    rows_has_more = rows_offset + rows_limit < total_rows
     return DataTableDetailResponse(
         table=_table_summary_from_row(
             table_row,
@@ -425,8 +427,9 @@ def _build_table_detail_response(
         pagination=build_offset_pagination_meta(
             limit=rows_limit,
             offset=rows_offset,
-            total=int(table_row.get("row_count") or 0),
-            count=len(rows) if include_rows else 0,
+            total=total_rows,
+            count=len(rows),
+            has_more=rows_has_more,
         ),
     )
 

--- a/tldw_Server_API/app/api/v1/endpoints/data_tables.py
+++ b/tldw_Server_API/app/api/v1/endpoints/data_tables.py
@@ -16,7 +16,7 @@ from cachetools import LRUCache
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, User
-
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.schemas.data_tables_schemas import (
@@ -421,6 +421,12 @@ def _build_table_detail_response(
         sources=sources,
         rows_limit=rows_limit,
         rows_offset=rows_offset,
+        pagination=build_offset_pagination_meta(
+            limit=rows_limit,
+            offset=rows_offset,
+            total=int(table_row.get("row_count") or 0),
+            count=len(rows) if include_rows else 0,
+        ),
     )
 
 
@@ -665,6 +671,12 @@ async def list_data_tables(
         total=total,
         limit=limit,
         offset=offset,
+        pagination=build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            total=total,
+            count=len(tables),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/data_tables.py
+++ b/tldw_Server_API/app/api/v1/endpoints/data_tables.py
@@ -16,6 +16,7 @@ from cachetools import LRUCache
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, rbac_rate_limit, RequirePermission, User
+
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_datasets.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_datasets.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_auth import (
     create_error_response,
     get_evaluation_identity,
@@ -132,10 +133,24 @@ async def list_datasets(
         identity = get_evaluation_identity(current_user)
         svc = get_unified_evaluation_service_for_user(identity.user_scope)
         items, has_more = svc.db.list_datasets(limit=limit, offset=offset, created_by=identity.created_by)
+        total = svc.db.count_datasets(created_by=identity.created_by)
         resp = [DatasetResponse(**_normalize_dataset_payload(r)) for r in items]
         first_id = resp[0].id if resp else None
         last_id = resp[-1].id if resp else None
-        return DatasetListResponse(data=resp, has_more=has_more, first_id=first_id, last_id=last_id)
+        return DatasetListResponse(
+            data=resp,
+            has_more=has_more,
+            first_id=first_id,
+            last_id=last_id,
+            total=total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(resp),
+                has_more=has_more,
+            ),
+        )
     except _UNIFIED_EVAL_NONCRITICAL_EXCEPTIONS as e:
         logger.error("Failed to list datasets")
         raise create_error_response(

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_synthetic.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_synthetic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_auth import (
     get_eval_request_user,
     require_eval_permissions,
@@ -99,7 +100,17 @@ async def list_synthetic_queue(
         limit=limit,
         offset=offset,
     )
-    return SyntheticEvalQueueResponse.model_validate(queue)
+    return SyntheticEvalQueueResponse.model_validate(
+        {
+            **queue,
+            "pagination": build_offset_pagination_meta(
+                total=queue["total"],
+                limit=limit,
+                offset=offset,
+                count=len(queue["data"]),
+            ),
+        }
+    )
 
 
 @synthetic_router.post(

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Query
 from fastapi.routing import APIRoute
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, rbac_rate_limit, RequireRole, User
-
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 
 # Import unified schemas
 from tldw_Server_API.app.api.v1.schemas.evaluation_schemas_unified import (
@@ -2151,7 +2151,13 @@ async def get_evaluation_history(
                         "end": request.end_date.isoformat() if request.end_date else None
                     }
                 }
-            }
+            },
+            pagination=build_offset_pagination_meta(
+                total=total_count,
+                limit=request.limit or 100,
+                offset=request.offset or 0,
+                count=len(evaluations),
+            ),
         )
 
     except _EVALS_NONCRITICAL_EXCEPTIONS as e:

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Query
 from fastapi.routing import APIRoute
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, rbac_rate_limit, RequireRole, User
+
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 
 # Import unified schemas

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -26,6 +26,7 @@ from tldw_Server_API.app.api.v1.schemas.flashcards import (
     Flashcard,
     FlashcardAnalyticsSummaryResponse,
     FlashcardAssetMetadata,
+    FlashcardBulkCreateResponse,
     FlashcardBulkUpdateError,
     FlashcardBulkUpdateItem,
     FlashcardBulkUpdateResponse,
@@ -907,7 +908,7 @@ def create_flashcard(payload: FlashcardCreate, db: CharactersRAGDB = Depends(get
         raise map_db_error_to_http(exc, default_detail="Failed to create flashcard") from exc
 
 
-@router.post("/bulk", response_model=FlashcardListResponse)
+@router.post("/bulk", response_model=FlashcardBulkCreateResponse)
 def create_flashcards_bulk(payload: list[FlashcardCreate], db: CharactersRAGDB = Depends(get_chacha_db_for_user)):
     try:
         card_dicts = []

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -11,6 +11,7 @@ from fastapi.responses import Response, StreamingResponse
 from loguru import logger
 from pydantic import BaseModel
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_owner, get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit, get_auth_principal, get_request_user, User
@@ -1104,7 +1105,18 @@ def list_flashcards(
             q=q,
             include_deleted=False,
         )
-        return {"items": items, "count": len(items), "total": int(total)}
+        total_int = int(total)
+        return {
+            "items": items,
+            "count": len(items),
+            "total": total_int,
+            "pagination": build_offset_pagination_meta(
+                total=total_int,
+                limit=limit,
+                offset=offset,
+                count=len(items),
+            ),
+        }
     except CharactersRAGDBError as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to list flashcards") from exc
 

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -2360,10 +2360,17 @@ def list_flashcard_templates(
 
     try:
         items = db.list_flashcard_templates(limit=limit, offset=offset)
+        total = db.count_flashcard_templates()
         return FlashcardTemplateListResponse(
             items=items,
             count=len(items),
-            total=db.count_flashcard_templates(),
+            total=total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(items),
+            ),
         )
     except CharactersRAGDBError as exc:
         raise map_db_error_to_http(

--- a/tldw_Server_API/app/api/v1/endpoints/media/document_references.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/document_references.py
@@ -15,6 +15,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac_rate_limit, User
 
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.document_references import (
     DocumentReferencesResponse,
     ReferenceEntry,
@@ -1430,6 +1431,17 @@ async def get_document_references(
     cached = get_cached_response(cache_key)
     if cached is not None:
         _etag, payload = cached
+        if "pagination" not in payload:
+            payload = dict(payload)
+            cached_refs = payload.get("references") or []
+            cached_count = int(payload.get("returned_count") or len(cached_refs))
+            cached_limit = int(payload.get("limit") or cached_count or 1)
+            payload["pagination"] = build_offset_pagination_meta(
+                total=int(payload.get("total_available") or 0),
+                limit=max(1, cached_limit),
+                offset=int(payload.get("offset") or 0),
+                count=cached_count,
+            )
         logger.debug("Returning cached references for media_id={}", media_id)
         return DocumentReferencesResponse(**payload)
 
@@ -1599,6 +1611,12 @@ async def get_document_references(
             total_available=total_available,
             has_more=False,
             next_offset=None,
+            pagination=build_offset_pagination_meta(
+                total=total_available,
+                limit=limit,
+                offset=offset,
+                count=0,
+            ),
         )
         cache_response(cache_key, response.model_dump(), media_id=media_id)
         return response
@@ -1694,6 +1712,12 @@ async def get_document_references(
         total_available=total_available,
         has_more=has_more,
         next_offset=page_end if has_more else None,
+        pagination=build_offset_pagination_meta(
+            total=total_available,
+            limit=limit,
+            offset=offset,
+            count=returned_count,
+        ),
     )
     cache_response(cache_key, response.model_dump(), media_id=media_id)
     return response

--- a/tldw_Server_API/app/api/v1/endpoints/media/document_references.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/document_references.py
@@ -1436,8 +1436,9 @@ async def get_document_references(
             cached_refs = payload.get("references") or []
             cached_count = int(payload.get("returned_count") or len(cached_refs))
             cached_limit = int(payload.get("limit") or cached_count or 1)
+            raw_total_available = payload.get("total_available")
             payload["pagination"] = build_offset_pagination_meta(
-                total=int(payload.get("total_available") or 0),
+                total=int(raw_total_available if raw_total_available is not None else cached_count or 0),
                 limit=max(1, cached_limit),
                 offset=int(payload.get("offset") or 0),
                 count=cached_count,

--- a/tldw_Server_API/app/api/v1/endpoints/media/listing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/listing.py
@@ -20,10 +20,12 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import (
     get_media_db_for_user,
     try_get_media_db_for_user,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_page_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.media_request_models import SearchRequest
 from tldw_Server_API.app.api.v1.schemas.media_response_models import (
     MediaListItem,
     MediaListResponse,
+    PaginationInfo,
 )
 from tldw_Server_API.app.api.v1.utils.cache import generate_etag, is_not_modified
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
@@ -309,14 +311,20 @@ async def list_media_endpoint(
                 base_payload["keywords"] = keywords_map.get(mid, [])
             items.append(base_payload)
 
+        pagination_info = PaginationInfo(
+            results_per_page=int(results_per_page),
+            total_items=int(total_items),
+            **build_page_pagination_meta(
+                page=int(current_page),
+                per_page=int(results_per_page),
+                total=int(total_items),
+                total_pages=int(total_pages),
+            ).model_dump(),
+        )
+
         payload: dict[str, Any] = {
             "items": items,
-            "pagination": {
-                "page": int(current_page),
-                "results_per_page": int(results_per_page),
-                "total_pages": int(total_pages),
-                "total_items": int(total_items),
-            },
+            "pagination": pagination_info.model_dump(),
         }
 
         if include_keywords and keywords_available is not None:
@@ -470,14 +478,20 @@ async def list_media_trash_endpoint(
                 base_payload["keywords"] = keywords_map.get(mid, [])
             items.append(base_payload)
 
+        pagination_info = PaginationInfo(
+            results_per_page=int(results_per_page),
+            total_items=int(total_items),
+            **build_page_pagination_meta(
+                page=int(current_page),
+                per_page=int(results_per_page),
+                total=int(total_items),
+                total_pages=int(total_pages),
+            ).model_dump(),
+        )
+
         payload: dict[str, Any] = {
             "items": items,
-            "pagination": {
-                "page": int(current_page),
-                "results_per_page": int(results_per_page),
-                "total_pages": int(total_pages),
-                "total_items": int(total_items),
-            },
+            "pagination": pagination_info.model_dump(),
         }
 
         if include_keywords and keywords_available is not None:
@@ -1009,15 +1023,15 @@ async def search_media_items(
 
         total_pages = ceil(total_items / results_per_page) if results_per_page > 0 and total_items > 0 else 0
 
-        from tldw_Server_API.app.api.v1.schemas.media_response_models import (
-            PaginationInfo,
-        )
-
         pagination_info = PaginationInfo(
-            page=page,
             results_per_page=results_per_page,
-            total_pages=total_pages,
             total_items=total_items,
+            **build_page_pagination_meta(
+                page=page,
+                per_page=results_per_page,
+                total=total_items,
+                total_pages=total_pages,
+            ).model_dump(),
         )
 
         try:

--- a/tldw_Server_API/app/api/v1/endpoints/monitoring.py
+++ b/tldw_Server_API/app/api/v1/endpoints/monitoring.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequirePermission, get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.monitoring_schemas import (
     AlertItem,
     AlertsListResponse,
@@ -366,7 +367,16 @@ async def list_alerts(
             overlay_by_identity.get(alert_identity),
         )
         items.append(AlertItem(**merged_row))
-    return AlertsListResponse(items=items)
+    return AlertsListResponse(
+        items=items,
+        total=None,
+        pagination=build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            total=None,
+            count=len(items),
+        ),
+    )
 
 
 @router.post(

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -2536,6 +2536,7 @@ async def list_moodboards_endpoint(
                 headers={"Retry-After": str(meta.get("retry_after", 60))},
             )
         rows = await _run_db_call(db.list_moodboards, limit=limit, offset=offset, include_deleted=include_deleted)
+        total = await _run_db_call(db.count_moodboards, include_deleted=include_deleted)
         payload = [_normalize_moodboard_payload(row) for row in rows]
         return MoodboardListResponse(
             items=payload,
@@ -2543,6 +2544,13 @@ async def list_moodboards_endpoint(
             count=len(payload),
             limit=limit,
             offset=offset,
+            total=total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(payload),
+            ),
         )
     except _NOTES_NONCRITICAL_EXCEPTIONS as e:
         handle_db_errors(e, "moodboard")

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -1302,6 +1302,12 @@ async def list_notes(
             "limit": limit,
             "offset": offset,
             "total": total,
+            "pagination": build_offset_pagination_meta(
+                limit=limit,
+                offset=offset,
+                total=total,
+                count=len(notes_data),
+            ),
         }
     except _NOTES_NONCRITICAL_EXCEPTIONS as e:
         handle_db_errors(e, "notes list")
@@ -1357,6 +1363,12 @@ async def list_deleted_notes(
             "limit": limit,
             "offset": offset,
             "total": total,
+            "pagination": build_offset_pagination_meta(
+                limit=limit,
+                offset=offset,
+                total=total,
+                count=len(notes_data),
+            ),
         }
     except _NOTES_NONCRITICAL_EXCEPTIONS as e:
         handle_db_errors(e, "deleted notes list")

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -1898,19 +1898,24 @@ async def list_keyword_collections_endpoint(
             )
 
         collections_data = db.list_keyword_collections(limit=limit, offset=offset)
-        total = db.count_keyword_collections()
+        total = None
+        try:
+            total = db.count_keyword_collections()
+        except _NOTES_NONCRITICAL_EXCEPTIONS as count_exc:
+            logger.warning("Counting keyword collections failed: {}", count_exc)
         if include_keywords:
             collections_data = [
                 _attach_collection_keywords_inline(db, dict(row))
                 for row in collections_data
             ]
+        response_total = total if total is not None else offset + len(collections_data)
 
         return {
             "collections": collections_data,
             "count": len(collections_data),
             "limit": limit,
             "offset": offset,
-            "total": total,
+            "total": response_total,
             "pagination": build_offset_pagination_meta(
                 total=total,
                 limit=limit,
@@ -2537,7 +2542,11 @@ async def list_moodboards_endpoint(
                 headers={"Retry-After": str(meta.get("retry_after", 60))},
             )
         rows = await _run_db_call(db.list_moodboards, limit=limit, offset=offset, include_deleted=include_deleted)
-        total = await _run_db_call(db.count_moodboards, include_deleted=include_deleted)
+        total = None
+        try:
+            total = await _run_db_call(db.count_moodboards, include_deleted=include_deleted)
+        except _NOTES_NONCRITICAL_EXCEPTIONS as count_exc:
+            logger.warning("Counting moodboards failed: {}", count_exc)
         payload = [_normalize_moodboard_payload(row) for row in rows]
         return MoodboardListResponse(
             items=payload,

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -1897,6 +1897,7 @@ async def list_keyword_collections_endpoint(
             )
 
         collections_data = db.list_keyword_collections(limit=limit, offset=offset)
+        total = db.count_keyword_collections()
         if include_keywords:
             collections_data = [
                 _attach_collection_keywords_inline(db, dict(row))
@@ -1908,7 +1909,13 @@ async def list_keyword_collections_endpoint(
             "count": len(collections_data),
             "limit": limit,
             "offset": offset,
-            "total": None,
+            "total": total,
+            "pagination": build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(collections_data),
+            ),
         }
     except _NOTES_NONCRITICAL_EXCEPTIONS as e:
         handle_db_errors(e, "collection")

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -30,6 +30,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
+
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 
 # Dependency to get user-specific ChaChaNotes_DB instance

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -30,7 +30,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
-
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 
 # Dependency to get user-specific ChaChaNotes_DB instance
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import (
@@ -2766,6 +2766,12 @@ async def list_moodboard_notes_endpoint(
             limit=limit,
             offset=offset,
             total=total,
+            pagination=build_offset_pagination_meta(
+                limit=limit,
+                offset=offset,
+                total=total,
+                count=len(notes),
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/orgs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/orgs.py
@@ -106,47 +106,23 @@ async def list_my_orgs(
     db_pool = await get_db_pool()
     repo = AuthnzOrgsTeamsRepo(db_pool=db_pool)
 
-    # Get user's org memberships
-    memberships = await repo.list_org_memberships_for_user(principal.user_id)
-    org_ids = [m["org_id"] for m in memberships]
-
-    if not org_ids:
-        return OrganizationListResponse(
-            items=[],
-            total=0,
-            limit=limit,
-            offset=offset,
-            has_more=False,
-            pagination=build_offset_pagination_meta(
-                limit=limit,
-                offset=offset,
-                total=0,
-                count=0,
-            ),
-        )
-
-    # Fetch org details
-    all_orgs, _ = await repo.list_organizations(with_total=True, limit=1000, offset=0)
-
-    # Filter to user's orgs and add role info
-    user_orgs = []
-    for org in all_orgs:
-        if org["id"] in org_ids:
-            user_orgs.append(org)
-
-    # Apply pagination
-    paginated = user_orgs[offset : offset + limit]
+    paginated, total = await repo.list_organizations_for_user(
+        principal.user_id,
+        limit=limit,
+        offset=offset,
+        with_total=True,
+    )
 
     return OrganizationListResponse(
         items=[OrganizationResponse(**org) for org in paginated],
-        total=len(user_orgs),
+        total=total,
         limit=limit,
         offset=offset,
-        has_more=offset + limit < len(user_orgs),
+        has_more=offset + len(paginated) < total,
         pagination=build_offset_pagination_meta(
             limit=limit,
             offset=offset,
-            total=len(user_orgs),
+            total=total,
             count=len(paginated),
         ),
     )

--- a/tldw_Server_API/app/api/v1/endpoints/orgs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/orgs.py
@@ -13,6 +13,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
     get_or_create_audit_service_for_user_id,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_auth_principal,
     get_db_transaction,
@@ -805,6 +806,14 @@ async def list_invites(
     return OrgInviteListResponse(
         items=[OrgInviteResponse(**inv) for inv in invites],
         total=total,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            total=total,
+            count=len(invites),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/orgs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/orgs.py
@@ -117,6 +117,12 @@ async def list_my_orgs(
             limit=limit,
             offset=offset,
             has_more=False,
+            pagination=build_offset_pagination_meta(
+                limit=limit,
+                offset=offset,
+                total=0,
+                count=0,
+            ),
         )
 
     # Fetch org details
@@ -137,6 +143,12 @@ async def list_my_orgs(
         limit=limit,
         offset=offset,
         has_more=offset + limit < len(user_orgs),
+        pagination=build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            total=len(user_orgs),
+            count=len(paginated),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/outputs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/outputs.py
@@ -14,6 +14,7 @@ from starlette.responses import FileResponse
 
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.endpoints.outputs_templates import (
     _build_items_context_from_media_ids,
     _select_media_ids_for_run,
@@ -146,7 +147,18 @@ async def list_outputs(
                 workspace_tag=r.workspace_tag,
             )
         )
-    return OutputListResponse(items=items, total=total, page=page, size=limit)
+    return OutputListResponse(
+        items=items,
+        total=total,
+        page=page,
+        size=limit,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 @router.get("/deleted", response_model=OutputListResponse, summary="List only soft-deleted outputs")
@@ -189,7 +201,18 @@ async def list_deleted_outputs(
                 workspace_tag=r.workspace_tag,
             )
         )
-    return OutputListResponse(items=items, total=total, page=page, size=limit)
+    return OutputListResponse(
+        items=items,
+        total=total,
+        page=page,
+        size=limit,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 @router.post("", response_model=OutputArtifact, summary="Generate and persist a rendered output artifact")

--- a/tldw_Server_API/app/api/v1/endpoints/outputs_templates.py
+++ b/tldw_Server_API/app/api/v1/endpoints/outputs_templates.py
@@ -18,6 +18,7 @@ from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.outputs_templates_schemas import (
     OutputTemplate,
     OutputTemplateCreate,
@@ -64,6 +65,12 @@ async def list_output_templates(
             for i in items
         ],
         total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -28,6 +28,7 @@ import contextlib
 
 from tldw_Server_API.app.api.v1.API_Deps.backpressure import guard_backpressure_and_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_page_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.paper_search_schemas import (
     BioRxivFunderPaper,
     BioRxivFunderSearchRequestForm,
@@ -298,6 +299,12 @@ async def paper_search_arxiv(
         page=search_params.page,
         results_per_page=search_params.results_per_page,
         total_pages=total_pages,
+        pagination=build_page_pagination_meta(
+            page=search_params.page,
+            per_page=search_params.results_per_page,
+            total=total_results_from_api,
+            total_pages=total_pages,
+        ),
     )
 
 
@@ -355,7 +362,13 @@ async def paper_search_biorxiv(
         total_results=total_results,
         page=search_params.page,
         results_per_page=search_params.results_per_page,
-    total_pages=total_pages,
+        total_pages=total_pages,
+        pagination=build_page_pagination_meta(
+            page=search_params.page,
+            per_page=search_params.results_per_page,
+            total=total_results,
+            total_pages=total_pages,
+        ),
     )
 
 
@@ -1684,6 +1697,12 @@ async def paper_search_semantic_scholar(
         next_offset=next_offset_api,
         page=search_params.page,
         total_pages=total_pages,
+        pagination=build_page_pagination_meta(
+            page=search_params.page,
+            per_page=search_params.results_per_page,
+            total=total_results_api,
+            total_pages=total_pages,
+        ),
     )
 
 
@@ -1814,6 +1833,12 @@ async def paper_search_pubmed(
         page=search_params.page,
         results_per_page=search_params.results_per_page,
         total_pages=total_pages,
+        pagination=build_page_pagination_meta(
+            page=search_params.page,
+            per_page=search_params.results_per_page,
+            total=total_results,
+            total_pages=total_pages,
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -4064,7 +4064,7 @@ async def osf_raw_by_id(osf_id: str = Query(..., min_length=3)):
 
 @router.get(
     "/zenodo",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search Zenodo published records",
     tags=["paper-search"],
 )
@@ -4084,13 +4084,19 @@ async def zenodo_search(
         if items is None:
             raise HTTPException(status_code=500, detail="Zenodo search failed to return data.")  # noqa: TRY301
         total_pages = math.ceil(total / results_per_page) if results_per_page > 0 else 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={"q": q, "type": type, "subtype": subtype, "communities": communities},
             items=[GenericPaper(**it) for it in items],
             total_results=total,
             page=page,
             results_per_page=results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=page,
+                per_page=results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise
@@ -5183,7 +5189,7 @@ async def vixra_ingest(
 
 @router.get(
     "/vixra/search",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Best-effort viXra search (HTML scrape)",
     tags=["paper-search"],
 )
@@ -5199,13 +5205,19 @@ async def vixra_search(
             _handle_provider_error(err)
         items = items or []
         total_pages = 1 if items else 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={"term": term},
             items=[GenericPaper(**it) for it in items],
             total_results=total,
             page=page,
             results_per_page=results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=page,
+                per_page=results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -5204,7 +5204,8 @@ async def vixra_search(
         if err:
             _handle_provider_error(err)
         items = items or []
-        total_pages = 1 if items else 0
+        total_count = int(total or 0)
+        total_pages = math.ceil(total_count / results_per_page) if total_count else 0
         return GenericPageSearchResponse(
             query_echo={"term": term},
             items=[GenericPaper(**it) for it in items],

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -2459,7 +2459,7 @@ async def repec_citations(handle: str = Query(..., min_length=8)):
 
 @router.get(
     "/ieee",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search IEEE Xplore (scaffold)",
     tags=["paper-search"],
 )
@@ -2485,7 +2485,7 @@ async def paper_search_ieee(search_params: IEEESearchRequestForm = Depends()):
         total_pages = math.ceil(total / search_params.results_per_page) if search_params.results_per_page > 0 else 0
         if total == 0:
             total_pages = 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={
                 "q": search_params.q,
                 "from_year": search_params.from_year,
@@ -2498,6 +2498,12 @@ async def paper_search_ieee(search_params: IEEESearchRequestForm = Depends()):
             page=search_params.page,
             results_per_page=search_params.results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=search_params.page,
+                per_page=search_params.results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise
@@ -2552,7 +2558,7 @@ async def paper_search_ieee_by_id(article_number: str = Query(...)):
 
 @router.get(
     "/springer",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search Springer Nature (scaffold)",
     tags=["paper-search"],
 )
@@ -2577,7 +2583,7 @@ async def paper_search_springer(search_params: SimpleVenueSearchForm = Depends()
         total_pages = math.ceil(total / search_params.results_per_page) if search_params.results_per_page > 0 else 0
         if total == 0:
             total_pages = 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={
                 "q": search_params.q,
                 "journal": search_params.venue,
@@ -2589,6 +2595,12 @@ async def paper_search_springer(search_params: SimpleVenueSearchForm = Depends()
             page=search_params.page,
             results_per_page=search_params.results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=search_params.page,
+                per_page=search_params.results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -2633,7 +2633,7 @@ async def paper_search_springer_by_doi(params: DOIRequestForm = Depends()):
 
 @router.get(
     "/scopus",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search Elsevier Scopus (scaffold)",
     tags=["paper-search"],
 )
@@ -2665,7 +2665,7 @@ async def paper_search_scopus(
         total_pages = math.ceil(total / results_per_page) if results_per_page > 0 else 0
         if total == 0:
             total_pages = 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={
                 "q": q,
                 "from_year": from_year,
@@ -2677,6 +2677,12 @@ async def paper_search_scopus(
             page=page,
             results_per_page=results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=page,
+                per_page=results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise
@@ -3463,7 +3469,7 @@ async def ingest_batch(
 
 @router.get(
     "/chemrxiv/items",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search ChemRxiv items",
     tags=["paper-search"],
 )
@@ -3490,7 +3496,7 @@ async def chemrxiv_items(search: ChemRxivSearchRequestForm = Depends()):
             raise HTTPException(status_code=500, detail="ChemRxiv search failed to return data.")  # noqa: TRY301
         page = (search.skip // max(1, search.limit)) + 1
         total_pages = math.ceil(total / search.limit) if search.limit > 0 else 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={
                 "term": search.term,
                 "skip": search.skip,
@@ -3503,6 +3509,12 @@ async def chemrxiv_items(search: ChemRxivSearchRequestForm = Depends()):
             page=page,
             results_per_page=search.limit,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=page,
+                per_page=search.limit,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -1933,6 +1933,12 @@ async def paper_search_biorxiv_publisher(
             page=search_params.page,
             results_per_page=search_params.results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=search_params.page,
+                per_page=search_params.results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise
@@ -1985,6 +1991,12 @@ async def paper_search_biorxiv_pub(
             page=search_params.page,
             results_per_page=search_params.results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=search_params.page,
+                per_page=search_params.results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -2709,7 +2709,7 @@ async def paper_search_scopus_by_doi(params: DOIRequestForm = Depends()):
 
 @router.get(
     "/acm",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search ACM Digital Library via aggregators (scaffold)",
     tags=["paper-search"],
 )
@@ -2736,7 +2736,7 @@ async def paper_search_acm(search_params: SimpleVenueSearchForm = Depends()):
         total_pages = math.ceil(total / search_params.results_per_page) if search_params.results_per_page > 0 else 0
         if total == 0:
             total_pages = 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={
                 "q": search_params.q,
                 "venue": search_params.venue or "ACM",
@@ -2748,6 +2748,12 @@ async def paper_search_acm(search_params: SimpleVenueSearchForm = Depends()):
             page=search_params.page,
             results_per_page=search_params.results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=search_params.page,
+                per_page=search_params.results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise
@@ -2780,7 +2786,7 @@ async def paper_search_acm_by_doi(params: DOIRequestForm = Depends()):
 
 @router.get(
     "/wiley",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search Wiley via aggregators (scaffold)",
     tags=["paper-search"],
 )
@@ -2806,7 +2812,7 @@ async def paper_search_wiley(search_params: SimpleVenueSearchForm = Depends()):
         total_pages = math.ceil(total / search_params.results_per_page) if search_params.results_per_page > 0 else 0
         if total == 0:
             total_pages = 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={
                 "q": search_params.q,
                 "venue": search_params.venue or "Wiley",
@@ -2818,6 +2824,12 @@ async def paper_search_wiley(search_params: SimpleVenueSearchForm = Depends()):
             page=search_params.page,
             results_per_page=search_params.results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=search_params.page,
+                per_page=search_params.results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -2043,6 +2043,12 @@ async def paper_search_biorxiv_funder(
             page=search_params.page,
             results_per_page=search_params.results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=search_params.page,
+                per_page=search_params.results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -1770,6 +1770,12 @@ async def paper_search_biorxiv_pubs(
         page=search_params.page,
         results_per_page=search_params.results_per_page,
         total_pages=total_pages,
+        pagination=build_page_pagination_meta(
+            page=search_params.page,
+            per_page=search_params.results_per_page,
+            total=total_results,
+            total_pages=total_pages,
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -2306,6 +2306,7 @@ from tldw_Server_API.app.api.v1.schemas.paper_search_schemas import (  # noqa: E
     ChemRxivSearchRequestForm,
     DOIRequestForm,
     GenericPaper,
+    GenericPageSearchResponse,
     GenericSearchResponse,
     IacrConferenceResponse,
     IEEESearchRequestForm,
@@ -4296,7 +4297,7 @@ async def zenodo_ingest(
 
 @router.get(
     "/figshare",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search Figshare records",
     tags=["paper-search"],
 )
@@ -4316,13 +4317,19 @@ async def figshare_search(
         if items is None:
             raise HTTPException(status_code=500, detail="Figshare search failed to return data.")  # noqa: TRY301
         total_pages = math.ceil(total / results_per_page) if results_per_page > 0 else 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={"q": q, "search_for": search_for, "order": order, "order_direction": order_direction},
             items=[GenericPaper(**it) for it in items],
             total_results=total,
             page=page,
             results_per_page=results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=page,
+                per_page=results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise
@@ -4720,7 +4727,7 @@ async def figshare_ingest_by_doi(
 
 @router.get(
     "/hal",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search HAL (Solr-like)",
     tags=["paper-search"],
 )
@@ -4743,13 +4750,19 @@ async def hal_search(
         if items is None:
             raise HTTPException(status_code=500, detail="HAL search failed to return data.")  # noqa: TRY301
         total_pages = math.ceil(total / results_per_page) if results_per_page > 0 else 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={"q": q, "fl": fl, "fq": fqs, "sort": sort, "scope": scope},
             items=[GenericPaper(**it) for it in items],
             total_results=total,
             page=page,
             results_per_page=results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=page,
+                per_page=results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -3683,7 +3683,7 @@ async def iacr_conf_raw(
 
 @router.get(
     "/earthrxiv",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search EarthArXiv (OSF) preprints",
     tags=["paper-search"],
 )
@@ -3701,13 +3701,19 @@ async def earthrxiv_search(
         if items is None:
             raise HTTPException(status_code=500, detail="EarthArXiv search failed to return data.")  # noqa: TRY301
         total_pages = math.ceil(total / results_per_page) if results_per_page > 0 else 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={"term": term, "from_date": from_date},
             items=[GenericPaper(**it) for it in items],
             total_results=total,
             page=page,
             results_per_page=results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=page,
+                per_page=results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise
@@ -3764,7 +3770,7 @@ async def earthrxiv_by_doi(doi: str = Query(..., min_length=3)):
 
 @router.get(
     "/osf",
-    response_model=GenericSearchResponse,
+    response_model=GenericPageSearchResponse,
     summary="Search OSF preprints (all providers or a specific provider)",
     tags=["paper-search"],
 )
@@ -3785,7 +3791,7 @@ async def osf_search(search: OSFSearchRequestForm = Depends()):
         if items is None:
             raise HTTPException(status_code=500, detail="OSF search failed to return data.")  # noqa: TRY301
         total_pages = math.ceil(total / search.results_per_page) if search.results_per_page > 0 else 0
-        return GenericSearchResponse(
+        return GenericPageSearchResponse(
             query_echo={
                 "term": search.term,
                 "provider": search.provider,
@@ -3796,6 +3802,12 @@ async def osf_search(search: OSFSearchRequestForm = Depends()):
             page=search.page,
             results_per_page=search.results_per_page,
             total_pages=total_pages,
+            pagination=build_page_pagination_meta(
+                page=search.page,
+                per_page=search.results_per_page,
+                total=total,
+                total_pages=total_pages,
+            ),
         )
     except HTTPException:
         raise

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_projects.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_projects.py
@@ -39,6 +39,7 @@ from tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps import (
     require_project_access,
     require_project_write_access,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_page_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 
 # Local imports
@@ -302,7 +303,14 @@ async def list_projects(
             "success": True,
             "data": projects,
             "metadata": result["pagination"],
-            "pagination": result["pagination"],
+            "pagination": model_dump_compat(
+                build_page_pagination_meta(
+                    page=result["pagination"]["page"],
+                    per_page=result["pagination"]["per_page"],
+                    total=result["pagination"]["total"],
+                    total_pages=result["pagination"]["total_pages"],
+                )
+            ),
             "projects": [p.model_dump() if hasattr(p, 'model_dump') else dict(p) for p in projects]
         }
 

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -546,16 +546,30 @@ async def list_prompts(
             include_deleted=include_deleted,
         )
         prompts = [PromptResponse(**prompt) for prompt in result.get("prompts", [])]
+        pagination_data = result.get("pagination") or {}
+        page_value = int(pagination_data.get("page") or page)
+        per_page_value = int(pagination_data.get("per_page") or pagination_data.get("limit") or per_page)
+        total_value = int(pagination_data.get("total") if pagination_data.get("total") is not None else len(prompts))
+        total_pages_value = pagination_data.get("total_pages")
+        if total_pages_value is None:
+            total_pages_value = (total_value + per_page_value - 1) // per_page_value if total_value else 0
+        total_pages_value = int(total_pages_value)
+        metadata = {
+            "page": page_value,
+            "per_page": per_page_value,
+            "total": total_value,
+            "total_pages": total_pages_value,
+        }
 
         return PageListResponse(
             success=True,
             data=prompts,
-            metadata=result.get("pagination", {}),
+            metadata=metadata,
             pagination=build_page_pagination_meta(
-                page=result["pagination"]["page"],
-                per_page=result["pagination"]["per_page"],
-                total=result["pagination"]["total"],
-                total_pages=result["pagination"]["total_pages"],
+                page=page_value,
+                per_page=per_page_value,
+                total=total_value,
+                total_pages=total_pages_value,
             ),
         )
 

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -33,10 +33,15 @@ from tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps import (
     require_project_access,
     require_project_write_access,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_page_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 
 # Local imports
-from tldw_Server_API.app.api.v1.schemas.prompt_studio_base import ListResponse, StandardResponse
+from tldw_Server_API.app.api.v1.schemas.prompt_studio_base import (
+    ListResponse,
+    PageListResponse,
+    StandardResponse,
+)
 from tldw_Server_API.app.api.v1.schemas.prompt_studio_project import (
     PromptCreate,
     StructuredPromptConvertRequest,
@@ -482,7 +487,7 @@ async def create_prompt(
 
 @router.get(
     "/list/{project_id}",
-    response_model=ListResponse,
+    response_model=PageListResponse,
     openapi_extra={
         "responses": {
             "200": {
@@ -519,7 +524,7 @@ async def list_prompts(
     include_deleted: bool = Query(False, description="Include deleted prompts"),
     _: bool = Depends(require_project_access),
     db: PromptStudioDatabase = Depends(get_prompt_studio_db)
-) -> ListResponse:
+) -> PageListResponse:
     """
     List prompts in a project.
 
@@ -542,10 +547,16 @@ async def list_prompts(
         )
         prompts = [PromptResponse(**prompt) for prompt in result.get("prompts", [])]
 
-        return ListResponse(
+        return PageListResponse(
             success=True,
             data=prompts,
             metadata=result.get("pagination", {}),
+            pagination=build_page_pagination_meta(
+                page=result["pagination"]["page"],
+                per_page=result["pagination"]["per_page"],
+                total=result["pagination"]["total"],
+                total_pages=result["pagination"]["total_pages"],
+            ),
         )
 
     except (DatabaseError, InputError) as e:
@@ -565,7 +576,7 @@ async def list_prompts(
         ) from e
 
 # Simple alias that mirrors the canonical list response shape
-@router.get("", response_model=ListResponse)
+@router.get("", response_model=PageListResponse)
 async def list_prompts_simple(
     project_id: int = Query(..., description="Project ID"),
     page: int = Query(1, ge=1, description="Page number"),
@@ -573,7 +584,7 @@ async def list_prompts_simple(
     include_deleted: bool = Query(False, description="Include deleted prompts"),
     _: bool = Depends(require_project_access),
     db: PromptStudioDatabase = Depends(get_prompt_studio_db)
-) -> ListResponse:
+) -> PageListResponse:
     return await list_prompts(project_id, page, per_page, include_deleted, True, db)  # type: ignore[arg-type]
 
 # Simple execute endpoint used by tests

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_test_cases.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_test_cases.py
@@ -35,10 +35,15 @@ from tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps import (
     require_project_access,
     require_project_write_access,
 )
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_page_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 
 # Local imports
-from tldw_Server_API.app.api.v1.schemas.prompt_studio_base import ListResponse, StandardResponse
+from tldw_Server_API.app.api.v1.schemas.prompt_studio_base import (
+    ListResponse,
+    PageListResponse,
+    StandardResponse,
+)
 from tldw_Server_API.app.api.v1.schemas.prompt_studio_test import (
     RunTestCasesSimpleRequest,
     TestCaseBulkCreate,
@@ -318,7 +323,7 @@ async def create_bulk_test_cases(
 
 @router.get(
     "/list/{project_id}",
-    response_model=ListResponse,
+    response_model=PageListResponse,
     openapi_extra={
         "responses": {
             "200": {
@@ -358,7 +363,7 @@ async def list_test_cases(
     signature_id: Optional[int] = Query(None, description="Filter by signature"),
     _: bool = Depends(require_project_access),
     db: PromptStudioDatabase = Depends(get_prompt_studio_db)
-) -> ListResponse:
+) -> PageListResponse:
     """
     List test cases in a project.
 
@@ -395,10 +400,16 @@ async def list_test_cases(
             return_pagination=True
         )
 
-        return ListResponse(
+        return PageListResponse(
             success=True,
             data=[TestCaseResponse(**tc) for tc in result["test_cases"]],
-            metadata=result["pagination"]
+            metadata=result["pagination"],
+            pagination=build_page_pagination_meta(
+                page=result["pagination"]["page"],
+                per_page=result["pagination"]["per_page"],
+                total=result["pagination"]["total"],
+                total_pages=result["pagination"]["total_pages"],
+            ),
         )
 
     except DatabaseError as e:

--- a/tldw_Server_API/app/api/v1/endpoints/prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompts.py
@@ -15,6 +15,7 @@ from loguru import logger
 from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas import prompt_schemas as schemas
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings as get_auth_settings
@@ -1138,8 +1139,18 @@ async def list_collections(
 ):
     try:
         items = db.list_prompt_collections(limit=limit, offset=offset)
+        total = db.count_prompt_collections()
         return schemas.PromptCollectionListResponse(
-            collections=[schemas.PromptCollectionResponse(**item) for item in items]
+            collections=[schemas.PromptCollectionResponse(**item) for item in items],
+            total=total,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(items),
+            ),
         )
     except (InputError, DatabaseError) as e:
         logger.error("Database error listing prompt collections: {}", e, exc_info=True)

--- a/tldw_Server_API/app/api/v1/endpoints/quizzes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/quizzes.py
@@ -6,6 +6,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.utils.http_errors import map_db_error_to_http
 from tldw_Server_API.app.api.v1.schemas.quizzes import (
     AttemptListResponse,
@@ -164,13 +165,25 @@ def list_quizzes(
 ):
     """List quizzes with pagination and optional filters."""
     try:
-        return db.list_quizzes(
+        payload = db.list_quizzes(
             q=q,
             media_id=media_id,
             workspace_id=workspace_id,
             include_workspace_items=include_workspace_items,
             limit=limit,
             offset=offset,
+        )
+        items = list(payload.get("items") or [])
+        total = int(payload.get("count") or 0)
+        return QuizListResponse(
+            items=items,
+            count=total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                offset=offset,
+                limit=limit,
+                count=len(items),
+            ),
         )
     except (InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to list quizzes") from exc
@@ -332,7 +345,19 @@ def list_questions(
 ):
     """List all questions for a quiz (use include_answers=true for Manage/Edit flows)."""
     try:
-        return db.list_questions(quiz_id, q=q, include_answers=include_answers, limit=limit, offset=offset)
+        payload = db.list_questions(quiz_id, q=q, include_answers=include_answers, limit=limit, offset=offset)
+        items = list(payload.get("items") or [])
+        total = int(payload.get("count") or 0)
+        return QuestionListResponse(
+            items=items,
+            count=total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                offset=offset,
+                limit=limit,
+                count=len(items),
+            ),
+        )
     except (InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to list questions") from exc
 
@@ -450,7 +475,19 @@ def list_attempts(
 ):
     """List quiz attempts."""
     try:
-        return db.list_attempts(quiz_id=quiz_id, limit=limit, offset=offset)
+        payload = db.list_attempts(quiz_id=quiz_id, limit=limit, offset=offset)
+        items = list(payload.get("items") or [])
+        total = int(payload.get("count") or 0)
+        return AttemptListResponse(
+            items=items,
+            count=total,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                offset=offset,
+                limit=limit,
+                count=len(items),
+            ),
+        )
     except (InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to list attempts") from exc
 

--- a/tldw_Server_API/app/api/v1/endpoints/quizzes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/quizzes.py
@@ -333,7 +333,6 @@ def delete_quiz(
 @router.get(
     "/{quiz_id:int}/questions",
     response_model=QuestionListResponse,
-    response_model_exclude_none=True,
 )
 def list_questions(
     quiz_id: int,
@@ -466,7 +465,7 @@ def submit_attempt(
         raise map_db_error_to_http(exc, default_detail="Failed to submit attempt") from exc
 
 
-@router.get("/attempts", response_model=AttemptListResponse, response_model_exclude_none=True)
+@router.get("/attempts", response_model=AttemptListResponse)
 def list_attempts(
     quiz_id: Optional[int] = None,
     limit: int = Query(50, ge=1, le=200),

--- a/tldw_Server_API/app/api/v1/endpoints/reading.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading.py
@@ -903,6 +903,12 @@ async def list_reading_import_jobs(
         total=total,
         limit=limit,
         offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(jobs),
+        ),
     )
 
 
@@ -1632,4 +1638,15 @@ async def list_reading_digest_outputs(
 
     total_matches = len(matched)
     page = matched[offset : offset + limit]
-    return ReadingDigestOutputsListResponse(items=page, total=total_matches, limit=limit, offset=offset)
+    return ReadingDigestOutputsListResponse(
+        items=page,
+        total=total_matches,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total_matches,
+            limit=limit,
+            offset=offset,
+            count=len(page),
+        ),
+    )

--- a/tldw_Server_API/app/api/v1/endpoints/reading.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading.py
@@ -20,6 +20,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.endpoints.items import bulk_update_items as bulk_update_items_handler
 from tldw_Server_API.app.api.v1.schemas.audio_schemas import OpenAISpeechRequest
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import DEFAULT_LLM_PROVIDER
@@ -632,6 +633,12 @@ async def list_reading_saved_searches(
         total=int(total),
         limit=limit,
         offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=int(total),
+            limit=limit,
+            offset=offset,
+            count=len(rows),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/reading.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading.py
@@ -584,6 +584,12 @@ async def list_reading_items(
         size=size,
         offset=resolved_offset,
         limit=resolved_limit,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=resolved_limit,
+            offset=resolved_offset,
+            count=len(rows),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/research.py
+++ b/tldw_Server_API/app/api/v1/endpoints/research.py
@@ -18,6 +18,7 @@ from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 
 #
 # Local Imports
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_page_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.research_schemas import (
     ArxivPaper,
     ArxivSearchRequestForm,
@@ -183,6 +184,12 @@ async def arxiv_search_endpoint(
         page=search_params.page,
         results_per_page=search_params.results_per_page,
         total_pages=total_pages_calculated,
+        pagination=build_page_pagination_meta(
+            page=search_params.page,
+            per_page=search_params.results_per_page,
+            total=total_results_from_api,
+            total_pages=total_pages_calculated,
+        ),
     )
 
 # FIXME - This needs to be updated/Integrated
@@ -326,6 +333,12 @@ async def semantic_scholar_search_endpoint(
         next_offset=next_offset_api,
         page=search_params.page,  # The page number we calculated offset from
         total_pages=total_pages_calculated,
+        pagination=build_page_pagination_meta(
+            page=search_params.page,
+            per_page=search_params.results_per_page,
+            total=total_results_api,
+            total_pages=total_pages_calculated,
+        ),
     )
 
 #

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -31,6 +31,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, RequireRole, User
 
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminMacOSDiagnosticsResponse,
     SandboxAdminMacOSReconciliationRepairRequest,
@@ -2323,7 +2324,20 @@ async def admin_list_runs(
             )
         )
     has_more = (offset + len(items)) < int(total)
-    return SandboxAdminRunListResponse(total=int(total), limit=int(limit), offset=int(offset), has_more=bool(has_more), items=items)
+    total_count = int(total)
+    return SandboxAdminRunListResponse(
+        total=total_count,
+        limit=int(limit),
+        offset=int(offset),
+        has_more=bool(has_more),
+        pagination=build_offset_pagination_meta(
+            total=total_count,
+            limit=int(limit),
+            offset=int(offset),
+            count=len(items),
+        ),
+        items=items,
+    )
 
 
 @router.get(
@@ -2466,7 +2480,20 @@ async def admin_list_idempotency(
             )
         )
     has_more = (offset + len(items)) < int(total)
-    return SandboxAdminIdempotencyListResponse(total=int(total), limit=int(limit), offset=int(offset), has_more=bool(has_more), items=items)
+    total_count = int(total)
+    return SandboxAdminIdempotencyListResponse(
+        total=total_count,
+        limit=int(limit),
+        offset=int(offset),
+        has_more=bool(has_more),
+        pagination=build_offset_pagination_meta(
+            total=total_count,
+            limit=int(limit),
+            offset=int(offset),
+            count=len(items),
+        ),
+        items=items,
+    )
 
 
 @router.get(
@@ -2500,4 +2527,17 @@ async def admin_usage(
             )
         )
     has_more = (offset + len(items)) < int(total)
-    return SandboxAdminUsageResponse(total=int(total), limit=int(limit), offset=int(offset), has_more=bool(has_more), items=items)
+    total_count = int(total)
+    return SandboxAdminUsageResponse(
+        total=total_count,
+        limit=int(limit),
+        offset=int(offset),
+        has_more=bool(has_more),
+        pagination=build_offset_pagination_meta(
+            total=total_count,
+            limit=int(limit),
+            offset=int(offset),
+            count=len(items),
+        ),
+        items=items,
+    )

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -30,6 +30,7 @@ from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import CurrentPrincipal
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 
 # Local Imports
 from tldw_Server_API.app.api.v1.schemas.skills_schemas import (
@@ -135,6 +136,12 @@ async def list_skills(
             total=total,
             limit=limit,
             offset=offset,
+            pagination=build_offset_pagination_meta(
+                limit=limit,
+                offset=offset,
+                total=total,
+                count=len(skills),
+            ),
         )
     except SkillsError as e:
         logger.error("Error listing skills")

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Slides_DB_Deps import get_slides_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import DEFAULT_LLM_PROVIDER
 from tldw_Server_API.app.api.v1.schemas.slides_schemas import (
     ExportFormat,
@@ -1220,6 +1221,12 @@ async def list_presentations(
         total=total,
         limit=limit,
         offset=offset,
+        pagination=build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            total=total,
+            count=len(rows),
+        ),
     )
 
 
@@ -1242,6 +1249,12 @@ async def search_presentations(
         total=total,
         limit=limit,
         offset=offset,
+        pagination=build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            total=total,
+            count=len(rows),
+        ),
     )
 
 
@@ -1609,7 +1622,18 @@ async def list_visual_styles(
         ),
         *(_visual_style_response_from_row(row) for row in user_rows),
     ]
-    return VisualStyleListResponse(styles=styles, total_count=total_count, limit=limit, offset=offset)
+    return VisualStyleListResponse(
+        styles=styles,
+        total_count=total_count,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            total=total_count,
+            count=len(styles),
+        ),
+    )
 
 
 @router.get(
@@ -1796,7 +1820,18 @@ async def list_presentation_versions(
                 payload=payload,
             )
         )
-    return PresentationVersionListResponse(versions=versions, total=total, limit=limit, offset=offset)
+    return PresentationVersionListResponse(
+        versions=versions,
+        total=total,
+        limit=limit,
+        offset=offset,
+        pagination=build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            total=total,
+            count=len(versions),
+        ),
+    )
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/storage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage.py
@@ -15,7 +15,7 @@ from pathlib import Path as PathlibPath
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, User
-
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     BulkDeleteRequest,
     BulkDeleteResponse,
@@ -199,6 +199,12 @@ async def list_files(
         total=total,
         offset=offset,
         limit=limit,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(files),
+        ),
     )
 
 
@@ -589,6 +595,12 @@ async def list_trashed_files(
         total=total,
         offset=offset,
         limit=limit,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(files),
+        ),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/storage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage.py
@@ -15,6 +15,7 @@ from pathlib import Path as PathlibPath
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, User
+
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     BulkDeleteRequest,

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -47,6 +47,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, rbac
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Watchlists_DB_Deps import get_watchlists_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool as _get_db_pool
 from tldw_Server_API.app.core.AuthNZ.ip_allowlist import (
@@ -1550,7 +1551,16 @@ async def list_sources(
                 updated_at=r.updated_at,
             )
         )
-    return SourcesListResponse(items=items, total=total)
+    return SourcesListResponse(
+        items=items,
+        total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 # OPML import/export placed before /sources/{source_id} to avoid route conflicts
@@ -2440,7 +2450,17 @@ async def list_tags(
     limit = size
     offset = (page - 1) * limit
     rows, total = db.list_tags(q=q, limit=limit, offset=offset)
-    return TagsListResponse(items=[Tag(id=r.id, name=r.name) for r in rows], total=total)
+    items = [Tag(id=r.id, name=r.name) for r in rows]
+    return TagsListResponse(
+        items=items,
+        total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 # --------------------
@@ -2470,7 +2490,17 @@ async def list_groups(
     limit = size
     offset = (page - 1) * limit
     rows, total = db.list_groups(q=q, limit=limit, offset=offset)
-    return GroupsListResponse(items=[Group(id=r.id, name=r.name, description=r.description, parent_group_id=r.parent_group_id) for r in rows], total=total)
+    items = [Group(id=r.id, name=r.name, description=r.description, parent_group_id=r.parent_group_id) for r in rows]
+    return GroupsListResponse(
+        items=items,
+        total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 @router.patch("/groups/{group_id}", response_model=Group, summary="Update group")
@@ -3078,7 +3108,16 @@ async def list_jobs(
                 next_run_at=r.next_run_at,
             )
         )
-    return JobsListResponse(items=items, total=total)
+    return JobsListResponse(
+        items=items,
+        total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 @router.get("/jobs/{job_id}", response_model=Job, summary="Get job")

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -3616,7 +3616,18 @@ async def list_runs_for_job(
     rows, total = target_db.list_runs_for_job(job_id, limit=limit, offset=offset)
     items = [Run(id=r.id, job_id=r.job_id, status=r.status, started_at=r.started_at, finished_at=r.finished_at, stats=(json.loads(r.stats_json or "{}") if r.stats_json else None), error_msg=r.error_msg) for r in rows]
     has_more = (offset + len(items)) < int(total or 0)
-    return RunsListResponse(items=items, total=total, has_more=has_more)
+    return RunsListResponse(
+        items=items,
+        total=total,
+        has_more=has_more,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+            has_more=has_more,
+        ),
+    )
 
 
 @router.get("/runs", response_model=RunsListResponse, summary="List runs across all jobs")
@@ -3654,7 +3665,18 @@ async def list_runs_global(
         for r in rows
     ]
     has_more = (offset + len(items)) < int(total or 0)
-    return RunsListResponse(items=items, total=total, has_more=has_more)
+    return RunsListResponse(
+        items=items,
+        total=total,
+        has_more=has_more,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+            has_more=has_more,
+        ),
+    )
 
 
 @router.get("/runs/export.csv", response_class=PlainTextResponse, summary="Export runs as CSV (global or by job)")
@@ -4525,7 +4547,17 @@ async def list_scraped_items(
         limit=limit,
         offset=offset,
     )
-    return ScrapedItemsListResponse(items=[_row_to_scraped_item(r) for r in rows], total=total)
+    items = [_row_to_scraped_item(r) for r in rows]
+    return ScrapedItemsListResponse(
+        items=items,
+        total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 @router.get("/items/{item_id}", response_model=ScrapedItem, summary="Get a scraped item")

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -5464,7 +5464,16 @@ async def list_outputs(
         if metadata.get("origin") != "watchlists":
             continue
         items.append(_row_to_output(row, user_id=user_id))
-    return WatchlistOutputsListResponse(items=items, total=total)
+    return WatchlistOutputsListResponse(
+        items=items,
+        total=total,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(items),
+        ),
+    )
 
 
 @router.get("/outputs/{output_id}", response_model=WatchlistOutput, summary="Get output metadata")

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -33,6 +33,10 @@ from pydantic import BaseModel, Field, ValidationError
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, RequirePermission, RequireRole, resolve_user_id_for_request, TokenScopeGuard, User
 
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
+    build_cursor_pagination_meta,
+    build_offset_pagination_meta,
+)
 from tldw_Server_API.app.api.v1.schemas.workflows import (
     AdhocRunRequest,
     EventResponse,
@@ -2236,8 +2240,27 @@ async def list_runs(
         except _WORKFLOWS_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"Workflows runs: failed to set Link headers: {e}")
 
+    pagination = (
+        build_cursor_pagination_meta(
+            limit=limit,
+            cursor=cursor,
+            next_cursor=next_cursor,
+            has_more=has_more,
+        )
+        if cursor_ts is not None
+        else build_offset_pagination_meta(
+            limit=limit,
+            offset=offset,
+            count=len(items),
+            has_more=has_more,
+        )
+    )
+
     return WorkflowRunListResponse(
         runs=items,
+        limit=limit,
+        offset=None if cursor_ts is not None else offset,
+        pagination=pagination,
         next_offset=(offset + limit) if (has_more and cursor_ts is None) else None,
         next_cursor=next_cursor,
     )

--- a/tldw_Server_API/app/api/v1/endpoints/writing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/writing.py
@@ -16,6 +16,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.endpoints.llm_providers import get_configured_providers_async
 from tldw_Server_API.app.api.v1.schemas.writing_schemas import (
     WritingCapabilitiesResponse,
@@ -1018,7 +1019,18 @@ async def list_writing_sessions(
         sessions = db.list_writing_sessions(limit=limit, offset=offset)
         total = db.count_writing_sessions()
         items = [WritingSessionListItem(**item) for item in sessions]
-        return WritingSessionListResponse(sessions=items, total=total)
+        return WritingSessionListResponse(
+            sessions=items,
+            total=total,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(items),
+            ),
+        )
     except _WRITING_NONCRITICAL_EXCEPTIONS as exc:
         _handle_db_errors(exc, "writing sessions")
 
@@ -1197,6 +1209,14 @@ async def list_writing_templates(
         return WritingTemplateListResponse(
             templates=[WritingTemplateResponse(**tmpl) for tmpl in templates],
             total=total,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(templates),
+            ),
         )
     except _WRITING_NONCRITICAL_EXCEPTIONS as exc:
         _handle_db_errors(exc, "writing templates")
@@ -1355,6 +1375,14 @@ async def list_writing_themes(
         return WritingThemeListResponse(
             themes=[WritingThemeResponse(**theme) for theme in themes],
             total=total,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(themes),
+            ),
         )
     except _WRITING_NONCRITICAL_EXCEPTIONS as exc:
         _handle_db_errors(exc, "writing themes")

--- a/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/writing_manuscripts.py
@@ -9,6 +9,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_rate_limiter_dep, get_request_user, RateLimiter, rbac_rate_limit, User
 
 from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.writing_manuscript_schemas import (
     ChapterSummary,
     ManuscriptAnalysisListResponse,
@@ -212,7 +213,18 @@ async def list_projects(
             status_filter=status_filter, limit=limit, offset=offset
         )
         items = [ManuscriptProjectResponse(**p) for p in projects]
-        return ManuscriptProjectListResponse(projects=items, total=total)
+        return ManuscriptProjectListResponse(
+            projects=items,
+            total=total,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                limit=limit,
+                offset=offset,
+                total=total,
+                count=len(items),
+            ),
+        )
     except _MANUSCRIPT_NONCRITICAL_EXCEPTIONS as exc:
         _handle_db_errors(exc, "manuscript projects")
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -555,6 +555,7 @@ class AuditLogResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1188,6 +1189,7 @@ class SystemLogsResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -1812,6 +1812,7 @@ class LLMUsageLogResponse(BaseModel):
     total: int
     page: int
     limit: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -200,6 +200,7 @@ class UserListResponse(BaseModel):
     page: int
     limit: int
     pages: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1763,6 +1764,7 @@ class OrgBudgetListResponse(BaseModel):
     total: int
     page: int
     limit: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -1024,6 +1024,7 @@ class DataSubjectRequestListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -2573,6 +2573,9 @@ class AdminWebhookListResponse(BaseModel):
 
     items: list[AdminWebhookResponse]
     total: int
+    limit: int
+    offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -2607,6 +2610,9 @@ class AdminWebhookDeliveryLogListResponse(BaseModel):
 
     items: list[AdminWebhookDeliveryLogEntry]
     total: int
+    limit: int
+    offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -781,6 +781,7 @@ class MaintenanceRotationRunListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -694,6 +694,7 @@ class BackupScheduleListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -1470,6 +1470,7 @@ class WebhookListResponse(BaseModel):
     """Response for webhook listing."""
     items: list[WebhookItem]
     total: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, NonNegativeInt, SecretStr, field_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.Security.egress import evaluate_url_policy
 
 
@@ -638,6 +639,7 @@ class BackupListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -17,6 +17,10 @@ from tldw_Server_API.app.core.Security.egress import evaluate_url_policy
 
 
 def _default_offset_pagination_aliases(response):
+    if hasattr(response, "limit") and response.limit is None:
+        response.limit = response.pagination.limit
+    if hasattr(response, "offset") and response.offset is None:
+        response.offset = response.pagination.offset
     if response.has_more is None:
         response.has_more = response.pagination.has_more
     if response.next_offset is None:
@@ -1530,6 +1534,8 @@ class WebhookListResponse(BaseModel):
     """Response for webhook listing."""
     items: list[WebhookItem]
     total: int
+    limit: int | None = Field(default=None, ge=1, description="Alias for pagination.limit")
+    offset: int | None = Field(default=None, ge=0, description="Alias for pagination.offset")
     pagination: OffsetPaginationMeta
     has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
     next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -10,10 +10,18 @@ from typing import Any, Literal
 from urllib.parse import urlsplit
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, NonNegativeInt, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, NonNegativeInt, SecretStr, field_validator, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.Security.egress import evaluate_url_policy
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 def _blank_string_to_none(value: Any) -> Any:
@@ -201,6 +209,12 @@ class UserListResponse(BaseModel):
     limit: int
     pages: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -557,6 +571,12 @@ class AuditLogResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -642,6 +662,12 @@ class BackupListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -697,6 +723,12 @@ class BackupScheduleListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -785,6 +817,12 @@ class MaintenanceRotationRunListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1028,6 +1066,12 @@ class DataSubjectRequestListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1191,6 +1235,12 @@ class SystemLogsResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1361,6 +1411,12 @@ class IncidentListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1475,6 +1531,12 @@ class WebhookListResponse(BaseModel):
     items: list[WebhookItem]
     total: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1765,6 +1827,12 @@ class OrgBudgetListResponse(BaseModel):
     page: int
     limit: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -1813,6 +1881,12 @@ class LLMUsageLogResponse(BaseModel):
     page: int
     limit: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -2576,6 +2650,12 @@ class AdminWebhookListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -2613,6 +2693,12 @@ class AdminWebhookDeliveryLogListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -1356,6 +1356,7 @@ class IncidentListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Any, Literal, Union
 
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 # -----------------------------------------------------------------------------
 # Agent Types
@@ -444,6 +445,7 @@ class ACPSessionListResponse(BaseModel):
     """Response for listing ACP sessions."""
     sessions: list[ACPSessionInfo] = Field(default_factory=list)
     total: int = Field(default=0, description="Total number of sessions matching filters")
+    pagination: OffsetPaginationMeta
 
 
 class ACPSessionDetailResponse(ACPSessionInfo):

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -3,8 +3,17 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Literal, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
 
 # -----------------------------------------------------------------------------
 # Agent Types
@@ -446,6 +455,12 @@ class ACPSessionListResponse(BaseModel):
     sessions: list[ACPSessionInfo] = Field(default_factory=list)
     total: int = Field(default=0, description="Total number of sessions matching filters")
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ACPSessionDetailResponse(ACPSessionInfo):

--- a/tldw_Server_API/app/api/v1/schemas/audio_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/audio_schemas.py
@@ -12,6 +12,8 @@ from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import CursorPaginationMeta
+
 
 class NormalizationOptions(BaseModel):
     """Options for the normalization system"""
@@ -615,6 +617,7 @@ class TTSHistoryListResponse(BaseModel):
     limit: int
     offset: int
     next_cursor: Optional[str] = None
+    pagination: CursorPaginationMeta
 
 
 class TTSHistoryDetailResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/audiobook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/audiobook_schemas.py
@@ -21,6 +21,14 @@ AudiobookArtifactScope = Literal["chapter", "merged"]
 AlignmentEngine = Literal["kokoro"]
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 class SourceRef(BaseModel):
     """Reference to an input source for audiobook processing."""
 
@@ -617,7 +625,13 @@ class VoiceProfileListResponse(BaseModel):
     total: int = Field(..., description="Total voice profiles matching the query")
     limit: int = Field(..., description="Applied page size")
     offset: int = Field(..., description="Applied offset")
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta = Field(..., description="Canonical pagination metadata")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self) -> VoiceProfileListResponse:
+        return _default_offset_pagination_aliases(self)
 
 
 class VoiceProfileDeleteResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/audiobook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/audiobook_schemas.py
@@ -414,7 +414,13 @@ class AudiobookProjectListResponse(BaseModel):
     total: int = Field(..., description="Total number of projects")
     limit: int = Field(..., description="Applied page limit")
     offset: int = Field(..., description="Applied page offset")
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta = Field(..., description="Canonical pagination metadata")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self) -> AudiobookProjectListResponse:
+        return _default_offset_pagination_aliases(self)
 
     model_config = {
         "json_schema_extra": {

--- a/tldw_Server_API/app/api/v1/schemas/audiobook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/audiobook_schemas.py
@@ -614,6 +614,10 @@ class VoiceProfileListResponse(BaseModel):
     """List response for voice profiles."""
 
     profiles: list[VoiceProfileResponse] = Field(..., description="Voice profiles")
+    total: int = Field(..., description="Total voice profiles matching the query")
+    limit: int = Field(..., description="Applied page size")
+    offset: int = Field(..., description="Applied offset")
+    pagination: OffsetPaginationMeta = Field(..., description="Canonical pagination metadata")
 
 
 class VoiceProfileDeleteResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/audiobook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/audiobook_schemas.py
@@ -8,6 +8,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 SourceInputType = Literal["epub", "pdf", "txt", "md", "srt", "vtt", "ass"]
 AudioFormat = Literal["wav", "mp3", "flac", "opus", "m4b"]
 SubtitleFormat = Literal["srt", "vtt", "ass"]
@@ -401,6 +403,10 @@ class AudiobookProjectListResponse(BaseModel):
     """List response for audiobook projects."""
 
     projects: list[AudiobookProjectInfo] = Field(..., description="Project list")
+    total: int = Field(..., description="Total number of projects")
+    limit: int = Field(..., description="Applied page limit")
+    offset: int = Field(..., description="Applied page offset")
+    pagination: OffsetPaginationMeta = Field(..., description="Canonical pagination metadata")
 
     model_config = {
         "json_schema_extra": {
@@ -416,7 +422,18 @@ class AudiobookProjectListResponse(BaseModel):
                         "created_at": "2025-01-21T10:00:00+00:00",
                         "updated_at": "2025-01-21T10:05:00+00:00",
                     }
-                ]
+                ],
+                "total": 1,
+                "limit": 100,
+                "offset": 0,
+                "pagination": {
+                    "mode": "offset",
+                    "total": 1,
+                    "limit": 100,
+                    "offset": 0,
+                    "has_more": False,
+                    "next_offset": None,
+                },
             }
         }
     }

--- a/tldw_Server_API/app/api/v1/schemas/bundle_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/bundle_schemas.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class BundleCreateRequest(BaseModel):
     """Request to create a backup bundle."""
@@ -63,6 +65,7 @@ class BundleListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/bundle_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/bundle_schemas.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class BundleCreateRequest(BaseModel):
@@ -66,8 +74,14 @@ class BundleListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class BundleMetadataResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/character_memory_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/character_memory_schemas.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Literal
 
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,9 @@ class CharacterMemoryListResponse(BaseModel):
     """Paginated list of memory entries."""
     memories: list[CharacterMemoryResponse]
     total: int
+    limit: int
+    offset: int
+    pagination: OffsetPaginationMeta
 
 
 class CharacterMemoryExtractResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/character_memory_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/character_memory_schemas.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 # ---------------------------------------------------------------------------
@@ -61,7 +69,13 @@ class CharacterMemoryListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class CharacterMemoryExtractResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/character_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/character_schemas.py
@@ -196,6 +196,8 @@ class CharacterListQueryResponse(BaseModel):
 
     @model_validator(mode="after")
     def default_pagination_aliases(self) -> "CharacterListQueryResponse":
+        if "has_more" not in self.__pydantic_fields_set__:
+            self.has_more = self.pagination.has_more
         if self.next_offset is None:
             self.next_offset = self.pagination.next_offset
         return self

--- a/tldw_Server_API/app/api/v1/schemas/character_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/character_schemas.py
@@ -9,6 +9,7 @@ from typing import Any, Literal, Optional, Union
 #
 # Third-party imports
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 #
 ######################################################################################################################
@@ -190,6 +191,7 @@ class CharacterListQueryResponse(BaseModel):
     page: int = Field(default=1, ge=1)
     page_size: int = Field(default=25, ge=1)
     has_more: bool = False
+    pagination: OffsetPaginationMeta
 
 
 class CharacterTagOperationRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/character_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/character_schemas.py
@@ -191,7 +191,14 @@ class CharacterListQueryResponse(BaseModel):
     page: int = Field(default=1, ge=1)
     page_size: int = Field(default=25, ge=1)
     has_more: bool = False
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def default_pagination_aliases(self) -> "CharacterListQueryResponse":
+        if self.next_offset is None:
+            self.next_offset = self.pagination.next_offset
+        return self
 
 
 class CharacterTagOperationRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/chat_dictionary_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_dictionary_schemas.py
@@ -16,6 +16,7 @@ from typing import Any, Optional, Union
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.Character_Chat.constants import MAX_CHAT_DICTIONARY_TEXT_LENGTH
 
 # Maximum length for regex patterns to prevent complexity attacks
@@ -509,6 +510,7 @@ class DictionaryActivityListResponse(BaseModel):
     total: int = Field(..., ge=0, description="Total number of matching events")
     limit: int = Field(..., ge=1, description="Applied page size")
     offset: int = Field(..., ge=0, description="Applied offset")
+    pagination: OffsetPaginationMeta
 
 
 class DictionaryVersionSummary(BaseModel):
@@ -551,6 +553,7 @@ class DictionaryVersionListResponse(BaseModel):
     total: int = Field(..., ge=0, description="Total number of snapshots for this dictionary")
     limit: int = Field(..., ge=1, description="Applied page size")
     offset: int = Field(..., ge=0, description="Applied offset")
+    pagination: OffsetPaginationMeta
 
 
 class DictionaryVersionRevertResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/chat_dictionary_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_dictionary_schemas.py
@@ -35,6 +35,15 @@ DANGEROUS_REGEX_PATTERNS = [
     r'([a-zA-Z]+)*',  # Character class with nested quantifier
 ]
 
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 MAX_DICTIONARY_TAGS = 20
 MAX_DICTIONARY_TAG_LENGTH = 40
 MAX_INCLUDED_DICTIONARIES = 50
@@ -510,7 +519,13 @@ class DictionaryActivityListResponse(BaseModel):
     total: int = Field(..., ge=0, description="Total number of matching events")
     limit: int = Field(..., ge=1, description="Applied page size")
     offset: int = Field(..., ge=0, description="Applied offset")
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class DictionaryVersionSummary(BaseModel):
@@ -553,7 +568,13 @@ class DictionaryVersionListResponse(BaseModel):
     total: int = Field(..., ge=0, description="Total number of snapshots for this dictionary")
     limit: int = Field(..., ge=1, description="Applied page size")
     offset: int = Field(..., ge=0, description="Applied offset")
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class DictionaryVersionRevertResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py
@@ -9,6 +9,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 ChatGrammarValidationStatus = Literal["unchecked", "valid", "invalid"]
 
 
@@ -76,3 +78,4 @@ class ChatGrammarListResponse(BaseModel):
 
     items: list[ChatGrammarResponse] = Field(default_factory=list, description="Saved grammar records")
     total: int = Field(..., description="Total number of matching saved grammars")
+    pagination: OffsetPaginationMeta

--- a/tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py
@@ -14,6 +14,14 @@ from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 ChatGrammarValidationStatus = Literal["unchecked", "valid", "invalid"]
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 class ChatGrammarBase(BaseModel):
     """Shared fields for stored chat grammars."""
 
@@ -79,3 +87,9 @@ class ChatGrammarListResponse(BaseModel):
     items: list[ChatGrammarResponse] = Field(default_factory=list, description="Saved grammar records")
     total: int = Field(..., description="Total number of matching saved grammars")
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self) -> "ChatGrammarListResponse":
+        return _default_offset_pagination_aliases(self)

--- a/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.LLM_Calls.routing.models import RoutingOverride
 
 ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
@@ -184,6 +185,7 @@ class ChatSessionListResponse(BaseModel):
     total: int = Field(..., description="Total number of chats")
     limit: int = Field(..., description="Number of items per page")
     offset: int = Field(..., description="Offset for pagination")
+    pagination: OffsetPaginationMeta
 
 
 class ChatLinkedResearchRunResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
@@ -309,6 +309,7 @@ class MessageListResponse(BaseModel):
     total: int = Field(..., description="Total number of messages")
     limit: int = Field(..., description="Number of items per page")
     offset: int = Field(..., description="Offset for pagination")
+    pagination: OffsetPaginationMeta
 
 
 # ========================================================================

--- a/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_session_schemas.py
@@ -15,6 +15,14 @@ ALLOWED_ASSISTANT_KINDS = ("character", "persona")
 ALLOWED_PERSONA_MEMORY_MODES = ("read_only", "read_write")
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 # ========================================================================
 # Chat Session Schemas
 # ========================================================================
@@ -186,6 +194,12 @@ class ChatSessionListResponse(BaseModel):
     limit: int = Field(..., description="Number of items per page")
     offset: int = Field(..., description="Offset for pagination")
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ChatLinkedResearchRunResponse(BaseModel):
@@ -310,6 +324,12 @@ class MessageListResponse(BaseModel):
     limit: int = Field(..., description="Number of items per page")
     offset: int = Field(..., description="Offset for pagination")
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 # ========================================================================

--- a/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
@@ -25,6 +25,14 @@ from tldw_Server_API.app.core.Chatbooks.chatbook_models import (
     ExportStatus,
     ImportStatus,
 )
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class ConflictResolution(str, Enum):
@@ -284,14 +292,26 @@ class ListExportJobsResponse(BaseModel):
     """Response for listing export jobs."""
     jobs: list[ExportJobResponse]
     total: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ListImportJobsResponse(BaseModel):
     """Response for listing import jobs."""
     jobs: list[ImportJobResponse]
     total: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class CleanupExpiredExportsResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chatbook_schemas.py
@@ -14,6 +14,8 @@ from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 # Import shared enums from the canonical models module to avoid divergence.
 # ConflictResolution is intentionally redefined here to constrain API input
 # to only the currently-supported strategies (skip, rename).
@@ -282,12 +284,14 @@ class ListExportJobsResponse(BaseModel):
     """Response for listing export jobs."""
     jobs: list[ExportJobResponse]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class ListImportJobsResponse(BaseModel):
     """Response for listing import jobs."""
     jobs: list[ImportJobResponse]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class CleanupExpiredExportsResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/claims_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/claims_schemas.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class ClaimsSettingsResponse(BaseModel):
@@ -442,7 +450,13 @@ class ClaimsAnalyticsExportListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ClaimsAnalyticsPerMediaCount(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/claims_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/claims_schemas.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class ClaimsSettingsResponse(BaseModel):
     """Current claims-related configuration values."""
@@ -440,6 +442,7 @@ class ClaimsAnalyticsExportListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
 
 class ClaimsAnalyticsPerMediaCount(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/companion.py
+++ b/tldw_Server_API/app/api/v1/schemas/companion.py
@@ -10,6 +10,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 class CompanionActivityItem(BaseModel):
     """One persisted companion activity event."""
 
@@ -31,7 +39,13 @@ class CompanionActivityListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class CompanionActivityDetail(CompanionActivityItem):

--- a/tldw_Server_API/app/api/v1/schemas/companion.py
+++ b/tldw_Server_API/app/api/v1/schemas/companion.py
@@ -7,6 +7,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class CompanionActivityItem(BaseModel):
     """One persisted companion activity event."""
@@ -29,6 +31,7 @@ class CompanionActivityListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
 
 class CompanionActivityDetail(CompanionActivityItem):

--- a/tldw_Server_API/app/api/v1/schemas/data_tables_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/data_tables_schemas.py
@@ -22,6 +22,14 @@ DataTableRowData = dict[str, Any] | list[Any]
 DATA_TABLES_MAX_ROWS_LIMIT = int(os.getenv("DATA_TABLES_MAX_ROWS", "2000") or "2000")
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 class DataTableColumnHint(BaseModel):
     """Optional schema hint supplied during generation."""
 
@@ -175,7 +183,14 @@ class DataTablesListResponse(BaseModel):
     limit: int
     offset: int
     total: int | None = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    if model_validator is not None:
+        @model_validator(mode="after")
+        def _default_pagination_aliases(self) -> DataTablesListResponse:
+            return _default_offset_pagination_aliases(self)
 
 
 class DataTableDetailResponse(BaseModel):
@@ -187,7 +202,14 @@ class DataTableDetailResponse(BaseModel):
     sources: list[DataTableSource]
     rows_limit: int
     rows_offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    if model_validator is not None:
+        @model_validator(mode="after")
+        def _default_pagination_aliases(self) -> DataTableDetailResponse:
+            return _default_offset_pagination_aliases(self)
 
 
 class DataTableContentUpdateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/data_tables_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/data_tables_schemas.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.api.v1.schemas.file_artifacts_schemas import FileExportInfo
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 try:
     # Pydantic v2
@@ -174,6 +175,7 @@ class DataTablesListResponse(BaseModel):
     limit: int
     offset: int
     total: int | None = None
+    pagination: OffsetPaginationMeta
 
 
 class DataTableDetailResponse(BaseModel):
@@ -185,6 +187,7 @@ class DataTableDetailResponse(BaseModel):
     sources: list[DataTableSource]
     rows_limit: int
     rows_offset: int
+    pagination: OffsetPaginationMeta
 
 
 class DataTableContentUpdateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/document_references.py
+++ b/tldw_Server_API/app/api/v1/schemas/document_references.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class ReferenceEntry(BaseModel):
     """A single reference/citation extracted from the document."""
@@ -84,6 +86,7 @@ class DocumentReferencesResponse(BaseModel):
         ge=0,
         description="Offset to request for the next page when has_more=true",
     )
+    pagination: OffsetPaginationMeta
 
 
 __all__ = ["ReferenceEntry", "DocumentReferencesResponse"]

--- a/tldw_Server_API/app/api/v1/schemas/evaluation_schemas_unified.py
+++ b/tldw_Server_API/app/api/v1/schemas/evaluation_schemas_unified.py
@@ -23,6 +23,14 @@ except Exception:
     bleach = None
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 # ============= Utility Functions =============
 
 def sanitize_html_text(value: Optional[str]) -> Optional[str]:
@@ -428,6 +436,12 @@ class DatasetListResponse(ListResponse):
     """Dataset list response"""
     data: list[DatasetResponse]
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 # ============= tldw-Specific Evaluation Schemas =============

--- a/tldw_Server_API/app/api/v1/schemas/evaluation_schemas_unified.py
+++ b/tldw_Server_API/app/api/v1/schemas/evaluation_schemas_unified.py
@@ -427,6 +427,7 @@ class RunListResponse(ListResponse):
 class DatasetListResponse(ListResponse):
     """Dataset list response"""
     data: list[DatasetResponse]
+    pagination: OffsetPaginationMeta
 
 
 # ============= tldw-Specific Evaluation Schemas =============

--- a/tldw_Server_API/app/api/v1/schemas/evaluation_schemas_unified.py
+++ b/tldw_Server_API/app/api/v1/schemas/evaluation_schemas_unified.py
@@ -825,7 +825,13 @@ class EvaluationHistoryResponse(BaseModel):
     total_count: int
     items: list[dict[str, Any]]
     aggregations: Optional[dict[str, Any]] = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 # ============= Webhook Schemas =============

--- a/tldw_Server_API/app/api/v1/schemas/evaluation_schemas_unified.py
+++ b/tldw_Server_API/app/api/v1/schemas/evaluation_schemas_unified.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, Optional, Union
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.core.Evaluations.run_state import normalize_run_status
 
 try:
@@ -809,6 +810,7 @@ class EvaluationHistoryResponse(BaseModel):
     total_count: int
     items: list[dict[str, Any]]
     aggregations: Optional[dict[str, Any]] = None
+    pagination: OffsetPaginationMeta
 
 
 # ============= Webhook Schemas =============

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.api.v1.schemas.study_packs import (
     FlashcardCitationResponse,
     FlashcardDeepDiveTarget,
@@ -332,6 +333,7 @@ class FlashcardListResponse(BaseModel):
     items: list[Flashcard]
     count: int
     total: int | None = None
+    pagination: OffsetPaginationMeta
 
 
 class FlashcardReviewRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -251,6 +251,7 @@ class FlashcardTemplateListResponse(BaseModel):
     items: list[FlashcardTemplate]
     count: int
     total: int | None = None
+    pagination: OffsetPaginationMeta
 
 
 class FlashcardReviewIntervalPreviews(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -18,6 +18,14 @@ FlashcardTemplateModelType = Literal["basic", "basic_reverse", "cloze"]
 FlashcardTemplateFieldTarget = Literal["front_template", "back_template", "notes_template", "extra_template"]
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 def _strip_required_string(value: Any) -> Any:
     if isinstance(value, str):
         return value.strip()
@@ -251,7 +259,13 @@ class FlashcardTemplateListResponse(BaseModel):
     items: list[FlashcardTemplate]
     count: int
     total: int | None = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class FlashcardReviewIntervalPreviews(BaseModel):
@@ -334,7 +348,18 @@ class FlashcardListResponse(BaseModel):
     items: list[Flashcard]
     count: int
     total: int | None = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
+
+
+class FlashcardBulkCreateResponse(BaseModel):
+    items: list[Flashcard]
+    count: int
 
 
 class FlashcardReviewRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/media_response_models.py
+++ b/tldw_Server_API/app/api/v1/schemas/media_response_models.py
@@ -13,17 +13,17 @@ from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 #
 # Local Imports
 #
+from tldw_Server_API.app.api.v1.schemas.pagination import PagePaginationMeta
+
 #######################################################################################################################
 #
 # Functions:
 
 # --- Common Reusable Models ---
 
-class PaginationInfo(BaseModel):
-    """Model for pagination details used in list responses."""
-    page: int = Field(..., description="The current page number.", json_schema_extra={"example": 1})
+class PaginationInfo(PagePaginationMeta):
+    """Legacy media pagination plus canonical page metadata."""
     results_per_page: int = Field(..., description="Number of items requested per page.", json_schema_extra={"example": 10})
-    total_pages: int = Field(..., description="Total number of pages available.", json_schema_extra={"example": 5})
     total_items: int = Field(..., description="Total number of items matching the query.", json_schema_extra={"example": 48})
 
 class PaginationInfoSearch(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/monitoring_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/monitoring_schemas.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 
 class WatchlistRule(BaseModel):
@@ -73,6 +74,7 @@ class AlertItem(BaseModel):
 class AlertsListResponse(BaseModel):
     items: list[AlertItem]
     total: int | None = None  # Optional future enhancement
+    pagination: OffsetPaginationMeta
 
 
 class MarkReadResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/monitoring_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/monitoring_schemas.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class WatchlistRule(BaseModel):
@@ -74,7 +82,13 @@ class AlertItem(BaseModel):
 class AlertsListResponse(BaseModel):
     items: list[AlertItem]
     total: int | None = None  # Optional future enhancement
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class MarkReadResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/notes_moodboards.py
+++ b/tldw_Server_API/app/api/v1/schemas/notes_moodboards.py
@@ -9,6 +9,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 def _normalize_nonempty_text(value: str) -> str:
     text = str(value or "").strip()
     if not text:
@@ -165,7 +173,13 @@ class MoodboardListResponse(BaseModel):
     limit: int = Field(..., ge=1)
     offset: int = Field(..., ge=0)
     total: int | None = Field(default=None, ge=0)
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class MoodboardPinResponse(BaseModel):
@@ -191,4 +205,10 @@ class MoodboardNotesListResponse(BaseModel):
     limit: int = Field(..., ge=1)
     offset: int = Field(..., ge=0)
     total: int | None = Field(default=None, ge=0)
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)

--- a/tldw_Server_API/app/api/v1/schemas/notes_moodboards.py
+++ b/tldw_Server_API/app/api/v1/schemas/notes_moodboards.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 def _normalize_nonempty_text(value: str) -> str:
     text = str(value or "").strip()
@@ -188,3 +190,4 @@ class MoodboardNotesListResponse(BaseModel):
     limit: int = Field(..., ge=1)
     offset: int = Field(..., ge=0)
     total: int | None = Field(default=None, ge=0)
+    pagination: OffsetPaginationMeta

--- a/tldw_Server_API/app/api/v1/schemas/notes_moodboards.py
+++ b/tldw_Server_API/app/api/v1/schemas/notes_moodboards.py
@@ -165,6 +165,7 @@ class MoodboardListResponse(BaseModel):
     limit: int = Field(..., ge=1)
     offset: int = Field(..., ge=0)
     total: int | None = Field(default=None, ge=0)
+    pagination: OffsetPaginationMeta
 
 
 class MoodboardPinResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/notes_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/notes_schemas.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 # 3rd-party Libraries
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 from .notes_studio import NoteStudioDocumentSummaryResponse
 
 #
@@ -434,6 +436,7 @@ class NotesListResponse(BaseModel):
     limit: int
     offset: int
     total: int | None = None
+    pagination: OffsetPaginationMeta
 
 
 class NotesExportResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/notes_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/notes_schemas.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any, Literal
 
 # 3rd-party Libraries
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
@@ -19,6 +19,14 @@ from .notes_studio import NoteStudioDocumentSummaryResponse
 #######################################################################################################################
 #
 # Schemas:
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
 
 def _split_keywords(value: Any) -> list[str] | None:
     if value is None:
@@ -343,7 +351,13 @@ class KeywordCollectionsListResponse(BaseModel):
     limit: int = Field(..., ge=1)
     offset: int = Field(..., ge=0)
     total: int = Field(..., ge=0)
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class CollectionKeywordLinkResponse(BaseModel):
@@ -437,7 +451,13 @@ class NotesListResponse(BaseModel):
     limit: int
     offset: int
     total: int | None = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class NotesExportResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/notes_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/notes_schemas.py
@@ -342,7 +342,8 @@ class KeywordCollectionsListResponse(BaseModel):
     count: int = Field(..., ge=0)
     limit: int = Field(..., ge=1)
     offset: int = Field(..., ge=0)
-    total: int | None = Field(default=None, ge=0)
+    total: int = Field(..., ge=0)
+    pagination: OffsetPaginationMeta
 
 
 class CollectionKeywordLinkResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/org_team_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/org_team_schemas.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class OrganizationCreateRequest(BaseModel):
@@ -283,7 +291,13 @@ class OrgInviteListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class OrgInvitePreviewResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/org_team_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/org_team_schemas.py
@@ -37,7 +37,12 @@ class OrganizationListResponse(BaseModel):
     limit: int
     offset: int
     has_more: bool
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def default_pagination_aliases(self) -> "OrganizationListResponse":
+        return _default_offset_pagination_aliases(self)
 
 
 class TeamCreateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/org_team_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/org_team_schemas.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class OrganizationCreateRequest(BaseModel):
     name: str = Field(..., min_length=2)
@@ -27,6 +29,7 @@ class OrganizationListResponse(BaseModel):
     limit: int
     offset: int
     has_more: bool
+    pagination: OffsetPaginationMeta
 
 
 class TeamCreateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/org_team_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/org_team_schemas.py
@@ -281,6 +281,9 @@ class OrgInviteListResponse(BaseModel):
     """List of organization invites."""
     items: list[OrgInviteResponse]
     total: int
+    limit: int
+    offset: int
+    pagination: OffsetPaginationMeta
 
 
 class OrgInvitePreviewResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/outputs_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/outputs_schemas.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class OutputCreateRequest(BaseModel):
     template_id: int
@@ -42,6 +44,7 @@ class OutputListResponse(BaseModel):
     total: int
     page: int
     size: int
+    pagination: OffsetPaginationMeta
 
 
 class OutputUpdateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/outputs_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/outputs_schemas.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class OutputCreateRequest(BaseModel):
@@ -44,7 +52,13 @@ class OutputListResponse(BaseModel):
     total: int
     page: int
     size: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class OutputUpdateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/outputs_templates_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/outputs_templates_schemas.py
@@ -18,6 +18,14 @@ TemplateType = Literal[
 TemplateFormat = Literal["md", "html", "mp3"]
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 class OutputTemplateCreate(BaseModel):
     """Create an output template used for rendering collections (items or runs)."""
 
@@ -74,6 +82,12 @@ class OutputTemplateList(BaseModel):
     items: list[OutputTemplate]
     total: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self) -> "OutputTemplateList":
+        return _default_offset_pagination_aliases(self)
 
 
 class TemplatePreviewRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/outputs_templates_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/outputs_templates_schemas.py
@@ -5,6 +5,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 TemplateType = Literal[
     "newsletter_markdown",
     "briefing_markdown",
@@ -71,6 +73,7 @@ class OutputTemplate(BaseModel):
 class OutputTemplateList(BaseModel):
     items: list[OutputTemplate]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class TemplatePreviewRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/pagination.py
+++ b/tldw_Server_API/app/api/v1/schemas/pagination.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class PaginationMode(str, Enum):
+    """Canonical pagination mode discriminator."""
+
+    OFFSET = "offset"
+    CURSOR = "cursor"
+
+
+class OffsetPaginationMeta(BaseModel):
+    """Canonical metadata for offset-based pagination."""
+
+    mode: PaginationMode = Field(default=PaginationMode.OFFSET)
+    limit: int = Field(..., ge=1, description="Canonical page size.")
+    offset: int = Field(..., ge=0, description="Canonical zero-based item offset.")
+    total: int | None = Field(default=None, ge=0, description="Total number of matching items, when known.")
+    has_more: bool = Field(..., description="Whether another page is available.")
+    next_offset: int | None = Field(default=None, ge=0, description="Next canonical offset, or null when exhausted.")
+
+
+class CursorPaginationMeta(BaseModel):
+    """Canonical metadata for cursor-based pagination."""
+
+    mode: PaginationMode = Field(default=PaginationMode.CURSOR)
+    limit: int = Field(..., ge=1, description="Canonical page size.")
+    cursor: str | None = Field(default=None, description="Canonical input cursor.")
+    next_cursor: str | None = Field(default=None, description="Next cursor, or null when exhausted.")
+    has_more: bool = Field(..., description="Whether another page is available.")

--- a/tldw_Server_API/app/api/v1/schemas/pagination.py
+++ b/tldw_Server_API/app/api/v1/schemas/pagination.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -16,7 +17,7 @@ class PaginationMode(str, Enum):
 class OffsetPaginationMeta(BaseModel):
     """Canonical metadata for offset-based pagination."""
 
-    mode: PaginationMode = Field(default=PaginationMode.OFFSET)
+    mode: Literal[PaginationMode.OFFSET] = Field(default=PaginationMode.OFFSET)
     limit: int = Field(..., ge=1, description="Canonical page size.")
     offset: int = Field(..., ge=0, description="Canonical zero-based item offset.")
     total: int | None = Field(default=None, ge=0, description="Total number of matching items, when known.")
@@ -27,7 +28,7 @@ class OffsetPaginationMeta(BaseModel):
 class CursorPaginationMeta(BaseModel):
     """Canonical metadata for cursor-based pagination."""
 
-    mode: PaginationMode = Field(default=PaginationMode.CURSOR)
+    mode: Literal[PaginationMode.CURSOR] = Field(default=PaginationMode.CURSOR)
     limit: int = Field(..., ge=1, description="Canonical page size.")
     cursor: str | None = Field(default=None, description="Canonical input cursor.")
     next_cursor: str | None = Field(default=None, description="Next cursor, or null when exhausted.")
@@ -37,9 +38,18 @@ class CursorPaginationMeta(BaseModel):
 class PagePaginationMeta(BaseModel):
     """Canonical metadata for page-number-based pagination."""
 
-    mode: PaginationMode = Field(default=PaginationMode.PAGE)
+    mode: Literal[PaginationMode.PAGE] = Field(default=PaginationMode.PAGE)
     page: int = Field(..., ge=1, description="Canonical 1-indexed page number.")
     per_page: int = Field(..., ge=1, description="Canonical page size.")
     total: int | None = Field(default=None, ge=0, description="Total number of matching items, when known.")
     total_pages: int | None = Field(default=None, ge=0, description="Total number of available pages, when known.")
     has_more: bool = Field(..., description="Whether another page is available.")
+
+
+def default_offset_pagination_aliases(response: Any) -> Any:
+    """Populate legacy top-level offset aliases from canonical pagination metadata."""
+    if getattr(response, "has_more", None) is None:
+        response.has_more = response.pagination.has_more
+    if getattr(response, "next_offset", None) is None:
+        response.next_offset = response.pagination.next_offset
+    return response

--- a/tldw_Server_API/app/api/v1/schemas/pagination.py
+++ b/tldw_Server_API/app/api/v1/schemas/pagination.py
@@ -10,6 +10,7 @@ class PaginationMode(str, Enum):
 
     OFFSET = "offset"
     CURSOR = "cursor"
+    PAGE = "page"
 
 
 class OffsetPaginationMeta(BaseModel):
@@ -30,4 +31,15 @@ class CursorPaginationMeta(BaseModel):
     limit: int = Field(..., ge=1, description="Canonical page size.")
     cursor: str | None = Field(default=None, description="Canonical input cursor.")
     next_cursor: str | None = Field(default=None, description="Next cursor, or null when exhausted.")
+    has_more: bool = Field(..., description="Whether another page is available.")
+
+
+class PagePaginationMeta(BaseModel):
+    """Canonical metadata for page-number-based pagination."""
+
+    mode: PaginationMode = Field(default=PaginationMode.PAGE)
+    page: int = Field(..., ge=1, description="Canonical 1-indexed page number.")
+    per_page: int = Field(..., ge=1, description="Canonical page size.")
+    total: int | None = Field(default=None, ge=0, description="Total number of matching items, when known.")
+    total_pages: int | None = Field(default=None, ge=0, description="Total number of available pages, when known.")
     has_more: bool = Field(..., description="Whether another page is available.")

--- a/tldw_Server_API/app/api/v1/schemas/paper_search_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/paper_search_schemas.py
@@ -256,6 +256,16 @@ class GenericSearchResponse(BaseModel):
     total_pages: int
 
 
+class GenericPageSearchResponse(BaseModel):
+    query_echo: dict[str, Any]
+    items: list[GenericPaper]
+    total_results: int
+    page: int
+    results_per_page: int
+    total_pages: int
+    pagination: PagePaginationMeta
+
+
 class IEEESearchRequestForm:
     def __init__(
         self,

--- a/tldw_Server_API/app/api/v1/schemas/paper_search_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/paper_search_schemas.py
@@ -82,6 +82,7 @@ class BioRxivPubsSearchResponse(BaseModel):
     page: int
     results_per_page: int
     total_pages: int
+    pagination: PagePaginationMeta
 
 
 class BioRxivPubsSearchRequestForm:

--- a/tldw_Server_API/app/api/v1/schemas/paper_search_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/paper_search_schemas.py
@@ -331,6 +331,7 @@ class BioRxivFunderSearchResponse(BaseModel):
     page: int
     results_per_page: int
     total_pages: int
+    pagination: PagePaginationMeta
 
 
 class BioRxivFunderSearchRequestForm:

--- a/tldw_Server_API/app/api/v1/schemas/paper_search_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/paper_search_schemas.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from fastapi import Query
 from pydantic import BaseModel
+from tldw_Server_API.app.api.v1.schemas.pagination import PagePaginationMeta
 
 
 class BioRxivPaper(BaseModel):
@@ -28,6 +29,7 @@ class BioRxivSearchResponse(BaseModel):
     page: int
     results_per_page: int
     total_pages: int
+    pagination: PagePaginationMeta
 
 
 class BioRxivSearchRequestForm:
@@ -129,6 +131,7 @@ class PubMedSearchResponse(BaseModel):
     page: int
     results_per_page: int
     total_pages: int
+    pagination: PagePaginationMeta
 
 
 class PubMedSearchRequestForm:

--- a/tldw_Server_API/app/api/v1/schemas/prompt_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prompt_schemas.py
@@ -7,6 +7,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 #
 # Third-party Imports
@@ -302,3 +304,7 @@ class PromptCollectionResponse(BaseModel):
 
 class PromptCollectionListResponse(BaseModel):
     collections: list[PromptCollectionResponse] = Field(default_factory=list)
+    total: int = 0
+    limit: int = 200
+    offset: int = 0
+    pagination: OffsetPaginationMeta

--- a/tldw_Server_API/app/api/v1/schemas/prompt_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prompt_schemas.py
@@ -5,9 +5,17 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 #
@@ -307,4 +315,10 @@ class PromptCollectionListResponse(BaseModel):
     total: int = 0
     limit: int = 200
     offset: int = 0
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)

--- a/tldw_Server_API/app/api/v1/schemas/prompt_studio_base.py
+++ b/tldw_Server_API/app/api/v1/schemas/prompt_studio_base.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+from tldw_Server_API.app.api.v1.schemas.pagination import PagePaginationMeta
 
 ########################################################################################################################
 # Enums
@@ -99,6 +100,12 @@ class ListResponse(StandardResponse):
     """Standard list response with pagination"""
     data: list[Any]
     metadata: PaginationMetadata
+
+
+class PageListResponse(ListResponse):
+    """Prompt Studio list response with canonical page pagination metadata."""
+
+    pagination: PagePaginationMeta
 
 ########################################################################################################################
 # Security Shim

--- a/tldw_Server_API/app/api/v1/schemas/quizzes.py
+++ b/tldw_Server_API/app/api/v1/schemas/quizzes.py
@@ -13,6 +13,14 @@ from .flashcards import (
 )
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 class QuestionType(str, Enum):
     MULTIPLE_CHOICE = "multiple_choice"
     MULTI_SELECT = "multi_select"
@@ -97,7 +105,13 @@ class QuizResponse(BaseModel):
 class QuizListResponse(BaseModel):
     items: list[QuizResponse]
     count: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class QuestionCreate(BaseModel):
@@ -158,7 +172,13 @@ class QuestionAdminResponse(QuestionPublicResponse):
 class QuestionListResponse(BaseModel):
     items: list[QuestionPublicResponse | QuestionAdminResponse]
     count: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class QuizAnswerInput(BaseModel):
@@ -200,7 +220,13 @@ class AttemptResponse(BaseModel):
 class AttemptListResponse(BaseModel):
     items: list[AttemptResponse]
     count: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class QuizRemediationConversionSummary(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/quizzes.py
+++ b/tldw_Server_API/app/api/v1/schemas/quizzes.py
@@ -3,6 +3,8 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 from .flashcards import (
     DeckReviewPromptSide,
     DeckSchedulerSettingsEnvelope,
@@ -95,6 +97,7 @@ class QuizResponse(BaseModel):
 class QuizListResponse(BaseModel):
     items: list[QuizResponse]
     count: int
+    pagination: OffsetPaginationMeta
 
 
 class QuestionCreate(BaseModel):
@@ -155,6 +158,7 @@ class QuestionAdminResponse(QuestionPublicResponse):
 class QuestionListResponse(BaseModel):
     items: list[QuestionPublicResponse | QuestionAdminResponse]
     count: int
+    pagination: OffsetPaginationMeta
 
 
 class QuizAnswerInput(BaseModel):
@@ -196,6 +200,7 @@ class AttemptResponse(BaseModel):
 class AttemptListResponse(BaseModel):
     items: list[AttemptResponse]
     count: int
+    pagination: OffsetPaginationMeta
 
 
 class QuizRemediationConversionSummary(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
@@ -32,8 +32,18 @@ _READING_SAVED_SEARCH_ALLOWED_SORTS = {
 def _default_offset_pagination_aliases(response):
     if response.has_more is None:
         response.has_more = response.pagination.has_more
+    elif response.has_more != response.pagination.has_more:
+        raise ValueError(
+            f"has_more alias mismatch: has_more={response.has_more} "
+            f"pagination.has_more={response.pagination.has_more}"
+        )
     if response.next_offset is None:
         response.next_offset = response.pagination.next_offset
+    elif response.next_offset != response.pagination.next_offset:
+        raise ValueError(
+            f"next_offset alias mismatch: next_offset={response.next_offset} "
+            f"pagination.next_offset={response.pagination.next_offset}"
+        )
     return response
 
 

--- a/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
@@ -158,6 +158,7 @@ class ReadingItemsListResponse(BaseModel):
     size: int
     offset: int | None = None
     limit: int | None = None
+    pagination: OffsetPaginationMeta
 
 
 class ReadingSavedSearchCreateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
@@ -288,6 +288,7 @@ class ReadingImportJobsListResponse(BaseModel):
     total: int
     limit: int | None = None
     offset: int | None = None
+    pagination: OffsetPaginationMeta
 
 
 class ReadingDigestSuggestionsConfig(BaseModel):
@@ -429,6 +430,7 @@ class ReadingDigestOutputsListResponse(BaseModel):
     total: int
     limit: int | None = None
     offset: int | None = None
+    pagination: OffsetPaginationMeta
 
 
 class ReadingArchiveCreateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, HttpUrl, validator
+from pydantic import BaseModel, HttpUrl, model_validator, validator
 
 from tldw_Server_API.app.api.v1.schemas._compat import Field
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
@@ -27,6 +27,14 @@ _READING_SAVED_SEARCH_ALLOWED_SORTS = {
     "title_desc",
     "relevance",
 }
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 def _normalize_nonempty_string(value: Any, *, field_name: str) -> str:
@@ -288,7 +296,13 @@ class ReadingImportJobsListResponse(BaseModel):
     total: int
     limit: int | None = None
     offset: int | None = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ReadingDigestSuggestionsConfig(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
@@ -166,7 +166,13 @@ class ReadingItemsListResponse(BaseModel):
     size: int
     offset: int | None = None
     limit: int | None = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ReadingSavedSearchCreateRequest(BaseModel):
@@ -233,7 +239,13 @@ class ReadingSavedSearchListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ReadingNoteLinkCreateRequest(BaseModel):
@@ -444,7 +456,13 @@ class ReadingDigestOutputsListResponse(BaseModel):
     total: int
     limit: int | None = None
     offset: int | None = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ReadingArchiveCreateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, HttpUrl, validator
 
 from tldw_Server_API.app.api.v1.schemas._compat import Field
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 _READING_SAVED_SEARCH_ALLOWED_QUERY_KEYS = {
     "q",
@@ -223,6 +224,7 @@ class ReadingSavedSearchListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
 
 class ReadingNoteLinkCreateRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/research_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/research_schemas.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 #
 # Local Imports
+from tldw_Server_API.app.api.v1.schemas.pagination import PagePaginationMeta
 from tldw_Server_API.app.core.Third_Party.Arxiv import ARXIV_DEFAULT_PAGE_SIZE
 from tldw_Server_API.app.core.Third_Party.Semantic_Scholar import FIELDS_OF_STUDY_CHOICES, PUBLICATION_TYPE_CHOICES
 
@@ -36,6 +37,7 @@ class ArxivSearchResponse(BaseModel):
     page: int
     results_per_page: int
     total_pages: int
+    pagination: PagePaginationMeta
 
 
 class ArxivSearchRequestForm:
@@ -95,6 +97,7 @@ class SemanticScholarSearchResponse(BaseModel):
     next_offset: Optional[int] = None # Semantic Scholar provides 'next' which is the next offset
     page: int # Calculated for user convenience
     total_pages: int # Calculated
+    pagination: PagePaginationMeta
 
 class SemanticScholarSearchRequestForm:
     def __init__(

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -9,6 +9,8 @@ try:
 except ImportError:  # pragma: no cover - pydantic v1 fallback
     from pydantic import root_validator as model_validator  # type: ignore
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 RuntimeType = Literal["docker", "firecracker", "lima", "vz_linux", "vz_macos", "seatbelt"]
 TrustLevelType = Literal["trusted", "standard", "untrusted"]
 
@@ -228,6 +230,7 @@ class SandboxAdminRunListResponse(BaseModel):
     limit: int
     offset: int
     has_more: bool
+    pagination: OffsetPaginationMeta
     items: list[SandboxAdminRunSummary]
 
 
@@ -250,6 +253,7 @@ class SandboxAdminIdempotencyListResponse(BaseModel):
     limit: int
     offset: int
     has_more: bool
+    pagination: OffsetPaginationMeta
     items: list[SandboxAdminIdempotencyItem]
 
 
@@ -266,6 +270,7 @@ class SandboxAdminUsageResponse(BaseModel):
     limit: int
     offset: int
     has_more: bool
+    pagination: OffsetPaginationMeta
     items: list[SandboxAdminUsageItem]
 
 

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -15,6 +15,12 @@ RuntimeType = Literal["docker", "firecracker", "lima", "vz_linux", "vz_macos", "
 TrustLevelType = Literal["trusted", "standard", "untrusted"]
 
 
+def _default_offset_pagination_aliases(response):
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 class SandboxRuntimeInfo(BaseModel):
     name: RuntimeType
     available: bool = Field(description="Whether this runtime is detected/usable on host")
@@ -230,8 +236,13 @@ class SandboxAdminRunListResponse(BaseModel):
     limit: int
     offset: int
     has_more: bool
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
     items: list[SandboxAdminRunSummary]
+
+    @model_validator(mode="after")
+    def default_pagination_aliases(self) -> "SandboxAdminRunListResponse":
+        return _default_offset_pagination_aliases(self)
 
 
 class SandboxAdminRunDetails(SandboxAdminRunSummary):
@@ -253,8 +264,13 @@ class SandboxAdminIdempotencyListResponse(BaseModel):
     limit: int
     offset: int
     has_more: bool
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
     items: list[SandboxAdminIdempotencyItem]
+
+    @model_validator(mode="after")
+    def default_pagination_aliases(self) -> "SandboxAdminIdempotencyListResponse":
+        return _default_offset_pagination_aliases(self)
 
 
 # Admin: Usage aggregates
@@ -270,8 +286,13 @@ class SandboxAdminUsageResponse(BaseModel):
     limit: int
     offset: int
     has_more: bool
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
     items: list[SandboxAdminUsageItem]
+
+    @model_validator(mode="after")
+    def default_pagination_aliases(self) -> "SandboxAdminUsageResponse":
+        return _default_offset_pagination_aliases(self)
 
 
 class SandboxAdminMacOSHostDiagnostics(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import Literal
 
 # 3rd-party Libraries
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
@@ -23,6 +23,14 @@ from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 # Skill name validation: lowercase letters, numbers, and hyphens only
 SKILL_NAME_PATTERN = re.compile(r'^[a-z][a-z0-9-]{0,63}$')
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 SUPPORTING_FILE_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$')
 
 # Aggregate limits for supporting files
@@ -194,9 +202,15 @@ class SkillsListResponse(BaseModel):
     total: int = Field(..., description="Total number of skills")
     limit: int = Field(..., description="Pagination limit")
     offset: int = Field(..., description="Pagination offset")
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta = Field(..., description="Canonical pagination metadata")
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class SkillExecuteRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/skills_schemas.py
@@ -12,6 +12,8 @@ from typing import Literal
 # 3rd-party Libraries
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 #
 # Local Imports
 #
@@ -192,6 +194,7 @@ class SkillsListResponse(BaseModel):
     total: int = Field(..., description="Total number of skills")
     limit: int = Field(..., description="Pagination limit")
     offset: int = Field(..., description="Pagination offset")
+    pagination: OffsetPaginationMeta = Field(..., description="Canonical pagination metadata")
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/slides_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/slides_schemas.py
@@ -11,6 +11,14 @@ from pydantic import BaseModel, Field, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 class SlideLayout(str, Enum):
     """Supported slide layout identifiers."""
 
@@ -140,6 +148,12 @@ class PresentationVersionListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class SlidesTemplateResponse(BaseModel):
@@ -210,6 +224,12 @@ class VisualStyleListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class PresentationSummary(BaseModel):
@@ -233,6 +253,12 @@ class PresentationListResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class PresentationSearchResponse(BaseModel):
@@ -243,6 +269,12 @@ class PresentationSearchResponse(BaseModel):
     limit: int
     offset: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class SlideGenerationBase(VisualStyleSelectionMixin):

--- a/tldw_Server_API/app/api/v1/schemas/slides_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/slides_schemas.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class SlideLayout(str, Enum):
     """Supported slide layout identifiers."""
@@ -137,6 +139,7 @@ class PresentationVersionListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
 
 class SlidesTemplateResponse(BaseModel):
@@ -206,6 +209,7 @@ class VisualStyleListResponse(BaseModel):
     total_count: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
 
 class PresentationSummary(BaseModel):
@@ -228,6 +232,7 @@ class PresentationListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
 
 class PresentationSearchResponse(BaseModel):
@@ -237,6 +242,7 @@ class PresentationSearchResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta
 
 
 class SlideGenerationBase(VisualStyleSelectionMixin):

--- a/tldw_Server_API/app/api/v1/schemas/storage_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/storage_schemas.py
@@ -9,6 +9,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 # File categories
 FileCategory = Literal["tts_audio", "stt_audio", "image", "voice_clone", "mindmap", "spreadsheet"]
 
@@ -88,6 +90,7 @@ class GeneratedFilesListResponse(BaseModel):
     total: int
     offset: int
     limit: int
+    pagination: OffsetPaginationMeta
 
 
 # =========================================================================
@@ -251,6 +254,7 @@ class TrashListResponse(BaseModel):
     total: int
     offset: int
     limit: int
+    pagination: OffsetPaginationMeta
 
 
 class RestoreResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/storage_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/storage_schemas.py
@@ -7,9 +7,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 # File categories
 FileCategory = Literal["tts_audio", "stt_audio", "image", "voice_clone", "mindmap", "spreadsheet"]
@@ -91,6 +99,12 @@ class GeneratedFilesListResponse(BaseModel):
     offset: int
     limit: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 # =========================================================================
@@ -255,6 +269,12 @@ class TrashListResponse(BaseModel):
     offset: int
     limit: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class RestoreResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/synthetic_eval_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/synthetic_eval_schemas.py
@@ -8,6 +8,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class SyntheticEvalProvenance(str, Enum):
     """Source provenance for a synthetic evaluation draft sample."""
@@ -166,6 +168,7 @@ class SyntheticEvalQueueResponse(BaseModel):
 
     data: list[SyntheticEvalDraftSampleRecord] = Field(default_factory=list)
     total: int = 0
+    pagination: OffsetPaginationMeta
 
 
 class SyntheticEvalReviewRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/synthetic_eval_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/synthetic_eval_schemas.py
@@ -6,9 +6,17 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class SyntheticEvalProvenance(str, Enum):
@@ -168,7 +176,13 @@ class SyntheticEvalQueueResponse(BaseModel):
 
     data: list[SyntheticEvalDraftSampleRecord] = Field(default_factory=list)
     total: int = 0
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class SyntheticEvalReviewRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/synthetic_eval_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/synthetic_eval_schemas.py
@@ -8,15 +8,10 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
-
-
-def _default_offset_pagination_aliases(response):
-    if response.has_more is None:
-        response.has_more = response.pagination.has_more
-    if response.next_offset is None:
-        response.next_offset = response.pagination.next_offset
-    return response
+from tldw_Server_API.app.api.v1.schemas.pagination import (
+    OffsetPaginationMeta,
+    default_offset_pagination_aliases,
+)
 
 
 class SyntheticEvalProvenance(str, Enum):
@@ -182,7 +177,7 @@ class SyntheticEvalQueueResponse(BaseModel):
 
     @model_validator(mode="after")
     def _default_pagination_aliases(self):
-        return _default_offset_pagination_aliases(self)
+        return default_offset_pagination_aliases(self)
 
 
 class SyntheticEvalReviewRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/user_keys.py
+++ b/tldw_Server_API/app/api/v1/schemas/user_keys.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class UserProviderKeyUpsertRequest(BaseModel):
@@ -204,4 +212,10 @@ class ByokValidationRunListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)

--- a/tldw_Server_API/app/api/v1/schemas/user_keys.py
+++ b/tldw_Server_API/app/api/v1/schemas/user_keys.py
@@ -5,6 +5,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 class UserProviderKeyUpsertRequest(BaseModel):
     provider: str = Field(..., description="Provider name (e.g., 'openai').")
@@ -202,3 +204,4 @@ class ByokValidationRunListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    pagination: OffsetPaginationMeta

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -296,6 +296,7 @@ class RunsListResponse(BaseModel):
     items: list[Run]
     total: int
     has_more: bool | None = None
+    pagination: OffsetPaginationMeta
 
 
 class WatchlistOnboardingTelemetryIngestRequest(BaseModel):
@@ -436,6 +437,7 @@ class ScrapedItem(BaseModel):
 class ScrapedItemsListResponse(BaseModel):
     items: list[ScrapedItem]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class ScrapedItemSmartCountsResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import AnyUrl, BaseModel, Field, field_validator
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 SourceType = Literal["rss", "site", "forum"]  # forums are feature-flagged for Phase 3
 
@@ -88,6 +89,7 @@ class Source(BaseModel):
 class SourcesListResponse(BaseModel):
     items: list[Source]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class ReversibleDeleteResponse(BaseModel):
@@ -186,6 +188,7 @@ class Group(BaseModel):
 class GroupsListResponse(BaseModel):
     items: list[Group]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class Tag(BaseModel):
@@ -196,6 +199,7 @@ class Tag(BaseModel):
 class TagsListResponse(BaseModel):
     items: list[Tag]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class JobCreateRequest(BaseModel):
@@ -264,6 +268,7 @@ class Job(BaseModel):
 class JobsListResponse(BaseModel):
     items: list[Job]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class JobDeleteResponse(ReversibleDeleteResponse):

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -3,10 +3,18 @@ from __future__ import annotations
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import AnyUrl, BaseModel, Field, field_validator
+from pydantic import AnyUrl, BaseModel, Field, field_validator, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 SourceType = Literal["rss", "site", "forum"]  # forums are feature-flagged for Phase 3
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 # --------------------
@@ -90,6 +98,12 @@ class SourcesListResponse(BaseModel):
     items: list[Source]
     total: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ReversibleDeleteResponse(BaseModel):
@@ -189,6 +203,12 @@ class GroupsListResponse(BaseModel):
     items: list[Group]
     total: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class Tag(BaseModel):
@@ -200,6 +220,12 @@ class TagsListResponse(BaseModel):
     items: list[Tag]
     total: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class JobCreateRequest(BaseModel):
@@ -269,6 +295,12 @@ class JobsListResponse(BaseModel):
     items: list[Job]
     total: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class JobDeleteResponse(ReversibleDeleteResponse):
@@ -295,8 +327,13 @@ class RunCancelResponse(BaseModel):
 class RunsListResponse(BaseModel):
     items: list[Run]
     total: int
-    has_more: bool | None = None
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class WatchlistOnboardingTelemetryIngestRequest(BaseModel):
@@ -438,6 +475,12 @@ class ScrapedItemsListResponse(BaseModel):
     items: list[ScrapedItem]
     total: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class ScrapedItemSmartCountsResponse(BaseModel):
@@ -598,6 +641,12 @@ class WatchlistOutputsListResponse(BaseModel):
     items: list[WatchlistOutput]
     total: int
     pagination: OffsetPaginationMeta
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class WatchlistTemplateSummary(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/watchlists_schemas.py
@@ -597,6 +597,7 @@ class WatchlistOutput(BaseModel):
 class WatchlistOutputsListResponse(BaseModel):
     items: list[WatchlistOutput]
     total: int
+    pagination: OffsetPaginationMeta
 
 
 class WatchlistTemplateSummary(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/workflows.py
+++ b/tldw_Server_API/app/api/v1/schemas/workflows.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from tldw_Server_API.app.api.v1.schemas.pagination import CursorPaginationMeta, OffsetPaginationMeta
 
 
 class WorkflowInputSchema(BaseModel):
@@ -201,9 +203,29 @@ class WorkflowRunListItem(BaseModel):
 
 class WorkflowRunListResponse(BaseModel):
     runs: list[WorkflowRunListItem]
+    limit: int
+    offset: int | None = None
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    total: int | None = Field(
+        default=None,
+        ge=0,
+        description="Alias for pagination.total when the total is known",
+    )
+    pagination: OffsetPaginationMeta | CursorPaginationMeta
     next_offset: int | None = None
     next_cursor: str | None = None
 
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self) -> "WorkflowRunListResponse":
+        if self.has_more is None:
+            self.has_more = self.pagination.has_more
+        if self.total is None and hasattr(self.pagination, "total"):
+            self.total = self.pagination.total
+        if self.next_offset is None and isinstance(self.pagination, OffsetPaginationMeta):
+            self.next_offset = self.pagination.next_offset
+        if self.next_cursor is None and isinstance(self.pagination, CursorPaginationMeta):
+            self.next_cursor = self.pagination.next_cursor
+        return self
 
 class WorkflowFailureSummary(BaseModel):
     reason_code_core: str | None = None

--- a/tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py
@@ -8,6 +8,8 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
 
 # ---------------------------------------------------------------------------
 # Project
@@ -68,6 +70,9 @@ class ManuscriptProjectResponse(BaseModel):
 class ManuscriptProjectListResponse(BaseModel):
     projects: list[ManuscriptProjectResponse]
     total: int
+    limit: int
+    offset: int
+    pagination: OffsetPaginationMeta
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py
@@ -78,8 +78,8 @@ class ManuscriptProjectResponse(BaseModel):
 class ManuscriptProjectListResponse(BaseModel):
     projects: list[ManuscriptProjectResponse]
     total: int
-    limit: int
-    offset: int
+    limit: int = Field(..., ge=1)
+    offset: int = Field(..., ge=0)
     has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
     next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta

--- a/tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/writing_manuscript_schemas.py
@@ -11,6 +11,14 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validat
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
+
+
 # ---------------------------------------------------------------------------
 # Project
 # ---------------------------------------------------------------------------
@@ -72,7 +80,13 @@ class ManuscriptProjectListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/app/api/v1/schemas/writing_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/writing_schemas.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+
+
+def _default_offset_pagination_aliases(response):
+    if response.has_more is None:
+        response.has_more = response.pagination.has_more
+    if response.next_offset is None:
+        response.next_offset = response.pagination.next_offset
+    return response
 
 
 class WritingVersionResponse(BaseModel):
@@ -55,7 +63,13 @@ class WritingSessionListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class WritingTemplateCreate(BaseModel):
@@ -93,7 +107,13 @@ class WritingTemplateListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class WritingThemeCreate(BaseModel):
@@ -137,7 +157,13 @@ class WritingThemeListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool | None = Field(default=None, description="Alias for pagination.has_more")
+    next_offset: int | None = Field(default=None, ge=0, description="Alias for pagination.next_offset")
     pagination: OffsetPaginationMeta
+
+    @model_validator(mode="after")
+    def _default_pagination_aliases(self):
+        return _default_offset_pagination_aliases(self)
 
 
 class WritingDefaultTemplate(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/writing_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/writing_schemas.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
 
 class WritingVersionResponse(BaseModel):
@@ -52,6 +53,9 @@ class WritingSessionListItem(BaseModel):
 class WritingSessionListResponse(BaseModel):
     sessions: list[WritingSessionListItem]
     total: int
+    limit: int
+    offset: int
+    pagination: OffsetPaginationMeta
 
 
 class WritingTemplateCreate(BaseModel):
@@ -87,6 +91,9 @@ class WritingTemplateResponse(BaseModel):
 class WritingTemplateListResponse(BaseModel):
     templates: list[WritingTemplateResponse]
     total: int
+    limit: int
+    offset: int
+    pagination: OffsetPaginationMeta
 
 
 class WritingThemeCreate(BaseModel):
@@ -128,6 +135,9 @@ class WritingThemeResponse(BaseModel):
 class WritingThemeListResponse(BaseModel):
     themes: list[WritingThemeResponse]
     total: int
+    limit: int
+    offset: int
+    pagination: OffsetPaginationMeta
 
 
 class WritingDefaultTemplate(BaseModel):

--- a/tldw_Server_API/app/api/v1/utils/pagination.py
+++ b/tldw_Server_API/app/api/v1/utils/pagination.py
@@ -1,0 +1,86 @@
+"""Shared pagination metadata builders for API routes and services."""
+
+from __future__ import annotations
+
+from tldw_Server_API.app.api.v1.schemas.pagination import (
+    CursorPaginationMeta,
+    OffsetPaginationMeta,
+    PagePaginationMeta,
+)
+
+
+def build_offset_pagination_meta(
+    *,
+    limit: int,
+    offset: int,
+    total: int | None = None,
+    count: int | None = None,
+    has_more: bool | None = None,
+) -> OffsetPaginationMeta:
+    """Build canonical offset pagination metadata from route-local values."""
+    normalized_count = max(count or 0, 0)
+
+    if has_more is None:
+        if total is not None:
+            has_more = offset + normalized_count < total
+        else:
+            has_more = normalized_count >= limit
+
+    next_offset = offset + limit if has_more else None
+
+    return OffsetPaginationMeta(
+        limit=limit,
+        offset=offset,
+        total=total,
+        has_more=has_more,
+        next_offset=next_offset,
+    )
+
+
+def build_cursor_pagination_meta(
+    *,
+    limit: int,
+    cursor: str | None = None,
+    next_cursor: str | None = None,
+    has_more: bool | None = None,
+) -> CursorPaginationMeta:
+    """Build canonical cursor pagination metadata from route-local values."""
+    normalized_has_more = bool(next_cursor) if has_more is None else bool(has_more)
+    return CursorPaginationMeta(
+        limit=limit,
+        cursor=cursor,
+        next_cursor=next_cursor,
+        has_more=normalized_has_more,
+    )
+
+
+def build_page_pagination_meta(
+    *,
+    page: int,
+    per_page: int,
+    total: int | None = None,
+    total_pages: int | None = None,
+    has_more: bool | None = None,
+) -> PagePaginationMeta:
+    """Build canonical page-based pagination metadata from route-local values."""
+    normalized_page = int(page)
+    normalized_per_page = int(per_page)
+    normalized_total = int(total) if total is not None else None
+    normalized_total_pages = int(total_pages) if total_pages is not None else None
+    if has_more is None:
+        if normalized_total_pages is not None:
+            normalized_has_more = normalized_page < normalized_total_pages
+        elif normalized_total is not None and normalized_per_page > 0:
+            expected_total_pages = (normalized_total + normalized_per_page - 1) // normalized_per_page
+            normalized_has_more = normalized_page < expected_total_pages
+        else:
+            normalized_has_more = False
+    else:
+        normalized_has_more = bool(has_more)
+    return PagePaginationMeta(
+        page=normalized_page,
+        per_page=normalized_per_page,
+        total=normalized_total,
+        total_pages=normalized_total_pages,
+        has_more=normalized_has_more,
+    )

--- a/tldw_Server_API/app/core/Character_Chat/modules/character_chat.py
+++ b/tldw_Server_API/app/core/Character_Chat/modules/character_chat.py
@@ -848,7 +848,8 @@ def start_new_chat_session(
             if greeting_strategy in {"alternate_random", "alternate_index"} and original_alternate_greetings:
                 if greeting_strategy == "alternate_random":
                     if original_alternate_greetings:
-                        selected_alt = random.choice(original_alternate_greetings)
+                        # Non-security greeting selection.
+                        selected_alt = random.choice(original_alternate_greetings)  # nosec B311
                 elif greeting_strategy == "alternate_index":
                     if isinstance(alternate_index, int) and alternate_index >= 0 and alternate_index < len(original_alternate_greetings):
                         selected_alt = original_alternate_greetings[alternate_index]
@@ -1500,6 +1501,7 @@ def find_messages_in_conversation(
     character_name_for_placeholders: str,
     user_name_for_placeholders: Optional[str],
     limit: int = 10,
+    offset: int = 0,
 ) -> list[dict[str, Any]]:
     """Search for messages within a specific conversation by content."""
 
@@ -1508,6 +1510,7 @@ def find_messages_in_conversation(
             content_query=search_query,
             conversation_id=conversation_id,
             limit=limit,
+            offset=offset,
         )
 
         processed_results = []

--- a/tldw_Server_API/app/core/Claims_Extraction/claims_service.py
+++ b/tldw_Server_API/app/core/Claims_Extraction/claims_service.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 from fastapi import HTTPException, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.utils.pagination import build_offset_pagination_meta
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.permissions import (
     CLAIMS_ADMIN,

--- a/tldw_Server_API/app/core/Claims_Extraction/claims_service.py
+++ b/tldw_Server_API/app/core/Claims_Extraction/claims_service.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 from fastapi import HTTPException, status
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.permissions import (
     CLAIMS_ADMIN,
@@ -3474,6 +3475,12 @@ def list_claims_analytics_exports(
         "total": int(total),
         "limit": int(limit),
         "offset": int(offset),
+        "pagination": build_offset_pagination_meta(
+            total=int(total),
+            limit=int(limit),
+            offset=int(offset),
+            count=len(exports),
+        ),
     }
 
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -23578,6 +23578,9 @@ for _message_store_method in (
 for _note_store_method in (
     "add_note",
     "get_note_by_id",
+    "get_note_studio_document",
+    "create_note_studio_document",
+    "upsert_note_studio_document",
     "list_notes",
     "list_deleted_notes",
     "get_notes_batch",

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -23604,6 +23604,7 @@ for _keyword_store_method in (
     "get_keyword_collection_by_id",
     "get_keyword_collection_by_name",
     "list_keyword_collections",
+    "count_keyword_collections",
     "update_keyword_collection",
     "soft_delete_keyword_collection",
     "search_keyword_collections",

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -15911,6 +15911,25 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         rows = cursor.fetchall()
         return [self._deserialize_moodboard_row(row) for row in rows if row]
 
+    def count_moodboards(
+        self,
+        include_deleted: bool = False,
+        only_deleted: bool = False,
+    ) -> int:
+        where_clause = ""
+        params: list[Any] = []
+        if only_deleted:
+            where_clause = " WHERE deleted = ?"
+            params.append(True if self.backend_type == BackendType.POSTGRESQL else 1)
+        elif not include_deleted:
+            where_clause = " WHERE deleted = ?"
+            params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
+
+        query = f"SELECT COUNT(*) AS total FROM moodboards{where_clause}"  # nosec B608
+        cursor = self.execute_query(query, tuple(params))
+        row = cursor.fetchone()
+        return int(row["total"]) if row and row["total"] is not None else 0
+
     def update_moodboard(self, moodboard_id: int, update_data: dict[str, Any], expected_version: int) -> bool | None:
         if not update_data:
             raise InputError("No data provided for moodboard update.")  # noqa: TRY003

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -3804,6 +3804,13 @@ class CollectionsDatabase:
         rows = self.backend.execute(q, (self.user_id, limit, offset)).rows
         return [AudiobookProjectRow(**row) for row in rows]
 
+    def count_audiobook_projects(self) -> int:
+        row = self.backend.execute(
+            "SELECT COUNT(*) AS total FROM audiobook_projects WHERE user_id = ?",
+            (self.user_id,),
+        ).first
+        return int(row["total"] if row and row["total"] is not None else 0)
+
     def update_audiobook_project_status(
         self,
         project_id: int,

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -71,6 +71,19 @@ _COLLECTIONS_NONCRITICAL_EXCEPTIONS = (
 )
 
 
+def _count_row_total(row: Any) -> int:
+    if not row:
+        return 0
+    if isinstance(row, dict):
+        value = row.get("total")
+    else:
+        try:
+            value = row["total"]
+        except (IndexError, KeyError, TypeError):
+            value = row[0]
+    return int(value if value is not None else 0)
+
+
 def _utcnow_iso() -> str:
     return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
 
@@ -3809,7 +3822,7 @@ class CollectionsDatabase:
             "SELECT COUNT(*) AS total FROM audiobook_projects WHERE user_id = ?",
             (self.user_id,),
         ).first
-        return int(row["total"] if row and row["total"] is not None else 0)
+        return _count_row_total(row)
 
     def update_audiobook_project_status(
         self,
@@ -3987,7 +4000,7 @@ class CollectionsDatabase:
             "SELECT COUNT(*) AS total FROM audiobook_voice_profiles WHERE user_id = ?",
             (self.user_id,),
         ).first
-        return int(row["total"] if row and row["total"] is not None else 0)
+        return _count_row_total(row)
 
     def delete_voice_profile(self, profile_id: str) -> None:
         q = "DELETE FROM audiobook_voice_profiles WHERE profile_id = ? AND user_id = ?"

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -3982,6 +3982,13 @@ class CollectionsDatabase:
         rows = self.backend.execute(q, (self.user_id, limit, offset)).rows
         return [VoiceProfileRow(**row) for row in rows]
 
+    def count_voice_profiles(self) -> int:
+        row = self.backend.execute(
+            "SELECT COUNT(*) AS total FROM audiobook_voice_profiles WHERE user_id = ?",
+            (self.user_id,),
+        ).first
+        return int(row["total"] if row and row["total"] is not None else 0)
+
     def delete_voice_profile(self, profile_id: str) -> None:
         q = "DELETE FROM audiobook_voice_profiles WHERE profile_id = ? AND user_id = ?"
         res = self.backend.execute(q, (profile_id, self.user_id))

--- a/tldw_Server_API/app/core/DB_Management/Evaluations_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Evaluations_DB.py
@@ -2130,6 +2130,28 @@ class EvaluationsDatabase:
 
             return datasets, has_more
 
+    def count_datasets(
+        self,
+        *,
+        after: Optional[str] = None,
+        created_by: Optional[str] = None,
+    ) -> int:
+        """Count datasets matching the same list filters."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+
+            query = "SELECT COUNT(*) FROM datasets WHERE 1=1"
+            params: list[Any] = []
+
+            if after:
+                query += " AND created_at < (SELECT created_at FROM datasets WHERE id = ?)"
+                params.append(after)
+
+            query, params = self._append_user_filter(query, params, "created_by", created_by)
+            cursor.execute(query, params)
+            row = cursor.fetchone()
+            return int(row[0] or 0) if row else 0
+
     def delete_dataset(self, dataset_id: str, *, created_by: Optional[str] = None) -> bool:
         """Delete dataset"""
         with self.get_connection() as conn:

--- a/tldw_Server_API/app/core/DB_Management/Evaluations_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Evaluations_DB.py
@@ -2140,7 +2140,7 @@ class EvaluationsDatabase:
         with self.get_connection() as conn:
             cursor = conn.cursor()
 
-            query = "SELECT COUNT(*) FROM datasets WHERE 1=1"
+            query = "SELECT COUNT(*) AS total FROM datasets WHERE 1=1"
             params: list[Any] = []
 
             if after:
@@ -2150,7 +2150,10 @@ class EvaluationsDatabase:
             query, params = self._append_user_filter(query, params, "created_by", created_by)
             cursor.execute(query, params)
             row = cursor.fetchone()
-            return int(row[0] or 0) if row else 0
+            if not row:
+                return 0
+            value = row.get("total") if isinstance(row, dict) else row[0]
+            return int(value or 0)
 
     def delete_dataset(self, dataset_id: str, *, created_by: Optional[str] = None) -> bool:
         """Delete dataset"""

--- a/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
@@ -2002,6 +2002,21 @@ class PromptsDatabase:
                 raise
             raise DatabaseError(f"Failed to list prompt collections: {e}") from e  # noqa: TRY003
 
+    def count_prompt_collections(self) -> int:
+        try:
+            row = self.execute_query(
+                """
+                SELECT COUNT(*) AS total
+                FROM PromptCollections
+                """
+            ).fetchone()
+            return int(row["total"] if row and row["total"] is not None else 0)
+        except (DatabaseError, sqlite3.Error) as e:
+            logger.error(f"Error counting prompt collections: {e}", exc_info=True)
+            if isinstance(e, DatabaseError):
+                raise
+            raise DatabaseError(f"Failed to count prompt collections: {e}") from e  # noqa: TRY003
+
     def update_prompt_collection(
         self,
         collection_id: int,

--- a/tldw_Server_API/app/core/DB_Management/chacha/keyword_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/keyword_store.py
@@ -553,6 +553,21 @@ class KeywordStore:
         """
         return self._db._list_generic_items("keyword_collections", "name COLLATE NOCASE", limit, offset)
 
+    def count_keyword_collections(self) -> int:
+        """Return count of active (non-deleted) keyword collections."""
+        collections_table = self._db._map_table_for_backend("keyword_collections")
+        query = (
+            f"SELECT COUNT(*) AS cnt FROM {collections_table} "  # nosec B608
+            f"WHERE deleted = {self._deleted_literal(False)}"
+        )
+        try:
+            cursor = self._db.execute_query(query)
+            row = cursor.fetchone()
+            return int(row["cnt"]) if row else 0
+        except CharactersRAGDBError as exc:
+            logger.error(f"Error counting keyword collections: {exc}")
+            raise
+
     def update_keyword_collection(self, collection_id: int, update_data: dict[str, Any], expected_version: int) -> bool:
         """
         Updates a keyword collection with optimistic locking.

--- a/tldw_Server_API/app/core/DB_Management/chacha/message_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/message_store.py
@@ -674,7 +674,13 @@ class MessageStore:
     # Full-text search
     # ------------------------------------------------------------------
 
-    def search_messages_by_content(self, content_query: str, conversation_id: str | None = None, limit: int = 10) -> list[dict[str, Any]]:
+    def search_messages_by_content(
+        self,
+        content_query: str,
+        conversation_id: str | None = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
         """
         Searches messages by content using FTS.
 
@@ -686,6 +692,7 @@ class MessageStore:
             content_query: The search term for content. Supports FTS query syntax.
             conversation_id: Optional conversation UUID to filter results.
             limit: Maximum number of results. Defaults to 10.
+            offset: Number of matching rows to skip. Defaults to 0.
 
         Returns:
             A list of matching message dictionaries. Can be empty.
@@ -712,8 +719,8 @@ class MessageStore:
                 params_list.append(conversation_id)
 
             base_query.append("ORDER BY rank DESC, m.last_modified DESC")
-            base_query.append("LIMIT ?")
-            params_list.append(limit)
+            base_query.append("LIMIT ? OFFSET ?")
+            params_list.extend([limit, offset])
 
             try:
                 cursor = self._db.execute_query("\n".join(base_query), tuple(params_list))
@@ -736,8 +743,8 @@ class MessageStore:
             base_query += " AND m.conversation_id = ?"
             params_list.append(conversation_id)
 
-        base_query += " ORDER BY bm25(messages_fts) ASC, m.last_modified DESC LIMIT ?"
-        params_list.append(limit)
+        base_query += " ORDER BY bm25(messages_fts) ASC, m.last_modified DESC LIMIT ? OFFSET ?"
+        params_list.extend([limit, offset])
 
         try:
             cursor = self._db.execute_query(base_query, tuple(params_list))

--- a/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from typing import TYPE_CHECKING, Any
 
@@ -10,6 +11,8 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     ConflictError,
     FTSQueryTranslator,
     InputError,
+    _SUPPORTED_NOTE_STUDIO_HANDWRITING_MODES,
+    _SUPPORTED_NOTE_STUDIO_TEMPLATE_TYPES,
     _CHACHA_NONCRITICAL_EXCEPTIONS,
     logger,
 )
@@ -119,8 +122,204 @@ class NoteStore:
         if note and include_studio_summary:
             studio_document = self._db.get_note_studio_document(note_id)
             if studio_document:
-                note["studio"] = self._db._build_note_studio_summary(studio_document)
+                note["studio"] = self._build_note_studio_summary(studio_document)
         return note
+
+    @staticmethod
+    def _serialize_note_studio_json_field(value: dict[str, Any] | None, field_name: str, *, required: bool) -> str | None:
+        if value is None:
+            if required:
+                raise InputError(f"{field_name} cannot be None.")  # noqa: TRY003
+            return None
+        if not isinstance(value, dict):
+            raise InputError(f"{field_name} must be a JSON object.")  # noqa: TRY003
+        try:
+            return json.dumps(value)
+        except TypeError as exc:
+            raise InputError(f"{field_name} must be JSON serializable.") from exc  # noqa: TRY003
+
+    @staticmethod
+    def _build_note_studio_summary(document: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "note_id": document["note_id"],
+            "template_type": document["template_type"],
+            "handwriting_mode": document["handwriting_mode"],
+            "source_note_id": document.get("source_note_id"),
+            "excerpt_hash": document.get("excerpt_hash"),
+            "companion_content_hash": document.get("companion_content_hash"),
+            "render_version": document.get("render_version", 1),
+        }
+
+    def _fetch_note_studio_document_row(
+        self,
+        note_id: str,
+        *,
+        conn: sqlite3.Connection | BackendConnectionWrapper | None = None,
+    ) -> dict[str, Any] | None:
+        query = "SELECT * FROM note_studio_documents WHERE note_id = ?"
+        if conn is None:
+            cursor = self._db.execute_query(query, (note_id,))
+        else:
+            cursor = conn.execute(query, (note_id,))
+        row = cursor.fetchone()
+        return self._db._deserialize_row_fields(row, ["payload_json", "diagram_manifest_json"]) if row else None
+
+    def get_note_studio_document(self, note_id: str) -> dict[str, Any] | None:
+        return self._fetch_note_studio_document_row(note_id)
+
+    def _write_note_studio_document(
+        self,
+        *,
+        note_id: str,
+        payload_json: dict[str, Any],
+        template_type: str,
+        handwriting_mode: str,
+        source_note_id: str | None,
+        excerpt_snapshot: str | None,
+        excerpt_hash: str | None,
+        diagram_manifest_json: dict[str, Any] | None,
+        companion_content_hash: str | None,
+        render_version: int,
+        conn: sqlite3.Connection | BackendConnectionWrapper | None,
+        upsert: bool,
+    ) -> dict[str, Any]:
+        normalized_note_id = str(note_id).strip()
+        if not normalized_note_id:
+            raise InputError("note_id cannot be empty.")  # noqa: TRY003
+        if template_type not in _SUPPORTED_NOTE_STUDIO_TEMPLATE_TYPES:
+            raise InputError(
+                f"template_type must be one of {sorted(_SUPPORTED_NOTE_STUDIO_TEMPLATE_TYPES)}."
+            )  # noqa: TRY003
+        if handwriting_mode not in _SUPPORTED_NOTE_STUDIO_HANDWRITING_MODES:
+            raise InputError(
+                f"handwriting_mode must be one of {sorted(_SUPPORTED_NOTE_STUDIO_HANDWRITING_MODES)}."
+            )  # noqa: TRY003
+        if not isinstance(render_version, int) or render_version < 1:
+            raise InputError("render_version must be an integer >= 1.")  # noqa: TRY003
+
+        payload_json_str = self._serialize_note_studio_json_field(payload_json, "payload_json", required=True)
+        diagram_manifest_json_str = self._serialize_note_studio_json_field(
+            diagram_manifest_json,
+            "diagram_manifest_json",
+            required=False,
+        )
+        now = self._db._get_current_utc_timestamp_iso()
+
+        if upsert:
+            query = (
+                "INSERT INTO note_studio_documents ("
+                "note_id, payload_json, template_type, handwriting_mode, source_note_id, "
+                "excerpt_snapshot, excerpt_hash, diagram_manifest_json, companion_content_hash, "
+                "render_version, created_at, last_modified"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(note_id) DO UPDATE SET "
+                "payload_json = excluded.payload_json, "
+                "template_type = excluded.template_type, "
+                "handwriting_mode = excluded.handwriting_mode, "
+                "source_note_id = excluded.source_note_id, "
+                "excerpt_snapshot = excluded.excerpt_snapshot, "
+                "excerpt_hash = excluded.excerpt_hash, "
+                "diagram_manifest_json = excluded.diagram_manifest_json, "
+                "companion_content_hash = excluded.companion_content_hash, "
+                "render_version = excluded.render_version, "
+                "last_modified = excluded.last_modified"
+            )
+        else:
+            query = (
+                "INSERT INTO note_studio_documents ("
+                "note_id, payload_json, template_type, handwriting_mode, source_note_id, "
+                "excerpt_snapshot, excerpt_hash, diagram_manifest_json, companion_content_hash, "
+                "render_version, created_at, last_modified"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            )
+
+        params = (
+            normalized_note_id,
+            payload_json_str,
+            template_type,
+            handwriting_mode,
+            source_note_id,
+            excerpt_snapshot,
+            excerpt_hash,
+            diagram_manifest_json_str,
+            companion_content_hash,
+            render_version,
+            now,
+            now,
+        )
+
+        def _execute(inner_conn: sqlite3.Connection | BackendConnectionWrapper) -> dict[str, Any]:
+            prepared_query, prepared_params = self._db._prepare_backend_statement(query, params)
+            inner_conn.execute(prepared_query, prepared_params or ())
+            document = self._fetch_note_studio_document_row(normalized_note_id, conn=inner_conn)
+            if not document:
+                raise CharactersRAGDBError(f"Failed to read note studio document for note ID '{normalized_note_id}'.")
+            return document
+
+        if conn is None:
+            with self._db.transaction() as transaction_conn:
+                return _execute(transaction_conn)
+        return _execute(conn)
+
+    def create_note_studio_document(
+        self,
+        *,
+        note_id: str,
+        payload_json: dict[str, Any],
+        template_type: str,
+        handwriting_mode: str,
+        source_note_id: str | None = None,
+        excerpt_snapshot: str | None = None,
+        excerpt_hash: str | None = None,
+        diagram_manifest_json: dict[str, Any] | None = None,
+        companion_content_hash: str | None = None,
+        render_version: int,
+        conn: sqlite3.Connection | BackendConnectionWrapper | None = None,
+    ) -> dict[str, Any]:
+        return self._write_note_studio_document(
+            note_id=note_id,
+            payload_json=payload_json,
+            template_type=template_type,
+            handwriting_mode=handwriting_mode,
+            source_note_id=source_note_id,
+            excerpt_snapshot=excerpt_snapshot,
+            excerpt_hash=excerpt_hash,
+            diagram_manifest_json=diagram_manifest_json,
+            companion_content_hash=companion_content_hash,
+            render_version=render_version,
+            conn=conn,
+            upsert=False,
+        )
+
+    def upsert_note_studio_document(
+        self,
+        *,
+        note_id: str,
+        payload_json: dict[str, Any],
+        template_type: str,
+        handwriting_mode: str,
+        source_note_id: str | None = None,
+        excerpt_snapshot: str | None = None,
+        excerpt_hash: str | None = None,
+        diagram_manifest_json: dict[str, Any] | None = None,
+        companion_content_hash: str | None = None,
+        render_version: int,
+        conn: sqlite3.Connection | BackendConnectionWrapper | None = None,
+    ) -> dict[str, Any]:
+        return self._write_note_studio_document(
+            note_id=note_id,
+            payload_json=payload_json,
+            template_type=template_type,
+            handwriting_mode=handwriting_mode,
+            source_note_id=source_note_id,
+            excerpt_snapshot=excerpt_snapshot,
+            excerpt_hash=excerpt_hash,
+            diagram_manifest_json=diagram_manifest_json,
+            companion_content_hash=companion_content_hash,
+            render_version=render_version,
+            conn=conn,
+            upsert=True,
+        )
 
     def list_notes(
         self,

--- a/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
+++ b/tldw_Server_API/app/core/DB_Management/chacha/note_store.py
@@ -256,10 +256,33 @@ class NoteStore:
                 raise CharactersRAGDBError(f"Failed to read note studio document for note ID '{normalized_note_id}'.")
             return document
 
-        if conn is None:
-            with self._db.transaction() as transaction_conn:
-                return _execute(transaction_conn)
-        return _execute(conn)
+        try:
+            if conn is None:
+                with self._db.transaction() as transaction_conn:
+                    return _execute(transaction_conn)
+            return _execute(conn)
+        except sqlite3.IntegrityError as e:
+            msg = str(e).lower()
+            if "foreign key" in msg:
+                raise ConflictError("Note not found.", entity="notes", entity_id=normalized_note_id) from e  # noqa: TRY003
+            if "unique constraint" in msg:
+                raise ConflictError(  # noqa: TRY003
+                    f"Note studio document for note ID '{normalized_note_id}' already exists.",
+                    entity="note_studio_documents",
+                    entity_id=normalized_note_id,
+                ) from e
+            raise CharactersRAGDBError(f"Database integrity error writing note studio document: {e}") from e  # noqa: TRY003
+        except BackendDatabaseError as e:
+            msg = str(e).lower()
+            if "foreign key" in msg:
+                raise ConflictError("Note not found.", entity="notes", entity_id=normalized_note_id) from e  # noqa: TRY003
+            if "duplicate key" in msg or "unique constraint" in msg:
+                raise ConflictError(  # noqa: TRY003
+                    f"Note studio document for note ID '{normalized_note_id}' already exists.",
+                    entity="note_studio_documents",
+                    entity_id=normalized_note_id,
+                ) from e
+            raise CharactersRAGDBError(f"Backend error writing note studio document: {e}") from e  # noqa: TRY003
 
     def create_note_studio_document(
         self,

--- a/tldw_Server_API/app/core/Evaluations/synthetic_eval_repository.py
+++ b/tldw_Server_API/app/core/Evaluations/synthetic_eval_repository.py
@@ -141,17 +141,15 @@ class SyntheticEvalRepository:
         payload.pop("review_summary_json", None)
         return payload
 
-    def list_draft_samples(
+    def _filtered_draft_samples(
         self,
         *,
         recipe_kind: str | None = None,
         review_state: str | SyntheticEvalReviewState | None = None,
         source_kind: str | None = None,
         generation_batch_id: str | None = None,
-        limit: int = 50,
-        offset: int = 0,
     ) -> list[dict[str, Any]]:
-        """List persisted synthetic draft samples with simple filters."""
+        """Return all matching synthetic draft samples before pagination."""
 
         query = "SELECT * FROM synthetic_eval_draft_samples WHERE 1=1"
         params: list[Any] = []
@@ -191,10 +189,50 @@ class SyntheticEvalRepository:
                 if str((sample.get("sample_metadata") or {}).get("generation_batch_id") or "") == generation_batch_id
             ]
 
+        return results
+
+    def list_draft_samples(
+        self,
+        *,
+        recipe_kind: str | None = None,
+        review_state: str | SyntheticEvalReviewState | None = None,
+        source_kind: str | None = None,
+        generation_batch_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List persisted synthetic draft samples with simple filters."""
+
+        results = self._filtered_draft_samples(
+            recipe_kind=recipe_kind,
+            review_state=review_state,
+            source_kind=source_kind,
+            generation_batch_id=generation_batch_id,
+        )
+
         start = max(0, int(offset))
         end = start + max(1, int(limit))
         results = results[start:end]
         return results
+
+    def count_draft_samples(
+        self,
+        *,
+        recipe_kind: str | None = None,
+        review_state: str | SyntheticEvalReviewState | None = None,
+        source_kind: str | None = None,
+        generation_batch_id: str | None = None,
+    ) -> int:
+        """Count matching synthetic draft samples before pagination."""
+
+        return len(
+            self._filtered_draft_samples(
+                recipe_kind=recipe_kind,
+                review_state=review_state,
+                source_kind=source_kind,
+                generation_batch_id=generation_batch_id,
+            )
+        )
 
     def get_draft_samples(self, sample_ids: list[str]) -> list[dict[str, Any]]:
         """Fetch multiple draft samples in caller-provided order."""

--- a/tldw_Server_API/app/core/Evaluations/synthetic_eval_repository.py
+++ b/tldw_Server_API/app/core/Evaluations/synthetic_eval_repository.py
@@ -49,6 +49,35 @@ def _is_synthetic_origin(provenance: str | SyntheticEvalProvenance) -> bool:
     return value.startswith("synthetic_")
 
 
+def _draft_sample_filter_clause(
+    *,
+    recipe_kind: str | None = None,
+    review_state: str | SyntheticEvalReviewState | None = None,
+    source_kind: str | None = None,
+    generation_batch_id: str | None = None,
+) -> tuple[str, list[Any]]:
+    query = " WHERE 1=1"
+    params: list[Any] = []
+    if recipe_kind:
+        query += " AND recipe_kind = ?"
+        params.append(recipe_kind)
+    if review_state:
+        normalized_state = (
+            review_state.value
+            if isinstance(review_state, SyntheticEvalReviewState)
+            else str(review_state)
+        )
+        query += " AND review_state = ?"
+        params.append(normalized_state)
+    if source_kind:
+        query += " AND source_kind = ?"
+        params.append(source_kind)
+    if generation_batch_id:
+        query += " AND CAST(sample_metadata_json AS TEXT) LIKE ?"
+        params.append(f'%\"generation_batch_id\":{_json_dumps(generation_batch_id)}%')
+    return query, params
+
+
 class SyntheticEvalRepository:
     """Persistence helper for synthetic evaluation draft samples."""
 
@@ -148,26 +177,23 @@ class SyntheticEvalRepository:
         review_state: str | SyntheticEvalReviewState | None = None,
         source_kind: str | None = None,
         generation_batch_id: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
-        """Return all matching synthetic draft samples before pagination."""
+        """Return matching synthetic draft samples."""
 
-        query = "SELECT * FROM synthetic_eval_draft_samples WHERE 1=1"
-        params: list[Any] = []
-        if recipe_kind:
-            query += " AND recipe_kind = ?"
-            params.append(recipe_kind)
-        if review_state:
-            normalized_state = (
-                review_state.value
-                if isinstance(review_state, SyntheticEvalReviewState)
-                else str(review_state)
-            )
-            query += " AND review_state = ?"
-            params.append(normalized_state)
-        if source_kind:
-            query += " AND source_kind = ?"
-            params.append(source_kind)
+        where_clause, params = _draft_sample_filter_clause(
+            recipe_kind=recipe_kind,
+            review_state=review_state,
+            source_kind=source_kind,
+            generation_batch_id=generation_batch_id,
+        )
+        # where_clause is assembled from fixed predicates and bound parameters.
+        query = "SELECT * FROM synthetic_eval_draft_samples" + where_clause  # nosec B608
         query += " ORDER BY created_at DESC, sample_id DESC"
+        if limit is not None:
+            query += " LIMIT ? OFFSET ?"
+            params.extend([max(1, int(limit)), max(0, int(offset))])
 
         with self._db.get_connection() as conn:
             cursor = conn.cursor()
@@ -181,13 +207,6 @@ class SyntheticEvalRepository:
             payload["sample_metadata"] = _json_load(payload.pop("sample_metadata_json", None)) or {}
             payload.pop("review_summary_json", None)
             results.append(payload)
-
-        if generation_batch_id:
-            results = [
-                sample
-                for sample in results
-                if str((sample.get("sample_metadata") or {}).get("generation_batch_id") or "") == generation_batch_id
-            ]
 
         return results
 
@@ -208,11 +227,9 @@ class SyntheticEvalRepository:
             review_state=review_state,
             source_kind=source_kind,
             generation_batch_id=generation_batch_id,
+            limit=limit,
+            offset=offset,
         )
-
-        start = max(0, int(offset))
-        end = start + max(1, int(limit))
-        results = results[start:end]
         return results
 
     def count_draft_samples(
@@ -225,14 +242,27 @@ class SyntheticEvalRepository:
     ) -> int:
         """Count matching synthetic draft samples before pagination."""
 
-        return len(
-            self._filtered_draft_samples(
-                recipe_kind=recipe_kind,
-                review_state=review_state,
-                source_kind=source_kind,
-                generation_batch_id=generation_batch_id,
-            )
+        where_clause, params = _draft_sample_filter_clause(
+            recipe_kind=recipe_kind,
+            review_state=review_state,
+            source_kind=source_kind,
+            generation_batch_id=generation_batch_id,
         )
+        # where_clause is assembled from fixed predicates and bound parameters.
+        query = "SELECT COUNT(*) AS total FROM synthetic_eval_draft_samples" + where_clause  # nosec B608
+
+        with self._db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, params)
+            row = cursor.fetchone()
+        if not row:
+            return 0
+        try:
+            row_dict = _row_to_dict(row)
+        except TypeError:
+            row_dict = {}
+        value = row_dict.get("total") if row_dict else row[0]
+        return int(value or 0)
 
     def get_draft_samples(self, sample_ids: list[str]) -> list[dict[str, Any]]:
         """Fetch multiple draft samples in caller-provided order."""

--- a/tldw_Server_API/app/core/Evaluations/synthetic_eval_service.py
+++ b/tldw_Server_API/app/core/Evaluations/synthetic_eval_service.py
@@ -307,9 +307,15 @@ class SyntheticEvalWorkflowService:
             limit=limit,
             offset=offset,
         )
+        total = self.repository.count_draft_samples(
+            recipe_kind=recipe_kind,
+            review_state=review_state,
+            source_kind=source_kind,
+            generation_batch_id=generation_batch_id,
+        )
         return {
             "data": rows,
-            "total": len(rows),
+            "total": total,
         }
 
     def review_sample(

--- a/tldw_Server_API/app/services/admin_budgets_service.py
+++ b/tldw_Server_API/app/services/admin_budgets_service.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import HTTPException
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.utils.pagination import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     OrgBudgetItem,
     OrgBudgetListResponse,

--- a/tldw_Server_API/app/services/admin_budgets_service.py
+++ b/tldw_Server_API/app/services/admin_budgets_service.py
@@ -7,6 +7,7 @@ from typing import Any
 from fastapi import HTTPException
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     OrgBudgetItem,
     OrgBudgetListResponse,
@@ -376,6 +377,12 @@ async def list_budgets(
             total=total,
             page=page,
             limit=limit,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=(page - 1) * limit,
+                count=len(items),
+            ),
         )
     except Exception as exc:
         logger.error("Failed to list org budgets")

--- a/tldw_Server_API/app/services/admin_maintenance_rotation_service.py
+++ b/tldw_Server_API/app/services/admin_maintenance_rotation_service.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from fastapi import HTTPException
 
-from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
+from tldw_Server_API.app.api.v1.utils.pagination import (
     build_offset_pagination_meta,
 )
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (

--- a/tldw_Server_API/app/services/admin_maintenance_rotation_service.py
+++ b/tldw_Server_API/app/services/admin_maintenance_rotation_service.py
@@ -7,6 +7,9 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
+    build_offset_pagination_meta,
+)
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     MaintenanceRotationRunItem,
     MaintenanceRotationRunListResponse,
@@ -172,6 +175,12 @@ class AdminMaintenanceRotationService:
             total=total,
             limit=limit,
             offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total,
+                limit=limit,
+                offset=offset,
+                count=len(rows),
+            ),
         )
         return response.model_dump(mode="json")
 

--- a/tldw_Server_API/app/services/admin_orgs_service.py
+++ b/tldw_Server_API/app/services/admin_orgs_service.py
@@ -6,6 +6,7 @@ from typing import Any
 from fastapi import HTTPException, status
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.org_team_schemas import (
     OrganizationCreateRequest,
     OrganizationResponse,
@@ -285,13 +286,20 @@ async def list_orgs(
         items = [OrganizationResponse(**r).model_dump() for r in rows]
 
         if wants_wrapper:
+            total_count = int(total or 0)
             has_more = (offset + len(items)) < int(total or 0)
             return {
                 "items": items,
-                "total": int(total or 0),
+                "total": total_count,
                 "limit": limit,
                 "offset": offset,
                 "has_more": has_more,
+                "pagination": build_offset_pagination_meta(
+                    total=total_count,
+                    limit=limit,
+                    offset=offset,
+                    count=len(items),
+                ),
             }
         return items
     except HTTPException:

--- a/tldw_Server_API/app/services/admin_orgs_service.py
+++ b/tldw_Server_API/app/services/admin_orgs_service.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import HTTPException, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.utils.pagination import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.org_team_schemas import (
     OrganizationCreateRequest,
     OrganizationResponse,

--- a/tldw_Server_API/app/services/admin_system_service.py
+++ b/tldw_Server_API/app/services/admin_system_service.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 from fastapi import HTTPException
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     ActivitySummaryResponse,
     AuditLogResponse,
@@ -513,7 +514,13 @@ async def get_audit_log(
         if org_id is not None:
             org_ids = [org_id] if org_ids is None else [org_id] if org_id in org_ids else []
         if org_ids is not None and len(org_ids) == 0:
-            return AuditLogResponse(entries=[], total=0, limit=limit, offset=offset)
+            return AuditLogResponse(
+                entries=[],
+                total=0,
+                limit=limit,
+                offset=offset,
+                pagination=build_offset_pagination_meta(total=0, limit=limit, offset=offset, count=0),
+            )
 
         if user_id:
             await admin_scope_service.enforce_admin_user_scope(principal, user_id, require_hierarchy=False)
@@ -675,7 +682,19 @@ async def get_audit_log(
                 }
                 entries.append(entry)
 
-        return AuditLogResponse(entries=entries, total=int(total or 0), limit=limit, offset=offset)
+        total_count = int(total or 0)
+        return AuditLogResponse(
+            entries=entries,
+            total=total_count,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(
+                total=total_count,
+                limit=limit,
+                offset=offset,
+                count=len(entries),
+            ),
+        )
 
     except HTTPException:
         raise
@@ -744,7 +763,13 @@ async def list_system_logs(
     if org_id is not None:
         org_ids = [org_id] if org_ids is None else [org_id] if org_id in org_ids else []
     if org_ids is not None and len(org_ids) == 0:
-        return SystemLogsResponse(items=[], total=0, limit=limit, offset=offset)
+        return SystemLogsResponse(
+            items=[],
+            total=0,
+            limit=limit,
+            offset=offset,
+            pagination=build_offset_pagination_meta(total=0, limit=limit, offset=offset, count=0),
+        )
 
     items, total = query_system_logs(
         start=start_dt,
@@ -763,6 +788,12 @@ async def list_system_logs(
         total=total,
         limit=limit,
         offset=offset,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            count=len(items),
+        ),
     )
 
 

--- a/tldw_Server_API/app/services/admin_system_service.py
+++ b/tldw_Server_API/app/services/admin_system_service.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 from fastapi import HTTPException
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.utils.pagination import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     ActivitySummaryResponse,
     AuditLogResponse,
@@ -848,11 +848,12 @@ async def get_error_breakdown(
                 org_condition = f" AND om.org_id IN ({placeholders})"
                 org_params = list(org_ids)
 
+        # Clauses are server-defined fragments; org values remain bound parameters.
         query = (
-            f"SELECT a.action, COUNT(*) as cnt, MAX(a.created_at) as last_at"
-            f" FROM audit_log a{join_clause}"
-            f" WHERE {time_clause} AND {error_actions_clause}{org_condition}"
-            f" GROUP BY a.action ORDER BY cnt DESC LIMIT 50"
+            f"SELECT a.action, COUNT(*) as cnt, MAX(a.created_at) as last_at"  # nosec B608
+            f" FROM audit_log a{join_clause}"  # nosec B608
+            f" WHERE {time_clause} AND {error_actions_clause}{org_condition}"  # nosec B608
+            f" GROUP BY a.action ORDER BY cnt DESC LIMIT 50"  # nosec B608
         )
         params = time_params + org_params
 

--- a/tldw_Server_API/app/services/admin_usage_service.py
+++ b/tldw_Server_API/app/services/admin_usage_service.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import HTTPException
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.utils.pagination import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     LLMTopSpenderRow,
     LLMTopSpendersResponse,

--- a/tldw_Server_API/app/services/admin_usage_service.py
+++ b/tldw_Server_API/app/services/admin_usage_service.py
@@ -5,6 +5,7 @@ from typing import Any
 from fastapi import HTTPException
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     LLMTopSpenderRow,
     LLMTopSpendersResponse,
@@ -863,7 +864,19 @@ async def get_llm_usage(
             org_ids=org_ids,
         )
         items = [LLMUsageLogRow(**r) for r in rows]
-        return LLMUsageLogResponse(items=items, total=int(total or 0), page=page, limit=limit)
+        total_count = int(total or 0)
+        return LLMUsageLogResponse(
+            items=items,
+            total=total_count,
+            page=page,
+            limit=limit,
+            pagination=build_offset_pagination_meta(
+                total=total_count,
+                limit=limit,
+                offset=(page - 1) * limit,
+                count=len(items),
+            ),
+        )
     except _ADMIN_USAGE_NONCRITICAL_EXCEPTIONS:
         logger.exception("Failed to query llm_usage_log")
         raise HTTPException(status_code=500, detail="Failed to load LLM usage data") from None

--- a/tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py
+++ b/tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py
@@ -77,7 +77,55 @@ async def _add_usage(store, session_id: str, prompt_tokens: int, completion_toke
 
 
 # ===========================================================================
-# 1. GET /admin/acp/agents/metrics
+# 1. GET /admin/acp/sessions
+# ===========================================================================
+
+
+class TestACPAdminSessionsList:
+    """Route-level tests for the ACP sessions admin list endpoint."""
+
+    def test_sessions_list_includes_canonical_pagination(self, monkeypatch, tmp_path):
+        """Listing ACP sessions preserves total and adds nested pagination."""
+        store = _make_store(tmp_path)
+
+        async def _seed():
+            await _register_session(store, "s1", user_id=1, agent_type="coder")
+            await _register_session(store, "s2", user_id=1, agent_type="coder")
+            await _register_session(store, "s3", user_id=1, agent_type="coder")
+            await _register_session(store, "s4", user_id=1, agent_type="coder")
+
+        _run(_seed())
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.api.v1.endpoints.admin.admin_acp_agents.get_acp_session_store",
+            mock.AsyncMock(return_value=store),
+        )
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from tldw_Server_API.app.api.v1.endpoints.admin import admin_acp_agents
+
+        app = FastAPI()
+        app.include_router(admin_acp_agents.router, prefix="/api/v1/admin")
+
+        response = TestClient(app).get("/api/v1/admin/acp/sessions?limit=2&offset=1")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 4
+        assert len(body["sessions"]) == 2
+        assert body["pagination"] == {
+            "mode": "offset",
+            "limit": 2,
+            "offset": 1,
+            "total": 4,
+            "has_more": True,
+            "next_offset": 3,
+        }
+
+
+# ===========================================================================
+# 2. GET /admin/acp/agents/metrics
 # ===========================================================================
 
 
@@ -218,7 +266,7 @@ class TestACPAgentMetrics:
 
 
 # ===========================================================================
-# 2. PATCH /admin/acp/sessions/{session_id}/budget
+# 3. PATCH /admin/acp/sessions/{session_id}/budget
 # ===========================================================================
 
 
@@ -331,7 +379,7 @@ class TestACPSessionBudget:
 
 
 # ===========================================================================
-# 3. Budget enforcement — check_and_enforce_budget()
+# 4. Budget enforcement — check_and_enforce_budget()
 # ===========================================================================
 
 

--- a/tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py
+++ b/tldw_Server_API/tests/Admin/test_admin_acp_new_endpoints.py
@@ -122,6 +122,8 @@ class TestACPAdminSessionsList:
             "has_more": True,
             "next_offset": 3,
         }
+        assert body["has_more"] is True
+        assert body["next_offset"] == 3
 
 
 # ===========================================================================

--- a/tldw_Server_API/tests/Admin/test_admin_budgets_endpoint.py
+++ b/tldw_Server_API/tests/Admin/test_admin_budgets_endpoint.py
@@ -104,3 +104,5 @@ async def test_admin_list_budgets_returns_canonical_pagination(
     assert payload["pagination"]["offset"] == 10
     assert payload["pagination"]["has_more"] is True
     assert payload["pagination"]["next_offset"] == 20
+    assert payload["has_more"] is True
+    assert payload["next_offset"] == 20

--- a/tldw_Server_API/tests/Admin/test_admin_budgets_endpoint.py
+++ b/tldw_Server_API/tests/Admin/test_admin_budgets_endpoint.py
@@ -2,8 +2,11 @@ from typing import Any
 
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.main import app
 from tldw_Server_API.app.api.v1.endpoints.admin import admin_budgets
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_db_transaction
 
 pytestmark = pytest.mark.unit
 
@@ -48,3 +51,56 @@ async def test_admin_get_budget_forecast_sanitizes_generic_error_log(
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Budget forecast failed"
     assert logger_stub.error_records == [("Budget forecast failed", (), {})]
+
+
+@pytest.mark.asyncio
+async def test_admin_list_budgets_returns_canonical_pagination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _db_override() -> object:
+        return object()
+
+    async def _fake_list_org_budgets(db, *, org_ids, page: int, limit: int):
+        assert db is not None
+        assert org_ids is None
+        assert page == 2
+        assert limit == 10
+        return (
+            [
+                {
+                    "org_id": 7,
+                    "org_name": "Research",
+                    "org_slug": "research",
+                    "plan_name": "default",
+                    "plan_display_name": "Default",
+                    "budgets": {},
+                    "custom_limits": {},
+                    "effective_limits": {},
+                    "updated_at": None,
+                }
+            ],
+            21,
+        )
+
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "unit-test-api-key")
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setattr(admin_budgets.admin_budgets_service, "list_org_budgets", _fake_list_org_budgets)
+    app.dependency_overrides[get_db_transaction] = _db_override
+
+    try:
+        with TestClient(app, headers={"X-API-KEY": "unit-test-api-key"}) as client:
+            response = client.get("/api/v1/admin/budgets", params={"page": 2, "limit": 10})
+    finally:
+        app.dependency_overrides.pop(get_db_transaction, None)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["total"] == 21
+    assert payload["page"] == 2
+    assert payload["limit"] == 10
+    assert payload["pagination"]["total"] == 21
+    assert payload["pagination"]["limit"] == 10
+    assert payload["pagination"]["offset"] == 10
+    assert payload["pagination"]["has_more"] is True
+    assert payload["pagination"]["next_offset"] == 20

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
@@ -141,6 +141,10 @@ async def test_admin_byok_validation_create_list_and_detail_roundtrip(monkeypatc
             assert list_resp.status_code == 200, list_resp.text
             listed = list_resp.json()
             assert listed["total"] == 1
+            assert listed["pagination"]["total"] == 1
+            assert listed["pagination"]["limit"] == 25
+            assert listed["pagination"]["offset"] == 0
+            assert listed["pagination"]["has_more"] is False
             assert listed["items"][0]["id"] == "run-1"
 
             detail_resp = client.get("/api/v1/admin/byok/validation-runs/run-1")

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
@@ -145,6 +145,9 @@ async def test_admin_byok_validation_create_list_and_detail_roundtrip(monkeypatc
             assert listed["pagination"]["limit"] == 25
             assert listed["pagination"]["offset"] == 0
             assert listed["pagination"]["has_more"] is False
+            assert listed["pagination"]["next_offset"] is None
+            assert listed["has_more"] is False
+            assert listed["next_offset"] is None
             assert listed["items"][0]["id"] == "run-1"
 
             detail_resp = client.get("/api/v1/admin/byok/validation-runs/run-1")

--- a/tldw_Server_API/tests/Admin/test_admin_orgs_search.py
+++ b/tldw_Server_API/tests/Admin/test_admin_orgs_search.py
@@ -76,6 +76,9 @@ def test_admin_orgs_list_with_total_and_search(monkeypatch, tmp_path, authnz_sch
             assert isinstance(data.get("total"), int)
             assert data.get("limit") == 2
             assert data.get("offset") == 0
+            assert data["pagination"]["total"] == data["total"]
+            assert data["pagination"]["limit"] == 2
+            assert data["pagination"]["offset"] == 0
             # If total > 2, has_more should be True
             assert data.get("has_more") == (data["total"] > 2)
 

--- a/tldw_Server_API/tests/Admin/test_admin_storage_quotas.py
+++ b/tldw_Server_API/tests/Admin/test_admin_storage_quotas.py
@@ -269,6 +269,34 @@ class TestCheckStorageQuota:
         instance.check_quota_status.assert_called_once_with(team_id=10)
 
 
+class TestAdminStorageQuotaSummaryPagination:
+    @pytest.mark.asyncio
+    async def test_get_storage_quota_summary_returns_canonical_pagination(self, monkeypatch):
+        repo = MagicMock()
+        repo.list_all_quotas = AsyncMock(
+            return_value=[
+                {"id": 1, "quota_mb": 1000},
+                {"id": 2, "quota_mb": 2000},
+            ]
+        )
+        monkeypatch.setattr(quotas_module, "_get_repo", AsyncMock(return_value=repo))
+
+        result = await quotas_module.get_storage_quota_summary(offset=10, limit=2)
+
+        assert result.total_quotas == 2
+        assert result.pagination.model_dump(mode="json") == {
+            "mode": "offset",
+            "limit": 2,
+            "offset": 10,
+            "total": None,
+            "has_more": True,
+            "next_offset": 12,
+        }
+        assert result.has_more is True
+        assert result.next_offset == 12
+        repo.list_all_quotas.assert_awaited_once_with(offset=10, limit=2)
+
+
 class TestAdminStorageQuotaEndpointErrorMapping:
     @pytest.mark.asyncio
     async def test_get_user_storage_quota_sanitizes_generic_failure(self, monkeypatch):

--- a/tldw_Server_API/tests/Admin/test_admin_user_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_user_api.py
@@ -81,3 +81,7 @@ async def test_list_users_forwards_admin_capable_filter(monkeypatch, tmp_path):
     payload = response.json()
     assert payload["total"] == 1
     assert payload["users"][0]["id"] == 7
+    assert payload["pagination"]["total"] == 1
+    assert payload["pagination"]["limit"] == 25
+    assert payload["pagination"]["offset"] == 0
+    assert payload["pagination"]["has_more"] is False

--- a/tldw_Server_API/tests/Admin/test_admin_user_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_user_api.py
@@ -85,3 +85,5 @@ async def test_list_users_forwards_admin_capable_filter(monkeypatch, tmp_path):
     assert payload["pagination"]["limit"] == 25
     assert payload["pagination"]["offset"] == 0
     assert payload["pagination"]["has_more"] is False
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None

--- a/tldw_Server_API/tests/Admin/test_admin_webhooks_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_webhooks_service.py
@@ -255,6 +255,8 @@ def test_list_webhooks_route_includes_canonical_pagination(monkeypatch: pytest.M
         "has_more": True,
         "next_offset": 3,
     }
+    assert payload["has_more"] is True
+    assert payload["next_offset"] == 3
     assert fake_service.list_webhooks_args == {"limit": 2, "offset": 1, "active_only": False}
 
 
@@ -277,6 +279,8 @@ def test_list_webhook_deliveries_route_includes_canonical_pagination(monkeypatch
         "has_more": True,
         "next_offset": 3,
     }
+    assert payload["has_more"] is True
+    assert payload["next_offset"] == 3
     assert fake_service.get_webhook_id == 1
     assert fake_service.list_delivery_args == {"webhook_id": 1, "limit": 2, "offset": 1}
 

--- a/tldw_Server_API/tests/Admin/test_admin_webhooks_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_webhooks_service.py
@@ -152,6 +152,135 @@ def webhook_secret_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"w"))
 
 
+# ---------------------------------------------------------------------------
+# Route response pagination
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdminWebhooksRouteService:
+    def __init__(self):
+        self.webhook_items = [
+            WebhookRecord(
+                id=1,
+                url="https://example.com/a",
+                secret="",
+                event_types=["*"],
+                description="first",
+                active=True,
+                retry_count=3,
+                timeout_seconds=10,
+                created_by=None,
+                created_at=None,
+                updated_at=None,
+            ),
+            WebhookRecord(
+                id=2,
+                url="https://example.com/b",
+                secret="",
+                event_types=["incident.created"],
+                description="second",
+                active=False,
+                retry_count=1,
+                timeout_seconds=5,
+                created_by=1,
+                created_at=None,
+                updated_at=None,
+            ),
+        ]
+        self.delivery_items = [
+            DeliveryLogEntry(
+                id=10,
+                webhook_id=1,
+                event_type="test.one",
+                status_code=200,
+                latency_ms=12,
+                retry_attempt=0,
+                error_message=None,
+                delivered_at=None,
+                created_at=None,
+            ),
+            DeliveryLogEntry(
+                id=11,
+                webhook_id=1,
+                event_type="test.two",
+                status_code=500,
+                latency_ms=24,
+                retry_attempt=1,
+                error_message="boom",
+                delivered_at=None,
+                created_at=None,
+            ),
+        ]
+
+    async def list_webhooks(self, *, limit: int, offset: int, active_only: bool = False):
+        self.list_webhooks_args = {"limit": limit, "offset": offset, "active_only": active_only}
+        return self.webhook_items, 4
+
+    async def get_webhook(self, webhook_id: int):
+        self.get_webhook_id = webhook_id
+        return self.webhook_items[0]
+
+    async def list_delivery_log(self, webhook_id: int, *, limit: int, offset: int):
+        self.list_delivery_args = {"webhook_id": webhook_id, "limit": limit, "offset": offset}
+        return self.delivery_items, 5
+
+
+def _make_admin_webhooks_route_client(monkeypatch: pytest.MonkeyPatch, fake_service):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_webhooks
+
+    monkeypatch.setattr(admin_webhooks, "get_admin_webhooks_service", lambda: fake_service)
+    app = FastAPI()
+    app.include_router(admin_webhooks.router, prefix="/api/v1/admin")
+    return TestClient(app)
+
+
+def test_list_webhooks_route_includes_canonical_pagination(monkeypatch: pytest.MonkeyPatch):
+    """Admin webhook list route preserves totals and exposes canonical pagination."""
+    fake_service = _FakeAdminWebhooksRouteService()
+    client = _make_admin_webhooks_route_client(monkeypatch, fake_service)
+
+    response = client.get("/api/v1/admin/webhooks?limit=2&offset=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 4
+    assert len(payload["items"]) == 2
+    assert payload["pagination"] == {
+        "mode": "offset",
+        "limit": 2,
+        "offset": 1,
+        "total": 4,
+        "has_more": True,
+        "next_offset": 3,
+    }
+    assert fake_service.list_webhooks_args == {"limit": 2, "offset": 1, "active_only": False}
+
+
+def test_list_webhook_deliveries_route_includes_canonical_pagination(monkeypatch: pytest.MonkeyPatch):
+    """Admin webhook delivery-log route returns canonical pagination metadata."""
+    fake_service = _FakeAdminWebhooksRouteService()
+    client = _make_admin_webhooks_route_client(monkeypatch, fake_service)
+
+    response = client.get("/api/v1/admin/webhooks/1/deliveries?limit=2&offset=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 5
+    assert len(payload["items"]) == 2
+    assert payload["pagination"] == {
+        "mode": "offset",
+        "limit": 2,
+        "offset": 1,
+        "total": 5,
+        "has_more": True,
+        "next_offset": 3,
+    }
+    assert fake_service.get_webhook_id == 1
+    assert fake_service.list_delivery_args == {"webhook_id": 1, "limit": 2, "offset": 1}
+
+
 @pytest.mark.asyncio
 async def test_create_webhook_generates_secret(svc: AdminWebhooksService):
     async def _return_inserted_row(_query: str, params: tuple[object, ...]) -> dict[str, object]:

--- a/tldw_Server_API/tests/Admin/test_backup_schedules_api.py
+++ b/tldw_Server_API/tests/Admin/test_backup_schedules_api.py
@@ -73,6 +73,9 @@ async def test_backup_schedule_roundtrip_crud(tmp_path) -> None:
         assert list_resp.status_code == 200, list_resp.text
         payload = list_resp.json()
         assert payload["total"] == 1
+        assert payload["pagination"]["total"] == 1
+        assert payload["pagination"]["limit"] == 100
+        assert payload["pagination"]["offset"] == 0
         assert payload["items"][0]["id"] == schedule_id
 
         update_resp = client.patch(
@@ -239,6 +242,9 @@ async def test_list_backup_schedules_hides_platform_rows_and_reports_visible_tot
             assert response.status_code == 200, response.text
             payload = response.json()
             assert payload["total"] == 1
+            assert payload["pagination"]["total"] == 1
+            assert payload["pagination"]["limit"] == 100
+            assert payload["pagination"]["offset"] == 0
             assert [item["id"] for item in payload["items"]] == [media_schedule["id"]]
     finally:
         app.dependency_overrides.clear()

--- a/tldw_Server_API/tests/Admin/test_backup_schedules_api.py
+++ b/tldw_Server_API/tests/Admin/test_backup_schedules_api.py
@@ -76,6 +76,8 @@ async def test_backup_schedule_roundtrip_crud(tmp_path) -> None:
         assert payload["pagination"]["total"] == 1
         assert payload["pagination"]["limit"] == 100
         assert payload["pagination"]["offset"] == 0
+        assert payload["has_more"] == payload["pagination"]["has_more"]
+        assert payload["next_offset"] == payload["pagination"]["next_offset"]
         assert payload["items"][0]["id"] == schedule_id
 
         update_resp = client.patch(

--- a/tldw_Server_API/tests/Admin/test_bundle_ops.py
+++ b/tldw_Server_API/tests/Admin/test_bundle_ops.py
@@ -10,6 +10,7 @@ import sqlite3
 import uuid
 import zipfile
 from datetime import datetime, timedelta, timezone
+from types import MappingProxyType
 from typing import Any
 
 import pytest
@@ -265,6 +266,43 @@ async def test_list_bundles_sanitizes_noncritical_failure_log(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_bundles_defaults_pagination_aliases(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_bundle_ops
+
+    def _list_bundles(**_kwargs):
+        return (
+            [
+                admin_bundle_ops.svc.BundleMetadata(
+                    bundle_id="bundle-a.zip",
+                    user_id=None,
+                    created_at=datetime.now(timezone.utc),
+                    size_bytes=100,
+                    datasets=("authnz",),
+                    schema_versions=MappingProxyType({"authnz": 1}),
+                    app_version="test",
+                    manifest_version=1,
+                    notes=None,
+                )
+            ],
+            3,
+        )
+
+    monkeypatch.setattr(admin_bundle_ops.svc, "list_bundles", _list_bundles)
+
+    response = await admin_bundle_ops.list_bundles(
+        user_id=None,
+        limit=1,
+        offset=0,
+        principal=object(),
+    )
+
+    assert response.pagination.has_more is True
+    assert response.pagination.next_offset == 1
+    assert response.has_more is True
+    assert response.next_offset == 1
+
+
+@pytest.mark.asyncio
 async def test_import_bundle_sanitizes_noncritical_failure_log(monkeypatch):
     from tldw_Server_API.app.api.v1.endpoints.admin import admin_bundle_ops
 
@@ -454,6 +492,8 @@ async def test_list_bundles_empty(tmp_path):
         assert data["pagination"]["total"] == 0
         assert data["pagination"]["limit"] == 100
         assert data["pagination"]["offset"] == 0
+        assert data["has_more"] is False
+        assert data["next_offset"] is None
 
 
 @pytest.mark.asyncio
@@ -504,6 +544,8 @@ async def test_list_bundles_pagination(tmp_path):
         assert data["pagination"]["total"] >= 2
         assert data["pagination"]["limit"] == 1
         assert data["pagination"]["offset"] == 0
+        assert data["has_more"] is True
+        assert data["next_offset"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/Admin/test_bundle_ops.py
+++ b/tldw_Server_API/tests/Admin/test_bundle_ops.py
@@ -451,6 +451,9 @@ async def test_list_bundles_empty(tmp_path):
         data = resp.json()
         assert data["items"] == []
         assert data["total"] == 0
+        assert data["pagination"]["total"] == 0
+        assert data["pagination"]["limit"] == 100
+        assert data["pagination"]["offset"] == 0
 
 
 @pytest.mark.asyncio
@@ -498,6 +501,9 @@ async def test_list_bundles_pagination(tmp_path):
         data = resp.json()
         assert len(data["items"]) == 1
         assert data["total"] >= 2
+        assert data["pagination"]["total"] >= 2
+        assert data["pagination"]["limit"] == 1
+        assert data["pagination"]["offset"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/Admin/test_data_ops.py
+++ b/tldw_Server_API/tests/Admin/test_data_ops.py
@@ -168,7 +168,11 @@ async def test_admin_data_ops_backups_and_exports(tmp_path):
 
         list_resp = client.get("/api/v1/admin/backups", params={"dataset": "authnz"})
         assert list_resp.status_code == 200, list_resp.text
-        listed = list_resp.json()["items"]
+        payload = list_resp.json()
+        assert payload["pagination"]["total"] >= 1
+        assert payload["pagination"]["limit"] == 100
+        assert payload["pagination"]["offset"] == 0
+        listed = payload["items"]
         assert any(item["id"] == backup_id for item in listed)
 
         restore_resp = client.post(
@@ -307,5 +311,9 @@ async def test_admin_data_ops_per_user_backup_success(tmp_path):
 
         list_resp = client.get("/api/v1/admin/backups", params={"dataset": "media", "user_id": user_id})
         assert list_resp.status_code == 200, list_resp.text
-        listed = list_resp.json()["items"]
+        payload = list_resp.json()
+        assert payload["pagination"]["total"] >= 1
+        assert payload["pagination"]["limit"] == 100
+        assert payload["pagination"]["offset"] == 0
+        listed = payload["items"]
         assert any(item["id"] == backup_id for item in listed)

--- a/tldw_Server_API/tests/Admin/test_data_ops.py
+++ b/tldw_Server_API/tests/Admin/test_data_ops.py
@@ -172,6 +172,8 @@ async def test_admin_data_ops_backups_and_exports(tmp_path):
         assert payload["pagination"]["total"] >= 1
         assert payload["pagination"]["limit"] == 100
         assert payload["pagination"]["offset"] == 0
+        assert payload["has_more"] == payload["pagination"]["has_more"]
+        assert payload["next_offset"] == payload["pagination"]["next_offset"]
         listed = payload["items"]
         assert any(item["id"] == backup_id for item in listed)
 

--- a/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
+++ b/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
@@ -325,6 +325,10 @@ async def test_list_returns_newest_first_with_limit_offset(monkeypatch, tmp_path
     assert listed.status_code == 200, listed.text
     payload = listed.json()
     assert payload["total"] == 3
+    assert payload["pagination"]["total"] == 3
+    assert payload["pagination"]["limit"] == 2
+    assert payload["pagination"]["offset"] == 1
+    assert payload["pagination"]["has_more"] is False
     assert [item["client_request_id"] for item in payload["items"]] == [
         "dsr-client-2",
         "dsr-client-1",

--- a/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
+++ b/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
@@ -9,6 +9,8 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import DataSubjectRequestListResponse
+from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 from tldw_Server_API.app.main import app
 
 
@@ -333,6 +335,36 @@ async def test_list_returns_newest_first_with_limit_offset(monkeypatch, tmp_path
         "dsr-client-2",
         "dsr-client-1",
     ]
+
+
+def test_data_subject_request_list_response_defaults_pagination_aliases():
+    response = DataSubjectRequestListResponse(
+        items=[
+            {
+                "id": 1,
+                "client_request_id": "dsr-client-1",
+                "requester_identifier": "subject@example.com",
+                "request_type": "access",
+                "status": "pending",
+                "selected_categories": ["authnz"],
+                "preview_summary": [],
+                "requested_at": "2026-03-10T12:00:00Z",
+            }
+        ],
+        total=3,
+        limit=2,
+        offset=1,
+        pagination=OffsetPaginationMeta(
+            total=3,
+            limit=2,
+            offset=1,
+            has_more=False,
+            next_offset=None,
+        ),
+    )
+
+    assert response.has_more is False
+    assert response.next_offset is None
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Admin/test_llm_usage_endpoints.py
+++ b/tldw_Server_API/tests/Admin/test_llm_usage_endpoints.py
@@ -136,6 +136,9 @@ async def test_llm_usage_endpoints_sqlite(monkeypatch, tmp_path):
         data = r.json()
         assert isinstance(data.get('items'), list)
         assert any(row.get('operation') == 'chat' for row in data['items'])
+        assert data["pagination"]["total"] == data["total"]
+        assert data["pagination"]["limit"] == 10
+        assert data["pagination"]["offset"] == 0
 
         # Summary by user
         r2 = client.get("/api/v1/admin/llm-usage/summary?group_by=user")

--- a/tldw_Server_API/tests/Admin/test_llm_usage_endpoints.py
+++ b/tldw_Server_API/tests/Admin/test_llm_usage_endpoints.py
@@ -139,6 +139,8 @@ async def test_llm_usage_endpoints_sqlite(monkeypatch, tmp_path):
         assert data["pagination"]["total"] == data["total"]
         assert data["pagination"]["limit"] == 10
         assert data["pagination"]["offset"] == 0
+        assert data["has_more"] == data["pagination"]["has_more"]
+        assert data["next_offset"] == data["pagination"]["next_offset"]
 
         # Summary by user
         r2 = client.get("/api/v1/admin/llm-usage/summary?group_by=user")

--- a/tldw_Server_API/tests/Admin/test_maintenance_rotation_api.py
+++ b/tldw_Server_API/tests/Admin/test_maintenance_rotation_api.py
@@ -154,6 +154,10 @@ async def test_maintenance_rotation_create_list_and_detail_roundtrip(monkeypatch
             assert list_resp.status_code == 200, list_resp.text
             listed = list_resp.json()
             assert listed["total"] == 1
+            assert listed["pagination"]["total"] == 1
+            assert listed["pagination"]["limit"] == 25
+            assert listed["pagination"]["offset"] == 0
+            assert listed["pagination"]["has_more"] is False
             assert listed["items"][0]["id"] == "run-1"
 
             detail_resp = client.get("/api/v1/admin/maintenance/rotation-runs/run-1")
@@ -348,6 +352,10 @@ async def test_maintenance_rotation_list_applies_domain_visibility_before_pagina
             assert response.status_code == 200, response.text
             payload = response.json()
             assert payload["total"] == 1
+            assert payload["pagination"]["total"] == 1
+            assert payload["pagination"]["limit"] == 1
+            assert payload["pagination"]["offset"] == 0
+            assert payload["pagination"]["has_more"] is False
             assert [item["id"] for item in payload["items"]] == [visible["id"]]
     finally:
         app.dependency_overrides.clear()

--- a/tldw_Server_API/tests/Admin/test_maintenance_rotation_api.py
+++ b/tldw_Server_API/tests/Admin/test_maintenance_rotation_api.py
@@ -158,6 +158,8 @@ async def test_maintenance_rotation_create_list_and_detail_roundtrip(monkeypatch
             assert listed["pagination"]["limit"] == 25
             assert listed["pagination"]["offset"] == 0
             assert listed["pagination"]["has_more"] is False
+            assert listed["has_more"] is False
+            assert listed["next_offset"] is None
             assert listed["items"][0]["id"] == "run-1"
 
             detail_resp = client.get("/api/v1/admin/maintenance/rotation-runs/run-1")

--- a/tldw_Server_API/tests/Admin/test_monitoring_alerts_overlay_integration.py
+++ b/tldw_Server_API/tests/Admin/test_monitoring_alerts_overlay_integration.py
@@ -87,6 +87,8 @@ async def test_monitoring_alerts_include_backend_overlay_and_authoritative_actio
         assert payload["pagination"]["offset"] == 0
         assert payload["pagination"]["has_more"] is False
         assert payload["pagination"]["next_offset"] is None
+        assert payload["has_more"] is False
+        assert payload["next_offset"] is None
         items = payload["items"]
         assert len(items) == 1
         assert items[0]["alert_identity"] == f"alert:{alert_id}"

--- a/tldw_Server_API/tests/Admin/test_monitoring_alerts_overlay_integration.py
+++ b/tldw_Server_API/tests/Admin/test_monitoring_alerts_overlay_integration.py
@@ -81,7 +81,13 @@ async def test_monitoring_alerts_include_backend_overlay_and_authoritative_actio
     with TestClient(app, headers=headers) as client:
         list_resp = client.get("/api/v1/monitoring/alerts")
         assert list_resp.status_code == 200, list_resp.text
-        items = list_resp.json()["items"]
+        payload = list_resp.json()
+        assert payload["pagination"]["total"] is None
+        assert payload["pagination"]["limit"] == 100
+        assert payload["pagination"]["offset"] == 0
+        assert payload["pagination"]["has_more"] is False
+        assert payload["pagination"]["next_offset"] is None
+        items = payload["items"]
         assert len(items) == 1
         assert items[0]["alert_identity"] == f"alert:{alert_id}"
         assert items[0]["assigned_to_user_id"] == 1

--- a/tldw_Server_API/tests/Admin/test_system_ops.py
+++ b/tldw_Server_API/tests/Admin/test_system_ops.py
@@ -175,6 +175,25 @@ async def test_admin_system_ops_endpoints(monkeypatch, tmp_path):
         delete_resp = client.delete(f"/api/v1/admin/incidents/{incident_id}")
         assert delete_resp.status_code == 200, delete_resp.text
 
+        webhook_create_resp = client.post(
+            "/api/v1/admin/webhooks",
+            json={
+                "url": "https://example.com/webhook",
+                "events": ["incident.created"],
+                "enabled": True,
+            },
+        )
+        assert webhook_create_resp.status_code == 200, webhook_create_resp.text
+
+        webhooks_resp = client.get("/api/v1/admin/webhooks")
+        assert webhooks_resp.status_code == 200, webhooks_resp.text
+        webhook_payload = webhooks_resp.json()
+        assert webhook_payload["total"] >= 1
+        assert webhook_payload["pagination"]["total"] >= 1
+        assert webhook_payload["pagination"]["offset"] == 0
+        assert webhook_payload["pagination"]["limit"] >= 1
+        assert any(item["url"] == "https://example.com/webhook" for item in webhook_payload["items"])
+
         # Reset maintenance state for subsequent tests
         client.put(
             "/api/v1/admin/maintenance",

--- a/tldw_Server_API/tests/Admin/test_system_ops.py
+++ b/tldw_Server_API/tests/Admin/test_system_ops.py
@@ -47,6 +47,9 @@ async def test_admin_system_ops_endpoints(monkeypatch, tmp_path):
         if logs_resp.status_code == 200:
             payload = logs_resp.json()
             assert "items" in payload
+            assert payload["pagination"]["limit"] == 100
+            assert payload["pagination"]["offset"] == 0
+            assert payload["pagination"]["total"] >= 1
             assert any("System ops log test entry" in (item.get("message") or "") for item in payload["items"])
         else:
             # Some deployments do not mount system logs endpoints.
@@ -69,6 +72,15 @@ async def test_admin_system_ops_endpoints(monkeypatch, tmp_path):
         maint_get = client.get("/api/v1/admin/maintenance")
         assert maint_get.status_code == 200, maint_get.text
         assert maint_get.json()["enabled"] is True
+
+        audit_log_resp = client.get("/api/v1/admin/audit-log")
+        if audit_log_resp.status_code == 200:
+            audit_payload = audit_log_resp.json()
+            assert audit_payload["pagination"]["limit"] == 100
+            assert audit_payload["pagination"]["offset"] == 0
+            assert audit_payload["pagination"]["total"] == audit_payload["total"]
+        else:
+            assert audit_log_resp.status_code == 404, audit_log_resp.text
 
         flag_resp = client.put(
             "/api/v1/admin/feature-flags/ops-test",

--- a/tldw_Server_API/tests/Admin/test_system_ops.py
+++ b/tldw_Server_API/tests/Admin/test_system_ops.py
@@ -166,7 +166,11 @@ async def test_admin_system_ops_endpoints(monkeypatch, tmp_path):
 
         list_resp = client.get("/api/v1/admin/incidents")
         assert list_resp.status_code == 200, list_resp.text
-        assert list_resp.json()["total"] >= 1
+        payload = list_resp.json()
+        assert payload["total"] >= 1
+        assert payload["pagination"]["total"] >= 1
+        assert payload["pagination"]["limit"] == 50
+        assert payload["pagination"]["offset"] == 0
 
         delete_resp = client.delete(f"/api/v1/admin/incidents/{incident_id}")
         assert delete_resp.status_code == 200, delete_resp.text

--- a/tldw_Server_API/tests/Admin/test_system_ops.py
+++ b/tldw_Server_API/tests/Admin/test_system_ops.py
@@ -50,6 +50,8 @@ async def test_admin_system_ops_endpoints(monkeypatch, tmp_path):
             assert payload["pagination"]["limit"] == 100
             assert payload["pagination"]["offset"] == 0
             assert payload["pagination"]["total"] >= 1
+            assert payload["has_more"] == payload["pagination"]["has_more"]
+            assert payload["next_offset"] == payload["pagination"]["next_offset"]
             assert any("System ops log test entry" in (item.get("message") or "") for item in payload["items"])
         else:
             # Some deployments do not mount system logs endpoints.
@@ -79,6 +81,8 @@ async def test_admin_system_ops_endpoints(monkeypatch, tmp_path):
             assert audit_payload["pagination"]["limit"] == 100
             assert audit_payload["pagination"]["offset"] == 0
             assert audit_payload["pagination"]["total"] == audit_payload["total"]
+            assert audit_payload["has_more"] == audit_payload["pagination"]["has_more"]
+            assert audit_payload["next_offset"] == audit_payload["pagination"]["next_offset"]
         else:
             assert audit_log_resp.status_code == 404, audit_log_resp.text
 
@@ -183,6 +187,8 @@ async def test_admin_system_ops_endpoints(monkeypatch, tmp_path):
         assert payload["pagination"]["total"] >= 1
         assert payload["pagination"]["limit"] == 50
         assert payload["pagination"]["offset"] == 0
+        assert payload["has_more"] == payload["pagination"]["has_more"]
+        assert payload["next_offset"] == payload["pagination"]["next_offset"]
 
         delete_resp = client.delete(f"/api/v1/admin/incidents/{incident_id}")
         assert delete_resp.status_code == 200, delete_resp.text
@@ -204,6 +210,8 @@ async def test_admin_system_ops_endpoints(monkeypatch, tmp_path):
         assert webhook_payload["pagination"]["total"] >= 1
         assert webhook_payload["pagination"]["offset"] == 0
         assert webhook_payload["pagination"]["limit"] >= 1
+        assert webhook_payload["has_more"] == webhook_payload["pagination"]["has_more"]
+        assert webhook_payload["next_offset"] == webhook_payload["pagination"]["next_offset"]
         assert any(item["url"] == "https://example.com/webhook" for item in webhook_payload["items"])
 
         # Reset maintenance state for subsequent tests

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py
@@ -192,6 +192,8 @@ def test_acp_list_sessions_status_schema_includes_tenancy(client_user_only, stub
     assert payload["pagination"]["offset"] == 0
     assert payload["pagination"]["has_more"] is False
     assert payload["pagination"]["next_offset"] is None
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None
     session = payload["sessions"][0]
     assert session["status"] == "active"
     assert session["has_websocket"] is True

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py
@@ -187,6 +187,11 @@ def test_acp_list_sessions_status_schema_includes_tenancy(client_user_only, stub
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["total"] == 1
+    assert payload["pagination"]["total"] == 1
+    assert payload["pagination"]["limit"] == 100
+    assert payload["pagination"]["offset"] == 0
+    assert payload["pagination"]["has_more"] is False
+    assert payload["pagination"]["next_offset"] is None
     session = payload["sessions"][0]
     assert session["status"] == "active"
     assert session["has_websocket"] is True

--- a/tldw_Server_API/tests/Audiobooks/integration/test_audiobook_voice_profiles.py
+++ b/tldw_Server_API/tests/Audiobooks/integration/test_audiobook_voice_profiles.py
@@ -49,6 +49,8 @@ def test_voice_profile_crud(client_voice_profiles):
     assert payload["total"] == 1
     assert payload["limit"] == 100
     assert payload["offset"] == 0
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None
     assert payload["pagination"] == {
         "mode": "offset",
         "total": 1,
@@ -71,6 +73,8 @@ def test_voice_profile_crud(client_voice_profiles):
         "total": 0,
         "limit": 100,
         "offset": 0,
+        "has_more": False,
+        "next_offset": None,
         "pagination": {
             "mode": "offset",
             "total": 0,

--- a/tldw_Server_API/tests/Audiobooks/integration/test_audiobook_voice_profiles.py
+++ b/tldw_Server_API/tests/Audiobooks/integration/test_audiobook_voice_profiles.py
@@ -41,10 +41,22 @@ def test_voice_profile_crud(client_voice_profiles):
 
     list_resp = client_voice_profiles.get("/api/v1/audiobooks/voices/profiles")
     assert list_resp.status_code == 200
-    listed = list_resp.json()["profiles"]
+    payload = list_resp.json()
+    listed = payload["profiles"]
     assert len(listed) == 1
     assert listed[0]["profile_id"] == created["profile_id"]
     assert listed[0]["chapter_overrides"] == create_payload["chapter_overrides"]
+    assert payload["total"] == 1
+    assert payload["limit"] == 100
+    assert payload["offset"] == 0
+    assert payload["pagination"] == {
+        "mode": "offset",
+        "total": 1,
+        "limit": 100,
+        "offset": 0,
+        "has_more": False,
+        "next_offset": None,
+    }
 
     delete_resp = client_voice_profiles.delete(f"/api/v1/audiobooks/voices/profiles/{created['profile_id']}")
     assert delete_resp.status_code == 200
@@ -54,4 +66,17 @@ def test_voice_profile_crud(client_voice_profiles):
 
     list_resp = client_voice_profiles.get("/api/v1/audiobooks/voices/profiles")
     assert list_resp.status_code == 200
-    assert list_resp.json()["profiles"] == []
+    assert list_resp.json() == {
+        "profiles": [],
+        "total": 0,
+        "limit": 100,
+        "offset": 0,
+        "pagination": {
+            "mode": "offset",
+            "total": 0,
+            "limit": 100,
+            "offset": 0,
+            "has_more": False,
+            "next_offset": None,
+        },
+    }

--- a/tldw_Server_API/tests/Audiobooks/integration/test_audiobook_worker_pipeline.py
+++ b/tldw_Server_API/tests/Audiobooks/integration/test_audiobook_worker_pipeline.py
@@ -947,11 +947,35 @@ def test_audiobook_project_pagination(
     assert page1.status_code == 200
     page2 = client_user_only.get("/api/v1/audiobooks/projects?limit=1&offset=1")
     assert page2.status_code == 200
-    projects_page1 = page1.json()["projects"]
-    projects_page2 = page2.json()["projects"]
+    page1_payload = page1.json()
+    page2_payload = page2.json()
+    projects_page1 = page1_payload["projects"]
+    projects_page2 = page2_payload["projects"]
     assert len(projects_page1) == 1
     assert len(projects_page2) == 1
     assert projects_page1[0]["project_id"] != projects_page2[0]["project_id"]
+    assert page1_payload["total"] == 2
+    assert page1_payload["limit"] == 1
+    assert page1_payload["offset"] == 0
+    assert page1_payload["pagination"] == {
+        "mode": "offset",
+        "total": 2,
+        "limit": 1,
+        "offset": 0,
+        "has_more": True,
+        "next_offset": 1,
+    }
+    assert page2_payload["total"] == 2
+    assert page2_payload["limit"] == 1
+    assert page2_payload["offset"] == 1
+    assert page2_payload["pagination"] == {
+        "mode": "offset",
+        "total": 2,
+        "limit": 1,
+        "offset": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
 
     project_id = project_ids[0]
     art_page1 = client_user_only.get(

--- a/tldw_Server_API/tests/Audiobooks/integration/test_audiobook_worker_pipeline.py
+++ b/tldw_Server_API/tests/Audiobooks/integration/test_audiobook_worker_pipeline.py
@@ -957,6 +957,8 @@ def test_audiobook_project_pagination(
     assert page1_payload["total"] == 2
     assert page1_payload["limit"] == 1
     assert page1_payload["offset"] == 0
+    assert page1_payload["has_more"] is True
+    assert page1_payload["next_offset"] == 1
     assert page1_payload["pagination"] == {
         "mode": "offset",
         "total": 2,
@@ -968,6 +970,8 @@ def test_audiobook_project_pagination(
     assert page2_payload["total"] == 2
     assert page2_payload["limit"] == 1
     assert page2_payload["offset"] == 1
+    assert page2_payload["has_more"] is False
+    assert page2_payload["next_offset"] is None
     assert page2_payload["pagination"] == {
         "mode": "offset",
         "total": 2,

--- a/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
@@ -301,6 +301,8 @@ async def test_list_invites_includes_canonical_pagination(monkeypatch):
         "has_more": True,
         "next_offset": 1,
     }
+    assert response.has_more is True
+    assert response.next_offset == 1
     assert len(response.items) == 1
     assert response.items[0].id == 42
 

--- a/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
@@ -315,21 +315,16 @@ async def test_list_my_orgs_includes_canonical_pagination(monkeypatch):
         def __init__(self, db_pool) -> None:  # noqa: ARG002
             pass
 
-        async def list_org_memberships_for_user(self, user_id):
+        async def list_organizations_for_user(self, user_id, **kwargs):
             assert user_id == 7
-            return [{"org_id": 11}, {"org_id": 22}]
-
-        async def list_organizations(self, **kwargs):
             assert kwargs["with_total"] is True
-            assert kwargs["limit"] == 1000
+            assert kwargs["limit"] == 1
             assert kwargs["offset"] == 0
             return (
                 [
                     {"id": 11, "name": "Alpha", "slug": "alpha", "owner_user_id": 7},
-                    {"id": 22, "name": "Beta", "slug": "beta", "owner_user_id": 8},
-                    {"id": 33, "name": "Gamma", "slug": "gamma", "owner_user_id": 9},
                 ],
-                3,
+                2,
             )
 
     async def _fake_get_db_pool():

--- a/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
@@ -306,6 +306,59 @@ async def test_list_invites_includes_canonical_pagination(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_my_orgs_includes_canonical_pagination(monkeypatch):
+    from tldw_Server_API.app.api.v1.endpoints import orgs
+
+    class _Repo:
+        def __init__(self, db_pool) -> None:  # noqa: ARG002
+            pass
+
+        async def list_org_memberships_for_user(self, user_id):
+            assert user_id == 7
+            return [{"org_id": 11}, {"org_id": 22}]
+
+        async def list_organizations(self, **kwargs):
+            assert kwargs["with_total"] is True
+            assert kwargs["limit"] == 1000
+            assert kwargs["offset"] == 0
+            return (
+                [
+                    {"id": 11, "name": "Alpha", "slug": "alpha", "owner_user_id": 7},
+                    {"id": 22, "name": "Beta", "slug": "beta", "owner_user_id": 8},
+                    {"id": 33, "name": "Gamma", "slug": "gamma", "owner_user_id": 9},
+                ],
+                3,
+            )
+
+    async def _fake_get_db_pool():
+        return object()
+
+    monkeypatch.setattr(orgs, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(orgs, "AuthnzOrgsTeamsRepo", _Repo)
+
+    response = await orgs.list_my_orgs(
+        principal=SimpleNamespace(user_id=7),
+        limit=1,
+        offset=0,
+    )
+
+    assert response.total == 2
+    assert response.limit == 1
+    assert response.offset == 0
+    assert response.has_more is True
+    assert response.pagination.model_dump() == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": 0,
+        "total": 2,
+        "has_more": True,
+        "next_offset": 1,
+    }
+    assert len(response.items) == 1
+    assert response.items[0].id == 11
+
+
+@pytest.mark.asyncio
 async def test_accept_invite_audit_failure_log_is_sanitized(monkeypatch):
     from tldw_Server_API.app.api.v1.endpoints import orgs
     from tldw_Server_API.app.api.v1.schemas.org_team_schemas import OrgInviteAcceptRequest

--- a/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
@@ -348,6 +348,7 @@ async def test_list_my_orgs_includes_canonical_pagination(monkeypatch):
     assert response.limit == 1
     assert response.offset == 0
     assert response.has_more is True
+    assert response.next_offset == 1
     assert response.pagination.model_dump() == {
         "mode": "offset",
         "limit": 1,

--- a/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_orgs_endpoint_sanitization.py
@@ -243,6 +243,69 @@ async def test_revoke_invite_audit_failure_log_is_sanitized(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_invites_includes_canonical_pagination(monkeypatch):
+    from tldw_Server_API.app.api.v1.API_Deps.org_deps import OrgContext
+    from tldw_Server_API.app.api.v1.endpoints import orgs
+
+    class _InviteService:
+        async def list_org_invites(self, org_id, **kwargs):
+            assert org_id == 9
+            assert kwargs["include_expired"] is False
+            assert kwargs["include_inactive"] is False
+            assert kwargs["limit"] == 1
+            assert kwargs["offset"] == 0
+            return (
+                [
+                    {
+                        "id": 42,
+                        "code": "secret-code-123",
+                        "org_id": 9,
+                        "org_name": "Example",
+                        "team_id": None,
+                        "team_name": None,
+                        "role_to_grant": "member",
+                        "max_uses": 1,
+                        "uses_count": 0,
+                        "is_active": True,
+                        "expires_at": None,
+                        "created_at": None,
+                        "created_by": 7,
+                        "description": None,
+                        "allowed_email_domain": None,
+                    }
+                ],
+                2,
+            )
+
+    async def _fake_get_invite_service():
+        return _InviteService()
+
+    monkeypatch.setattr(orgs, "get_invite_service", _fake_get_invite_service)
+
+    response = await orgs.list_invites(
+        ctx=OrgContext(org_id=9, role="admin"),
+        include_expired=False,
+        include_inactive=False,
+        limit=1,
+        offset=0,
+    )
+
+    assert response.total == 2
+    assert response.limit == 1
+    assert response.offset == 0
+    assert response.pagination.model_dump() == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": 0,
+        "total": 2,
+        "has_more": True,
+        "next_offset": 1,
+    }
+    assert len(response.items) == 1
+    assert response.items[0].id == 42
+
+
+@pytest.mark.asyncio
 async def test_accept_invite_audit_failure_log_is_sanitized(monkeypatch):
     from tldw_Server_API.app.api.v1.endpoints import orgs
     from tldw_Server_API.app.api.v1.schemas.org_team_schemas import OrgInviteAcceptRequest

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py
@@ -182,6 +182,52 @@ async def test_sandbox_admin_runs_allowed_for_admin_principal(monkeypatch):
     body = resp.json()
     assert isinstance(body.get("items"), list)
     assert body.get("total") == 0
+    assert body["has_more"] is False
+    assert body["next_offset"] is None
+
+
+@pytest.mark.asyncio
+async def test_sandbox_admin_idempotency_includes_pagination_aliases(monkeypatch):
+    principal = _make_principal(
+        roles=[ROLE_ADMIN],
+        permissions=[],
+        is_admin=True,
+    )
+    fake_service = _FakeService()
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+
+    app = _build_app_with_overrides(principal)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/sandbox/admin/idempotency")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body.get("items"), list)
+    assert body.get("total") == 0
+    assert body["has_more"] is False
+    assert body["next_offset"] is None
+
+
+@pytest.mark.asyncio
+async def test_sandbox_admin_usage_includes_pagination_aliases(monkeypatch):
+    principal = _make_principal(
+        roles=[ROLE_ADMIN],
+        permissions=[],
+        is_admin=True,
+    )
+    fake_service = _FakeService()
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+
+    app = _build_app_with_overrides(principal)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/sandbox/admin/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body.get("items"), list)
+    assert body.get("total") == 0
+    assert body["has_more"] is False
+    assert body["next_offset"] is None
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_note_studio_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_note_studio_db.py
@@ -12,7 +12,7 @@ from tldw_Server_API.app.api.v1.schemas.notes_studio import (
     NoteStudioDocumentCreateRequest,
     NoteStudioDocumentResponse,
 )
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, InputError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError, InputError
 
 
 @pytest.fixture
@@ -90,6 +90,41 @@ def test_create_and_fetch_note_studio_document_by_note_id(db: CharactersRAGDB) -
     assert studio["template_type"] == "lined"  # nosec B101
     assert studio["handwriting_mode"] == "accented"  # nosec B101
     assert studio["payload_json"]["meta"]["source_note_id"] == note_id  # nosec B101
+
+
+def test_create_note_studio_document_translates_duplicate_to_conflict(db: CharactersRAGDB) -> None:
+    note_id = db.add_note(title="Source", content="Alpha beta gamma")
+    payload = {
+        "note_id": note_id,
+        "payload_json": {"meta": {"source_note_id": note_id}, "sections": []},
+        "template_type": "lined",
+        "handwriting_mode": "accented",
+        "source_note_id": note_id,
+        "excerpt_snapshot": "beta",
+        "excerpt_hash": "sha256:demo",
+        "companion_content_hash": "sha256:markdown",
+        "render_version": 1,
+    }
+
+    db.create_note_studio_document(**payload)
+
+    with pytest.raises(ConflictError, match="already exists"):
+        db.create_note_studio_document(**payload)
+
+
+def test_create_note_studio_document_translates_missing_note_to_conflict(db: CharactersRAGDB) -> None:
+    with pytest.raises(ConflictError, match="Note not found"):
+        db.create_note_studio_document(
+            note_id="missing-note",
+            payload_json={"meta": {}, "sections": []},
+            template_type="lined",
+            handwriting_mode="accented",
+            source_note_id=None,
+            excerpt_snapshot="beta",
+            excerpt_hash="sha256:demo",
+            companion_content_hash="sha256:markdown",
+            render_version=1,
+        )
 
 
 def test_note_studio_document_rejects_non_dict_json_shapes(db: CharactersRAGDB) -> None:

--- a/tldw_Server_API/tests/Character_Chat/test_character_chat_endpoints.py
+++ b/tldw_Server_API/tests/Character_Chat/test_character_chat_endpoints.py
@@ -101,6 +101,14 @@ async def test_character_chat_flow_sessions_messages_worldbooks():
             # When not using format_for_completions, response is a dict with messages list
             assert "messages" in msgs
             assert any(m.get("id") == message_id for m in msgs["messages"])  # our message present
+            assert msgs["pagination"] == {
+                "mode": "offset",
+                "limit": 50,
+                "offset": 0,
+                "total": 1,
+                "has_more": False,
+                "next_offset": None,
+            }
 
             # 6) Delete the message (optimistic lock)
             r = await client.delete(
@@ -266,9 +274,18 @@ async def test_message_placeholders_and_length_guard(monkeypatch):
             # Standard message listing should replace placeholders
             r = await client.get(f"/api/v1/chats/{chat_id}/messages", headers=headers)
             assert r.status_code == 200
-            msgs = r.json().get("messages", [])
+            body = r.json()
+            msgs = body.get("messages", [])
             assistant_msg = next(m for m in msgs if m.get("sender") == "assistant")
             assert assistant_msg["content"] == f"Hi User, I'm {char_name}."
+            assert body["pagination"] == {
+                "mode": "offset",
+                "limit": 50,
+                "offset": 0,
+                "total": 1,
+                "has_more": False,
+                "next_offset": None,
+            }
 
             # Completions-formatted messages should replace placeholders in system context
             r = await client.get(

--- a/tldw_Server_API/tests/Character_Chat/test_character_chat_endpoints.py
+++ b/tldw_Server_API/tests/Character_Chat/test_character_chat_endpoints.py
@@ -109,6 +109,8 @@ async def test_character_chat_flow_sessions_messages_worldbooks():
                 "has_more": False,
                 "next_offset": None,
             }
+            assert msgs["has_more"] is False
+            assert msgs["next_offset"] is None
 
             # 6) Delete the message (optimistic lock)
             r = await client.delete(
@@ -286,6 +288,8 @@ async def test_message_placeholders_and_length_guard(monkeypatch):
                 "has_more": False,
                 "next_offset": None,
             }
+            assert body["has_more"] is False
+            assert body["next_offset"] is None
 
             # Completions-formatted messages should replace placeholders in system context
             r = await client.get(

--- a/tldw_Server_API/tests/Character_Chat/unit/test_chat_session_character_scope_api.py
+++ b/tldw_Server_API/tests/Character_Chat/unit/test_chat_session_character_scope_api.py
@@ -120,6 +120,14 @@ def test_list_chat_sessions_uses_batched_message_counts_and_filters_character_sc
     body = response.json()
     assert [item["id"] for item in body["chats"]] == ["character-chat"]
     assert body["total"] == 1
+    assert body["pagination"] == {
+        "mode": "offset",
+        "limit": 50,
+        "offset": 0,
+        "total": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
     assert single_calls == []
     assert batched_calls == [["character-chat"]]
 

--- a/tldw_Server_API/tests/Character_Chat/unit/test_chat_session_character_scope_api.py
+++ b/tldw_Server_API/tests/Character_Chat/unit/test_chat_session_character_scope_api.py
@@ -128,6 +128,8 @@ def test_list_chat_sessions_uses_batched_message_counts_and_filters_character_sc
         "has_more": False,
         "next_offset": None,
     }
+    assert body["has_more"] is False
+    assert body["next_offset"] is None
     assert single_calls == []
     assert batched_calls == [["character-chat"]]
 

--- a/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
@@ -103,6 +103,39 @@ def test_extract_character_memories_allows_owned_chat_by_client_id(
     assert response.json() == {"extracted": 0, "skipped_duplicates": 0, "memories": []}
 
 
+def test_list_character_memories_includes_canonical_pagination(
+    test_client: TestClient,
+    auth_headers,
+) -> None:
+    """List character memories preserves total and adds canonical pagination."""
+    character_id = _create_character(test_client, auth_headers, name="Paginated Memory Character")
+    for index in range(4):
+        response = test_client.post(
+            f"/api/v1/characters/{character_id}/memories",
+            json={"content": f"Remembered fact {index}", "memory_type": "manual"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+
+    response = test_client.get(
+        f"/api/v1/characters/{character_id}/memories?limit=2&offset=1",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 4
+    assert len(payload["memories"]) == 2
+    assert payload["pagination"] == {
+        "mode": "offset",
+        "limit": 2,
+        "offset": 1,
+        "total": 4,
+        "has_more": True,
+        "next_offset": 3,
+    }
+
+
 def test_extract_character_memories_allows_string_owner_client_id(
     test_client: TestClient,
     auth_headers,

--- a/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_memory_endpoint.py
@@ -134,6 +134,8 @@ def test_list_character_memories_includes_canonical_pagination(
         "has_more": True,
         "next_offset": 3,
     }
+    assert payload["has_more"] is True
+    assert payload["next_offset"] == 3
 
 
 def test_extract_character_memories_allows_string_owner_client_id(

--- a/tldw_Server_API/tests/Characters/test_character_functionality_db.py
+++ b/tldw_Server_API/tests/Characters/test_character_functionality_db.py
@@ -1338,6 +1338,11 @@ class TestMessageCRUD:
 
         results_all_keyword = db.search_messages_by_content("keyword")
         assert len(results_all_keyword) >= 2  # At least the two we added
+        first_page = db.search_messages_by_content("keyword", limit=1, offset=0)
+        second_page = db.search_messages_by_content("keyword", limit=1, offset=1)
+        assert first_page
+        assert second_page
+        assert first_page[0]["id"] != second_page[0]["id"]
 
 
 class TestKeywordAndCollectionCRUD:

--- a/tldw_Server_API/tests/Characters/test_characters_endpoint.py
+++ b/tldw_Server_API/tests/Characters/test_characters_endpoint.py
@@ -1808,6 +1808,7 @@ class TestCharacterAPIIntegration:
         assert page_data["pagination"]["offset"] == 0
         assert page_data["pagination"]["has_more"] is True
         assert page_data["pagination"]["next_offset"] == 2
+        assert page_data["next_offset"] == 2
         assert len(page_data["items"]) <= 2
         assert page_data["total"] >= 3
 

--- a/tldw_Server_API/tests/Characters/test_characters_endpoint.py
+++ b/tldw_Server_API/tests/Characters/test_characters_endpoint.py
@@ -1803,6 +1803,11 @@ class TestCharacterAPIIntegration:
         assert page_data["page"] == 1
         assert page_data["page_size"] == 2
         assert isinstance(page_data["has_more"], bool)
+        assert page_data["pagination"]["total"] >= 3
+        assert page_data["pagination"]["limit"] == 2
+        assert page_data["pagination"]["offset"] == 0
+        assert page_data["pagination"]["has_more"] is True
+        assert page_data["pagination"]["next_offset"] == 2
         assert len(page_data["items"]) <= 2
         assert page_data["total"] >= 3
 

--- a/tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py
@@ -938,6 +938,10 @@ async def test_process_text_uses_dictionary_default_token_budget_and_records_act
     assert activity.pagination.total == activity.total
     assert activity.pagination.limit == 10
     assert activity.pagination.offset == 0
+    assert activity.pagination.has_more is False
+    assert activity.pagination.next_offset is None
+    assert activity.has_more is False
+    assert activity.next_offset is None
     assert len(activity.events) >= 1
 
     event = activity.events[0]
@@ -1276,6 +1280,10 @@ async def test_dictionary_version_history_endpoints_list_and_read_snapshots(
     assert versions_response.pagination.total == versions_response.total
     assert versions_response.pagination.limit == 20
     assert versions_response.pagination.offset == 0
+    assert versions_response.pagination.has_more is False
+    assert versions_response.pagination.next_offset is None
+    assert versions_response.has_more is False
+    assert versions_response.next_offset is None
     assert len(versions_response.versions) >= 3
     latest_revision = versions_response.versions[0].revision
     assert latest_revision >= 1

--- a/tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_dictionary_endpoints.py
@@ -935,6 +935,9 @@ async def test_process_text_uses_dictionary_default_token_budget_and_records_act
     )
     assert activity.dictionary_id == dictionary_id
     assert activity.total >= 1
+    assert activity.pagination.total == activity.total
+    assert activity.pagination.limit == 10
+    assert activity.pagination.offset == 0
     assert len(activity.events) >= 1
 
     event = activity.events[0]
@@ -1270,6 +1273,9 @@ async def test_dictionary_version_history_endpoints_list_and_read_snapshots(
     )
     assert versions_response.dictionary_id == dictionary_id
     assert versions_response.total >= 3
+    assert versions_response.pagination.total == versions_response.total
+    assert versions_response.pagination.limit == 20
+    assert versions_response.pagination.offset == 0
     assert len(versions_response.versions) >= 3
     latest_revision = versions_response.versions[0].revision
     assert latest_revision >= 1

--- a/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
@@ -66,7 +66,7 @@ async def test_create_and_list_chat_grammars(chacha_db: CharactersRAGDB):
 
 
 @pytest.mark.asyncio
-async def test_list_chat_grammars_returns_canonical_pagination(monkeypatch: pytest.MonkeyPatch):
+async def test_list_chat_grammars_returns_canonical_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ChatGrammarService, "__init__", lambda self, db: None)
     monkeypatch.setattr(
         ChatGrammarService,

--- a/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
@@ -66,6 +66,46 @@ async def test_create_and_list_chat_grammars(chacha_db: CharactersRAGDB):
 
 
 @pytest.mark.asyncio
+async def test_list_chat_grammars_returns_canonical_pagination(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(ChatGrammarService, "__init__", lambda self, db: None)
+    monkeypatch.setattr(
+        ChatGrammarService,
+        "list_grammars",
+        lambda self, include_archived=False, limit=100, offset=0: [
+            {
+                "id": "grammar-1",
+                "name": "Root",
+                "description": "desc",
+                "grammar_text": 'root ::= "ok"',
+                "validation_status": "valid",
+                "validation_error": None,
+                "last_validated_at": None,
+                "is_archived": False,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "version": 1,
+            }
+        ],
+    )
+    monkeypatch.setattr(ChatGrammarService, "count_grammars", lambda self, include_archived=False: 1)
+
+    listing = await chat_grammar_endpoints.list_chat_grammars(
+        include_archived=False,
+        limit=100,
+        offset=0,
+        db=object(),
+    )
+
+    assert listing.total == 1
+    assert listing.items[0].id == "grammar-1"
+    assert listing.pagination.total == 1
+    assert listing.pagination.limit == 100
+    assert listing.pagination.offset == 0
+    assert listing.pagination.has_more is False
+    assert listing.pagination.next_offset is None
+
+
+@pytest.mark.asyncio
 async def test_get_archived_grammar_requires_include_archived(chacha_db: CharactersRAGDB):
     service = ChatGrammarService(chacha_db)
     grammar_id = service.create_grammar(

--- a/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
@@ -103,6 +103,8 @@ async def test_list_chat_grammars_returns_canonical_pagination(monkeypatch: pyte
     assert listing.pagination.offset == 0
     assert listing.pagination.has_more is False
     assert listing.pagination.next_offset is None
+    assert listing.has_more is False
+    assert listing.next_offset is None
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py
@@ -9,7 +9,14 @@ from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.api.v1.endpoints import chatbooks as chatbooks_endpoints
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
-from tldw_Server_API.app.core.Chatbooks.chatbook_models import ChatbookManifest, ChatbookVersion
+from tldw_Server_API.app.core.Chatbooks.chatbook_models import (
+    ChatbookManifest,
+    ChatbookVersion,
+    ExportJob,
+    ExportStatus,
+    ImportJob,
+    ImportStatus,
+)
 from tldw_Server_API.app.core.Chatbooks.exceptions import JobError
 
 
@@ -113,6 +120,45 @@ class _PreviewExplodingService:
         raise RuntimeError("preview exploded")
 
 
+class _ListJobsService:
+    db = None
+
+    def __init__(self) -> None:
+        created = datetime(2024, 1, 1)
+        self._export_jobs = [
+            ExportJob(
+                job_id=f"export-{index}",
+                user_id="1",
+                status=ExportStatus.PENDING,
+                chatbook_name=f"Export {index}",
+                created_at=created,
+            )
+            for index in range(3)
+        ]
+        self._import_jobs = [
+            ImportJob(
+                job_id=f"import-{index}",
+                user_id="1",
+                status=ImportStatus.PENDING,
+                chatbook_path=f"/tmp/import-{index}.chatbook",
+                created_at=created,
+            )
+            for index in range(3)
+        ]
+
+    def count_export_jobs(self) -> int:
+        return len(self._export_jobs)
+
+    def list_export_jobs(self, *, limit: int, offset: int):
+        return self._export_jobs[offset:offset + limit]
+
+    def count_import_jobs(self) -> int:
+        return len(self._import_jobs)
+
+    def list_import_jobs(self, *, limit: int, offset: int):
+        return self._import_jobs[offset:offset + limit]
+
+
 class _ContinuationFailedService:
     db = None
 
@@ -192,6 +238,40 @@ def test_preview_maps_unexpected_service_failures_to_500():
 
     assert response.status_code == 500
     assert response.json().get("detail") == "An error occurred while previewing the chatbook"
+
+
+def test_job_list_routes_include_canonical_pagination():
+    app = _make_app(_ListJobsService())
+
+    with TestClient(app) as client:
+        export_response = client.get("/api/v1/chatbooks/export/jobs?limit=2&offset=0")
+        import_response = client.get("/api/v1/chatbooks/import/jobs?limit=1&offset=1")
+
+    assert export_response.status_code == 200, export_response.text
+    export_payload = export_response.json()
+    assert len(export_payload["jobs"]) == 2
+    assert export_payload["total"] == 3
+    assert export_payload["pagination"] == {
+        "mode": "offset",
+        "total": 3,
+        "limit": 2,
+        "offset": 0,
+        "has_more": True,
+        "next_offset": 2,
+    }
+
+    assert import_response.status_code == 200, import_response.text
+    import_payload = import_response.json()
+    assert len(import_payload["jobs"]) == 1
+    assert import_payload["total"] == 3
+    assert import_payload["pagination"] == {
+        "mode": "offset",
+        "total": 3,
+        "limit": 1,
+        "offset": 1,
+        "has_more": True,
+        "next_offset": 2,
+    }
 
 
 def test_continue_export_sanitizes_service_failure_message():

--- a/tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py
+++ b/tldw_Server_API/tests/Chatbooks/test_chatbooks_api_error_and_preview_mapping.py
@@ -251,6 +251,8 @@ def test_job_list_routes_include_canonical_pagination():
     export_payload = export_response.json()
     assert len(export_payload["jobs"]) == 2
     assert export_payload["total"] == 3
+    assert export_payload["has_more"] is True
+    assert export_payload["next_offset"] == 2
     assert export_payload["pagination"] == {
         "mode": "offset",
         "total": 3,
@@ -264,6 +266,8 @@ def test_job_list_routes_include_canonical_pagination():
     import_payload = import_response.json()
     assert len(import_payload["jobs"]) == 1
     assert import_payload["total"] == 3
+    assert import_payload["has_more"] is True
+    assert import_payload["next_offset"] == 2
     assert import_payload["pagination"] == {
         "mode": "offset",
         "total": 3,

--- a/tldw_Server_API/tests/Claims/test_claims_dashboard_analytics.py
+++ b/tldw_Server_API/tests/Claims/test_claims_dashboard_analytics.py
@@ -203,6 +203,14 @@ def test_claims_dashboard_analytics_and_export():
             list_payload = r4.json()
             export_ids = [item["export_id"] for item in list_payload.get("exports", [])]
             assert export_meta["export_id"] in export_ids
+            assert list_payload["pagination"] == {
+                "mode": "offset",
+                "limit": 10,
+                "offset": 0,
+                "total": list_payload["total"],
+                "has_more": False,
+                "next_offset": None,
+            }
     finally:
         fastapi_app.dependency_overrides.pop(get_auth_principal, None)
         fastapi_app.dependency_overrides.pop(get_request_user, None)

--- a/tldw_Server_API/tests/Claims/test_claims_dashboard_analytics.py
+++ b/tldw_Server_API/tests/Claims/test_claims_dashboard_analytics.py
@@ -203,6 +203,8 @@ def test_claims_dashboard_analytics_and_export():
             list_payload = r4.json()
             export_ids = [item["export_id"] for item in list_payload.get("exports", [])]
             assert export_meta["export_id"] in export_ids
+            assert list_payload["has_more"] is False
+            assert list_payload["next_offset"] is None
             assert list_payload["pagination"] == {
                 "mode": "offset",
                 "limit": 10,

--- a/tldw_Server_API/tests/Collections/test_items_and_outputs_api.py
+++ b/tldw_Server_API/tests/Collections/test_items_and_outputs_api.py
@@ -829,6 +829,10 @@ async def test_outputs_list_deleted_invalid_path_fallback_log_is_sanitized(monke
     )
 
     assert result.items[0].storage_path == "../private/deleted.md"
+    assert result.pagination.total == 1
+    assert result.pagination.limit == 50
+    assert result.pagination.offset == 0
+    assert result.pagination.has_more is False
     assert logger.warnings == ["outputs.list_deleted: invalid storage path skipped"]
     logged = "\n".join(logger.warnings)
     assert "888" not in logged
@@ -1159,6 +1163,9 @@ def test_outputs_preview_with_inline_data_and_generate(client_with_user, tmp_pat
     assert r.status_code == 200
     lst = r.json()
     assert lst["total"] >= 1
+    assert lst["pagination"]["total"] >= 1
+    assert lst["pagination"]["limit"] == 10
+    assert lst["pagination"]["offset"] == 0
     assert any(it["id"] == oid for it in lst.get("items", []))
 
 

--- a/tldw_Server_API/tests/Collections/test_items_and_outputs_api.py
+++ b/tldw_Server_API/tests/Collections/test_items_and_outputs_api.py
@@ -1166,6 +1166,8 @@ def test_outputs_preview_with_inline_data_and_generate(client_with_user, tmp_pat
     assert lst["pagination"]["total"] >= 1
     assert lst["pagination"]["limit"] == 10
     assert lst["pagination"]["offset"] == 0
+    assert lst["has_more"] == lst["pagination"]["has_more"]
+    assert lst["next_offset"] == lst["pagination"]["next_offset"]
     assert any(it["id"] == oid for it in lst.get("items", []))
 
 

--- a/tldw_Server_API/tests/Collections/test_outputs_templates_api.py
+++ b/tldw_Server_API/tests/Collections/test_outputs_templates_api.py
@@ -73,6 +73,9 @@ def test_templates_crud_and_preview(client_with_user):
     assert r.status_code == 200, r.text
     lst = r.json()
     assert lst["total"] >= 1
+    assert lst["pagination"]["total"] >= 1
+    assert lst["pagination"]["limit"] == 50
+    assert lst["pagination"]["offset"] == 0
     assert any(t["name"] == "daily-brief" for t in lst["items"])
 
     # Get

--- a/tldw_Server_API/tests/Collections/test_outputs_templates_api.py
+++ b/tldw_Server_API/tests/Collections/test_outputs_templates_api.py
@@ -76,6 +76,8 @@ def test_templates_crud_and_preview(client_with_user):
     assert lst["pagination"]["total"] >= 1
     assert lst["pagination"]["limit"] == 50
     assert lst["pagination"]["offset"] == 0
+    assert lst["has_more"] == lst["pagination"]["has_more"]
+    assert lst["next_offset"] == lst["pagination"]["next_offset"]
     assert any(t["name"] == "daily-brief" for t in lst["items"])
 
     # Get

--- a/tldw_Server_API/tests/Collections/test_reading_api.py
+++ b/tldw_Server_API/tests/Collections/test_reading_api.py
@@ -91,6 +91,8 @@ def test_reading_save_get_search_delete(reading_app):
             "has_more": False,
             "next_offset": None,
         }
+        assert listed_payload["has_more"] is False
+        assert listed_payload["next_offset"] is None
 
         r = client.delete(f"/api/v1/reading/items/{item_id}")
         assert r.status_code == 200, r.text
@@ -214,6 +216,8 @@ def test_saved_search_endpoints_crud(reading_app):
             "has_more": False,
             "next_offset": None,
         }
+        assert body["has_more"] is False
+        assert body["next_offset"] is None
 
         r = client.patch(
             f"/api/v1/reading/saved-searches/{search_id}",
@@ -234,6 +238,8 @@ def test_saved_search_endpoints_crud(reading_app):
             "total": 0,
             "limit": 10,
             "offset": 0,
+            "has_more": False,
+            "next_offset": None,
             "pagination": {
                 "mode": "offset",
                 "total": 0,

--- a/tldw_Server_API/tests/Collections/test_reading_api.py
+++ b/tldw_Server_API/tests/Collections/test_reading_api.py
@@ -197,6 +197,14 @@ def test_saved_search_endpoints_crud(reading_app):
         body = r.json()
         assert body["total"] == 1
         assert body["items"][0]["id"] == search_id
+        assert body["pagination"] == {
+            "mode": "offset",
+            "total": 1,
+            "limit": 10,
+            "offset": 0,
+            "has_more": False,
+            "next_offset": None,
+        }
 
         r = client.patch(
             f"/api/v1/reading/saved-searches/{search_id}",
@@ -212,7 +220,20 @@ def test_saved_search_endpoints_crud(reading_app):
 
         r = client.get("/api/v1/reading/saved-searches", params={"limit": 10, "offset": 0})
         assert r.status_code == 200, r.text
-        assert r.json()["total"] == 0
+        assert r.json() == {
+            "items": [],
+            "total": 0,
+            "limit": 10,
+            "offset": 0,
+            "pagination": {
+                "mode": "offset",
+                "total": 0,
+                "limit": 10,
+                "offset": 0,
+                "has_more": False,
+                "next_offset": None,
+            },
+        }
 
 
 def test_saved_search_rejects_unsupported_query_key(reading_app):

--- a/tldw_Server_API/tests/Collections/test_reading_api.py
+++ b/tldw_Server_API/tests/Collections/test_reading_api.py
@@ -80,8 +80,17 @@ def test_reading_save_get_search_delete(reading_app):
 
         r = client.get("/api/v1/reading/items", params={"q": "Example"})
         assert r.status_code == 200, r.text
-        listed_ids = [item["id"] for item in r.json()["items"]]
+        listed_payload = r.json()
+        listed_ids = [item["id"] for item in listed_payload["items"]]
         assert item_id in listed_ids
+        assert listed_payload["pagination"] == {
+            "mode": "offset",
+            "total": 1,
+            "limit": 20,
+            "offset": 0,
+            "has_more": False,
+            "next_offset": None,
+        }
 
         r = client.delete(f"/api/v1/reading/items/{item_id}")
         assert r.status_code == 200, r.text

--- a/tldw_Server_API/tests/Collections/test_reading_endpoint_error_logs.py
+++ b/tldw_Server_API/tests/Collections/test_reading_endpoint_error_logs.py
@@ -185,6 +185,8 @@ async def test_list_reading_digest_outputs_includes_canonical_pagination():
     assert response.pagination.offset == 0
     assert response.pagination.has_more is False
     assert response.pagination.next_offset is None
+    assert response.has_more is False
+    assert response.next_offset is None
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Collections/test_reading_endpoint_error_logs.py
+++ b/tldw_Server_API/tests/Collections/test_reading_endpoint_error_logs.py
@@ -147,6 +147,8 @@ async def test_list_reading_import_jobs_includes_canonical_pagination():
     assert response.pagination.offset == 1
     assert response.pagination.has_more is True
     assert response.pagination.next_offset == 3
+    assert response.has_more is True
+    assert response.next_offset == 3
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Collections/test_reading_endpoint_error_logs.py
+++ b/tldw_Server_API/tests/Collections/test_reading_endpoint_error_logs.py
@@ -94,6 +94,98 @@ async def test_delete_saved_search_sanitizes_backend_log(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_reading_import_jobs_includes_canonical_pagination():
+    class _JobManager:
+        def list_jobs(self, **_kwargs):
+            return [
+                {
+                    "id": 1,
+                    "uuid": "job-1",
+                    "status": "queued",
+                    "payload_json": "{}",
+                    "result_json": None,
+                    "error_message": None,
+                    "progress": 0,
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                    "started_at": None,
+                    "completed_at": None,
+                },
+                {
+                    "id": 2,
+                    "uuid": "job-2",
+                    "status": "processing",
+                    "payload_json": "{}",
+                    "result_json": None,
+                    "error_message": None,
+                    "progress": 25,
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                    "started_at": None,
+                    "completed_at": None,
+                },
+            ]
+
+        def count_jobs(self, **_kwargs):
+            return 5
+
+    response = await reading.list_reading_import_jobs(
+        status=None,
+        limit=2,
+        offset=1,
+        current_user=SimpleNamespace(id=42),
+        jm=_JobManager(),
+    )
+
+    assert response.total == 5
+    assert response.limit == 2
+    assert response.offset == 1
+    assert [job.job_id for job in response.jobs] == [2]
+    assert response.pagination.mode == "offset"
+    assert response.pagination.total == 5
+    assert response.pagination.limit == 2
+    assert response.pagination.offset == 1
+    assert response.pagination.has_more is True
+    assert response.pagination.next_offset == 3
+
+
+@pytest.mark.asyncio
+async def test_list_reading_digest_outputs_includes_canonical_pagination():
+    row = SimpleNamespace(
+        id=11,
+        title="Digest A",
+        format="md",
+        created_at="2026-01-01T00:00:00",
+        metadata_json='{"schedule_id":"sched-1","schedule_name":"Morning","item_count":3}',
+    )
+
+    class _CollectionsDB:
+        def list_output_artifacts(self, **kwargs):
+            if kwargs["offset"] == 0:
+                return [row], 1
+            return [], 1
+
+    response = await reading.list_reading_digest_outputs(
+        schedule_id="sched-1",
+        limit=1,
+        offset=0,
+        _current_user=SimpleNamespace(id=42),
+        collections_db=_CollectionsDB(),
+    )
+
+    assert response.total == 1
+    assert response.limit == 1
+    assert response.offset == 0
+    assert [item.output_id for item in response.items] == [11]
+    assert response.pagination.mode == "offset"
+    assert response.pagination.total == 1
+    assert response.pagination.limit == 1
+    assert response.pagination.offset == 0
+    assert response.pagination.has_more is False
+    assert response.pagination.next_offset is None
+
+
+@pytest.mark.asyncio
 async def test_create_note_link_sanitizes_backend_log(monkeypatch):
     logger_stub = MagicMock()
 

--- a/tldw_Server_API/tests/DataTables/test_data_tables_api.py
+++ b/tldw_Server_API/tests/DataTables/test_data_tables_api.py
@@ -96,6 +96,14 @@ def test_generate_and_get_data_table(tmp_path, data_tables_app_factory):
         detail_payload = detail.json()
         assert detail_payload["table"]["uuid"] == table_uuid
         assert detail_payload["sources"]
+        assert detail_payload["pagination"] == {
+            "mode": "offset",
+            "limit": 200,
+            "offset": 0,
+            "total": 0,
+            "has_more": False,
+            "next_offset": None,
+        }
 
 
 def test_mark_data_table_generate_failed_sanitizes_update_failure_log(monkeypatch):
@@ -430,8 +438,30 @@ def test_list_update_delete_data_table(tmp_path, data_tables_app_factory):
         assert resp.status_code == 200, resp.text
         payload = resp.json()
         assert payload["count"] >= 1
+        assert payload["pagination"] == {
+            "mode": "offset",
+            "limit": 50,
+            "offset": 0,
+            "total": payload["total"],
+            "has_more": False,
+            "next_offset": None,
+        }
 
         table_uuid = table.get("uuid")
+        detail = client.get(f"/api/v1/data-tables/{table_uuid}?rows_limit=1&rows_offset=0")
+        assert detail.status_code == 200, detail.text
+        detail_payload = detail.json()
+        assert detail_payload["rows_limit"] == 1
+        assert detail_payload["rows_offset"] == 0
+        assert detail_payload["pagination"] == {
+            "mode": "offset",
+            "limit": 1,
+            "offset": 0,
+            "total": 1,
+            "has_more": False,
+            "next_offset": None,
+        }
+
         patch = client.patch(
             f"/api/v1/data-tables/{table_uuid}",
             json={"name": "Renamed Table"},

--- a/tldw_Server_API/tests/DataTables/test_data_tables_api.py
+++ b/tldw_Server_API/tests/DataTables/test_data_tables_api.py
@@ -474,6 +474,52 @@ def test_list_update_delete_data_table(tmp_path, data_tables_app_factory):
         assert delete.json()["success"] is True
 
 
+def test_get_data_table_without_rows_preserves_pagination_window(tmp_path, data_tables_app_factory) -> None:
+    db_path = tmp_path / "media.db"
+    seed_db = MediaDatabase(db_path=str(db_path), client_id="test_client")
+    table = seed_db.create_data_table(
+        name="Seed Table",
+        prompt="Seed prompt",
+        description="Seed",
+        status="ready",
+        row_count=2,
+    )
+    table_id = int(table.get("id"))
+    seed_db.insert_data_table_columns(
+        table_id,
+        [{"name": "Name", "type": "text", "position": 0}],
+    )
+    columns = seed_db.list_data_table_columns(table_id)
+    column_id = columns[0].get("column_id")
+    seed_db.insert_data_table_rows(
+        table_id,
+        [
+            {"row_index": 0, "row_json": {column_id: "Alpha"}},
+            {"row_index": 1, "row_json": {column_id: "Beta"}},
+        ],
+    )
+    seed_db.close_connection()
+
+    app, _ = data_tables_app_factory(db_path)
+    with TestClient(app) as client:
+        table_uuid = table.get("uuid")
+        detail = client.get(
+            f"/api/v1/data-tables/{table_uuid}"
+            "?include_rows=false&include_sources=false&rows_limit=1&rows_offset=0"
+        )
+        assert detail.status_code == 200, detail.text
+        detail_payload = detail.json()
+        assert detail_payload["rows"] == []
+        assert detail_payload["pagination"] == {
+            "mode": "offset",
+            "limit": 1,
+            "offset": 0,
+            "total": 2,
+            "has_more": True,
+            "next_offset": 1,
+        }
+
+
 def test_list_data_tables_maps_database_error(tmp_path, data_tables_app_factory, monkeypatch):
     db_path = tmp_path / "media.db"
     app, _ = data_tables_app_factory(db_path)

--- a/tldw_Server_API/tests/DataTables/test_data_tables_api.py
+++ b/tldw_Server_API/tests/DataTables/test_data_tables_api.py
@@ -438,6 +438,8 @@ def test_list_update_delete_data_table(tmp_path, data_tables_app_factory):
         assert resp.status_code == 200, resp.text
         payload = resp.json()
         assert payload["count"] >= 1
+        assert payload["has_more"] is False
+        assert payload["next_offset"] is None
         assert payload["pagination"] == {
             "mode": "offset",
             "limit": 50,
@@ -453,6 +455,8 @@ def test_list_update_delete_data_table(tmp_path, data_tables_app_factory):
         detail_payload = detail.json()
         assert detail_payload["rows_limit"] == 1
         assert detail_payload["rows_offset"] == 0
+        assert detail_payload["has_more"] is False
+        assert detail_payload["next_offset"] is None
         assert detail_payload["pagination"] == {
             "mode": "offset",
             "limit": 1,
@@ -518,6 +522,8 @@ def test_get_data_table_without_rows_preserves_pagination_window(tmp_path, data_
             "has_more": True,
             "next_offset": 1,
         }
+        assert detail_payload["has_more"] is True
+        assert detail_payload["next_offset"] == 1
 
 
 def test_list_data_tables_maps_database_error(tmp_path, data_tables_app_factory, monkeypatch):

--- a/tldw_Server_API/tests/Evaluations/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/Evaluations/integration/test_api_endpoints.py
@@ -435,6 +435,14 @@ class TestEvaluationHistoryEndpoint:
         assert "items" in result
         assert "total_count" in result
         assert len(result["items"]) <= 10
+        assert result["pagination"] == {
+            "mode": "offset",
+            "limit": 10,
+            "offset": 0,
+            "total": result["total_count"],
+            "has_more": result["total_count"] > 10,
+            "next_offset": 10 if result["total_count"] > 10 else None,
+        }
 
     @pytest.mark.asyncio
     async def test_history_with_date_filter(self, async_api_client, auth_headers):

--- a/tldw_Server_API/tests/Evaluations/integration/test_synthetic_eval_api.py
+++ b/tldw_Server_API/tests/Evaluations/integration/test_synthetic_eval_api.py
@@ -79,6 +79,15 @@ async def test_synthetic_queue_filters_by_recipe_kind(async_api_client, auth_hea
     assert response.status_code == 200
     body = response.json()
     assert body["data"]
+    assert body["total"] == 2
+    assert body["pagination"] == {
+        "mode": "offset",
+        "limit": 50,
+        "offset": 0,
+        "total": 2,
+        "has_more": False,
+        "next_offset": None,
+    }
     assert all(item["recipe_kind"] == "rag_answer_quality" for item in body["data"])
 
 
@@ -155,6 +164,15 @@ async def test_synthetic_queue_filters_by_generation_batch_id(async_api_client, 
     assert response.status_code == 200
     body = response.json()
     assert body["data"]
+    assert body["total"] == 2
+    assert body["pagination"] == {
+        "mode": "offset",
+        "limit": 50,
+        "offset": 0,
+        "total": 2,
+        "has_more": False,
+        "next_offset": None,
+    }
     assert all(
         item["sample_metadata"]["generation_batch_id"] == generation_batch_id
         for item in body["data"]

--- a/tldw_Server_API/tests/Evaluations/integration/test_synthetic_eval_api.py
+++ b/tldw_Server_API/tests/Evaluations/integration/test_synthetic_eval_api.py
@@ -88,6 +88,8 @@ async def test_synthetic_queue_filters_by_recipe_kind(async_api_client, auth_hea
         "has_more": False,
         "next_offset": None,
     }
+    assert body["has_more"] is False
+    assert body["next_offset"] is None
     assert all(item["recipe_kind"] == "rag_answer_quality" for item in body["data"])
 
 
@@ -173,6 +175,8 @@ async def test_synthetic_queue_filters_by_generation_batch_id(async_api_client, 
         "has_more": False,
         "next_offset": None,
     }
+    assert body["has_more"] is False
+    assert body["next_offset"] is None
     assert all(
         item["sample_metadata"]["generation_batch_id"] == generation_batch_id
         for item in body["data"]

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_stage1_route_and_error_regressions.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_stage1_route_and_error_regressions.py
@@ -188,6 +188,50 @@ def test_history_preserves_http_403_for_non_admin_cross_user_request(monkeypatch
     assert "Admin privileges required" in response.json()["detail"]
 
 
+def test_history_includes_canonical_offset_pagination(monkeypatch):
+    app = _build_eval_only_app(monkeypatch)
+
+    class _DummyService:
+        async def get_evaluation_history(self, **_kwargs):
+            return [
+                {
+                    "id": "eval_1",
+                    "created_at": "2026-01-01T00:00:00",
+                    "evaluation_type": "g_eval",
+                }
+            ]
+
+        async def count_evaluations(self, **_kwargs):
+            return 3
+
+    monkeypatch.setattr(
+        eval_unified,
+        "get_unified_evaluation_service_for_user",
+        lambda _user_id: _DummyService(),
+    )
+    app.dependency_overrides[eval_unified.get_auth_principal] = lambda: SimpleNamespace(
+        is_admin=False, roles=[], permissions=[]
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/evaluations/history",
+            json={"limit": 1, "offset": 1},
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total_count"] == 3
+    assert body["pagination"] == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": 1,
+        "total": 3,
+        "has_more": True,
+        "next_offset": 2,
+    }
+
+
 def test_propositions_uses_stable_user_id_instead_of_auth_context_token(monkeypatch):
     app = _build_eval_only_app(monkeypatch)
 

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_stage1_route_and_error_regressions.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_stage1_route_and_error_regressions.py
@@ -230,6 +230,8 @@ def test_history_includes_canonical_offset_pagination(monkeypatch):
         "has_more": True,
         "next_offset": 2,
     }
+    assert body["has_more"] is True
+    assert body["next_offset"] == 2
 
 
 def test_propositions_uses_stable_user_id_instead_of_auth_context_token(monkeypatch):

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_stage4_auth_policy_and_dataset_permissions.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_stage4_auth_policy_and_dataset_permissions.py
@@ -167,6 +167,9 @@ def test_dataset_routes_require_read_vs_manage_permissions(monkeypatch):
         current_permissions[:] = [EVALS_READ]
         list_resp = client.get("/api/v1/evaluations/datasets")
         assert list_resp.status_code == 200, list_resp.text
+        list_payload = list_resp.json()
+        assert list_payload["has_more"] == list_payload["pagination"]["has_more"]
+        assert list_payload["next_offset"] == list_payload["pagination"]["next_offset"]
         get_resp = client.get("/api/v1/evaluations/datasets/ds_1")
         assert get_resp.status_code == 200, get_resp.text
 

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_stage4_auth_policy_and_dataset_permissions.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_stage4_auth_policy_and_dataset_permissions.py
@@ -92,6 +92,10 @@ def test_dataset_routes_require_read_vs_manage_permissions(monkeypatch):
             _ = (limit, offset, created_by)
             return [stored_datasets["ds_1"]], False
 
+        def count_datasets(self, *, created_by, after=None):
+            _ = (created_by, after)
+            return len(stored_datasets)
+
         def get_dataset(
             self,
             dataset_id,

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_unified.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_unified.py
@@ -15,8 +15,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch, AsyncMock
 from fastapi.testclient import TestClient
-from fastapi import status
-from httpx import AsyncClient
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
 
 # Import centralized test configuration
 import sys
@@ -27,8 +27,7 @@ from test_config import test_config
 test_config.setup_test_environment()
 test_config.reset_settings()
 
-# Import the FastAPI app
-from tldw_Server_API.app.main import app
+from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_unified import router as evaluations_router
 from tldw_Server_API.app.core.Evaluations.unified_evaluation_service import (
     UnifiedEvaluationService, get_unified_evaluation_service
 )
@@ -41,23 +40,29 @@ TEST_SK_KEY = test_config.TEST_SK_KEY
 
 
 @pytest.fixture(scope="function")
-def client():
+def evaluations_test_app():
+    app = FastAPI()
+    app.include_router(evaluations_router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture(scope="function")
+def client(evaluations_test_app):
     """Create a test client"""
-    with TestClient(app) as c:
+    with TestClient(evaluations_test_app) as c:
         yield c
 
 
 import pytest_asyncio
 @pytest_asyncio.fixture(scope="function")
-async def async_client():
+async def async_client(evaluations_test_app):
     """Create an async test client"""
-    from httpx import ASGITransport
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+    async with AsyncClient(transport=ASGITransport(app=evaluations_test_app), base_url="http://test") as ac:
         yield ac
 
 
 @pytest.fixture(autouse=True)
-def use_temp_evaluations_db(temp_db_path, monkeypatch, event_loop):
+def use_temp_evaluations_db(temp_db_path, monkeypatch, event_loop, evaluations_test_app):
     """Route all evaluation storage to the per-test temporary database."""
 
     from tldw_Server_API.app.core.Evaluations import unified_evaluation_service as _svc_module
@@ -113,7 +118,7 @@ def use_temp_evaluations_db(temp_db_path, monkeypatch, event_loop):
     async def _dependency_override():
         return service
 
-    app.dependency_overrides[get_unified_evaluation_service] = _dependency_override
+    evaluations_test_app.dependency_overrides[get_unified_evaluation_service] = _dependency_override
 
     try:
         yield
@@ -128,7 +133,7 @@ def use_temp_evaluations_db(temp_db_path, monkeypatch, event_loop):
         except Exception:
             _ = None
         event_loop.run_until_complete(service.shutdown())
-        app.dependency_overrides.pop(get_unified_evaluation_service, None)
+        evaluations_test_app.dependency_overrides.pop(get_unified_evaluation_service, None)
 
 
 @pytest.fixture

--- a/tldw_Server_API/tests/Evaluations/test_evaluations_unified.py
+++ b/tldw_Server_API/tests/Evaluations/test_evaluations_unified.py
@@ -661,6 +661,15 @@ class TestDatasetManagement:
         data = response.json()
         assert data["object"] == "list"
         assert len(data["data"]) <= 2
+        assert data["total"] == 3
+        assert data["pagination"] == {
+            "mode": "offset",
+            "limit": 2,
+            "offset": 0,
+            "total": 3,
+            "has_more": True,
+            "next_offset": 2,
+        }
 
     def test_delete_dataset(self, client, auth_headers, sample_dataset_request):
 

--- a/tldw_Server_API/tests/Evaluations/test_synthetic_eval_service.py
+++ b/tldw_Server_API/tests/Evaluations/test_synthetic_eval_service.py
@@ -263,7 +263,9 @@ def test_service_reports_true_queue_total_before_pagination(tmp_path) -> None:
 
     queue = service.list_queue(generation_batch_id="batch-total", limit=2, offset=0)
 
-    assert [row["sample_id"] for row in queue["data"]] == ["sample-total-c", "sample-total-b"]  # nosec B101
+    page_sample_ids = {row["sample_id"] for row in queue["data"]}
+    assert len(page_sample_ids) == 2  # nosec B101
+    assert page_sample_ids <= {"sample-total-a", "sample-total-b", "sample-total-c"}  # nosec B101
     assert queue["total"] == 3  # nosec B101
 
 

--- a/tldw_Server_API/tests/Evaluations/test_synthetic_eval_service.py
+++ b/tldw_Server_API/tests/Evaluations/test_synthetic_eval_service.py
@@ -248,6 +248,25 @@ def test_service_filters_queue_by_generation_batch_id(tmp_path) -> None:
     assert [row["sample_id"] for row in queue["data"]] == ["sample-service-a"]  # nosec B101
 
 
+def test_service_reports_true_queue_total_before_pagination(tmp_path) -> None:
+    service = _workflow_service(tmp_path)
+
+    for sample_id in ("sample-total-a", "sample-total-b", "sample-total-c"):
+        service.repository.create_draft_sample(
+            sample_id=sample_id,
+            recipe_kind="rag_answer_quality",
+            sample_payload={"query": sample_id},
+            provenance=SyntheticEvalProvenance.SYNTHETIC_FROM_CORPUS.value,
+            review_state=SyntheticEvalReviewState.DRAFT.value,
+            sample_metadata={"generation_batch_id": "batch-total"},
+        )
+
+    queue = service.list_queue(generation_batch_id="batch-total", limit=2, offset=0)
+
+    assert [row["sample_id"] for row in queue["data"]] == ["sample-total-c", "sample-total-b"]  # nosec B101
+    assert queue["total"] == 3  # nosec B101
+
+
 def test_generation_prefers_real_examples_before_seed_and_synthetic_fill(tmp_path) -> None:
     service = _service(tmp_path)
     generation_calls: list[dict[str, object]] = []

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -867,6 +867,8 @@ def test_flashcard_visibility_endpoints_respect_default_general_only_and_explici
         "has_more": False,
         "next_offset": None,
     }
+    assert default_payload["has_more"] is False
+    assert default_payload["next_offset"] is None
     assert any(item["uuid"] == general_card["uuid"] for item in default_items)
     assert all(item["deck_id"] != workspace_deck_id for item in default_items)
 
@@ -897,6 +899,8 @@ def test_flashcard_visibility_endpoints_respect_default_general_only_and_explici
         "has_more": True,
         "next_offset": 1,
     }
+    assert all_payload["has_more"] is True
+    assert all_payload["next_offset"] == 1
 
     all_list_page2 = client_with_flashcards_db.get(
         "/api/v1/flashcards",
@@ -916,6 +920,8 @@ def test_flashcard_visibility_endpoints_respect_default_general_only_and_explici
         "has_more": False,
         "next_offset": None,
     }
+    assert page2_payload["has_more"] is False
+    assert page2_payload["next_offset"] is None
     assert {
         all_payload["items"][0]["uuid"],
         page2_payload["items"][0]["uuid"],

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -855,8 +855,18 @@ def test_flashcard_visibility_endpoints_respect_default_general_only_and_explici
 
     default_list = client_with_flashcards_db.get("/api/v1/flashcards", headers=AUTH_HEADERS)
     assert default_list.status_code == 200
-    default_items = default_list.json()["items"]
-    assert default_list.json()["total"] == 1
+    default_payload = default_list.json()
+    default_items = default_payload["items"]
+    assert default_payload["total"] == 1
+    assert default_payload["count"] == 1
+    assert default_payload["pagination"] == {
+        "mode": "offset",
+        "total": 1,
+        "limit": 100,
+        "offset": 0,
+        "has_more": False,
+        "next_offset": None,
+    }
     assert any(item["uuid"] == general_card["uuid"] for item in default_items)
     assert all(item["deck_id"] != workspace_deck_id for item in default_items)
 
@@ -871,12 +881,45 @@ def test_flashcard_visibility_endpoints_respect_default_general_only_and_explici
 
     all_list = client_with_flashcards_db.get(
         "/api/v1/flashcards",
-        params={"include_workspace_items": True},
+        params={"include_workspace_items": True, "limit": 1, "offset": 0},
         headers=AUTH_HEADERS,
     )
     assert all_list.status_code == 200
-    assert all_list.json()["total"] == 2
-    assert {item["uuid"] for item in all_list.json()["items"]} == {general_card["uuid"], workspace_card["uuid"]}
+    all_payload = all_list.json()
+    assert all_payload["total"] == 2
+    assert all_payload["count"] == 1
+    assert len(all_payload["items"]) == 1
+    assert all_payload["pagination"] == {
+        "mode": "offset",
+        "total": 2,
+        "limit": 1,
+        "offset": 0,
+        "has_more": True,
+        "next_offset": 1,
+    }
+
+    all_list_page2 = client_with_flashcards_db.get(
+        "/api/v1/flashcards",
+        params={"include_workspace_items": True, "limit": 1, "offset": 1},
+        headers=AUTH_HEADERS,
+    )
+    assert all_list_page2.status_code == 200
+    page2_payload = all_list_page2.json()
+    assert page2_payload["total"] == 2
+    assert page2_payload["count"] == 1
+    assert len(page2_payload["items"]) == 1
+    assert page2_payload["pagination"] == {
+        "mode": "offset",
+        "total": 2,
+        "limit": 1,
+        "offset": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
+    assert {
+        all_payload["items"][0]["uuid"],
+        page2_payload["items"][0]["uuid"],
+    } == {general_card["uuid"], workspace_card["uuid"]}
 
     deck_list = client_with_flashcards_db.get(
         "/api/v1/flashcards",

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_templates_api.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_templates_api.py
@@ -294,6 +294,8 @@ def test_flashcard_template_list_returns_items(client_with_flashcards_db: TestCl
         "has_more": False,
         "next_offset": None,
     }
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None
     assert payload["items"][0]["id"] == created_payload["id"]
     assert payload["items"][0]["name"] == "List template"
 

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_templates_api.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_templates_api.py
@@ -286,6 +286,14 @@ def test_flashcard_template_list_returns_items(client_with_flashcards_db: TestCl
     payload = response.json()
     assert payload["count"] == 1
     assert payload["total"] == 1
+    assert payload["pagination"] == {
+        "mode": "offset",
+        "total": 1,
+        "limit": 100,
+        "offset": 0,
+        "has_more": False,
+        "next_offset": None,
+    }
     assert payload["items"][0]["id"] == created_payload["id"]
     assert payload["items"][0]["name"] == "List template"
 

--- a/tldw_Server_API/tests/Media/test_document_references.py
+++ b/tldw_Server_API/tests/Media/test_document_references.py
@@ -308,6 +308,14 @@ async def test_references_endpoint_cache_hit(mock_user, mock_db):
     assert response.status_code == 200
     data = response.json()
     assert data["references"][0]["title"] == "Cached Title"
+    assert data["pagination"] == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": 0,
+        "total": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
 
     app.dependency_overrides.clear()
 

--- a/tldw_Server_API/tests/Media/test_document_references.py
+++ b/tldw_Server_API/tests/Media/test_document_references.py
@@ -161,6 +161,14 @@ async def test_references_endpoint_applies_pagination_window(mock_user, mock_db)
     assert data["total_available"] == 6
     assert data["has_more"] is True
     assert data["next_offset"] == 4
+    assert data["pagination"] == {
+        "mode": "offset",
+        "limit": 2,
+        "offset": 2,
+        "total": 6,
+        "has_more": True,
+        "next_offset": 4,
+    }
     assert "Example 3" in data["references"][0]["raw_text"]
     assert "Example 4" in data["references"][1]["raw_text"]
 
@@ -194,6 +202,14 @@ async def test_references_endpoint_applies_search_before_pagination(mock_user, m
     assert data["total_available"] == 1
     assert data["has_more"] is False
     assert data["next_offset"] is None
+    assert data["pagination"] == {
+        "mode": "offset",
+        "limit": 2,
+        "offset": 0,
+        "total": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
     assert "Example 6" in data["references"][0]["raw_text"]
 
     app.dependency_overrides.clear()

--- a/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_add_endpoint_real.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_add_endpoint_real.py
@@ -48,9 +48,12 @@ def client_with_auth():
     app.dependency_overrides[get_auth_principal] = override_principal
     settings = get_settings()
     headers = {"X-API-KEY": settings.SINGLE_USER_API_KEY}
-    with TestClient(app, headers=headers) as client:
+    client = TestClient(app, headers=headers)
+    try:
         yield client
-    app.dependency_overrides.clear()
+    finally:
+        client.close()
+        app.dependency_overrides.clear()
 
 
 def test_add_document_with_content_real(client_with_auth: TestClient, tmp_path):
@@ -133,6 +136,10 @@ def test_list_and_search_media_after_add(client_with_auth: TestClient, tmp_path)
     assert "pagination" in data and isinstance(data["pagination"], dict)
     for key in ("page", "results_per_page", "total_pages", "total_items"):
         assert key in data["pagination"]
+    assert data["pagination"]["mode"] == "page"
+    assert data["pagination"]["per_page"] == 5
+    assert data["pagination"]["total"] >= len(data["items"])
+    assert isinstance(data["pagination"]["has_more"], bool)
     # Validate an item shape if present (with keywords)
     if data["items"]:
         item = data["items"][0]
@@ -161,6 +168,10 @@ def test_list_and_search_media_after_add(client_with_auth: TestClient, tmp_path)
     assert "pagination" in sdata and isinstance(sdata["pagination"], dict)
     for key in ("page", "results_per_page", "total_pages", "total_items"):
         assert key in sdata["pagination"]
+    assert sdata["pagination"]["mode"] == "page"
+    assert sdata["pagination"]["per_page"] == 5
+    assert sdata["pagination"]["total"] >= len(sdata["items"])
+    assert isinstance(sdata["pagination"]["has_more"], bool)
     assert any("Alpha" in item.get("title", "") for item in sdata.get("items", []))
 
 

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_versions.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_versions.py
@@ -114,11 +114,13 @@ def client_module(db_instance_session):
     app.dependency_overrides[get_media_db_for_user] = override_get_media_db_for_user
     app.dependency_overrides[get_request_user] = _override_user
 
-    client = TestClient(fastapi_app_instance)
+    client = None
     try:
+        client = TestClient(fastapi_app_instance)
         yield client
     finally:
-        client.close()
+        if client is not None:
+            client.close()
 
         # Restore original overrides AFTER client is closed
         app.dependency_overrides = original_overrides

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_versions.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_media_versions.py
@@ -114,11 +114,14 @@ def client_module(db_instance_session):
     app.dependency_overrides[get_media_db_for_user] = override_get_media_db_for_user
     app.dependency_overrides[get_request_user] = _override_user
 
-    with TestClient(fastapi_app_instance) as client:
+    client = TestClient(fastapi_app_instance)
+    try:
         yield client
+    finally:
+        client.close()
 
-    # Restore original overrides AFTER client is closed
-    app.dependency_overrides = original_overrides
+        # Restore original overrides AFTER client is closed
+        app.dependency_overrides = original_overrides
     # test_db_instance_ref = None # Consider if shutdown handler is still needed
     # print("--- CLEARED get_media_db_for_user override ---")
 
@@ -805,6 +808,10 @@ class TestMediaListDetailEndpoints:
         assert data["pagination"]["results_per_page"] > 0 # Default value
         assert data["pagination"]["total_items"] >= len(self.media_ids)
         assert data["pagination"]["total_pages"] >= 1
+        assert data["pagination"]["mode"] == "page"
+        assert data["pagination"]["per_page"] == data["pagination"]["results_per_page"]
+        assert data["pagination"]["total"] == data["pagination"]["total_items"]
+        assert isinstance(data["pagination"]["has_more"], bool)
 
     def test_get_all_media_pagination(self):
 
@@ -818,6 +825,10 @@ class TestMediaListDetailEndpoints:
         assert data["pagination"]["page"] == 1
         assert data["pagination"]["results_per_page"] == 2
         assert data["pagination"]["total_items"] >= len(self.media_ids)
+        assert data["pagination"]["mode"] == "page"
+        assert data["pagination"]["per_page"] == 2
+        assert data["pagination"]["total"] == data["pagination"]["total_items"]
+        assert data["pagination"]["has_more"] == (data["pagination"]["page"] < data["pagination"]["total_pages"])
 
         # Get page 2, 2 items per page
         response_p2 = self.client.get("/api/v1/media?page=2&results_per_page=2")
@@ -836,6 +847,23 @@ class TestMediaListDetailEndpoints:
                 assert len(data_p2["items"]) == 0 # Should be empty if past the last page
         else:
             assert len(data_p2["items"]) == 0 # Should be empty if only one page
+
+    def test_get_media_trash_pagination_includes_canonical_page_metadata(self):
+        doc_id = self.media_ids["document"]
+        trash_response = self.client.delete(f"/api/v1/media/{doc_id}")
+        assert trash_response.status_code == status.HTTP_204_NO_CONTENT
+
+        response = self.client.get("/api/v1/media/trash?page=1&results_per_page=10")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "pagination" in data
+        assert data["pagination"]["page"] == 1
+        assert data["pagination"]["results_per_page"] == 10
+        assert data["pagination"]["mode"] == "page"
+        assert data["pagination"]["per_page"] == 10
+        assert data["pagination"]["total"] == data["pagination"]["total_items"]
+        assert isinstance(data["pagination"]["has_more"], bool)
+        assert any(item["id"] == doc_id for item in data["items"])
 
 
     def test_get_all_media_invalid_pagination_params(self):

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_moodboards_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_moodboards_api.py
@@ -85,8 +85,21 @@ def test_moodboard_crud_and_membership_flow(moodboard_client: TestClient):
 
     list_resp = client.get("/api/v1/notes/moodboards")
     assert list_resp.status_code == 200
-    boards = list_resp.json()["moodboards"]
+    list_payload = list_resp.json()
+    boards = list_payload["moodboards"]
     assert any(int(item["id"]) == int(moodboard_id) for item in boards)
+    assert list_payload["count"] == 1
+    assert list_payload["total"] == 1
+    assert list_payload["limit"] == 100
+    assert list_payload["offset"] == 0
+    assert list_payload["pagination"] == {
+        "mode": "offset",
+        "limit": 100,
+        "offset": 0,
+        "total": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
 
     pin_manual = client.post(f"/api/v1/notes/moodboards/{moodboard_id}/notes/{note_manual['id']}")
     pin_both = client.post(f"/api/v1/notes/moodboards/{moodboard_id}/notes/{note_both['id']}")

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_moodboards_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_moodboards_api.py
@@ -108,6 +108,14 @@ def test_moodboard_crud_and_membership_flow(moodboard_client: TestClient):
     paged_body = paged.json()
     assert paged_body["count"] == 1
     assert paged_body["total"] == 2
+    assert paged_body["pagination"] == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": 0,
+        "total": 2,
+        "has_more": True,
+        "next_offset": 1,
+    }
 
     unpin_both = client.delete(f"/api/v1/notes/moodboards/{moodboard_id}/notes/{note_both['id']}")
     assert unpin_both.status_code == 200

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_moodboards_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_moodboards_api.py
@@ -100,6 +100,8 @@ def test_moodboard_crud_and_membership_flow(moodboard_client: TestClient):
         "has_more": False,
         "next_offset": None,
     }
+    assert list_payload["has_more"] is False
+    assert list_payload["next_offset"] is None
 
     pin_manual = client.post(f"/api/v1/notes/moodboards/{moodboard_id}/notes/{note_manual['id']}")
     pin_both = client.post(f"/api/v1/notes/moodboards/{moodboard_id}/notes/{note_both['id']}")
@@ -129,6 +131,8 @@ def test_moodboard_crud_and_membership_flow(moodboard_client: TestClient):
         "has_more": True,
         "next_offset": 1,
     }
+    assert paged_body["has_more"] is True
+    assert paged_body["next_offset"] == 1
 
     unpin_both = client.delete(f"/api/v1/notes/moodboards/{moodboard_id}/notes/{note_both['id']}")
     assert unpin_both.status_code == 200

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
@@ -241,6 +241,18 @@ def test_list_and_search_pagination_and_404s(client_with_notes_db: TestClient):
     d1, d2 = page1.json(), page2.json()
     assert isinstance(d1, dict) and isinstance(d2, dict)
     assert isinstance(d1.get("notes"), list) and isinstance(d2.get("notes"), list)
+    assert d1["pagination"]["mode"] == "offset"
+    assert d1["pagination"]["limit"] == 2
+    assert d1["pagination"]["offset"] == 0
+    assert d1["pagination"]["total"] == d1["total"]
+    assert d1["pagination"]["has_more"] is True
+    assert d1["pagination"]["next_offset"] == 2
+    assert d2["pagination"]["mode"] == "offset"
+    assert d2["pagination"]["limit"] == 2
+    assert d2["pagination"]["offset"] == 2
+    assert d2["pagination"]["total"] == d2["total"]
+    assert d2["pagination"]["has_more"] is True
+    assert d2["pagination"]["next_offset"] == 4
     # Verify disjointness of pages by IDs
     ids1 = {n.get("id") for n in d1.get("notes", [])}
     ids2 = {n.get("id") for n in d2.get("notes", [])}

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
@@ -377,6 +377,9 @@ def test_keyword_collections_list_includes_canonical_pagination(client_with_note
     payload2 = page2.json()
     assert len(payload1["collections"]) == 1
     assert len(payload2["collections"]) == 1
+    page1_ids = {collection["id"] for collection in payload1["collections"]}
+    page2_ids = {collection["id"] for collection in payload2["collections"]}
+    assert page1_ids.isdisjoint(page2_ids)
     assert payload1["total"] == 2
     assert payload1["count"] == 1
     assert payload1["limit"] == 1

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
@@ -247,12 +247,16 @@ def test_list_and_search_pagination_and_404s(client_with_notes_db: TestClient):
     assert d1["pagination"]["total"] == d1["total"]
     assert d1["pagination"]["has_more"] is True
     assert d1["pagination"]["next_offset"] == 2
+    assert d1["has_more"] is True
+    assert d1["next_offset"] == 2
     assert d2["pagination"]["mode"] == "offset"
     assert d2["pagination"]["limit"] == 2
     assert d2["pagination"]["offset"] == 2
     assert d2["pagination"]["total"] == d2["total"]
     assert d2["pagination"]["has_more"] is True
     assert d2["pagination"]["next_offset"] == 4
+    assert d2["has_more"] is True
+    assert d2["next_offset"] == 4
     # Verify disjointness of pages by IDs
     ids1 = {n.get("id") for n in d1.get("notes", [])}
     ids2 = {n.get("id") for n in d2.get("notes", [])}
@@ -385,6 +389,8 @@ def test_keyword_collections_list_includes_canonical_pagination(client_with_note
         "has_more": True,
         "next_offset": 1,
     }
+    assert payload1["has_more"] is True
+    assert payload1["next_offset"] == 1
     assert payload2["total"] == 2
     assert payload2["count"] == 1
     assert payload2["limit"] == 1
@@ -397,6 +403,8 @@ def test_keyword_collections_list_includes_canonical_pagination(client_with_note
         "has_more": False,
         "next_offset": None,
     }
+    assert payload2["has_more"] is False
+    assert payload2["next_offset"] is None
 
 
 def test_keywords_list_without_trailing_slash_does_not_hit_note_lookup(client_with_notes_db: TestClient):

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
@@ -356,6 +356,49 @@ def test_keywords_list_pagination_and_search_limit(client_with_notes_db: TestCli
     assert len(results) <= 7
 
 
+def test_keyword_collections_list_includes_canonical_pagination(client_with_notes_db: TestClient):
+    client = client_with_notes_db
+
+    first = client.post("/api/v1/notes/collections", json={"name": "Collection A"})
+    second = client.post("/api/v1/notes/collections", json={"name": "Collection B"})
+    assert first.status_code == 201, first.text
+    assert second.status_code == 201, second.text
+
+    page1 = client.get("/api/v1/notes/collections", params={"limit": 1, "offset": 0})
+    page2 = client.get("/api/v1/notes/collections", params={"limit": 1, "offset": 1})
+    assert page1.status_code == 200, page1.text
+    assert page2.status_code == 200, page2.text
+
+    payload1 = page1.json()
+    payload2 = page2.json()
+    assert len(payload1["collections"]) == 1
+    assert len(payload2["collections"]) == 1
+    assert payload1["total"] == 2
+    assert payload1["count"] == 1
+    assert payload1["limit"] == 1
+    assert payload1["offset"] == 0
+    assert payload1["pagination"] == {
+        "mode": "offset",
+        "total": 2,
+        "limit": 1,
+        "offset": 0,
+        "has_more": True,
+        "next_offset": 1,
+    }
+    assert payload2["total"] == 2
+    assert payload2["count"] == 1
+    assert payload2["limit"] == 1
+    assert payload2["offset"] == 1
+    assert payload2["pagination"] == {
+        "mode": "offset",
+        "total": 2,
+        "limit": 1,
+        "offset": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
+
+
 def test_keywords_list_without_trailing_slash_does_not_hit_note_lookup(client_with_notes_db: TestClient):
     client = client_with_notes_db
 

--- a/tldw_Server_API/tests/Personalization/test_companion_api.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_api.py
@@ -67,6 +67,10 @@ def test_companion_activity_endpoint_returns_provenance(client_with_companion_db
     assert response.status_code == 200, response.text
     payload = response.json()
     assert payload["total"] == 1
+    assert payload["pagination"]["total"] == 1
+    assert payload["pagination"]["limit"] == 10
+    assert payload["pagination"]["offset"] == 0
+    assert payload["pagination"]["has_more"] is False
     assert len(payload["items"]) == 1
     assert payload["items"][0]["event_type"] == "reading.saved"
     assert payload["items"][0]["provenance"]["capture_mode"] == "explicit"

--- a/tldw_Server_API/tests/Personalization/test_companion_api.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_api.py
@@ -71,6 +71,9 @@ def test_companion_activity_endpoint_returns_provenance(client_with_companion_db
     assert payload["pagination"]["limit"] == 10
     assert payload["pagination"]["offset"] == 0
     assert payload["pagination"]["has_more"] is False
+    assert payload["pagination"]["next_offset"] is None
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None
     assert len(payload["items"]) == 1
     assert payload["items"][0]["event_type"] == "reading.saved"
     assert payload["items"][0]["provenance"]["capture_mode"] == "explicit"

--- a/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_api.py
+++ b/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_api.py
@@ -484,7 +484,20 @@ class TestCollectionEndpoints:
 
         assert response.status_code == 200, response.text
         payload = response.json()
-        assert payload == {"collections": []}
+        assert payload == {
+            "collections": [],
+            "total": 0,
+            "limit": 200,
+            "offset": 0,
+            "pagination": {
+                "mode": "offset",
+                "total": 0,
+                "limit": 200,
+                "offset": 0,
+                "has_more": False,
+                "next_offset": None,
+            },
+        }
 
     @pytest.mark.integration
     def test_create_collection_endpoint(self, test_client, auth_headers):
@@ -571,6 +584,15 @@ class TestCollectionEndpoints:
         assert "collections" in payload
         names = {item["name"] for item in payload["collections"]}
         assert {"List Collection A", "List Collection B"}.issubset(names)
+        assert payload["total"] >= 2
+        assert payload["limit"] == 200
+        assert payload["offset"] == 0
+        assert payload["pagination"]["mode"] == "offset"
+        assert payload["pagination"]["total"] >= 2
+        assert payload["pagination"]["limit"] == 200
+        assert payload["pagination"]["offset"] == 0
+        assert payload["pagination"]["has_more"] is False
+        assert payload["pagination"]["next_offset"] is None
 
     @pytest.mark.integration
     def test_update_collection_endpoint(self, test_client, auth_headers):

--- a/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_api.py
+++ b/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_api.py
@@ -489,6 +489,8 @@ class TestCollectionEndpoints:
             "total": 0,
             "limit": 200,
             "offset": 0,
+            "has_more": False,
+            "next_offset": None,
             "pagination": {
                 "mode": "offset",
                 "total": 0,
@@ -593,6 +595,8 @@ class TestCollectionEndpoints:
         assert payload["pagination"]["offset"] == 0
         assert payload["pagination"]["has_more"] is False
         assert payload["pagination"]["next_offset"] is None
+        assert payload["has_more"] is False
+        assert payload["next_offset"] is None
 
     @pytest.mark.integration
     def test_update_collection_endpoint(self, test_client, auth_headers):

--- a/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+++ b/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
@@ -678,6 +678,10 @@ def test_quiz_list_ignores_workspace_tag_query_param(client_with_quizzes_db: Tes
     assert baseline.status_code == 200
     assert filtered.status_code == 200
     assert filtered.json()["count"] == baseline.json()["count"]
+    assert filtered.json()["pagination"]["total"] == filtered.json()["count"]
+    assert filtered.json()["pagination"]["limit"] == 50
+    assert filtered.json()["pagination"]["offset"] == 0
+    assert filtered.json()["pagination"]["has_more"] is False
 
 
 def test_list_quizzes_maps_input_error_to_400(
@@ -746,6 +750,46 @@ def test_list_questions_maps_input_error_to_400(
     assert response.json()["detail"] == "invalid question list query"
 
 
+def test_question_list_returns_canonical_pagination(client_with_quizzes_db: TestClient):
+    create_quiz_response = client_with_quizzes_db.post(
+        "/api/v1/quizzes",
+        json={"name": "Question Pagination Quiz"},
+        headers=AUTH_HEADERS,
+    )
+    assert create_quiz_response.status_code == 200
+    quiz_id = create_quiz_response.json()["id"]
+
+    for index in range(2):
+        create_question_response = client_with_quizzes_db.post(
+            f"/api/v1/quizzes/{quiz_id}/questions",
+            json={
+                "question_type": "multiple_choice",
+                "question_text": f"Question {index}",
+                "options": ["A", "B"],
+                "correct_answer": 1,
+                "points": 1,
+                "order_index": index,
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert create_question_response.status_code == 200
+
+    response = client_with_quizzes_db.get(
+        f"/api/v1/quizzes/{quiz_id}/questions",
+        params={"limit": 1, "offset": 1},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 2
+    assert len(payload["items"]) == 1
+    assert payload["pagination"]["total"] == 2
+    assert payload["pagination"]["limit"] == 1
+    assert payload["pagination"]["offset"] == 1
+    assert payload["pagination"]["has_more"] is False
+
+
 def test_attempts_list_route_is_not_shadowed_by_quiz_id(client_with_quizzes_db: TestClient):
     create_quiz_response = client_with_quizzes_db.post(
         "/api/v1/quizzes",
@@ -793,6 +837,9 @@ def test_attempts_list_route_is_not_shadowed_by_quiz_id(client_with_quizzes_db: 
     assert attempts_payload["count"] >= 1
     assert any(item["id"] == attempt_id for item in attempts_payload["items"])
     assert all(item["quiz_id"] == quiz_id for item in attempts_payload["items"])
+    assert attempts_payload["pagination"]["total"] >= 1
+    assert attempts_payload["pagination"]["limit"] == 20
+    assert attempts_payload["pagination"]["offset"] == 0
 
 
 def test_start_attempt_returns_404_for_missing_quiz(client_with_quizzes_db: TestClient):

--- a/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+++ b/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
@@ -682,6 +682,8 @@ def test_quiz_list_ignores_workspace_tag_query_param(client_with_quizzes_db: Tes
     assert filtered.json()["pagination"]["limit"] == 50
     assert filtered.json()["pagination"]["offset"] == 0
     assert filtered.json()["pagination"]["has_more"] is False
+    assert filtered.json()["has_more"] is False
+    assert filtered.json()["next_offset"] is None
 
 
 def test_list_quizzes_maps_input_error_to_400(
@@ -776,7 +778,7 @@ def test_question_list_returns_canonical_pagination(client_with_quizzes_db: Test
 
     response = client_with_quizzes_db.get(
         f"/api/v1/quizzes/{quiz_id}/questions",
-        params={"limit": 1, "offset": 1},
+        params={"limit": 1, "offset": 0},
         headers=AUTH_HEADERS,
     )
 
@@ -786,8 +788,11 @@ def test_question_list_returns_canonical_pagination(client_with_quizzes_db: Test
     assert len(payload["items"]) == 1
     assert payload["pagination"]["total"] == 2
     assert payload["pagination"]["limit"] == 1
-    assert payload["pagination"]["offset"] == 1
-    assert payload["pagination"]["has_more"] is False
+    assert payload["pagination"]["offset"] == 0
+    assert payload["pagination"]["has_more"] is True
+    assert payload["pagination"]["next_offset"] == 1
+    assert payload["has_more"] is True
+    assert payload["next_offset"] == 1
 
 
 def test_attempts_list_route_is_not_shadowed_by_quiz_id(client_with_quizzes_db: TestClient):
@@ -826,20 +831,31 @@ def test_attempts_list_route_is_not_shadowed_by_quiz_id(client_with_quizzes_db: 
         headers=AUTH_HEADERS,
     )
     assert submit_attempt_response.status_code == 200
+    second_attempt_response = client_with_quizzes_db.post(
+        f"/api/v1/quizzes/{quiz_id}/attempts",
+        headers=AUTH_HEADERS,
+    )
+    assert second_attempt_response.status_code == 200
+    second_attempt_id = second_attempt_response.json()["id"]
 
     list_attempts_response = client_with_quizzes_db.get(
         "/api/v1/quizzes/attempts",
-        params={"quiz_id": quiz_id, "limit": 20, "offset": 0},
+        params={"quiz_id": quiz_id, "limit": 1, "offset": 0},
         headers=AUTH_HEADERS,
     )
     assert list_attempts_response.status_code == 200
     attempts_payload = list_attempts_response.json()
     assert attempts_payload["count"] >= 1
-    assert any(item["id"] == attempt_id for item in attempts_payload["items"])
+    assert all(item["id"] in {attempt_id, second_attempt_id} for item in attempts_payload["items"])
+    assert len(attempts_payload["items"]) == 1
     assert all(item["quiz_id"] == quiz_id for item in attempts_payload["items"])
-    assert attempts_payload["pagination"]["total"] >= 1
-    assert attempts_payload["pagination"]["limit"] == 20
+    assert attempts_payload["pagination"]["total"] >= 2
+    assert attempts_payload["pagination"]["limit"] == 1
     assert attempts_payload["pagination"]["offset"] == 0
+    assert attempts_payload["pagination"]["has_more"] is True
+    assert attempts_payload["pagination"]["next_offset"] == 1
+    assert attempts_payload["has_more"] is True
+    assert attempts_payload["next_offset"] == 1
 
 
 def test_start_attempt_returns_404_for_missing_quiz(client_with_quizzes_db: TestClient):

--- a/tldw_Server_API/tests/Research/test_legacy_research_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_legacy_research_search_endpoints.py
@@ -41,6 +41,47 @@ def test_arxiv_search_sanitizes_generic_failure(
     assert resp.json()["detail"] == "An unexpected error occurred while searching arXiv"
 
 
+def test_arxiv_search_includes_canonical_page_pagination(
+    legacy_research_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints import research as research_module
+
+    def fake_search_arxiv_custom_api(query, author, year, start_index, results_per_page):
+        return (
+            [
+                {
+                    "id": "arxiv-1",
+                    "title": "Transformer Paper",
+                    "authors": "A. Researcher",
+                    "published_date": "2024-01-01",
+                    "abstract": "Test abstract",
+                    "pdf_url": "https://arxiv.org/pdf/1234.5678",
+                }
+            ],
+            1,
+            None,
+        )
+
+    monkeypatch.setattr(research_module, "search_arxiv_custom_api", fake_search_arxiv_custom_api)
+
+    resp = legacy_research_client.get(
+        "/api/v1/research/arxiv-search",
+        params={"query": "transformer", "page": 1, "results_per_page": 2},
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["pagination"] == {
+        "mode": "page",
+        "page": 1,
+        "per_page": 2,
+        "total": 1,
+        "total_pages": 1,
+        "has_more": False,
+    }
+
+
 def test_semantic_scholar_search_sanitizes_generic_failure(
     legacy_research_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -76,3 +117,59 @@ def test_semantic_scholar_search_sanitizes_generic_failure(
         resp.json()["detail"]
         == "An unexpected error occurred while searching Semantic Scholar"
     )
+
+
+def test_semantic_scholar_search_includes_canonical_page_pagination(
+    legacy_research_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from tldw_Server_API.app.api.v1.endpoints import research as research_module
+
+    def fake_search_papers_semantic_scholar(
+        query,
+        offset,
+        limit,
+        fields_of_study_list,
+        publication_types_list,
+        year_range,
+        venue_list,
+        min_citations,
+        open_access_only,
+    ):
+        return (
+            {
+                "total": 1,
+                "offset": 0,
+                "next": None,
+                "data": [
+                    {
+                        "paperId": "paper-1",
+                        "title": "Semantic Scholar Result",
+                        "authors": [{"authorId": "1", "name": "A. Researcher"}],
+                    }
+                ],
+            },
+            None,
+        )
+
+    monkeypatch.setattr(
+        research_module,
+        "search_papers_semantic_scholar",
+        fake_search_papers_semantic_scholar,
+    )
+
+    resp = legacy_research_client.get(
+        "/api/v1/research/semantic-scholar-search",
+        params={"query": "transformer", "page": 1, "results_per_page": 2},
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["pagination"] == {
+        "mode": "page",
+        "page": 1,
+        "per_page": 2,
+        "total": 1,
+        "total_pages": 1,
+        "has_more": False,
+    }

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -294,6 +294,86 @@ async def test_hal_search_success(monkeypatch, paper_search_app):
 
 
 @pytest.mark.asyncio
+async def test_ieee_search_success(monkeypatch, paper_search_app):
+
+    def _fake_ieee(q, offset, results_per_page, from_year, to_year, publication_title, authors):
+
+        items = [
+            {
+                "id": "ieee-123",
+                "title": "IEEE Conference Paper",
+                "authors": "Smith, A.",
+                "pub_date": "2022-06-01",
+                "doi": "10.1109/TEST.2022.123",
+                "url": "https://ieeexplore.ieee.org/document/123",
+                "provider": "ieee",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import IEEE_Xplore as _IEEE
+    monkeypatch.setattr(_IEEE, "search_ieee", _fake_ieee)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/ieee",
+            params={"q": "transformer", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_springer_search_success(monkeypatch, paper_search_app):
+
+    def _fake_springer(q, offset, results_per_page, venue, from_year, to_year):
+
+        items = [
+            {
+                "id": "springer-456",
+                "title": "Springer Journal Article",
+                "authors": "Taylor, B.",
+                "pub_date": "2021-03-15",
+                "doi": "10.1007/s00134-021-456",
+                "url": "https://link.springer.com/article/10.1007/s00134-021-456",
+                "provider": "springer",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import Springer_Nature as _Springer
+    monkeypatch.setattr(_Springer, "search_springer", _fake_springer)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/springer",
+            params={"q": "critical care", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
 async def test_biorxiv_by_doi_success(monkeypatch, paper_search_app):
 
     def _fake_by_doi(doi, server):

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -36,6 +36,9 @@ async def test_paper_search_arxiv_success(monkeypatch, paper_search_app):
         assert r.status_code == 200
         data = r.json()
         assert data["total_results"] == 2
+        assert data["page"] == 1
+        assert data["results_per_page"] == 2
+        assert data["total_pages"] == 1
         assert len(data["items"]) == 2
         assert data["pagination"] == {
             "mode": "page",
@@ -79,6 +82,9 @@ async def test_paper_search_biorxiv_success(monkeypatch, paper_search_app):
         assert r.status_code == 200
         data = r.json()
         assert data["total_results"] == 1
+        assert data["page"] == 1
+        assert data["results_per_page"] == 1
+        assert data["total_pages"] == 1
         assert len(data["items"]) == 1
         assert data["pagination"] == {
             "mode": "page",
@@ -122,6 +128,10 @@ async def test_paper_search_semantic_scholar_success(monkeypatch, paper_search_a
         assert r.status_code == 200
         data = r.json()
         assert data["total_results"] == 1
+        assert data["page"] == 1
+        assert data["limit"] == 2
+        assert data["offset"] == 0
+        assert data["total_pages"] == 1
         assert len(data["items"]) == 1
         assert data["pagination"] == {
             "mode": "page",
@@ -184,6 +194,9 @@ async def test_paper_search_pubmed_success(monkeypatch, paper_search_app):
         assert r.status_code == 200
         data = r.json()
         assert data["total_results"] == 1
+        assert data["page"] == 1
+        assert data["results_per_page"] == 1
+        assert data["total_pages"] == 1
         assert len(data["items"]) == 1
         assert data["pagination"] == {
             "mode": "page",
@@ -229,7 +242,7 @@ async def test_figshare_search_success(monkeypatch, paper_search_app):
                 "provider": "figshare",
             }
         ]
-        return items, 1, None
+        return items, 21, None
 
     from tldw_Server_API.app.core.Third_Party import Figshare as _Figshare
     monkeypatch.setattr(_Figshare, "search_articles", _fake_figshare)
@@ -241,15 +254,18 @@ async def test_figshare_search_success(monkeypatch, paper_search_app):
         )
         assert r.status_code == 200
         data = r.json()
-        assert data["total_results"] == 1
+        assert data["total_results"] == 21
+        assert data["page"] == 1
+        assert data["results_per_page"] == 10
+        assert data["total_pages"] == 3
         assert len(data["items"]) == 1
         assert data["pagination"] == {
             "mode": "page",
             "page": 1,
             "per_page": 10,
-            "total": 1,
-            "total_pages": 1,
-            "has_more": False,
+            "total": 21,
+            "total_pages": 3,
+            "has_more": True,
         }
 
 

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -374,6 +374,86 @@ async def test_springer_search_success(monkeypatch, paper_search_app):
 
 
 @pytest.mark.asyncio
+async def test_acm_search_success(monkeypatch, paper_search_app):
+
+    def _fake_openalex(q, offset, results_per_page, venue, from_year, to_year):
+
+        items = [
+            {
+                "id": "acm-789",
+                "title": "ACM Proceedings Paper",
+                "authors": "Nguyen, C.",
+                "pub_date": "2020-09-20",
+                "doi": "10.1145/1234567.8901234",
+                "url": "https://dl.acm.org/doi/10.1145/1234567.8901234",
+                "provider": "acm",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import OpenAlex as _OpenAlex
+    monkeypatch.setattr(_OpenAlex, "search_openalex", _fake_openalex)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/acm",
+            params={"q": "distributed systems", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_wiley_search_success(monkeypatch, paper_search_app):
+
+    def _fake_openalex(q, offset, results_per_page, venue, from_year, to_year):
+
+        items = [
+            {
+                "id": "wiley-012",
+                "title": "Wiley Review Article",
+                "authors": "Patel, D.",
+                "pub_date": "2019-11-11",
+                "doi": "10.1002/wiley.012",
+                "url": "https://onlinelibrary.wiley.com/doi/10.1002/wiley.012",
+                "provider": "wiley",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import OpenAlex as _OpenAlex
+    monkeypatch.setattr(_OpenAlex, "search_openalex", _fake_openalex)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/wiley",
+            params={"q": "cardiology", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
 async def test_biorxiv_by_doi_success(monkeypatch, paper_search_app):
 
     def _fake_by_doi(doi, server):

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -448,6 +448,14 @@ async def test_biorxiv_pubs_search_success(monkeypatch):
         assert r.status_code == 200
         data = r.json()
         assert data["total_results"] == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
         # Now request compact (no abstracts)
         r2 = await client.get(
             "/api/v1/paper-search/biorxiv-pubs",
@@ -455,6 +463,14 @@ async def test_biorxiv_pubs_search_success(monkeypatch):
         )
         assert r2.status_code == 200
         d2 = r2.json()
+        assert d2["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
         assert d2["items"][0].get("preprint_abstract") is None
 
 

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -549,3 +549,87 @@ async def test_biorxiv_funder_search_success(monkeypatch):
             "total_pages": 1,
             "has_more": False,
         }
+
+
+@pytest.mark.asyncio
+async def test_biorxiv_publisher_search_success(monkeypatch):
+    from tldw_Server_API.app.main import app
+
+    def _fake_publisher(publisher_prefix, from_date, to_date, offset, limit, recent_days, recent_count):
+
+        items = [{
+            "biorxiv_doi": "10.1101/2024.02.02.234567",
+            "published_doi": "10.7554/eLife.99999",
+            "published_journal": "eLife",
+            "preprint_platform": "biorxiv",
+            "preprint_title": "Publisher Mapped Preprint",
+            "preprint_authors": "Doe, J.; Roe, R.",
+            "preprint_category": "cell biology",
+            "preprint_date": "2024-02-02",
+            "published_date": "2024-03-01",
+            "preprint_abstract": "Test",
+        }]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import BioRxiv as _Bio
+    monkeypatch.setattr(_Bio, "search_biorxiv_publisher", _fake_publisher)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/biorxiv/publisher",
+            params={"publisher_prefix": "10.7554", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_biorxiv_pub_search_success(monkeypatch):
+    from tldw_Server_API.app.main import app
+
+    def _fake_pub(from_date, to_date, offset, limit, recent_days, recent_count):
+
+        items = [{
+            "biorxiv_doi": "10.1101/2024.04.04.456789",
+            "published_doi": "10.7554/eLife.88888",
+            "published_journal": "eLife",
+            "preprint_platform": "biorxiv",
+            "preprint_title": "Published Article Detail",
+            "preprint_authors": "Doe, J.; Roe, R.",
+            "preprint_category": "genetics",
+            "preprint_date": "2024-04-04",
+            "published_date": "2024-05-01",
+            "preprint_abstract": "Test",
+        }]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import BioRxiv as _Bio
+    monkeypatch.setattr(_Bio, "search_biorxiv_pub", _fake_pub)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/biorxiv/pub",
+            params={"recent_days": 7, "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -742,9 +742,7 @@ async def test_biorxiv_by_doi_not_found(monkeypatch, paper_search_app):
 
 
 @pytest.mark.asyncio
-async def test_arxiv_by_id_success(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_arxiv_by_id_success(monkeypatch, paper_search_app):
     def _fake_arxiv_by_id(paper_id):
 
         return {
@@ -759,7 +757,7 @@ async def test_arxiv_by_id_success(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import Arxiv as _Arxiv
     monkeypatch.setattr(_Arxiv, "get_arxiv_by_id", _fake_arxiv_by_id)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/arxiv/by-id",
             params={"id": "1706.03762"},
@@ -770,9 +768,7 @@ async def test_arxiv_by_id_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_arxiv_by_id_not_found(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_arxiv_by_id_not_found(monkeypatch, paper_search_app):
     def _fake_arxiv_by_id_notfound(paper_id):
 
         return None, None
@@ -780,7 +776,7 @@ async def test_arxiv_by_id_not_found(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import Arxiv as _Arxiv
     monkeypatch.setattr(_Arxiv, "get_arxiv_by_id", _fake_arxiv_by_id_notfound)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/arxiv/by-id",
             params={"id": "0000.00000"},
@@ -789,9 +785,7 @@ async def test_arxiv_by_id_not_found(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_semantic_scholar_by_id_success(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_semantic_scholar_by_id_success(monkeypatch, paper_search_app):
     def _fake_s2_details(paper_id, fields_to_return='paperId,title,abstract,year,citationCount,authors,venue,openAccessPdf,url,publicationTypes,publicationDate,externalIds'):
 
         return {
@@ -812,7 +806,7 @@ async def test_semantic_scholar_by_id_success(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import Semantic_Scholar as _S2
     monkeypatch.setattr(_S2, "get_paper_details_semantic_scholar", _fake_s2_details)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/semantic-scholar/by-id",
             params={"paper_id": "abcdef"},
@@ -823,9 +817,7 @@ async def test_semantic_scholar_by_id_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_semantic_scholar_by_id_not_found(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_semantic_scholar_by_id_not_found(monkeypatch, paper_search_app):
     def _fake_s2_notfound(paper_id, fields_to_return='paperId,title,abstract,year,citationCount,authors,venue,openAccessPdf,url,publicationTypes,publicationDate,externalIds'):
 
         return None, "Semantic Scholar API HTTP Error: 404 - Not Found"
@@ -833,7 +825,7 @@ async def test_semantic_scholar_by_id_not_found(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import Semantic_Scholar as _S2
     monkeypatch.setattr(_S2, "get_paper_details_semantic_scholar", _fake_s2_notfound)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/semantic-scholar/by-id",
             params={"paper_id": "notfound"},
@@ -842,9 +834,7 @@ async def test_semantic_scholar_by_id_not_found(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pubmed_by_id_success(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_pubmed_by_id_success(monkeypatch, paper_search_app):
     def _fake_pubmed_by_id(pmid):
 
         return {
@@ -864,7 +854,7 @@ async def test_pubmed_by_id_success(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import PubMed as _Pub
     monkeypatch.setattr(_Pub, "get_pubmed_by_id", _fake_pubmed_by_id)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/pubmed/by-id",
             params={"pmid": "12345678"},
@@ -876,9 +866,7 @@ async def test_pubmed_by_id_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pubmed_by_id_not_found(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_pubmed_by_id_not_found(monkeypatch, paper_search_app):
     def _fake_pubmed_by_id_notfound(pmid):
 
         return None, None
@@ -886,7 +874,7 @@ async def test_pubmed_by_id_not_found(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import PubMed as _Pub
     monkeypatch.setattr(_Pub, "get_pubmed_by_id", _fake_pubmed_by_id_notfound)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/pubmed/by-id",
             params={"pmid": "99999999"},
@@ -895,9 +883,7 @@ async def test_pubmed_by_id_not_found(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_biorxiv_pubs_search_success(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_biorxiv_pubs_search_success(monkeypatch, paper_search_app):
     def _fake_pubs(server, f, t, offset, limit, recent_days, recent_count, q):
 
         items = [{
@@ -919,7 +905,7 @@ async def test_biorxiv_pubs_search_success(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import BioRxiv as _Bio
     monkeypatch.setattr(_Bio, "search_biorxiv_pubs", _fake_pubs)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/biorxiv-pubs",
             params={"server": "biorxiv", "recent_days": 7, "page": 1, "results_per_page": 10},
@@ -954,9 +940,7 @@ async def test_biorxiv_pubs_search_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_biorxiv_pubs_by_doi_success(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_biorxiv_pubs_by_doi_success(monkeypatch, paper_search_app):
     def _fake_pub_by_doi(doi, server):
 
         return {
@@ -969,7 +953,7 @@ async def test_biorxiv_pubs_by_doi_success(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import BioRxiv as _Bio
     monkeypatch.setattr(_Bio, "get_biorxiv_published_by_doi", _fake_pub_by_doi)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/biorxiv-pubs/by-doi",
             params={"doi": "10.1101/2021.11.09.467936", "server": "biorxiv"},
@@ -988,9 +972,7 @@ async def test_biorxiv_pubs_by_doi_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_biorxiv_funder_search_success(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_biorxiv_funder_search_success(monkeypatch, paper_search_app):
     def _fake_funder(server, ror_id, from_date, to_date, offset, limit, recent_days, recent_count, category):
 
         items = [{
@@ -1011,7 +993,7 @@ async def test_biorxiv_funder_search_success(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import BioRxiv as _Bio
     monkeypatch.setattr(_Bio, "search_biorxiv_funder", _fake_funder)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/biorxiv/funder",
             params={"server": "biorxiv", "ror_id": "03yrm5c26", "page": 1, "results_per_page": 10},
@@ -1031,9 +1013,7 @@ async def test_biorxiv_funder_search_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_biorxiv_publisher_search_success(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_biorxiv_publisher_search_success(monkeypatch, paper_search_app):
     def _fake_publisher(publisher_prefix, from_date, to_date, offset, limit, recent_days, recent_count):
 
         items = [{
@@ -1053,7 +1033,7 @@ async def test_biorxiv_publisher_search_success(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import BioRxiv as _Bio
     monkeypatch.setattr(_Bio, "search_biorxiv_publisher", _fake_publisher)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/biorxiv/publisher",
             params={"publisher_prefix": "10.7554", "page": 1, "results_per_page": 10},
@@ -1073,9 +1053,7 @@ async def test_biorxiv_publisher_search_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_biorxiv_pub_search_success(monkeypatch):
-    from tldw_Server_API.app.main import app
-
+async def test_biorxiv_pub_search_success(monkeypatch, paper_search_app):
     def _fake_pub(from_date, to_date, offset, limit, recent_days, recent_count):
 
         items = [{
@@ -1095,7 +1073,7 @@ async def test_biorxiv_pub_search_success(monkeypatch):
     from tldw_Server_API.app.core.Third_Party import BioRxiv as _Bio
     monkeypatch.setattr(_Bio, "search_biorxiv_pub", _fake_pub)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
         r = await client.get(
             "/api/v1/paper-search/biorxiv/pub",
             params={"recent_days": 7, "page": 1, "results_per_page": 10},

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -454,6 +454,86 @@ async def test_wiley_search_success(monkeypatch, paper_search_app):
 
 
 @pytest.mark.asyncio
+async def test_scopus_search_success(monkeypatch, paper_search_app):
+
+    def _fake_scopus(q, offset, results_per_page, from_year, to_year, open_access_only):
+
+        items = [
+            {
+                "id": "scopus-345",
+                "title": "Scopus Indexed Article",
+                "authors": "Kim, E.",
+                "pub_date": "2018-07-07",
+                "doi": "10.1016/j.test.2018.07.007",
+                "url": "https://www.scopus.com/record/display.uri?eid=2-s2.0-345",
+                "provider": "scopus",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import Elsevier_Scopus as _Scopus
+    monkeypatch.setattr(_Scopus, "search_scopus", _fake_scopus)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/scopus",
+            params={"q": "graph learning", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_chemrxiv_items_search_success(monkeypatch, paper_search_app):
+
+    def _fake_chemrxiv(term, skip, limit, sort, author, searchDateFrom, searchDateTo, searchLicense, categoryIds_list, subjectIds_list):
+
+        items = [
+            {
+                "id": "chemrxiv-678",
+                "title": "ChemRxiv Preprint",
+                "authors": "Lopez, F.",
+                "pub_date": "2024-02-14",
+                "doi": "10.26434/chemrxiv-678",
+                "url": "https://chemrxiv.org/engage/chemrxiv/article-details/678",
+                "provider": "chemrxiv",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import ChemRxiv as _ChemRxiv
+    monkeypatch.setattr(_ChemRxiv, "search_items", _fake_chemrxiv)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/chemrxiv/items",
+            params={"term": "catalysis", "skip": 0, "limit": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
 async def test_biorxiv_by_doi_success(monkeypatch, paper_search_app):
 
     def _fake_by_doi(doi, server):

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -534,6 +534,86 @@ async def test_chemrxiv_items_search_success(monkeypatch, paper_search_app):
 
 
 @pytest.mark.asyncio
+async def test_earthrxiv_search_success(monkeypatch, paper_search_app):
+
+    def _fake_earthrxiv(term, page, results_per_page, from_date):
+
+        items = [
+            {
+                "id": "earthrxiv-901",
+                "title": "EarthArXiv Preprint",
+                "authors": "Garcia, H.",
+                "pub_date": "2023-08-18",
+                "doi": "10.31223/earthrxiv.901",
+                "url": "https://eartharxiv.org/repository/view/901/",
+                "provider": "earthrxiv",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import EarthRxiv as _EarthRxiv
+    monkeypatch.setattr(_EarthRxiv, "search_items", _fake_earthrxiv)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/earthrxiv",
+            params={"term": "climate", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_osf_search_success(monkeypatch, paper_search_app):
+
+    def _fake_osf(term, page, results_per_page, provider, from_date):
+
+        items = [
+            {
+                "id": "osf-234",
+                "title": "OSF Preprint",
+                "authors": "Ivanov, I.",
+                "pub_date": "2022-04-22",
+                "doi": "10.31219/osf.io/234ab",
+                "url": "https://osf.io/preprints/osf/234ab",
+                "provider": "osf",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import OSF as _OSF
+    monkeypatch.setattr(_OSF, "search_preprints", _fake_osf)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/osf",
+            params={"term": "reproducibility", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
 async def test_biorxiv_by_doi_success(monkeypatch, paper_search_app):
 
     def _fake_by_doi(doi, server):

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -506,3 +506,46 @@ async def test_biorxiv_pubs_by_doi_success(monkeypatch):
         assert r2.status_code == 200
         d2 = r2.json()
         assert d2.get("preprint_abstract") is None
+
+
+@pytest.mark.asyncio
+async def test_biorxiv_funder_search_success(monkeypatch):
+    from tldw_Server_API.app.main import app
+
+    def _fake_funder(server, ror_id, from_date, to_date, offset, limit, recent_days, recent_count, category):
+
+        items = [{
+            "doi": "10.1101/2024.01.01.123456",
+            "title": "Funded Preprint",
+            "authors": "Doe, J.; Roe, R.",
+            "category": "bioinformatics",
+            "date": "2024-01-01",
+            "abstract": "Test abstract",
+            "server": server,
+            "version": 1,
+            "url": "https://www.biorxiv.org/content/10.1101/2024.01.01.123456v1",
+            "pdf_url": "https://www.biorxiv.org/content/10.1101/2024.01.01.123456v1.full.pdf",
+            "funder": {"name": "Test Funder", "id": ror_id},
+        }]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import BioRxiv as _Bio
+    monkeypatch.setattr(_Bio, "search_biorxiv_funder", _fake_funder)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/biorxiv/funder",
+            params={"server": "biorxiv", "ror_id": "03yrm5c26", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -37,6 +37,14 @@ async def test_paper_search_arxiv_success(monkeypatch, paper_search_app):
         data = r.json()
         assert data["total_results"] == 2
         assert len(data["items"]) == 2
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 2,
+            "total": 2,
+            "total_pages": 1,
+            "has_more": False,
+        }
 
 
 @pytest.mark.asyncio
@@ -72,6 +80,57 @@ async def test_paper_search_biorxiv_success(monkeypatch, paper_search_app):
         data = r.json()
         assert data["total_results"] == 1
         assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 1,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_paper_search_semantic_scholar_success(monkeypatch, paper_search_app):
+
+    def _fake_s2(query, offset, limit, fos, pub_types, year_range, venue, min_citations, open_access_only, fields_to_return=None):
+
+        return (
+            {
+                "total": 1,
+                "offset": 0,
+                "next": None,
+                "data": [
+                    {
+                        "paperId": "paper-1",
+                        "title": "Graph Neural Networks",
+                        "authors": [{"authorId": "1", "name": "A. Researcher"}],
+                    }
+                ],
+            },
+            None,
+        )
+
+    from tldw_Server_API.app.core.Third_Party import Semantic_Scholar as _S2
+    monkeypatch.setattr(_S2, "search_papers_semantic_scholar", _fake_s2)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/semantic-scholar",
+            params={"query": "graph neural networks", "page": 1, "results_per_page": 2},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 2,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
 
 
 @pytest.mark.asyncio
@@ -126,6 +185,14 @@ async def test_paper_search_pubmed_success(monkeypatch, paper_search_app):
         data = r.json()
         assert data["total_results"] == 1
         assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 1,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -614,6 +614,85 @@ async def test_osf_search_success(monkeypatch, paper_search_app):
 
 
 @pytest.mark.asyncio
+async def test_zenodo_search_success(monkeypatch, paper_search_app):
+
+    def _fake_zenodo(q, page, results_per_page, type, subtype, communities):
+
+        items = [
+            {
+                "id": "zenodo-567",
+                "title": "Zenodo Record",
+                "authors": "Brown, J.",
+                "pub_date": "2021-12-12",
+                "doi": "10.5281/zenodo.567",
+                "url": "https://zenodo.org/records/567",
+                "provider": "zenodo",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import Zenodo as _Zenodo
+    monkeypatch.setattr(_Zenodo, "search_records", _fake_zenodo)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/zenodo",
+            params={"q": "llm", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_vixra_search_success(monkeypatch, paper_search_app):
+
+    def _fake_vixra(term, page, results_per_page):
+
+        items = [
+            {
+                "id": "vixra-890",
+                "title": "viXra Submission",
+                "authors": "Singh, K.",
+                "pub_date": "2020-10-10",
+                "url": "https://vixra.org/abs/2010.0890",
+                "provider": "vixra",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import Vixra as _Vixra
+    monkeypatch.setattr(_Vixra, "search", _fake_vixra)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/vixra/search",
+            params={"term": "quantum", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
 async def test_biorxiv_by_doi_success(monkeypatch, paper_search_app):
 
     def _fake_by_doi(doi, server):

--- a/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
+++ b/tldw_Server_API/tests/Research/test_paper_search_endpoints.py
@@ -214,6 +214,86 @@ async def test_paper_search_pubmed_error_mapping(monkeypatch, paper_search_app):
 
 
 @pytest.mark.asyncio
+async def test_figshare_search_success(monkeypatch, paper_search_app):
+
+    def _fake_figshare(q, page, results_per_page, order, order_direction, search_for):
+
+        items = [
+            {
+                "id": "42",
+                "title": "Figshare Dataset",
+                "authors": "Doe, J.",
+                "pub_date": "2024-01-01",
+                "doi": "10.6084/m9.figshare.42",
+                "url": "https://figshare.com/articles/dataset/42",
+                "provider": "figshare",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import Figshare as _Figshare
+    monkeypatch.setattr(_Figshare, "search_articles", _fake_figshare)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/figshare",
+            params={"q": "dataset", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_hal_search_success(monkeypatch, paper_search_app):
+
+    def _fake_hal(q, start, rows, fl, fqs, sort, scope):
+
+        items = [
+            {
+                "id": "hal-01234567",
+                "title": "HAL Research Record",
+                "authors": "Roe, R.",
+                "pub_date": "2023-05-01",
+                "doi": "10.1000/hal-record",
+                "url": "https://hal.science/hal-01234567",
+                "provider": "hal",
+            }
+        ]
+        return items, 1, None
+
+    from tldw_Server_API.app.core.Third_Party import HAL as _HAL
+    monkeypatch.setattr(_HAL, "search", _fake_hal)
+
+    async with AsyncClient(transport=ASGITransport(app=paper_search_app), base_url="http://test") as client:
+        r = await client.get(
+            "/api/v1/paper-search/hal",
+            params={"q": "title_t:japon", "page": 1, "results_per_page": 10},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total_results"] == 1
+        assert len(data["items"]) == 1
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 10,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
+
+
+@pytest.mark.asyncio
 async def test_biorxiv_by_doi_success(monkeypatch, paper_search_app):
 
     def _fake_by_doi(doi, server):

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -303,12 +303,28 @@ class TestListSkills:
         data = r.json()
         assert data["count"] == 2
         assert data["total"] == 3
+        assert data["pagination"] == {
+            "mode": "offset",
+            "limit": 2,
+            "offset": 0,
+            "total": 3,
+            "has_more": True,
+            "next_offset": 2,
+        }
 
         # Page 2
         r = client.get(f"{SKILLS_PREFIX}/?limit=2&offset=2")
         assert r.status_code == 200
         data = r.json()
         assert data["count"] == 1
+        assert data["pagination"] == {
+            "mode": "offset",
+            "limit": 2,
+            "offset": 2,
+            "total": 3,
+            "has_more": False,
+            "next_offset": None,
+        }
 
 
 class TestCreateAndGetSkill:

--- a/tldw_Server_API/tests/Skills/integration/test_skills_api.py
+++ b/tldw_Server_API/tests/Skills/integration/test_skills_api.py
@@ -311,6 +311,8 @@ class TestListSkills:
             "has_more": True,
             "next_offset": 2,
         }
+        assert data["has_more"] is True
+        assert data["next_offset"] == 2
 
         # Page 2
         r = client.get(f"{SKILLS_PREFIX}/?limit=2&offset=2")
@@ -325,6 +327,8 @@ class TestListSkills:
             "has_more": False,
             "next_offset": None,
         }
+        assert data["has_more"] is False
+        assert data["next_offset"] is None
 
 
 class TestCreateAndGetSkill:

--- a/tldw_Server_API/tests/Slides/test_slides_api.py
+++ b/tldw_Server_API/tests/Slides/test_slides_api.py
@@ -948,6 +948,12 @@ def test_slides_styles_list_returns_builtin_and_user_styles(slides_client):
     assert payload["total_count"] >= len(styles)
     assert payload["limit"] == 50
     assert payload["offset"] == 0
+    assert payload["pagination"]["mode"] == "offset"
+    assert payload["pagination"]["limit"] == 50
+    assert payload["pagination"]["offset"] == 0
+    assert payload["pagination"]["total"] == payload["total_count"]
+    assert payload["pagination"]["has_more"] is False
+    assert payload["pagination"]["next_offset"] is None
 
 
 def test_slides_builtin_style_detail_exposes_catalog_metadata_and_compact_defaults(slides_client):
@@ -1031,6 +1037,54 @@ def test_slides_styles_list_supports_pagination(slides_client):
     assert payload["offset"] == builtin_count
     assert len(payload["styles"]) == 1
     assert payload["styles"][0]["scope"] == "user"
+    assert payload["pagination"] == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": builtin_count,
+        "total": payload["total_count"],
+        "has_more": False,
+        "next_offset": None,
+    }
+
+
+def test_slides_presentations_list_and_search_include_pagination_metadata(slides_client):
+    first_resp = slides_client.post(
+        "/api/v1/slides/presentations",
+        json={"title": "Alpha Deck", "slides": []},
+    )
+    assert first_resp.status_code == 201, first_resp.text
+
+    second_resp = slides_client.post(
+        "/api/v1/slides/presentations",
+        json={"title": "Beta Deck", "slides": []},
+    )
+    assert second_resp.status_code == 201, second_resp.text
+
+    list_resp = slides_client.get("/api/v1/slides/presentations?limit=1&offset=0")
+    assert list_resp.status_code == 200, list_resp.text
+    list_payload = list_resp.json()
+    assert len(list_payload["presentations"]) == 1
+    assert list_payload["pagination"] == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": 0,
+        "total": 2,
+        "has_more": True,
+        "next_offset": 1,
+    }
+
+    search_resp = slides_client.get("/api/v1/slides/presentations/search?q=Deck&limit=1&offset=1")
+    assert search_resp.status_code == 200, search_resp.text
+    search_payload = search_resp.json()
+    assert len(search_payload["presentations"]) == 1
+    assert search_payload["pagination"] == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": 1,
+        "total": 2,
+        "has_more": False,
+        "next_offset": None,
+    }
 
 
 def test_slides_styles_crud_for_user_styles(slides_client):
@@ -1901,6 +1955,14 @@ def test_slides_versions_and_restore(slides_client):
     versions_data = versions_resp.json()
     assert versions_data["total"] == 2
     assert versions_data["versions"][0]["version"] == 2
+    assert versions_data["pagination"] == {
+        "mode": "offset",
+        "limit": 50,
+        "offset": 0,
+        "total": 2,
+        "has_more": False,
+        "next_offset": None,
+    }
 
     version_resp = slides_client.get(f"/api/v1/slides/presentations/{presentation_id}/versions/1")
     assert version_resp.status_code == 200

--- a/tldw_Server_API/tests/Slides/test_slides_api.py
+++ b/tldw_Server_API/tests/Slides/test_slides_api.py
@@ -954,6 +954,8 @@ def test_slides_styles_list_returns_builtin_and_user_styles(slides_client):
     assert payload["pagination"]["total"] == payload["total_count"]
     assert payload["pagination"]["has_more"] is False
     assert payload["pagination"]["next_offset"] is None
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None
 
 
 def test_slides_builtin_style_detail_exposes_catalog_metadata_and_compact_defaults(slides_client):
@@ -1045,6 +1047,8 @@ def test_slides_styles_list_supports_pagination(slides_client):
         "has_more": False,
         "next_offset": None,
     }
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None
 
 
 def test_slides_presentations_list_and_search_include_pagination_metadata(slides_client):
@@ -1072,6 +1076,8 @@ def test_slides_presentations_list_and_search_include_pagination_metadata(slides
         "has_more": True,
         "next_offset": 1,
     }
+    assert list_payload["has_more"] is True
+    assert list_payload["next_offset"] == 1
 
     search_resp = slides_client.get("/api/v1/slides/presentations/search?q=Deck&limit=1&offset=1")
     assert search_resp.status_code == 200, search_resp.text
@@ -1085,6 +1091,8 @@ def test_slides_presentations_list_and_search_include_pagination_metadata(slides
         "has_more": False,
         "next_offset": None,
     }
+    assert search_payload["has_more"] is False
+    assert search_payload["next_offset"] is None
 
 
 def test_slides_styles_crud_for_user_styles(slides_client):
@@ -1963,6 +1971,8 @@ def test_slides_versions_and_restore(slides_client):
         "has_more": False,
         "next_offset": None,
     }
+    assert versions_data["has_more"] is False
+    assert versions_data["next_offset"] is None
 
     version_resp = slides_client.get(f"/api/v1/slides/presentations/{presentation_id}/versions/1")
     assert version_resp.status_code == 200

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -10,7 +10,7 @@ Tests cover:
 - Soft/hard limit warnings in usage responses
 """
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock
 from datetime import datetime, timezone
@@ -18,6 +18,14 @@ from datetime import datetime, timezone
 from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoints
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import SetQuotaRequest
 from tldw_Server_API.app.core.AuthNZ.exceptions import StorageError
+
+
+def _storage_download_test_app(mock_user) -> FastAPI:
+    """Create an isolated app for route-level storage download assertions."""
+    app = FastAPI()
+    app.include_router(storage_endpoints.router, prefix="/api/v1")
+    app.dependency_overrides[storage_endpoints.get_request_user] = lambda: mock_user
+    return app
 
 
 class TestListFilesEndpoint:
@@ -236,8 +244,6 @@ class TestDownloadFileEndpointIntegration:
         monkeypatch,
     ):
         """Successful download returns file bytes."""
-        from tldw_Server_API.app.main import app
-        from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
         from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
 
         rel_path = "tts_audio/test.mp3"
@@ -267,14 +273,11 @@ class TestDownloadFileEndpointIntegration:
             lambda user_id: temp_user_outputs_dir,
         )
 
-        app.dependency_overrides[get_request_user] = lambda: mock_user
-        try:
-            with TestClient(app) as client:
-                resp = client.get("/api/v1/storage/files/1/download")
-                assert resp.status_code == 200
-                assert resp.content == b"test-bytes"
-        finally:
-            app.dependency_overrides.clear()
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/storage/files/1/download")
+            assert resp.status_code == 200
+            assert resp.content == b"test-bytes"
 
     @pytest.mark.unit
     def test_download_file_blocks_path_traversal(
@@ -286,8 +289,6 @@ class TestDownloadFileEndpointIntegration:
         monkeypatch,
     ):
         """Path traversal storage paths are rejected."""
-        from tldw_Server_API.app.main import app
-        from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
         from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
 
         file_record = {
@@ -312,13 +313,10 @@ class TestDownloadFileEndpointIntegration:
             lambda user_id: temp_user_outputs_dir,
         )
 
-        app.dependency_overrides[get_request_user] = lambda: mock_user
-        try:
-            with TestClient(app) as client:
-                resp = client.get("/api/v1/storage/files/2/download")
-                assert resp.status_code == 403
-        finally:
-            app.dependency_overrides.clear()
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/storage/files/2/download")
+            assert resp.status_code == 403
 
     @pytest.mark.unit
     def test_download_file_uses_voices_dir_for_voice_clones(
@@ -330,8 +328,6 @@ class TestDownloadFileEndpointIntegration:
         monkeypatch,
     ):
         """Voice clone downloads resolve against the voices directory."""
-        from tldw_Server_API.app.main import app
-        from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import get_request_user
         from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
 
         voices_dir = temp_storage_dir / "1" / "voices"
@@ -362,14 +358,11 @@ class TestDownloadFileEndpointIntegration:
             lambda user_id: voices_dir,
         )
 
-        app.dependency_overrides[get_request_user] = lambda: mock_user
-        try:
-            with TestClient(app) as client:
-                resp = client.get("/api/v1/storage/files/3/download")
-                assert resp.status_code == 200
-                assert resp.content == b"voice-bytes"
-        finally:
-            app.dependency_overrides.clear()
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/storage/files/3/download")
+            assert resp.status_code == 200
+            assert resp.content == b"voice-bytes"
 
     @pytest.mark.unit
     def test_path_traversal_blocked_encoded(self, temp_user_outputs_dir):

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -73,6 +73,111 @@ class TestListFilesEndpoint:
         call_kwargs = mock_files_repo.list_files.call_args[1]
         assert call_kwargs["file_category"] == "tts_audio"
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_list_files_returns_canonical_pagination(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """List files returns additive canonical pagination metadata."""
+        mock_files_repo.list_files = AsyncMock(
+            return_value=(
+                [
+                    {
+                        "id": 1,
+                        "uuid": "uuid-1",
+                        "user_id": mock_user.id,
+                        "filename": "file_1.wav",
+                        "storage_path": "tts_audio/file_1.wav",
+                        "file_category": "tts_audio",
+                        "source_feature": "tts",
+                        "file_size_bytes": 1024,
+                        "is_deleted": False,
+                        "is_transient": False,
+                        "tags": [],
+                        "created_at": datetime.now(timezone.utc),
+                        "updated_at": datetime.now(timezone.utc),
+                    }
+                ],
+                7,
+            )
+        )
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        response = await storage_endpoints.list_files(user=mock_user, offset=2, limit=3)
+
+        assert response.total == 7
+        assert response.offset == 2
+        assert response.limit == 3
+        assert response.pagination.total == 7
+        assert response.pagination.offset == 2
+        assert response.pagination.limit == 3
+        assert response.pagination.has_more is True
+        assert response.pagination.next_offset == 5
+
+
+class TestTrashEndpoint:
+    """Tests for GET /storage/trash endpoint."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_list_trashed_files_returns_canonical_pagination(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """Trashed files listing returns additive canonical pagination metadata."""
+        mock_files_repo.list_trashed_files = AsyncMock(
+            return_value=(
+                [
+                    {
+                        "id": 9,
+                        "uuid": "uuid-9",
+                        "user_id": mock_user.id,
+                        "filename": "deleted.wav",
+                        "storage_path": "tts_audio/deleted.wav",
+                        "file_category": "tts_audio",
+                        "source_feature": "tts",
+                        "file_size_bytes": 2048,
+                        "is_deleted": True,
+                        "is_transient": False,
+                        "tags": [],
+                        "created_at": datetime.now(timezone.utc),
+                        "updated_at": datetime.now(timezone.utc),
+                        "deleted_at": datetime.now(timezone.utc),
+                    }
+                ],
+                4,
+            )
+        )
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        response = await storage_endpoints.list_trashed_files(user=mock_user, offset=1, limit=2)
+
+        assert response.total == 4
+        assert response.offset == 1
+        assert response.limit == 2
+        assert response.pagination.total == 4
+        assert response.pagination.offset == 1
+        assert response.pagination.limit == 2
+        assert response.pagination.has_more is True
+        assert response.pagination.next_offset == 3
+
 
 class TestDownloadFileEndpoint:
     """Tests for GET /storage/files/{file_id}/download endpoint."""

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -130,6 +130,8 @@ class TestListFilesEndpoint:
         assert response.pagination.limit == 3
         assert response.pagination.has_more is True
         assert response.pagination.next_offset == 5
+        assert response.has_more is True
+        assert response.next_offset == 5
 
 
 class TestTrashEndpoint:
@@ -185,6 +187,8 @@ class TestTrashEndpoint:
         assert response.pagination.limit == 2
         assert response.pagination.has_more is True
         assert response.pagination.next_offset == 3
+        assert response.has_more is True
+        assert response.next_offset == 3
 
 
 class TestDownloadFileEndpoint:

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_tts_history_perf_sanity.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_tts_history_perf_sanity.py
@@ -35,6 +35,13 @@ def test_tts_history_cursor_pagination_sanity(test_client, auth_headers, monkeyp
     payload = resp.json()
     assert len(payload["items"]) == 100
     assert payload["next_cursor"]
+    assert payload["pagination"] == {
+        "mode": "cursor",
+        "limit": 100,
+        "cursor": None,
+        "next_cursor": payload["next_cursor"],
+        "has_more": True,
+    }
 
     first_page_ids = {item["id"] for item in payload["items"]}
 
@@ -45,6 +52,13 @@ def test_tts_history_cursor_pagination_sanity(test_client, auth_headers, monkeyp
     assert resp_page2.status_code == status.HTTP_200_OK
     payload_page2 = resp_page2.json()
     assert len(payload_page2["items"]) == 100
+    assert payload_page2["pagination"] == {
+        "mode": "cursor",
+        "limit": 100,
+        "cursor": payload["next_cursor"],
+        "next_cursor": payload_page2["next_cursor"],
+        "has_more": True,
+    }
 
     second_page_ids = {item["id"] for item in payload_page2["items"]}
     assert first_page_ids.isdisjoint(second_page_ids)
@@ -80,3 +94,10 @@ def test_tts_history_include_total_sanity(test_client, auth_headers, monkeypatch
     total_payload = resp_total.json()
     assert len(total_payload["items"]) == 25
     assert int(total_payload["total"]) == total_rows
+    assert total_payload["pagination"] == {
+        "mode": "cursor",
+        "limit": 25,
+        "cursor": None,
+        "next_cursor": total_payload["next_cursor"],
+        "has_more": True,
+    }

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_history_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_history_endpoints.py
@@ -209,19 +209,15 @@ def test_history_next_cursor_failure_log_is_sanitized(test_client, auth_headers,
     dep_keys = _set_media_db_override(fastapi_app, db)
     try:
         resp = test_client.get("/api/v1/audio/history?limit=1", headers=auth_headers)
-        assert resp.status_code == status.HTTP_200_OK
-        payload = resp.json()
-        assert payload["next_cursor"] is None
-        assert payload["pagination"] == {
-            "mode": "cursor",
-            "limit": 1,
-            "cursor": None,
-            "next_cursor": None,
-            "has_more": False,
-        }
-        fake_logger.debug.assert_called_once_with(
-            "TTS history: failed to build next cursor"
-        )
+        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert resp.json()["detail"] == "Failed to list TTS history"
+        fake_logger.error.assert_called_once()
+        error_args, error_kwargs = fake_logger.error.call_args
+        assert error_args[0] == "TTS history: failed to build next cursor for id={} created_at={}"
+        assert error_args[1] == 2
+        assert error_args[2]
+        assert error_kwargs == {"exc_info": True}
+        assert "/private/tts-cursor" not in repr(fake_logger.error.call_args)
     finally:
         _clear_media_db_override(fastapi_app, dep_keys)
         db.close_connection()

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_history_endpoints.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_history_endpoints.py
@@ -80,6 +80,13 @@ def test_history_list_favorite_delete(test_client, auth_headers):
         payload = resp.json()
         assert len(payload["items"]) == 1
         assert payload["items"][0]["id"] == entry_two
+        assert payload["pagination"] == {
+            "mode": "cursor",
+            "limit": 50,
+            "cursor": None,
+            "next_cursor": None,
+            "has_more": False,
+        }
 
         resp = test_client.patch(
             f"/api/v1/audio/history/{entry_one}",
@@ -203,7 +210,15 @@ def test_history_next_cursor_failure_log_is_sanitized(test_client, auth_headers,
     try:
         resp = test_client.get("/api/v1/audio/history?limit=1", headers=auth_headers)
         assert resp.status_code == status.HTTP_200_OK
-        assert resp.json()["next_cursor"] is None
+        payload = resp.json()
+        assert payload["next_cursor"] is None
+        assert payload["pagination"] == {
+            "mode": "cursor",
+            "limit": 1,
+            "cursor": None,
+            "next_cursor": None,
+            "has_more": False,
+        }
         fake_logger.debug.assert_called_once_with(
             "TTS history: failed to build next cursor"
         )

--- a/tldw_Server_API/tests/Utils/test_pagination_contract.py
+++ b/tldw_Server_API/tests/Utils/test_pagination_contract.py
@@ -5,7 +5,8 @@ from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
 )
 
 
-def test_build_offset_pagination_meta_computes_has_more_and_next_offset():
+def test_build_offset_pagination_meta_computes_has_more_and_next_offset() -> None:
+    """Offset metadata reports a next page when returned count does not exhaust total."""
     pagination = build_offset_pagination_meta(
         limit=25,
         offset=50,
@@ -21,7 +22,8 @@ def test_build_offset_pagination_meta_computes_has_more_and_next_offset():
     assert pagination.next_offset == 75
 
 
-def test_build_offset_pagination_meta_ends_without_next_offset():
+def test_build_offset_pagination_meta_ends_without_next_offset() -> None:
+    """Offset metadata omits next_offset when the requested page reaches the total."""
     pagination = build_offset_pagination_meta(
         limit=25,
         offset=100,
@@ -33,7 +35,8 @@ def test_build_offset_pagination_meta_ends_without_next_offset():
     assert pagination.next_offset is None
 
 
-def test_build_pagination_link_header_uses_offset_metadata():
+def test_build_pagination_link_header_uses_offset_metadata() -> None:
+    """Link header construction uses canonical offset pagination metadata."""
     pagination = build_offset_pagination_meta(
         limit=25,
         offset=50,
@@ -54,7 +57,8 @@ def test_build_pagination_link_header_uses_offset_metadata():
     )
 
 
-def test_build_link_header_offset_compatibility_signature_stays_stable():
+def test_build_link_header_offset_compatibility_signature_stays_stable() -> None:
+    """Legacy offset Link header callers keep the same output shape."""
     link_header = build_link_header(
         base_path="/api/v1/workflows/runs",
         common_params=[("status", "running")],

--- a/tldw_Server_API/tests/Utils/test_pagination_contract.py
+++ b/tldw_Server_API/tests/Utils/test_pagination_contract.py
@@ -1,0 +1,70 @@
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
+    build_link_header,
+    build_offset_pagination_meta,
+    build_pagination_link_header,
+)
+
+
+def test_build_offset_pagination_meta_computes_has_more_and_next_offset():
+    pagination = build_offset_pagination_meta(
+        limit=25,
+        offset=50,
+        total=123,
+        count=25,
+    )
+
+    assert pagination.mode == "offset"
+    assert pagination.limit == 25
+    assert pagination.offset == 50
+    assert pagination.total == 123
+    assert pagination.has_more is True
+    assert pagination.next_offset == 75
+
+
+def test_build_offset_pagination_meta_ends_without_next_offset():
+    pagination = build_offset_pagination_meta(
+        limit=25,
+        offset=100,
+        total=123,
+        count=23,
+    )
+
+    assert pagination.has_more is False
+    assert pagination.next_offset is None
+
+
+def test_build_pagination_link_header_uses_offset_metadata():
+    pagination = build_offset_pagination_meta(
+        limit=25,
+        offset=50,
+        total=123,
+        count=25,
+    )
+
+    link_header = build_pagination_link_header(
+        base_path="/api/v1/skills",
+        common_params=[("include_hidden", "false")],
+        pagination=pagination,
+    )
+
+    assert link_header == (
+        '</api/v1/skills?include_hidden=false&limit=25&offset=75>; rel="next", '
+        '</api/v1/skills?include_hidden=false&limit=25&offset=25>; rel="prev", '
+        '</api/v1/skills?include_hidden=false&limit=25&offset=0>; rel="first"'
+    )
+
+
+def test_build_link_header_offset_compatibility_signature_stays_stable():
+    link_header = build_link_header(
+        base_path="/api/v1/workflows/runs",
+        common_params=[("status", "running")],
+        limit=25,
+        offset=50,
+        has_more=True,
+    )
+
+    assert link_header == (
+        '</api/v1/workflows/runs?status=running&limit=25&offset=75>; rel="next", '
+        '</api/v1/workflows/runs?status=running&limit=25&offset=25>; rel="prev", '
+        '</api/v1/workflows/runs?status=running&limit=25&offset=0>; rel="first"'
+    )

--- a/tldw_Server_API/tests/Utils/test_pagination_contract.py
+++ b/tldw_Server_API/tests/Utils/test_pagination_contract.py
@@ -1,8 +1,21 @@
+import pytest
+from pydantic import ValidationError
+
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import (
     build_link_header,
     build_offset_pagination_meta,
+    build_page_pagination_meta,
     build_pagination_link_header,
 )
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import WebhookListResponse
+from tldw_Server_API.app.api.v1.schemas.character_schemas import CharacterListQueryResponse
+from tldw_Server_API.app.api.v1.schemas.pagination import (
+    CursorPaginationMeta,
+    OffsetPaginationMeta,
+    PagePaginationMeta,
+)
+from tldw_Server_API.app.api.v1.schemas.reading_schemas import ReadingItemsListResponse
+from tldw_Server_API.app.api.v1.schemas.writing_manuscript_schemas import ManuscriptProjectListResponse
 
 
 def test_build_offset_pagination_meta_computes_has_more_and_next_offset() -> None:
@@ -33,6 +46,85 @@ def test_build_offset_pagination_meta_ends_without_next_offset() -> None:
 
     assert pagination.has_more is False
     assert pagination.next_offset is None
+
+
+def test_build_page_pagination_meta_derives_has_more_from_total() -> None:
+    """Page metadata uses total and per_page when total_pages is not provided."""
+    pagination = build_page_pagination_meta(page=2, per_page=10, total=25)
+
+    assert pagination.has_more is True
+    assert pagination.total_pages is None
+
+
+def test_pagination_meta_modes_are_fixed_discriminators() -> None:
+    """Pagination mode fields reject contradictory discriminator values."""
+    with pytest.raises(ValidationError):
+        OffsetPaginationMeta(mode="cursor", limit=10, offset=0, total=20, has_more=True, next_offset=10)
+    with pytest.raises(ValidationError):
+        CursorPaginationMeta(mode="offset", limit=10, cursor=None, next_cursor=None, has_more=False)
+    with pytest.raises(ValidationError):
+        PagePaginationMeta(mode="offset", page=1, per_page=10, total=20, total_pages=2, has_more=True)
+
+
+def test_character_list_backfills_has_more_alias_when_omitted() -> None:
+    """Character list responses derive omitted top-level aliases from canonical metadata."""
+    response = CharacterListQueryResponse(
+        items=[],
+        total=2,
+        page=1,
+        page_size=1,
+        pagination=build_offset_pagination_meta(limit=1, offset=0, total=2, count=1),
+    )
+
+    assert response.has_more is True
+    assert response.next_offset == 1
+
+
+def test_reading_list_rejects_contradictory_pagination_aliases() -> None:
+    """Reading responses reject drift between legacy aliases and canonical metadata."""
+    pagination = build_offset_pagination_meta(limit=1, offset=0, total=2, count=1)
+
+    with pytest.raises(ValidationError, match="has_more alias mismatch"):
+        ReadingItemsListResponse(
+            items=[],
+            total=2,
+            page=1,
+            size=1,
+            has_more=False,
+            pagination=pagination,
+        )
+
+    with pytest.raises(ValidationError, match="next_offset alias mismatch"):
+        ReadingItemsListResponse(
+            items=[],
+            total=2,
+            page=1,
+            size=1,
+            next_offset=99,
+            pagination=pagination,
+        )
+
+
+def test_manuscript_project_list_rejects_negative_pagination_aliases() -> None:
+    """Manuscript list responses constrain newly restored offset fields."""
+    pagination = build_offset_pagination_meta(limit=10, offset=0, total=0, count=0)
+
+    with pytest.raises(ValidationError):
+        ManuscriptProjectListResponse(projects=[], total=0, limit=0, offset=0, pagination=pagination)
+    with pytest.raises(ValidationError):
+        ManuscriptProjectListResponse(projects=[], total=0, limit=10, offset=-1, pagination=pagination)
+
+
+def test_webhook_list_backfills_legacy_limit_offset_aliases() -> None:
+    """Webhook list responses preserve legacy top-level limit and offset fields."""
+    pagination = build_offset_pagination_meta(limit=25, offset=50, total=100, count=25)
+
+    response = WebhookListResponse(items=[], total=100, pagination=pagination)
+
+    assert response.limit == 25
+    assert response.offset == 50
+    assert response.has_more is True
+    assert response.next_offset == 75
 
 
 def test_build_pagination_link_header_uses_offset_metadata() -> None:

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
@@ -92,6 +92,10 @@ def test_sources_crud_and_tags(client_with_user):
     assert r.status_code == 200
     data = r.json()
     assert data["total"] >= 1
+    assert data["pagination"]["total"] >= 1
+    assert data["pagination"]["limit"] == 50
+    assert data["pagination"]["offset"] == 0
+    assert data["pagination"]["has_more"] is False
     assert any(it["id"] == sid for it in data["items"])
 
     # Get source
@@ -117,6 +121,10 @@ def test_sources_crud_and_tags(client_with_user):
     r = c.get("/api/v1/watchlists/tags")
     assert r.status_code == 200
     tags = r.json().get("items", [])
+    pagination = r.json()["pagination"]
+    assert pagination["total"] >= 2
+    assert pagination["limit"] == 50
+    assert pagination["offset"] == 0
     names = {t["name"] for t in tags}
     assert {"news", "tech", "updates"}.issubset(names)
 
@@ -504,7 +512,11 @@ def test_bulk_sources_and_groups_and_jobs(client_with_user):
     gid = g["id"]
     r = c.get("/api/v1/watchlists/groups")
     assert r.status_code == 200
-    assert any(x["id"] == gid for x in r.json().get("items", []))
+    groups_payload = r.json()
+    assert groups_payload["pagination"]["total"] >= 1
+    assert groups_payload["pagination"]["limit"] == 50
+    assert groups_payload["pagination"]["offset"] == 0
+    assert any(x["id"] == gid for x in groups_payload.get("items", []))
     r = c.patch(f"/api/v1/watchlists/groups/{gid}", json={"description": "Updated"})
     assert r.status_code == 200
     assert r.json()["description"] == "Updated"
@@ -523,7 +535,11 @@ def test_bulk_sources_and_groups_and_jobs(client_with_user):
     jid = job["id"]
     r = c.get("/api/v1/watchlists/jobs")
     assert r.status_code == 200
-    assert any(x["id"] == jid for x in r.json().get("items", []))
+    jobs_payload = r.json()
+    assert jobs_payload["pagination"]["total"] >= 1
+    assert jobs_payload["pagination"]["limit"] == 50
+    assert jobs_payload["pagination"]["offset"] == 0
+    assert any(x["id"] == jid for x in jobs_payload.get("items", []))
     r = c.get(f"/api/v1/watchlists/jobs/{jid}")
     assert r.status_code == 200
     # Update job

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
@@ -246,7 +246,11 @@ def test_sources_check_now_endpoint_triggers_runs_and_items(client_with_user, mo
 
     runs_resp = c.get("/api/v1/watchlists/runs", params={"page": 1, "size": 20})
     assert runs_resp.status_code == 200, runs_resp.text
-    run_ids = [int(run["id"]) for run in runs_resp.json().get("items", [])]
+    runs_payload = runs_resp.json()
+    assert runs_payload["pagination"]["total"] >= 1
+    assert runs_payload["pagination"]["limit"] == 20
+    assert runs_payload["pagination"]["offset"] == 0
+    run_ids = [int(run["id"]) for run in runs_payload.get("items", [])]
     assert run_id in run_ids
 
     items_resp = c.get("/api/v1/watchlists/items", params={"source_id": source_id, "page": 1, "size": 20})
@@ -822,6 +826,9 @@ def test_items_and_outputs_flow(client_with_user, monkeypatch):
     assert r.status_code == 200, r.text
     data = r.json()
     assert data["total"] >= 1
+    assert data["pagination"]["total"] >= 1
+    assert data["pagination"]["limit"] == 50
+    assert data["pagination"]["offset"] == 0
     first_item = data["items"][0]
     item_id = first_item["id"]
     assert first_item["status"] in {"ingested", "error", "duplicate"}

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
@@ -96,6 +96,8 @@ def test_sources_crud_and_tags(client_with_user):
     assert data["pagination"]["limit"] == 50
     assert data["pagination"]["offset"] == 0
     assert data["pagination"]["has_more"] is False
+    assert data["has_more"] is False
+    assert data["next_offset"] is None
     assert any(it["id"] == sid for it in data["items"])
 
     # Get source
@@ -120,11 +122,14 @@ def test_sources_crud_and_tags(client_with_user):
     # Tags list
     r = c.get("/api/v1/watchlists/tags")
     assert r.status_code == 200
-    tags = r.json().get("items", [])
-    pagination = r.json()["pagination"]
+    tags_payload = r.json()
+    tags = tags_payload.get("items", [])
+    pagination = tags_payload["pagination"]
     assert pagination["total"] >= 2
     assert pagination["limit"] == 50
     assert pagination["offset"] == 0
+    assert tags_payload["has_more"] == pagination["has_more"]
+    assert tags_payload["next_offset"] == pagination["next_offset"]
     names = {t["name"] for t in tags}
     assert {"news", "tech", "updates"}.issubset(names)
 
@@ -250,6 +255,8 @@ def test_sources_check_now_endpoint_triggers_runs_and_items(client_with_user, mo
     assert runs_payload["pagination"]["total"] >= 1
     assert runs_payload["pagination"]["limit"] == 20
     assert runs_payload["pagination"]["offset"] == 0
+    assert runs_payload["has_more"] == runs_payload["pagination"]["has_more"]
+    assert runs_payload["next_offset"] == runs_payload["pagination"]["next_offset"]
     run_ids = [int(run["id"]) for run in runs_payload.get("items", [])]
     assert run_id in run_ids
 
@@ -257,6 +264,8 @@ def test_sources_check_now_endpoint_triggers_runs_and_items(client_with_user, mo
     assert items_resp.status_code == 200, items_resp.text
     items_payload = items_resp.json()
     assert int(items_payload.get("total", 0)) >= 1
+    assert items_payload["has_more"] == items_payload["pagination"]["has_more"]
+    assert items_payload["next_offset"] == items_payload["pagination"]["next_offset"]
     assert any(int(item.get("source_id", -1)) == source_id for item in items_payload.get("items", []))
 
 
@@ -520,6 +529,8 @@ def test_bulk_sources_and_groups_and_jobs(client_with_user):
     assert groups_payload["pagination"]["total"] >= 1
     assert groups_payload["pagination"]["limit"] == 50
     assert groups_payload["pagination"]["offset"] == 0
+    assert groups_payload["has_more"] == groups_payload["pagination"]["has_more"]
+    assert groups_payload["next_offset"] == groups_payload["pagination"]["next_offset"]
     assert any(x["id"] == gid for x in groups_payload.get("items", []))
     r = c.patch(f"/api/v1/watchlists/groups/{gid}", json={"description": "Updated"})
     assert r.status_code == 200
@@ -543,6 +554,8 @@ def test_bulk_sources_and_groups_and_jobs(client_with_user):
     assert jobs_payload["pagination"]["total"] >= 1
     assert jobs_payload["pagination"]["limit"] == 50
     assert jobs_payload["pagination"]["offset"] == 0
+    assert jobs_payload["has_more"] == jobs_payload["pagination"]["has_more"]
+    assert jobs_payload["next_offset"] == jobs_payload["pagination"]["next_offset"]
     assert any(x["id"] == jid for x in jobs_payload.get("items", []))
     r = c.get(f"/api/v1/watchlists/jobs/{jid}")
     assert r.status_code == 200
@@ -829,6 +842,8 @@ def test_items_and_outputs_flow(client_with_user, monkeypatch):
     assert data["pagination"]["total"] >= 1
     assert data["pagination"]["limit"] == 50
     assert data["pagination"]["offset"] == 0
+    assert data["has_more"] == data["pagination"]["has_more"]
+    assert data["next_offset"] == data["pagination"]["next_offset"]
     first_item = data["items"][0]
     item_id = first_item["id"]
     assert first_item["status"] in {"ingested", "error", "duplicate"}
@@ -946,6 +961,8 @@ def test_items_and_outputs_flow(client_with_user, monkeypatch):
     assert outputs["pagination"]["total"] >= 2
     assert outputs["pagination"]["limit"] == 50
     assert outputs["pagination"]["offset"] == 0
+    assert outputs["has_more"] == outputs["pagination"]["has_more"]
+    assert outputs["next_offset"] == outputs["pagination"]["next_offset"]
     assert any(o["id"] == output_id for o in outputs["items"])
 
     # Output metadata
@@ -1219,6 +1236,8 @@ def test_watchlists_outputs_pagination_excludes_mixed_origin_rows(client_with_us
     assert page1["pagination"]["limit"] == 1
     assert page1["pagination"]["offset"] == 0
     assert page1["pagination"]["has_more"] is True
+    assert page1["has_more"] is True
+    assert page1["next_offset"] == page1["pagination"]["next_offset"]
     assert len(page1["items"]) == 1
     assert page1["items"][0]["id"] == wl_new.id
 
@@ -1230,6 +1249,8 @@ def test_watchlists_outputs_pagination_excludes_mixed_origin_rows(client_with_us
     assert page2["pagination"]["limit"] == 1
     assert page2["pagination"]["offset"] == 1
     assert page2["pagination"]["has_more"] is False
+    assert page2["has_more"] is False
+    assert page2["next_offset"] is None
     assert len(page2["items"]) == 1
     assert page2["items"][0]["id"] == wl_old.id
 

--- a/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
+++ b/tldw_Server_API/tests/Watchlists/test_watchlists_api.py
@@ -943,6 +943,9 @@ def test_items_and_outputs_flow(client_with_user, monkeypatch):
     assert r.status_code == 200, r.text
     outputs = r.json()
     assert outputs["total"] >= 2
+    assert outputs["pagination"]["total"] >= 2
+    assert outputs["pagination"]["limit"] == 50
+    assert outputs["pagination"]["offset"] == 0
     assert any(o["id"] == output_id for o in outputs["items"])
 
     # Output metadata
@@ -1063,6 +1066,10 @@ def test_watchlists_outputs_variants_and_ingest(client_with_user, monkeypatch):
 
     monkeypatch.setattr(
         "tldw_Server_API.app.core.TTS.tts_service_v2.get_tts_service_v2",
+        _fake_get_tts_service_v2,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.outputs_service.get_tts_service_v2",
         _fake_get_tts_service_v2,
     )
 
@@ -1208,6 +1215,10 @@ def test_watchlists_outputs_pagination_excludes_mixed_origin_rows(client_with_us
     assert r.status_code == 200, r.text
     page1 = r.json()
     assert page1["total"] == 2
+    assert page1["pagination"]["total"] == 2
+    assert page1["pagination"]["limit"] == 1
+    assert page1["pagination"]["offset"] == 0
+    assert page1["pagination"]["has_more"] is True
     assert len(page1["items"]) == 1
     assert page1["items"][0]["id"] == wl_new.id
 
@@ -1215,6 +1226,10 @@ def test_watchlists_outputs_pagination_excludes_mixed_origin_rows(client_with_us
     assert r.status_code == 200, r.text
     page2 = r.json()
     assert page2["total"] == 2
+    assert page2["pagination"]["total"] == 2
+    assert page2["pagination"]["limit"] == 1
+    assert page2["pagination"]["offset"] == 1
+    assert page2["pagination"]["has_more"] is False
     assert len(page2["items"]) == 1
     assert page2["items"][0]["id"] == wl_old.id
 

--- a/tldw_Server_API/tests/Workflows/test_runs_cursor_pagination.py
+++ b/tldw_Server_API/tests/Workflows/test_runs_cursor_pagination.py
@@ -6,7 +6,9 @@ from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.api.v1.endpoints import workflows as wf_mod
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 
 
@@ -15,13 +17,32 @@ def client(tmp_path, auth_headers):
     db = WorkflowsDatabase(str(tmp_path / "wf.db"))
 
     async def override_user():
-        return User(id=1, username="tester", email="t@e.com", is_active=True, is_admin=True)
+        return User(
+            id=1,
+            username="tester",
+            email="t@e.com",
+            is_active=True,
+            is_admin=True,
+            roles=["admin"],
+            permissions=["*"],
+        )
+
+    async def override_principal():
+        return AuthPrincipal(
+            kind="user",
+            user_id=1,
+            username="tester",
+            roles=["admin"],
+            permissions=["*"],
+            is_admin=True,
+        )
 
     def override_db():
 
         return db
 
     app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[get_auth_principal] = override_principal
     app.dependency_overrides[wf_mod._get_db] = override_db
 
     with TestClient(app, headers=auth_headers) as c:
@@ -78,6 +99,13 @@ def test_runs_cursor_pagination_flow(client: TestClient):
     p1 = r1.json()
     assert isinstance(p1.get("runs"), list)
     assert len(p1["runs"]) <= 2
+    assert p1["pagination"]["mode"] == "offset"
+    assert p1["pagination"]["limit"] == 2
+    assert p1["pagination"]["offset"] == 0
+    assert p1["pagination"]["has_more"] is True
+    assert p1["pagination"]["next_offset"] == 2
+    assert p1["has_more"] is True
+    assert p1["next_offset"] == 2
     next_cursor = p1.get("next_cursor")
     assert isinstance(next_cursor, str) and next_cursor, "expected next_cursor token"
 

--- a/tldw_Server_API/tests/Writing/test_manuscript_endpoint_integration.py
+++ b/tldw_Server_API/tests/Writing/test_manuscript_endpoint_integration.py
@@ -245,6 +245,34 @@ def test_project_list_and_filter(client: TestClient):
     assert any(p["title"] == "Completed Novel B" for p in data["projects"])
 
 
+def test_project_list_includes_canonical_pagination(client: TestClient):
+    client.post(f"{PREFIX}/projects", json={"title": "Pagination Novel A", "status": "draft"})
+    client.post(f"{PREFIX}/projects", json={"title": "Pagination Novel B", "status": "complete"})
+
+    page1_resp = client.get(f"{PREFIX}/projects", params={"limit": 1, "offset": 0})
+    assert page1_resp.status_code == 200, page1_resp.text
+    page1 = page1_resp.json()
+    assert page1["total"] >= 2
+    assert len(page1["projects"]) == 1
+    assert page1["pagination"] == {
+        "mode": "offset",
+        "limit": 1,
+        "offset": 0,
+        "total": page1["total"],
+        "has_more": True,
+        "next_offset": 1,
+    }
+
+    page2_resp = client.get(f"{PREFIX}/projects", params={"limit": 1, "offset": 1})
+    assert page2_resp.status_code == 200, page2_resp.text
+    page2 = page2_resp.json()
+    assert len(page2["projects"]) == 1
+    assert page2["pagination"]["mode"] == "offset"
+    assert page2["pagination"]["limit"] == 1
+    assert page2["pagination"]["offset"] == 1
+    assert page2["pagination"]["total"] == page2["total"]
+
+
 def test_manuscript_version_history_and_trash_restore(client: TestClient):
     project_resp = client.post(f"{PREFIX}/projects", json={"title": "Versioned Novel"})
     assert project_resp.status_code == 201, project_resp.text

--- a/tldw_Server_API/tests/Writing/test_manuscript_endpoint_integration.py
+++ b/tldw_Server_API/tests/Writing/test_manuscript_endpoint_integration.py
@@ -262,6 +262,8 @@ def test_project_list_includes_canonical_pagination(client: TestClient):
         "has_more": True,
         "next_offset": 1,
     }
+    assert page1["has_more"] is True
+    assert page1["next_offset"] == 1
 
     page2_resp = client.get(f"{PREFIX}/projects", params={"limit": 1, "offset": 1})
     assert page2_resp.status_code == 200, page2_resp.text
@@ -271,6 +273,8 @@ def test_project_list_includes_canonical_pagination(client: TestClient):
     assert page2["pagination"]["limit"] == 1
     assert page2["pagination"]["offset"] == 1
     assert page2["pagination"]["total"] == page2["total"]
+    assert page2["has_more"] == page2["pagination"]["has_more"]
+    assert page2["next_offset"] == page2["pagination"]["next_offset"]
 
 
 def test_manuscript_version_history_and_trash_restore(client: TestClient):

--- a/tldw_Server_API/tests/Writing/test_writing_endpoint_integration.py
+++ b/tldw_Server_API/tests/Writing/test_writing_endpoint_integration.py
@@ -82,6 +82,14 @@ def test_writing_sessions_crud_and_clone(client_with_writing_db: TestClient):
     assert list_resp.status_code == 200, list_resp.text
     listed = list_resp.json()
     assert listed["total"] >= 1
+    assert listed["pagination"] == {
+        "mode": "offset",
+        "limit": 100,
+        "offset": 0,
+        "total": listed["total"],
+        "has_more": False,
+        "next_offset": None,
+    }
     assert any(item["id"] == session_id for item in listed["sessions"])
 
     get_resp = client.get(f"/api/v1/writing/sessions/{session_id}")
@@ -140,6 +148,14 @@ def test_writing_templates_and_themes_crud(client_with_writing_db: TestClient):
     assert list_templates.status_code == 200
     templates_payload = list_templates.json()
     assert templates_payload["total"] == 1
+    assert templates_payload["pagination"] == {
+        "mode": "offset",
+        "limit": 100,
+        "offset": 0,
+        "total": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
 
     upd_tmpl = client.patch(
         "/api/v1/writing/templates/Template A",
@@ -170,6 +186,14 @@ def test_writing_templates_and_themes_crud(client_with_writing_db: TestClient):
     assert list_themes.status_code == 200
     themes_payload = list_themes.json()
     assert themes_payload["total"] == 1
+    assert themes_payload["pagination"] == {
+        "mode": "offset",
+        "limit": 100,
+        "offset": 0,
+        "total": 1,
+        "has_more": False,
+        "next_offset": None,
+    }
 
     upd_theme = client.patch(
         "/api/v1/writing/themes/Theme A",

--- a/tldw_Server_API/tests/Writing/test_writing_endpoint_integration.py
+++ b/tldw_Server_API/tests/Writing/test_writing_endpoint_integration.py
@@ -90,6 +90,8 @@ def test_writing_sessions_crud_and_clone(client_with_writing_db: TestClient):
         "has_more": False,
         "next_offset": None,
     }
+    assert listed["has_more"] is False
+    assert listed["next_offset"] is None
     assert any(item["id"] == session_id for item in listed["sessions"])
 
     get_resp = client.get(f"/api/v1/writing/sessions/{session_id}")
@@ -156,6 +158,8 @@ def test_writing_templates_and_themes_crud(client_with_writing_db: TestClient):
         "has_more": False,
         "next_offset": None,
     }
+    assert templates_payload["has_more"] is False
+    assert templates_payload["next_offset"] is None
 
     upd_tmpl = client.patch(
         "/api/v1/writing/templates/Template A",
@@ -194,6 +198,8 @@ def test_writing_templates_and_themes_crud(client_with_writing_db: TestClient):
         "has_more": False,
         "next_offset": None,
     }
+    assert themes_payload["has_more"] is False
+    assert themes_payload["next_offset"] is None
 
     upd_theme = client.patch(
         "/api/v1/writing/themes/Theme A",

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -407,6 +407,14 @@ class TestPromptEndpoints:
             assert data["success"] is True
             assert isinstance(data["data"], list)
             assert "metadata" in data
+            assert data["pagination"]["mode"] == "page"
+            assert data["pagination"]["page"] == 1
+            assert data["pagination"]["per_page"] == 20
+            assert data["pagination"]["total"] >= len(data["data"])
+            assert data["pagination"]["total_pages"] >= 0
+            assert data["pagination"]["has_more"] == (
+                data["pagination"]["page"] < data["pagination"]["total_pages"]
+            )
 
     def test_execute_prompt(self, client, auth_headers, mock_user):
 
@@ -968,6 +976,46 @@ class TestTestCaseEndpoints:
             data = response.json()
             assert data["name"] == "Test Case 1"
             assert data["project_id"] == project_id
+
+    def test_list_test_cases(self, client, auth_headers, mock_user, project_id):
+
+        """Test listing test cases for a project."""
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        with patch('tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps.get_current_active_user', return_value=mock_user):
+            create_response = client.post(
+                "/api/v1/prompt-studio/test-cases",
+                json={
+                    "project_id": project_id,
+                    "name": "Listed Test Case",
+                    "description": "A listed test case",
+                    "inputs": {"input": "test data"},
+                    "expected_outputs": {"output": "expected result"},
+                    "is_golden": False,
+                    "tags": ["integration"],
+                },
+                headers=auth_headers,
+            )
+            assert create_response.status_code in [200, 201]
+
+            response = client.get(
+                f"/api/v1/prompt-studio/test-cases/list/{project_id}?page=1&per_page=20",
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert isinstance(data["data"], list)
+            assert data["pagination"] == {
+                "mode": "page",
+                "page": 1,
+                "per_page": 20,
+                "total": 1,
+                "total_pages": 1,
+                "has_more": False,
+            }
 
     def test_run_test_cases(self, client, auth_headers, mock_user):
 

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -156,6 +156,31 @@ def mock_user():
         "permissions": ["read", "write", "delete"]
     }
 
+
+@pytest.mark.asyncio
+async def test_list_prompts_safely_defaults_missing_pagination() -> None:
+    """Prompt listing does not 500 when storage omits pagination metadata."""
+    from tldw_Server_API.app.api.v1.endpoints.prompt_studio import prompt_studio_prompts
+
+    class _PromptDbWithoutPagination:
+        def list_prompts(self, *_args, **_kwargs):
+            return {"prompts": []}
+
+    response = await prompt_studio_prompts.list_prompts(
+        project_id=123,
+        page=2,
+        per_page=10,
+        include_deleted=False,
+        _=True,
+        db=_PromptDbWithoutPagination(),
+    )
+
+    assert response.metadata.page == 2
+    assert response.metadata.per_page == 10
+    assert response.metadata.total == 0
+    assert response.pagination.page == 2
+    assert response.pagination.has_more is False
+
 ########################################################################################################################
 # Project Endpoints Tests
 

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -210,6 +210,20 @@ class TestProjectEndpoints:
         assert "data" in data
         assert "metadata" in data
         assert isinstance(data["data"], list)
+        assert data["metadata"] == {
+            "page": 1,
+            "per_page": 20,
+            "total": 1,
+            "total_pages": 1,
+        }
+        assert data["pagination"] == {
+            "mode": "page",
+            "page": 1,
+            "per_page": 20,
+            "total": 1,
+            "total_pages": 1,
+            "has_more": False,
+        }
 
     def test_get_project(self, client, test_db):
 

--- a/tldw_Server_API/tests/prompt_studio/integration/test_projects_prompts_flows.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_projects_prompts_flows.py
@@ -79,6 +79,20 @@ def test_project_crud_list(prompt_studio_dual_backend_client):
     data = lst.json()
     assert data.get("success") is True
     assert isinstance(data.get("data"), list)
+    assert data.get("metadata") == {
+        "page": 1,
+        "per_page": 10,
+        "total": 1,
+        "total_pages": 1,
+    }
+    assert data.get("pagination") == {
+        "mode": "page",
+        "page": 1,
+        "per_page": 10,
+        "total": 1,
+        "total_pages": 1,
+        "has_more": False,
+    }
     # Get project details
     getp = client.get(f"/api/v1/prompt-studio/projects/get/{pid}")
     assert getp.status_code == 200

--- a/tldw_Server_API/tests/prompt_studio/integration/test_projects_prompts_flows.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_projects_prompts_flows.py
@@ -125,8 +125,22 @@ def test_prompt_create_list_under_project(prompt_studio_dual_backend_client):
     assert pr.status_code in (200, 201), f"{backend_label}: {pr.text}"
 
     # List prompts (endpoint definition depends on app; verify at least one is retrievable via project get)
-    gp = client.get(f"/api/v1/prompt-studio/projects/get/{pid}")
-    assert gp.status_code == 200
+    plist = client.get(
+        f"/api/v1/prompt-studio/prompts",
+        params={"project_id": pid, "page": 1, "per_page": 20},
+    )
+    assert plist.status_code == 200
+    plist_data = plist.json()
+    assert plist_data.get("success") is True
+    assert isinstance(plist_data.get("data"), list)
+    assert plist_data.get("pagination") == {
+        "mode": "page",
+        "page": 1,
+        "per_page": 20,
+        "total": 1,
+        "total_pages": 1,
+        "has_more": False,
+    }
 
 
 def test_test_cases_and_evaluations_flow(prompt_studio_dual_backend_client):
@@ -179,6 +193,14 @@ def test_test_cases_and_evaluations_flow(prompt_studio_dual_backend_client):
     tlist_data = tlist.json()
     assert tlist_data.get("success") is True
     assert isinstance(tlist_data.get("data"), list)
+    assert tlist_data.get("pagination") == {
+        "mode": "page",
+        "page": 1,
+        "per_page": 10,
+        "total": 1,
+        "total_pages": 1,
+        "has_more": False,
+    }
 
     # Create an evaluation (synchronous path)
     ev = client.post(

--- a/tldw_Server_API/tests/sandbox/test_admin_idempotency_and_usage.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_idempotency_and_usage.py
@@ -61,7 +61,11 @@ def test_admin_idempotency_list_filters_and_pagination(monkeypatch) -> None:
         })
         assert lr.status_code == 200
         payload = lr.json()
-        assert set(payload.keys()) == {"total", "limit", "offset", "has_more", "items"}
+        assert set(payload.keys()) == {"total", "limit", "offset", "has_more", "items", "pagination"}
+        assert payload["pagination"]["total"] == payload["total"]
+        assert payload["pagination"]["limit"] == 10
+        assert payload["pagination"]["offset"] == 0
+        assert payload["pagination"]["has_more"] == payload["has_more"]
         items = payload["items"]
         assert isinstance(items, list)
         assert len(items) >= 1
@@ -95,7 +99,11 @@ def test_admin_usage_aggregates_schema_and_filters(monkeypatch) -> None:
         ur = client.get("/api/v1/sandbox/admin/usage", params={"limit": 50, "offset": 0})
         assert ur.status_code == 200
         payload = ur.json()
-        assert set(payload.keys()) == {"total", "limit", "offset", "has_more", "items"}
+        assert set(payload.keys()) == {"total", "limit", "offset", "has_more", "items", "pagination"}
+        assert payload["pagination"]["total"] == payload["total"]
+        assert payload["pagination"]["limit"] == 50
+        assert payload["pagination"]["offset"] == 0
+        assert payload["pagination"]["has_more"] == payload["has_more"]
         assert isinstance(payload["items"], list)
         # If the default user exists, ensure schema for first item
         if payload["items"]:
@@ -109,6 +117,9 @@ def test_admin_usage_aggregates_schema_and_filters(monkeypatch) -> None:
         assert p2["total"] in (0, p2["total"])  # total should be an int; accept 0
         assert p2["limit"] == 1
         assert p2["offset"] == 0
+        assert p2["pagination"]["total"] == p2["total"]
+        assert p2["pagination"]["limit"] == 1
+        assert p2["pagination"]["offset"] == 0
 
         client.app.dependency_overrides.clear()
 

--- a/tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_list_filters_pagination.py
@@ -66,6 +66,11 @@ def test_admin_list_filters_and_pagination(monkeypatch):
         assert j["limit"] == 1
         assert j["offset"] == 0
         assert j["has_more"] is True
+        assert j["pagination"]["total"] == 2
+        assert j["pagination"]["limit"] == 1
+        assert j["pagination"]["offset"] == 0
+        assert j["pagination"]["has_more"] is True
+        assert j["pagination"]["next_offset"] == 1
         assert len(j["items"]) == 1
 
         # Next page
@@ -74,6 +79,11 @@ def test_admin_list_filters_and_pagination(monkeypatch):
         j2 = r2.json()
         assert j2["total"] == 2
         assert j2["has_more"] is False
+        assert j2["pagination"]["total"] == 2
+        assert j2["pagination"]["limit"] == 1
+        assert j2["pagination"]["offset"] == 1
+        assert j2["pagination"]["has_more"] is False
+        assert j2["pagination"]["next_offset"] is None
         assert len(j2["items"]) == 1
 
         # Date filter: only include recent (exclude r1 by from cutoff)


### PR DESCRIPTION
## Summary
- add shared canonical offset pagination schema/helpers
- adopt additive nested pagination metadata in skills, slides, data tables, storage, chat grammars, and outputs templates
- add focused backend and UI coverage for the new compatibility contract

## Verification
- focused backend pagination tests passed
- focused UI vitest selection passed
- Bandit on touched Python sources passed
- git diff --check passed

## Notes
- existing legacy top-level pagination fields are intentionally preserved for compatibility
- a human-written Change summary is still required before merge per repo policy
