### PR TITLE
Add FTUE tutorial sequence foundation

### DIFF
--- a/apps/packages/ui/src/components/Common/PageHelpModal.tsx
+++ b/apps/packages/ui/src/components/Common/PageHelpModal.tsx
@@ -218,8 +218,12 @@ export function PageHelpModal() {
 
   // Get tutorials for current route
   const availableTutorials = useMemo(
-    () => getTutorialsForRoute(location.pathname),
-    [location.pathname]
+    () =>
+      getTutorialsForRoute(location.pathname, {
+        completedTutorialIds: completedTutorials,
+        includeLocked: true
+      }),
+    [location.pathname, completedTutorials]
   )
 
   // Determine default tab based on available tutorials

--- a/apps/packages/ui/src/components/Common/QuickChatHelper/QuickChatGuidesPanel.tsx
+++ b/apps/packages/ui/src/components/Common/QuickChatHelper/QuickChatGuidesPanel.tsx
@@ -47,7 +47,9 @@ export const buildQuickChatPageTutorialEntries = (
   }
 
   const tutorials = getTutorialsForRoute(normalizedRoute, {
-    ignoreRuntimeSuppression: true
+    ignoreRuntimeSuppression: true,
+    completedTutorialIds,
+    includeLocked: true
   })
   const completedSet = new Set(completedTutorialIds)
 

--- a/apps/packages/ui/src/components/Common/TutorialPrompt.tsx
+++ b/apps/packages/ui/src/components/Common/TutorialPrompt.tsx
@@ -44,9 +44,13 @@ export const TutorialPrompt: React.FC = () => {
   const startTutorial = useTutorialStore((state) => state.startTutorial)
   const isHelpModalOpen = useTutorialStore((state) => state.isHelpModalOpen)
   const activeTutorialId = useTutorialStore((state) => state.activeTutorialId)
+  const completedTutorials = useTutorialStore((state) => state.completedTutorials)
 
   useEffect(() => {
     const pageKey = location.pathname
+    const tutorialLookupOptions = {
+      completedTutorialIds: completedTutorials
+    }
 
     // Clean up previous timeout
     if (timeoutRef.current) {
@@ -75,7 +79,7 @@ export const TutorialPrompt: React.FC = () => {
     }
 
     // Skip if page has no tutorials
-    if (!hasTutorialsForRoute(pageKey)) {
+    if (!hasTutorialsForRoute(pageKey, tutorialLookupOptions)) {
       return
     }
 
@@ -85,7 +89,10 @@ export const TutorialPrompt: React.FC = () => {
     }
 
     // Get the primary tutorial for this page
-    const primaryTutorial = getPrimaryTutorialForRoute(pageKey)
+    const primaryTutorial = getPrimaryTutorialForRoute(
+      pageKey,
+      tutorialLookupOptions
+    )
     if (!primaryTutorial) {
       return
     }
@@ -188,6 +195,7 @@ export const TutorialPrompt: React.FC = () => {
     activeTutorialId,
     api,
     isHelpModalOpen,
+    completedTutorials,
     t,
     hasSeenPromptForPage,
     markPromptSeen,

--- a/apps/packages/ui/src/components/Common/__tests__/TutorialPrompt.behavior.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/TutorialPrompt.behavior.test.tsx
@@ -10,6 +10,7 @@ const markPromptSeenMock = vi.fn()
 const startTutorialMock = vi.fn()
 
 const tutorialStoreState = {
+  completedTutorials: [] as string[],
   hasSeenPromptForPage: vi.fn(() => false),
   markPromptSeen: markPromptSeenMock,
   startTutorial: startTutorialMock,
@@ -17,9 +18,18 @@ const tutorialStoreState = {
   activeTutorialId: null as string | null
 }
 
-const hasTutorialsForRouteMock = vi.fn<(route: string) => boolean>(() => true)
+type TutorialRouteOptions = {
+  completedTutorialIds?: readonly string[]
+}
+
+const hasTutorialsForRouteMock = vi.fn<
+  (route: string, options?: TutorialRouteOptions) => boolean
+>(() => true)
 const getPrimaryTutorialForRouteMock = vi.fn<
-  (route: string) => {
+  (
+    route: string,
+    options?: TutorialRouteOptions
+  ) => {
     id: string
     labelKey: string
     labelFallback: string
@@ -84,9 +94,10 @@ vi.mock("@/store/tutorials", () => ({
 }))
 
 vi.mock("@/tutorials", () => ({
-  hasTutorialsForRoute: (route: string) => hasTutorialsForRouteMock(route),
-  getPrimaryTutorialForRoute: (route: string) =>
-    getPrimaryTutorialForRouteMock(route)
+  hasTutorialsForRoute: (route: string, options?: TutorialRouteOptions) =>
+    hasTutorialsForRouteMock(route, options),
+  getPrimaryTutorialForRoute: (route: string, options?: TutorialRouteOptions) =>
+    getPrimaryTutorialForRouteMock(route, options)
 }))
 
 describe("TutorialPrompt behavior", () => {
@@ -94,6 +105,7 @@ describe("TutorialPrompt behavior", () => {
     vi.useFakeTimers()
     vi.clearAllMocks()
     tutorialStoreState.hasSeenPromptForPage.mockReturnValue(false)
+    tutorialStoreState.completedTutorials = []
     tutorialStoreState.isHelpModalOpen = false
     tutorialStoreState.activeTutorialId = null
     capturedNavigate = null
@@ -126,6 +138,42 @@ describe("TutorialPrompt behavior", () => {
 
     expect(infoMock).toHaveBeenCalledTimes(1)
     expect(infoMock.mock.calls[0][0]?.key).toBe("tutorial-prompt-global")
+  })
+
+  it("passes completed tutorial IDs into tutorial route lookups", () => {
+    tutorialStoreState.completedTutorials = ["getting-started"]
+
+    render(
+      <MemoryRouter initialEntries={["/knowledge"]}>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <>
+                <NavigatorBridge />
+                <TutorialPrompt />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    const expectedOptions = {
+      completedTutorialIds: ["getting-started"]
+    }
+    expect(hasTutorialsForRouteMock).toHaveBeenCalledWith(
+      "/knowledge",
+      expectedOptions
+    )
+    expect(getPrimaryTutorialForRouteMock).toHaveBeenCalledWith(
+      "/knowledge",
+      expectedOptions
+    )
   })
 
   it("avoids rapid duplicate prompts across route changes", () => {

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/ViewerToolbar.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentViewer/ViewerToolbar.tsx
@@ -238,58 +238,60 @@ export const ViewerToolbar: React.FC<ViewerToolbarProps> = ({
         <TTSPanel />
         {isEpub && !isMobile && <EpubSettingsPanel />}
 
-        <Tooltip title={t("option:documentWorkspace.previousPage", "Previous")}>
-          <button
-            onClick={onPreviousPage}
-            disabled={currentPage <= 1}
-            className={TOOLBAR_ICON_BUTTON_CLASS}
-            aria-label={t("option:documentWorkspace.previousPage", "Previous")}
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </button>
-        </Tooltip>
+        <div className="flex items-center gap-1" data-testid="document-navigation">
+          <Tooltip title={t("option:documentWorkspace.previousPage", "Previous")}>
+            <button
+              onClick={onPreviousPage}
+              disabled={currentPage <= 1}
+              className={TOOLBAR_ICON_BUTTON_CLASS}
+              aria-label={t("option:documentWorkspace.previousPage", "Previous")}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+          </Tooltip>
 
-        {isEpub ? (
-          <div className="flex items-center gap-2 min-w-[120px]">
-            <Progress
-              percent={Math.round(percentage)}
-              size="small"
-              showInfo={false}
-              className="w-16"
-            />
-            <span className="text-sm text-muted tabular-nums">
-              {Math.round(percentage)}%
-            </span>
-          </div>
-        ) : (
-          <div className="flex items-center gap-1 text-sm">
-            <Input
-              type="number"
-              min={1}
-              max={totalPages}
-              value={currentPage}
-              onChange={handlePageInputChange}
-              onBlur={handlePageInputBlur}
-              className="w-14 text-center"
-              size="small"
-              data-testid="document-page-input"
-            />
-            <span className="text-muted">
-              / {totalPages || "-"}
-            </span>
-          </div>
-        )}
+          {isEpub ? (
+            <div className="flex items-center gap-2 min-w-[120px]">
+              <Progress
+                percent={Math.round(percentage)}
+                size="small"
+                showInfo={false}
+                className="w-16"
+              />
+              <span className="text-sm text-muted tabular-nums">
+                {Math.round(percentage)}%
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1 text-sm">
+              <Input
+                type="number"
+                min={1}
+                max={totalPages}
+                value={currentPage}
+                onChange={handlePageInputChange}
+                onBlur={handlePageInputBlur}
+                className="w-14 text-center"
+                size="small"
+                data-testid="document-page-input"
+              />
+              <span className="text-muted">
+                / {totalPages || "-"}
+              </span>
+            </div>
+          )}
 
-        <Tooltip title={t("option:documentWorkspace.nextPage", "Next")}>
-          <button
-            onClick={onNextPage}
-            disabled={currentPage >= totalPages}
-            className={TOOLBAR_ICON_BUTTON_CLASS}
-            aria-label={t("option:documentWorkspace.nextPage", "Next")}
-          >
-            <ChevronRight className="h-4 w-4" />
-          </button>
-        </Tooltip>
+          <Tooltip title={t("option:documentWorkspace.nextPage", "Next")}>
+            <button
+              onClick={onNextPage}
+              disabled={currentPage >= totalPages}
+              className={TOOLBAR_ICON_BUTTON_CLASS}
+              aria-label={t("option:documentWorkspace.nextPage", "Next")}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </Tooltip>
+        </div>
 
         {/* Overflow menu on mobile for secondary controls */}
         {isMobile && overflowItems.length > 0 && (

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
@@ -427,6 +427,7 @@ const WorkspaceHeader: React.FC<{
             onClick={() => onOpenPicker("library")}
             className="rounded p-1.5 hover:bg-hover text-text-subtle hover:text-text"
             aria-label={t("option:documentWorkspace.openDocument", "Open document")}
+            data-testid="document-open-picker-button"
           >
             <Plus className="h-5 w-5" />
           </button>

--- a/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
+++ b/apps/packages/ui/src/components/DocumentWorkspace/DocumentWorkspacePage.tsx
@@ -1034,7 +1034,10 @@ export const DocumentWorkspacePage: React.FC = () => {
 
     return (
       <DocumentWorkspaceErrorBoundary>
-        <div className="flex h-full min-h-0 flex-col bg-bg text-text">
+        <div
+          className="flex h-full min-h-0 flex-col bg-bg text-text"
+          data-testid="document-workspace-root"
+        >
           <WorkspaceHeader
             leftPaneOpen={false}
             rightPaneOpen={false}
@@ -1096,7 +1099,10 @@ export const DocumentWorkspacePage: React.FC = () => {
   // Tablet/Desktop layout
   return (
     <DocumentWorkspaceErrorBoundary>
-      <div className="flex h-full min-h-0 flex-col bg-bg text-text">
+      <div
+        className="flex h-full min-h-0 flex-col bg-bg text-text"
+        data-testid="document-workspace-root"
+      >
         <WorkspaceHeader
           leftPaneOpen={!!leftPaneOpen}
           rightPaneOpen={!!rightPaneOpen}

--- a/apps/packages/ui/src/tutorials/__tests__/registry.test.ts
+++ b/apps/packages/ui/src/tutorials/__tests__/registry.test.ts
@@ -128,13 +128,16 @@ describe("tutorial registry route matching", () => {
 
     expect(areTutorialPrerequisitesMet(lockedTutorial, [])).toBe(false)
     expect(
+      areTutorialPrerequisitesMet(lockedTutorial, new Set(["getting-started"]))
+    ).toBe(true)
+    expect(
       getTutorialsForRoute("/knowledge", { completedTutorialIds: [] }).some(
         (tutorial) => tutorial.id === lockedTutorial.id
       )
     ).toBe(false)
     expect(
       getTutorialsForRoute("/knowledge", {
-        completedTutorialIds: [],
+        completedTutorialIds: new Set<string>(),
         includeLocked: true
       }).some((tutorial) => tutorial.id === lockedTutorial.id)
     ).toBe(true)
@@ -145,9 +148,9 @@ describe("tutorial registry route matching", () => {
     ).toBe(true)
   })
 
-  it("prefers the sequence-specific tutorial once prerequisites are completed", () => {
+  it("uses knowledge basics as the second getting started sequence step", () => {
     expect(
-      getTutorialsForRoute("/knowledge", { completedTutorialIds: [] }).some(
+      TUTORIAL_REGISTRY.some(
         (tutorial) => tutorial.id === "getting-started-knowledge"
       )
     ).toBe(false)
@@ -156,15 +159,15 @@ describe("tutorial registry route matching", () => {
       completedTutorialIds: ["getting-started"]
     })
 
-    expect(primaryTutorial?.id).toBe("getting-started-knowledge")
+    expect(primaryTutorial?.id).toBe("knowledge-basics")
   })
 
   it("resolves the next eligible tutorial in the getting started sequence", () => {
     expect(getNextTutorialInSequence("getting-started")?.id).toBe(
-      "getting-started-knowledge"
+      "knowledge-basics"
     )
     expect(
-      getNextTutorialInSequence("getting-started-knowledge", ["getting-started"])
+      getNextTutorialInSequence("knowledge-basics", new Set(["getting-started"]))
         ?.id
     ).toBe("document-workspace-basics")
   })
@@ -175,6 +178,15 @@ describe("tutorial registry route matching", () => {
     expect(primaryTutorial?.id).toBe("document-workspace-basics")
     expect(primaryTutorial?.steps[0]?.target).toBe(
       '[data-testid="document-workspace-root"]'
+    )
+    expect(
+      primaryTutorial?.steps.some(
+        (step) => step.target === '[data-testid="document-open-picker-button"]'
+      )
+    ).toBe(true)
+    const lastStep = primaryTutorial?.steps[primaryTutorial.steps.length - 1]
+    expect(lastStep?.target).toBe(
+      '[data-testid="document-navigation"]'
     )
   })
 

--- a/apps/packages/ui/src/tutorials/__tests__/registry.test.ts
+++ b/apps/packages/ui/src/tutorials/__tests__/registry.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest"
 import {
   TUTORIAL_REGISTRY,
+  areTutorialPrerequisitesMet,
   getPrimaryTutorialForRoute,
+  getNextTutorialInSequence,
   getTutorialsForRoute,
   isTutorialRuntimeSuppressed,
   normalizeTutorialRoute,
@@ -100,6 +102,82 @@ describe("tutorial registry route matching", () => {
     expect(primaryTutorial?.id).toBe("playground-basics")
   })
 
+  it("filters prerequisite-gated tutorials until their prerequisites are completed", () => {
+    const lockedTutorial: TutorialDefinition = {
+      id: "test-locked-knowledge-tour",
+      routePattern: "/knowledge",
+      labelKey: "tutorials:test.lockedKnowledge.label",
+      labelFallback: "Locked Knowledge Tour",
+      descriptionKey: "tutorials:test.lockedKnowledge.description",
+      descriptionFallback: "A locked route tutorial",
+      prerequisites: ["getting-started"],
+      priority: 0,
+      steps: [
+        {
+          target: "body",
+          titleKey: "tutorials:test.lockedKnowledge.stepTitle",
+          titleFallback: "Step",
+          contentKey: "tutorials:test.lockedKnowledge.stepContent",
+          contentFallback: "Locked route tutorial test"
+        }
+      ]
+    }
+
+    TUTORIAL_REGISTRY.push(lockedTutorial)
+    injectedTutorials.push(lockedTutorial)
+
+    expect(areTutorialPrerequisitesMet(lockedTutorial, [])).toBe(false)
+    expect(
+      getTutorialsForRoute("/knowledge", { completedTutorialIds: [] }).some(
+        (tutorial) => tutorial.id === lockedTutorial.id
+      )
+    ).toBe(false)
+    expect(
+      getTutorialsForRoute("/knowledge", {
+        completedTutorialIds: [],
+        includeLocked: true
+      }).some((tutorial) => tutorial.id === lockedTutorial.id)
+    ).toBe(true)
+    expect(
+      getTutorialsForRoute("/knowledge", {
+        completedTutorialIds: ["getting-started"]
+      }).some((tutorial) => tutorial.id === lockedTutorial.id)
+    ).toBe(true)
+  })
+
+  it("prefers the sequence-specific tutorial once prerequisites are completed", () => {
+    expect(
+      getTutorialsForRoute("/knowledge", { completedTutorialIds: [] }).some(
+        (tutorial) => tutorial.id === "getting-started-knowledge"
+      )
+    ).toBe(false)
+
+    const primaryTutorial = getPrimaryTutorialForRoute("/knowledge", {
+      completedTutorialIds: ["getting-started"]
+    })
+
+    expect(primaryTutorial?.id).toBe("getting-started-knowledge")
+  })
+
+  it("resolves the next eligible tutorial in the getting started sequence", () => {
+    expect(getNextTutorialInSequence("getting-started")?.id).toBe(
+      "getting-started-knowledge"
+    )
+    expect(
+      getNextTutorialInSequence("getting-started-knowledge", ["getting-started"])
+        ?.id
+    ).toBe("document-workspace-basics")
+  })
+
+  it("starts the document workspace tutorial on an always-rendered route shell", () => {
+    const primaryTutorial = getPrimaryTutorialForRoute("/document-workspace")
+
+    expect(primaryTutorial?.id).toBe("document-workspace-basics")
+    expect(primaryTutorial?.steps[0]?.target).toBe(
+      '[data-testid="document-workspace-root"]'
+    )
+  })
+
   it("includes basics tutorials for all P0/P1 page routes", () => {
     const expectedBasicsByRoute: Record<string, string> = {
       "/chat": "playground-basics",
@@ -111,7 +189,8 @@ describe("tutorial registry route matching", () => {
       "/evaluations": "evaluations-basics",
       "/notes": "notes-basics",
       "/flashcards": "flashcards-basics",
-      "/world-books": "world-books-basics"
+      "/world-books": "world-books-basics",
+      "/document-workspace": "document-workspace-basics"
     }
 
     for (const [route, expectedId] of Object.entries(expectedBasicsByRoute)) {
@@ -133,6 +212,9 @@ describe("tutorial registry route matching", () => {
     expect(normalizeTutorialRoute("/options/notes")).toBe("/notes")
     expect(normalizeTutorialRoute("/options/flashcards")).toBe("/flashcards")
     expect(normalizeTutorialRoute("/options/world-books")).toBe("/world-books")
+    expect(normalizeTutorialRoute("/options/document-workspace")).toBe(
+      "/document-workspace"
+    )
     expect(normalizeTutorialRoute("/knowledge/thread/abc123")).toBe("/knowledge")
     expect(normalizeTutorialRoute("/knowledge/shared/share-token")).toBe("/knowledge")
   })

--- a/apps/packages/ui/src/tutorials/definitions/document-workspace.ts
+++ b/apps/packages/ui/src/tutorials/definitions/document-workspace.ts
@@ -27,6 +27,15 @@ const documentWorkspaceBasics: TutorialDefinition = {
       disableBeacon: true
     },
     {
+      target: '[data-testid="document-open-picker-button"]',
+      titleKey: "tutorials:documentWorkspace.basics.openDocumentTitle",
+      titleFallback: "Open or Select a Document",
+      contentKey: "tutorials:documentWorkspace.basics.openDocumentContent",
+      contentFallback:
+        "Use the open document button to pick a saved source or upload a new PDF or EPUB for study.",
+      placement: "bottom"
+    },
+    {
       target: '[data-testid="document-workspace-toggle-left"]',
       titleKey: "tutorials:documentWorkspace.basics.leftPaneTitle",
       titleFallback: "Document Navigation",
@@ -54,7 +63,7 @@ const documentWorkspaceBasics: TutorialDefinition = {
       placement: "bottom"
     },
     {
-      target: '[data-testid="document-page-input"]',
+      target: '[data-testid="document-navigation"]',
       titleKey: "tutorials:documentWorkspace.basics.navigationTitle",
       titleFallback: "Jump Through Long Documents",
       contentKey: "tutorials:documentWorkspace.basics.navigationContent",

--- a/apps/packages/ui/src/tutorials/definitions/document-workspace.ts
+++ b/apps/packages/ui/src/tutorials/definitions/document-workspace.ts
@@ -1,0 +1,70 @@
+/**
+ * Document Workspace Tutorial Definitions
+ */
+
+import { FileText } from "lucide-react"
+import type { TutorialDefinition } from "../registry"
+
+const documentWorkspaceBasics: TutorialDefinition = {
+  id: "document-workspace-basics",
+  routePattern: "/document-workspace",
+  labelKey: "tutorials:documentWorkspace.basics.label",
+  labelFallback: "Document Workspace Basics",
+  descriptionKey: "tutorials:documentWorkspace.basics.description",
+  descriptionFallback:
+    "Read, navigate, annotate, and ask questions about documents in one workspace",
+  icon: FileText,
+  priority: 1,
+  steps: [
+    {
+      target: '[data-testid="document-workspace-root"]',
+      titleKey: "tutorials:documentWorkspace.basics.workspaceTitle",
+      titleFallback: "Document Workspace",
+      contentKey: "tutorials:documentWorkspace.basics.workspaceContent",
+      contentFallback:
+        "Use this workspace to read source documents while keeping navigation, notes, citations, quizzes, and chat close at hand.",
+      placement: "bottom",
+      disableBeacon: true
+    },
+    {
+      target: '[data-testid="document-workspace-toggle-left"]',
+      titleKey: "tutorials:documentWorkspace.basics.leftPaneTitle",
+      titleFallback: "Document Navigation",
+      contentKey: "tutorials:documentWorkspace.basics.leftPaneContent",
+      contentFallback:
+        "Open the left pane for contents, page thumbnails, references, document info, and quick insights.",
+      placement: "bottom"
+    },
+    {
+      target: '[data-testid="document-workspace-toggle-right"]',
+      titleKey: "tutorials:documentWorkspace.basics.rightPaneTitle",
+      titleFallback: "Document Tools",
+      contentKey: "tutorials:documentWorkspace.basics.rightPaneContent",
+      contentFallback:
+        "Open the right pane for document chat, highlights, citations, and generated quizzes.",
+      placement: "bottom"
+    },
+    {
+      target: '[data-testid="document-viewer"]',
+      titleKey: "tutorials:documentWorkspace.basics.viewerTitle",
+      titleFallback: "Read in Context",
+      contentKey: "tutorials:documentWorkspace.basics.viewerContent",
+      contentFallback:
+        "The center viewer keeps your active PDF or EPUB in focus while side panels add research context.",
+      placement: "bottom"
+    },
+    {
+      target: '[data-testid="document-page-input"]',
+      titleKey: "tutorials:documentWorkspace.basics.navigationTitle",
+      titleFallback: "Jump Through Long Documents",
+      contentKey: "tutorials:documentWorkspace.basics.navigationContent",
+      contentFallback:
+        "Use page navigation, search, zoom, and keyboard shortcuts to move through long documents efficiently.",
+      placement: "bottom"
+    }
+  ]
+}
+
+export const documentWorkspaceTutorials: TutorialDefinition[] = [
+  documentWorkspaceBasics
+]

--- a/apps/packages/ui/src/tutorials/definitions/getting-started.ts
+++ b/apps/packages/ui/src/tutorials/definitions/getting-started.ts
@@ -17,6 +17,12 @@ const gettingStarted: TutorialDefinition = {
     "A quick tour of the main features to help you get the most out of tldw",
   icon: Rocket,
   priority: 0,
+  sequence: {
+    nextTutorialId: "getting-started-knowledge",
+    nextRoute: "/knowledge",
+    nextLabelKey: "tutorials:gettingStarted.sequence.knowledgeLabel",
+    nextLabelFallback: "Continue in Knowledge"
+  },
   steps: [
     {
       target: '[data-testid="companion-home-shell"]',

--- a/apps/packages/ui/src/tutorials/definitions/getting-started.ts
+++ b/apps/packages/ui/src/tutorials/definitions/getting-started.ts
@@ -18,7 +18,7 @@ const gettingStarted: TutorialDefinition = {
   icon: Rocket,
   priority: 0,
   sequence: {
-    nextTutorialId: "getting-started-knowledge",
+    nextTutorialId: "knowledge-basics",
     nextRoute: "/knowledge",
     nextLabelKey: "tutorials:gettingStarted.sequence.knowledgeLabel",
     nextLabelFallback: "Continue in Knowledge"

--- a/apps/packages/ui/src/tutorials/definitions/knowledge.ts
+++ b/apps/packages/ui/src/tutorials/definitions/knowledge.ts
@@ -5,6 +5,64 @@
 import { BrainCircuit } from "lucide-react"
 import type { TutorialDefinition } from "../registry"
 
+const gettingStartedKnowledge: TutorialDefinition = {
+  id: "getting-started-knowledge",
+  routePattern: "/knowledge",
+  labelKey: "tutorials:gettingStarted.knowledge.label",
+  labelFallback: "Getting Started: Knowledge",
+  descriptionKey: "tutorials:gettingStarted.knowledge.description",
+  descriptionFallback:
+    "Continue the getting started path by searching your first indexed sources",
+  icon: BrainCircuit,
+  prerequisites: ["getting-started"],
+  priority: 0,
+  sequence: {
+    nextTutorialId: "document-workspace-basics",
+    nextRoute: "/document-workspace",
+    nextLabelKey: "tutorials:gettingStarted.sequence.documentWorkspaceLabel",
+    nextLabelFallback: "Continue in Document Workspace"
+  },
+  steps: [
+    {
+      target: '[data-testid="knowledge-page-root"]',
+      titleKey: "tutorials:gettingStarted.knowledge.workspaceTitle",
+      titleFallback: "Search Your Knowledge Base",
+      contentKey: "tutorials:gettingStarted.knowledge.workspaceContent",
+      contentFallback:
+        "Knowledge is where your ingested documents, notes, and media become searchable evidence for research questions.",
+      placement: "bottom",
+      disableBeacon: true
+    },
+    {
+      target: "#knowledge-search-input",
+      titleKey: "tutorials:gettingStarted.knowledge.searchTitle",
+      titleFallback: "Ask a Focused Question",
+      contentKey: "tutorials:gettingStarted.knowledge.searchContent",
+      contentFallback:
+        "Start with a focused question. The retrieval pipeline will search across the sources you select.",
+      placement: "bottom"
+    },
+    {
+      target: "#knowledge-source-selector-toggle",
+      titleKey: "tutorials:gettingStarted.knowledge.sourcesTitle",
+      titleFallback: "Pick the Right Sources",
+      contentKey: "tutorials:gettingStarted.knowledge.sourcesContent",
+      contentFallback:
+        "Use source groups to keep answers grounded in the documents or media that matter for the current task.",
+      placement: "bottom"
+    },
+    {
+      target: '[data-testid="knowledge-results-shell"]',
+      titleKey: "tutorials:gettingStarted.knowledge.resultsTitle",
+      titleFallback: "Review Answers and Evidence",
+      contentKey: "tutorials:gettingStarted.knowledge.resultsContent",
+      contentFallback:
+        "After a search, use the results workspace to inspect answers, citations, and supporting source snippets.",
+      placement: "left"
+    }
+  ]
+}
+
 const knowledgeBasics: TutorialDefinition = {
   id: "knowledge-basics",
   routePattern: "/knowledge",
@@ -66,4 +124,7 @@ const knowledgeBasics: TutorialDefinition = {
   ]
 }
 
-export const knowledgeTutorials: TutorialDefinition[] = [knowledgeBasics]
+export const knowledgeTutorials: TutorialDefinition[] = [
+  gettingStartedKnowledge,
+  knowledgeBasics
+]

--- a/apps/packages/ui/src/tutorials/definitions/knowledge.ts
+++ b/apps/packages/ui/src/tutorials/definitions/knowledge.ts
@@ -5,64 +5,6 @@
 import { BrainCircuit } from "lucide-react"
 import type { TutorialDefinition } from "../registry"
 
-const gettingStartedKnowledge: TutorialDefinition = {
-  id: "getting-started-knowledge",
-  routePattern: "/knowledge",
-  labelKey: "tutorials:gettingStarted.knowledge.label",
-  labelFallback: "Getting Started: Knowledge",
-  descriptionKey: "tutorials:gettingStarted.knowledge.description",
-  descriptionFallback:
-    "Continue the getting started path by searching your first indexed sources",
-  icon: BrainCircuit,
-  prerequisites: ["getting-started"],
-  priority: 0,
-  sequence: {
-    nextTutorialId: "document-workspace-basics",
-    nextRoute: "/document-workspace",
-    nextLabelKey: "tutorials:gettingStarted.sequence.documentWorkspaceLabel",
-    nextLabelFallback: "Continue in Document Workspace"
-  },
-  steps: [
-    {
-      target: '[data-testid="knowledge-page-root"]',
-      titleKey: "tutorials:gettingStarted.knowledge.workspaceTitle",
-      titleFallback: "Search Your Knowledge Base",
-      contentKey: "tutorials:gettingStarted.knowledge.workspaceContent",
-      contentFallback:
-        "Knowledge is where your ingested documents, notes, and media become searchable evidence for research questions.",
-      placement: "bottom",
-      disableBeacon: true
-    },
-    {
-      target: "#knowledge-search-input",
-      titleKey: "tutorials:gettingStarted.knowledge.searchTitle",
-      titleFallback: "Ask a Focused Question",
-      contentKey: "tutorials:gettingStarted.knowledge.searchContent",
-      contentFallback:
-        "Start with a focused question. The retrieval pipeline will search across the sources you select.",
-      placement: "bottom"
-    },
-    {
-      target: "#knowledge-source-selector-toggle",
-      titleKey: "tutorials:gettingStarted.knowledge.sourcesTitle",
-      titleFallback: "Pick the Right Sources",
-      contentKey: "tutorials:gettingStarted.knowledge.sourcesContent",
-      contentFallback:
-        "Use source groups to keep answers grounded in the documents or media that matter for the current task.",
-      placement: "bottom"
-    },
-    {
-      target: '[data-testid="knowledge-results-shell"]',
-      titleKey: "tutorials:gettingStarted.knowledge.resultsTitle",
-      titleFallback: "Review Answers and Evidence",
-      contentKey: "tutorials:gettingStarted.knowledge.resultsContent",
-      contentFallback:
-        "After a search, use the results workspace to inspect answers, citations, and supporting source snippets.",
-      placement: "left"
-    }
-  ]
-}
-
 const knowledgeBasics: TutorialDefinition = {
   id: "knowledge-basics",
   routePattern: "/knowledge",
@@ -73,6 +15,12 @@ const knowledgeBasics: TutorialDefinition = {
     "Search your indexed sources and review grounded answers with citations",
   icon: BrainCircuit,
   priority: 1,
+  sequence: {
+    nextTutorialId: "document-workspace-basics",
+    nextRoute: "/document-workspace",
+    nextLabelKey: "tutorials:gettingStarted.sequence.documentWorkspaceLabel",
+    nextLabelFallback: "Continue in Document Workspace"
+  },
   steps: [
     {
       target: "#knowledge-search-input",
@@ -124,7 +72,4 @@ const knowledgeBasics: TutorialDefinition = {
   ]
 }
 
-export const knowledgeTutorials: TutorialDefinition[] = [
-  gettingStartedKnowledge,
-  knowledgeBasics
-]
+export const knowledgeTutorials: TutorialDefinition[] = [knowledgeBasics]

--- a/apps/packages/ui/src/tutorials/index.ts
+++ b/apps/packages/ui/src/tutorials/index.ts
@@ -4,7 +4,11 @@
  */
 
 // Types
-export type { TutorialStep, TutorialDefinition } from "./registry"
+export type {
+  TutorialStep,
+  TutorialDefinition,
+  TutorialSequence
+} from "./registry"
 
 // Registry and helpers
 export {
@@ -12,6 +16,8 @@ export {
   getTutorialsForRoute,
   getTutorialById,
   getPrimaryTutorialForRoute,
+  getNextTutorialInSequence,
+  areTutorialPrerequisitesMet,
   hasTutorialsForRoute,
   getTutorialCountForRoute,
   normalizeTutorialRoute
@@ -28,6 +34,7 @@ export { evaluationsTutorials } from "./definitions/evaluations"
 export { notesTutorials } from "./definitions/notes"
 export { flashcardsTutorials } from "./definitions/flashcards"
 export { worldBooksTutorials } from "./definitions/world-books"
+export { documentWorkspaceTutorials } from "./definitions/document-workspace"
 export { gettingStartedTutorials } from "./definitions/getting-started"
 export { ttsTutorials } from "./definitions/tts"
 export { sttTutorials } from "./definitions/stt"

--- a/apps/packages/ui/src/tutorials/registry.ts
+++ b/apps/packages/ui/src/tutorials/registry.ts
@@ -254,22 +254,27 @@ export function normalizeTutorialRoute(routeLike: string): string {
  */
 type GetTutorialsForRouteOptions = {
   ignoreRuntimeSuppression?: boolean
-  completedTutorialIds?: readonly string[]
+  completedTutorialIds?: CompletedTutorialIds
   includeLocked?: boolean
 }
 
+type CompletedTutorialIds = readonly string[] | ReadonlySet<string>
+
 const getCompletedTutorialSet = (
-  completedTutorialIds: readonly string[] = []
-): Set<string> => new Set(completedTutorialIds)
+  completedTutorialIds: CompletedTutorialIds = []
+): ReadonlySet<string> =>
+  completedTutorialIds instanceof Set
+    ? completedTutorialIds
+    : new Set(completedTutorialIds)
 
 const sortTutorialsByPriority = (
-  tutorials: TutorialDefinition[]
+  tutorials: readonly TutorialDefinition[]
 ): TutorialDefinition[] =>
-  tutorials.sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100))
+  [...tutorials].sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100))
 
 export function areTutorialPrerequisitesMet(
   tutorial: TutorialDefinition,
-  completedTutorialIds: readonly string[] = []
+  completedTutorialIds: CompletedTutorialIds = []
 ): boolean {
   const prerequisites = tutorial.prerequisites ?? []
   if (prerequisites.length === 0) {
@@ -293,10 +298,11 @@ export function getTutorialsForRoute(
   const matches = TUTORIAL_REGISTRY.filter((tutorial) =>
     matchRoute(tutorial.routePattern, pathname)
   )
+  const completedSet = getCompletedTutorialSet(options.completedTutorialIds)
   const eligibleMatches = options.includeLocked
     ? matches
     : matches.filter((tutorial) =>
-        areTutorialPrerequisitesMet(tutorial, options.completedTutorialIds)
+        areTutorialPrerequisitesMet(tutorial, completedSet)
       )
 
   // Sort by priority (lower priority number = higher in list)
@@ -368,12 +374,10 @@ export function getTutorialCountForRoute(
  */
 export function getNextTutorialInSequence(
   completedTutorialId: string,
-  completedTutorialIds: readonly string[] = []
+  completedTutorialIds: CompletedTutorialIds = []
 ): TutorialDefinition | undefined {
-  const completedTutorials = getCompletedTutorialSet([
-    ...completedTutorialIds,
-    completedTutorialId
-  ])
+  const completedTutorials = new Set(completedTutorialIds)
+  completedTutorials.add(completedTutorialId)
   const currentTutorial = getTutorialById(completedTutorialId)
   const explicitNextId = currentTutorial?.sequence?.nextTutorialId
 
@@ -382,10 +386,7 @@ export function getNextTutorialInSequence(
     if (
       explicitNextTutorial &&
       !completedTutorials.has(explicitNextTutorial.id) &&
-      areTutorialPrerequisitesMet(
-        explicitNextTutorial,
-        Array.from(completedTutorials)
-      )
+      areTutorialPrerequisitesMet(explicitNextTutorial, completedTutorials)
     ) {
       return explicitNextTutorial
     }
@@ -396,7 +397,7 @@ export function getNextTutorialInSequence(
       (tutorial) =>
         !completedTutorials.has(tutorial.id) &&
         (tutorial.prerequisites ?? []).includes(completedTutorialId) &&
-        areTutorialPrerequisitesMet(tutorial, Array.from(completedTutorials))
+        areTutorialPrerequisitesMet(tutorial, completedTutorials)
     )
   )[0]
 }

--- a/apps/packages/ui/src/tutorials/registry.ts
+++ b/apps/packages/ui/src/tutorials/registry.ts
@@ -37,6 +37,17 @@ export interface TutorialStep {
 /**
  * A complete tutorial definition
  */
+export interface TutorialSequence {
+  /** Explicit next tutorial in a multi-page sequence */
+  nextTutorialId: string
+  /** Route to navigate to before starting the next tutorial */
+  nextRoute?: string
+  /** i18n key for a continue/progression label */
+  nextLabelKey?: string
+  /** Fallback progression label */
+  nextLabelFallback?: string
+}
+
 export interface TutorialDefinition {
   /** Unique identifier for this tutorial */
   id: string
@@ -56,6 +67,8 @@ export interface TutorialDefinition {
   steps: TutorialStep[]
   /** IDs of other tutorials that should be completed first (optional) */
   prerequisites?: string[]
+  /** Optional sequence metadata for multi-page tutorial flows */
+  sequence?: TutorialSequence
   /** Priority for ordering in the tutorial list (lower = higher priority) */
   priority?: number
 }
@@ -85,6 +98,7 @@ import { ttsTutorials } from "./definitions/tts"
 import { sttTutorials } from "./definitions/stt"
 import { watchlistsTutorials } from "./definitions/watchlists"
 import { monitoringTutorials } from "./definitions/monitoring"
+import { documentWorkspaceTutorials } from "./definitions/document-workspace"
 
 /**
  * Central registry of all available tutorials
@@ -101,6 +115,7 @@ export const TUTORIAL_REGISTRY: TutorialDefinition[] = [
   ...notesTutorials,
   ...flashcardsTutorials,
   ...worldBooksTutorials,
+  ...documentWorkspaceTutorials,
   ...moderationTutorials,
   ...mcpHubTutorials,
   ...quizTutorials,
@@ -153,7 +168,8 @@ const LEGACY_ROUTE_ALIASES: Record<string, string> = {
   "/options/evaluations": "/evaluations",
   "/options/notes": "/notes",
   "/options/flashcards": "/flashcards",
-  "/options/world-books": "/world-books"
+  "/options/world-books": "/world-books",
+  "/options/document-workspace": "/document-workspace"
 }
 
 const PREFIX_ROUTE_ALIASES: Array<{ pattern: RegExp; canonical: string }> = [
@@ -238,6 +254,32 @@ export function normalizeTutorialRoute(routeLike: string): string {
  */
 type GetTutorialsForRouteOptions = {
   ignoreRuntimeSuppression?: boolean
+  completedTutorialIds?: readonly string[]
+  includeLocked?: boolean
+}
+
+const getCompletedTutorialSet = (
+  completedTutorialIds: readonly string[] = []
+): Set<string> => new Set(completedTutorialIds)
+
+const sortTutorialsByPriority = (
+  tutorials: TutorialDefinition[]
+): TutorialDefinition[] =>
+  tutorials.sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100))
+
+export function areTutorialPrerequisitesMet(
+  tutorial: TutorialDefinition,
+  completedTutorialIds: readonly string[] = []
+): boolean {
+  const prerequisites = tutorial.prerequisites ?? []
+  if (prerequisites.length === 0) {
+    return true
+  }
+
+  const completedTutorials = getCompletedTutorialSet(completedTutorialIds)
+  return prerequisites.every((prerequisiteId) =>
+    completedTutorials.has(prerequisiteId)
+  )
 }
 
 export function getTutorialsForRoute(
@@ -251,9 +293,14 @@ export function getTutorialsForRoute(
   const matches = TUTORIAL_REGISTRY.filter((tutorial) =>
     matchRoute(tutorial.routePattern, pathname)
   )
+  const eligibleMatches = options.includeLocked
+    ? matches
+    : matches.filter((tutorial) =>
+        areTutorialPrerequisitesMet(tutorial, options.completedTutorialIds)
+      )
 
   // Sort by priority (lower priority number = higher in list)
-  return matches.sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100))
+  return sortTutorialsByPriority(eligibleMatches)
 }
 
 /**
@@ -273,13 +320,19 @@ export function getTutorialById(
  * @returns The primary tutorial (first one with "basics" in ID, or first tutorial)
  */
 export function getPrimaryTutorialForRoute(
-  pathname: string
+  pathname: string,
+  options: GetTutorialsForRouteOptions = {}
 ): TutorialDefinition | undefined {
-  const tutorials = getTutorialsForRoute(pathname)
+  const tutorials = getTutorialsForRoute(pathname, options)
   if (tutorials.length === 0) return undefined
 
-  // Prefer tutorials with "basics" or "overview" in the ID
-  const basicsTutorial = tutorials.find(
+  const topPriority = tutorials[0].priority ?? 100
+  const topPriorityTutorials = tutorials.filter(
+    (tutorial) => (tutorial.priority ?? 100) === topPriority
+  )
+
+  // Prefer basics/overview only within the highest-priority group.
+  const basicsTutorial = topPriorityTutorials.find(
     (t) => t.id.includes("basics") || t.id.includes("overview")
   )
 
@@ -291,8 +344,11 @@ export function getPrimaryTutorialForRoute(
  * @param pathname - The current route pathname
  * @returns True if at least one tutorial is available
  */
-export function hasTutorialsForRoute(pathname: string): boolean {
-  return getTutorialsForRoute(pathname).length > 0
+export function hasTutorialsForRoute(
+  pathname: string,
+  options: GetTutorialsForRouteOptions = {}
+): boolean {
+  return getTutorialsForRoute(pathname, options).length > 0
 }
 
 /**
@@ -300,6 +356,47 @@ export function hasTutorialsForRoute(pathname: string): boolean {
  * @param pathname - The current route pathname
  * @returns Number of available tutorials
  */
-export function getTutorialCountForRoute(pathname: string): number {
-  return getTutorialsForRoute(pathname).length
+export function getTutorialCountForRoute(
+  pathname: string,
+  options: GetTutorialsForRouteOptions = {}
+): number {
+  return getTutorialsForRoute(pathname, options).length
+}
+
+/**
+ * Resolve the next eligible tutorial in a sequence after a tutorial completes.
+ */
+export function getNextTutorialInSequence(
+  completedTutorialId: string,
+  completedTutorialIds: readonly string[] = []
+): TutorialDefinition | undefined {
+  const completedTutorials = getCompletedTutorialSet([
+    ...completedTutorialIds,
+    completedTutorialId
+  ])
+  const currentTutorial = getTutorialById(completedTutorialId)
+  const explicitNextId = currentTutorial?.sequence?.nextTutorialId
+
+  if (explicitNextId) {
+    const explicitNextTutorial = getTutorialById(explicitNextId)
+    if (
+      explicitNextTutorial &&
+      !completedTutorials.has(explicitNextTutorial.id) &&
+      areTutorialPrerequisitesMet(
+        explicitNextTutorial,
+        Array.from(completedTutorials)
+      )
+    ) {
+      return explicitNextTutorial
+    }
+  }
+
+  return sortTutorialsByPriority(
+    TUTORIAL_REGISTRY.filter(
+      (tutorial) =>
+        !completedTutorials.has(tutorial.id) &&
+        (tutorial.prerequisites ?? []).includes(completedTutorialId) &&
+        areTutorialPrerequisitesMet(tutorial, Array.from(completedTutorials))
+    )
+  )[0]
 }


### PR DESCRIPTION
## Change summary

Adds the first implementation slice for issue #1008:

- makes tutorial prerequisites operational in the shared registry
- adds explicit tutorial sequence metadata and a next-tutorial resolver
- wires first-visit prompts to use persisted completion state
- keeps Help and Quick Chat able to show locked tutorials
- adds a sequence-aware Knowledge tutorial and a Document Workspace basics tutorial

This intentionally leaves the larger cross-page continuation prompt UI for a follow-up slice, so this PR uses `Part of #1008` rather than closing the issue.

## Testing

- `bun run test src/tutorials/__tests__/registry.test.ts src/components/Common/__tests__/TutorialPrompt.behavior.test.tsx`
- `git diff --cached --check`
- Filtered TypeScript compile pass for touched files: no touched-file errors

## Notes

Full `bunx tsc --noEmit -p tsconfig.json --ignoreDeprecations 6.0` still reports unrelated baseline errors across the UI package. The first plain TypeScript attempt also hit the repo's existing `baseUrl` deprecation under latest TypeScript.

Part of #1008.
