### PR TITLE
feat(audio): explain hosted TTS and STT limits

### DIFF
--- a/apps/packages/ui/src/assets/locale/en/option.json
+++ b/apps/packages/ui/src/assets/locale/en/option.json
@@ -67,7 +67,9 @@
     "modePrompts": "Prompts",
     "modePromptsPlayground": "Prompts",
     "modeStt": "STT Playground",
+    "modeSttHostedDesc": "Requires a self-hosted tldw server for speech transcription.",
     "modeSpeech": "Speech",
+    "modeTtsHostedDesc": "Requires a self-hosted tldw server for speech generation.",
     "modePromptStudio": "Prompt Studio",
     "modeDocumentation": "Documentation",
     "modeFlashcards": "Flashcards",
@@ -826,6 +828,15 @@
   },
   "tts": {
     "playground": "TTS Playground"
+  },
+  "hostedAudio": {
+    "badge": "Hosted mode",
+    "title": "Audio features require a self-hosted tldw server",
+    "description": "{{featureName}} depends on server-side audio runtimes, local model dependencies, host audio tooling, or provider keys that are only exposed in self-hosted deployments. The hosted product keeps these routes visible so you can find the feature boundary without exposing controls that cannot run here.",
+    "quickstart": "Open self-hosting quickstart",
+    "opensInNewTab": "(opens in new tab)",
+    "loadingTts": "Loading TTS playground.",
+    "loadingStt": "Loading STT playground."
   },
   "notesEmpty": {
     "connectTitle": "Connect to use Notes",

--- a/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts
+++ b/apps/packages/ui/src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts
@@ -28,6 +28,32 @@ describe("header shortcut items hosted mode", () => {
     )
   })
 
+  it("keeps audio playground shortcuts discoverable with self-host messaging in hosted mode", async () => {
+    vi.doMock("@/services/tldw/deployment-mode", () => ({
+      isHostedTldwDeployment: () => true,
+    }))
+
+    const mod = await import("../header-shortcut-items")
+    const shortcutItems = mod.getHeaderShortcutItems()
+
+    expect(shortcutItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "stt-playground",
+          to: "/stt",
+          descriptionKey: "option:header.modeSttHostedDesc",
+          descriptionDefault: expect.stringMatching(/self-hosted/i)
+        }),
+        expect.objectContaining({
+          id: "tts-playground",
+          to: "/tts",
+          descriptionKey: "option:header.modeTtsHostedDesc",
+          descriptionDefault: expect.stringMatching(/self-hosted/i)
+        })
+      ])
+    )
+  })
+
   it("re-evaluates deployment mode when shortcut groups are requested", async () => {
     const isHostedTldwDeployment = vi.fn(() => false)
     vi.doMock("@/services/tldw/deployment-mode", () => ({

--- a/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
+++ b/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
@@ -495,13 +495,43 @@ const HOSTED_VISIBLE_SHORTCUT_PATHS = new Set([
   "/chat",
   "/knowledge",
   "/media",
-  "/collections"
+  "/collections",
+  "/stt",
+  "/tts"
 ])
+
+const HOSTED_AUDIO_SHORTCUT_DESCRIPTIONS: Partial<
+  Record<
+    HeaderShortcutId,
+    Pick<HeaderShortcutItem, "descriptionKey" | "descriptionDefault">
+  >
+> = {
+  "stt-playground": {
+    descriptionKey: "option:header.modeSttHostedDesc",
+    descriptionDefault:
+      "Requires a self-hosted tldw server for speech transcription."
+  },
+  "tts-playground": {
+    descriptionKey: "option:header.modeTtsHostedDesc",
+    descriptionDefault:
+      "Requires a self-hosted tldw server for speech generation."
+  }
+}
 
 const getHostedHeaderShortcutGroups = (): HeaderShortcutGroup[] => {
   const filteredGroups = BASE_HEADER_SHORTCUT_GROUPS.map((group) => ({
     ...group,
-    items: group.items.filter((item) => HOSTED_VISIBLE_SHORTCUT_PATHS.has(item.to))
+    items: group.items
+      .filter((item) => HOSTED_VISIBLE_SHORTCUT_PATHS.has(item.to))
+      .map((item) => {
+        const hostedDescription = HOSTED_AUDIO_SHORTCUT_DESCRIPTIONS[item.id]
+        return hostedDescription
+          ? {
+              ...item,
+              ...hostedDescription
+            }
+          : item
+      })
   })).filter((group) => group.items.length > 0)
 
   filteredGroups.push({

--- a/apps/packages/ui/src/routes/HostedAudioFeatureMessage.tsx
+++ b/apps/packages/ui/src/routes/HostedAudioFeatureMessage.tsx
@@ -1,0 +1,54 @@
+import { ExternalLink } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+type HostedAudioFeatureMessageProps = {
+  featureName: string
+}
+
+export const HostedAudioFeatureMessage = ({
+  featureName
+}: HostedAudioFeatureMessageProps) => {
+  const { t } = useTranslation("option")
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-10">
+      <section
+        aria-labelledby="hosted-audio-feature-title"
+        className="rounded-lg border border-border bg-surface px-5 py-6 shadow-sm"
+      >
+        <p className="text-xs font-semibold uppercase tracking-wide text-text-subtle">
+          {t("hostedAudio.badge", "Hosted mode")}
+        </p>
+        <h1
+          id="hosted-audio-feature-title"
+          className="mt-2 text-2xl font-semibold text-text"
+        >
+          {t(
+            "hostedAudio.title",
+            "Audio features require a self-hosted tldw server"
+          )}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-text-muted">
+          {t(
+            "hostedAudio.description",
+            "{{featureName}} depends on server-side audio runtimes, local model dependencies, host audio tooling, or provider keys that are only exposed in self-hosted deployments. The hosted product keeps these routes visible so you can find the feature boundary without exposing controls that cannot run here.",
+            { featureName }
+          )}
+        </p>
+        <a
+          href="https://github.com/rmusser01/tldw_server#quickstart"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-5 inline-flex items-center gap-2 rounded-md border border-border bg-surface2 px-3 py-2 text-sm font-medium text-text transition-colors hover:bg-surface3"
+        >
+          {t("hostedAudio.quickstart", "Open self-hosting quickstart")}
+          <span className="sr-only">
+            {" "}
+            {t("hostedAudio.opensInNewTab", "(opens in new tab)")}
+          </span>
+          <ExternalLink className="size-4" aria-hidden="true" />
+        </a>
+      </section>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/routes/__tests__/option-audio-hosted-message.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-audio-hosted-message.test.tsx
@@ -1,0 +1,107 @@
+import React from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+vi.mock("~/components/Layouts/Layout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="option-layout">{children}</div>
+  )
+}))
+
+vi.mock("@/components/Common/RouteErrorBoundary", () => ({
+  RouteErrorBoundary: ({
+    children,
+    routeId,
+    routeLabel
+  }: {
+    children: React.ReactNode
+    routeId: string
+    routeLabel: string
+  }) => (
+    <div data-testid="route-boundary" data-route-id={routeId} data-route-label={routeLabel}>
+      {children}
+    </div>
+  )
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      fallback: string,
+      values?: Record<string, string>
+    ) => fallback.replace("{{featureName}}", values?.featureName ?? "")
+  })
+}))
+
+describe("hosted audio route messaging", () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.doUnmock("@/services/tldw/deployment-mode")
+    vi.doUnmock("@/components/Option/Speech/SpeechPlaygroundPage")
+    vi.doUnmock("@/components/Option/STT/SttPlaygroundPage")
+  })
+
+  it("shows self-hosting guidance instead of the TTS playground in hosted mode", async () => {
+    const speechPlaygroundFactory = vi.fn(() => ({
+      __esModule: true,
+      default: () => <div data-testid="speech-playground">Speech</div>
+    }))
+
+    vi.doMock("@/services/tldw/deployment-mode", () => ({
+      isHostedTldwDeployment: () => true
+    }))
+    vi.doMock("@/components/Option/Speech/SpeechPlaygroundPage", speechPlaygroundFactory)
+
+    const { default: OptionTts } = await import("../option-tts")
+    render(<OptionTts />)
+
+    expect(screen.getByTestId("option-layout")).toBeVisible()
+    expect(screen.getByRole("heading", {
+      name: /audio features require a self-hosted tldw server/i
+    })).toBeVisible()
+    expect(screen.getByText(/TTS Playground/i)).toBeVisible()
+    expect(screen.queryByTestId("speech-playground")).not.toBeInTheDocument()
+    expect(speechPlaygroundFactory).not.toHaveBeenCalled()
+  })
+
+  it("shows self-hosting guidance instead of the STT playground in hosted mode", async () => {
+    const sttPlaygroundFactory = vi.fn(() => ({
+      __esModule: true,
+      default: () => <div data-testid="stt-playground">STT</div>
+    }))
+
+    vi.doMock("@/services/tldw/deployment-mode", () => ({
+      isHostedTldwDeployment: () => true
+    }))
+    vi.doMock("@/components/Option/STT/SttPlaygroundPage", sttPlaygroundFactory)
+
+    const { default: OptionStt } = await import("../option-stt")
+    render(<OptionStt />)
+
+    expect(screen.getByTestId("option-layout")).toBeVisible()
+    expect(screen.getByRole("heading", {
+      name: /audio features require a self-hosted tldw server/i
+    })).toBeVisible()
+    expect(screen.getByText(/STT Playground/i)).toBeVisible()
+    expect(screen.queryByTestId("stt-playground")).not.toBeInTheDocument()
+    expect(sttPlaygroundFactory).not.toHaveBeenCalled()
+  })
+
+  it("marks the quickstart link as a safe new-tab link with accessible context", async () => {
+    vi.doMock("@/services/tldw/deployment-mode", () => ({
+      isHostedTldwDeployment: () => true
+    }))
+
+    const { default: OptionTts } = await import("../option-tts")
+    render(<OptionTts />)
+
+    const quickstartLink = screen.getByRole("link", {
+      name: /open self-hosting quickstart.*opens in new tab/i
+    })
+
+    expect(quickstartLink).toHaveAttribute("target", "_blank")
+    expect(quickstartLink).toHaveAttribute("rel", "noopener noreferrer")
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx
@@ -28,6 +28,12 @@ vi.mock("@/components/Common/RouteErrorBoundary", () => ({
   )
 }))
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback
+  })
+}))
+
 vi.mock("@/components/Option/TTS/TtsPlaygroundPage", () => ({
   __esModule: true,
   default: () => <div data-testid="tts-playground">TTS</div>
@@ -61,10 +67,10 @@ vi.mock("@/components/Option/Speech/SpeechPlaygroundPage", () => ({
 }))
 
 describe("audio option routes", () => {
-  it("routes /tts into the shared speech playground locked to TTS mode", () => {
+  it("routes /tts into the shared speech playground locked to TTS mode", async () => {
     render(<OptionTts />)
 
-    const speech = screen.getByTestId("speech-playground")
+    const speech = await screen.findByTestId("speech-playground")
     const boundary = screen.getByTestId("route-boundary")
 
     expect(screen.getByTestId("option-layout")).toBeVisible()
@@ -76,10 +82,10 @@ describe("audio option routes", () => {
     expect(screen.queryByTestId("tts-playground")).not.toBeInTheDocument()
   })
 
-  it("renders dedicated STT playground on /stt route component", () => {
+  it("renders dedicated STT playground on /stt route component", async () => {
     render(<OptionStt />)
     expect(screen.getByTestId("option-layout")).toBeVisible()
-    expect(screen.getByTestId("stt-playground")).toBeVisible()
+    expect(await screen.findByTestId("stt-playground")).toBeVisible()
     expect(screen.queryByTestId("speech-playground")).not.toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/routes/__tests__/option-route-visibility.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/option-route-visibility.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest"
+
+import { isHostedVisibleOptionPath } from "../option-route-visibility"
+
+describe("hosted option route visibility", () => {
+  it("keeps audio explainer routes visible in hosted mode", () => {
+    expect(isHostedVisibleOptionPath("/tts")).toBe(true)
+    expect(isHostedVisibleOptionPath("/stt")).toBe(true)
+  })
+})

--- a/apps/packages/ui/src/routes/option-route-visibility.ts
+++ b/apps/packages/ui/src/routes/option-route-visibility.ts
@@ -3,7 +3,9 @@ export const HOSTED_VISIBLE_OPTION_PATHS = new Set([
   "/chat",
   "/media",
   "/knowledge",
-  "/collections"
+  "/collections",
+  "/stt",
+  "/tts"
 ])
 
 export const isHostedVisibleOptionPath = (path: string) =>

--- a/apps/packages/ui/src/routes/option-stt.tsx
+++ b/apps/packages/ui/src/routes/option-stt.tsx
@@ -1,10 +1,33 @@
+import { lazy, Suspense } from "react"
 import OptionLayout from "~/components/Layouts/Layout"
-import SttPlaygroundPage from "@/components/Option/STT/SttPlaygroundPage"
+import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
+import { useTranslation } from "react-i18next"
+import { HostedAudioFeatureMessage } from "./HostedAudioFeatureMessage"
+
+const SttPlaygroundPage = lazy(() =>
+  import("@/components/Option/STT/SttPlaygroundPage")
+)
 
 const OptionStt = () => {
+  const { t } = useTranslation("option")
+
   return (
     <OptionLayout>
-      <SttPlaygroundPage />
+      {isHostedTldwDeployment() ? (
+        <HostedAudioFeatureMessage
+          featureName={t("header.modeStt", "STT Playground")}
+        />
+      ) : (
+        <Suspense
+          fallback={
+            <div className="sr-only" role="status">
+              {t("hostedAudio.loadingStt", "Loading STT playground.")}
+            </div>
+          }
+        >
+          <SttPlaygroundPage />
+        </Suspense>
+      )}
     </OptionLayout>
   )
 }

--- a/apps/packages/ui/src/routes/option-tts.tsx
+++ b/apps/packages/ui/src/routes/option-tts.tsx
@@ -1,12 +1,35 @@
+import { lazy, Suspense } from "react"
 import OptionLayout from "~/components/Layouts/Layout"
-import SpeechPlaygroundPage from "@/components/Option/Speech/SpeechPlaygroundPage"
 import { RouteErrorBoundary } from "@/components/Common/RouteErrorBoundary"
+import { isHostedTldwDeployment } from "@/services/tldw/deployment-mode"
+import { useTranslation } from "react-i18next"
+import { HostedAudioFeatureMessage } from "./HostedAudioFeatureMessage"
+
+const SpeechPlaygroundPage = lazy(() =>
+  import("@/components/Option/Speech/SpeechPlaygroundPage")
+)
 
 const OptionTts = () => {
+  const { t } = useTranslation("option")
+
   return (
     <RouteErrorBoundary routeId="tts" routeLabel="TTS Playground">
       <OptionLayout>
-        <SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />
+        {isHostedTldwDeployment() ? (
+          <HostedAudioFeatureMessage
+            featureName={t("tts.playground", "TTS Playground")}
+          />
+        ) : (
+          <Suspense
+            fallback={
+              <div className="sr-only" role="status">
+                {t("hostedAudio.loadingTts", "Loading TTS playground.")}
+              </div>
+            }
+          >
+            <SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />
+          </Suspense>
+        )}
       </OptionLayout>
     </RouteErrorBoundary>
   )


### PR DESCRIPTION
## Change summary

- Keeps `/tts` and `/stt` discoverable in hosted mode by making those routes and launcher shortcuts hosted-visible.
- Routes hosted `/tts` and `/stt` requests to a clear self-hosting requirement page instead of silently hiding audio features or rendering controls that cannot run in hosted deployments.
- Adds focused Vitest coverage for hosted shortcut visibility, hosted route visibility, hosted audio message behavior, and existing self-host route identity.

Why: #992 asks for hosted deployments to explain why TTS/STT are unavailable. The route-message option avoids exposing nonfunctional audio controls while still letting users discover the self-hosting boundary.

## Verification

- Red tests failed before implementation for missing hosted route/message behavior.
- `bun run test -- src/components/Layouts/__tests__/header-shortcut-items.hosted.test.ts src/routes/__tests__/option-route-visibility.test.ts src/routes/__tests__/option-audio-hosted-message.test.tsx src/routes/__tests__/option-audio-route-identity.test.tsx --maxWorkers=1 --no-file-parallelism`
- `git diff --check`
- Bandit: not run; frontend TypeScript/TSX only.
- Note: a broader combined `HeaderShortcuts.test.tsx` sweep hung after startup and was terminated; the focused hosted shortcut and route identity suites passed.

Closes #992