### PR TITLE
feat(tts): add inline ElevenLabs key setup

### DIFF
--- a/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
@@ -77,6 +77,10 @@ import { VoicePickerModal, type VoiceSelection } from "@/components/Option/Speec
 import { useAudioSourceCatalog } from "@/hooks/useAudioSourceCatalog"
 import { useAudioSourcePreferences } from "@/hooks/useAudioSourcePreferences"
 import { useMultiRenderState } from "@/hooks/useMultiRenderState"
+import {
+  getModels as getElevenLabsModels,
+  getVoices as getElevenLabsVoices
+} from "@/services/elevenlabs"
 
 const { Text, Title, Paragraph } = Typography
 
@@ -111,6 +115,7 @@ const STREAMING_FORMATS = new Set(["mp3", "opus", "aac", "flac", "wav", "pcm"])
 const TTS_CHAR_WARNING = 2000
 const TTS_CHAR_LIMIT = 8000
 const TTS_ESTIMATE_CHARS_PER_SEC = 15
+const ELEVENLABS_INLINE_TEST_TIMEOUT_MS = 10_000
 const TTS_JOB_STEPS = [
   { key: "tts_started", label: "Queued" },
   { key: "tts_synthesizing", label: "Synthesizing" },
@@ -845,6 +850,13 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
   const [responseSplitting, setResponseSplitting] = React.useState("punctuation")
   const [openAiModel, setOpenAiModel] = React.useState<string | undefined>(undefined)
   const [openAiVoice, setOpenAiVoice] = React.useState<string | undefined>(undefined)
+  const [inlineElevenLabsApiKey, setInlineElevenLabsApiKey] = React.useState("")
+  const [inlineElevenLabsSaving, setInlineElevenLabsSaving] = React.useState(false)
+  const [inlineElevenLabsResult, setInlineElevenLabsResult] = React.useState<{
+    ok: boolean
+    message: string
+  } | null>(null)
+  const [inlineElevenLabsDetailsOpen, setInlineElevenLabsDetailsOpen] = React.useState(true)
   const provider = ttsSettings?.ttsProvider || DEFAULT_TTS_PROVIDER
   const isTldw = provider === "tldw"
   const inferredProviderKey = React.useMemo(() => {
@@ -871,6 +883,14 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
     queryFn: listCustomVoices,
     enabled: isTldw && hasAudio
   })
+
+  React.useEffect(() => {
+    if (provider !== "elevenlabs" || ttsSettings?.elevenLabsApiKey) {
+      setInlineElevenLabsApiKey("")
+      setInlineElevenLabsResult(null)
+      setInlineElevenLabsDetailsOpen(true)
+    }
+  }, [provider, ttsSettings?.elevenLabsApiKey])
 
   const handleAddRenderStrip = React.useCallback(() => {
     // Try to use last-used voice config from localStorage
@@ -1822,7 +1842,7 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
       )
     : t(
         "playground:tts.elevenLabsMissingBody",
-        "Add your ElevenLabs API key in Settings to load voices and models."
+        "Enter your ElevenLabs API key below to load voices and models. You can also manage it in Settings."
       )
   const elevenLabsTimeoutBody = t(
     "playground:tts.elevenLabsTimeoutBody",
@@ -1902,14 +1922,94 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
     setInspectorOpen
   ])
 
-  const handleElevenLabsApiKeyFocus = React.useCallback(() => {
-    const el = document.getElementById("elevenlabs-api-key")
-    if (!el) return
+  const handleInlineElevenLabsSave = React.useCallback(async () => {
+    const trimmedKey = inlineElevenLabsApiKey.trim()
+    if (!trimmedKey) {
+      setInlineElevenLabsResult({
+        ok: false,
+        message: t(
+          "playground:tts.elevenLabsInlineKeyRequired",
+          "Enter an ElevenLabs API key first."
+        ) as string
+      })
+      return
+    }
+
+    setInlineElevenLabsSaving(true)
+    setInlineElevenLabsResult(null)
     try {
-      el.scrollIntoView({ block: "center" })
-    } catch {}
-    ;(el as HTMLElement).focus()
-  }, [])
+      const [voices, models] = await Promise.all([
+        getElevenLabsVoices(trimmedKey, {
+          timeoutMs: ELEVENLABS_INLINE_TEST_TIMEOUT_MS
+        }),
+        getElevenLabsModels(trimmedKey, {
+          timeoutMs: ELEVENLABS_INLINE_TEST_TIMEOUT_MS
+        })
+      ])
+      if (
+        !Array.isArray(voices) ||
+        voices.length === 0 ||
+        !Array.isArray(models) ||
+        models.length === 0
+      ) {
+        setInlineElevenLabsResult({
+          ok: false,
+          message: t(
+            "playground:tts.elevenLabsInlineKeyNoResources",
+            "API key accepted, but no voices or models were returned."
+          ) as string
+        })
+        return
+      }
+
+      const currentSettings = await getTTSSettings()
+      await setTTSSettings({
+        ...currentSettings,
+        elevenLabsApiKey: trimmedKey
+      })
+      await queryClient.invalidateQueries({ queryKey: ["fetchTTSSettings"] })
+      const savedMessage = t(
+        "playground:tts.elevenLabsInlineKeySaved",
+        "API key saved. ElevenLabs voices can now load."
+      ) as string
+      notification.success({ message: savedMessage })
+      setInlineElevenLabsResult(null)
+    } catch (error: unknown) {
+      const status =
+        typeof error === "object" && error !== null
+          ? Number((error as { response?: { status?: unknown } }).response?.status)
+          : NaN
+      const code =
+        typeof error === "object" && error !== null
+          ? String((error as { code?: unknown }).code ?? "")
+          : ""
+      const message = isTimeoutLikeError(error)
+        ? t(
+            "playground:tts.elevenLabsInlineKeyTimeout",
+            "Request timed out while validating the API key."
+          )
+        : status === 401 || status === 403
+          ? t(
+              "playground:tts.elevenLabsInlineKeyInvalid",
+              "Invalid ElevenLabs API key. Check the key and try again."
+            )
+          : code === "ERR_NETWORK" || code === "ENOTFOUND" || code === "ECONNREFUSED"
+            ? t(
+                "playground:tts.elevenLabsInlineKeyNetworkError",
+                "Network error while validating the API key. Check your connection and try again."
+              )
+            : t(
+                "playground:tts.elevenLabsInlineKeyFailed",
+                "Unable to validate the ElevenLabs API key."
+              )
+      setInlineElevenLabsResult({
+        ok: false,
+        message: message as string
+      })
+    } finally {
+      setInlineElevenLabsSaving(false)
+    }
+  }, [inlineElevenLabsApiKey, queryClient, t])
 
   const handleAddVoiceCard = () => {
     if (voiceCards.length >= 4) return
@@ -2492,33 +2592,80 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                         showIcon
                         title={elevenLabsHintTitle}
                         description={
-                          <div className="flex flex-wrap items-center gap-2">
+                          <div className="space-y-3">
                             <span>
                               {hasElevenLabsLoadError && isTimeoutLikeError(elevenLabsError)
                                 ? elevenLabsTimeoutBody
                                 : elevenLabsHintBody}
                             </span>
-                            {hasElevenLabsKey && (
-                              <Button
-                                size="small"
-                                type="link"
-                                onClick={() => {
-                                  void refetchElevenLabs()
+                            {hasElevenLabsKey ? (
+                              <div>
+                                <Button
+                                  size="small"
+                                  type="link"
+                                  onClick={() => {
+                                    void refetchElevenLabs()
+                                  }}
+                                >
+                                  {t("common:retry", "Retry")}
+                                </Button>
+                              </div>
+                            ) : (
+                              <details
+                                open={inlineElevenLabsDetailsOpen}
+                                onToggle={(event) => {
+                                  setInlineElevenLabsDetailsOpen(event.currentTarget.open)
                                 }}
+                                className="rounded-md border border-border bg-background/60 px-3 py-2"
                               >
-                                {t("common:retry", "Retry")}
-                              </Button>
+                                <summary className="cursor-pointer text-sm font-medium text-text">
+                                  {t(
+                                    "playground:tts.elevenLabsInlineKeySummary",
+                                    "Enter API key"
+                                  )}
+                                </summary>
+                                <div className="mt-3 space-y-2">
+                                  <Space.Compact className="w-full max-w-xl">
+                                    <Input.Password
+                                      id="elevenlabs-api-key"
+                                      aria-label={t(
+                                        "playground:tts.elevenLabsInlineKeyLabel",
+                                        "ElevenLabs API key"
+                                      ) as string}
+                                      placeholder="sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                                      value={inlineElevenLabsApiKey}
+                                      onChange={(event) => {
+                                        setInlineElevenLabsApiKey(event.target.value)
+                                        setInlineElevenLabsResult(null)
+                                      }}
+                                      onPressEnter={() => {
+                                        void handleInlineElevenLabsSave()
+                                      }}
+                                    />
+                                    <Button
+                                      type="primary"
+                                      loading={inlineElevenLabsSaving}
+                                      disabled={!inlineElevenLabsApiKey.trim()}
+                                      onClick={() => {
+                                        void handleInlineElevenLabsSave()
+                                      }}
+                                    >
+                                      {t(
+                                        "playground:tts.elevenLabsInlineKeySave",
+                                        "Test & Save"
+                                      )}
+                                    </Button>
+                                  </Space.Compact>
+                                  {inlineElevenLabsResult && (
+                                    <Alert
+                                      type={inlineElevenLabsResult.ok ? "success" : "error"}
+                                      showIcon
+                                      title={inlineElevenLabsResult.message}
+                                    />
+                                  )}
+                                </div>
+                              </details>
                             )}
-                            <Button
-                              size="small"
-                              type="link"
-                              onClick={handleElevenLabsApiKeyFocus}
-                            >
-                              {t(
-                                "playground:tts.elevenLabsMissingCta",
-                                "Set API key in Settings"
-                              )}
-                            </Button>
                           </div>
                         }
                       />

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 type QueryOptions = {
@@ -24,13 +24,47 @@ const updateStoredValue = (
   storageValues.set(key, resolvedValue)
 }
 
-const { invalidateQueriesMock, transcribeAudioMock, getTranscriptionModelsMock } =
+const createDeferred = <T,>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+const {
+  invalidateQueriesMock,
+  transcribeAudioMock,
+  getTranscriptionModelsMock,
+  getElevenLabsVoicesMock,
+  getElevenLabsModelsMock,
+  setTTSSettingsMock,
+  ttsSettingsRef,
+} =
   vi.hoisted(() => ({
     invalidateQueriesMock: vi.fn(),
     transcribeAudioMock: vi.fn(),
     getTranscriptionModelsMock: vi.fn(async () => ({
       all_models: ["whisper-1"],
     })),
+    getElevenLabsVoicesMock: vi.fn(),
+    getElevenLabsModelsMock: vi.fn(),
+    setTTSSettingsMock: vi.fn(async () => undefined),
+    ttsSettingsRef: {
+      current: {
+        ttsProvider: "",
+        ttsEnabled: true,
+        tldwTtsSpeed: 1,
+        tldwTtsStreaming: false,
+        responseSplitting: "punctuation",
+      } as any,
+    },
   }))
 
 const { storageValues, setSpeechModeMock, setSpeechHistoryMock } = vi.hoisted(() => ({
@@ -82,13 +116,7 @@ vi.mock("@tanstack/react-query", () => ({
   useQuery: vi.fn((options: QueryOptions | undefined) => {
     if (options?.queryKey?.[0] === "fetchTTSSettings") {
       return {
-        data: {
-          ttsProvider: "",
-          ttsEnabled: true,
-          tldwTtsSpeed: 1,
-          tldwTtsStreaming: false,
-          responseSplitting: "punctuation",
-        },
+        data: ttsSettingsRef.current,
         isLoading: false,
       }
     }
@@ -242,14 +270,8 @@ vi.mock("@/services/tts-providers", () => ({
 
 vi.mock("@/services/tts", () => ({
   getTTSProvider: vi.fn(async () => "tldw"),
-  getTTSSettings: vi.fn(async () => ({
-    ttsProvider: "",
-    ttsEnabled: true,
-    responseSplitting: "punctuation",
-    tldwTtsSpeed: 1,
-    tldwTtsStreaming: false,
-  })),
-  setTTSSettings: vi.fn(async () => undefined),
+  getTTSSettings: vi.fn(async () => ttsSettingsRef.current),
+  setTTSSettings: setTTSSettingsMock,
   SUPPORTED_TLDW_TTS_FORMATS: ["mp3"],
   setTldwTTSSpeed: vi.fn(),
   setTldwTTSResponseFormat: vi.fn(),
@@ -258,6 +280,11 @@ vi.mock("@/services/tts", () => ({
   DEFAULT_TTS_PROVIDER: "tldw",
   DEFAULT_TLDW_TTS_MODEL: "KittenML/kitten-tts-nano-0.8",
   DEFAULT_TLDW_TTS_VOICE: "Bella",
+}))
+
+vi.mock("@/services/elevenlabs", () => ({
+  getVoices: getElevenLabsVoicesMock,
+  getModels: getElevenLabsModelsMock,
 }))
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
@@ -315,6 +342,16 @@ describe("SpeechPlaygroundPage", () => {
     invalidateQueriesMock.mockReset()
     transcribeAudioMock.mockReset()
     getTranscriptionModelsMock.mockClear()
+    getElevenLabsVoicesMock.mockReset()
+    getElevenLabsModelsMock.mockReset()
+    setTTSSettingsMock.mockClear()
+    ttsSettingsRef.current = {
+      ttsProvider: "",
+      ttsEnabled: true,
+      tldwTtsSpeed: 1,
+      tldwTtsStreaming: false,
+      responseSplitting: "punctuation",
+    }
     storageValues.clear()
     storageValues.set("speechPlaygroundMode", "roundtrip")
     storageValues.set("speechPlaygroundHistory", [])
@@ -405,5 +442,155 @@ describe("SpeechPlaygroundPage", () => {
     expect(
       screen.getByLabelText("Speech playground input source")
     ).toBeInTheDocument()
+  })
+
+  it("offers inline ElevenLabs API key entry when ElevenLabs is selected without a key", (): void => {
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: "",
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    expect(screen.getByLabelText("ElevenLabs API key")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Enter your ElevenLabs API key below to load voices and models. You can also manage it in Settings."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Test & Save" })
+    ).toBeDisabled()
+    expect(screen.queryByText("Set API key in Settings")).not.toBeInTheDocument()
+  })
+
+  it("validates and saves the inline ElevenLabs API key to local TTS settings", async (): Promise<void> => {
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: "",
+    }
+    getElevenLabsVoicesMock.mockResolvedValue([
+      { voice_id: "voice-1", name: "Voice 1" },
+    ])
+    getElevenLabsModelsMock.mockResolvedValue([
+      { model_id: "model-1", name: "Model 1" },
+    ])
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("ElevenLabs API key"), {
+      target: { value: "sk_test_inline" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Test & Save" }))
+
+    await waitFor(() => {
+      expect(setTTSSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ttsProvider: "elevenlabs",
+          elevenLabsApiKey: "sk_test_inline",
+        })
+      )
+    })
+    expect(getElevenLabsVoicesMock).toHaveBeenCalledWith("sk_test_inline", {
+      timeoutMs: 10_000,
+    })
+    expect(getElevenLabsModelsMock).toHaveBeenCalledWith("sk_test_inline", {
+      timeoutMs: 10_000,
+    })
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ["fetchTTSSettings"],
+    })
+  })
+
+  it("keeps the inline key details collapsed across input rerenders", (): void => {
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: "",
+    }
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    const details = screen.getByText("Enter API key").closest("details") as HTMLDetailsElement
+    expect(details.open).toBe(true)
+
+    fireEvent.click(screen.getByText("Enter API key"))
+    expect(details.open).toBe(false)
+
+    fireEvent.change(screen.getByLabelText("ElevenLabs API key"), {
+      target: { value: "sk_test_inline" },
+    })
+    expect(details.open).toBe(false)
+  })
+
+  it("does not force ElevenLabs as the provider if provider changes while validation is pending", async (): Promise<void> => {
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: "",
+    }
+    const voices = createDeferred<Array<{ voice_id: string; name: string }>>()
+    const models = createDeferred<Array<{ model_id: string; name: string }>>()
+    getElevenLabsVoicesMock.mockReturnValue(voices.promise)
+    getElevenLabsModelsMock.mockReturnValue(models.promise)
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("ElevenLabs API key"), {
+      target: { value: "sk_test_inline" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Test & Save" }))
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "browser",
+    }
+    voices.resolve([{ voice_id: "voice-1", name: "Voice 1" }])
+    models.resolve([{ model_id: "model-1", name: "Model 1" }])
+
+    await waitFor(() => {
+      expect(setTTSSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ttsProvider: "browser",
+          elevenLabsApiKey: "sk_test_inline",
+        })
+      )
+    })
+    expect(setTTSSettingsMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        ttsProvider: "elevenlabs",
+        elevenLabsApiKey: "sk_test_inline",
+      })
+    )
+  })
+
+  it("shows stable validation errors without exposing raw ElevenLabs details", async (): Promise<void> => {
+    ttsSettingsRef.current = {
+      ...ttsSettingsRef.current,
+      ttsProvider: "elevenlabs",
+      elevenLabsApiKey: "",
+    }
+    getElevenLabsVoicesMock.mockRejectedValue(
+      Object.assign(new Error("Request failed for sk_secret_inline"), {
+        response: { status: 401 },
+      })
+    )
+    getElevenLabsModelsMock.mockResolvedValue([
+      { model_id: "model-1", name: "Model 1" },
+    ])
+
+    render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+    fireEvent.change(screen.getByLabelText("ElevenLabs API key"), {
+      target: { value: "sk_secret_inline" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Test & Save" }))
+
+    expect(
+      await screen.findByText("Invalid ElevenLabs API key. Check the key and try again.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/sk_secret_inline/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Request failed/)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Change summary

Adds an inline ElevenLabs API key setup path to the TTS playground when ElevenLabs is selected and no local key is configured. The playground now validates the key by loading ElevenLabs voices/models, persists it through the existing local `setTTSSettings` path, and refreshes the TTS settings query so voices can load without sending users to Speech Settings.

This intentionally does not write to BYOK storage; issue #990 called out the local settings path as the smallest self-contained fix for the playground flow.

Closes #990

## Tests

- `bunx vitest run ../packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx ../packages/ui/src/hooks/__tests__/useTtsProviderData.test.tsx`
- `git diff --check`
- `git diff --cached --check`

Bandit was not run because this PR only touches frontend TypeScript/TSX files.
