### PR TITLE
Register WebSub renewal worker in lifecycle inventory

### DIFF
--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -102,7 +102,7 @@ async def shutdown_post_worker_services(
         jobs_notifications_bridge_task=jobs_notifications_bridge_task,
         embeddings_compactor_task=embeddings_compactor_task,
         embeddings_compactor_stop_event=embeddings_compactor_stop_event,
-        websub_renewal_task=websub_renewal_task,
+        websub_renewal_task=_task_if_not_stopped("websub_renewal_task", websub_renewal_task),
         guard_exceptions=guard_exceptions,
     )
     usage_shutdown_handles = await _stop_usage_aggregators(
@@ -299,7 +299,7 @@ async def run_shutdown_post_worker_services(
             jobs_notifications_bridge_task=jobs_notifications_bridge_task,
             embeddings_compactor_task=embeddings_compactor_task,
             embeddings_compactor_stop_event=embeddings_compactor_stop_event,
-            websub_renewal_task=websub_renewal_task,
+            websub_renewal_task=_fallback_if_not_stopped("websub_renewal_task", websub_renewal_task),
             usage_task=usage_task,
             llm_usage_task=llm_usage_task,
             jobs_metrics_task=_fallback_if_not_stopped("jobs_metrics_task", jobs_metrics_task),

--- a/tldw_Server_API/app/services/startup_compactor_websub_workers.py
+++ b/tldw_Server_API/app/services/startup_compactor_websub_workers.py
@@ -34,12 +34,14 @@ class CompactorWebsubStartupHandles:
 async def start_compactor_websub_workers(
     *,
     should_start_worker: Callable[..., bool],
+    worker_inventory: Any | None = None,
 ) -> CompactorWebsubStartupHandles:
     """Start the embeddings compactor and WebSub renewal worker."""
 
     embeddings_compactor_stop_event, embeddings_compactor_task = await _start_embeddings_vector_compactor()
     websub_renewal_task = await _start_websub_renewal_worker(
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     return CompactorWebsubStartupHandles(
         embeddings_compactor_stop_event=embeddings_compactor_stop_event,
@@ -52,8 +54,9 @@ def _make_event() -> Any:
     return asyncio.Event()
 
 
-def _create_task(awaitable: Any) -> Any:
-    return asyncio.create_task(awaitable)
+def _create_task(awaitable: Any, *, name: str | None = None) -> Any:
+    """Create a task with an optional asyncio task name for diagnostics."""
+    return asyncio.create_task(awaitable, name=name)
 
 
 async def _start_embeddings_vector_compactor() -> tuple[Any | None, Any | None]:
@@ -75,6 +78,7 @@ async def _start_embeddings_vector_compactor() -> tuple[Any | None, Any | None]:
 async def _start_websub_renewal_worker(
     *,
     should_start_worker: Callable[..., bool],
+    worker_inventory: Any | None = None,
 ) -> Any | None:
     try:
         callback_base_url = os.getenv("WEBSUB_CALLBACK_BASE_URL", "").strip()
@@ -86,7 +90,32 @@ async def _start_websub_renewal_worker(
             logger.info("WebSub renewal worker disabled (no WEBSUB_CALLBACK_BASE_URL or flag off)")
             return None
 
-        task = _create_task(_run_websub_renewal_loop())
+        task = _create_task(_run_websub_renewal_loop(), name="websub_renewal_task")
+        if worker_inventory is not None:
+            from tldw_Server_API.app.services.lifecycle_workers import (
+                ManagedWorker,
+                ShutdownPhase,
+            )
+
+            try:
+                worker_inventory.register(
+                    ManagedWorker(
+                        name="websub_renewal_task",
+                        task=task,
+                        stop_event=None,
+                        category="collections-websub",
+                        shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+                    )
+                )
+            except Exception:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception as exc:
+                    logger.debug(f"WebSub renewal task raised during startup rollback: {exc}")
+                raise
         logger.info("WebSub lease renewal worker started")
         return task
     except _STARTUP_GUARD_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/services/startup_worker_bootstrap.py
+++ b/tldw_Server_API/app/services/startup_worker_bootstrap.py
@@ -46,6 +46,7 @@ async def initialize_startup_worker_bootstrap(
         route_enabled=route_enabled,
         startup_guard_exceptions=startup_guard_exceptions,
         owned_job_pollers=owned_job_pollers,
+        worker_inventory=worker_inventory,
         register_owned_job_poller=register_owned_job_poller,
     )
     startup_service_tail_handles = await _initialize_startup_service_tail(

--- a/tldw_Server_API/app/services/startup_worker_groups.py
+++ b/tldw_Server_API/app/services/startup_worker_groups.py
@@ -81,6 +81,7 @@ async def start_worker_groups(
     startup_guard_exceptions: tuple[type[BaseException], ...],
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
+    worker_inventory: Any | None = None,
 ) -> StartupWorkerGroupHandles:
     """Start the startup worker/poller groups in the legacy order."""
     cleanup_worker_handles = await _start_cleanup_workers(
@@ -127,6 +128,7 @@ async def start_worker_groups(
     )
     compactor_websub_startup_handles = await _start_compactor_websub_workers(
         should_start_worker=_should_start_worker,
+        worker_inventory=worker_inventory,
     )
     content_jobs_poller_handles = await _start_content_jobs_pollers(
         app=app,

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -301,6 +301,129 @@ async def test_shutdown_post_worker_services_skips_jobs_webhooks_after_backgroun
 
 
 @pytest.mark.asyncio
+async def test_shutdown_post_worker_services_skips_websub_after_background_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_post_worker_services as shutdown_services
+
+    notification_kwargs: dict[str, object] = {}
+
+    async def _claims(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            claims_task=kwargs["claims_task"],
+            jobs_prune_task=kwargs["jobs_prune_task"],
+            files_export_gc_task=kwargs["files_export_gc_task"],
+            notifications_prune_task=kwargs["notifications_prune_task"],
+        )
+
+    async def _notifications(**kwargs: object) -> SimpleNamespace:
+        notification_kwargs.update(kwargs)
+        return SimpleNamespace(
+            jobs_notifications_bridge_task=kwargs["jobs_notifications_bridge_task"],
+            embeddings_compactor_task=kwargs["embeddings_compactor_task"],
+            embeddings_compactor_stop_event=kwargs["embeddings_compactor_stop_event"],
+            websub_renewal_task=kwargs["websub_renewal_task"],
+        )
+
+    async def _usage(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            usage_task=kwargs["usage_task"],
+            llm_usage_task=kwargs["llm_usage_task"],
+        )
+
+    async def _recurring(**kwargs: object) -> None:
+        return None
+
+    async def _runtime(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_metrics_task=kwargs["jobs_metrics_task"],
+            loop_lag_task=kwargs["loop_lag_task"],
+        )
+
+    async def _reconcile(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_metrics_reconcile_task=kwargs["jobs_metrics_reconcile_task"],
+            jobs_metrics_reconcile_stop=kwargs["jobs_metrics_reconcile_stop"],
+        )
+
+    async def _personalization(**kwargs: object) -> None:
+        return None
+
+    async def _optional(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_crypto_rotate_task=kwargs["jobs_crypto_rotate_task"],
+            jobs_integrity_task=kwargs["jobs_integrity_task"],
+            jobs_webhooks_task=kwargs["jobs_webhooks_task"],
+            meetings_webhook_dlq_task=kwargs["meetings_webhook_dlq_task"],
+            workflows_dlq_task=kwargs["workflows_dlq_task"],
+            workflows_gc_task=kwargs["workflows_gc_task"],
+            workflows_maint_task=kwargs["workflows_maint_task"],
+        )
+
+    monkeypatch.setattr(shutdown_services, "_shutdown_claims_maintenance_tasks", _claims)
+    monkeypatch.setattr(
+        shutdown_services,
+        "_shutdown_notifications_compactor_websub_workers",
+        _notifications,
+    )
+    monkeypatch.setattr(shutdown_services, "_stop_usage_aggregators", _usage)
+    monkeypatch.setattr(shutdown_services, "_stop_recurring_schedulers", _recurring)
+    monkeypatch.setattr(shutdown_services, "_shutdown_runtime_monitors", _runtime)
+    monkeypatch.setattr(shutdown_services, "_shutdown_jobs_metrics_reconcile", _reconcile)
+    monkeypatch.setattr(shutdown_services, "_shutdown_personalization_consolidation", _personalization)
+    monkeypatch.setattr(shutdown_services, "_shutdown_optional_workers", _optional)
+
+    handles = await shutdown_services.shutdown_post_worker_services(
+        claims_task=None,
+        jobs_prune_task=None,
+        files_export_gc_task=None,
+        notifications_prune_task=None,
+        jobs_notifications_bridge_task="bridge-task",
+        embeddings_compactor_task="compactor-task",
+        embeddings_compactor_stop_event="compactor-stop",
+        websub_renewal_task="websub-task",
+        coordinated_legacy_component_names=set(),
+        usage_task=None,
+        llm_usage_task=None,
+        workflows_sched_task=None,
+        reading_digest_sched_task=None,
+        admin_backup_sched_task=None,
+        companion_reflection_sched_task=None,
+        reminders_sched_task=None,
+        connectors_sync_sched_task=None,
+        jobs_metrics_task=None,
+        jobs_metrics_stop_event=None,
+        loop_lag_task=None,
+        loop_lag_stop_event=None,
+        jobs_metrics_reconcile_task=None,
+        jobs_metrics_reconcile_stop=None,
+        jobs_crypto_rotate_task=None,
+        jobs_crypto_rotate_stop_event=None,
+        jobs_integrity_task=None,
+        jobs_integrity_stop_event=None,
+        jobs_webhooks_task=None,
+        jobs_webhooks_stop_event=None,
+        meetings_webhook_dlq_task=None,
+        meetings_webhook_dlq_stop_event=None,
+        workflows_dlq_task=None,
+        workflows_dlq_stop_event=None,
+        workflows_gc_task=None,
+        workflows_gc_stop_event=None,
+        workflows_maint_task=None,
+        workflows_maint_stop_event=None,
+        guard_exceptions=(RuntimeError,),
+        stopped_background_worker_names={"websub_renewal_task"},
+    )
+
+    assert notification_kwargs["jobs_notifications_bridge_task"] == "bridge-task"
+    assert notification_kwargs["embeddings_compactor_task"] == "compactor-task"
+    assert notification_kwargs["websub_renewal_task"] is None
+    assert handles.jobs_notifications_bridge_task == "bridge-task"
+    assert handles.embeddings_compactor_task == "compactor-task"
+    assert handles.websub_renewal_task is None
+
+
+@pytest.mark.asyncio
 async def test_run_shutdown_post_worker_services_delegates_and_returns_handles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -471,6 +594,7 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
             "jobs_metrics_reconcile_task",
             "jobs_crypto_rotate_task",
             "jobs_integrity_task",
+            "websub_renewal_task",
         },
     )
 
@@ -482,7 +606,7 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
     assert handles.jobs_notifications_bridge_task == "bridge-input"
     assert handles.embeddings_compactor_task == "compactor-input"
     assert handles.embeddings_compactor_stop_event == "compactor-stop-input"
-    assert handles.websub_renewal_task == "websub-input"
+    assert handles.websub_renewal_task is None
     assert handles.usage_task == "usage-input"
     assert handles.llm_usage_task == "llm-input"
     assert handles.jobs_metrics_task is None

--- a/tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py
+++ b/tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Generator
+from contextlib import suppress
 import importlib
 import sys
 
+from fastapi import FastAPI
 import pytest
 
 
@@ -112,18 +116,18 @@ async def test_start_websub_renewal_worker_starts_when_callback_and_worker_enabl
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     startup_workers = _import_startup_compactor_websub_workers()
-    created_coroutines: list[object] = []
+    created_tasks: list[tuple[object, str | None]] = []
+
+    def _fake_create_task(coro: object, *, name: str | None = None) -> str:
+        created_tasks.append((coro, name))
+        return "websub-task"
 
     monkeypatch.setattr(
         startup_workers.os,
         "getenv",
         lambda key, default=None: "http://callback.example" if key == "WEBSUB_CALLBACK_BASE_URL" else default,
     )
-    monkeypatch.setattr(
-        startup_workers,
-        "_create_task",
-        lambda coro: created_coroutines.append(coro) or "websub-task",
-    )
+    monkeypatch.setattr(startup_workers, "_create_task", _fake_create_task)
     monkeypatch.setattr(startup_workers, "_run_websub_renewal_loop", lambda: "websub-coro")
 
     task = await startup_workers._start_websub_renewal_worker(
@@ -135,7 +139,124 @@ async def test_start_websub_renewal_worker_starts_when_callback_and_worker_enabl
     )
 
     assert task == "websub-task"
-    assert created_coroutines == ["websub-coro"]
+    assert created_tasks == [("websub-coro", "websub_renewal_task")]
+
+
+@pytest.mark.asyncio
+async def test_start_websub_renewal_worker_registers_background_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_workers = _import_startup_compactor_websub_workers()
+    from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase, WorkerRegistry
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    started = asyncio.Event()
+
+    async def _fake_websub_loop() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        startup_workers.os,
+        "getenv",
+        lambda key, default=None: "http://callback.example" if key == "WEBSUB_CALLBACK_BASE_URL" else default,
+    )
+    monkeypatch.setattr(startup_workers, "_run_websub_renewal_loop", _fake_websub_loop)
+
+    task = await startup_workers._start_websub_renewal_worker(
+        should_start_worker=lambda flag, route, **kwargs: (flag, route, kwargs) == (
+            "WEBSUB_RENEWAL_WORKER_ENABLED",
+            "collections-websub",
+            {},
+        ),
+        worker_inventory=worker_inventory,
+    )
+
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        assert task is not None
+        assert task.get_name() == "websub_renewal_task"
+        assert len(worker_inventory.handles) == 1
+        handle = worker_inventory.handles[0]
+        assert handle.name == "websub_renewal_task"
+        assert handle.task is task
+        assert handle.stop_event is None
+        assert handle.category == "collections-websub"
+        assert handle.shutdown_phase is ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+        assert app.state._tldw_shutdown_worker_inventory == [
+            {
+                "name": "websub_renewal_task",
+                "task_name": "websub_renewal_task",
+                "has_stop_event": False,
+                "timeout_sec": 5.0,
+                "category": "collections-websub",
+                "shutdown_phase": "background_worker_shutdown",
+            }
+        ]
+        assert app.state._tldw_shutdown_job_poller_inventory == []
+    finally:
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+
+@pytest.mark.asyncio
+async def test_start_websub_renewal_worker_cancels_task_when_registration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_workers = _import_startup_compactor_websub_workers()
+    created_task_names: list[str | None] = []
+    registered_workers: list[object] = []
+
+    class FakeTask:
+        def __init__(self) -> None:
+            self.cancelled = False
+            self.awaited = False
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+        def __await__(self) -> Generator[object, None, None]:
+            self.awaited = True
+
+            async def _cancelled() -> None:
+                raise asyncio.CancelledError
+
+            return _cancelled().__await__()
+
+    class FailingInventory:
+        def register(self, worker: object) -> object:
+            registered_workers.append(worker)
+            raise RuntimeError("inventory failed")
+
+    fake_task = FakeTask()
+
+    def _fake_create_task(coro: object, *, name: str | None = None) -> FakeTask:
+        del coro
+        created_task_names.append(name)
+        return fake_task
+
+    monkeypatch.setattr(
+        startup_workers.os,
+        "getenv",
+        lambda key, default=None: "http://callback.example" if key == "WEBSUB_CALLBACK_BASE_URL" else default,
+    )
+    monkeypatch.setattr(startup_workers, "_create_task", _fake_create_task)
+    monkeypatch.setattr(startup_workers, "_run_websub_renewal_loop", lambda: "websub-coro")
+
+    task = await startup_workers._start_websub_renewal_worker(
+        should_start_worker=lambda *args, **kwargs: True,
+        worker_inventory=FailingInventory(),
+    )
+
+    assert task is None
+    assert created_task_names == ["websub_renewal_task"]
+    assert fake_task.cancelled is True
+    assert fake_task.awaited is True
+    assert len(registered_workers) == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py
@@ -61,6 +61,7 @@ async def test_initialize_startup_worker_bootstrap_runs_helpers_in_order_and_ret
     assert calls[1][1]["test_mode"] is True
     assert calls[1][1]["route_enabled"] == "route-enabled"
     assert calls[1][1]["owned_job_pollers"] == []
+    assert calls[1][1]["worker_inventory"].handles is calls[1][1]["owned_job_pollers"]
     assert calls[1][1]["register_owned_job_poller"] == "register-poller"
     assert calls[1][1]["startup_guard_exceptions"] == (RuntimeError,)
     assert calls[2][1]["app"] == "app"

--- a/tldw_Server_API/tests/Services/test_startup_worker_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_groups.py
@@ -77,8 +77,9 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
             privilege_snapshot_task="privilege-task",
         )
 
-    async def _record_compactor_websub_workers(*, should_start_worker):
+    async def _record_compactor_websub_workers(*, should_start_worker, worker_inventory):
         assert should_start_worker("AUDIO_JOBS_WORKER_ENABLED", "audio-jobs") is True
+        assert worker_inventory == "worker-inventory"
         calls.append("compactor")
         return SimpleNamespace(
             embeddings_compactor_stop_event="embeddings-stop",
@@ -189,6 +190,7 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
         startup_guard_exceptions=(RuntimeError,),
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
+        worker_inventory="worker-inventory",
     )
 
     assert calls == [


### PR DESCRIPTION
Change summary
- Registers the WebSub renewal worker with the lifecycle WorkerRegistry when startup owns a worker inventory.
- Preserves the existing custom enablement contract: WebSub renewal still requires WEBSUB_CALLBACK_BASE_URL and the existing route/flag worker gate.
- Marks WebSub renewal as background_worker_shutdown and keeps it out of the job-poller quiesce inventory.
- Filters websub_renewal_task out of legacy post-worker shutdown once the background-worker phase has already stopped it.

Why
- Issue #1114 calls out WebSub renewal as a remaining custom-enable worker.
- This keeps the migration small while proving that non-stop-event background tasks can use the same phase-aware inventory without being tied to Jobs lease waiting.

Tests
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py::test_start_websub_renewal_worker_registers_background_inventory_when_enabled tldw_Server_API/tests/Services/test_startup_worker_groups.py::test_start_worker_groups_runs_helpers_in_order_and_returns_handles tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py::test_initialize_startup_worker_bootstrap_runs_helpers_in_order_and_returns_handles tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py::test_shutdown_post_worker_services_skips_websub_after_background_phase -v
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_shutdown_notifications_compactor_websub_workers.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -v
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py -v
- git diff --check
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/startup_compactor_websub_workers.py tldw_Server_API/app/services/startup_worker_groups.py tldw_Server_API/app/services/startup_worker_bootstrap.py tldw_Server_API/app/services/shutdown_post_worker_services.py -f json -o /tmp/bandit_websub_worker_registry_app.json
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/startup_compactor_websub_workers.py tldw_Server_API/app/services/startup_worker_groups.py tldw_Server_API/app/services/startup_worker_bootstrap.py tldw_Server_API/app/services/shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py -s B101 -f json -o /tmp/bandit_websub_worker_registry_skip_b101.json

Part of #1114.
