### PR TITLE
Add VZ helper VM ownership metadata and gated orphan repair

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -187,9 +187,24 @@ healthy, stale, unhealthy, active, and orphan facts without changing either side
 admin-only repair endpoint. Repair defaults to dry-run, skips active sessions,
 and can delete stale or unhealthy inactive persisted session-control rows when
 requested. It can terminate orphan helper VMs only when
-`terminate_orphaned_vms=true` is explicitly requested; operators should inspect
-the dry-run plan first. Helper unavailable or protocol mismatch conditions fail
-closed and block mutating repair.
+`terminate_orphaned_vms=true` is explicitly requested and helper metadata proves
+the VM is owned by this `tldw` `vz_linux` sandbox control plane. Operators should
+inspect the dry-run plan first. Helper unavailable or protocol mismatch
+conditions fail closed and block mutating repair.
+
+Orphan VM classifications are:
+
+- `owned_orphaned_vm`: metadata has `owner=tldw`, `runtime=vz_linux`, non-empty
+  `run_id`, non-empty helper-created `created_at`, and a `session_id` when
+  `session_mode=true`; repair may terminate these when explicitly requested.
+- `unknown_orphaned_vm`: metadata is missing, legacy, or incomplete; repair
+  reports and skips these.
+- `foreign_orphaned_vm`: metadata exists but owner or runtime does not match this
+  sandbox control plane; repair reports and skips these.
+
+This metadata is local helper ownership metadata, not cryptographic proof. Unknown,
+foreign, or legacy helper VMs may require manual operator cleanup outside the
+automated repair endpoint.
 
 ## Current Limits
 
@@ -204,7 +219,7 @@ closed and block mutating repair.
 - No allowlist networking for the new macOS runtimes
 - No `vz_macos` warm-session VM reuse yet
 - Managed helper lifecycle is available through `tools/macos-vz-helper/scripts/vz-helperctl.py`, but it remains operator-driven and does not install or load launchd services automatically
-- No automatic orphan VM termination during diagnostics or repair; orphan termination is explicit repair-only behavior
+- No automatic orphan VM termination during diagnostics or repair; orphan termination is explicit repair-only behavior and is limited to owned `vz_linux` helper VMs
 
 Current diagnostics are mixed-mode:
 

--- a/Docs/superpowers/plans/2026-04-30-vz-helper-vm-ownership-metadata-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-04-30-vz-helper-vm-ownership-metadata-implementation-plan.md
@@ -1,0 +1,824 @@
+# VZ Helper VM Ownership Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add helper-owned VM metadata and use it to restrict orphan VM repair to VMs that can be classified as owned by the tldw `vz_linux` sandbox path.
+
+**Architecture:** Keep the Python service as the trusted control plane and the Swift helper as the owner of live VM state. Python supplies ownership metadata on `create_vm`; the helper stores it with VM registry records and reports it through status/list responses; Python reconciliation uses that metadata to classify orphan VMs and repair only terminates owned orphans.
+
+**Tech Stack:** Swift Package Manager, Swift Testing, Python dataclasses, pytest, existing `MacOSVirtualizationHelperClient`, existing sandbox reconciliation and repair APIs.
+
+---
+
+## File Structure
+
+- Modify `tools/macos-vz-helper/Sources/Protocol/Response.swift`
+  - Add `VMOwnershipMetadata`.
+  - Add metadata to `VMRecord`, `HelperVMResponse`, and `HelperVMStatusResponse`.
+- Modify `tools/macos-vz-helper/Sources/VM/VMRegistry.swift`
+  - Store metadata with records.
+  - Preserve metadata across `upsert()` state transitions unless replacement metadata is supplied.
+- Modify `tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift`
+  - Accept metadata during VM creation and pass it into the registry.
+- Modify `tools/macos-vz-helper/Sources/Server/HelperService.swift`
+  - Accept metadata for `createVM()`.
+  - Assign helper-created `created_at` when missing.
+  - Include metadata in create/status/list responses.
+- Modify `tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift`
+  - Forward `owner`, `runtime`, `run_id`, `session_id`, `session_mode`, `template`, `template_path`, and `workspace_path` into `HelperService.createVM()`.
+- Modify Swift tests:
+  - `tools/macos-vz-helper/Tests/VMRegistryTests.swift`
+  - `tools/macos-vz-helper/Tests/HelperServiceVMTests.swift`
+  - `tools/macos-vz-helper/Tests/UnixSocketServerTests.swift`
+- Modify Python helper models and client:
+  - `tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py`
+  - `tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py`
+- Modify Python runtime/reconciliation/repair:
+  - `tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
+  - `tldw_Server_API/app/core/Sandbox/vz_reconciliation.py`
+  - `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify Python tests:
+  - `tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py`
+  - `tldw_Server_API/tests/sandbox/test_macos_helper_client.py`
+  - `tldw_Server_API/tests/sandbox/test_vz_reconciliation.py`
+  - `tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py`
+  - `tldw_Server_API/tests/sandbox/test_vz_linux_runner.py`
+  - `tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py`
+- Modify docs:
+  - `tools/macos-vz-helper/PROTOCOL.md`
+  - `tools/macos-vz-helper/README.md`
+  - `Docs/Sandbox/macos-runtime-operator-notes.md`
+  - `tldw_Server_API/app/core/Sandbox/README.md`
+
+## Task 1: Add Swift VM Metadata Storage
+
+**Files:**
+- Modify: `tools/macos-vz-helper/Sources/Protocol/Response.swift`
+- Modify: `tools/macos-vz-helper/Sources/VM/VMRegistry.swift`
+- Test: `tools/macos-vz-helper/Tests/VMRegistryTests.swift`
+
+- [ ] **Step 1: Write failing registry metadata tests**
+
+Add tests for:
+
+```swift
+@Test func vmRegistryStoresOwnershipMetadata() throws {
+    let registry = VMRegistry()
+    let metadata = VMOwnershipMetadata(
+        owner: "tldw",
+        runtime: "vz_linux",
+        runID: "run-1",
+        sessionID: "session-1",
+        sessionMode: true,
+        templatePath: "/tmp/bundle",
+        workspacePath: "/tmp/workspace",
+        createdAt: "2026-04-30T18:00:00Z"
+    )
+
+    registry.upsert(vmID: "vm-1", state: "booting", healthy: false, metadata: metadata)
+
+    #expect(registry.status(vmID: "vm-1")?.metadata.owner == "tldw")
+    #expect(registry.status(vmID: "vm-1")?.metadata.runID == "run-1")
+}
+
+@Test func vmRegistryPreservesMetadataAcrossStateUpdates() throws {
+    let registry = VMRegistry()
+    let metadata = VMOwnershipMetadata(
+        owner: "tldw",
+        runtime: "vz_linux",
+        runID: "run-1",
+        sessionID: "",
+        sessionMode: false,
+        templatePath: "/tmp/bundle",
+        workspacePath: "/tmp/workspace",
+        createdAt: "2026-04-30T18:00:00Z"
+    )
+
+    registry.upsert(vmID: "vm-1", state: "booting", healthy: false, metadata: metadata)
+    registry.upsert(vmID: "vm-1", state: "running", healthy: true)
+
+    let record = registry.status(vmID: "vm-1")
+    #expect(record?.state == "running")
+    #expect(record?.metadata.runID == "run-1")
+}
+```
+
+- [ ] **Step 2: Run Swift tests to verify failure**
+
+Run:
+
+```bash
+swift test --package-path tools/macos-vz-helper --filter VMRegistryTests
+```
+
+Expected: fail because `VMOwnershipMetadata` and metadata-aware `upsert()` do not exist.
+
+- [ ] **Step 3: Implement metadata model and registry storage**
+
+Add to `Response.swift`:
+
+```swift
+struct VMOwnershipMetadata: Codable, Equatable {
+    let owner: String
+    let runtime: String
+    let runID: String
+    let sessionID: String
+    let sessionMode: Bool
+    let templatePath: String
+    let workspacePath: String
+    let createdAt: String
+
+    static let unknown = VMOwnershipMetadata(
+        owner: "unknown",
+        runtime: "",
+        runID: "",
+        sessionID: "",
+        sessionMode: false,
+        templatePath: "",
+        workspacePath: "",
+        createdAt: ""
+    )
+
+    private enum CodingKeys: String, CodingKey {
+        case owner
+        case runtime
+        case runID = "run_id"
+        case sessionID = "session_id"
+        case sessionMode = "session_mode"
+        case templatePath = "template_path"
+        case workspacePath = "workspace_path"
+        case createdAt = "created_at"
+    }
+}
+
+struct VMRecord {
+    let vmID: String
+    let state: String
+    let healthy: Bool
+    let metadata: VMOwnershipMetadata
+}
+```
+
+Update `VMRegistry.upsert()`:
+
+```swift
+func upsert(vmID: String, state: String, healthy: Bool, metadata: VMOwnershipMetadata? = nil) {
+    lock.lock()
+    defer { lock.unlock() }
+    let existingMetadata = records[vmID]?.metadata ?? .unknown
+    records[vmID] = VMRecord(
+        vmID: vmID,
+        state: state,
+        healthy: healthy,
+        metadata: metadata ?? existingMetadata
+    )
+}
+```
+
+- [ ] **Step 4: Run registry tests**
+
+Run:
+
+```bash
+swift test --package-path tools/macos-vz-helper --filter VMRegistryTests
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/macos-vz-helper/Sources/Protocol/Response.swift tools/macos-vz-helper/Sources/VM/VMRegistry.swift tools/macos-vz-helper/Tests/VMRegistryTests.swift
+git commit -m "feat(sandbox): store helper vm ownership metadata"
+```
+
+## Task 2: Surface Metadata Through Helper Service Responses
+
+**Files:**
+- Modify: `tools/macos-vz-helper/Sources/Protocol/Response.swift`
+- Modify: `tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift`
+- Modify: `tools/macos-vz-helper/Sources/Server/HelperService.swift`
+- Modify: `tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift`
+- Test: `tools/macos-vz-helper/Tests/HelperServiceVMTests.swift`
+- Test: `tools/macos-vz-helper/Tests/UnixSocketServerTests.swift`
+
+- [ ] **Step 1: Write failing helper service tests**
+
+Add tests that:
+
+- call `HelperService.createVM()` with metadata and assert create/status/list responses include it
+- call `HelperService.createVM()` without metadata and assert `owner == "unknown"`
+- send a `create_vm` JSON request through `UnixSocketServer.handleRequestData()` and assert nested response metadata contains `owner`, `runtime`, `run_id`, `session_id`, `session_mode`, `template_path`, and `workspace_path`
+
+Use this assertion shape:
+
+```swift
+let response = try service.createVM(
+    vmID: "vm-owned",
+    templatePath: "/tmp/template.img",
+    workspacePath: "/tmp/workspace",
+    readinessTimeoutSeconds: 5,
+    metadata: VMOwnershipMetadata(
+        owner: "tldw",
+        runtime: "vz_linux",
+        runID: "run-owned",
+        sessionID: "session-owned",
+        sessionMode: true,
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        createdAt: ""
+    )
+)
+
+#expect(response.metadata.owner == "tldw")
+#expect(response.metadata.createdAt.isEmpty == false)
+```
+
+- [ ] **Step 2: Run Swift tests to verify failure**
+
+Run:
+
+```bash
+swift test --package-path tools/macos-vz-helper --filter HelperServiceVMTests
+swift test --package-path tools/macos-vz-helper --filter UnixSocketServerTests
+```
+
+Expected: fail because service signatures and response metadata do not exist.
+
+- [ ] **Step 3: Implement service and response metadata**
+
+Update response structs:
+
+```swift
+struct HelperVMResponse: Encodable {
+    let protocolVersion: String
+    let helperVersion: String
+    let vmID: String
+    let state: String
+    let metadata: VMOwnershipMetadata
+    let details: [String: String]
+    ...
+}
+
+struct HelperVMStatusResponse: Encodable {
+    let protocolVersion: String
+    let helperVersion: String
+    let vmID: String
+    let state: String
+    let healthy: Bool
+    let metadata: VMOwnershipMetadata
+    let details: [String: String]
+    ...
+}
+```
+
+Update `VZLinuxVMManager.createVM(..., metadata:)` to write metadata on the initial `booting` upsert and preserve it on the `running` upsert.
+
+Update `HelperService.createVM(..., metadata: VMOwnershipMetadata = .unknown)` to normalize metadata with a helper-created timestamp when missing:
+
+```swift
+private func normalizeMetadata(_ metadata: VMOwnershipMetadata, templatePath: String, workspacePath: String) -> VMOwnershipMetadata {
+    VMOwnershipMetadata(
+        owner: metadata.owner.isEmpty ? "unknown" : metadata.owner,
+        runtime: metadata.runtime.isEmpty ? "vz_linux" : metadata.runtime,
+        runID: metadata.runID,
+        sessionID: metadata.sessionID,
+        sessionMode: metadata.sessionMode,
+        templatePath: metadata.templatePath.isEmpty ? templatePath : metadata.templatePath,
+        workspacePath: metadata.workspacePath.isEmpty ? workspacePath : metadata.workspacePath,
+        createdAt: metadata.createdAt.isEmpty ? ISO8601DateFormatter().string(from: Date()) : metadata.createdAt
+    )
+}
+```
+
+Update `UnixSocketServer` to build metadata from request fields:
+
+```swift
+let templatePath = request.request["template"]?.stringValue ?? request.request["template_path"]?.stringValue ?? ""
+let metadata = VMOwnershipMetadata(
+    owner: request.request["owner"]?.stringValue ?? "unknown",
+    runtime: request.request["runtime"]?.stringValue ?? "vz_linux",
+    runID: request.request["run_id"]?.stringValue ?? "",
+    sessionID: request.request["session_id"]?.stringValue ?? "",
+    sessionMode: request.request["session_mode"]?.boolValue ?? false,
+    templatePath: templatePath,
+    workspacePath: request.request["workspace_path"]?.stringValue ?? "",
+    createdAt: ""
+)
+```
+
+For missing VM status, return `.unknown` metadata.
+
+- [ ] **Step 4: Run helper Swift tests**
+
+Run:
+
+```bash
+swift test --package-path tools/macos-vz-helper --filter HelperServiceVMTests
+swift test --package-path tools/macos-vz-helper --filter UnixSocketServerTests
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/macos-vz-helper/Sources/Protocol/Response.swift tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift tools/macos-vz-helper/Sources/Server/HelperService.swift tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift tools/macos-vz-helper/Tests/HelperServiceVMTests.swift tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
+git commit -m "feat(sandbox): expose helper vm metadata"
+```
+
+## Task 3: Parse VM Metadata In Python Helper Models
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py`
+- Test: `tldw_Server_API/tests/sandbox/test_macos_helper_client.py`
+- Test: `tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py`
+
+- [ ] **Step 1: Write failing Python parser tests**
+
+Add model/parser tests for:
+
+```python
+def test_parse_helper_vm_status_reads_metadata() -> None:
+    reply = parse_helper_vm_status({
+        "protocol_version": "1",
+        "helper_version": "0.1.0",
+        "vm_id": "vm-1",
+        "state": "running",
+        "healthy": True,
+        "metadata": {
+            "owner": "tldw",
+            "runtime": "vz_linux",
+            "run_id": "run-1",
+            "session_id": "session-1",
+            "session_mode": True,
+            "template_path": "/tmp/bundle",
+            "workspace_path": "/tmp/workspace",
+            "created_at": "2026-04-30T18:00:00Z",
+        },
+    })
+
+    assert reply.metadata.owner == "tldw"
+    assert reply.metadata.session_mode is True
+```
+
+Add tests that missing or malformed `metadata` returns an unknown/default metadata object and does not mark ownership as trusted.
+
+- [ ] **Step 2: Run parser tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_helper_client.py tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py -q
+```
+
+Expected: fail because `HelperVMStatusReply.metadata` does not exist.
+
+- [ ] **Step 3: Implement metadata dataclass and parser**
+
+Add to `models.py`:
+
+```python
+@dataclass(slots=True)
+class HelperVMMetadata:
+    owner: str = "unknown"
+    runtime: str = ""
+    run_id: str = ""
+    session_id: str = ""
+    session_mode: bool = False
+    template_path: str = ""
+    workspace_path: str = ""
+    created_at: str = ""
+
+    @property
+    def has_tldw_owner(self) -> bool:
+        return self.owner == "tldw" and self.runtime == "vz_linux"
+```
+
+Add `metadata: HelperVMMetadata = field(default_factory=HelperVMMetadata)` to `HelperVMReply` and `HelperVMStatusReply`.
+
+Add:
+
+```python
+def _metadata_field(payload: dict[str, Any]) -> HelperVMMetadata:
+    raw = payload.get("metadata")
+    if not isinstance(raw, dict):
+        return HelperVMMetadata()
+    return HelperVMMetadata(
+        owner=_str_field(raw, "owner", "unknown").strip() or "unknown",
+        runtime=_str_field(raw, "runtime").strip(),
+        run_id=_str_field(raw, "run_id").strip(),
+        session_id=_str_field(raw, "session_id").strip(),
+        session_mode=_bool_field(raw, "session_mode"),
+        template_path=_str_field(raw, "template_path").strip(),
+        workspace_path=_str_field(raw, "workspace_path").strip(),
+        created_at=_str_field(raw, "created_at").strip(),
+    )
+```
+
+Update `parse_helper_vm_status()`, `parse_helper_vm_list()`, real `create_vm()`, and TEST_MODE fake replies to set metadata. The fake `create_vm()` should echo owner/runtime/run/session values from the request so runner tests can inspect behavior without a real helper.
+
+- [ ] **Step 4: Run parser/client tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_helper_client.py tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py tldw_Server_API/tests/sandbox/test_macos_helper_client.py tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+git commit -m "feat(sandbox): parse helper vm metadata"
+```
+
+## Task 4: Attach Ownership Metadata To Runner VM Creation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
+- Test: `tldw_Server_API/tests/sandbox/test_vz_linux_runner.py`
+- Test: `tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py`
+
+- [ ] **Step 1: Write failing runner tests**
+
+Update existing fake-helper tests to assert `create_vm()` receives:
+
+```python
+assert request["owner"] == "tldw"
+assert request["runtime"] == "vz_linux"
+assert request["run_id"] == run_id
+assert request["session_mode"] is expected_session_mode
+assert request["session_id"] == expected_session_id
+assert request["template"] == template_source
+```
+
+For ephemeral runs, `session_id` should be an empty string. For session reuse creation, `session_id` should be the sandbox session id.
+
+- [ ] **Step 2: Run runner tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py -q
+```
+
+Expected: fail because `owner` and `session_id` are not sent on create.
+
+- [ ] **Step 3: Add metadata to `create_vm` request**
+
+Update `VZLinuxRunner._run_real()` create request:
+
+```python
+vm = helper.create_vm(
+    {
+        "owner": "tldw",
+        "runtime": self.runtime_type.value,
+        "vm_name": run_id,
+        "run_id": run_id,
+        "session_id": str(spec.session_id or "").strip(),
+        "session_mode": session_mode,
+        "workspace_path": workspace,
+        "workspace_mount": "virtiofs",
+        "template": template_source,
+        "network_policy": str(spec.network_policy or "deny_all").strip().lower() or "deny_all",
+        "timeout_sec": int(spec.startup_timeout_sec or spec.timeout_sec or 300),
+    }
+)
+```
+
+- [ ] **Step 4: Run runner tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py
+git commit -m "feat(sandbox): tag vz linux helper vms"
+```
+
+## Task 5: Classify Owned, Unknown, And Foreign Orphan VMs
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/vz_reconciliation.py`
+- Test: `tldw_Server_API/tests/sandbox/test_vz_reconciliation.py`
+- Test: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+- Test: `tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py`
+
+- [ ] **Step 1: Write failing reconciliation tests**
+
+Add helper VM factories that accept metadata. Test:
+
+- owned orphan has `status == "owned_orphaned_vm"`, `termination_eligible is True`, and reason `owned_orphan`
+- missing metadata is `unknown_orphaned_vm`, `termination_eligible is False`, and reason `unknown_ownership`
+- tldw metadata missing `run_id`, missing `created_at`, or session-mode missing `session_id` is `unknown_orphaned_vm`
+- owner/runtime mismatch is `foreign_orphaned_vm`, `termination_eligible is False`, and reason `foreign_owner`
+- `orphaned_vm_ids` includes all three categories
+- `owned_orphaned_vm_ids`, `unknown_orphaned_vm_ids`, and `foreign_orphaned_vm_ids` are deterministic sorted lists
+
+- [ ] **Step 2: Run reconciliation tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_vz_reconciliation.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py -q
+```
+
+Expected: fail because reconciliation still emits only `orphaned_vm`.
+
+- [ ] **Step 3: Implement orphan classification**
+
+Add constants:
+
+```python
+STATUS_OWNED_ORPHAN = "owned_orphaned_vm"
+STATUS_UNKNOWN_ORPHAN = "unknown_orphaned_vm"
+STATUS_FOREIGN_ORPHAN = "foreign_orphaned_vm"
+REASON_OWNED_ORPHAN = "owned_orphan"
+REASON_UNKNOWN_OWNERSHIP = "unknown_ownership"
+REASON_FOREIGN_OWNER = "foreign_owner"
+```
+
+Add helper:
+
+```python
+def _classify_orphan_vm(vm: object) -> tuple[str, bool, str]:
+    metadata = getattr(vm, "metadata", None)
+    owner = str(getattr(metadata, "owner", "") or "").strip()
+    runtime = str(getattr(metadata, "runtime", "") or "").strip()
+    if not owner or owner == "unknown" or not runtime:
+        return STATUS_UNKNOWN_ORPHAN, False, REASON_UNKNOWN_OWNERSHIP
+    if owner != "tldw" or runtime != "vz_linux":
+        return STATUS_FOREIGN_ORPHAN, False, REASON_FOREIGN_OWNER
+    run_id = str(getattr(metadata, "run_id", "") or "").strip()
+    created_at = str(getattr(metadata, "created_at", "") or "").strip()
+    session_mode = bool(getattr(metadata, "session_mode", False))
+    session_id = str(getattr(metadata, "session_id", "") or "").strip()
+    if not run_id or not created_at or (session_mode and not session_id):
+        return STATUS_UNKNOWN_ORPHAN, False, REASON_UNKNOWN_OWNERSHIP
+    return STATUS_OWNED_ORPHAN, True, REASON_OWNED_ORPHAN
+```
+
+Update `_empty_report()` with the three new id lists. When appending orphan items, include:
+
+```python
+termination_eligible=eligible
+```
+
+Extend `_append_item()` to accept `termination_eligible: bool | None`.
+
+- [ ] **Step 4: Run reconciliation and diagnostics tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_vz_reconciliation.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/vz_reconciliation.py tldw_Server_API/tests/sandbox/test_vz_reconciliation.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+git commit -m "feat(sandbox): classify helper vm ownership"
+```
+
+## Task 6: Gate Orphan VM Repair By Ownership
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Test: `tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py`
+
+- [ ] **Step 1: Write failing repair tests**
+
+Update existing orphan termination tests to use `owned_orphaned_vm` instead of generic `orphaned_vm` for actual termination.
+
+Add tests:
+
+- `unknown_orphaned_vm` with `terminate_orphaned_vms=True` returns a `skip_orphaned_vm` action and does not call helper
+- `foreign_orphaned_vm` with `terminate_orphaned_vms=True` returns a `skip_orphaned_vm` action and does not call helper
+- legacy `orphaned_vm` without `termination_eligible=True` is skipped, not terminated
+- summary `orphaned_vms` counts owned, unknown, foreign, and legacy orphan statuses
+
+Expected skipped action shape:
+
+```python
+{
+    "type": "skip_orphaned_vm",
+    "session_id": None,
+    "vm_id": "vm-unknown",
+    "status": "skipped",
+    "reason": "unknown_ownership",
+    "termination_eligible": False,
+}
+```
+
+- [ ] **Step 2: Run repair tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py -q
+```
+
+Expected: fail because repair still terminates generic orphan items.
+
+- [ ] **Step 3: Implement ownership-gated repair**
+
+Update `SandboxService.repair_macos_reconciliation()`:
+
+```python
+orphan_statuses = {
+    "owned_orphaned_vm",
+    "unknown_orphaned_vm",
+    "foreign_orphaned_vm",
+    "orphaned_vm",
+}
+orphaned_items = [
+    item for item in report_items
+    if str(item.get("status") or "").strip() in orphan_statuses
+]
+```
+
+For orphan items:
+
+```python
+eligible = status == "owned_orphaned_vm" and bool(item.get("termination_eligible"))
+if status == "orphaned_vm":
+    eligible = bool(item.get("termination_eligible")) and (reason == "owned_orphan")
+if not eligible:
+    if terminate_orphaned_vms and vm_id:
+        actions.append({
+            "type": "skip_orphaned_vm",
+            "session_id": None,
+            "vm_id": vm_id,
+            "status": "skipped",
+            "reason": reason or "unknown_ownership",
+            "termination_eligible": False,
+        })
+    continue
+```
+
+For eligible owned orphans, keep the existing helper-specific exception mapping and add `termination_eligible: True` to termination actions.
+
+- [ ] **Step 4: Run repair tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+git commit -m "fix(sandbox): gate orphan repair by vm ownership"
+```
+
+## Task 7: Update Protocol And Operator Docs
+
+**Files:**
+- Modify: `tools/macos-vz-helper/PROTOCOL.md`
+- Modify: `tools/macos-vz-helper/README.md`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+
+- [ ] **Step 1: Update protocol docs**
+
+Document `create_vm` request ownership fields and include `metadata` in `get_vm_status` and `list_vms` reply examples.
+
+- [ ] **Step 2: Update operator docs**
+
+Clarify:
+
+- orphan termination is explicit and dry-run-first
+- repair only terminates owned `vz_linux` helper VMs
+- unknown/foreign helper VMs are reported and skipped
+- metadata is local helper ownership metadata, not cryptographic proof
+- legacy VMs without metadata may require manual operator cleanup
+
+- [ ] **Step 3: Run docs diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/macos-vz-helper/PROTOCOL.md tools/macos-vz-helper/README.md Docs/Sandbox/macos-runtime-operator-notes.md tldw_Server_API/app/core/Sandbox/README.md
+git commit -m "docs(sandbox): document helper vm ownership gate"
+```
+
+## Task 8: Run Full Focused Verification
+
+**Files:**
+- All touched files from Tasks 1-7.
+
+- [ ] **Step 1: Run Swift helper tests**
+
+Run:
+
+```bash
+swift test --package-path tools/macos-vz-helper
+```
+
+Expected: all Swift helper tests pass.
+
+- [ ] **Step 2: Run focused Python sandbox tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/sandbox/test_macos_helper_client.py \
+  tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py \
+  tldw_Server_API/tests/sandbox/test_vz_reconciliation.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py \
+  tldw_Server_API/tests/sandbox/test_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_runner.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py \
+  -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Run Bandit on touched Python scope**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit \
+  -r tldw_Server_API/app/core/Sandbox/macos_virtualization tldw_Server_API/app/core/Sandbox/vz_reconciliation.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py \
+  -s B101,B106 \
+  -f json \
+  -o /tmp/bandit_vz_helper_vm_ownership_metadata.json
+```
+
+Expected: command exits 0 and reports no findings in touched production code. If Bandit is unavailable in the venv, record that explicitly before finishing.
+
+- [ ] **Step 4: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 5: Run final status check**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate --max-count=8
+```
+
+Expected: branch contains the design, plan, and implementation commits. Worktree is clean except for intentional uncommitted changes if a review checkpoint requires them.
+
+- [ ] **Step 6: Commit plan updates if needed**
+
+If the plan was adjusted during implementation, commit the final plan state:
+
+```bash
+git add Docs/superpowers/plans/2026-04-30-vz-helper-vm-ownership-metadata-implementation-plan.md
+git commit -m "docs(sandbox): update vm ownership metadata plan"
+```
+
+## Review Checkpoints
+
+- After Task 2, review Swift protocol compatibility before moving to Python parsing.
+- After Task 5, review reconciliation output shape against diagnostics tests to avoid breaking admin consumers.
+- After Task 6, review repair behavior carefully: unknown, foreign, and legacy orphan records must not call `terminate_vm`.
+- Before PR creation, run the full focused verification in Task 8 and summarize any host-gated tests not run.

--- a/Docs/superpowers/specs/2026-04-30-vz-helper-vm-ownership-metadata-design.md
+++ b/Docs/superpowers/specs/2026-04-30-vz-helper-vm-ownership-metadata-design.md
@@ -1,0 +1,270 @@
+# VZ Helper VM Ownership Metadata Design
+
+**Date:** 2026-04-30
+**Status:** Draft for implementation planning
+**Scope:** `tools/macos-vz-helper/`, `tldw_Server_API/app/core/Sandbox/`, sandbox tests, and macOS operator docs
+
+## Summary
+
+The next `vz_linux` hardening slice should make helper VM identity explicit before adding more lifecycle automation. The merged orphan-VM repair path can terminate helper VMs when an operator passes `terminate_orphaned_vms=true`, but the helper's live VM records currently expose only `vm_id`, `state`, and `healthy`. That is not enough to distinguish a VM created by this sandbox service from a VM created by another helper user, a stale helper process, or a race during session persistence.
+
+This PR should extend helper VM records with first-party ownership metadata, surface that metadata through the helper protocol and Python client, and tighten reconciliation repair so only owned orphan VMs are eligible for termination. Unknown or foreign orphan VMs should remain report-only.
+
+## Source Documents
+
+- `Docs/Sandbox/sandbox-architecture-doctrine.md`
+- `Docs/superpowers/specs/2026-04-27-vz-linux-lifecycle-recovery-hardening-design.md`
+- `Docs/superpowers/specs/2026-04-29-vz-helper-lifecycle-hardening-design.md`
+- `Docs/superpowers/plans/2026-04-30-vz-orphan-vm-repair-implementation-plan.md`
+- `Docs/Sandbox/macos-runtime-operator-notes.md`
+- `tools/macos-vz-helper/PROTOCOL.md`
+
+The sandbox doctrine keeps Python as the trusted control plane and the helper as the owner of live VM state. This design preserves that boundary: Python supplies identity metadata when creating VMs, and the helper preserves and reports it as live runtime truth.
+
+## Current State
+
+The helper flow is:
+
+- Python calls `MacOSVirtualizationHelperClient.create_vm()` with `vm_name`, `runtime`, `run_id`, and template/workspace paths.
+- `HelperService.createVM()` passes only `vmID`, `templatePath`, `workspacePath`, and readiness timeout to `VZLinuxVMManager`.
+- `VMRegistry.upsert()` stores `VMRecord(vmID, state, healthy)`.
+- `get_vm_status` and `list_vms` return `vm_id`, `state`, `healthy`, and generic transport details.
+- Reconciliation treats any live helper VM whose id is not referenced by persisted session controls as `orphaned_vm`.
+- Repair can terminate every reported orphan when explicitly requested.
+
+That last step is too broad for long-term safety because orphan classification lacks ownership proof.
+
+## Goals
+
+1. Preserve helper VM ownership metadata at VM creation time.
+2. Expose ownership metadata through `get_vm_status` and `list_vms`.
+3. Parse and retain the metadata in Python helper models.
+4. Classify orphan VMs by termination eligibility.
+5. Allow repair to terminate only VMs proven to be owned by this sandbox control plane.
+6. Keep unknown or foreign helper VMs visible but non-mutating.
+7. Keep the protocol backward-compatible within protocol version `1` unless a true breaking field is required.
+
+## Non-Goals
+
+1. Persisting helper VM records across helper restarts.
+2. Making the helper authoritative for sandbox sessions or run history.
+3. Adding launchd install/uninstall behavior.
+4. Adding APFS clone-backed provisioning.
+5. Adding `vz_macos` real execution.
+6. Terminating unknown or foreign orphan VMs.
+7. Introducing cryptographic VM ownership attestation.
+
+## Recommended Approach
+
+Use additive helper metadata fields and conservative repair gating.
+
+The helper should store a `VMOwnershipMetadata` value with each `VMRecord`. Python should provide the metadata during `create_vm`; if a caller omits it, the helper should mark the ownership as `unknown` rather than inventing ownership. Reconciliation should classify live VMs as:
+
+- `owned_orphaned_vm`: helper VM has `owner="tldw"`, `runtime="vz_linux"`, and enough run/session metadata to prove it was created by this sandbox path
+- `unknown_orphaned_vm`: helper VM lacks ownership metadata or has partial legacy metadata
+- `foreign_orphaned_vm`: helper VM has ownership metadata that does not match the expected sandbox owner/runtime
+
+Only `owned_orphaned_vm` is eligible for `terminate_orphaned_vms=true`. The existing `orphaned_vm` summary field can remain as a total for compatibility, but action items should carry the more precise status/reason.
+
+## Metadata Contract
+
+### Helper Request Metadata
+
+`create_vm` should accept these optional fields in the request object:
+
+```json
+{
+  "owner": "tldw",
+  "runtime": "vz_linux",
+  "run_id": "run-123",
+  "session_id": "session-456",
+  "session_mode": true,
+  "template_path": "/path/to/bundle",
+  "workspace_path": "/path/to/workspace"
+}
+```
+
+Rules:
+
+- `owner` defaults to `unknown` when omitted.
+- `runtime` defaults to `vz_linux` only for the existing `create_vm` operation, but reconciliation should still require the explicit returned value before terminating orphans.
+- `run_id` should be the sandbox run id.
+- `session_id` may be empty for ephemeral runs.
+- `session_mode` should be true only when a sandbox session VM is intended for reuse.
+- `template_path` and `workspace_path` should be preserved as strings but should not be used as authority for filesystem access decisions.
+- `created_at` should be assigned by the helper at creation time in UTC ISO-8601 format.
+
+### Helper Response Metadata
+
+`get_vm_status` and `list_vms` should include explicit metadata fields or a nested `metadata` object. Prefer a nested object to keep the top-level status fields stable:
+
+```json
+{
+  "protocol_version": "1",
+  "helper_version": "0.1.0",
+  "vm_id": "run-123",
+  "state": "running",
+  "healthy": true,
+  "metadata": {
+    "owner": "tldw",
+    "runtime": "vz_linux",
+    "run_id": "run-123",
+    "session_id": "session-456",
+    "session_mode": true,
+    "template_path": "/path/to/bundle",
+    "workspace_path": "/path/to/workspace",
+    "created_at": "2026-04-30T18:00:00Z"
+  },
+  "details": {
+    "transport": "vsock"
+  }
+}
+```
+
+Python should tolerate both the new nested `metadata` object and older helper responses with no metadata. Missing metadata must not be treated as owned.
+
+## Reconciliation Behavior
+
+Reconciliation should keep existing persisted-session checks intact:
+
+- healthy persisted sessions remain `healthy`
+- missing persisted VMs remain `stale_session`
+- unhealthy persisted VMs remain `unhealthy_vm`
+- active sessions remain `skipped_active_session`
+
+For live VMs not referenced by persisted session-control rows:
+
+- return `owned_orphaned_vm` when metadata proves `owner=tldw` and `runtime=vz_linux`
+- return `foreign_orphaned_vm` when metadata exists but owner/runtime does not match
+- return `unknown_orphaned_vm` when metadata is absent or incomplete
+
+The report should include:
+
+- `orphaned_vm_ids`: all orphan VM ids for compatibility
+- `owned_orphaned_vm_ids`
+- `unknown_orphaned_vm_ids`
+- `foreign_orphaned_vm_ids`
+
+Each item should carry a `termination_eligible` boolean and a reason string, such as `owned_orphan`, `unknown_ownership`, or `foreign_owner`.
+
+## Repair Behavior
+
+`terminate_orphaned_vms=true` should:
+
+- plan termination actions only for `owned_orphaned_vm`
+- execute termination only for `owned_orphaned_vm` when `dry_run=false`
+- report unknown and foreign orphan VMs as skipped actions
+- preserve helper-specific failure reasons from `terminate_vm`
+- keep dry-run as the default
+
+Recommended action examples:
+
+```json
+{
+  "type": "terminate_orphaned_vm",
+  "vm_id": "run-owned",
+  "status": "planned",
+  "reason": "owned_orphan",
+  "termination_eligible": true
+}
+```
+
+```json
+{
+  "type": "skip_orphaned_vm",
+  "vm_id": "vm-unknown",
+  "status": "skipped",
+  "reason": "unknown_ownership",
+  "termination_eligible": false
+}
+```
+
+## Protocol Compatibility
+
+This can remain an additive protocol-version-`1` change if:
+
+- existing clients ignore unknown helper response fields
+- Python parser treats missing metadata as unknown
+- helper tests cover old response parsing behavior
+
+If the Swift helper needs to reject malformed metadata, it should reject only invalid types that would make VM creation ambiguous. Missing metadata should be allowed for compatibility but should produce `owner=unknown`.
+
+## Error Handling
+
+Use explicit reason strings:
+
+- `owned_orphan`
+- `unknown_ownership`
+- `foreign_owner`
+- `vm_metadata_invalid`
+- `macos_virtualization_helper_unavailable`
+- `macos_virtualization_helper_protocol_mismatch`
+- helper-specific `MacOSVirtualizationHelperFailure.error_code`
+
+Repair should not turn metadata ambiguity into a hard failure. It should skip ambiguous orphan termination and include the reason in the response.
+
+## Testing Strategy
+
+### Swift Helper Tests
+
+- `VMRegistry` stores and returns metadata.
+- `HelperService.createVM()` records metadata from request fields.
+- `get_vm_status` includes metadata for created VMs.
+- `list_vms` includes metadata for every record.
+- missing metadata defaults to unknown ownership.
+
+### Python Helper Model Tests
+
+- parser reads nested VM metadata.
+- parser tolerates missing metadata.
+- parser coerces malformed metadata to empty or unknown values without marking ownership as trusted.
+
+### Reconciliation Tests
+
+- owned orphan is classified as `owned_orphaned_vm` and termination eligible.
+- unknown orphan is classified as `unknown_orphaned_vm` and not termination eligible.
+- foreign orphan is classified as `foreign_orphaned_vm` and not termination eligible.
+- existing healthy/stale/unhealthy persisted-session behavior is unchanged.
+
+### Repair Tests
+
+- dry-run plans termination for owned orphan VMs only.
+- mutating repair calls `terminate_vm` for owned orphan VMs only.
+- unknown and foreign orphan VMs produce skipped actions.
+- helper termination errors preserve specific reason codes.
+
+### Docs Tests
+
+No dedicated docs test is required, but docs should be updated with the new ownership gate and reviewed via `git diff --check`.
+
+## Design Review
+
+### Issue: Metadata Can Be Spoofed By A Direct Helper Caller
+
+The helper currently trusts local socket clients. Metadata proves that a VM was created through the helper with tldw-shaped metadata, not that the caller was authenticated. This is acceptable for this slice only because the lifecycle hardening work already makes the helper socket owner-private. The docs should avoid calling this cryptographic proof.
+
+### Issue: Existing Legacy VMs Will Lack Metadata
+
+Legacy helper VMs created before this PR should be reported as `unknown_orphaned_vm` and skipped by repair. Operators can still inspect and terminate them manually through lower-level tools if needed.
+
+### Issue: Session Persist Race Could Temporarily Look Like An Orphan
+
+A newly created session VM could appear in `list_vms()` before Python persists session-control metadata. Classification as owned orphan should not imply automatic termination. Since repair is explicit and dry-run-first, this is acceptable. Docs should tell operators to re-run diagnostics before mutating repair if a run is in progress.
+
+### Issue: Template And Workspace Paths Are Sensitive
+
+Returning full paths improves diagnostics but may expose local filesystem layout to admin API users. The existing diagnostics endpoint is admin-only. Still, docs and tests should avoid treating these paths as secrets, and future API redaction can be added if admin surface scope changes.
+
+### Issue: Protocol Version Drift
+
+Because this is additive, keeping protocol version `1` is reasonable. If later clients require metadata for normal execution, that should become protocol version `2`. This slice only requires metadata for orphan termination eligibility.
+
+## Success Criteria
+
+- Helper VM records expose ownership metadata through status and list calls.
+- Python reconciliation distinguishes owned, unknown, and foreign orphan VMs.
+- Explicit orphan repair terminates only owned orphan VMs.
+- Unknown and foreign orphan VMs remain visible and skipped.
+- Existing session reuse and stale-session repair behavior remains unchanged.
+- Portable Swift and Python tests cover the metadata contract.
+- Operator docs describe the ownership gate and avoid overstating proof strength.

--- a/Docs/superpowers/specs/2026-04-30-vz-helper-vm-ownership-metadata-design.md
+++ b/Docs/superpowers/specs/2026-04-30-vz-helper-vm-ownership-metadata-design.md
@@ -25,7 +25,7 @@ The sandbox doctrine keeps Python as the trusted control plane and the helper as
 
 The helper flow is:
 
-- Python calls `MacOSVirtualizationHelperClient.create_vm()` with `vm_name`, `runtime`, `run_id`, and template/workspace paths.
+- Python calls `MacOSVirtualizationHelperClient.create_vm()` with `vm_name`, `runtime`, `run_id`, `session_mode`, `workspace_path`, and the template source under the existing `template` key.
 - `HelperService.createVM()` passes only `vmID`, `templatePath`, `workspacePath`, and readiness timeout to `VZLinuxVMManager`.
 - `VMRegistry.upsert()` stores `VMRecord(vmID, state, healthy)`.
 - `get_vm_status` and `list_vms` return `vm_id`, `state`, `healthy`, and generic transport details.
@@ -58,13 +58,34 @@ That last step is too broad for long-term safety because orphan classification l
 
 Use additive helper metadata fields and conservative repair gating.
 
-The helper should store a `VMOwnershipMetadata` value with each `VMRecord`. Python should provide the metadata during `create_vm`; if a caller omits it, the helper should mark the ownership as `unknown` rather than inventing ownership. Reconciliation should classify live VMs as:
+The helper should store a `VMOwnershipMetadata` value with each `VMRecord`. Python should provide the metadata during `create_vm`; if a caller omits it, the helper should mark the ownership as `unknown` rather than inventing ownership. `VMRegistry.upsert()` must preserve existing metadata across state transitions unless explicit replacement metadata is supplied, because `VZLinuxVMManager.createVM()` currently writes `booting` and then `running` records.
 
-- `owned_orphaned_vm`: helper VM has `owner="tldw"`, `runtime="vz_linux"`, and enough run/session metadata to prove it was created by this sandbox path
+Reconciliation should classify live VMs as:
+
+- `owned_orphaned_vm`: helper VM satisfies the exact ownership eligibility contract below
 - `unknown_orphaned_vm`: helper VM lacks ownership metadata or has partial legacy metadata
 - `foreign_orphaned_vm`: helper VM has ownership metadata that does not match the expected sandbox owner/runtime
 
 Only `owned_orphaned_vm` is eligible for `terminate_orphaned_vms=true`. The existing `orphaned_vm` summary field can remain as a total for compatibility, but action items should carry the more precise status/reason.
+
+### Ownership Eligibility Contract
+
+A live helper VM is termination-eligible only when all of these conditions are true:
+
+- `metadata.owner == "tldw"`
+- `metadata.runtime == "vz_linux"`
+- `metadata.run_id` is non-empty
+- `metadata.created_at` is non-empty and parseable enough to display as helper-created metadata
+- when `metadata.session_mode == true`, `metadata.session_id` is non-empty
+
+Everything else must be non-eligible:
+
+- missing metadata -> `unknown_orphaned_vm`
+- missing `run_id` or `created_at` -> `unknown_orphaned_vm`
+- session-mode VM with no `session_id` -> `unknown_orphaned_vm`
+- owner/runtime mismatch -> `foreign_orphaned_vm`
+
+The first implementation should not require `vm_id == run_id` because the helper protocol already allows callers to choose `vm_name`, but docs should note that the current `vz_linux` runner uses `run_id` as `vm_name`.
 
 ## Metadata Contract
 
@@ -79,7 +100,7 @@ Only `owned_orphaned_vm` is eligible for `terminate_orphaned_vms=true`. The exis
   "run_id": "run-123",
   "session_id": "session-456",
   "session_mode": true,
-  "template_path": "/path/to/bundle",
+  "template": "/path/to/bundle",
   "workspace_path": "/path/to/workspace"
 }
 ```
@@ -91,8 +112,10 @@ Rules:
 - `run_id` should be the sandbox run id.
 - `session_id` may be empty for ephemeral runs.
 - `session_mode` should be true only when a sandbox session VM is intended for reuse.
+- the helper should continue accepting the existing `template` key and may also accept `template_path` as an alias; response metadata should normalize this value as `template_path`.
 - `template_path` and `workspace_path` should be preserved as strings but should not be used as authority for filesystem access decisions.
 - `created_at` should be assigned by the helper at creation time in UTC ISO-8601 format.
+- Python's `vz_linux` runner must add `owner="tldw"` and `session_id` to the existing `create_vm` request. It should keep sending `template` for compatibility with the current helper request parser.
 
 ### Helper Response Metadata
 
@@ -146,6 +169,8 @@ The report should include:
 - `foreign_orphaned_vm_ids`
 
 Each item should carry a `termination_eligible` boolean and a reason string, such as `owned_orphan`, `unknown_ownership`, or `foreign_owner`.
+
+Compatibility note: any existing code that counts `status == "orphaned_vm"` must be updated to count all three precise orphan statuses. The aggregate `orphaned_vm_ids` list should remain the complete set of owned, unknown, and foreign orphan VM ids.
 
 ## Repair Behavior
 
@@ -208,7 +233,9 @@ Repair should not turn metadata ambiguity into a hard failure. It should skip am
 ### Swift Helper Tests
 
 - `VMRegistry` stores and returns metadata.
+- `VMRegistry.upsert()` preserves metadata when state/health is updated without replacement metadata.
 - `HelperService.createVM()` records metadata from request fields.
+- `UnixSocketServer` forwards `owner`, `runtime`, `run_id`, `session_id`, `session_mode`, `template`, and `workspace_path` into `HelperService.createVM()`.
 - `get_vm_status` includes metadata for created VMs.
 - `list_vms` includes metadata for every record.
 - missing metadata defaults to unknown ownership.
@@ -224,7 +251,9 @@ Repair should not turn metadata ambiguity into a hard failure. It should skip am
 - owned orphan is classified as `owned_orphaned_vm` and termination eligible.
 - unknown orphan is classified as `unknown_orphaned_vm` and not termination eligible.
 - foreign orphan is classified as `foreign_orphaned_vm` and not termination eligible.
+- partial tldw metadata missing `run_id`, `created_at`, or session `session_id` is not termination eligible.
 - existing healthy/stale/unhealthy persisted-session behavior is unchanged.
+- orphan summary counts include owned, unknown, and foreign orphan statuses.
 
 ### Repair Tests
 

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -364,6 +364,7 @@ class SandboxAdminMacOSReconciliationRepairAction(BaseModel):
     vm_id: str | None = None
     status: str
     reason: str | None = None
+    termination_eligible: bool | None = None
 
 
 class SandboxAdminMacOSReconciliationRepairSummary(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -320,6 +320,7 @@ class SandboxAdminMacOSReconciliationItem(BaseModel):
     state: str | None = None
     healthy: bool | None = None
     reason: str | None = None
+    termination_eligible: bool | None = None
 
 
 class SandboxAdminMacOSReconciliationDiagnostics(BaseModel):
@@ -333,6 +334,9 @@ class SandboxAdminMacOSReconciliationDiagnostics(BaseModel):
     unhealthy_session_ids: list[str] = Field(default_factory=list)
     skipped_active_session_ids: list[str] = Field(default_factory=list)
     orphaned_vm_ids: list[str] = Field(default_factory=list)
+    owned_orphaned_vm_ids: list[str] = Field(default_factory=list)
+    unknown_orphaned_vm_ids: list[str] = Field(default_factory=list)
+    foreign_orphaned_vm_ids: list[str] = Field(default_factory=list)
     items: list[SandboxAdminMacOSReconciliationItem] = Field(default_factory=list)
     reasons: list[str] = Field(default_factory=list)
 

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -66,7 +66,8 @@ Current limitations:
 - `vz_linux` supports session VM reuse through persisted VZ session-control metadata; `vz_macos` does not.
 - `vz_linux` admin diagnostics include reconciliation data comparing persisted VZ session-control rows against live helper VM state.
 - `vz_linux` repair is explicit and admin-only through `POST /api/v1/sandbox/admin/macos-reconciliation/repair`; diagnostics do not mutate state.
-- `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and can terminate orphan helper VMs only when `terminate_orphaned_vms=true` is explicitly requested.
+- `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and can terminate orphan helper VMs only when `terminate_orphaned_vms=true` is explicitly requested and helper metadata proves `owner=tldw` plus `runtime=vz_linux`.
+- `vz_linux` orphan VM diagnostics split live unreferenced helper VMs into `owned_orphaned_vm`, `unknown_orphaned_vm`, and `foreign_orphaned_vm`; unknown, foreign, and legacy generic orphan records are reported but skipped by automated repair.
 - Helper unavailable or protocol mismatch conditions fail closed and block mutating repair.
 - Orphan VM termination is not automatic repair behavior; operators should inspect the dry-run plan before running mutating repair.
 - `tools/macos-vz-helper/scripts/vz-helperctl.py` is the preferred operator helper lifecycle command for `check`, `build`, `sign`, `start`, `status`, `stop`, `plist`, and `smoke`; it can generate launchd plist scaffolding but does not install or load services automatically.
@@ -109,7 +110,8 @@ included in the public discovery payload, plus reconciliation data for persisted
 admin-only repair surface. Repair defaults to dry-run, skips active sessions,
 can delete stale or unhealthy inactive persisted session-control rows when
 requested, and can terminate orphan helper VMs only when
-`terminate_orphaned_vms=true` is explicitly requested.
+`terminate_orphaned_vms=true` is explicitly requested and the reconciliation item
+is ownership-eligible.
 
 Selected configuration knobs:
 

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -66,8 +66,8 @@ Current limitations:
 - `vz_linux` supports session VM reuse through persisted VZ session-control metadata; `vz_macos` does not.
 - `vz_linux` admin diagnostics include reconciliation data comparing persisted VZ session-control rows against live helper VM state.
 - `vz_linux` repair is explicit and admin-only through `POST /api/v1/sandbox/admin/macos-reconciliation/repair`; diagnostics do not mutate state.
-- `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and can terminate orphan helper VMs only when `terminate_orphaned_vms=true` is explicitly requested and helper metadata proves `owner=tldw` plus `runtime=vz_linux`.
-- `vz_linux` orphan VM diagnostics split live unreferenced helper VMs into `owned_orphaned_vm`, `unknown_orphaned_vm`, and `foreign_orphaned_vm`; unknown, foreign, and legacy generic orphan records are reported but skipped by automated repair.
+- `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and can terminate orphan helper VMs only when `terminate_orphaned_vms=true` is explicitly requested, helper metadata proves `owner=tldw` and `runtime=vz_linux`, and the ownership record remains eligibility-complete. Eligibility-complete means `run_id` and `created_at` are present, and `session_id` is also present when `session_mode=true`.
+- `vz_linux` orphan VM diagnostics split live unreferenced helper VMs into `owned_orphaned_vm`, `unknown_orphaned_vm`, and `foreign_orphaned_vm`. Only ownership-eligible `owned_orphaned_vm` records can be terminated automatically; unknown, foreign, and legacy generic orphan records are reported but skipped by automated repair.
 - Helper unavailable or protocol mismatch conditions fail closed and block mutating repair.
 - Orphan VM termination is not automatic repair behavior; operators should inspect the dry-run plan before running mutating repair.
 - `tools/macos-vz-helper/scripts/vz-helperctl.py` is the preferred operator helper lifecycle command for `check`, `build`, `sign`, `start`, `status`, `stop`, `plist`, and `smoke`; it can generate launchd plist scaffolding but does not install or load services automatically.
@@ -111,7 +111,9 @@ admin-only repair surface. Repair defaults to dry-run, skips active sessions,
 can delete stale or unhealthy inactive persisted session-control rows when
 requested, and can terminate orphan helper VMs only when
 `terminate_orphaned_vms=true` is explicitly requested and the reconciliation item
-is ownership-eligible.
+is ownership-eligible. Ownership-eligible means helper metadata proves
+`owner=tldw`, `runtime=vz_linux`, a non-empty `run_id`, a non-empty
+`created_at`, and a non-empty `session_id` when `session_mode=true`.
 
 Selected configuration knobs:
 

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -17,6 +17,7 @@ from .models import (
     parse_helper_host_validation,
     parse_helper_ping,
     parse_helper_vm_list,
+    parse_helper_vm_reply,
     parse_helper_vm_status,
 )
 
@@ -88,17 +89,26 @@ class MacOSVirtualizationHelperClient:
         if is_truthy(os.getenv("TEST_MODE")):
             vm_name = str(request.get("vm_name") or "").strip() or "vm-test"
             runtime = str(request.get("runtime") or "").strip()
-            return HelperVMReply(
-                vm_id=vm_name,
-                state="created",
-                details={"runtime": runtime or None, "transport": "vsock"},
+            template_path = str(request.get("template") or request.get("template_path") or "").strip()
+            return parse_helper_vm_reply(
+                {
+                    "vm_id": vm_name,
+                    "state": "created",
+                    "metadata": {
+                        "owner": request.get("owner") or "unknown",
+                        "runtime": runtime,
+                        "run_id": request.get("run_id") or "",
+                        "session_id": request.get("session_id") or "",
+                        "session_mode": bool(request.get("session_mode")),
+                        "template_path": template_path,
+                        "workspace_path": request.get("workspace_path") or "",
+                        "created_at": request.get("created_at") or "",
+                    },
+                    "details": {"runtime": runtime or None, "transport": "vsock"},
+                }
             )
         payload = self._request("create_vm", request, timeout_sec=self._operation_timeout_sec(request))
-        return HelperVMReply(
-            vm_id=str(payload.get("vm_id") or "").strip(),
-            state=str(payload.get("state") or "").strip(),
-            details=dict(payload.get("details") or {}) if isinstance(payload.get("details"), dict) else {},
-        )
+        return parse_helper_vm_reply(payload)
 
     def validate_vz_linux_host(self, request: dict[str, Any]) -> dict[str, Any]:
         if is_truthy(os.getenv("TEST_MODE")):

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import socket
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,7 @@ from .models import (
     HelperVMListReply,
     HelperVMReply,
     HelperVMStatusReply,
+    _bool_field,
     parse_helper_host_validation,
     parse_helper_ping,
     parse_helper_vm_list,
@@ -88,8 +90,11 @@ class MacOSVirtualizationHelperClient:
     def create_vm(self, request: dict[str, Any]) -> HelperVMReply:
         if is_truthy(os.getenv("TEST_MODE")):
             vm_name = str(request.get("vm_name") or "").strip() or "vm-test"
-            runtime = str(request.get("runtime") or "").strip()
+            runtime = str(request.get("runtime") or "").strip() or "vz_linux"
             template_path = str(request.get("template") or request.get("template_path") or "").strip()
+            raw_session_mode = request.get("session_mode")
+            session_mode = _bool_field({"session_mode": raw_session_mode}, "session_mode")
+            created_at = str(request.get("created_at") or "").strip() or datetime.now(timezone.utc).isoformat()
             return parse_helper_vm_reply(
                 {
                     "vm_id": vm_name,
@@ -99,10 +104,10 @@ class MacOSVirtualizationHelperClient:
                         "runtime": runtime,
                         "run_id": request.get("run_id") or "",
                         "session_id": request.get("session_id") or "",
-                        "session_mode": bool(request.get("session_mode")),
+                        "session_mode": session_mode,
                         "template_path": template_path,
                         "workspace_path": request.get("workspace_path") or "",
-                        "created_at": request.get("created_at") or "",
+                        "created_at": created_at,
                     },
                     "details": {"runtime": runtime or None, "transport": "vsock"},
                 }

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py
@@ -15,6 +15,10 @@ def _bool_field(payload: dict[str, Any], key: str, default: bool = False) -> boo
     value = payload.get(key)
     if value is None:
         return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
 
 
@@ -33,9 +37,42 @@ def _list_field(payload: dict[str, Any], key: str) -> list[str]:
 
 
 @dataclass(slots=True)
+class HelperVMMetadata:
+    owner: str = "unknown"
+    runtime: str = ""
+    run_id: str = ""
+    session_id: str = ""
+    session_mode: bool = False
+    template_path: str = ""
+    workspace_path: str = ""
+    created_at: str = ""
+
+    @property
+    def has_tldw_owner(self) -> bool:
+        return self.owner == "tldw" and self.runtime == "vz_linux"
+
+
+def _metadata_field(payload: dict[str, Any]) -> HelperVMMetadata:
+    raw = payload.get("metadata")
+    if not isinstance(raw, dict):
+        return HelperVMMetadata()
+    return HelperVMMetadata(
+        owner=_str_field(raw, "owner", "unknown").strip() or "unknown",
+        runtime=_str_field(raw, "runtime").strip(),
+        run_id=_str_field(raw, "run_id").strip(),
+        session_id=_str_field(raw, "session_id").strip(),
+        session_mode=_bool_field(raw, "session_mode"),
+        template_path=_str_field(raw, "template_path").strip(),
+        workspace_path=_str_field(raw, "workspace_path").strip(),
+        created_at=_str_field(raw, "created_at").strip(),
+    )
+
+
+@dataclass(slots=True)
 class HelperVMReply:
     vm_id: str
     state: str
+    metadata: HelperVMMetadata = field(default_factory=HelperVMMetadata)
     details: dict[str, Any] = field(default_factory=dict)
 
 
@@ -73,6 +110,7 @@ class HelperVMStatusReply:
     vm_id: str
     state: str
     healthy: bool
+    metadata: HelperVMMetadata = field(default_factory=HelperVMMetadata)
     details: dict[str, Any] = field(default_factory=dict)
 
 
@@ -107,6 +145,15 @@ def parse_helper_host_validation(payload: dict[str, Any]) -> HelperHostValidatio
     )
 
 
+def parse_helper_vm_reply(payload: dict[str, Any]) -> HelperVMReply:
+    return HelperVMReply(
+        vm_id=_str_field(payload, "vm_id").strip(),
+        state=_str_field(payload, "state").strip(),
+        metadata=_metadata_field(payload),
+        details=_dict_field(payload),
+    )
+
+
 def parse_helper_vm_status(payload: dict[str, Any]) -> HelperVMStatusReply:
     return HelperVMStatusReply(
         protocol_version=_str_field(payload, "protocol_version"),
@@ -114,6 +161,7 @@ def parse_helper_vm_status(payload: dict[str, Any]) -> HelperVMStatusReply:
         vm_id=_str_field(payload, "vm_id"),
         state=_str_field(payload, "state"),
         healthy=_bool_field(payload, "healthy"),
+        metadata=_metadata_field(payload),
         details=_dict_field(payload),
     )
 

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py
@@ -5,21 +5,29 @@ from typing import Any
 
 
 def _str_field(payload: dict[str, Any], key: str, default: str = "") -> str:
+    """Return a string field only when the payload value is already a string."""
     value = payload.get(key)
     if value is None:
         return default
-    return str(value)
+    if isinstance(value, str):
+        return value
+    return default
 
 
 def _bool_field(payload: dict[str, Any], key: str, default: bool = False) -> bool:
+    """Parse helper booleans without promoting malformed values to trusted truthy values."""
     value = payload.get(key)
     if value is None:
         return default
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return default
 
 
 def _dict_field(payload: dict[str, Any], key: str = "details") -> dict[str, Any]:
@@ -38,6 +46,8 @@ def _list_field(payload: dict[str, Any], key: str) -> list[str]:
 
 @dataclass(slots=True)
 class HelperVMMetadata:
+    """Ownership metadata returned by the helper for a live VM record."""
+
     owner: str = "unknown"
     runtime: str = ""
     run_id: str = ""
@@ -53,8 +63,25 @@ class HelperVMMetadata:
 
 
 def _metadata_field(payload: dict[str, Any]) -> HelperVMMetadata:
+    """Parse helper VM metadata, downgrading malformed payloads to unknown ownership."""
     raw = payload.get("metadata")
     if not isinstance(raw, dict):
+        return HelperVMMetadata()
+    string_keys = (
+        "owner",
+        "runtime",
+        "run_id",
+        "session_id",
+        "template_path",
+        "workspace_path",
+        "created_at",
+    )
+    for key in string_keys:
+        value = raw.get(key)
+        if value is not None and not isinstance(value, str):
+            return HelperVMMetadata()
+    session_mode_value = raw.get("session_mode")
+    if session_mode_value is not None and not isinstance(session_mode_value, (bool, str)):
         return HelperVMMetadata()
     return HelperVMMetadata(
         owner=_str_field(raw, "owner", "unknown").strip() or "unknown",
@@ -146,6 +173,7 @@ def parse_helper_host_validation(payload: dict[str, Any]) -> HelperHostValidatio
 
 
 def parse_helper_vm_reply(payload: dict[str, Any]) -> HelperVMReply:
+    """Parse a `create_vm` helper reply into the normalized Python response model."""
     return HelperVMReply(
         vm_id=_str_field(payload, "vm_id").strip(),
         state=_str_field(payload, "state").strip(),

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -309,9 +309,11 @@ class VZLinuxRunner(VZBaseRunner):
                 template_source = str(template_validation.get("source") or "").strip() or spec.base_image
                 vm = helper.create_vm(
                     {
+                        "owner": "tldw",
                         "runtime": self.runtime_type.value,
                         "vm_name": run_id,
                         "run_id": run_id,
+                        "session_id": str(spec.session_id or "").strip(),
                         "session_mode": session_mode,
                         "workspace_path": workspace,
                         "workspace_mount": "virtiofs",

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -1032,7 +1032,15 @@ class SandboxService:
         stale_items = [item for item in report_items if str(item.get("status") or "").strip() == "stale_session"]
         unhealthy_items = [item for item in report_items if str(item.get("status") or "").strip() == "unhealthy_vm"]
         skipped_items = [item for item in report_items if str(item.get("status") or "").strip() == "skipped_active_session"]
-        orphaned_items = [item for item in report_items if str(item.get("status") or "").strip() == "orphaned_vm"]
+        orphan_statuses = {
+            "owned_orphaned_vm",
+            "unknown_orphaned_vm",
+            "foreign_orphaned_vm",
+            "orphaned_vm",
+        }
+        orphaned_items = [
+            item for item in report_items if str(item.get("status") or "").strip() in orphan_statuses
+        ]
         actions: list[dict[str, object]] = []
         summary: dict[str, int] = {
             "stale_session_controls": len(stale_items),
@@ -1062,8 +1070,24 @@ class SandboxService:
                 actions.append(action)
                 continue
 
-            if status == "orphaned_vm":
+            if status in orphan_statuses:
                 if not terminate_orphaned_vms or not vm_id:
+                    continue
+
+                termination_eligible = status == "owned_orphaned_vm" and bool(item.get("termination_eligible"))
+                if status == "orphaned_vm":
+                    termination_eligible = bool(item.get("termination_eligible")) and reason == "owned_orphan"
+                if not termination_eligible:
+                    action = {
+                        "type": "skip_orphaned_vm",
+                        "session_id": None,
+                        "vm_id": vm_id,
+                        "status": "skipped",
+                        "reason": reason or "unknown_ownership",
+                        "termination_eligible": False,
+                    }
+                    logger.info("Skipping VZ reconciliation orphan repair action: {}", action)
+                    actions.append(action)
                     continue
 
                 action_status = "planned"
@@ -1102,6 +1126,7 @@ class SandboxService:
                     "vm_id": vm_id,
                     "status": action_status,
                     "reason": reason or None,
+                    "termination_eligible": True,
                 }
                 logger.info("VZ reconciliation repair action: {}", action)
                 actions.append(action)

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -58,6 +58,7 @@ from .snapshots import SnapshotManager
 from .store import get_store_mode
 from .streams import get_hub
 from .vz_reconciliation import collect_vz_reconciliation
+from .vz_reconciliation import ORPHAN_STATUSES, REASON_OWNED_ORPHAN, REASON_UNKNOWN_OWNERSHIP, STATUS_OWNED_ORPHAN
 
 _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -1032,14 +1033,8 @@ class SandboxService:
         stale_items = [item for item in report_items if str(item.get("status") or "").strip() == "stale_session"]
         unhealthy_items = [item for item in report_items if str(item.get("status") or "").strip() == "unhealthy_vm"]
         skipped_items = [item for item in report_items if str(item.get("status") or "").strip() == "skipped_active_session"]
-        orphan_statuses = {
-            "owned_orphaned_vm",
-            "unknown_orphaned_vm",
-            "foreign_orphaned_vm",
-            "orphaned_vm",
-        }
         orphaned_items = [
-            item for item in report_items if str(item.get("status") or "").strip() in orphan_statuses
+            item for item in report_items if str(item.get("status") or "").strip() in ORPHAN_STATUSES
         ]
         actions: list[dict[str, object]] = []
         summary: dict[str, int] = {
@@ -1070,20 +1065,21 @@ class SandboxService:
                 actions.append(action)
                 continue
 
-            if status in orphan_statuses:
+            if status in ORPHAN_STATUSES:
                 if not terminate_orphaned_vms or not vm_id:
                     continue
 
-                termination_eligible = status == "owned_orphaned_vm" and bool(item.get("termination_eligible"))
-                if status == "orphaned_vm":
-                    termination_eligible = bool(item.get("termination_eligible")) and reason == "owned_orphan"
+                termination_eligible = (
+                    (status == STATUS_OWNED_ORPHAN and bool(item.get("termination_eligible")))
+                    or (status == "orphaned_vm" and bool(item.get("termination_eligible")) and reason == REASON_OWNED_ORPHAN)
+                )
                 if not termination_eligible:
                     action = {
                         "type": "skip_orphaned_vm",
                         "session_id": None,
                         "vm_id": vm_id,
                         "status": "skipped",
-                        "reason": reason or "unknown_ownership",
+                        "reason": reason or REASON_UNKNOWN_OWNERSHIP,
                         "termination_eligible": False,
                     }
                     logger.info("Skipping VZ reconciliation orphan repair action: {}", action)

--- a/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
+++ b/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
@@ -16,6 +16,12 @@ REASON_HELPER_UNAVAILABLE = "macos_virtualization_helper_unavailable"
 REASON_PROTOCOL_MISMATCH = "macos_virtualization_helper_protocol_mismatch"
 REASON_HELPER_FAILURE = "macos_virtualization_helper_failure"
 REASON_RECONCILIATION_UNAVAILABLE = "vz_reconciliation_unavailable"
+STATUS_OWNED_ORPHAN = "owned_orphaned_vm"
+STATUS_UNKNOWN_ORPHAN = "unknown_orphaned_vm"
+STATUS_FOREIGN_ORPHAN = "foreign_orphaned_vm"
+REASON_OWNED_ORPHAN = "owned_orphan"
+REASON_UNKNOWN_OWNERSHIP = "unknown_ownership"
+REASON_FOREIGN_OWNER = "foreign_owner"
 
 
 def _empty_report() -> dict[str, object]:
@@ -28,6 +34,9 @@ def _empty_report() -> dict[str, object]:
         "unhealthy_session_ids": [],
         "skipped_active_session_ids": [],
         "orphaned_vm_ids": [],
+        "owned_orphaned_vm_ids": [],
+        "unknown_orphaned_vm_ids": [],
+        "foreign_orphaned_vm_ids": [],
         "items": [],
         "reasons": [],
     }
@@ -46,6 +55,7 @@ def _append_item(
     state: str | None = None,
     healthy: bool | None = None,
     reason: str | None = None,
+    termination_eligible: bool | None = None,
 ) -> None:
     item: dict[str, object] = {"status": status}
     if session_id:
@@ -58,6 +68,8 @@ def _append_item(
         item["healthy"] = bool(healthy)
     if reason:
         item["reason"] = reason
+    if termination_eligible is not None:
+        item["termination_eligible"] = bool(termination_eligible)
     items.append(item)
 
 
@@ -70,6 +82,24 @@ def _sort_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
             str(item.get("vm_id") or ""),
         ),
     )
+
+
+def _classify_orphan_vm(vm: object) -> tuple[str, bool, str]:
+    metadata = getattr(vm, "metadata", None)
+    owner = _clean_id(getattr(metadata, "owner", ""))
+    runtime = _clean_id(getattr(metadata, "runtime", ""))
+    if not owner or owner == "unknown" or not runtime:
+        return STATUS_UNKNOWN_ORPHAN, False, REASON_UNKNOWN_OWNERSHIP
+    if owner != "tldw" or runtime != "vz_linux":
+        return STATUS_FOREIGN_ORPHAN, False, REASON_FOREIGN_OWNER
+
+    run_id = _clean_id(getattr(metadata, "run_id", ""))
+    created_at = _clean_id(getattr(metadata, "created_at", ""))
+    session_mode = bool(getattr(metadata, "session_mode", False))
+    session_id = _clean_id(getattr(metadata, "session_id", ""))
+    if not run_id or not created_at or (session_mode and not session_id):
+        return STATUS_UNKNOWN_ORPHAN, False, REASON_UNKNOWN_OWNERSHIP
+    return STATUS_OWNED_ORPHAN, True, REASON_OWNED_ORPHAN
 
 
 def collect_vz_reconciliation(
@@ -138,6 +168,9 @@ def collect_vz_reconciliation(
     unhealthy_session_ids: list[str] = []
     skipped_active_session_ids: list[str] = []
     orphaned_vm_ids: list[str] = []
+    owned_orphaned_vm_ids: list[str] = []
+    unknown_orphaned_vm_ids: list[str] = []
+    foreign_orphaned_vm_ids: list[str] = []
     items: list[dict[str, object]] = []
 
     for session_id, vm_id in persisted_vm_by_session.items():
@@ -205,14 +238,22 @@ def collect_vz_reconciliation(
     for vm_id, vm in live_vm_by_id.items():
         if vm_id in persisted_vm_ids:
             continue
+        status, termination_eligible, reason = _classify_orphan_vm(vm)
         orphaned_vm_ids.append(vm_id)
+        if status == STATUS_OWNED_ORPHAN:
+            owned_orphaned_vm_ids.append(vm_id)
+        elif status == STATUS_FOREIGN_ORPHAN:
+            foreign_orphaned_vm_ids.append(vm_id)
+        else:
+            unknown_orphaned_vm_ids.append(vm_id)
         _append_item(
             items,
-            status="orphaned_vm",
+            status=status,
             vm_id=vm_id,
             state=_clean_id(getattr(vm, "state", "")),
             healthy=bool(getattr(vm, "healthy", False)),
-            reason="session_missing",
+            reason=reason,
+            termination_eligible=termination_eligible,
         )
 
     report["computed"] = True
@@ -222,5 +263,8 @@ def collect_vz_reconciliation(
     report["unhealthy_session_ids"] = sorted(unhealthy_session_ids)
     report["skipped_active_session_ids"] = sorted(skipped_active_session_ids)
     report["orphaned_vm_ids"] = sorted(orphaned_vm_ids)
+    report["owned_orphaned_vm_ids"] = sorted(owned_orphaned_vm_ids)
+    report["unknown_orphaned_vm_ids"] = sorted(unknown_orphaned_vm_ids)
+    report["foreign_orphaned_vm_ids"] = sorted(foreign_orphaned_vm_ids)
     report["items"] = _sort_items(items)
     return report

--- a/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
+++ b/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
@@ -22,6 +22,12 @@ STATUS_FOREIGN_ORPHAN = "foreign_orphaned_vm"
 REASON_OWNED_ORPHAN = "owned_orphan"
 REASON_UNKNOWN_OWNERSHIP = "unknown_ownership"
 REASON_FOREIGN_OWNER = "foreign_owner"
+ORPHAN_STATUSES = {
+    STATUS_OWNED_ORPHAN,
+    STATUS_UNKNOWN_ORPHAN,
+    STATUS_FOREIGN_ORPHAN,
+    "orphaned_vm",
+}
 
 
 def _empty_report() -> dict[str, object]:
@@ -85,6 +91,7 @@ def _sort_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
 
 
 def _classify_orphan_vm(vm: object) -> tuple[str, bool, str]:
+    """Return orphan classification, repair eligibility, and reason for a live helper VM."""
     metadata = getattr(vm, "metadata", None)
     owner = _clean_id(getattr(metadata, "owner", ""))
     runtime = _clean_id(getattr(metadata, "runtime", ""))

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -107,6 +107,9 @@ def _diagnostics_payload() -> dict:
             "unhealthy_session_ids": [],
             "skipped_active_session_ids": [],
             "orphaned_vm_ids": [],
+            "owned_orphaned_vm_ids": [],
+            "unknown_orphaned_vm_ids": [],
+            "foreign_orphaned_vm_ids": [],
             "items": [],
             "reasons": ["macos_virtualization_helper_unavailable"],
         }

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
@@ -645,12 +645,13 @@ def test_repair_orphan_vm_termination_false_reports_missing(monkeypatch: pytest.
 @pytest.mark.parametrize(
     ("status", "reason"),
     [
+        ("owned_orphaned_vm", "owned_orphan"),
         ("unknown_orphaned_vm", "unknown_ownership"),
         ("foreign_orphaned_vm", "foreign_owner"),
         ("orphaned_vm", "session_missing"),
     ],
 )
-def test_repair_non_owned_orphan_vm_skips_without_helper_call(
+def test_repair_ineligible_or_unknown_orphan_vm_skips_without_helper_call(
     monkeypatch: pytest.MonkeyPatch,
     status: str,
     reason: str,

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py
@@ -96,12 +96,15 @@ def _reconciliation_report(
         "live_vms": 0,
         "healthy_session_ids": [],
         "stale_session_ids": [],
-        "unhealthy_session_ids": [],
-        "skipped_active_session_ids": [],
-        "orphaned_vm_ids": [],
-        "items": list(items or []),
-        "reasons": list(reasons or []),
-    }
+            "unhealthy_session_ids": [],
+            "skipped_active_session_ids": [],
+            "orphaned_vm_ids": [],
+            "owned_orphaned_vm_ids": [],
+            "unknown_orphaned_vm_ids": [],
+            "foreign_orphaned_vm_ids": [],
+            "items": list(items or []),
+            "reasons": list(reasons or []),
+        }
 
 
 def _service_with_orchestrator(orch: SimpleNamespace) -> SandboxService:
@@ -510,9 +513,10 @@ def test_repair_orphan_vm_dry_run_plans_termination_without_helper_call(
         lambda *args, **kwargs: _reconciliation_report(
             items=[
                 {
-                    "status": "orphaned_vm",
+                    "status": "owned_orphaned_vm",
                     "vm_id": "vm-orphan",
-                    "reason": "session_missing",
+                    "reason": "owned_orphan",
+                    "termination_eligible": True,
                 }
             ]
         ),
@@ -536,7 +540,8 @@ def test_repair_orphan_vm_dry_run_plans_termination_without_helper_call(
             "session_id": None,
             "vm_id": "vm-orphan",
             "status": "planned",
-            "reason": "session_missing",
+            "reason": "owned_orphan",
+            "termination_eligible": True,
         }
     ]
 
@@ -552,9 +557,10 @@ def test_repair_orphan_vm_mutating_run_calls_helper(monkeypatch: pytest.MonkeyPa
         lambda *args, **kwargs: _reconciliation_report(
             items=[
                 {
-                    "status": "orphaned_vm",
+                    "status": "owned_orphaned_vm",
                     "vm_id": "vm-orphan",
-                    "reason": "session_missing",
+                    "reason": "owned_orphan",
+                    "termination_eligible": True,
                 }
             ]
         ),
@@ -586,7 +592,8 @@ def test_repair_orphan_vm_mutating_run_calls_helper(monkeypatch: pytest.MonkeyPa
             "session_id": None,
             "vm_id": "vm-orphan",
             "status": "terminated",
-            "reason": "session_missing",
+            "reason": "owned_orphan",
+            "termination_eligible": True,
         }
     ]
 
@@ -602,9 +609,10 @@ def test_repair_orphan_vm_termination_false_reports_missing(monkeypatch: pytest.
         lambda *args, **kwargs: _reconciliation_report(
             items=[
                 {
-                    "status": "orphaned_vm",
+                    "status": "owned_orphaned_vm",
                     "vm_id": "vm-orphan",
-                    "reason": "session_missing",
+                    "reason": "owned_orphan",
+                    "termination_eligible": True,
                 }
             ]
         ),
@@ -631,6 +639,90 @@ def test_repair_orphan_vm_termination_false_reports_missing(monkeypatch: pytest.
     assert result["summary"]["orphaned_vms"] == 1
     assert result["summary"]["terminated_orphaned_vms"] == 0
     assert result["actions"][0]["status"] == "missing"
+    assert result["actions"][0]["termination_eligible"] is True
+
+
+@pytest.mark.parametrize(
+    ("status", "reason"),
+    [
+        ("unknown_orphaned_vm", "unknown_ownership"),
+        ("foreign_orphaned_vm", "foreign_owner"),
+        ("orphaned_vm", "session_missing"),
+    ],
+)
+def test_repair_non_owned_orphan_vm_skips_without_helper_call(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    reason: str,
+) -> None:
+    terminated_vm_ids: list[str] = []
+    orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {
+                    "status": status,
+                    "vm_id": "vm-skip",
+                    "reason": reason,
+                    "termination_eligible": False,
+                }
+            ]
+        ),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        service_mod,
+        "MacOSVirtualizationHelperClient",
+        lambda: SimpleNamespace(terminate_vm=terminated_vm_ids.append),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation(
+        terminate_orphaned_vms=True,
+        dry_run=False,
+    )
+
+    assert terminated_vm_ids == []
+    assert result["summary"]["orphaned_vms"] == 1
+    assert result["summary"]["terminated_orphaned_vms"] == 0
+    assert result["actions"] == [
+        {
+            "type": "skip_orphaned_vm",
+            "session_id": None,
+            "vm_id": "vm-skip",
+            "status": "skipped",
+            "reason": reason,
+            "termination_eligible": False,
+        }
+    ]
+
+
+def test_repair_summary_counts_all_orphan_statuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch = SimpleNamespace(delete_vz_session_control=lambda session_id: True)
+    service = _service_with_orchestrator(orch)
+    monkeypatch.setattr(service, "_active_session_run_count", lambda session_id: 0)
+    monkeypatch.setattr(
+        service_mod,
+        "collect_vz_reconciliation",
+        lambda *args, **kwargs: _reconciliation_report(
+            items=[
+                {"status": "owned_orphaned_vm", "vm_id": "vm-owned", "termination_eligible": True},
+                {"status": "unknown_orphaned_vm", "vm_id": "vm-unknown", "termination_eligible": False},
+                {"status": "foreign_orphaned_vm", "vm_id": "vm-foreign", "termination_eligible": False},
+                {"status": "orphaned_vm", "vm_id": "vm-legacy", "termination_eligible": False},
+            ]
+        ),
+        raising=True,
+    )
+
+    result = service.repair_macos_reconciliation()
+
+    assert result["summary"]["orphaned_vms"] == 4
+    assert result["actions"] == []
 
 
 @pytest.mark.parametrize(
@@ -664,9 +756,10 @@ def test_repair_orphan_vm_termination_helper_errors_preserve_reason(
         lambda *args, **kwargs: _reconciliation_report(
             items=[
                 {
-                    "status": "orphaned_vm",
+                    "status": "owned_orphaned_vm",
                     "vm_id": "vm-orphan",
-                    "reason": "session_missing",
+                    "reason": "owned_orphan",
+                    "termination_eligible": True,
                 }
             ]
         ),
@@ -705,9 +798,10 @@ def test_repair_orphan_vm_termination_unexpected_exception_maps_to_fallback(
         lambda *args, **kwargs: _reconciliation_report(
             items=[
                 {
-                    "status": "orphaned_vm",
+                    "status": "owned_orphaned_vm",
                     "vm_id": "vm-orphan",
-                    "reason": "session_missing",
+                    "reason": "owned_orphan",
+                    "termination_eligible": True,
                 }
             ]
         ),

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -74,6 +74,9 @@ def _sample_diagnostics_payload() -> dict:
             "unhealthy_session_ids": [],
             "skipped_active_session_ids": [],
             "orphaned_vm_ids": [],
+            "owned_orphaned_vm_ids": [],
+            "unknown_orphaned_vm_ids": [],
+            "foreign_orphaned_vm_ids": [],
             "items": [
                 {
                     "status": "healthy",
@@ -330,6 +333,7 @@ def test_admin_schema_accepts_macos_diagnostics_payload() -> None:
     assert model.reconciliation is not None
     assert model.reconciliation.computed is True
     assert model.reconciliation.healthy_session_ids == ["sess-live"]
+    assert model.reconciliation.owned_orphaned_vm_ids == []
     assert model.reconciliation.items
 
 

--- a/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
@@ -12,10 +12,23 @@ def test_helper_client_uses_fake_transport_in_test_mode(monkeypatch) -> None:
     monkeypatch.setenv("TEST_MODE", "1")
 
     client = MacOSVirtualizationHelperClient()
-    reply = client.create_vm({"runtime": "vz_linux", "vm_name": "run-123"})
+    reply = client.create_vm(
+        {
+            "owner": "tldw",
+            "runtime": "vz_linux",
+            "vm_name": "run-123",
+            "run_id": "run-123",
+            "session_mode": False,
+            "template": "/tmp/template.img",
+            "workspace_path": "/tmp/workspace",
+        }
+    )
 
     assert reply.vm_id == "run-123"
     assert reply.state == "created"
+    assert reply.metadata.owner == "tldw"
+    assert reply.metadata.run_id == "run-123"
+    assert reply.metadata.has_tldw_owner is True
 
 
 def test_helper_client_raises_custom_exception_when_helper_unavailable(monkeypatch) -> None:

--- a/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
@@ -115,13 +115,25 @@ def test_fake_helper_supports_vz_linux_vm_create_and_exec(monkeypatch) -> None:
     client = MacOSVirtualizationHelperClient()
     created = client.create_vm(
         {
+            "owner": "tldw",
             "runtime": "vz_linux",
             "vm_name": "vz-linux-run-1",
+            "run_id": "run-1",
+            "session_id": "session-1",
             "session_mode": True,
+            "template": "/tmp/template.img",
+            "workspace_path": "/tmp/workspace",
         }
     )
 
     assert created.state == "created"
+    assert created.metadata.owner == "tldw"
+    assert created.metadata.runtime == "vz_linux"
+    assert created.metadata.run_id == "run-1"
+    assert created.metadata.session_id == "session-1"
+    assert created.metadata.session_mode is True
+    assert created.metadata.template_path == "/tmp/template.img"
+    assert created.metadata.workspace_path == "/tmp/workspace"
     assert created.details["runtime"] == "vz_linux"
     assert created.details["transport"] == "vsock"
 
@@ -235,6 +247,57 @@ def test_parse_helper_vm_status_returns_runtime_state() -> None:
     assert result.details["runtime"] == "vz_linux"
 
 
+def test_parse_helper_vm_status_reads_metadata() -> None:
+    result = parse_helper_vm_status(
+        {
+            "protocol_version": "1",
+            "helper_version": "0.1.0",
+            "vm_id": "vm-123",
+            "state": "running",
+            "healthy": True,
+            "metadata": {
+                "owner": "tldw",
+                "runtime": "vz_linux",
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "session_mode": True,
+                "template_path": "/tmp/bundle",
+                "workspace_path": "/tmp/workspace",
+                "created_at": "2026-04-30T18:00:00Z",
+            },
+        }
+    )
+
+    assert result.metadata.owner == "tldw"
+    assert result.metadata.runtime == "vz_linux"
+    assert result.metadata.run_id == "run-1"
+    assert result.metadata.session_id == "session-1"
+    assert result.metadata.session_mode is True
+    assert result.metadata.template_path == "/tmp/bundle"
+    assert result.metadata.workspace_path == "/tmp/workspace"
+    assert result.metadata.created_at == "2026-04-30T18:00:00Z"
+    assert result.metadata.has_tldw_owner is True
+
+
+@pytest.mark.parametrize("metadata", [None, "invalid", ["invalid"]])
+def test_parse_helper_vm_status_defaults_missing_or_malformed_metadata_to_unknown(metadata) -> None:
+    payload = {
+        "protocol_version": "1",
+        "helper_version": "0.1.0",
+        "vm_id": "vm-123",
+        "state": "running",
+        "healthy": True,
+    }
+    if metadata is not None:
+        payload["metadata"] = metadata
+
+    result = parse_helper_vm_status(payload)
+
+    assert result.metadata.owner == "unknown"
+    assert result.metadata.runtime == ""
+    assert result.metadata.has_tldw_owner is False
+
+
 def test_parse_helper_vm_list_normalizes_status_entries() -> None:
     result = parse_helper_vm_list(
         {
@@ -290,6 +353,16 @@ def test_socket_helper_supports_ping_validate_create_exec_status_and_terminate(m
                 "helper_version": "0.1.0",
                 "vm_id": "vm-transport-1",
                 "state": "created",
+                "metadata": {
+                    "owner": "tldw",
+                    "runtime": "vz_linux",
+                    "run_id": "run-1",
+                    "session_id": "",
+                    "session_mode": False,
+                    "template_path": "/tmp/template.img",
+                    "workspace_path": "/tmp/workspace",
+                    "created_at": "2026-04-30T18:00:00Z",
+                },
                 "details": {"runtime": "vz_linux", "transport": "vsock"},
             },
             "exec_guest": {
@@ -328,6 +401,8 @@ def test_socket_helper_supports_ping_validate_create_exec_status_and_terminate(m
     assert ping.protocol_version == "1"
     assert host["available"] is True
     assert vm.vm_id == "vm-transport-1"
+    assert vm.metadata.owner == "tldw"
+    assert vm.metadata.run_id == "run-1"
     assert exec_reply.stdout == b"ok\n"
     assert status.vm_id == "vm-transport-1"
     assert terminated is True

--- a/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
@@ -134,6 +134,7 @@ def test_fake_helper_supports_vz_linux_vm_create_and_exec(monkeypatch) -> None:
     assert created.metadata.session_mode is True
     assert created.metadata.template_path == "/tmp/template.img"
     assert created.metadata.workspace_path == "/tmp/workspace"
+    assert created.metadata.created_at != ""
     assert created.details["runtime"] == "vz_linux"
     assert created.details["transport"] == "vsock"
 
@@ -296,6 +297,49 @@ def test_parse_helper_vm_status_defaults_missing_or_malformed_metadata_to_unknow
     assert result.metadata.owner == "unknown"
     assert result.metadata.runtime == ""
     assert result.metadata.has_tldw_owner is False
+
+
+def test_parse_helper_vm_status_downgrades_non_string_metadata_fields_to_unknown() -> None:
+    result = parse_helper_vm_status(
+        {
+            "protocol_version": "1",
+            "helper_version": "0.1.0",
+            "vm_id": "vm-123",
+            "state": "running",
+            "healthy": True,
+            "metadata": {
+                "owner": ["tldw"],
+                "runtime": "vz_linux",
+                "run_id": "run-1",
+            },
+        }
+    )
+
+    assert result.metadata.owner == "unknown"
+    assert result.metadata.runtime == ""
+    assert result.metadata.has_tldw_owner is False
+
+
+def test_fake_helper_create_vm_normalizes_string_session_mode_and_created_at(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+
+    client = MacOSVirtualizationHelperClient()
+    created = client.create_vm(
+        {
+            "owner": "tldw",
+            "runtime": "",
+            "vm_name": "vz-linux-run-2",
+            "run_id": "run-2",
+            "session_id": "",
+            "session_mode": "false",
+            "template": "/tmp/template.img",
+            "workspace_path": "/tmp/workspace",
+        }
+    )
+
+    assert created.metadata.runtime == "vz_linux"
+    assert created.metadata.session_mode is False
+    assert created.metadata.created_at != ""
 
 
 def test_parse_helper_vm_list_normalizes_status_entries() -> None:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -136,6 +136,12 @@ def test_vz_linux_start_run_executes_real_ephemeral_vm_command(monkeypatch, tmp_
     assert status.exit_code == 0
     assert [name for name, _payload in calls] == ["validate_template", "create_vm", "exec_guest", "terminate_vm"]
     assert calls[0][1]["template"] == "ubuntu-24.04"
+    assert calls[1][1]["owner"] == "tldw"
+    assert calls[1][1]["runtime"] == "vz_linux"
+    assert calls[1][1]["vm_name"] == run_id
+    assert calls[1][1]["run_id"] == run_id
+    assert calls[1][1]["session_id"] == ""
+    assert calls[1][1]["session_mode"] is False
     assert calls[1][1]["workspace_path"] == str(tmp_path)
     assert calls[1][1]["workspace_mount"] == "virtiofs"
     assert calls[1][1]["template"] == "ubuntu-24.04"
@@ -382,6 +388,12 @@ def test_vz_linux_session_run_recreates_unhealthy_vm(monkeypatch, tmp_path) -> N
 
         def create_vm(self, request: dict[str, object]) -> HelperVMReply:
             calls.append("create_vm")
+            assert request["owner"] == "tldw"
+            assert request["runtime"] == "vz_linux"
+            assert request["run_id"] == "vz-run-recreate"
+            assert request["session_id"] == "sess-2"
+            assert request["session_mode"] is True
+            assert request["template"] == "ubuntu-24.04"
             return HelperVMReply(vm_id="vm-new", state="created")
 
         def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py
@@ -54,7 +54,12 @@ def test_vz_linux_session_reuses_existing_vm_for_second_run(monkeypatch, tmp_pat
             }
 
         def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            assert request["owner"] == "tldw"
+            assert request["runtime"] == "vz_linux"
+            assert request["run_id"] == "run-1"
+            assert request["session_id"] == "sess-vz-1"
             assert request["session_mode"] is True
+            assert request["template"] == "ubuntu-24.04"
             calls.append("create_vm")
             return HelperVMReply(vm_id="vm-session-1", state="created", details={"session_mode": True})
 

--- a/tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_reconciliation.py
@@ -6,6 +6,7 @@ from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import 
     MacOSVirtualizationHelperUnavailable,
 )
 from tldw_Server_API.app.core.Sandbox.macos_virtualization.models import (
+    HelperVMMetadata,
     HelperVMListReply,
     HelperVMStatusReply,
 )
@@ -66,13 +67,41 @@ class _FailureHelper:
         raise MacOSVirtualizationHelperFailure("helper_internal_error", "list failed")
 
 
-def _vm(vm_id: str, *, state: str = "running", healthy: bool = True) -> HelperVMStatusReply:
+def _metadata(
+    *,
+    owner: str = "tldw",
+    runtime: str = "vz_linux",
+    run_id: str = "run-owned",
+    session_id: str = "",
+    session_mode: bool = False,
+    created_at: str = "2026-04-30T18:00:00Z",
+) -> HelperVMMetadata:
+    return HelperVMMetadata(
+        owner=owner,
+        runtime=runtime,
+        run_id=run_id,
+        session_id=session_id,
+        session_mode=session_mode,
+        template_path="/tmp/template",
+        workspace_path="/tmp/workspace",
+        created_at=created_at,
+    )
+
+
+def _vm(
+    vm_id: str,
+    *,
+    state: str = "running",
+    healthy: bool = True,
+    metadata: HelperVMMetadata | None = None,
+) -> HelperVMStatusReply:
     return HelperVMStatusReply(
         protocol_version="1",
         helper_version="0.1.0",
         vm_id=vm_id,
         state=state,
         healthy=healthy,
+        metadata=metadata or HelperVMMetadata(),
     )
 
 
@@ -107,10 +136,65 @@ def test_reconciliation_reports_healthy_stale_unhealthy_and_orphaned_vms():
         "healthy",
         "stale_session",
         "unhealthy_vm",
-        "orphaned_vm",
+        "unknown_orphaned_vm",
     }
     assert helper.terminated_vm_ids == []
     assert helper.deleted_vm_ids == []
+
+
+def test_reconciliation_classifies_orphaned_vms_by_ownership_metadata():
+    helper = _FakeHelper(
+        [
+            _vm("vm-owned", metadata=_metadata(run_id="run-owned")),
+            _vm("vm-unknown"),
+            _vm("vm-foreign-owner", metadata=_metadata(owner="other", run_id="run-foreign-owner")),
+            _vm("vm-foreign-runtime", metadata=_metadata(runtime="vz_macos", run_id="run-foreign-runtime")),
+            _vm("vm-missing-run", metadata=_metadata(run_id="")),
+            _vm("vm-missing-created", metadata=_metadata(run_id="run-missing-created", created_at="")),
+            _vm(
+                "vm-missing-session",
+                metadata=_metadata(run_id="run-missing-session", session_mode=True, session_id=""),
+            ),
+        ]
+    )
+
+    report = collect_vz_reconciliation(
+        orchestrator=_FakeOrchestrator([]),
+        helper_client=helper,
+    )
+
+    assert report["orphaned_vm_ids"] == [
+        "vm-foreign-owner",
+        "vm-foreign-runtime",
+        "vm-missing-created",
+        "vm-missing-run",
+        "vm-missing-session",
+        "vm-owned",
+        "vm-unknown",
+    ]
+    assert report["owned_orphaned_vm_ids"] == ["vm-owned"]
+    assert report["unknown_orphaned_vm_ids"] == [
+        "vm-missing-created",
+        "vm-missing-run",
+        "vm-missing-session",
+        "vm-unknown",
+    ]
+    assert report["foreign_orphaned_vm_ids"] == ["vm-foreign-owner", "vm-foreign-runtime"]
+
+    items_by_vm = {str(item["vm_id"]): item for item in report["items"] if "vm_id" in item}
+    assert items_by_vm["vm-owned"]["status"] == "owned_orphaned_vm"
+    assert items_by_vm["vm-owned"]["reason"] == "owned_orphan"
+    assert items_by_vm["vm-owned"]["termination_eligible"] is True
+    assert items_by_vm["vm-unknown"]["status"] == "unknown_orphaned_vm"
+    assert items_by_vm["vm-unknown"]["reason"] == "unknown_ownership"
+    assert items_by_vm["vm-unknown"]["termination_eligible"] is False
+    assert items_by_vm["vm-missing-run"]["status"] == "unknown_orphaned_vm"
+    assert items_by_vm["vm-missing-created"]["status"] == "unknown_orphaned_vm"
+    assert items_by_vm["vm-missing-session"]["status"] == "unknown_orphaned_vm"
+    assert items_by_vm["vm-foreign-owner"]["status"] == "foreign_orphaned_vm"
+    assert items_by_vm["vm-foreign-owner"]["reason"] == "foreign_owner"
+    assert items_by_vm["vm-foreign-owner"]["termination_eligible"] is False
+    assert items_by_vm["vm-foreign-runtime"]["status"] == "foreign_orphaned_vm"
 
 
 def test_reconciliation_classifies_helper_unavailable():
@@ -200,6 +284,9 @@ def test_reconciliation_unavailable_without_orchestrator():
         "unhealthy_session_ids": [],
         "skipped_active_session_ids": [],
         "orphaned_vm_ids": [],
+        "owned_orphaned_vm_ids": [],
+        "unknown_orphaned_vm_ids": [],
+        "foreign_orphaned_vm_ids": [],
         "items": [],
         "reasons": ["vz_reconciliation_unavailable"],
     }
@@ -241,6 +328,9 @@ def test_reconciliation_orders_id_lists_and_items_deterministically():
     assert report["stale_session_ids"] == ["sess-stale-a", "sess-stale-b"]
     assert report["unhealthy_session_ids"] == ["sess-unhealthy-a", "sess-unhealthy-b"]
     assert report["orphaned_vm_ids"] == ["vm-orphan-a", "vm-orphan-b"]
+    assert report["unknown_orphaned_vm_ids"] == ["vm-orphan-a", "vm-orphan-b"]
+    assert report["owned_orphaned_vm_ids"] == []
+    assert report["foreign_orphaned_vm_ids"] == []
     assert report["items"] == sorted(
         report["items"],
         key=lambda item: (

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -75,8 +75,64 @@ Every failure response should include:
   "vm_id": "vm-123",
   "state": "running",
   "healthy": true,
+  "metadata": {
+    "owner": "tldw",
+    "runtime": "vz_linux",
+    "run_id": "run-123",
+    "session_id": "session-456",
+    "session_mode": true,
+    "template_path": "/var/lib/tldw/vz-linux/debian-arm64",
+    "workspace_path": "/tmp/tldw-vz-linux-workspace",
+    "created_at": "2026-04-30T18:00:00Z"
+  },
   "details": {
     "runtime": "vz_linux"
+  }
+}
+```
+
+### `create_vm`
+
+Request:
+
+```json
+{
+  "operation": "create_vm",
+  "protocol_version": "1",
+  "request": {
+    "owner": "tldw",
+    "runtime": "vz_linux",
+    "vm_name": "run-123",
+    "run_id": "run-123",
+    "session_id": "session-456",
+    "session_mode": true,
+    "template": "/var/lib/tldw/vz-linux/debian-arm64",
+    "workspace_path": "/tmp/tldw-vz-linux-workspace",
+    "timeout_sec": 300
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "protocol_version": "1",
+  "helper_version": "0.1.0",
+  "vm_id": "run-123",
+  "state": "running",
+  "metadata": {
+    "owner": "tldw",
+    "runtime": "vz_linux",
+    "run_id": "run-123",
+    "session_id": "session-456",
+    "session_mode": true,
+    "template_path": "/var/lib/tldw/vz-linux/debian-arm64",
+    "workspace_path": "/tmp/tldw-vz-linux-workspace",
+    "created_at": "2026-04-30T18:00:00Z"
+  },
+  "details": {
+    "transport": "vsock"
   }
 }
 ```
@@ -109,6 +165,16 @@ Every failure response should include:
       "vm_id": "vm-123",
       "state": "running",
       "healthy": true,
+      "metadata": {
+        "owner": "tldw",
+        "runtime": "vz_linux",
+        "run_id": "run-123",
+        "session_id": "session-456",
+        "session_mode": true,
+        "template_path": "/var/lib/tldw/vz-linux/debian-arm64",
+        "workspace_path": "/tmp/tldw-vz-linux-workspace",
+        "created_at": "2026-04-30T18:00:00Z"
+      },
       "details": {
         "runtime": "vz_linux"
       }
@@ -121,6 +187,11 @@ Every failure response should include:
 
 - Python must reject incompatible `protocol_version` values.
 - Helper runtime truth wins over env-only scaffolding.
+- VM ownership metadata is additive in protocol version `1`. Missing or malformed
+  metadata must parse as unknown ownership on the Python side.
+- The helper assigns `created_at` when VM creation metadata omits it. Python uses
+  `owner=tldw`, `runtime=vz_linux`, non-empty `run_id`, and session metadata to
+  decide whether orphan repair may terminate a live VM.
 - Template validation must report `boot_mode` and `validation_strength` when the
   helper can resolve the template successfully.
 - Python remains the source of truth for sandbox sessions; the helper only reports

--- a/tools/macos-vz-helper/README.md
+++ b/tools/macos-vz-helper/README.md
@@ -12,6 +12,7 @@ The helper is intentionally narrow:
 - owns `Virtualization.framework` lifecycle
 - owns host readiness and runnable-template truth
 - owns VM create, exec, status, list, and terminate operations
+- stores per-VM ownership metadata supplied by the Python sandbox control plane
 
 ## Non-Goals
 
@@ -22,10 +23,13 @@ The first helper slice is not a generic macOS sandbox backend:
 - no second persistence layer for sandbox sessions
 - no APFS clone execution path yet
 - no automatic launchd installation or helper auto-upgrade yet
-- no automatic orphan VM termination during admin repair; Python can request it only through explicit dry-run-first reconciliation repair
+- no automatic orphan VM termination during admin repair; Python can request it only through explicit dry-run-first reconciliation repair, and only for helper VMs whose metadata proves `owner=tldw` and `runtime=vz_linux`
 
 Python remains authoritative for sandbox admission, session identity, artifacts, and ACP
 integration. The helper only owns runtime VM facts and control-plane operations.
+Helper VM metadata is local control-plane metadata, not cryptographic attestation.
+Legacy or manually created helper VMs without metadata are reported as unknown and skipped
+by automated repair.
 
 ## Managed Helper Lifecycle
 

--- a/tools/macos-vz-helper/Sources/Protocol/Response.swift
+++ b/tools/macos-vz-helper/Sources/Protocol/Response.swift
@@ -105,6 +105,7 @@ struct HelperVMResponse: Encodable {
     let helperVersion: String
     let vmID: String
     let state: String
+    let metadata: VMOwnershipMetadata
     let details: [String: String]
 
     private enum CodingKeys: String, CodingKey {
@@ -112,6 +113,7 @@ struct HelperVMResponse: Encodable {
         case helperVersion = "helper_version"
         case vmID = "vm_id"
         case state
+        case metadata
         case details
     }
 }
@@ -122,6 +124,7 @@ struct HelperVMStatusResponse: Encodable {
     let vmID: String
     let state: String
     let healthy: Bool
+    let metadata: VMOwnershipMetadata
     let details: [String: String]
 
     private enum CodingKeys: String, CodingKey {
@@ -130,6 +133,7 @@ struct HelperVMStatusResponse: Encodable {
         case vmID = "vm_id"
         case state
         case healthy
+        case metadata
         case details
     }
 }

--- a/tools/macos-vz-helper/Sources/Protocol/Response.swift
+++ b/tools/macos-vz-helper/Sources/Protocol/Response.swift
@@ -48,10 +48,56 @@ struct TemplateValidationResponse: Encodable {
     }
 }
 
+struct VMOwnershipMetadata: Codable, Equatable {
+    let owner: String
+    let runtime: String
+    let runID: String
+    let sessionID: String
+    let sessionMode: Bool
+    let templatePath: String
+    let workspacePath: String
+    let createdAt: String
+
+    static let unknown = VMOwnershipMetadata(
+        owner: "unknown",
+        runtime: "",
+        runID: "",
+        sessionID: "",
+        sessionMode: false,
+        templatePath: "",
+        workspacePath: "",
+        createdAt: ""
+    )
+
+    private enum CodingKeys: String, CodingKey {
+        case owner
+        case runtime
+        case runID = "run_id"
+        case sessionID = "session_id"
+        case sessionMode = "session_mode"
+        case templatePath = "template_path"
+        case workspacePath = "workspace_path"
+        case createdAt = "created_at"
+    }
+}
+
 struct VMRecord {
     let vmID: String
     let state: String
     let healthy: Bool
+    let metadata: VMOwnershipMetadata
+
+    init(
+        vmID: String,
+        state: String,
+        healthy: Bool,
+        metadata: VMOwnershipMetadata = .unknown
+    ) {
+        self.vmID = vmID
+        self.state = state
+        self.healthy = healthy
+        self.metadata = metadata
+    }
 }
 
 struct HelperVMResponse: Encodable {

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -12,6 +12,7 @@ final class HelperService {
     private let templateValidator: TemplateValidator
     private let registry: VMRegistry
     private let vmManager: VZLinuxVMManager
+    private let metadataDateFormatter = ISO8601DateFormatter()
 
     init(
         hostFacts: HostFacts = HostFacts(isMacOS: true, isAppleSilicon: true),
@@ -78,19 +79,27 @@ final class HelperService {
         vmID: String,
         templatePath: String,
         workspacePath: String,
-        readinessTimeoutSeconds: TimeInterval
+        readinessTimeoutSeconds: TimeInterval,
+        metadata: VMOwnershipMetadata = .unknown
     ) throws -> HelperVMResponse {
+        let normalizedMetadata = normalizeMetadata(
+            metadata,
+            templatePath: templatePath,
+            workspacePath: workspacePath
+        )
         let record = try vmManager.createVM(
             vmID: vmID,
             templatePath: templatePath,
             workspacePath: workspacePath,
-            readinessTimeoutSeconds: readinessTimeoutSeconds
+            readinessTimeoutSeconds: readinessTimeoutSeconds,
+            metadata: normalizedMetadata
         )
         return HelperVMResponse(
             protocolVersion: protocolVersion,
             helperVersion: helperVersion,
             vmID: record.vmID,
             state: record.state,
+            metadata: record.metadata,
             details: ["transport": "vsock"]
         )
     }
@@ -105,6 +114,7 @@ final class HelperService {
             vmID: record.vmID,
             state: record.state,
             healthy: record.healthy,
+            metadata: record.metadata,
             details: ["transport": "vsock"]
         )
     }
@@ -117,6 +127,7 @@ final class HelperService {
                 vmID: record.vmID,
                 state: record.state,
                 healthy: record.healthy,
+                metadata: record.metadata,
                 details: ["transport": "vsock"]
             )
         }
@@ -152,6 +163,23 @@ final class HelperService {
             stdout: result.stdout,
             stderr: result.stderr,
             details: ["transport": "vsock", "vm_id": vmID]
+        )
+    }
+
+    private func normalizeMetadata(
+        _ metadata: VMOwnershipMetadata,
+        templatePath: String,
+        workspacePath: String
+    ) -> VMOwnershipMetadata {
+        VMOwnershipMetadata(
+            owner: metadata.owner.isEmpty ? "unknown" : metadata.owner,
+            runtime: metadata.runtime.isEmpty ? "vz_linux" : metadata.runtime,
+            runID: metadata.runID,
+            sessionID: metadata.sessionID,
+            sessionMode: metadata.sessionMode,
+            templatePath: metadata.templatePath.isEmpty ? templatePath : metadata.templatePath,
+            workspacePath: metadata.workspacePath.isEmpty ? workspacePath : metadata.workspacePath,
+            createdAt: metadata.createdAt.isEmpty ? metadataDateFormatter.string(from: Date()) : metadata.createdAt
         )
     }
 }

--- a/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
+++ b/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
@@ -124,12 +124,27 @@ final class UnixSocketServer {
                 )
             )
         case "create_vm":
+            let templatePath = request.request["template"]?.stringValue
+                ?? request.request["template_path"]?.stringValue
+                ?? ""
+            let workspacePath = request.request["workspace_path"]?.stringValue ?? ""
+            let metadata = VMOwnershipMetadata(
+                owner: request.request["owner"]?.stringValue ?? "unknown",
+                runtime: request.request["runtime"]?.stringValue ?? "vz_linux",
+                runID: request.request["run_id"]?.stringValue ?? "",
+                sessionID: request.request["session_id"]?.stringValue ?? "",
+                sessionMode: request.request["session_mode"]?.boolValue ?? false,
+                templatePath: templatePath,
+                workspacePath: workspacePath,
+                createdAt: ""
+            )
             return try encoder.encode(
                 try service.createVM(
                     vmID: request.request["vm_name"]?.stringValue ?? request.request["run_id"]?.stringValue ?? "",
-                    templatePath: request.request["template"]?.stringValue ?? "",
-                    workspacePath: request.request["workspace_path"]?.stringValue ?? "",
-                    readinessTimeoutSeconds: TimeInterval(request.request["timeout_sec"]?.intValue ?? 30)
+                    templatePath: templatePath,
+                    workspacePath: workspacePath,
+                    readinessTimeoutSeconds: TimeInterval(request.request["timeout_sec"]?.intValue ?? 30),
+                    metadata: metadata
                 )
             )
         case "get_vm_status":
@@ -144,6 +159,7 @@ final class UnixSocketServer {
                     vmID: vmID,
                     state: "missing",
                     healthy: false,
+                    metadata: .unknown,
                     details: ["error_code": "vm_not_found"]
                 )
             )

--- a/tools/macos-vz-helper/Sources/VM/VMRegistry.swift
+++ b/tools/macos-vz-helper/Sources/VM/VMRegistry.swift
@@ -4,10 +4,16 @@ final class VMRegistry {
     private var records: [String: VMRecord] = [:]
     private let lock = NSLock()
 
-    func upsert(vmID: String, state: String, healthy: Bool) {
+    func upsert(vmID: String, state: String, healthy: Bool, metadata: VMOwnershipMetadata? = nil) {
         lock.lock()
         defer { lock.unlock() }
-        records[vmID] = VMRecord(vmID: vmID, state: state, healthy: healthy)
+        let existingMetadata = records[vmID]?.metadata ?? .unknown
+        records[vmID] = VMRecord(
+            vmID: vmID,
+            state: state,
+            healthy: healthy,
+            metadata: metadata ?? existingMetadata
+        )
     }
 
     func status(vmID: String) -> VMRecord? {

--- a/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
+++ b/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
@@ -38,9 +38,10 @@ final class VZLinuxVMManager {
         vmID: String,
         templatePath: String,
         workspacePath: String,
-        readinessTimeoutSeconds: TimeInterval
+        readinessTimeoutSeconds: TimeInterval,
+        metadata: VMOwnershipMetadata = .unknown
     ) throws -> VMRecord {
-        registry.upsert(vmID: vmID, state: "booting", healthy: false)
+        registry.upsert(vmID: vmID, state: "booting", healthy: false, metadata: metadata)
         do {
             try bootDriver.boot(
                 vmID: vmID,
@@ -50,7 +51,12 @@ final class VZLinuxVMManager {
             )
             try guestBridge.waitUntilReady(vmID: vmID, timeoutSeconds: readinessTimeoutSeconds)
             registry.upsert(vmID: vmID, state: "running", healthy: true)
-            return VMRecord(vmID: vmID, state: "running", healthy: true)
+            return registry.status(vmID: vmID) ?? VMRecord(
+                vmID: vmID,
+                state: "running",
+                healthy: true,
+                metadata: metadata
+            )
         } catch {
             try? bootDriver.stop(vmID: vmID)
             registry.remove(vmID: vmID)

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -26,6 +26,76 @@ import Testing
     #expect(response.details["transport"] == "vsock")
 }
 
+@Test func helperServiceCreateVMReturnsOwnershipMetadata() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+    let metadata = VMOwnershipMetadata(
+        owner: "tldw",
+        runtime: "vz_linux",
+        runID: "run-owned",
+        sessionID: "session-owned",
+        sessionMode: true,
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        createdAt: ""
+    )
+
+    let response = try service.createVM(
+        vmID: "vm-owned",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        readinessTimeoutSeconds: 5,
+        metadata: metadata
+    )
+    let status = service.getVMStatus(vmID: "vm-owned")
+    let listed = service.listVMs().vms.first
+
+    #expect(response.metadata.owner == "tldw")
+    #expect(response.metadata.runID == "run-owned")
+    #expect(response.metadata.sessionID == "session-owned")
+    #expect(response.metadata.sessionMode == true)
+    #expect(response.metadata.templatePath == "/tmp/template.img")
+    #expect(response.metadata.workspacePath == "/tmp/workspace")
+    #expect(response.metadata.createdAt.isEmpty == false)
+    #expect(status?.metadata.runID == "run-owned")
+    #expect(listed?.metadata.runID == "run-owned")
+}
+
+@Test func helperServiceCreateVMDefaultsMissingOwnershipMetadataToUnknown() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    let response = try service.createVM(
+        vmID: "vm-unknown",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        readinessTimeoutSeconds: 5
+    )
+
+    #expect(response.metadata.owner == "unknown")
+    #expect(response.metadata.runtime == "vz_linux")
+    #expect(response.metadata.runID == "")
+    #expect(response.metadata.createdAt.isEmpty == false)
+}
+
 @Test func helperServiceListVMsReturnsKnownVMs() throws {
     let registry = VMRegistry()
     let manager = VZLinuxVMManager(

--- a/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
+++ b/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
@@ -61,6 +61,41 @@ import Testing
     #expect(guestBridge.lastExec?.vmID == "vm-route")
 }
 
+@Test func unixSocketServerForwardsCreateVMOwnershipMetadata() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+    let server = UnixSocketServer(
+        socketPath: "/tmp/macos-vz-helper.sock",
+        service: service
+    )
+
+    let createRequest = """
+    {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-owned","owner":"tldw","runtime":"vz_linux","run_id":"run-owned","session_id":"session-owned","session_mode":true,"template":"/tmp/template.img","workspace_path":"/workspace"}}
+    """.data(using: .utf8)!
+    let createResponseData = try server.handleRequestData(createRequest)
+    let createJSON = try JSONSerialization.jsonObject(with: createResponseData) as? [String: Any]
+    let metadata = createJSON?["metadata"] as? [String: Any]
+
+    #expect(createJSON?["vm_id"] as? String == "vm-owned")
+    #expect(metadata?["owner"] as? String == "tldw")
+    #expect(metadata?["runtime"] as? String == "vz_linux")
+    #expect(metadata?["run_id"] as? String == "run-owned")
+    #expect(metadata?["session_id"] as? String == "session-owned")
+    #expect(metadata?["session_mode"] as? Bool == true)
+    #expect(metadata?["template_path"] as? String == "/tmp/template.img")
+    #expect(metadata?["workspace_path"] as? String == "/workspace")
+    #expect((metadata?["created_at"] as? String)?.isEmpty == false)
+}
+
 @Test func unixSocketServerServesPingOverRealSocket() throws {
     let socketDirectory = try makePrivateTemporaryDirectory()
     defer { try? FileManager.default.removeItem(at: socketDirectory) }

--- a/tools/macos-vz-helper/Tests/VMRegistryTests.swift
+++ b/tools/macos-vz-helper/Tests/VMRegistryTests.swift
@@ -12,6 +12,46 @@ import Testing
     #expect(status?.healthy == false)
 }
 
+@Test func vmRegistryStoresOwnershipMetadata() throws {
+    let registry = VMRegistry()
+    let metadata = VMOwnershipMetadata(
+        owner: "tldw",
+        runtime: "vz_linux",
+        runID: "run-1",
+        sessionID: "session-1",
+        sessionMode: true,
+        templatePath: "/tmp/bundle",
+        workspacePath: "/tmp/workspace",
+        createdAt: "2026-04-30T18:00:00Z"
+    )
+
+    registry.upsert(vmID: "vm-1", state: "booting", healthy: false, metadata: metadata)
+
+    #expect(registry.status(vmID: "vm-1")?.metadata.owner == "tldw")
+    #expect(registry.status(vmID: "vm-1")?.metadata.runID == "run-1")
+}
+
+@Test func vmRegistryPreservesMetadataAcrossStateUpdates() throws {
+    let registry = VMRegistry()
+    let metadata = VMOwnershipMetadata(
+        owner: "tldw",
+        runtime: "vz_linux",
+        runID: "run-1",
+        sessionID: "",
+        sessionMode: false,
+        templatePath: "/tmp/bundle",
+        workspacePath: "/tmp/workspace",
+        createdAt: "2026-04-30T18:00:00Z"
+    )
+
+    registry.upsert(vmID: "vm-1", state: "booting", healthy: false, metadata: metadata)
+    registry.upsert(vmID: "vm-1", state: "running", healthy: true)
+
+    let record = registry.status(vmID: "vm-1")
+    #expect(record?.state == "running")
+    #expect(record?.metadata.runID == "run-1")
+}
+
 @Test func listVMsReturnsKnownVMs() throws {
     let registry = VMRegistry()
     registry.upsert(vmID: "vm-1", state: "running", healthy: true)


### PR DESCRIPTION
## Summary
- add helper-side VM ownership metadata storage and surface it through the Swift helper protocol plus Python client models
- tag real `vz_linux` helper VM creation requests with owner/run/session metadata, classify orphan VMs as owned, unknown, or foreign, and only allow repair to terminate eligible owned orphans
- document the ownership metadata contract and repair gate across the helper protocol, sandbox README, and macOS operator notes

## Test Plan
- [x] `swift test --package-path tools/macos-vz-helper`
- [x] `python -m pytest tldw_Server_API/tests/sandbox/test_macos_helper_client.py tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py tldw_Server_API/tests/sandbox/test_vz_reconciliation.py tldw_Server_API/tests/sandbox/test_admin_macos_reconciliation_repair.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_session_lifecycle.py -q`
- [x] `python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_virtualization tldw_Server_API/app/core/Sandbox/vz_reconciliation.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py -s B101,B106 -f json -o /tmp/bandit_vz_helper_vm_ownership_metadata.json`

## Note
- Human change summary to be added before merge per repo policy.