### PR TITLE
feat(tts): persist ElevenLabs key validation status

### DIFF
--- a/apps/packages/ui/src/components/Option/Settings/TTSModeSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/TTSModeSettings.tsx
@@ -27,12 +27,21 @@ import {
 import { normalizeTtsProviderKey, toServerTtsProviderKey } from "@/services/tldw/tts-provider-keys"
 import { listCustomVoices, type TldwCustomVoice } from "@/services/tldw/voice-cloning"
 import { useWebUI } from "@/store/webui"
-import { Alert, Button, Input, InputNumber, Select, Skeleton, Switch, Space } from "antd"
+import { Alert, Button, Input, InputNumber, Select, Skeleton, Switch, Space, Tag } from "antd"
 import { useTranslation } from "react-i18next"
 import React, { useState } from "react"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { useSimpleForm } from "@/hooks/useSimpleForm"
 import { isTimeoutLikeError } from "@/utils/request-timeout"
+
+const ELEVENLABS_KEY_DEBOUNCE_MS = 350
+
+const formatValidationTimestamp = (value?: string | null) => {
+  if (!value) return ""
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleString()
+}
 
 export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
   const { t } = useTranslation("settings")
@@ -43,6 +52,8 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
   // API key test states
   const [elevenLabsTestResult, setElevenLabsTestResult] = useState<{ ok: boolean; message: string } | null>(null)
   const [testingElevenLabs, setTestingElevenLabs] = useState(false)
+  const [debouncedElevenLabsApiKey, setDebouncedElevenLabsApiKey] = useState("")
+  const lastPersistedElevenLabsValidationRef = React.useRef<string | null>(null)
 
   const ids = {
     ttsEnabled: "tts-enabled-toggle",
@@ -83,6 +94,8 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
       elevenLabsApiKey: "",
       elevenLabsVoiceId: "",
       elevenLabsModel: "",
+      elevenLabsKeyValid: null as boolean | null,
+      elevenLabsKeyTestedAt: "",
       responseSplitting: "",
       openAITTSBaseUrl: "",
       openAITTSApiKey: "",
@@ -126,18 +139,73 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
     }
   })
 
+  React.useEffect(() => {
+    const key = String(form.values.elevenLabsApiKey || "").trim()
+    const timer = window.setTimeout(() => {
+      setDebouncedElevenLabsApiKey(key)
+    }, ELEVENLABS_KEY_DEBOUNCE_MS)
+    return () => window.clearTimeout(timer)
+  }, [form.values.elevenLabsApiKey])
+
   const { data: elevenLabsData, error: elevenLabsError } = useQuery({
-    queryKey: ["fetchElevenLabsData", form.values.elevenLabsApiKey],
+    queryKey: ["fetchElevenLabsData", debouncedElevenLabsApiKey],
     queryFn: async () => {
       const [voices, models] = await Promise.all([
-        getVoices(form.values.elevenLabsApiKey),
-        getModels(form.values.elevenLabsApiKey)
+        getVoices(debouncedElevenLabsApiKey),
+        getModels(debouncedElevenLabsApiKey)
       ])
       return { voices, models }
     },
     enabled:
-      form.values.ttsProvider === "elevenlabs" && !!form.values.elevenLabsApiKey
+      form.values.ttsProvider === "elevenlabs" && !!debouncedElevenLabsApiKey
   })
+
+  const persistElevenLabsValidation = React.useCallback(
+    async (ok: boolean, validatedKey?: string) => {
+      const currentKey = String(form.values.elevenLabsApiKey || "").trim()
+      if (validatedKey && currentKey !== validatedKey) return
+      const testedAt = new Date().toISOString()
+      const nextValues = {
+        ...form.values,
+        elevenLabsApiKey: currentKey,
+        elevenLabsKeyValid: ok,
+        elevenLabsKeyTestedAt: testedAt
+      }
+      form.setValues({
+        elevenLabsKeyValid: ok,
+        elevenLabsKeyTestedAt: testedAt
+      })
+      await setTTSSettings(nextValues)
+      queryClient.setQueryData(["fetchTTSSettings"], nextValues)
+    },
+    [form, queryClient]
+  )
+
+  React.useEffect(() => {
+    if (form.values.ttsProvider !== "elevenlabs" || !debouncedElevenLabsApiKey) {
+      return
+    }
+    if (!elevenLabsData && !elevenLabsError) return
+    const ok =
+      Boolean(elevenLabsData) &&
+      !elevenLabsError &&
+      Array.isArray(elevenLabsData.voices) &&
+      elevenLabsData.voices.length > 0 &&
+      Array.isArray(elevenLabsData.models) &&
+      elevenLabsData.models.length > 0
+    const persistKey = `${debouncedElevenLabsApiKey}:${ok}:${String(
+      elevenLabsError || ""
+    )}`
+    if (lastPersistedElevenLabsValidationRef.current === persistKey) return
+    lastPersistedElevenLabsValidationRef.current = persistKey
+    void persistElevenLabsValidation(ok, debouncedElevenLabsApiKey)
+  }, [
+    debouncedElevenLabsApiKey,
+    elevenLabsData,
+    elevenLabsError,
+    form.values.ttsProvider,
+    persistElevenLabsValidation
+  ])
 
   const inferredTldwProviderKey = React.useMemo(
     () => inferTldwProviderFromModel(form.values.tldwTtsModel),
@@ -403,6 +471,7 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
           "API key valid! Found {{voiceCount}} voices and {{modelCount}} models.",
           { voiceCount: voices.length, modelCount: models.length }
         )
+        await persistElevenLabsValidation(true, form.values.elevenLabsApiKey.trim())
         message.success(successMessage as string)
         setElevenLabsTestResult({
           ok: true,
@@ -413,6 +482,7 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
           "generalSettings.tts.apiKeyTest.noVoices",
           "API key accepted but no voices or models found"
         )
+        await persistElevenLabsValidation(false, form.values.elevenLabsApiKey.trim())
         setElevenLabsTestResult({
           ok: false,
           message: noResourcesMessage as string
@@ -432,6 +502,7 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
             ? e
             : JSON.stringify(e)
       const failureMessage = `${baseMessage} (${errorDetail})`
+      await persistElevenLabsValidation(false, form.values.elevenLabsApiKey.trim())
       message.error(failureMessage)
       setElevenLabsTestResult({
         ok: false,
@@ -441,6 +512,40 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
       setTestingElevenLabs(false)
     }
   }
+
+  const elevenLabsValidationBadge = React.useMemo(() => {
+    if (form.values.elevenLabsKeyValid === true) {
+      return {
+        color: "success",
+        label: t("generalSettings.tts.apiKeyStatus.valid", "Valid") as string
+      }
+    }
+    if (form.values.elevenLabsKeyValid === false) {
+      return {
+        color: "error",
+        label: t("generalSettings.tts.apiKeyStatus.failed", "Failed") as string
+      }
+    }
+    return {
+      color: "default",
+      label: t("generalSettings.tts.apiKeyStatus.untested", "Untested") as string
+    }
+  }, [form.values.elevenLabsKeyValid, t])
+  const elevenLabsLastTested = formatValidationTimestamp(
+    form.values.elevenLabsKeyTestedAt
+  )
+
+  const handleElevenLabsKeyChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      form.setValues({
+        elevenLabsApiKey: event.target.value,
+        elevenLabsKeyValid: null,
+        elevenLabsKeyTestedAt: ""
+      })
+      setElevenLabsTestResult(null)
+    },
+    [form]
+  )
 
   if (status === "pending") {
     return <Skeleton active />
@@ -554,16 +659,33 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
         {form.values.ttsProvider === "elevenlabs" && (
           <>
             <div className="flex sm:flex-row flex-col space-y-4 sm:space-y-0 sm:justify-between">
-              <span className="text-text">
-                {t("generalSettings.tts.elevenLabs.apiKey", "API Key")}
-              </span>
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-text">
+                    {t("generalSettings.tts.elevenLabs.apiKey", "API Key")}
+                  </span>
+                  <Tag color={elevenLabsValidationBadge.color}>
+                    {elevenLabsValidationBadge.label}
+                  </Tag>
+                </div>
+                {elevenLabsLastTested && (
+                  <span className="text-xs text-text-subtle">
+                    {t(
+                      "generalSettings.tts.apiKeyStatus.lastTested",
+                      "Last tested {{timestamp}}",
+                      { timestamp: elevenLabsLastTested }
+                    )}
+                  </span>
+                )}
+              </div>
               <Space.Compact className="mt-4 sm:mt-0">
                 <Input.Password
                   id={ids.elevenApiKey}
                   placeholder="sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
                   className="!w-[220px]"
                   required
-                  {...form.getInputProps("elevenLabsApiKey")}
+                  value={form.values.elevenLabsApiKey}
+                  onChange={handleElevenLabsKeyChange}
                   onFocus={() => setElevenLabsTestResult(null)}
                 />
                 <Button

--- a/apps/packages/ui/src/components/Option/Settings/TTSModeSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/TTSModeSettings.tsx
@@ -231,7 +231,7 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
         }
       }
     },
-    [form, form.values, message, queryClient, t]
+    [form, message, queryClient, t]
   )
 
   React.useEffect(() => {

--- a/apps/packages/ui/src/components/Option/Settings/TTSModeSettings.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/TTSModeSettings.tsx
@@ -3,6 +3,9 @@ import { getModels, getVoices } from "@/services/elevenlabs"
 import {
   DEFAULT_TLDW_TTS_MODEL,
   getTTSSettings,
+  setElevenLabsApiKey,
+  setElevenLabsKeyTestedAt,
+  setElevenLabsKeyValid,
   setTTSSettings,
   SUPPORTED_TLDW_TTS_FORMATS
 } from "@/services/tts"
@@ -28,6 +31,11 @@ import { normalizeTtsProviderKey, toServerTtsProviderKey } from "@/services/tldw
 import { listCustomVoices, type TldwCustomVoice } from "@/services/tldw/voice-cloning"
 import { useWebUI } from "@/store/webui"
 import { Alert, Button, Input, InputNumber, Select, Skeleton, Switch, Space, Tag } from "antd"
+import {
+  CheckCircleOutlined,
+  ExclamationCircleOutlined,
+  QuestionCircleOutlined
+} from "@ant-design/icons"
 import { useTranslation } from "react-i18next"
 import React, { useState } from "react"
 import { useAntdMessage } from "@/hooks/useAntdMessage"
@@ -41,6 +49,17 @@ const formatValidationTimestamp = (value?: string | null) => {
   const parsed = new Date(value)
   if (Number.isNaN(parsed.getTime())) return value
   return parsed.toLocaleString()
+}
+
+const getErrorSignature = (error: unknown) => {
+  if (!error) return ""
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
 }
 
 export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
@@ -101,6 +120,8 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
       openAITTSApiKey: "",
       openAITTSModel: "",
       openAITTSVoice: "",
+      openAITTSKeyValid: null as boolean | null,
+      openAITTSKeyTestedAt: "",
       ttsAutoPlay: false,
       playbackSpeed: 1,
     tldwTtsModel: "",
@@ -161,24 +182,56 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
   })
 
   const persistElevenLabsValidation = React.useCallback(
-    async (ok: boolean, validatedKey?: string) => {
+    async (
+      ok: boolean,
+      validatedKey?: string,
+      options?: { notifyOnError?: boolean }
+    ) => {
       const currentKey = String(form.values.elevenLabsApiKey || "").trim()
       if (validatedKey && currentKey !== validatedKey) return
       const testedAt = new Date().toISOString()
-      const nextValues = {
-        ...form.values,
+      const validationValues = {
         elevenLabsApiKey: currentKey,
         elevenLabsKeyValid: ok,
         elevenLabsKeyTestedAt: testedAt
       }
-      form.setValues({
-        elevenLabsKeyValid: ok,
-        elevenLabsKeyTestedAt: testedAt
-      })
-      await setTTSSettings(nextValues)
-      queryClient.setQueryData(["fetchTTSSettings"], nextValues)
+
+      try {
+        await Promise.all([
+          setElevenLabsApiKey(currentKey),
+          setElevenLabsKeyValid(ok),
+          setElevenLabsKeyTestedAt(testedAt)
+        ])
+        const wasDirty = form.isDirty()
+        const nextFormValues = {
+          ...form.values,
+          ...validationValues
+        }
+        form.setValues(validationValues)
+        if (!wasDirty) {
+          form.resetDirty(nextFormValues)
+        }
+        queryClient.setQueryData(
+          ["fetchTTSSettings"],
+          (previous: typeof form.values | undefined) => ({
+            ...(previous || form.values),
+            ...validationValues
+          })
+        )
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to persist ElevenLabs validation status:", error)
+        if (options?.notifyOnError) {
+          message.error(
+            t(
+              "generalSettings.tts.apiKeyStatus.persistError",
+              "API key validation completed, but the validation status could not be saved."
+            ) as string
+          )
+        }
+      }
     },
-    [form, queryClient]
+    [form, form.values, message, queryClient, t]
   )
 
   React.useEffect(() => {
@@ -193,8 +246,8 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
       elevenLabsData.voices.length > 0 &&
       Array.isArray(elevenLabsData.models) &&
       elevenLabsData.models.length > 0
-    const persistKey = `${debouncedElevenLabsApiKey}:${ok}:${String(
-      elevenLabsError || ""
+    const persistKey = `${debouncedElevenLabsApiKey}:${ok}:${getErrorSignature(
+      elevenLabsError
     )}`
     if (lastPersistedElevenLabsValidationRef.current === persistKey) return
     lastPersistedElevenLabsValidationRef.current = persistKey
@@ -426,7 +479,12 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
   // Save mutation with loading state
   const { mutate: saveTTSMutation, isPending: isSaving } = useMutation({
     mutationFn: async (values: typeof form.values) => {
-      await setTTSSettings(values)
+      const normalizedValues = {
+        ...values,
+        elevenLabsApiKey: String(values.elevenLabsApiKey || "").trim(),
+        openAITTSApiKey: String(values.openAITTSApiKey || "").trim()
+      }
+      await setTTSSettings(normalizedValues)
       setTTSEnabled(values.ttsEnabled)
     },
     onSuccess: () => {
@@ -451,7 +509,8 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
 
   // Test ElevenLabs API key
   const testElevenLabsApiKey = async () => {
-    if (!form.values.elevenLabsApiKey) {
+    const elevenLabsApiKey = String(form.values.elevenLabsApiKey || "").trim()
+    if (!elevenLabsApiKey) {
       setElevenLabsTestResult({ ok: false, message: t("generalSettings.tts.apiKeyTest.enterKey", "Please enter an API key first") })
       return
     }
@@ -459,8 +518,8 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
     setElevenLabsTestResult(null)
     try {
       const [voices, models] = await Promise.all([
-        getVoices(form.values.elevenLabsApiKey),
-        getModels(form.values.elevenLabsApiKey)
+        getVoices(elevenLabsApiKey),
+        getModels(elevenLabsApiKey)
       ])
       const hasVoices = Array.isArray(voices) && voices.length > 0
       const hasModels = Array.isArray(models) && models.length > 0
@@ -471,7 +530,7 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
           "API key valid! Found {{voiceCount}} voices and {{modelCount}} models.",
           { voiceCount: voices.length, modelCount: models.length }
         )
-        await persistElevenLabsValidation(true, form.values.elevenLabsApiKey.trim())
+        await persistElevenLabsValidation(true, elevenLabsApiKey, { notifyOnError: true })
         message.success(successMessage as string)
         setElevenLabsTestResult({
           ok: true,
@@ -482,7 +541,7 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
           "generalSettings.tts.apiKeyTest.noVoices",
           "API key accepted but no voices or models found"
         )
-        await persistElevenLabsValidation(false, form.values.elevenLabsApiKey.trim())
+        await persistElevenLabsValidation(false, elevenLabsApiKey, { notifyOnError: true })
         setElevenLabsTestResult({
           ok: false,
           message: noResourcesMessage as string
@@ -502,7 +561,7 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
             ? e
             : JSON.stringify(e)
       const failureMessage = `${baseMessage} (${errorDetail})`
-      await persistElevenLabsValidation(false, form.values.elevenLabsApiKey.trim())
+      await persistElevenLabsValidation(false, elevenLabsApiKey, { notifyOnError: true })
       message.error(failureMessage)
       setElevenLabsTestResult({
         ok: false,
@@ -517,17 +576,20 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
     if (form.values.elevenLabsKeyValid === true) {
       return {
         color: "success",
+        icon: <CheckCircleOutlined aria-label="valid" />,
         label: t("generalSettings.tts.apiKeyStatus.valid", "Valid") as string
       }
     }
     if (form.values.elevenLabsKeyValid === false) {
       return {
         color: "error",
+        icon: <ExclamationCircleOutlined aria-label="failed" />,
         label: t("generalSettings.tts.apiKeyStatus.failed", "Failed") as string
       }
     }
     return {
       color: "default",
+      icon: <QuestionCircleOutlined aria-label="untested" />,
       label: t("generalSettings.tts.apiKeyStatus.untested", "Untested") as string
     }
   }, [form.values.elevenLabsKeyValid, t])
@@ -535,14 +597,50 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
     form.values.elevenLabsKeyTestedAt
   )
 
+  const openAIValidationBadge = React.useMemo(() => {
+    if (form.values.openAITTSKeyValid === true) {
+      return {
+        color: "success",
+        icon: <CheckCircleOutlined aria-label="valid" />,
+        label: t("generalSettings.tts.apiKeyStatus.valid", "Valid") as string
+      }
+    }
+    if (form.values.openAITTSKeyValid === false) {
+      return {
+        color: "error",
+        icon: <ExclamationCircleOutlined aria-label="failed" />,
+        label: t("generalSettings.tts.apiKeyStatus.failed", "Failed") as string
+      }
+    }
+    return {
+      color: "default",
+      icon: <QuestionCircleOutlined aria-label="untested" />,
+      label: t("generalSettings.tts.apiKeyStatus.untested", "Untested") as string
+    }
+  }, [form.values.openAITTSKeyValid, t])
+  const openAILastTested = formatValidationTimestamp(
+    form.values.openAITTSKeyTestedAt
+  )
+
   const handleElevenLabsKeyChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       form.setValues({
-        elevenLabsApiKey: event.target.value,
+        elevenLabsApiKey: event.target.value.trim(),
         elevenLabsKeyValid: null,
         elevenLabsKeyTestedAt: ""
       })
       setElevenLabsTestResult(null)
+    },
+    [form]
+  )
+
+  const handleOpenAIKeyChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      form.setValues({
+        openAITTSApiKey: event.target.value.trim(),
+        openAITTSKeyValid: null,
+        openAITTSKeyTestedAt: ""
+      })
     },
     [form]
   )
@@ -664,7 +762,10 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
                   <span className="text-text">
                     {t("generalSettings.tts.elevenLabs.apiKey", "API Key")}
                   </span>
-                  <Tag color={elevenLabsValidationBadge.color}>
+                  <Tag
+                    color={elevenLabsValidationBadge.color}
+                    icon={elevenLabsValidationBadge.icon}
+                  >
                     {elevenLabsValidationBadge.label}
                   </Tag>
                 </div>
@@ -775,13 +876,33 @@ export const TTSModeSettings = ({ hideBorder }: { hideBorder?: boolean }) => {
             </div>
 
             <div className="flex sm:flex-row flex-col space-y-4 sm:space-y-0 sm:justify-between">
-              <span className="text-text">
-                API Key
-              </span>
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-text">
+                    API Key
+                  </span>
+                  <Tag
+                    color={openAIValidationBadge.color}
+                    icon={openAIValidationBadge.icon}
+                  >
+                    {openAIValidationBadge.label}
+                  </Tag>
+                </div>
+                {openAILastTested && (
+                  <span className="text-xs text-text-subtle">
+                    {t(
+                      "generalSettings.tts.apiKeyStatus.lastTested",
+                      "Last tested {{timestamp}}",
+                      { timestamp: openAILastTested }
+                    )}
+                  </span>
+                )}
+              </div>
               <Input.Password
                 placeholder="sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
                 className=" mt-4 sm:mt-0 !w-[300px] sm:w-[200px]"
-                {...form.getInputProps("openAITTSApiKey")}
+                value={form.values.openAITTSApiKey}
+                onChange={handleOpenAIKeyChange}
               />
             </div>
 

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/TTSModeSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/TTSModeSettings.test.tsx
@@ -1,0 +1,207 @@
+import React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TTSModeSettings } from "../TTSModeSettings"
+
+const {
+  getTTSSettingsMock,
+  setTTSSettingsMock,
+  getVoicesMock,
+  getModelsMock,
+  messageSuccessMock,
+  messageErrorMock,
+  setTTSEnabledMock,
+} = vi.hoisted(() => ({
+  getTTSSettingsMock: vi.fn(),
+  setTTSSettingsMock: vi.fn(async () => undefined),
+  getVoicesMock: vi.fn(),
+  getModelsMock: vi.fn(),
+  messageSuccessMock: vi.fn(),
+  messageErrorMock: vi.fn(),
+  setTTSEnabledMock: vi.fn(),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      fallback?: string,
+      values?: Record<string, string | number>
+    ) => {
+      if (!fallback) return _key
+      if (!values) return fallback
+      return Object.entries(values).reduce(
+        (text, [key, value]) => text.replace(`{{${key}}}`, String(value)),
+        fallback
+      )
+    },
+  }),
+}))
+
+vi.mock("@/services/tts", () => ({
+  DEFAULT_TLDW_TTS_MODEL: "KittenML/kitten-tts-nano-0.8",
+  SUPPORTED_TLDW_TTS_FORMATS: ["mp3"],
+  getTTSSettings: getTTSSettingsMock,
+  setTTSSettings: setTTSSettingsMock,
+}))
+
+vi.mock("@/services/elevenlabs", () => ({
+  getVoices: getVoicesMock,
+  getModels: getModelsMock,
+}))
+
+vi.mock("@/services/tldw/audio-voices", () => ({
+  fetchTldwVoiceCatalog: vi.fn(async () => []),
+  fetchTldwVoices: vi.fn(async () => []),
+}))
+
+vi.mock("@/services/tldw/audio-providers", () => ({
+  fetchTtsProviders: vi.fn(async () => null),
+}))
+
+vi.mock("@/services/tldw/audio-models", () => ({
+  fetchTldwTtsModels: vi.fn(async () => []),
+}))
+
+vi.mock("@/services/tldw/voice-cloning", () => ({
+  listCustomVoices: vi.fn(async () => []),
+}))
+
+vi.mock("@/services/tldw/tts-provider-keys", () => ({
+  normalizeTtsProviderKey: vi.fn((value?: string) => value || ""),
+  toServerTtsProviderKey: vi.fn((value?: string) => value || ""),
+}))
+
+vi.mock("@/services/tts-provider", () => ({
+  inferTldwProviderFromModel: vi.fn(() => null),
+}))
+
+vi.mock("@/store/webui", () => ({
+  useWebUI: () => ({
+    setTTSEnabled: setTTSEnabledMock,
+  }),
+}))
+
+vi.mock("@/hooks/useAntdMessage", () => ({
+  useAntdMessage: () => ({
+    success: messageSuccessMock,
+    error: messageErrorMock,
+  }),
+}))
+
+const buildTtsSettings = (overrides: Record<string, unknown> = {}) => ({
+  ttsEnabled: true,
+  ttsProvider: "elevenlabs",
+  browserTTSVoices: [],
+  voice: "",
+  ssmlEnabled: false,
+  removeReasoningTagTTS: true,
+  elevenLabsApiKey: "sk_existing",
+  elevenLabsVoiceId: "",
+  elevenLabsModel: "",
+  elevenLabsKeyValid: null,
+  elevenLabsKeyTestedAt: "",
+  responseSplitting: "punctuation",
+  openAITTSBaseUrl: "https://api.openai.com/v1",
+  openAITTSApiKey: "",
+  openAITTSModel: "tts-1",
+  openAITTSVoice: "alloy",
+  ttsAutoPlay: false,
+  playbackSpeed: 1,
+  tldwTtsModel: "KittenML/kitten-tts-nano-0.8",
+  tldwTtsVoice: "Bella",
+  tldwTtsResponseFormat: "mp3",
+  tldwTtsSpeed: 1,
+  tldwTtsLanguage: "",
+  tldwTtsStreaming: false,
+  tldwTtsEmotion: "",
+  tldwTtsEmotionIntensity: 1,
+  tldwTtsNormalize: true,
+  tldwTtsNormalizeUnits: false,
+  tldwTtsNormalizeUrls: true,
+  tldwTtsNormalizeEmails: true,
+  tldwTtsNormalizePhones: true,
+  tldwTtsNormalizePlurals: true,
+  ...overrides,
+})
+
+const renderSettings = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={client}>
+      <TTSModeSettings />
+    </QueryClientProvider>
+  )
+}
+
+describe("TTSModeSettings ElevenLabs key validation status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getTTSSettingsMock.mockResolvedValue(buildTtsSettings())
+    getVoicesMock.mockResolvedValue([{ voice_id: "voice-1", name: "Voice 1" }])
+    getModelsMock.mockResolvedValue([{ model_id: "model-1", name: "Model 1" }])
+  })
+
+  it("shows persisted ElevenLabs validation status and last tested timestamp", async () => {
+    getTTSSettingsMock.mockResolvedValue(
+      buildTtsSettings({
+        elevenLabsKeyValid: true,
+        elevenLabsKeyTestedAt: "2026-04-30T12:00:00.000Z",
+      })
+    )
+
+    renderSettings()
+
+    expect(await screen.findByText("Valid")).toBeInTheDocument()
+    expect(screen.getByText(/Last tested/)).toBeInTheDocument()
+  })
+
+  it("persists validation status when the user tests an ElevenLabs key", async () => {
+    getTTSSettingsMock.mockResolvedValue(
+      buildTtsSettings({
+        elevenLabsApiKey: "",
+        elevenLabsKeyValid: null,
+        elevenLabsKeyTestedAt: "",
+      })
+    )
+
+    renderSettings()
+
+    fireEvent.change(await screen.findByPlaceholderText("sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"), {
+      target: { value: "sk_valid" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Test" }))
+
+    await waitFor(() => {
+      expect(setTTSSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          elevenLabsApiKey: "sk_valid",
+          elevenLabsKeyValid: true,
+          elevenLabsKeyTestedAt: expect.any(String),
+        })
+      )
+    })
+    expect(await screen.findByText("Valid")).toBeInTheDocument()
+  })
+
+  it("auto-revalidates a saved ElevenLabs key on settings load", async () => {
+    renderSettings()
+
+    await waitFor(() => {
+      expect(setTTSSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          elevenLabsApiKey: "sk_existing",
+          elevenLabsKeyValid: true,
+          elevenLabsKeyTestedAt: expect.any(String),
+        })
+      )
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Settings/__tests__/TTSModeSettings.test.tsx
+++ b/apps/packages/ui/src/components/Option/Settings/__tests__/TTSModeSettings.test.tsx
@@ -8,6 +8,9 @@ import { TTSModeSettings } from "../TTSModeSettings"
 const {
   getTTSSettingsMock,
   setTTSSettingsMock,
+  setElevenLabsApiKeyMock,
+  setElevenLabsKeyValidMock,
+  setElevenLabsKeyTestedAtMock,
   getVoicesMock,
   getModelsMock,
   messageSuccessMock,
@@ -16,6 +19,9 @@ const {
 } = vi.hoisted(() => ({
   getTTSSettingsMock: vi.fn(),
   setTTSSettingsMock: vi.fn(async () => undefined),
+  setElevenLabsApiKeyMock: vi.fn(async () => undefined),
+  setElevenLabsKeyValidMock: vi.fn(async () => undefined),
+  setElevenLabsKeyTestedAtMock: vi.fn(async () => undefined),
   getVoicesMock: vi.fn(),
   getModelsMock: vi.fn(),
   messageSuccessMock: vi.fn(),
@@ -45,6 +51,9 @@ vi.mock("@/services/tts", () => ({
   SUPPORTED_TLDW_TTS_FORMATS: ["mp3"],
   getTTSSettings: getTTSSettingsMock,
   setTTSSettings: setTTSSettingsMock,
+  setElevenLabsApiKey: setElevenLabsApiKeyMock,
+  setElevenLabsKeyValid: setElevenLabsKeyValidMock,
+  setElevenLabsKeyTestedAt: setElevenLabsKeyTestedAtMock,
 }))
 
 vi.mock("@/services/elevenlabs", () => ({
@@ -108,6 +117,8 @@ const buildTtsSettings = (overrides: Record<string, unknown> = {}) => ({
   openAITTSApiKey: "",
   openAITTSModel: "tts-1",
   openAITTSVoice: "alloy",
+  openAITTSKeyValid: null,
+  openAITTSKeyTestedAt: "",
   ttsAutoPlay: false,
   playbackSpeed: 1,
   tldwTtsModel: "KittenML/kitten-tts-nano-0.8",
@@ -160,6 +171,7 @@ describe("TTSModeSettings ElevenLabs key validation status", () => {
     renderSettings()
 
     expect(await screen.findByText("Valid")).toBeInTheDocument()
+    expect(screen.getByLabelText("valid")).toBeInTheDocument()
     expect(screen.getByText(/Last tested/)).toBeInTheDocument()
   })
 
@@ -180,28 +192,38 @@ describe("TTSModeSettings ElevenLabs key validation status", () => {
     fireEvent.click(screen.getByRole("button", { name: "Test" }))
 
     await waitFor(() => {
-      expect(setTTSSettingsMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          elevenLabsApiKey: "sk_valid",
-          elevenLabsKeyValid: true,
-          elevenLabsKeyTestedAt: expect.any(String),
-        })
-      )
+      expect(setElevenLabsApiKeyMock).toHaveBeenCalledWith("sk_valid")
+      expect(setElevenLabsKeyValidMock).toHaveBeenCalledWith(true)
+      expect(setElevenLabsKeyTestedAtMock).toHaveBeenCalledWith(expect.any(String))
     })
+    expect(setTTSSettingsMock).not.toHaveBeenCalled()
     expect(await screen.findByText("Valid")).toBeInTheDocument()
   })
 
-  it("auto-revalidates a saved ElevenLabs key on settings load", async () => {
+  it("auto-revalidates a saved ElevenLabs key without saving unrelated settings", async () => {
     renderSettings()
 
     await waitFor(() => {
-      expect(setTTSSettingsMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          elevenLabsApiKey: "sk_existing",
-          elevenLabsKeyValid: true,
-          elevenLabsKeyTestedAt: expect.any(String),
-        })
-      )
+      expect(setElevenLabsApiKeyMock).toHaveBeenCalledWith("sk_existing")
+      expect(setElevenLabsKeyValidMock).toHaveBeenCalledWith(true)
+      expect(setElevenLabsKeyTestedAtMock).toHaveBeenCalledWith(expect.any(String))
     })
+    expect(setTTSSettingsMock).not.toHaveBeenCalled()
+  })
+
+  it("shows persisted OpenAI validation status and last tested timestamp", async () => {
+    getTTSSettingsMock.mockResolvedValue(
+      buildTtsSettings({
+        ttsProvider: "openai",
+        openAITTSKeyValid: false,
+        openAITTSKeyTestedAt: "2026-04-30T12:00:00.000Z",
+      })
+    )
+
+    renderSettings()
+
+    expect(await screen.findByText("Failed")).toBeInTheDocument()
+    expect(screen.getByLabelText("failed")).toBeInTheDocument()
+    expect(screen.getByText(/Last tested/)).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/services/__tests__/tts.defaults.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tts.defaults.test.ts
@@ -30,7 +30,8 @@ import {
   DEFAULT_TLDW_TTS_MODEL,
   DEFAULT_TLDW_TTS_VOICE,
   DEFAULT_TTS_PROVIDER,
-  getTTSSettings
+  getTTSSettings,
+  setTTSSettings
 } from "@/services/tts"
 
 describe("tts defaults service", () => {
@@ -56,5 +57,20 @@ describe("tts defaults service", () => {
     expect(settings.ttsProvider).toBe("browser")
     expect(settings.tldwTtsModel).toBe("kokoro")
     expect(settings.tldwTtsVoice).toBe("af_heart")
+  })
+
+  it("round-trips ElevenLabs validation status metadata", async () => {
+    const baseSettings = await getTTSSettings()
+
+    await setTTSSettings({
+      ...baseSettings,
+      elevenLabsKeyValid: false,
+      elevenLabsKeyTestedAt: "2026-04-30T12:00:00.000Z"
+    })
+
+    const settings = await getTTSSettings()
+
+    expect(settings.elevenLabsKeyValid).toBe(false)
+    expect(settings.elevenLabsKeyTestedAt).toBe("2026-04-30T12:00:00.000Z")
   })
 })

--- a/apps/packages/ui/src/services/__tests__/tts.defaults.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tts.defaults.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/services/settings/registry", async () => {
 })
 
 vi.mock("@/services/tts-providers", () => ({
-  TTS_PROVIDER_VALUES: ["browser", "elevenlabs", "tldw"]
+  TTS_PROVIDER_VALUES: ["browser", "elevenlabs", "openai", "tldw"]
 }))
 
 import {
@@ -59,18 +59,22 @@ describe("tts defaults service", () => {
     expect(settings.tldwTtsVoice).toBe("af_heart")
   })
 
-  it("round-trips ElevenLabs validation status metadata", async () => {
+  it("round-trips provider validation status metadata", async () => {
     const baseSettings = await getTTSSettings()
 
     await setTTSSettings({
       ...baseSettings,
       elevenLabsKeyValid: false,
-      elevenLabsKeyTestedAt: "2026-04-30T12:00:00.000Z"
+      elevenLabsKeyTestedAt: "2026-04-30T12:00:00.000Z",
+      openAITTSKeyValid: true,
+      openAITTSKeyTestedAt: "2026-04-30T13:00:00.000Z"
     })
 
     const settings = await getTTSSettings()
 
     expect(settings.elevenLabsKeyValid).toBe(false)
     expect(settings.elevenLabsKeyTestedAt).toBe("2026-04-30T12:00:00.000Z")
+    expect(settings.openAITTSKeyValid).toBe(true)
+    expect(settings.openAITTSKeyTestedAt).toBe("2026-04-30T13:00:00.000Z")
   })
 })

--- a/apps/packages/ui/src/services/tts.ts
+++ b/apps/packages/ui/src/services/tts.ts
@@ -121,6 +121,16 @@ const OPENAI_TTS_VOICE_SETTING = defineSetting(
   "alloy",
   (value) => coerceString(value, "alloy")
 )
+const OPENAI_TTS_KEY_VALID_SETTING = defineSetting(
+  "openAITTSKeyValid",
+  null as boolean | null,
+  coerceBooleanOrNull
+)
+const OPENAI_TTS_KEY_TESTED_AT_SETTING = defineSetting(
+  "openAITTSKeyTestedAt",
+  "",
+  (value) => coerceOptionalString(value) || ""
+)
 const RESPONSE_SPLITTING_SETTING = defineSetting(
   "ttsResponseSplitting",
   "punctuation",
@@ -330,6 +340,24 @@ export const setOpenAITTSVoice = async (openAITTSVoice: string) => {
   await setSetting(OPENAI_TTS_VOICE_SETTING, openAITTSVoice)
 }
 
+export const getOpenAITTSKeyValid = async () =>
+  getSetting(OPENAI_TTS_KEY_VALID_SETTING)
+
+export const setOpenAITTSKeyValid = async (
+  openAITTSKeyValid: boolean | null
+) => {
+  await setSetting(OPENAI_TTS_KEY_VALID_SETTING, openAITTSKeyValid)
+}
+
+export const getOpenAITTSKeyTestedAt = async () =>
+  getSetting(OPENAI_TTS_KEY_TESTED_AT_SETTING)
+
+export const setOpenAITTSKeyTestedAt = async (
+  openAITTSKeyTestedAt: string
+) => {
+  await setSetting(OPENAI_TTS_KEY_TESTED_AT_SETTING, openAITTSKeyTestedAt)
+}
+
 export const getResponseSplitting = async () =>
   getSetting(RESPONSE_SPLITTING_SETTING)
 
@@ -474,6 +502,8 @@ export const getTTSSettings = async () => {
     openAITTSApiKey,
     openAITTSModel,
     openAITTSVoice,
+    openAITTSKeyValid,
+    openAITTSKeyTestedAt,
     // UTILS
     ttsAutoPlay,
     playbackSpeed,
@@ -510,6 +540,8 @@ export const getTTSSettings = async () => {
     getOpenAITTSApiKey(),
     getOpenAITTSModel(),
     getOpenAITTSVoice(),
+    getOpenAITTSKeyValid(),
+    getOpenAITTSKeyTestedAt(),
     // UTILS
     isTTSAutoPlayEnabled(),
     getSpeechPlaybackSpeed(),
@@ -548,6 +580,8 @@ export const getTTSSettings = async () => {
     openAITTSApiKey,
     openAITTSModel,
     openAITTSVoice,
+    openAITTSKeyValid,
+    openAITTSKeyTestedAt,
     ttsAutoPlay,
     playbackSpeed,
     tldwTtsModel,
@@ -583,6 +617,8 @@ export const setTTSSettings = async ({
   openAITTSApiKey,
   openAITTSModel,
   openAITTSVoice,
+  openAITTSKeyValid,
+  openAITTSKeyTestedAt,
   ttsAutoPlay,
   playbackSpeed,
   tldwTtsModel,
@@ -615,6 +651,8 @@ export const setTTSSettings = async ({
   openAITTSApiKey: string
   openAITTSModel: string
   openAITTSVoice: string
+  openAITTSKeyValid?: boolean | null
+  openAITTSKeyTestedAt?: string
   ttsAutoPlay: boolean
   playbackSpeed: number
   tldwTtsModel: string
@@ -668,6 +706,12 @@ export const setTTSSettings = async ({
   }
   if (elevenLabsKeyTestedAt !== undefined) {
     updates.push(setElevenLabsKeyTestedAt(elevenLabsKeyTestedAt))
+  }
+  if (openAITTSKeyValid !== undefined) {
+    updates.push(setOpenAITTSKeyValid(openAITTSKeyValid))
+  }
+  if (openAITTSKeyTestedAt !== undefined) {
+    updates.push(setOpenAITTSKeyTestedAt(openAITTSKeyTestedAt))
   }
   await Promise.all(updates)
 }

--- a/apps/packages/ui/src/services/tts.ts
+++ b/apps/packages/ui/src/services/tts.ts
@@ -4,6 +4,7 @@ import {
   getSetting,
   setSetting,
   coerceBoolean,
+  coerceBooleanOrNull,
   coerceNumber,
   coerceOptionalString,
   coerceString
@@ -89,6 +90,16 @@ const ELEVEN_LABS_MODEL_SETTING = defineSetting(
   "elevenLabsModel",
   undefined as string | undefined,
   coerceOptionalString
+)
+const ELEVEN_LABS_KEY_VALID_SETTING = defineSetting(
+  "elevenLabsKeyValid",
+  null as boolean | null,
+  coerceBooleanOrNull
+)
+const ELEVEN_LABS_KEY_TESTED_AT_SETTING = defineSetting(
+  "elevenLabsKeyTestedAt",
+  "",
+  (value) => coerceOptionalString(value) || ""
 )
 const OPENAI_TTS_BASE_URL_SETTING = defineSetting(
   "openAITTSBaseUrl",
@@ -273,6 +284,24 @@ export const setElevenLabsModel = async (elevenLabsModel: string) => {
   await setSetting(ELEVEN_LABS_MODEL_SETTING, elevenLabsModel)
 }
 
+export const getElevenLabsKeyValid = async () =>
+  getSetting(ELEVEN_LABS_KEY_VALID_SETTING)
+
+export const setElevenLabsKeyValid = async (
+  elevenLabsKeyValid: boolean | null
+) => {
+  await setSetting(ELEVEN_LABS_KEY_VALID_SETTING, elevenLabsKeyValid)
+}
+
+export const getElevenLabsKeyTestedAt = async () =>
+  getSetting(ELEVEN_LABS_KEY_TESTED_AT_SETTING)
+
+export const setElevenLabsKeyTestedAt = async (
+  elevenLabsKeyTestedAt: string
+) => {
+  await setSetting(ELEVEN_LABS_KEY_TESTED_AT_SETTING, elevenLabsKeyTestedAt)
+}
+
 export const getOpenAITTSBaseUrl = async () =>
   getSetting(OPENAI_TTS_BASE_URL_SETTING)
 
@@ -436,6 +465,8 @@ export const getTTSSettings = async () => {
     elevenLabsApiKey,
     elevenLabsVoiceId,
     elevenLabsModel,
+    elevenLabsKeyValid,
+    elevenLabsKeyTestedAt,
     responseSplitting,
     removeReasoningTagTTS,
     // OPENAI
@@ -470,6 +501,8 @@ export const getTTSSettings = async () => {
     getElevenLabsApiKey(),
     getElevenLabsVoiceId(),
     getElevenLabsModel(),
+    getElevenLabsKeyValid(),
+    getElevenLabsKeyTestedAt(),
     getResponseSplitting(),
     getRemoveReasoningTagTTS(),
     // OPENAI
@@ -506,6 +539,8 @@ export const getTTSSettings = async () => {
     elevenLabsApiKey,
     elevenLabsVoiceId,
     elevenLabsModel,
+    elevenLabsKeyValid,
+    elevenLabsKeyTestedAt,
     responseSplitting,
     removeReasoningTagTTS,
     // OPENAI
@@ -540,6 +575,8 @@ export const setTTSSettings = async ({
   elevenLabsApiKey,
   elevenLabsVoiceId,
   elevenLabsModel,
+  elevenLabsKeyValid,
+  elevenLabsKeyTestedAt,
   responseSplitting,
   removeReasoningTagTTS,
   openAITTSBaseUrl,
@@ -570,6 +607,8 @@ export const setTTSSettings = async ({
   elevenLabsApiKey: string
   elevenLabsVoiceId: string
   elevenLabsModel: string
+  elevenLabsKeyValid?: boolean | null
+  elevenLabsKeyTestedAt?: string
   responseSplitting: string
   removeReasoningTagTTS: boolean
   openAITTSBaseUrl: string
@@ -593,7 +632,7 @@ export const setTTSSettings = async ({
   tldwTtsNormalizePhones: boolean
   tldwTtsNormalizePlurals: boolean
 }) => {
-  await Promise.all([
+  const updates = [
     setTTSEnabled(ttsEnabled),
     setTTSProvider(ttsProvider),
     setVoice(voice),
@@ -623,5 +662,12 @@ export const setTTSSettings = async ({
     setTldwTTSNormalizeEmails(tldwTtsNormalizeEmails),
     setTldwTTSNormalizePhones(tldwTtsNormalizePhones),
     setTldwTTSNormalizePlurals(tldwTtsNormalizePlurals)
-  ])
+  ]
+  if (elevenLabsKeyValid !== undefined) {
+    updates.push(setElevenLabsKeyValid(elevenLabsKeyValid))
+  }
+  if (elevenLabsKeyTestedAt !== undefined) {
+    updates.push(setElevenLabsKeyTestedAt(elevenLabsKeyTestedAt))
+  }
+  await Promise.all(updates)
 }

--- a/tldw_Server_API/tests/Admin/test_admin_smoke.py
+++ b/tldw_Server_API/tests/Admin/test_admin_smoke.py
@@ -1,20 +1,19 @@
 import asyncio
 import importlib
 import os
-import tempfile
-import importlib
-import asyncio
 import shutil
-from contextlib import suppress
-from uuid import uuid4
+import tempfile
+from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
 from tldw_Server_API.app.core.AuthNZ.initialize import ensure_single_user_rbac_seed_if_needed
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 from tldw_Server_API.app.core.DB_Management.backends import factory as backend_factory
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 
@@ -82,14 +81,20 @@ def _fresh_client(test_mode: bool = False, user_db_base_dir: Optional[str] = Non
     }
 
     try:
-        asyncio.run(reset_db_pool())
-    except Exception:
-        _ = None
-    _reset_media_storage_state()
+        os.environ["AUTH_MODE"] = "single_user"
+        os.environ["SINGLE_USER_API_KEY"] = os.getenv("SINGLE_USER_API_KEY", "test-api-key-12345")
+        os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path}"
+        os.environ["TEST_MODE"] = "1" if test_mode else "0"
+        os.environ["TLDW_TEST_MODE"] = "1" if test_mode else "0"
+        if user_db_base_dir:
+            os.environ["USER_DB_BASE_DIR"] = user_db_base_dir
+        else:
+            os.environ.pop("USER_DB_BASE_DIR", None)
 
-        # Reset singletons so the app picks up new settings/DB
+        # Reset singletons so the app picks up the isolated settings and DB.
         reset_settings()
         _reset_auth_pool_for_smoke()
+        _reset_media_storage_state()
 
         # Ensure schema migrations and RBAC seed exist on the fresh database
         ensure_authnz_tables(Path(tmp_path))


### PR DESCRIPTION
## Change summary

Closes #991.

This persists ElevenLabs API key validation metadata in the local TTS settings store:

- Adds `elevenLabsKeyValid` and `elevenLabsKeyTestedAt` settings and includes them in `getTTSSettings` / `setTTSSettings`.
- Shows a Valid / Failed / Untested badge beside the ElevenLabs key field, plus the last-tested timestamp when available.
- Persists validation status from both the manual Test action and the debounced settings-load validation path, while guarding against stale validation results after the user changes the key.

Scope note: this PR handles ElevenLabs only because the current settings page has a concrete ElevenLabs validation path. OpenAI key validation would need a separate validation surface rather than sharing the ElevenLabs voice/model probe.

## Verification

- `bunx vitest run ../packages/ui/src/components/Option/Settings/__tests__/TTSModeSettings.test.tsx ../packages/ui/src/services/__tests__/tts.defaults.test.ts`
- `./tldw-frontend/node_modules/.bin/eslint --config tldw-frontend/eslint.config.mjs packages/ui/src/components/Option/Settings/TTSModeSettings.tsx packages/ui/src/components/Option/Settings/__tests__/TTSModeSettings.test.tsx packages/ui/src/services/tts.ts packages/ui/src/services/__tests__/tts.defaults.test.ts`
- `git diff --check`
- `git diff --cached --check`

Bandit was not run because the touched scope is frontend TypeScript/TSX only.
