### PR TITLE
Allow explicit VZ orphan VM repair

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -186,9 +186,10 @@ healthy, stale, unhealthy, active, and orphan facts without changing either side
 `POST /api/v1/sandbox/admin/macos-reconciliation/repair` is the explicit
 admin-only repair endpoint. Repair defaults to dry-run, skips active sessions,
 and can delete stale or unhealthy inactive persisted session-control rows when
-requested. It does not terminate orphan helper VMs yet; orphan termination
-remains deferred and manual. Helper unavailable or protocol mismatch conditions
-fail closed and block mutating repair.
+requested. It can terminate orphan helper VMs only when
+`terminate_orphaned_vms=true` is explicitly requested; operators should inspect
+the dry-run plan first. Helper unavailable or protocol mismatch conditions fail
+closed and block mutating repair.
 
 ## Current Limits
 
@@ -203,7 +204,7 @@ fail closed and block mutating repair.
 - No allowlist networking for the new macOS runtimes
 - No `vz_macos` warm-session VM reuse yet
 - Managed helper lifecycle is available through `tools/macos-vz-helper/scripts/vz-helperctl.py`, but it remains operator-driven and does not install or load launchd services automatically
-- No automatic orphan VM termination during diagnostics or repair yet
+- No automatic orphan VM termination during diagnostics or repair; orphan termination is explicit repair-only behavior
 
 Current diagnostics are mixed-mode:
 

--- a/Docs/superpowers/plans/2026-04-30-vz-orphan-vm-repair-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-30-vz-orphan-vm-repair-implementation-plan.md
@@ -1,0 +1,85 @@
+# VZ Orphan VM Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow the explicit macOS reconciliation repair endpoint to terminate orphaned helper VMs when the operator requests mutation.
+
+**Architecture:** Keep diagnostics read-only and keep repair dry-run by default. Reuse the existing reconciliation report and `MacOSVirtualizationHelperClient.terminate_vm()` contract, adding only explicit `terminate_orphaned_vms=True` behavior for items marked `orphaned_vm`.
+
+**Tech Stack:** Python, FastAPI/Pydantic schemas, pytest, existing macOS helper client abstraction.
+
+---
+
+### Task 1: Add Service Tests For Orphan VM Termination
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Sandbox/test_admin_macos_reconciliation_repair.py`
+
+- [x] **Step 1: Write failing tests**
+
+Add tests that verify:
+- dry-run with `terminate_orphaned_vms=True` plans `terminate_orphaned_vm` actions without calling the helper
+- mutating repair calls helper `terminate_vm(vm_id)` and increments `terminated_orphaned_vms`
+- helper returning `False` records `missing` without incrementing the terminated count
+- helper exception maps to `SandboxReconciliationRepairError("vz_orphan_vm_termination_failed", 503)`
+
+- [x] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Sandbox/test_admin_macos_reconciliation_repair.py -q
+```
+
+Expected: new orphan termination tests fail because the service still rejects `terminate_orphaned_vms=True`.
+
+### Task 2: Wire Existing Helper Termination Into Repair
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+
+- [x] **Step 1: Implement minimal service behavior**
+
+Remove the unconditional unsupported error. For each `orphaned_vm` item with a VM id:
+- append a `terminate_orphaned_vm` action when `terminate_orphaned_vms=True`
+- use `planned` during dry-run
+- call `MacOSVirtualizationHelperClient().terminate_vm(vm_id)` only when `dry_run=False`
+- record `terminated` or `missing`
+- increment `terminated_orphaned_vms` only on `terminated`
+
+- [x] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Sandbox/test_admin_macos_reconciliation_repair.py -q
+```
+
+Expected: repair tests pass.
+
+### Task 3: Update API And Operator Docs
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Sandbox/test_admin_macos_reconciliation_repair.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Modify: `tools/macos-vz-helper/README.md`
+
+- [x] **Step 1: Replace endpoint rejection test**
+
+Update the API test that currently expects `orphan_termination_not_supported` so it asserts `terminate_orphaned_vms=True` is passed through to the service.
+
+- [x] **Step 2: Update docs**
+
+Replace claims that orphan VM termination is unsupported/manual with the new explicit, dry-run-first repair behavior.
+
+- [x] **Step 3: Run focused verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Sandbox/test_admin_macos_reconciliation_repair.py -q
+git diff --check
+```
+
+Expected: tests pass and diff check reports no whitespace errors.

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -66,9 +66,9 @@ Current limitations:
 - `vz_linux` supports session VM reuse through persisted VZ session-control metadata; `vz_macos` does not.
 - `vz_linux` admin diagnostics include reconciliation data comparing persisted VZ session-control rows against live helper VM state.
 - `vz_linux` repair is explicit and admin-only through `POST /api/v1/sandbox/admin/macos-reconciliation/repair`; diagnostics do not mutate state.
-- `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and does not terminate orphan helper VMs yet.
+- `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and can terminate orphan helper VMs only when `terminate_orphaned_vms=true` is explicitly requested.
 - Helper unavailable or protocol mismatch conditions fail closed and block mutating repair.
-- Orphan VM termination remains future work and is not automatic repair behavior.
+- Orphan VM termination is not automatic repair behavior; operators should inspect the dry-run plan before running mutating repair.
 - `tools/macos-vz-helper/scripts/vz-helperctl.py` is the preferred operator helper lifecycle command for `check`, `build`, `sign`, `start`, `status`, `stop`, `plist`, and `smoke`; it can generate launchd plist scaffolding but does not install or load services automatically.
 - helper-backed template validation now distinguishes canonical bundles from
   raw-disk compatibility mode through `boot_mode` and `validation_strength`.
@@ -108,7 +108,8 @@ included in the public discovery payload, plus reconciliation data for persisted
 `POST /api/v1/sandbox/admin/macos-reconciliation/repair` is the separate
 admin-only repair surface. Repair defaults to dry-run, skips active sessions,
 can delete stale or unhealthy inactive persisted session-control rows when
-requested, and currently leaves orphan helper VMs running for manual handling.
+requested, and can terminate orphan helper VMs only when
+`terminate_orphaned_vms=true` is explicitly requested.
 
 Selected configuration knobs:
 

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -1011,9 +1011,6 @@ class SandboxService:
         terminate_orphaned_vms: bool = False,
         dry_run: bool = True,
     ) -> dict[str, object]:
-        if terminate_orphaned_vms:
-            raise SandboxReconciliationRepairError("orphan_termination_not_supported", 400)
-
         helper_status = probe_helper()
         report = collect_vz_reconciliation(
             self._orch,
@@ -1043,6 +1040,7 @@ class SandboxService:
             "orphaned_vms": len(orphaned_items),
             "terminated_orphaned_vms": 0,
         }
+        helper_client: MacOSVirtualizationHelperClient | None = None
 
         for item in report_items:
             status = str(item.get("status") or "").strip()
@@ -1059,6 +1057,36 @@ class SandboxService:
                     "reason": reason or "active_session",
                 }
                 logger.info("Skipping VZ reconciliation repair action: {}", action)
+                actions.append(action)
+                continue
+
+            if status == "orphaned_vm":
+                if not terminate_orphaned_vms or not vm_id:
+                    continue
+
+                action_status = "planned"
+                if not dry_run:
+                    try:
+                        if helper_client is None:
+                            helper_client = MacOSVirtualizationHelperClient()
+                        terminated = bool(helper_client.terminate_vm(vm_id))
+                    except Exception as exc:
+                        logger.exception("VZ reconciliation repair orphan termination failed for vm_id={}", vm_id)
+                        raise SandboxReconciliationRepairError("vz_orphan_vm_termination_failed", 503) from exc
+                    if terminated:
+                        summary["terminated_orphaned_vms"] += 1
+                        action_status = "terminated"
+                    else:
+                        action_status = "missing"
+
+                action = {
+                    "type": "terminate_orphaned_vm",
+                    "session_id": None,
+                    "vm_id": vm_id,
+                    "status": action_status,
+                    "reason": reason or None,
+                }
+                logger.info("VZ reconciliation repair action: {}", action)
                 actions.append(action)
                 continue
 

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -40,6 +40,8 @@ from .models import (
 from .macos_virtualization.helper_client import (
     MacOSVirtualizationHelperClient,
     MacOSVirtualizationHelperFailure,
+    MacOSVirtualizationHelperProtocolError,
+    MacOSVirtualizationHelperUnavailable,
 )
 from .macos_diagnostics import collect_macos_diagnostics, probe_helper
 from .orchestrator import SandboxOrchestrator, SessionActiveRunsConflict
@@ -1070,6 +1072,21 @@ class SandboxService:
                         if helper_client is None:
                             helper_client = MacOSVirtualizationHelperClient()
                         terminated = bool(helper_client.terminate_vm(vm_id))
+                    except MacOSVirtualizationHelperUnavailable as exc:
+                        reason_code = str(exc) or "macos_virtualization_helper_unavailable"
+                        logger.info("VZ reconciliation repair orphan termination blocked: {}", reason_code)
+                        raise SandboxReconciliationRepairError(reason_code, 503) from exc
+                    except MacOSVirtualizationHelperProtocolError as exc:
+                        reason_code = "macos_virtualization_helper_protocol_mismatch"
+                        logger.info("VZ reconciliation repair orphan termination blocked: {}", reason_code)
+                        raise SandboxReconciliationRepairError(reason_code, 503) from exc
+                    except MacOSVirtualizationHelperFailure as exc:
+                        logger.info(
+                            "VZ reconciliation repair orphan termination helper failure for vm_id={}: {}",
+                            vm_id,
+                            exc.error_code,
+                        )
+                        raise SandboxReconciliationRepairError(exc.error_code, 503) from exc
                     except Exception as exc:
                         logger.exception("VZ reconciliation repair orphan termination failed for vm_id={}", vm_id)
                         raise SandboxReconciliationRepairError("vz_orphan_vm_termination_failed", 503) from exc

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
@@ -12,6 +12,11 @@ from tldw_Server_API.app.api.v1.endpoints import sandbox as sandbox_mod
 from tldw_Server_API.app.core.AuthNZ.permissions import ROLE_ADMIN
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.Sandbox import service as service_mod
+from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperFailure,
+    MacOSVirtualizationHelperProtocolError,
+    MacOSVirtualizationHelperUnavailable,
+)
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 
 
@@ -174,12 +179,14 @@ def test_admin_reconciliation_repair_runs_service_in_thread(monkeypatch) -> None
     assert to_thread_calls[0]["kwargs"]["dry_run"] is True
 
 
-def test_admin_reconciliation_repair_orphan_termination_passes_through(monkeypatch) -> None:
+def test_admin_reconciliation_repair_orphan_termination_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     seen_kwargs: dict[str, object] = {}
 
-    def _repair(**kwargs) -> dict[str, object]:
+    def _repair(**kwargs: object) -> dict[str, object]:
         seen_kwargs.update(kwargs)
-        return _repair_payload(dry_run=kwargs["dry_run"], action_status="planned")
+        return _repair_payload(dry_run=bool(kwargs["dry_run"]), action_status="planned")
 
     monkeypatch.setattr(sandbox_mod, "_service", SimpleNamespace(repair_macos_reconciliation=_repair), raising=True)
 
@@ -490,7 +497,9 @@ def test_repair_active_session_item_is_skipped(monkeypatch) -> None:
     assert result["actions"][0]["reason"] == "active_session"
 
 
-def test_repair_orphan_vm_dry_run_plans_termination_without_helper_call(monkeypatch) -> None:
+def test_repair_orphan_vm_dry_run_plans_termination_without_helper_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     terminated_vm_ids: list[str] = []
     orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
     service = _service_with_orchestrator(orch)
@@ -532,7 +541,7 @@ def test_repair_orphan_vm_dry_run_plans_termination_without_helper_call(monkeypa
     ]
 
 
-def test_repair_orphan_vm_mutating_run_calls_helper(monkeypatch) -> None:
+def test_repair_orphan_vm_mutating_run_calls_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     terminated_vm_ids: list[str] = []
     orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
     service = _service_with_orchestrator(orch)
@@ -582,7 +591,7 @@ def test_repair_orphan_vm_mutating_run_calls_helper(monkeypatch) -> None:
     ]
 
 
-def test_repair_orphan_vm_termination_false_reports_missing(monkeypatch) -> None:
+def test_repair_orphan_vm_termination_false_reports_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     terminated_vm_ids: list[str] = []
     orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
     service = _service_with_orchestrator(orch)
@@ -624,7 +633,69 @@ def test_repair_orphan_vm_termination_false_reports_missing(monkeypatch) -> None
     assert result["actions"][0]["status"] == "missing"
 
 
-def test_repair_orphan_vm_termination_exception_maps_to_structured_error(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("helper_exc", "expected_reason"),
+    [
+        (
+            MacOSVirtualizationHelperUnavailable("macos_virtualization_helper_unavailable"),
+            "macos_virtualization_helper_unavailable",
+        ),
+        (
+            MacOSVirtualizationHelperProtocolError("macos_virtualization_helper_protocol_error"),
+            "macos_virtualization_helper_protocol_mismatch",
+        ),
+        (
+            MacOSVirtualizationHelperFailure("vm_shutdown_denied", "helper refused termination"),
+            "vm_shutdown_denied",
+        ),
+    ],
+)
+def test_repair_orphan_vm_termination_helper_errors_preserve_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    helper_exc: Exception,
+    expected_reason: str,
+) -> None:
+    orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "orphaned_vm",
+                    "vm_id": "vm-orphan",
+                    "reason": "session_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    def _terminate_vm(vm_id: str) -> bool:
+        raise helper_exc
+
+    monkeypatch.setattr(
+        service_mod,
+        "MacOSVirtualizationHelperClient",
+        lambda: SimpleNamespace(terminate_vm=_terminate_vm),
+        raising=True,
+    )
+
+    with pytest.raises(service_mod.SandboxReconciliationRepairError) as exc_info:
+        service.repair_macos_reconciliation(
+            terminate_orphaned_vms=True,
+            dry_run=False,
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.reason == expected_reason
+
+
+def test_repair_orphan_vm_termination_unexpected_exception_maps_to_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
     service = _service_with_orchestrator(orch)
     monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
@@ -174,9 +174,12 @@ def test_admin_reconciliation_repair_runs_service_in_thread(monkeypatch) -> None
     assert to_thread_calls[0]["kwargs"]["dry_run"] is True
 
 
-def test_admin_reconciliation_repair_rejects_orphan_termination(monkeypatch) -> None:
+def test_admin_reconciliation_repair_orphan_termination_passes_through(monkeypatch) -> None:
+    seen_kwargs: dict[str, object] = {}
+
     def _repair(**kwargs) -> dict[str, object]:
-        raise service_mod.SandboxReconciliationRepairError("orphan_termination_not_supported", 400)
+        seen_kwargs.update(kwargs)
+        return _repair_payload(dry_run=kwargs["dry_run"], action_status="planned")
 
     monkeypatch.setattr(sandbox_mod, "_service", SimpleNamespace(repair_macos_reconciliation=_repair), raising=True)
 
@@ -188,8 +191,8 @@ def test_admin_reconciliation_repair_rejects_orphan_termination(monkeypatch) -> 
             json={"terminate_orphaned_vms": True},
         )
 
-    assert resp.status_code == 400
-    assert resp.json()["detail"] == "orphan_termination_not_supported"
+    assert resp.status_code == 200
+    assert seen_kwargs["terminate_orphaned_vms"] is True
 
 
 def test_admin_reconciliation_repair_maps_service_unavailable_error(monkeypatch) -> None:
@@ -485,6 +488,179 @@ def test_repair_active_session_item_is_skipped(monkeypatch) -> None:
     assert result["summary"]["skipped_active_sessions"] == 1
     assert result["actions"][0]["status"] == "skipped"
     assert result["actions"][0]["reason"] == "active_session"
+
+
+def test_repair_orphan_vm_dry_run_plans_termination_without_helper_call(monkeypatch) -> None:
+    terminated_vm_ids: list[str] = []
+    orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "orphaned_vm",
+                    "vm_id": "vm-orphan",
+                    "reason": "session_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        service_mod,
+        "MacOSVirtualizationHelperClient",
+        lambda: SimpleNamespace(terminate_vm=terminated_vm_ids.append),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(terminate_orphaned_vms=True)
+
+    assert terminated_vm_ids == []
+    assert result["summary"]["orphaned_vms"] == 1
+    assert result["summary"]["terminated_orphaned_vms"] == 0
+    assert result["actions"] == [
+        {
+            "type": "terminate_orphaned_vm",
+            "session_id": None,
+            "vm_id": "vm-orphan",
+            "status": "planned",
+            "reason": "session_missing",
+        }
+    ]
+
+
+def test_repair_orphan_vm_mutating_run_calls_helper(monkeypatch) -> None:
+    terminated_vm_ids: list[str] = []
+    orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "orphaned_vm",
+                    "vm_id": "vm-orphan",
+                    "reason": "session_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    def _terminate_vm(vm_id: str) -> bool:
+        terminated_vm_ids.append(vm_id)
+        return True
+
+    monkeypatch.setattr(
+        service_mod,
+        "MacOSVirtualizationHelperClient",
+        lambda: SimpleNamespace(terminate_vm=_terminate_vm),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(
+        terminate_orphaned_vms=True,
+        dry_run=False,
+    )
+
+    assert terminated_vm_ids == ["vm-orphan"]
+    assert result["summary"]["orphaned_vms"] == 1
+    assert result["summary"]["terminated_orphaned_vms"] == 1
+    assert result["actions"] == [
+        {
+            "type": "terminate_orphaned_vm",
+            "session_id": None,
+            "vm_id": "vm-orphan",
+            "status": "terminated",
+            "reason": "session_missing",
+        }
+    ]
+
+
+def test_repair_orphan_vm_termination_false_reports_missing(monkeypatch) -> None:
+    terminated_vm_ids: list[str] = []
+    orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "orphaned_vm",
+                    "vm_id": "vm-orphan",
+                    "reason": "session_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    def _terminate_vm(vm_id: str) -> bool:
+        terminated_vm_ids.append(vm_id)
+        return False
+
+    monkeypatch.setattr(
+        service_mod,
+        "MacOSVirtualizationHelperClient",
+        lambda: SimpleNamespace(terminate_vm=_terminate_vm),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(
+        terminate_orphaned_vms=True,
+        dry_run=False,
+    )
+
+    assert terminated_vm_ids == ["vm-orphan"]
+    assert result["summary"]["orphaned_vms"] == 1
+    assert result["summary"]["terminated_orphaned_vms"] == 0
+    assert result["actions"][0]["status"] == "missing"
+
+
+def test_repair_orphan_vm_termination_exception_maps_to_structured_error(monkeypatch) -> None:
+    orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": "orphaned_vm",
+                    "vm_id": "vm-orphan",
+                    "reason": "session_missing",
+                }
+            ]
+        ),
+        raising=True,
+    )
+
+    def _terminate_vm(vm_id: str) -> bool:
+        raise RuntimeError("helper disconnected")
+
+    monkeypatch.setattr(
+        service_mod,
+        "MacOSVirtualizationHelperClient",
+        lambda: SimpleNamespace(terminate_vm=_terminate_vm),
+        raising=True,
+    )
+
+    with pytest.raises(service_mod.SandboxReconciliationRepairError) as exc_info:
+        service.repair_macos_reconciliation(
+            terminate_orphaned_vms=True,
+            dry_run=False,
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.reason == "vz_orphan_vm_termination_failed"
 
 
 @pytest.mark.parametrize(

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -22,7 +22,7 @@ The first helper slice is not a generic macOS sandbox backend:
 - no second persistence layer for sandbox sessions
 - no APFS clone execution path yet
 - no automatic launchd installation or helper auto-upgrade yet
-- no automatic orphan VM termination during admin repair yet
+- no automatic orphan VM termination during admin repair; Python can request it only through explicit dry-run-first reconciliation repair
 
 Python remains authoritative for sandbox admission, session identity, artifacts, and ACP
 integration. The helper only owns runtime VM facts and control-plane operations.


### PR DESCRIPTION
## Summary
- Wires `terminate_orphaned_vms=true` through macOS reconciliation repair using the existing helper `terminate_vm` operation.
- Keeps repair dry-run by default and reports planned, terminated, or missing orphan VM actions.
- Updates sandbox/helper docs to describe orphan termination as explicit repair-only behavior.

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_vz_reconciliation.py tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py -q`
- `git diff --check origin/dev..HEAD`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py -s B101,B106 -f json -o /tmp/bandit_vz_orphan_vm_repair_filtered.json`

## Change summary
Human-authored summary required before merge.