### PR TITLE
feat(flashcards): add deck sharing foundation

### DIFF
--- a/IMPLEMENTATION_PLAN_flashcard_sharing_foundation_989.md
+++ b/IMPLEMENTATION_PLAN_flashcard_sharing_foundation_989.md
@@ -1,0 +1,22 @@
+# Flashcard Sharing Foundation
+
+## Stage 1: Sharing Foundation
+
+**Goal**: Add durable deck visibility and per-user share metadata without changing study/review access semantics yet.
+**Success Criteria**: Decks persist a `visibility` value, deck shares can be upserted/listed/removed, deleted decks drop share records, and existing deck responses remain compatible.
+**Tests**: Focused ChaChaNotes DB tests plus flashcards endpoint integration tests.
+**Status**: Complete
+
+## Stage 2: Shared Deck Access
+
+**Goal**: Teach API reads how to resolve shared deck access across owner databases.
+**Success Criteria**: A recipient can see decks shared with them in a separate section without mutating owner deck data.
+**Tests**: Multi-user endpoint tests using owner/recipient DB fixtures.
+**Status**: Not Started
+
+## Stage 3: Per-User Review State
+
+**Goal**: Separate shared-card content from each recipient's scheduling metadata.
+**Success Criteria**: Reviews by recipients do not modify owner SRS state or other recipients' progress.
+**Tests**: DB and API tests for owner and recipient review sessions on the same shared card content.
+**Status**: Not Started

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -21,6 +21,9 @@ from tldw_Server_API.app.api.v1.schemas.flashcards import (
     Deck,
     DeckCreate,
     DeckDeleteResponse,
+    DeckShare,
+    DeckShareDeleteResponse,
+    DeckShareUpsert,
     DeckUpdate,
     Flashcard,
     FlashcardAnalyticsSummaryResponse,
@@ -677,6 +680,7 @@ def _get_flashcards_apkg_max_media_bytes() -> int:
 def create_deck(payload: DeckCreate, db: CharactersRAGDB = Depends(get_chacha_db_for_user)):
     try:
         _ensure_workspace_exists(db, payload.workspace_id)
+        visibility = payload.visibility if "visibility" in payload.model_fields_set else None
         review_prompt_side = payload.review_prompt_side if "review_prompt_side" in payload.model_fields_set else None
         deck_id = db.add_deck(
             payload.name,
@@ -684,6 +688,7 @@ def create_deck(payload: DeckCreate, db: CharactersRAGDB = Depends(get_chacha_db
             payload.scheduler_settings.model_dump() if payload.scheduler_settings else None,
             scheduler_type=payload.scheduler_type,
             workspace_id=payload.workspace_id,
+            visibility=visibility,
             review_prompt_side=review_prompt_side,
         )
         # Return the exact deck row by id
@@ -696,6 +701,7 @@ def create_deck(payload: DeckCreate, db: CharactersRAGDB = Depends(get_chacha_db
             "name": payload.name,
             "description": payload.description,
             "workspace_id": payload.workspace_id,
+            "visibility": visibility or "private",
             "review_prompt_side": payload.review_prompt_side,
             "created_at": None,
             "last_modified": None,
@@ -750,6 +756,7 @@ def update_deck(
     scheduler_settings = data.pop("scheduler_settings", None)
     scheduler_type = data.pop("scheduler_type", None)
     review_prompt_side = data.pop("review_prompt_side", None)
+    visibility = data.pop("visibility", None)
     workspace_id = data.pop("workspace_id", ...)
     try:
         if workspace_id is not ...:
@@ -759,6 +766,7 @@ def update_deck(
             name=data.get("name"),
             description=data.get("description"),
             review_prompt_side=review_prompt_side,
+            visibility=visibility,
             scheduler_settings=scheduler_settings,
             scheduler_type=scheduler_type,
             workspace_id=workspace_id,
@@ -776,6 +784,82 @@ def update_deck(
         raise map_db_error_to_http(e) from e
     except (InputError, CharactersRAGDBError) as exc:
         raise map_db_error_to_http(exc, default_detail="Failed to update deck") from exc
+
+
+@router.get(
+    "/decks/{deck_id}/shares",
+    response_model=list[DeckShare],
+    dependencies=[Depends(check_rate_limit)],
+)
+def list_deck_shares(
+    deck_id: int,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> list[DeckShare]:
+    """List all per-user share grants for a deck owned by the current user."""
+    try:
+        deck = db.get_deck(deck_id)
+        if not deck or deck.get("deleted"):
+            raise HTTPException(status_code=404, detail="Deck not found")
+        return [DeckShare.model_validate(item) for item in db.list_deck_shares(deck_id)]
+    except HTTPException:
+        raise
+    except CharactersRAGDBError as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to list deck shares") from exc
+
+
+@router.put(
+    "/decks/{deck_id}/shares/{user_id}",
+    response_model=DeckShare,
+    dependencies=[Depends(check_rate_limit)],
+)
+def upsert_deck_share(
+    deck_id: int,
+    user_id: int,
+    payload: DeckShareUpsert,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    current_user: User = Depends(get_request_user),
+) -> DeckShare:
+    """Create or update a user's share role for a deck owned by the current user."""
+    try:
+        deck = db.get_deck(deck_id)
+        if not deck or deck.get("deleted"):
+            raise HTTPException(status_code=404, detail="Deck not found")
+        return DeckShare.model_validate(
+            db.upsert_deck_share(
+                deck_id,
+                user_id=user_id,
+                role=payload.role,
+                shared_by=int(current_user.id),
+            )
+        )
+    except HTTPException:
+        raise
+    except ConflictError as exc:
+        raise map_db_error_to_http(exc) from exc
+    except (InputError, CharactersRAGDBError) as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to share deck") from exc
+
+
+@router.delete(
+    "/decks/{deck_id}/shares/{user_id}",
+    response_model=DeckShareDeleteResponse,
+    dependencies=[Depends(check_rate_limit)],
+)
+def delete_deck_share(
+    deck_id: int,
+    user_id: int,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> DeckShareDeleteResponse:
+    """Remove a per-user share grant from a deck owned by the current user."""
+    try:
+        deck = db.get_deck(deck_id)
+        if not deck or deck.get("deleted"):
+            raise HTTPException(status_code=404, detail="Deck not found")
+        return DeckShareDeleteResponse(removed=db.delete_deck_share(deck_id, user_id=user_id))
+    except HTTPException:
+        raise
+    except CharactersRAGDBError as exc:
+        raise map_db_error_to_http(exc, default_detail="Failed to remove deck share") from exc
 
 
 @router.delete("/decks/{deck_id}", response_model=DeckDeleteResponse)

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -13,6 +13,8 @@ from tldw_Server_API.app.api.v1.schemas.study_packs import (
 
 DeckSchedulerType = Literal["sm2_plus", "fsrs"]
 DeckReviewPromptSide = Literal["front", "back"]
+DeckVisibility = Literal["private", "team", "org", "public"]
+DeckShareRole = Literal["owner", "editor", "viewer"]
 FlashcardTemplateModelType = Literal["basic", "basic_reverse", "cloze"]
 FlashcardTemplateFieldTarget = Literal["front_template", "back_template", "notes_template", "extra_template"]
 
@@ -99,6 +101,7 @@ class DeckCreate(BaseModel):
     name: str = Field(..., description="Deck name (unique)")
     description: Optional[str] = Field(None, description="Deck description")
     workspace_id: Optional[str] = Field(None, description="Canonical owning workspace ID; null means general scope")
+    visibility: DeckVisibility = "private"
     review_prompt_side: DeckReviewPromptSide = "front"
     scheduler_type: DeckSchedulerType = "sm2_plus"
     scheduler_settings: Optional[DeckSchedulerSettingsEnvelope] = None
@@ -116,6 +119,7 @@ class DeckUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     workspace_id: Optional[str] = None
+    visibility: Optional[DeckVisibility] = None
     review_prompt_side: Optional[DeckReviewPromptSide] = None
     scheduler_type: Optional[DeckSchedulerType] = None
     scheduler_settings: Optional[DeckSchedulerSettingsEnvelope] = None
@@ -130,7 +134,9 @@ class DeckUpdate(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def _reject_explicit_null_review_prompt_side(self) -> "DeckUpdate":
+    def _reject_explicit_null_restricted_fields(self) -> "DeckUpdate":
+        if "visibility" in self.model_fields_set and self.visibility is None:
+            raise ValueError("visibility cannot be null")
         if "review_prompt_side" in self.model_fields_set and self.review_prompt_side is None:
             raise ValueError("review_prompt_side cannot be null")
         return self
@@ -141,6 +147,7 @@ class Deck(BaseModel):
     name: str
     description: Optional[str] = None
     workspace_id: Optional[str] = None
+    visibility: DeckVisibility = "private"
     review_prompt_side: DeckReviewPromptSide = "front"
     created_at: Optional[str] = None
     last_modified: Optional[str] = None
@@ -166,6 +173,25 @@ class Deck(BaseModel):
             except Exception:
                 data["scheduler_settings"] = DeckSchedulerSettingsEnvelope().model_dump()
         return data
+
+
+class DeckShareUpsert(BaseModel):
+    role: DeckShareRole = "viewer"
+
+
+class DeckShare(BaseModel):
+    deck_id: int
+    user_id: int
+    role: DeckShareRole
+    shared_by: int
+    shared_at: Optional[str] = None
+    last_modified: Optional[str] = None
+    client_id: str
+    version: int
+
+
+class DeckShareDeleteResponse(BaseModel):
+    removed: bool
 
 
 class DeckDeleteResponse(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -133,11 +133,29 @@ _SUPPORTED_WEB_CLIPPER_OUTCOME_STATES = {"saved", "saved_with_warnings", "partia
 _SUPPORTED_WEB_CLIPPER_ENRICHMENT_TYPES = {"ocr", "vlm"}
 _FLASHCARD_TEMPLATE_FIELD_NAMES = ("front_template", "back_template", "notes_template", "extra_template")
 _FLASHCARD_TEMPLATE_TOKEN_RE = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}")
+_DECK_VISIBILITIES = frozenset({"private", "team", "org", "public"})
+_DECK_SHARE_ROLES = frozenset({"owner", "editor", "viewer"})
 
 
 def _coerce_scheduler_type(value: Any) -> str:
     normalized = str(value or "").strip().lower()
     return normalized if normalized in _SUPPORTED_FLASHCARD_SCHEDULERS else "sm2_plus"
+
+
+def _normalize_deck_visibility(value: Any) -> str:
+    normalized = str(value or "private").strip().lower()
+    if normalized not in _DECK_VISIBILITIES:
+        raise InputError(
+            "Invalid deck visibility. Must be one of: private, team, org, public"
+        )
+    return normalized
+
+
+def _normalize_deck_share_role(value: Any) -> str:
+    normalized = str(value or "viewer").strip().lower()
+    if normalized not in _DECK_SHARE_ROLES:
+        raise InputError("Invalid deck share role. Must be one of: owner, editor, viewer")
+    return normalized
 
 
 def _normalize_scheduler_settings_envelope(raw: Mapping[str, Any] | str | None) -> dict[str, Any]:
@@ -8916,6 +8934,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 self._ensure_flashcard_asset_schema_sqlite(conn)
                 self._ensure_flashcard_template_schema_sqlite(conn)
                 self._ensure_flashcard_scheduler_schema_sqlite(conn)
+                self._ensure_flashcard_deck_sharing_schema_sqlite(conn)
                 self._ensure_study_pack_schema_sqlite(conn)
                 self._ensure_study_assistant_schema_sqlite(conn)
                 self._ensure_quiz_remediation_conversion_schema_sqlite(conn)
@@ -9474,6 +9493,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'create',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'visibility',NEW.visibility,
                                      'review_prompt_side',NEW.review_prompt_side,
                                      'scheduler_type',NEW.scheduler_type,
                                      'scheduler_settings_json',NEW.scheduler_settings_json,
@@ -9486,6 +9506,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 WHEN OLD.deleted = NEW.deleted AND (
                      OLD.name IS NOT NEW.name OR
                      OLD.description IS NOT NEW.description OR
+                     OLD.visibility IS NOT NEW.visibility OR
                      OLD.review_prompt_side IS NOT NEW.review_prompt_side OR
                      OLD.scheduler_type IS NOT NEW.scheduler_type OR
                      OLD.scheduler_settings_json IS NOT NEW.scheduler_settings_json OR
@@ -9495,6 +9516,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'update',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'visibility',NEW.visibility,
                                      'review_prompt_side',NEW.review_prompt_side,
                                      'scheduler_type',NEW.scheduler_type,
                                      'scheduler_settings_json',NEW.scheduler_settings_json,
@@ -9519,6 +9541,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'update',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'visibility',NEW.visibility,
                                      'review_prompt_side',NEW.review_prompt_side,
                                      'scheduler_type',NEW.scheduler_type,
                                      'scheduler_settings_json',NEW.scheduler_settings_json,
@@ -9740,6 +9763,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     conn.execute("ALTER TABLE decks ADD COLUMN scheduler_type TEXT NOT NULL DEFAULT 'sm2_plus'")
                 if "review_prompt_side" not in deck_cols:
                     conn.execute("ALTER TABLE decks ADD COLUMN review_prompt_side TEXT NOT NULL DEFAULT 'front'")
+                if "visibility" not in deck_cols:
+                    conn.execute("ALTER TABLE decks ADD COLUMN visibility TEXT NOT NULL DEFAULT 'private'")
                 conn.execute(
                     """
                     UPDATE decks
@@ -9762,6 +9787,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                      WHERE review_prompt_side IS NULL OR trim(review_prompt_side) = ''
                     """
                 )
+                conn.execute(
+                    """
+                    UPDATE decks
+                       SET visibility = 'private'
+                     WHERE visibility IS NULL OR trim(visibility) = ''
+                    """
+                )
+                conn.execute("CREATE INDEX IF NOT EXISTS idx_decks_visibility ON decks(visibility)")
         except sqlite3.Error as exc:
             raise SchemaError(f"Failed ensuring decks review-orientation schema: {exc}") from exc  # noqa: TRY003
 
@@ -9939,6 +9972,36 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             sync_log_exists=sync_log_exists,
         )
 
+    def _ensure_flashcard_deck_sharing_schema_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Ensure owner-side flashcard deck sharing metadata exists for SQLite."""
+        try:
+            existing_tables = {
+                str(row[0])
+                for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            if "decks" not in existing_tables:
+                return
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS deck_shares(
+                  deck_id       INTEGER NOT NULL REFERENCES decks(id) ON DELETE CASCADE,
+                  user_id       INTEGER NOT NULL,
+                  role          TEXT NOT NULL CHECK(role IN ('owner', 'editor', 'viewer')),
+                  shared_by     INTEGER NOT NULL,
+                  shared_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  last_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  client_id     TEXT NOT NULL DEFAULT 'unknown',
+                  version       INTEGER NOT NULL DEFAULT 1,
+                  PRIMARY KEY(deck_id, user_id)
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_deck_shares_user ON deck_shares(user_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_deck_shares_role ON deck_shares(role)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_deck_shares_shared_by ON deck_shares(shared_by)")
+        except sqlite3.Error as exc:
+            raise SchemaError(f"Failed ensuring flashcard deck sharing schema: {exc}") from exc  # noqa: TRY003
+
     def _ensure_flashcard_fts_triggers_sqlite(self, conn: sqlite3.Connection) -> None:
         """Rebuild flashcard FTS around sanitized search shadow columns."""
         try:
@@ -10084,6 +10147,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 connection=conn,
             )
             self.backend.execute(
+                "ALTER TABLE decks ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'private'",
+                connection=conn,
+            )
+            self.backend.execute(
                 "UPDATE decks SET scheduler_settings_json = %s WHERE scheduler_settings_json IS NULL OR btrim(scheduler_settings_json) = ''",
                 (default_settings_json,),
                 connection=conn,
@@ -10094,6 +10161,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
             self.backend.execute(
                 "UPDATE decks SET review_prompt_side = 'front' WHERE review_prompt_side IS NULL OR btrim(review_prompt_side) = ''",
+                connection=conn,
+            )
+            self.backend.execute(
+                "UPDATE decks SET visibility = 'private' WHERE visibility IS NULL OR btrim(visibility) = ''",
+                connection=conn,
+            )
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_decks_visibility ON decks(visibility)",
                 connection=conn,
             )
             self.backend.execute(
@@ -10195,6 +10270,40 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
         except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:
             raise SchemaError(f"Failed ensuring PostgreSQL flashcard scheduler schema: {exc}") from exc  # noqa: TRY003
+
+    def _ensure_flashcard_deck_sharing_schema_postgres(self, conn: Any) -> None:
+        """Ensure owner-side flashcard deck sharing metadata exists for PostgreSQL."""
+        try:
+            self.backend.execute(
+                """
+                CREATE TABLE IF NOT EXISTS deck_shares(
+                  deck_id BIGINT NOT NULL REFERENCES decks(id) ON DELETE CASCADE,
+                  user_id BIGINT NOT NULL,
+                  role TEXT NOT NULL CHECK(role IN ('owner', 'editor', 'viewer')),
+                  shared_by BIGINT NOT NULL,
+                  shared_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  last_modified TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  client_id TEXT NOT NULL DEFAULT 'unknown',
+                  version INTEGER NOT NULL DEFAULT 1,
+                  PRIMARY KEY(deck_id, user_id)
+                )
+                """,
+                connection=conn,
+            )
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_deck_shares_user ON deck_shares(user_id)",
+                connection=conn,
+            )
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_deck_shares_role ON deck_shares(role)",
+                connection=conn,
+            )
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_deck_shares_shared_by ON deck_shares(shared_by)",
+                connection=conn,
+            )
+        except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:
+            raise SchemaError(f"Failed ensuring PostgreSQL flashcard deck sharing schema: {exc}") from exc  # noqa: TRY003
 
     def _ensure_study_assistant_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Ensure study assistant thread/message tables exist for SQLite."""
@@ -12612,6 +12721,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             self._ensure_flashcard_asset_schema_postgres(conn)
             self._ensure_flashcard_template_schema_postgres(conn)
             self._ensure_flashcard_scheduler_schema_postgres(conn)
+            self._ensure_flashcard_deck_sharing_schema_postgres(conn)
             self._ensure_study_pack_schema_postgres(conn)
             self._ensure_study_assistant_schema_postgres(conn)
             self._ensure_workspace_study_material_schema_postgres(conn)
@@ -16683,11 +16793,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         *,
         scheduler_type: str = "sm2_plus",
         workspace_id: str | None = None,
+        visibility: str | None = None,
         review_prompt_side: str | None = None,
     ) -> int:
         """Create a deck and return its id."""
         now = self._get_current_utc_timestamp_iso()
         scheduler_type = _coerce_scheduler_type(scheduler_type)
+        normalized_visibility = None if visibility is None else _normalize_deck_visibility(visibility)
+        visibility_for_insert = normalized_visibility or "private"
         normalized_prompt_side = (
             None
             if review_prompt_side is None
@@ -16711,6 +16824,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                             "UPDATE decks SET deleted = ?, last_modified = ?, version = ?, client_id = ?, "
                             "description = COALESCE(?, description), "
                             "workspace_id = ?, "
+                            "visibility = COALESCE(?, visibility), "
                             "review_prompt_side = COALESCE(?, review_prompt_side), "
                             "scheduler_type = COALESCE(?, scheduler_type), "
                             "scheduler_settings_json = COALESCE(?, scheduler_settings_json) "
@@ -16723,6 +16837,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                             self.client_id,
                             description,
                             workspace_id,
+                            normalized_visibility,
                             normalized_prompt_side,
                             scheduler_type,
                             scheduler_settings_json,
@@ -16739,13 +16854,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     return deck_id
                 insert_sql = (
                     "INSERT INTO decks("
-                    "name, description, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, client_id, version, deleted"
-                    ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                    "name, description, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, client_id, version, deleted"
+                    ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
                 )
                 params = (
                     name,
                     description,
                     workspace_id,
+                    visibility_for_insert,
                     prompt_side_for_insert,
                     scheduler_settings_json,
                     scheduler_type,
@@ -16785,9 +16901,35 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         include_deleted: bool = False,
         workspace_id: str | None = None,
         include_workspace_items: bool = False,
+        shared_with_user_id: int | None = None,
     ) -> list[dict[str, Any]]:
+        if shared_with_user_id is not None:
+            query = (
+                "SELECT d.id, d.name, d.description, d.workspace_id, d.visibility, d.review_prompt_side, "
+                "d.scheduler_settings_json, d.scheduler_type, d.created_at, d.last_modified, "
+                "d.deleted, d.client_id, d.version FROM decks d "
+                "JOIN deck_shares ds ON ds.deck_id = d.id "
+            )
+            conditions = ["ds.user_id = ?"]
+            params_list: list[Any] = [int(shared_with_user_id)]
+            if not include_deleted:
+                conditions.append("d.deleted = 0")
+            if workspace_id is not None:
+                if include_workspace_items:
+                    conditions.append("(d.workspace_id = ? OR d.workspace_id IS NULL)")
+                else:
+                    conditions.append("d.workspace_id = ?")
+                params_list.append(workspace_id)
+            query += "WHERE " + " AND ".join(conditions) + " ORDER BY d.name LIMIT ? OFFSET ?"
+            params_list.extend([limit, offset])
+            try:
+                cursor = self.execute_query(query, tuple(params_list))
+                return [dict(row) for row in cursor.fetchall()]
+            except CharactersRAGDBError:  # noqa: TRY203
+                raise
+
         select_sql = (
-            "SELECT id, name, description, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, "
+            "SELECT id, name, description, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, "
             "deleted, client_id, version FROM decks "
         )
         if include_deleted:
@@ -16819,7 +16961,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def get_deck(self, deck_id: int) -> dict[str, Any] | None:
         """Fetch a single deck row by id."""
         query = (
-            "SELECT id, name, description, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, deleted, client_id, version "
+            "SELECT id, name, description, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, deleted, client_id, version "
             "FROM decks WHERE id = ?"
         )
         try:
@@ -16834,13 +16976,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if include_deleted:
             query = (
                 "SELECT id, name, description, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, "
-                "last_modified, deleted, client_id, version FROM decks WHERE name = ? "
+                "last_modified, deleted, client_id, version, visibility FROM decks WHERE name = ? "
                 "ORDER BY id LIMIT 1"
             )
         else:
             query = (
                 "SELECT id, name, description, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, "
-                "last_modified, deleted, client_id, version FROM decks WHERE name = ? AND deleted = 0 "
+                "last_modified, deleted, client_id, version, visibility FROM decks WHERE name = ? AND deleted = 0 "
                 "ORDER BY id LIMIT 1"
             )
         try:
@@ -16850,6 +16992,126 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except CharactersRAGDBError:  # noqa: TRY203
             raise
 
+    def upsert_deck_share(
+        self,
+        deck_id: int,
+        *,
+        user_id: int,
+        role: str = "viewer",
+        shared_by: int,
+    ) -> dict[str, Any]:
+        """Create or update a per-user share record for a deck owned by this DB."""
+        target_user_id = int(user_id)
+        sharing_user_id = int(shared_by)
+        if target_user_id <= 0:
+            raise InputError("user_id must be a positive integer")  # noqa: TRY003
+        if sharing_user_id <= 0:
+            raise InputError("shared_by must be a positive integer")  # noqa: TRY003
+        if target_user_id == sharing_user_id:
+            raise InputError("Cannot share a deck with its owner")  # noqa: TRY003
+
+        normalized_role = _normalize_deck_share_role(role)
+        now = self._get_current_utc_timestamp_iso()
+        try:
+            with self.transaction() as conn:
+                deck = conn.execute(
+                    "SELECT id FROM decks WHERE id = ? AND deleted = 0",
+                    (int(deck_id),),
+                ).fetchone()
+                if deck is None:
+                    raise ConflictError("Deck not found", entity="decks", identifier=deck_id)  # noqa: TRY003
+
+                insert_sql = """
+                    INSERT INTO deck_shares(
+                        deck_id, user_id, role, shared_by, shared_at, last_modified, client_id, version
+                    ) VALUES(?, ?, ?, ?, ?, ?, ?, 1)
+                    ON CONFLICT(deck_id, user_id) DO UPDATE SET
+                        role = excluded.role,
+                        shared_by = excluded.shared_by,
+                        last_modified = excluded.last_modified,
+                        client_id = excluded.client_id,
+                        version = deck_shares.version + 1
+                """
+                params = (
+                    int(deck_id),
+                    target_user_id,
+                    normalized_role,
+                    sharing_user_id,
+                    now,
+                    now,
+                    self.client_id,
+                )
+                if self.backend_type == BackendType.POSTGRESQL:
+                    row = conn.execute(
+                        insert_sql
+                        + " RETURNING deck_id, user_id, role, shared_by, shared_at, last_modified, client_id, version",
+                        params,
+                    ).fetchone()
+                    return dict(row)
+
+                conn.execute(insert_sql, params)
+                row = conn.execute(
+                    """
+                    SELECT deck_id, user_id, role, shared_by, shared_at, last_modified, client_id, version
+                      FROM deck_shares
+                     WHERE deck_id = ? AND user_id = ?
+                    """,
+                    (int(deck_id), target_user_id),
+                ).fetchone()
+                if row is None:
+                    raise CharactersRAGDBError("Failed to read deck share after upsert")  # noqa: TRY003
+                return dict(row)
+        except sqlite3.Error as exc:
+            raise CharactersRAGDBError(f"Failed to share deck: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            raise CharactersRAGDBError(f"Failed to share deck: {exc}") from exc  # noqa: TRY003
+
+    def list_deck_shares(self, deck_id: int) -> list[dict[str, Any]]:
+        """List all per-user share records for a deck owned by this DB."""
+        try:
+            cursor = self.execute_query(
+                """
+                SELECT deck_id, user_id, role, shared_by, shared_at, last_modified, client_id, version
+                  FROM deck_shares
+                 WHERE deck_id = ?
+                 ORDER BY user_id
+                """,
+                (int(deck_id),),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+        except CharactersRAGDBError:  # noqa: TRY203
+            raise
+
+    def get_deck_share(self, deck_id: int, *, user_id: int) -> dict[str, Any] | None:
+        """Fetch one per-user share record for a deck owned by this DB."""
+        try:
+            cursor = self.execute_query(
+                """
+                SELECT deck_id, user_id, role, shared_by, shared_at, last_modified, client_id, version
+                  FROM deck_shares
+                 WHERE deck_id = ? AND user_id = ?
+                """,
+                (int(deck_id), int(user_id)),
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+        except CharactersRAGDBError:  # noqa: TRY203
+            raise
+
+    def delete_deck_share(self, deck_id: int, *, user_id: int) -> bool:
+        """Remove one per-user share record from a deck owned by this DB."""
+        try:
+            with self.transaction() as conn:
+                rowcount = conn.execute(
+                    "DELETE FROM deck_shares WHERE deck_id = ? AND user_id = ?",
+                    (int(deck_id), int(user_id)),
+                ).rowcount
+                return rowcount > 0
+        except sqlite3.Error as exc:
+            raise CharactersRAGDBError(f"Failed to remove deck share: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            raise CharactersRAGDBError(f"Failed to remove deck share: {exc}") from exc  # noqa: TRY003
+
     def update_deck(
         self,
         deck_id: int,
@@ -16857,6 +17119,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         name: str | None = None,
         description: str | None = None,
         review_prompt_side: str | None = None,
+        visibility: str | None = None,
         scheduler_settings: Mapping[str, Any] | str | None = None,
         scheduler_type: str | None = None,
         workspace_id: Any = ...,
@@ -16874,6 +17137,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if review_prompt_side is not None:
             set_parts.append("review_prompt_side = ?")
             params.append("back" if str(review_prompt_side).strip().lower() == "back" else "front")
+        if visibility is not None:
+            set_parts.append("visibility = ?")
+            params.append(_normalize_deck_visibility(visibility))
         if scheduler_settings is not None:
             set_parts.append("scheduler_settings_json = ?")
             params.append(scheduler_settings_to_json(scheduler_settings))
@@ -20001,6 +20267,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     if existing is None:
                         raise ConflictError("Deck not found", entity="decks", identifier=deck_id)  # noqa: TRY003
                     raise ConflictError("Version mismatch deleting deck", entity="decks", identifier=deck_id)  # noqa: TRY003
+                if rowcount > 0:
+                    conn.execute("DELETE FROM deck_shares WHERE deck_id = ?", (int(deck_id),))
         except sqlite3.Error as exc:
             raise CharactersRAGDBError(f"Failed to soft-delete deck: {exc}") from exc  # noqa: TRY003
         except BackendDatabaseError as exc:

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_flashcard_deck_sharing.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_flashcard_deck_sharing.py
@@ -1,0 +1,138 @@
+import os
+import tempfile
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    ConflictError,
+    InputError,
+)
+
+
+def test_deck_visibility_and_share_records_persist():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = CharactersRAGDB(os.path.join(tmpdir, "ChaChaNotes.db"), client_id="owner-1")
+
+        deck_id = db.add_deck("Shared Biology", visibility="team")
+        deck = db.get_deck(deck_id)
+
+        assert deck is not None
+        assert deck["visibility"] == "team"
+
+        share = db.upsert_deck_share(
+            deck_id,
+            user_id=22,
+            role="viewer",
+            shared_by=11,
+        )
+
+        assert share["deck_id"] == deck_id
+        assert share["user_id"] == 22
+        assert share["role"] == "viewer"
+        assert share["shared_by"] == 11
+        assert share["shared_at"]
+        assert db.get_deck_share(deck_id, user_id=22)["role"] == "viewer"
+        assert [item["user_id"] for item in db.list_deck_shares(deck_id)] == [22]
+
+
+def test_deck_share_upsert_normalizes_role_and_updates_existing_share():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = CharactersRAGDB(os.path.join(tmpdir, "ChaChaNotes.db"), client_id="owner-1")
+        deck_id = db.add_deck("Role Update Deck")
+        timestamps = iter(("2026-04-30T12:00:00Z", "2026-04-30T12:00:01Z"))
+        db._get_current_utc_timestamp_iso = lambda: next(timestamps)
+
+        first = db.upsert_deck_share(deck_id, user_id=22, role="viewer", shared_by=11)
+        second = db.upsert_deck_share(deck_id, user_id=22, role="OWNER", shared_by=12)
+
+        shares = db.list_deck_shares(deck_id)
+        assert len(shares) == 1
+        assert first["deck_id"] == second["deck_id"] == deck_id
+        assert second["role"] == "owner"
+        assert second["shared_by"] == 12
+        assert second["shared_at"] == first["shared_at"]
+        assert second["last_modified"] == "2026-04-30T12:00:01Z"
+
+
+def test_deck_share_rejects_invalid_role_missing_deck_and_self_share():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = CharactersRAGDB(os.path.join(tmpdir, "ChaChaNotes.db"), client_id="owner-1")
+        deck_id = db.add_deck("Private Deck")
+
+        with pytest.raises(InputError):
+            db.upsert_deck_share(deck_id, user_id=22, role="admin", shared_by=11)
+
+        with pytest.raises(InputError):
+            db.upsert_deck_share(deck_id, user_id=11, role="viewer", shared_by=11)
+
+        with pytest.raises(ConflictError):
+            db.upsert_deck_share(9999, user_id=22, role="viewer", shared_by=11)
+
+
+def test_deleting_deck_removes_deck_share_records():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = CharactersRAGDB(os.path.join(tmpdir, "ChaChaNotes.db"), client_id="owner-1")
+        deck_id = db.add_deck("Temporary Shared Deck")
+        db.upsert_deck_share(deck_id, user_id=22, role="viewer", shared_by=11)
+
+        db.soft_delete_deck_by_id(deck_id)
+
+        assert db.list_deck_shares(deck_id) == []
+
+
+def test_shared_with_user_filter_lists_matching_active_decks_only():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = CharactersRAGDB(os.path.join(tmpdir, "ChaChaNotes.db"), client_id="owner-1")
+        shared_deck = db.add_deck("Shared Deck")
+        private_deck = db.add_deck("Private Deck")
+        deleted_deck = db.add_deck("Deleted Shared Deck")
+        db.upsert_deck_share(shared_deck, user_id=22, role="viewer", shared_by=11)
+        db.upsert_deck_share(deleted_deck, user_id=22, role="viewer", shared_by=11)
+        db.soft_delete_deck_by_id(deleted_deck)
+
+        decks = db.list_decks(shared_with_user_id=22)
+
+        assert [deck["id"] for deck in decks] == [shared_deck]
+        assert all(deck["id"] != private_deck for deck in decks)
+
+
+def test_add_deck_undelete_preserves_visibility_when_omitted():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = CharactersRAGDB(os.path.join(tmpdir, "ChaChaNotes.db"), client_id="owner-1")
+        deck_id = db.add_deck("Restored Shared Deck", visibility="team")
+        db.soft_delete_deck_by_id(deck_id)
+
+        restored_id = db.add_deck("Restored Shared Deck")
+
+        assert restored_id == deck_id
+        restored = db.get_deck(deck_id)
+        assert restored is not None
+        assert restored["deleted"] == 0
+        assert restored["visibility"] == "team"
+
+        db.soft_delete_deck_by_id(deck_id)
+        db.add_deck("Restored Shared Deck", visibility="public")
+        assert db.get_deck(deck_id)["visibility"] == "public"
+
+
+def test_shared_with_user_workspace_filter_can_include_general_scope():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = CharactersRAGDB(os.path.join(tmpdir, "ChaChaNotes.db"), client_id="owner-1")
+        db.upsert_workspace("ws-1", "Workspace One")
+        db.upsert_workspace("ws-2", "Workspace Two")
+        general_deck = db.add_deck("General Shared Deck")
+        workspace_deck = db.add_deck("Workspace Shared Deck", workspace_id="ws-1")
+        other_workspace_deck = db.add_deck("Other Workspace Shared Deck", workspace_id="ws-2")
+        for deck_id in (general_deck, workspace_deck, other_workspace_deck):
+            db.upsert_deck_share(deck_id, user_id=22, role="viewer", shared_by=11)
+
+        strict_decks = db.list_decks(shared_with_user_id=22, workspace_id="ws-1")
+        inclusive_decks = db.list_decks(
+            shared_with_user_id=22,
+            workspace_id="ws-1",
+            include_workspace_items=True,
+        )
+
+        assert {deck["id"] for deck in strict_decks} == {workspace_deck}
+        assert {deck["id"] for deck in inclusive_decks} == {general_deck, workspace_deck}

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -20,7 +20,7 @@ os.environ.setdefault("TEST_MODE", "1")
 from tldw_Server_API.app.api.v1.endpoints import flashcards as flashcards_endpoint
 from tldw_Server_API.app.api.v1.endpoints.config_info import router as config_info_router
 from tldw_Server_API.app.api.v1.endpoints.flashcards import router as flashcards_router
-from tldw_Server_API.app.api.v1.schemas.flashcards import DeckDeleteResponse
+from tldw_Server_API.app.api.v1.schemas.flashcards import DeckDeleteResponse, DeckShare, DeckShareDeleteResponse
 from tldw_Server_API.app.api.v1.schemas.study_packs import (
     StudyPackJobAcceptedResponse,
     StudyPackJobListResponse,
@@ -69,6 +69,9 @@ fastapi_app = _build_flashcards_test_app()
 
 def test_flashcards_reviewed_endpoints_have_explicit_return_annotations() -> None:
     assert flashcards_endpoint.delete_deck.__annotations__["return"] is DeckDeleteResponse
+    assert flashcards_endpoint.list_deck_shares.__annotations__["return"] == list[DeckShare]
+    assert flashcards_endpoint.upsert_deck_share.__annotations__["return"] is DeckShare
+    assert flashcards_endpoint.delete_deck_share.__annotations__["return"] is DeckShareDeleteResponse
     assert flashcards_endpoint.create_study_pack_job.__annotations__["return"] is StudyPackJobAcceptedResponse
     assert flashcards_endpoint.list_study_pack_jobs.__annotations__["return"] is StudyPackJobListResponse
     assert flashcards_endpoint.get_study_pack_job_status.__annotations__["return"] is StudyPackJobStatusResponse
@@ -297,6 +300,95 @@ def test_deck_workspace_id_contract_and_scope_filters(
     assert any(item["id"] == deck_id for item in general_list.json())
 
 
+def test_deck_share_endpoints_manage_user_roles(
+    client_with_flashcards_db: TestClient,
+):
+    create_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Shareable Deck", "visibility": "team"},
+        headers=AUTH_HEADERS,
+    )
+    assert create_response.status_code == 200
+    deck = create_response.json()
+    assert deck["visibility"] == "team"
+
+    share_response = client_with_flashcards_db.put(
+        f"/api/v1/flashcards/decks/{deck['id']}/shares/22",
+        json={"role": "viewer"},
+        headers=AUTH_HEADERS,
+    )
+    assert share_response.status_code == 200
+    share = share_response.json()
+    assert share["deck_id"] == deck["id"]
+    assert share["user_id"] == 22
+    assert share["role"] == "viewer"
+    assert share["shared_by"] == 1
+
+    promote_response = client_with_flashcards_db.put(
+        f"/api/v1/flashcards/decks/{deck['id']}/shares/22",
+        json={"role": "editor"},
+        headers=AUTH_HEADERS,
+    )
+    assert promote_response.status_code == 200
+    assert promote_response.json()["role"] == "editor"
+
+    owner_response = client_with_flashcards_db.put(
+        f"/api/v1/flashcards/decks/{deck['id']}/shares/22",
+        json={"role": "owner"},
+        headers=AUTH_HEADERS,
+    )
+    assert owner_response.status_code == 200
+    assert owner_response.json()["role"] == "owner"
+
+    list_response = client_with_flashcards_db.get(
+        f"/api/v1/flashcards/decks/{deck['id']}/shares",
+        headers=AUTH_HEADERS,
+    )
+    assert list_response.status_code == 200
+    assert [item["user_id"] for item in list_response.json()] == [22]
+
+    delete_response = client_with_flashcards_db.delete(
+        f"/api/v1/flashcards/decks/{deck['id']}/shares/22",
+        headers=AUTH_HEADERS,
+    )
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"removed": True}
+    assert client_with_flashcards_db.get(
+        f"/api/v1/flashcards/decks/{deck['id']}/shares",
+        headers=AUTH_HEADERS,
+    ).json() == []
+
+
+def test_deck_share_endpoint_rejects_self_share(client_with_flashcards_db: TestClient):
+    create_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Self Share Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert create_response.status_code == 200
+    deck_id = create_response.json()["id"]
+
+    share_response = client_with_flashcards_db.put(
+        f"/api/v1/flashcards/decks/{deck_id}/shares/1",
+        json={"role": "viewer"},
+        headers=AUTH_HEADERS,
+    )
+
+    assert share_response.status_code == 400
+    assert share_response.json()["detail"] == "Cannot share a deck with its owner"
+
+
+def test_deck_share_endpoint_returns_404_for_missing_deck(client_with_flashcards_db: TestClient):
+    share_response = client_with_flashcards_db.put(
+        "/api/v1/flashcards/decks/999999/shares/22",
+        json={"role": "viewer"},
+        headers=AUTH_HEADERS,
+    )
+
+    assert share_response.status_code == 404
+    assert share_response.json()["detail"] == "Deck not found"
+
+
 def test_list_decks_returns_500_for_db_error(
     client_with_flashcards_db: TestClient,
     flashcards_db: CharactersRAGDB,
@@ -466,6 +558,45 @@ def test_create_deck_undelete_preserves_orientation_unless_explicit_front_overri
     assert explicit_front_response.json()["review_prompt_side"] == "front"
 
 
+def test_create_deck_undelete_preserves_visibility_unless_explicit_override(
+    client_with_flashcards_db: TestClient,
+    flashcards_db: CharactersRAGDB,
+):
+    create_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={
+            "name": "Visibility API Deck",
+            "visibility": "team",
+        },
+        headers=AUTH_HEADERS,
+    )
+
+    assert create_response.status_code == 200
+    deck_id = create_response.json()["id"]
+    flashcards_db.soft_delete_deck_by_id(deck_id)
+
+    omitted_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Visibility API Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert omitted_response.status_code == 200
+    assert omitted_response.json()["visibility"] == "team"
+
+    flashcards_db.soft_delete_deck_by_id(deck_id)
+
+    explicit_public_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={
+            "name": "Visibility API Deck",
+            "visibility": "public",
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert explicit_public_response.status_code == 200
+    assert explicit_public_response.json()["visibility"] == "public"
+
+
 def test_update_deck_rejects_null_review_prompt_side(client_with_flashcards_db: TestClient):
     create_response = client_with_flashcards_db.post(
         "/api/v1/flashcards/decks",
@@ -478,6 +609,26 @@ def test_update_deck_rejects_null_review_prompt_side(client_with_flashcards_db: 
         f"/api/v1/flashcards/decks/{create_response.json()['id']}",
         json={
             "review_prompt_side": None,
+            "expected_version": create_response.json()["version"],
+        },
+        headers=AUTH_HEADERS,
+    )
+
+    assert update_response.status_code == 422
+
+
+def test_update_deck_rejects_null_visibility(client_with_flashcards_db: TestClient):
+    create_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Patch Null Visibility Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert create_response.status_code == 200
+
+    update_response = client_with_flashcards_db.patch(
+        f"/api/v1/flashcards/decks/{create_response.json()['id']}",
+        json={
+            "visibility": None,
             "expected_version": create_response.json()["version"],
         },
         headers=AUTH_HEADERS,


### PR DESCRIPTION
## Change summary

- Adds a backend foundation for collaborative flashcard decks: deck `visibility`, owner-side `deck_shares` metadata, share role normalization, and share cleanup when decks are soft-deleted.
- Exposes owner-managed share endpoints for listing, upserting, and removing per-user deck roles.
- Adds a staged implementation plan for the larger #989 work so this PR stays limited to durable sharing metadata and does not pretend to solve cross-user study access yet.

Why: #989 needs a permission model before shared deck UI or recipient review flows can be implemented safely. This slice lands the schema/API contract first and deliberately leaves shared deck discovery plus per-user SRS state for follow-up PRs.

## Verification

- Red tests failed first for missing `visibility`, share DB methods, and share endpoints.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/ChaChaNotesDB/test_flashcard_deck_sharing.py tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py::test_deck_share_endpoints_manage_user_roles tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py::test_deck_share_endpoint_rejects_self_share tldw_Server_API/tests/ChaChaNotesDB/test_flashcards_basic.py tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py::test_deck_workspace_id_contract_and_scope_filters tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py::test_create_deck_returns_review_prompt_side tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py::test_create_deck_rejects_null_review_prompt_side tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py::test_create_deck_undelete_preserves_review_prompt_side tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py::test_update_deck_rejects_null_review_prompt_side -q`
- `git diff --check`
- `git diff --cached --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/endpoints/flashcards.py tldw_Server_API/app/api/v1/schemas/flashcards.py -f json -o /tmp/bandit_flashcard_sharing_989.json` (`results: []`)

Refs #989