### PR TITLE
Add persona wake phrase support

### DIFF
--- a/Docs/Design/Personas.md
+++ b/Docs/Design/Personas.md
@@ -73,6 +73,12 @@ UI integration:
 - Allow scope-rule editing with clear include/exclude affordances.
 - Provide policy visibility (what tools are blocked/allowed and why).
 
+Wake phrase support:
+- Persona Live wake phrase support is manually armed per session.
+- V1 uses the selected persona profile's saved `voice_chat_trigger_phrases` as wake phrases and detects them in the active browser or extension surface before sending a scoped `wake_activation` frame to `/api/v1/persona/stream`.
+- V1 is not true background always-on listening. Wake listening is visible, manually armed, and only active while the Persona Live surface is open and the browser speech recognition API is available.
+- Pre-wake audio is not sent to the tldw server.
+
 Compatibility and migration:
 - Existing character-card flows remain valid; personas can optionally reference `character_card_id`.
 - Legacy sessions without persona links should continue operating with default behavior.

--- a/Docs/superpowers/plans/2026-05-01-persona-wake-word-support-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-01-persona-wake-word-support-implementation-plan.md
@@ -1,0 +1,2079 @@
+# Persona Wake Word Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add manually armed, client-side wake phrase support for Persona Live while keeping all persona turns on the existing persona websocket runtime.
+
+**Architecture:** V1 wake detection runs in the active browser or extension surface through a frontend `WakeDetector` abstraction. The detector matches the selected persona profile's saved `voice_chat_trigger_phrases`, then sends a scoped `wake_activation` frame to the existing `/api/v1/persona/stream` websocket. The backend stores short-lived session-local wake state, validates activations against the saved persona profile and current `voice_runtime`, and only bypasses trigger phrase gating inside the active post-wake window.
+
+**Tech Stack:** FastAPI, Pydantic, pytest, React, TypeScript, Ant Design, browser `SpeechRecognition` feature detection, Vitest, Testing Library.
+
+---
+
+## Source Spec
+
+- `Docs/superpowers/specs/2026-04-30-persona-wake-word-support-design.md`
+
+## Stages
+
+### Stage 1: Persist Wake Defaults
+
+**Goal:** Store and return the persona default wake behavior without changing existing profiles.
+
+**Success Criteria:** Profile create, read, and update preserve `voice_defaults.wake_behavior`; invalid values fail validation; missing values remain accepted.
+
+**Tests:** Backend profile API tests covering roundtrip, missing value, and invalid enum values.
+
+**Status:** Not Started
+
+### Stage 2: Backend Wake Activation Runtime
+
+**Goal:** Add websocket `wake_activation` and `wake_deactivation` handling with session-local state and existing trigger gate preservation.
+
+**Success Criteria:** A valid activation allows the next post-wake turn to omit the trigger phrase; invalid activations leave gating unchanged; deactivation clears the bypass.
+
+**Tests:** Focused persona websocket tests for valid activation, invalid phrase, explicit deactivation, one-shot expiry, and no-command timeout.
+
+**Status:** Not Started
+
+### Stage 3: Frontend Types, Defaults, And Detector
+
+**Goal:** Add wake behavior to frontend persona voice defaults and introduce the browser transcript detector behind a small interface.
+
+**Success Criteria:** Defaults resolve to `one_shot`; profile settings can persist another behavior; detector normalizes and matches configured phrases only.
+
+**Tests:** Hook tests for default resolution, panel tests for persistence, detector unit tests for matching and unavailable state.
+
+**Status:** Not Started
+
+### Stage 4: Persona Live Wake Controls
+
+**Goal:** Wire manual arm/disarm, session-local behavior selection, detector lifecycle, and websocket activation into Persona Live.
+
+**Success Criteria:** Users can arm wake listening only when the selected saved profile has trigger phrases; wake mode sends activation/deactivation frames and suspends during active mic capture.
+
+**Tests:** Controller tests, voice card tests, and sidepanel route tests.
+
+**Status:** Not Started
+
+### Stage 5: Verification And Documentation
+
+**Goal:** Run focused backend/frontend checks, Bandit on touched backend files, and document V1 limitations without overwriting unrelated work.
+
+**Success Criteria:** Focused tests pass; `git diff --check` is clean; Bandit report has no new findings in touched backend code; docs explain that V1 is manually armed and browser-lifecycle bounded.
+
+**Tests:** Focused pytest and Vitest commands plus static checks.
+
+**Status:** Not Started
+
+## File Map
+
+### Backend
+
+- Modify `tldw_Server_API/app/api/v1/schemas/persona.py`
+  - Add `PersonaWakeBehavior` literal type.
+  - Add nullable `wake_behavior` to `PersonaVoiceDefaults`.
+  - Rely on Pydantic enum validation for invalid values.
+
+- Modify `tldw_Server_API/app/api/v1/endpoints/persona.py`
+  - Add wake behavior and deactivation reason constants.
+  - Add a configurable no-command timeout helper.
+  - Add helper functions for canonical wake phrase normalization/matching.
+  - Add session-local wake activation state for `/api/v1/persona/stream`.
+  - Add `wake_activation` and `wake_deactivation` websocket handlers.
+  - Update `_commit_persona_live_turn` so active wake state can bypass trigger gating only inside the scoped window.
+  - Clear wake state during websocket/session cleanup.
+
+- Modify `tldw_Server_API/tests/Persona/test_persona_profiles_api.py`
+  - Extend the existing voice defaults roundtrip test.
+  - Add a validation test for invalid wake behavior.
+
+- Modify `tldw_Server_API/tests/Persona/test_persona_ws.py`
+  - Add or extend seed helpers for persona profile `voice_defaults`.
+  - Add focused wake activation/deactivation websocket tests.
+
+### Frontend
+
+- Modify `apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx`
+  - Add `PersonaWakeBehavior`.
+  - Add nullable saved `wake_behavior`.
+  - Add resolved `wakeBehavior` with fixed fallback `one_shot`.
+
+- Create `apps/packages/ui/src/hooks/personaWakeDetector.ts`
+  - Export detector types and `BrowserTranscriptWakeDetector`.
+  - Export pure phrase normalization and matching helpers.
+  - Feature-detect `window.SpeechRecognition` and `window.webkitSpeechRecognition`.
+
+- Modify `apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx`
+  - Accept raw saved `wakeTriggerPhrases`.
+  - Accept or create a `WakeDetector`.
+  - Own manual arming state, detector state, wake warnings, and session-local wake behavior.
+  - Send `wake_activation` and `wake_deactivation` frames.
+  - Stop or pause the detector during active Persona Live mic capture.
+
+- Modify `apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx`
+  - Add persistent default wake behavior control near voice defaults.
+  - Include `wake_behavior` in form state, payload, and resolved preview.
+
+- Modify `apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx`
+  - Add explicit `Listen for wake phrase` arm/disarm control.
+  - Add wake status, behavior selector, no-phrases blocked state, and unavailable/error copy.
+
+- Modify `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+  - Derive `wakeTriggerPhrases` from the raw saved selected profile `voice_defaults.voice_chat_trigger_phrases`.
+  - Do not use `resolvedDefaults.voiceChatTriggerPhrases` for wake arming because that value can include global fallback phrases.
+  - Pass wake controller state and actions into `AssistantVoiceCard`.
+  - Stop wake listening before persona/session switches.
+
+- Modify `apps/packages/ui/src/routes/personaTypes.ts`
+  - Re-export or consume updated `PersonaVoiceDefaults` shape.
+  - Keep turn-detection helpers focused on VAD fields; do not mix wake behavior into VAD change detection.
+
+### Frontend Tests
+
+- Modify `apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx`
+- Create `apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts`
+- Modify `apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx`
+- Modify `apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx`
+- Modify `apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx`
+- Modify `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+### Documentation
+
+- Prefer updating `Docs/Design/Personas.md` only if it has no unrelated working-tree changes when implementation reaches the docs task.
+- If `Docs/Design/Personas.md` is still dirty with unrelated edits, create `Docs/Design/Persona_Wake_Word_Support.md` instead and leave the dirty file untouched.
+
+## Cross-Cutting Invariants
+
+- V1 must never auto-arm wake listening.
+- V1 must not send pre-wake audio to the tldw server.
+- Wake arming must use raw saved selected-profile trigger phrases only.
+- Existing ordinary Persona Live trigger phrase behavior may continue to use existing resolved fallback phrases.
+- `wake_activation` and `wake_behavior` must not authorize tools, memory access, or policy bypass.
+- Invalid wake activation must be recoverable and non-fatal.
+- Websocket cleanup must clear session-local wake state even if the frontend fails to send `wake_deactivation`.
+- Do not touch unrelated dirty changes. At plan creation time `Docs/Design/Personas.md` had an unrelated modification.
+
+## Task 1: Backend Wake Behavior Schema
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_profiles_api.py`
+
+- [ ] **Step 1: Add failing profile roundtrip assertions**
+
+In `tldw_Server_API/tests/Persona/test_persona_profiles_api.py`, extend `test_persona_profile_voice_defaults_roundtrip`:
+
+```python
+created_voice_defaults = payload["voice_defaults"]
+assert created_voice_defaults["voice_chat_trigger_phrases"] == [
+    "hey helper",
+    "okay helper",
+]
+assert created_voice_defaults["wake_behavior"] == "continuous"
+```
+
+Assert the create, fetch, and update responses:
+
+```python
+assert payload["voice_defaults"]["wake_behavior"] == "continuous"
+assert fetched_payload["voice_defaults"]["wake_behavior"] == "continuous"
+assert updated_payload["voice_defaults"]["wake_behavior"] == "push_to_talk_after_wake"
+```
+
+Add `"wake_behavior": "continuous"` to the create payload and `"wake_behavior": "push_to_talk_after_wake"` to the patch payload.
+
+- [ ] **Step 2: Add failing invalid-value test**
+
+Add a new test in `tldw_Server_API/tests/Persona/test_persona_profiles_api.py`:
+
+```python
+def test_persona_profile_voice_defaults_rejects_invalid_wake_behavior(
+    persona_db: CharactersRAGDB,
+):
+    with _client_for_user(1, persona_db) as client:
+        created = client.post(
+            "/api/v1/persona/profiles",
+            json={
+                "name": "Bad Wake Helper",
+                "mode": "persistent_scoped",
+                "voice_defaults": {"wake_behavior": "always_on_background"},
+            },
+        )
+        assert created.status_code == 422, created.text
+
+    fastapi_app.dependency_overrides.clear()
+```
+
+- [ ] **Step 3: Run the failing tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q -k "voice_defaults"
+```
+
+Expected: FAIL because `wake_behavior` is not accepted or not returned yet.
+
+- [ ] **Step 4: Implement schema field**
+
+In `tldw_Server_API/app/api/v1/schemas/persona.py`, add the literal near the existing persona mode literals:
+
+```python
+PersonaWakeBehavior = Literal["one_shot", "continuous", "push_to_talk_after_wake"]
+```
+
+Add the nullable field to `PersonaVoiceDefaults`:
+
+```python
+wake_behavior: PersonaWakeBehavior | None = None
+```
+
+Do not add a separate `wake_phrases` field.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q -k "voice_defaults"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py
+git commit -m "feat(persona): persist wake behavior default"
+```
+
+## Task 2: Backend Wake Activation State
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_ws.py`
+
+- [ ] **Step 1: Extend the websocket seed helper**
+
+In `tldw_Server_API/tests/Persona/test_persona_ws.py`, update `_seed_persona_session` with an optional `voice_defaults` parameter:
+
+```python
+def _seed_persona_session(
+    tmp_path,
+    monkeypatch,
+    *,
+    user_id: str,
+    session_id: str,
+    mode: str,
+    use_persona_state_context_default: bool = True,
+    scope_snapshot_json: dict | None = None,
+    preferences_json: dict | None = None,
+    voice_defaults: dict | None = None,
+) -> None:
+```
+
+Include it in the persona profile row:
+
+```python
+"voice_defaults": dict(voice_defaults or {}),
+```
+
+`CharactersRAGDB.create_persona_profile` hydrates `voice_defaults_json` from a `voice_defaults` dict, so the seed helper should pass `voice_defaults`.
+
+- [ ] **Step 2: Add failing valid activation test**
+
+Add reusable fake voice helpers near the existing audio chunk tests:
+
+```python
+class _WakeFakePersonaTranscriber:
+    def __init__(self, transcript: str):
+        self.transcript = transcript
+        self.initialize_called = False
+
+    def initialize(self):
+        self.initialize_called = True
+
+    async def process_audio_chunk(self, audio_data: bytes):
+        return {
+            "type": "partial",
+            "text": self.transcript,
+            "is_final": False,
+        }
+
+    def get_full_transcript(self) -> str:
+        return self.transcript
+
+    def reset(self):
+        return None
+
+    def cleanup(self):
+        return None
+
+
+class _WakeFakeTurnDetector:
+    def __init__(self):
+        self.available = True
+        self.unavailable_reason = None
+        self.last_trigger_at = None
+        self._triggered = False
+
+    def observe(self, audio_data: bytes) -> bool:
+        if self._triggered:
+            return False
+        self._triggered = True
+        self.last_trigger_at = 123.456
+        return True
+
+    def reset(self):
+        self._triggered = False
+
+
+def _install_wake_voice_fakes(monkeypatch, transcript: str):
+    fake_transcriber = _WakeFakePersonaTranscriber(transcript)
+    fake_turn_detector = _WakeFakeTurnDetector()
+    monkeypatch.setattr(
+        persona_ep,
+        "_create_persona_live_stt_transcriber",
+        lambda *args, **kwargs: fake_transcriber,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        persona_ep,
+        "_create_persona_live_turn_detector",
+        lambda *args, **kwargs: fake_turn_detector,
+        raising=False,
+    )
+    return fake_transcriber, fake_turn_detector
+```
+
+Then add a test near existing audio chunk trigger phrase tests:
+
+```python
+def test_persona_wake_activation_allows_next_voice_turn_without_trigger(
+    tmp_path,
+    monkeypatch,
+):
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_valid",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            ws.send_text(json.dumps({
+                "type": "voice_config",
+                "session_id": "sess_wake_valid",
+                "voice": {"trigger_phrases": ["hey helper"]},
+                "stt": {"enable_vad": True},
+            }))
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_CONFIG_UPDATED",
+            )
+            ws.send_text(json.dumps({
+                "type": "wake_activation",
+                "session_id": "sess_wake_valid",
+                "matched_phrase": "hey helper",
+                "detector_kind": "browser_transcript",
+                "wake_behavior": "one_shot",
+                "detected_at_ms": 1714500000000,
+            }))
+            accepted = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED",
+            )
+            assert accepted.get("session_id") == "sess_wake_valid"
+
+            ws.send_text(json.dumps({
+                "type": "audio_chunk",
+                "session_id": "sess_wake_valid",
+                "audio_format": "pcm16",
+                "bytes_base64": base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode("ascii"),
+            }))
+            plan = _recv_until(ws, lambda d: d.get("event") == "tool_plan")
+            assert plan.get("session_id") == "sess_wake_valid"
+```
+
+Expected current failure: no `wake_activation` handler and the no-trigger transcript is ignored.
+
+- [ ] **Step 3: Add failing invalid activation tests**
+
+Add a helper that asserts rejection does not disable the existing trigger gate:
+
+```python
+def _assert_wake_activation_rejected_keeps_trigger_gate(
+    *,
+    tmp_path,
+    monkeypatch,
+    session_id: str,
+    saved_phrases: list[str],
+    runtime_phrases: list[str],
+    matched_phrase: str,
+    wake_behavior: str = "one_shot",
+) -> None:
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id=session_id,
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": saved_phrases,
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode("ascii")
+            ws.send_text(json.dumps({
+                "type": "voice_config",
+                "session_id": session_id,
+                "voice": {"trigger_phrases": runtime_phrases},
+                "stt": {"model": "whisper-1", "language": "en-US"},
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_CONFIG_UPDATED")
+            ws.send_text(json.dumps({
+                "type": "wake_activation",
+                "session_id": session_id,
+                "matched_phrase": matched_phrase,
+                "detector_kind": "browser_transcript",
+                "wake_behavior": wake_behavior,
+                "detected_at_ms": 1714500000000,
+            }))
+            rejected = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_REJECTED",
+            )
+            assert rejected.get("session_id") == session_id
+            ws.send_text(json.dumps({
+                "type": "audio_chunk",
+                "session_id": session_id,
+                "audio_format": "pcm16",
+                "bytes_base64": audio_payload,
+            }))
+            ignored = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TRIGGER_NOT_HEARD",
+            )
+            assert ignored.get("session_id") == session_id
+```
+
+Add these three tests:
+
+```python
+def test_persona_wake_activation_rejects_phrase_not_saved_in_profile(tmp_path, monkeypatch):
+    _assert_wake_activation_rejected_keeps_trigger_gate(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="sess_wake_reject_saved",
+        saved_phrases=["hey helper"],
+        runtime_phrases=["runtime only"],
+        matched_phrase="runtime only",
+    )
+
+
+def test_persona_wake_activation_rejects_phrase_missing_from_runtime_config(tmp_path, monkeypatch):
+    _assert_wake_activation_rejected_keeps_trigger_gate(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="sess_wake_reject_runtime",
+        saved_phrases=["hey helper"],
+        runtime_phrases=["okay helper"],
+        matched_phrase="hey helper",
+    )
+
+
+def test_persona_wake_activation_rejects_invalid_wake_behavior(tmp_path, monkeypatch):
+    _assert_wake_activation_rejected_keeps_trigger_gate(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="sess_wake_reject_behavior",
+        saved_phrases=["hey helper"],
+        runtime_phrases=["hey helper"],
+        matched_phrase="hey helper",
+        wake_behavior="always_on_background",
+    )
+```
+
+- [ ] **Step 4: Add failing deactivation and expiry tests**
+
+Add `test_persona_wake_deactivation_restores_trigger_gating`:
+
+```python
+def test_persona_wake_deactivation_restores_trigger_gating(tmp_path, monkeypatch):
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_deactivated",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "continuous",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode("ascii")
+            ws.send_text(json.dumps({
+                "type": "voice_config",
+                "session_id": "sess_wake_deactivated",
+                "voice": {"trigger_phrases": ["hey helper"]},
+                "stt": {"model": "whisper-1", "language": "en-US"},
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_CONFIG_UPDATED")
+            ws.send_text(json.dumps({
+                "type": "wake_activation",
+                "session_id": "sess_wake_deactivated",
+                "matched_phrase": "hey helper",
+                "detector_kind": "browser_transcript",
+                "wake_behavior": "continuous",
+                "detected_at_ms": 1714500000000,
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED")
+            ws.send_text(json.dumps({
+                "type": "wake_deactivation",
+                "session_id": "sess_wake_deactivated",
+                "reason": "disarmed",
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "WAKE_DEACTIVATED")
+            ws.send_text(json.dumps({
+                "type": "audio_chunk",
+                "session_id": "sess_wake_deactivated",
+                "audio_format": "pcm16",
+                "bytes_base64": audio_payload,
+            }))
+            ignored = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TRIGGER_NOT_HEARD",
+            )
+            assert ignored.get("session_id") == "sess_wake_deactivated"
+```
+
+Add `test_persona_wake_activation_one_shot_expires_after_commit`:
+
+```python
+def test_persona_wake_activation_one_shot_expires_after_commit(tmp_path, monkeypatch):
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_one_shot",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode("ascii")
+            ws.send_text(json.dumps({
+                "type": "voice_config",
+                "session_id": "sess_wake_one_shot",
+                "voice": {"trigger_phrases": ["hey helper"]},
+                "stt": {"model": "whisper-1", "language": "en-US"},
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_CONFIG_UPDATED")
+            ws.send_text(json.dumps({
+                "type": "wake_activation",
+                "session_id": "sess_wake_one_shot",
+                "matched_phrase": "hey helper",
+                "detector_kind": "browser_transcript",
+                "wake_behavior": "one_shot",
+                "detected_at_ms": 1714500000000,
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED")
+            ws.send_text(json.dumps({
+                "type": "audio_chunk",
+                "session_id": "sess_wake_one_shot",
+                "audio_format": "pcm16",
+                "bytes_base64": audio_payload,
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_TURN_COMMITTED")
+            _ = _recv_until(ws, lambda d: d.get("event") == "tool_plan")
+            ws.send_text(json.dumps({
+                "type": "audio_chunk",
+                "session_id": "sess_wake_one_shot",
+                "audio_format": "pcm16",
+                "bytes_base64": audio_payload,
+            }))
+            ignored = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TRIGGER_NOT_HEARD",
+            )
+            assert ignored.get("session_id") == "sess_wake_one_shot"
+```
+
+Add `test_persona_wake_activation_expires_after_no_command_timeout`:
+
+```python
+def test_persona_wake_activation_expires_after_no_command_timeout(tmp_path, monkeypatch):
+    import time
+
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    monkeypatch.setattr(persona_ep, "_get_persona_wake_no_command_timeout_s", lambda: 0.01)
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_timeout",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode("ascii")
+            ws.send_text(json.dumps({
+                "type": "voice_config",
+                "session_id": "sess_wake_timeout",
+                "voice": {"trigger_phrases": ["hey helper"]},
+                "stt": {"model": "whisper-1", "language": "en-US"},
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_CONFIG_UPDATED")
+            ws.send_text(json.dumps({
+                "type": "wake_activation",
+                "session_id": "sess_wake_timeout",
+                "matched_phrase": "hey helper",
+                "detector_kind": "browser_transcript",
+                "wake_behavior": "one_shot",
+                "detected_at_ms": 1714500000000,
+            }))
+            _ = _recv_until(ws, lambda d: d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED")
+            time.sleep(0.02)
+            ws.send_text(json.dumps({
+                "type": "audio_chunk",
+                "session_id": "sess_wake_timeout",
+                "audio_format": "pcm16",
+                "bytes_base64": audio_payload,
+            }))
+            ignored = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TRIGGER_NOT_HEARD",
+            )
+            assert ignored.get("session_id") == "sess_wake_timeout"
+```
+
+For timeout, monkeypatch the new helper planned below:
+
+```python
+monkeypatch.setattr(persona_ep, "_get_persona_wake_no_command_timeout_s", lambda: 0.01)
+```
+
+The timeout test should sleep briefly before committing:
+
+```python
+import time
+time.sleep(0.02)
+```
+
+Expected: transcript without trigger is ignored after timeout.
+
+- [ ] **Step 5: Run failing websocket tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_ws.py -q -k "wake_activation or wake_deactivation or persona_audio_chunk_vad_auto_commit_ignores_missing_trigger_phrase"
+```
+
+Expected: FAIL on new wake tests; existing missing-trigger test should still pass.
+
+- [ ] **Step 6: Add constants and helpers**
+
+In `tldw_Server_API/app/api/v1/endpoints/persona.py`, near other persona live constants/helpers, add:
+
+```python
+_PERSONA_WAKE_BEHAVIORS = {
+    "one_shot",
+    "continuous",
+    "push_to_talk_after_wake",
+}
+_PERSONA_WAKE_DEACTIVATION_REASONS = {
+    "disarmed",
+    "stop_live_voice",
+    "persona_switch",
+    "route_leave",
+    "session_close",
+}
+
+
+def _get_persona_wake_no_command_timeout_s() -> float:
+    try:
+        return max(
+            1.0,
+            min(300.0, float(os.getenv("PERSONA_WAKE_NO_COMMAND_TIMEOUT_S", "30"))),
+        )
+    except (TypeError, ValueError):
+        return 30.0
+```
+
+If `os` is not already imported in the file, add the import.
+
+Add pure normalization helpers close to `_apply_persona_live_trigger_phrases`:
+
+```python
+def _normalize_persona_wake_phrase(value: object) -> str:
+    text = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    return re.sub(r"(^[^\w]+|[^\w]+$)", "", text)
+
+
+def _match_persona_wake_phrase(
+    matched_phrase: object,
+    configured_phrases: list[str] | None,
+) -> str | None:
+    normalized_match = _normalize_persona_wake_phrase(matched_phrase)
+    if not normalized_match:
+        return None
+    for phrase in configured_phrases or []:
+        if _normalize_persona_wake_phrase(phrase) == normalized_match:
+            return str(phrase or "").strip()
+    return None
+```
+
+- [ ] **Step 7: Add websocket-scoped wake state**
+
+Inside `stream_persona` where `persona_live_stt_state_by_session` is used, add a sibling dict:
+
+```python
+persona_live_wake_state_by_session: dict[str, dict[str, Any]] = {}
+```
+
+Add nested helpers so they can reuse `session_manager`, `persona_scope_db`, and authenticated user values:
+
+```python
+def _get_active_wake_state(session_id: str) -> dict[str, Any] | None:
+    state = persona_live_wake_state_by_session.get(session_id)
+    if not isinstance(state, dict):
+        return None
+    expires_at = state.get("expires_at_monotonic")
+    if isinstance(expires_at, (int, float)) and time.monotonic() > float(expires_at):
+        persona_live_wake_state_by_session.pop(session_id, None)
+        return None
+    return state
+
+
+def _clear_wake_state(session_id: str) -> None:
+    persona_live_wake_state_by_session.pop(session_id, None)
+```
+
+If `time` is already imported, reuse it; otherwise add the import.
+
+- [ ] **Step 8: Validate saved profile phrases**
+
+Add a nested helper to resolve saved phrases for the authenticated session:
+
+```python
+def _get_saved_wake_phrases_for_session(session_id: str) -> list[str]:
+    runtime_context = _load_persona_policy_rules_for_session(
+        persona_scope_db,
+        session_id=session_id,
+        user_id=authenticated_user_id,
+    )
+    persona_id = str(runtime_context.get("persona_id") or "").strip()
+    if not persona_id:
+        return []
+    profile = persona_scope_db.get_persona_profile(
+        persona_id=persona_id,
+        user_id=authenticated_user_id,
+    )
+    if not isinstance(profile, dict):
+        return []
+    voice_defaults = profile.get("voice_defaults")
+    if not isinstance(voice_defaults, dict):
+        return []
+    return [
+        str(phrase or "").strip()
+        for phrase in voice_defaults.get("voice_chat_trigger_phrases") or []
+        if str(phrase or "").strip()
+    ]
+```
+
+Adjust the profile access if the DB helper returns JSON field names instead of hydrated `voice_defaults`; inspect `CharactersRAGDB.get_persona_profile` before implementing.
+
+- [ ] **Step 9: Add `wake_activation` handler**
+
+In the websocket message loop, add a branch before `voice_commit`:
+
+```python
+elif mtype == "wake_activation":
+    original_session_id = msg.get("session_id")
+    session_id = _normalize_ws_identifier(original_session_id, fallback="")
+    if not session_id:
+        await _emit_notice(
+            session_id=default_session_id,
+            level="error",
+            message="session_id is required",
+            reason_code="SESSION_ID_REQUIRED",
+        )
+        continue
+
+    wake_behavior = str(msg.get("wake_behavior") or "one_shot").strip()
+    matched_phrase = str(msg.get("matched_phrase") or "").strip()
+    detector_kind = _bounded_label(
+        msg.get("detector_kind"),
+        allowed={"browser_transcript", "native_companion", "test"},
+        fallback="browser_transcript",
+    )
+    saved_phrases = _get_saved_wake_phrases_for_session(session_id)
+    runtime_preferences = session_manager.get_preferences(
+        session_id=session_id,
+        user_id=connection_user_id,
+    )
+    voice_runtime = runtime_preferences.get("voice_runtime")
+    runtime_phrases = (
+        list(voice_runtime.get("trigger_phrases") or [])
+        if isinstance(voice_runtime, dict)
+        else []
+    )
+    saved_match = _match_persona_wake_phrase(matched_phrase, saved_phrases)
+    runtime_match = _match_persona_wake_phrase(matched_phrase, runtime_phrases)
+    if (
+        wake_behavior not in _PERSONA_WAKE_BEHAVIORS
+        or not saved_match
+        or not runtime_match
+    ):
+        await _emit_notice(
+            session_id=session_id,
+            level="warning",
+            reason_code="WAKE_ACTIVATION_REJECTED",
+            message="Wake activation was rejected for this persona session.",
+        )
+        continue
+
+    expires_at = None
+    if wake_behavior in {"one_shot", "push_to_talk_after_wake"}:
+        expires_at = time.monotonic() + _get_persona_wake_no_command_timeout_s()
+    persona_live_wake_state_by_session[session_id] = {
+        "wake_behavior": wake_behavior,
+        "matched_phrase": saved_match,
+        "detector_kind": detector_kind,
+        "expires_at_monotonic": expires_at,
+    }
+    await _emit_notice(
+        session_id=session_id,
+        level="info",
+        reason_code="WAKE_ACTIVATION_ACCEPTED",
+        message="Wake activation accepted for this live session.",
+        wake_behavior=wake_behavior,
+        detector_kind=detector_kind,
+    )
+```
+
+- [ ] **Step 10: Add `wake_deactivation` handler**
+
+Add another branch:
+
+```python
+elif mtype == "wake_deactivation":
+    session_id = _normalize_ws_identifier(msg.get("session_id"), fallback="")
+    if not session_id:
+        await _emit_notice(
+            session_id=default_session_id,
+            level="error",
+            message="session_id is required",
+            reason_code="SESSION_ID_REQUIRED",
+        )
+        continue
+    reason = _bounded_label(
+        msg.get("reason"),
+        allowed=_PERSONA_WAKE_DEACTIVATION_REASONS,
+        fallback="disarmed",
+    )
+    _clear_wake_state(session_id)
+    await _emit_notice(
+        session_id=session_id,
+        level="info",
+        reason_code="WAKE_DEACTIVATED",
+        message="Wake activation cleared for this live session.",
+        reason=reason,
+    )
+```
+
+- [ ] **Step 11: Update trigger gating in `_commit_persona_live_turn`**
+
+Inside `_commit_persona_live_turn`, before `_apply_persona_live_trigger_phrases`, read active state:
+
+```python
+wake_state = _get_active_wake_state(session_id)
+if wake_state:
+    trigger_matched = True
+    cleaned_transcript = str(transcript or "").strip()
+else:
+    trigger_matched, cleaned_transcript = _apply_persona_live_trigger_phrases(
+        transcript,
+        trigger_phrases=trigger_phrases,
+    )
+```
+
+After a successful commit and before returning, expire one-shot style activations:
+
+```python
+if wake_state and wake_state.get("wake_behavior") in {
+    "one_shot",
+    "push_to_talk_after_wake",
+}:
+    _clear_wake_state(session_id)
+```
+
+Do not clear `continuous` here.
+
+- [ ] **Step 12: Clear wake state on voice config and cleanup**
+
+When `voice_config` successfully updates runtime preferences, clear any stale wake state for that session before emitting `VOICE_CONFIG_UPDATED`:
+
+```python
+_clear_wake_state(session_id)
+```
+
+In websocket cleanup or disconnect handling, clear wake state for known sessions. If the function already tracks connected session ids, iterate those. If not, clear `default_session_id` and any `persona_live_wake_state_by_session` keys before returning:
+
+```python
+persona_live_wake_state_by_session.clear()
+```
+
+This dict is scoped to the websocket connection, so clearing it on disconnect is correct.
+
+- [ ] **Step 13: Run focused websocket tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_ws.py -q -k "wake_activation or wake_deactivation or persona_audio_chunk_vad_auto_commit_ignores_missing_trigger_phrase"
+```
+
+Expected: PASS.
+
+- [ ] **Step 14: Commit**
+
+Run:
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/tests/Persona/test_persona_ws.py
+git commit -m "feat(persona): add wake activation websocket state"
+```
+
+## Task 3: Frontend Wake Defaults
+
+**Files:**
+- Modify: `apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx`
+- Modify: `apps/packages/ui/src/routes/personaTypes.ts`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx`
+- Modify: `apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx`
+
+- [ ] **Step 1: Add failing resolver tests**
+
+In `apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx`, add:
+
+```ts
+it("resolves explicit persona wake behavior", () => {
+  const { result } = renderHook(() =>
+    useResolvedPersonaVoiceDefaults({
+      wake_behavior: "continuous"
+    })
+  )
+
+  expect(result.current.wakeBehavior).toBe("continuous")
+})
+
+it("falls back to one_shot when wake behavior is unset", () => {
+  const { result } = renderHook(() => useResolvedPersonaVoiceDefaults(null))
+
+  expect(result.current.wakeBehavior).toBe("one_shot")
+})
+```
+
+- [ ] **Step 2: Add failing defaults panel test**
+
+In `apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx`, add a test that:
+
+1. Renders `AssistantDefaultsPanel` with `voice_defaults.wake_behavior = "continuous"`.
+2. Changes the wake behavior select to `push_to_talk_after_wake`.
+3. Saves.
+4. Asserts the API payload includes:
+
+```ts
+expect(fetchMock).toHaveBeenCalledWith(
+  expect.any(String),
+  expect.objectContaining({
+    body: expect.stringContaining('"wake_behavior":"push_to_talk_after_wake"')
+  })
+)
+```
+
+Follow the existing fetch mock and save assertions in this test file.
+
+- [ ] **Step 3: Run failing frontend defaults tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx ../packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
+```
+
+Expected: FAIL because `wakeBehavior` and the panel field do not exist yet.
+
+- [ ] **Step 4: Add frontend wake behavior types**
+
+In `apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx`, add:
+
+```ts
+export type PersonaWakeBehavior =
+  | "one_shot"
+  | "continuous"
+  | "push_to_talk_after_wake"
+```
+
+Extend `PersonaVoiceDefaults`:
+
+```ts
+wake_behavior?: PersonaWakeBehavior | null
+```
+
+Extend `ResolvedPersonaVoiceDefaults`:
+
+```ts
+wakeBehavior: PersonaWakeBehavior
+```
+
+Add:
+
+```ts
+const DEFAULT_WAKE_BEHAVIOR: PersonaWakeBehavior = "one_shot"
+const normalizeWakeBehavior = (
+  value: PersonaWakeBehavior | null | undefined
+): PersonaWakeBehavior =>
+  value === "continuous" || value === "push_to_talk_after_wake" || value === "one_shot"
+    ? value
+    : DEFAULT_WAKE_BEHAVIOR
+```
+
+Return:
+
+```ts
+wakeBehavior: normalizeWakeBehavior(personaVoiceDefaults?.wake_behavior)
+```
+
+- [ ] **Step 5: Wire defaults panel form state**
+
+In `apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx`:
+
+Add to `AssistantDefaultsFormState`:
+
+```ts
+wakeBehavior: PersonaWakeBehavior
+```
+
+Import the type:
+
+```ts
+type PersonaWakeBehavior
+```
+
+Add to `buildFormState`:
+
+```ts
+wakeBehavior: voiceDefaults?.wake_behavior || "one_shot",
+```
+
+Add to `buildPayload`:
+
+```ts
+wake_behavior: formState.wakeBehavior,
+```
+
+Add an Ant Design `Select` near the trigger phrases controls:
+
+```tsx
+<Select
+  data-testid="assistant-wake-behavior"
+  value={formState.wakeBehavior}
+  onChange={(wakeBehavior: PersonaWakeBehavior) =>
+    setFormState((current) => ({ ...current, wakeBehavior }))
+  }
+  options={[
+    { value: "one_shot", label: "One turn after wake" },
+    { value: "continuous", label: "Continuous after wake" },
+    { value: "push_to_talk_after_wake", label: "Push to talk after wake" }
+  ]}
+/>
+```
+
+Add `Wake behavior` to the resolved preview.
+
+- [ ] **Step 6: Keep route types aligned**
+
+In `apps/packages/ui/src/routes/personaTypes.ts`, make no independent duplicate enum if it can import `PersonaWakeBehavior` from `useResolvedPersonaVoiceDefaults.tsx`. If any helper enumerates voice default keys, include `wake_behavior` there.
+
+Do not include `wake_behavior` in `buildTurnDetectionValuesFromSavedDefaults`; that helper is for VAD change detection only.
+
+- [ ] **Step 7: Run defaults tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx ../packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx apps/packages/ui/src/routes/personaTypes.ts apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
+git commit -m "feat(persona): expose wake behavior defaults"
+```
+
+## Task 4: Frontend WakeDetector Abstraction
+
+**Files:**
+- Create: `apps/packages/ui/src/hooks/personaWakeDetector.ts`
+- Create: `apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts`
+
+- [ ] **Step 1: Add failing detector tests**
+
+Create `apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts`:
+
+```ts
+import {
+  BrowserTranscriptWakeDetector,
+  findCanonicalWakePhrase,
+  normalizeWakePhraseText
+} from "../personaWakeDetector"
+
+describe("personaWakeDetector", () => {
+  it("normalizes phrase text for matching", () => {
+    expect(normalizeWakePhraseText("  Hey,   Helper! ")).toBe("hey helper")
+  })
+
+  it("matches whole normalized phrase sequences", () => {
+    expect(
+      findCanonicalWakePhrase("um hey helper please wake up", ["Hey Helper"])
+    ).toBe("Hey Helper")
+    expect(
+      findCanonicalWakePhrase("the helper is nearby", ["hey helper"])
+    ).toBeNull()
+  })
+
+  it("reports unavailable when SpeechRecognition is absent", async () => {
+    ;(window as any).SpeechRecognition = undefined
+    ;(window as any).webkitSpeechRecognition = undefined
+
+    const detector = new BrowserTranscriptWakeDetector()
+    await expect(detector.isAvailable()).resolves.toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run failing detector tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Implement detector types and pure helpers**
+
+Create `apps/packages/ui/src/hooks/personaWakeDetector.ts`:
+
+```ts
+export type WakeDetectorState =
+  | "idle"
+  | "starting"
+  | "listening"
+  | "detected"
+  | "unavailable"
+  | "error"
+
+export type WakeDetectorKind = "browser_transcript"
+
+export type WakeDetectedEvent = {
+  canonicalPhrase: string
+  transcript: string
+  detectedAtMs: number
+  detectorKind: WakeDetectorKind
+}
+
+export type WakeDetectorError = {
+  message: string
+  code?: string
+}
+
+export type WakeDetectorConfig = {
+  phrases: string[]
+  locale?: string
+  onWake: (event: WakeDetectedEvent) => void
+  onStateChange?: (state: WakeDetectorState) => void
+  onError?: (error: WakeDetectorError) => void
+}
+
+export interface WakeDetector {
+  isAvailable(): Promise<boolean>
+  start(config: WakeDetectorConfig): Promise<void>
+  stop(): Promise<void>
+}
+```
+
+Implement helpers:
+
+```ts
+export const normalizeWakePhraseText = (value: unknown): string =>
+  String(value || "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+
+export const findCanonicalWakePhrase = (
+  transcript: unknown,
+  phrases: string[]
+): string | null => {
+  const normalizedTranscript = ` ${normalizeWakePhraseText(transcript)} `
+  if (!normalizedTranscript.trim()) return null
+  for (const phrase of phrases || []) {
+    const normalizedPhrase = normalizeWakePhraseText(phrase)
+    if (!normalizedPhrase) continue
+    if (normalizedTranscript.includes(` ${normalizedPhrase} `)) {
+      return String(phrase || "").trim()
+    }
+  }
+  return null
+}
+```
+
+- [ ] **Step 4: Implement `BrowserTranscriptWakeDetector`**
+
+Add a class in the same file:
+
+```ts
+type SpeechRecognitionCtor = new () => {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  onresult: ((event: any) => void) | null
+  onerror: ((event: any) => void) | null
+  onend: (() => void) | null
+  start: () => void
+  stop: () => void
+}
+
+const getSpeechRecognitionCtor = (): SpeechRecognitionCtor | null => {
+  if (typeof window === "undefined") return null
+  return (
+    (window as any).SpeechRecognition ||
+    (window as any).webkitSpeechRecognition ||
+    null
+  )
+}
+
+export class BrowserTranscriptWakeDetector implements WakeDetector {
+  private recognition: InstanceType<SpeechRecognitionCtor> | null = null
+  private active = false
+
+  async isAvailable(): Promise<boolean> {
+    return Boolean(getSpeechRecognitionCtor())
+  }
+
+  async start(config: WakeDetectorConfig): Promise<void> {
+    await this.stop()
+    const Ctor = getSpeechRecognitionCtor()
+    const phrases = (config.phrases || []).map((phrase) => String(phrase || "").trim()).filter(Boolean)
+    if (!Ctor || phrases.length === 0) {
+      config.onStateChange?.("unavailable")
+      return
+    }
+    config.onStateChange?.("starting")
+    const recognition = new Ctor()
+    this.recognition = recognition
+    this.active = true
+    recognition.continuous = true
+    recognition.interimResults = true
+    recognition.lang = config.locale || "en-US"
+    recognition.onresult = (event: any) => {
+      if (!this.active) return
+      const transcript = Array.from(event?.results || [])
+        .map((result: any) => result?.[0]?.transcript || "")
+        .join(" ")
+      const canonicalPhrase = findCanonicalWakePhrase(transcript, phrases)
+      if (!canonicalPhrase) return
+      config.onStateChange?.("detected")
+      config.onWake({
+        canonicalPhrase,
+        transcript,
+        detectedAtMs: Date.now(),
+        detectorKind: "browser_transcript"
+      })
+    }
+    recognition.onerror = (event: any) => {
+      config.onStateChange?.("error")
+      config.onError?.({
+        code: String(event?.error || ""),
+        message: String(event?.message || event?.error || "Wake detector error")
+      })
+    }
+    recognition.onend = () => {
+      if (this.active) {
+        config.onStateChange?.("idle")
+      }
+    }
+    recognition.start()
+    config.onStateChange?.("listening")
+  }
+
+  async stop(): Promise<void> {
+    this.active = false
+    const recognition = this.recognition
+    this.recognition = null
+    try {
+      recognition?.stop()
+    } catch {
+      // SpeechRecognition implementations throw when stop races with end.
+    }
+  }
+}
+```
+
+If lint flags `any`, replace with the local structural types already used in `useSpeechRecognition.tsx`.
+
+- [ ] **Step 5: Add event lifecycle tests**
+
+Extend `personaWakeDetector.test.ts` with a mock recognition constructor and assert:
+
+- `start` emits `starting` then `listening`.
+- matching result calls `onWake` with canonical configured phrase.
+- `stop` calls recognition `stop`.
+- empty phrase lists produce `unavailable` and do not start recognition.
+
+- [ ] **Step 6: Run detector tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add apps/packages/ui/src/hooks/personaWakeDetector.ts apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
+git commit -m "feat(persona): add wake detector abstraction"
+```
+
+## Task 5: Frontend Controller Wake Runtime
+
+**Files:**
+- Modify: `apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx`
+- Modify: `apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx`
+
+- [ ] **Step 1: Add test detector helper**
+
+In `apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx`, add a fake detector:
+
+```ts
+const createWakeDetectorHarness = () => {
+  let config: WakeDetectorConfig | null = null
+  const detector: WakeDetector = {
+    isAvailable: vi.fn(async () => true),
+    start: vi.fn(async (nextConfig) => {
+      config = nextConfig
+      nextConfig.onStateChange?.("listening")
+    }),
+    stop: vi.fn(async () => undefined)
+  }
+  return {
+    detector,
+    fireWake: (canonicalPhrase = "hey helper") => {
+      config?.onWake({
+        canonicalPhrase,
+        transcript: `${canonicalPhrase} status`,
+        detectedAtMs: 1714500000000,
+        detectorKind: "browser_transcript"
+      })
+    }
+  }
+}
+```
+
+Import `WakeDetector` and `WakeDetectorConfig` from `../personaWakeDetector`.
+
+- [ ] **Step 2: Add failing arming tests**
+
+Add tests that assert:
+
+```ts
+it("blocks wake arming when the selected profile has no saved trigger phrases", async () => {
+  const { result } = renderHook(() =>
+    usePersonaLiveVoiceController({
+      ...baseArgs,
+      wakeTriggerPhrases: [],
+      wakeDetectorFactory: () => detector
+    })
+  )
+  await act(async () => result.current.toggleWakeArmed())
+  expect(detector.start).not.toHaveBeenCalled()
+  expect(result.current.wakeWarning).toMatch(/trigger phrase/i)
+})
+```
+
+And:
+
+```ts
+it("starts the wake detector with raw saved phrases", async () => {
+  const { result } = renderHook(() =>
+    usePersonaLiveVoiceController({
+      ...baseArgs,
+      wakeTriggerPhrases: ["hey helper"],
+      wakeDetectorFactory: () => detector
+    })
+  )
+  await act(async () => result.current.toggleWakeArmed())
+  expect(detector.start).toHaveBeenCalledWith(expect.objectContaining({
+    phrases: ["hey helper"]
+  }))
+})
+```
+
+- [ ] **Step 3: Add failing activation/deactivation tests**
+
+Add tests that assert:
+
+- `fireWake()` sends:
+
+```ts
+{
+  type: "wake_activation",
+  session_id: "sess-1",
+  matched_phrase: "hey helper",
+  detector_kind: "browser_transcript",
+  wake_behavior: "one_shot",
+  detected_at_ms: 1714500000000
+}
+```
+
+- `toggleWakeArmed()` from armed to disarmed sends:
+
+```ts
+{
+  type: "wake_deactivation",
+  session_id: "sess-1",
+  reason: "disarmed"
+}
+```
+
+- Unmount sends `wake_deactivation` with `reason: "route_leave"` when armed and websocket is open.
+
+- Starting live mic capture stops the detector to avoid microphone contention.
+
+- [ ] **Step 4: Run failing controller tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+```
+
+Expected: FAIL on new wake controller tests.
+
+- [ ] **Step 5: Extend controller args and state**
+
+In `apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx`, import detector pieces:
+
+```ts
+import {
+  BrowserTranscriptWakeDetector,
+  type WakeDetector,
+  type WakeDetectorState,
+  type WakeDetectedEvent
+} from "@/hooks/personaWakeDetector"
+import type { PersonaWakeBehavior } from "@/hooks/useResolvedPersonaVoiceDefaults"
+```
+
+Extend args:
+
+```ts
+wakeTriggerPhrases?: string[]
+wakeDetectorFactory?: () => WakeDetector
+```
+
+Add state:
+
+```ts
+const [wakeArmed, setWakeArmed] = React.useState(false)
+const [wakeDetectorState, setWakeDetectorState] =
+  React.useState<WakeDetectorState>("idle")
+const [wakeWarning, setWakeWarning] = React.useState<string | null>(null)
+const [sessionWakeBehavior, setSessionWakeBehavior] =
+  React.useState<PersonaWakeBehavior>(resolvedDefaults.wakeBehavior)
+```
+
+Add refs:
+
+```ts
+const wakeDetectorRef = React.useRef<WakeDetector | null>(null)
+const wakeActiveRef = React.useRef(false)
+```
+
+- [ ] **Step 6: Add send helpers**
+
+Add callback helpers:
+
+```ts
+const sendWakeActivation = React.useCallback((event: WakeDetectedEvent) => {
+  if (!connected || !sessionId || !ws || ws.readyState !== WebSocket.OPEN) {
+    setWakeWarning("Wake phrase heard, but Persona Live is not connected.")
+    return
+  }
+  ws.send(JSON.stringify({
+    type: "wake_activation",
+    session_id: sessionId,
+    matched_phrase: event.canonicalPhrase,
+    detector_kind: event.detectorKind,
+    wake_behavior: sessionWakeBehavior,
+    detected_at_ms: event.detectedAtMs
+  }))
+}, [connected, sessionId, sessionWakeBehavior, ws])
+
+const sendWakeDeactivation = React.useCallback((reason: string) => {
+  if (!sessionId || !ws || ws.readyState !== WebSocket.OPEN) return
+  ws.send(JSON.stringify({
+    type: "wake_deactivation",
+    session_id: sessionId,
+    reason
+  }))
+}, [sessionId, ws])
+```
+
+Wrap sends in `try/catch` consistent with the existing `voice_config` send effect.
+
+- [ ] **Step 7: Add detector start/stop callbacks**
+
+Add:
+
+```ts
+const stopWakeListening = React.useCallback(async (reason: "disarmed" | "route_leave" | "stop_live_voice" | "persona_switch" = "disarmed") => {
+  wakeActiveRef.current = false
+  await wakeDetectorRef.current?.stop()
+  wakeDetectorRef.current = null
+  setWakeDetectorState("idle")
+  setWakeArmed(false)
+  sendWakeDeactivation(reason)
+}, [sendWakeDeactivation])
+
+const startWakeListening = React.useCallback(async () => {
+  const phrases = (wakeTriggerPhrases || []).map((phrase) => String(phrase || "").trim()).filter(Boolean)
+  if (phrases.length === 0) {
+    setWakeWarning("Add a persona trigger phrase before arming wake listening.")
+    return
+  }
+  const detector = wakeDetectorFactory?.() || new BrowserTranscriptWakeDetector()
+  wakeDetectorRef.current = detector
+  const available = await detector.isAvailable()
+  if (!available) {
+    setWakeDetectorState("unavailable")
+    setWakeWarning("Wake listening is unavailable in this browser context.")
+    return
+  }
+  setWakeArmed(true)
+  setWakeWarning(null)
+  await detector.start({
+    phrases,
+    locale: resolvedDefaults.sttLanguage,
+    onStateChange: setWakeDetectorState,
+    onError: (error) => setWakeWarning(error.message),
+    onWake: (event) => {
+      if (wakeActiveRef.current) return
+      wakeActiveRef.current = true
+      void detector.stop()
+      sendWakeActivation(event)
+      if (sessionWakeBehavior !== "push_to_talk_after_wake") {
+        void startListening()
+      }
+    }
+  })
+}, [resolvedDefaults.sttLanguage, sendWakeActivation, sessionWakeBehavior, startListening, wakeDetectorFactory, wakeTriggerPhrases])
+```
+
+If dependency order creates a circular callback issue because `startListening` is declared later, move wake callbacks below the listening callbacks.
+
+Add `toggleWakeArmed`:
+
+```ts
+const toggleWakeArmed = React.useCallback(() => {
+  if (wakeArmed) {
+    void stopWakeListening("disarmed")
+    return
+  }
+  void startWakeListening()
+}, [startWakeListening, stopWakeListening, wakeArmed])
+```
+
+- [ ] **Step 8: Suspend detector during live mic capture**
+
+At the start of `startListening`, before opening the mic stream, stop the detector without disarming the UI:
+
+```ts
+if (wakeArmed) {
+  await wakeDetectorRef.current?.stop()
+  wakeDetectorRef.current = null
+  setWakeDetectorState("idle")
+}
+```
+
+At `stopListening` or `finishVoiceTurn`, decide behavior:
+
+- For `one_shot`: if still `wakeArmed`, set `wakeActiveRef.current = false` and call `startWakeListening()` after the assistant turn fully completes.
+- For `continuous`: leave Persona Live in the normal live voice loop until the user stops/disarms.
+- For `push_to_talk_after_wake`: do not auto-start live mic capture; keep manual controls available.
+
+Use existing `finishVoiceTurn`, `pendingResumeRef`, `audioFinish`, and TTS/text-only completion points so wake resumes after the turn is actually done, not immediately after commit.
+
+- [ ] **Step 9: Handle server notices**
+
+In `handlePayload`, add notice handling:
+
+```ts
+if (reasonCode === "WAKE_ACTIVATION_ACCEPTED") {
+  setWakeWarning(null)
+  return
+}
+if (reasonCode === "WAKE_ACTIVATION_REJECTED") {
+  wakeActiveRef.current = false
+  setWakeWarning(String(payload?.message || "Wake activation was rejected."))
+  if (wakeArmed) void startWakeListening()
+  return
+}
+if (reasonCode === "WAKE_DEACTIVATED") {
+  wakeActiveRef.current = false
+  return
+}
+```
+
+When `VOICE_TRIGGER_NOT_HEARD` or `VOICE_EMPTY_COMMAND_AFTER_TRIGGER` fires and `wakeArmed` is true, clear `wakeActiveRef` and restart wake listening if behavior is `one_shot`.
+
+- [ ] **Step 10: Cleanup on unmount and session/persona changes**
+
+Extend the existing cleanup effect:
+
+```ts
+void stopWakeListening("route_leave")
+```
+
+Add an effect watching `personaId` and `sessionId`:
+
+```ts
+React.useEffect(() => {
+  return () => {
+    if (wakeArmed) {
+      void stopWakeListening("persona_switch")
+    }
+  }
+}, [personaId, sessionId])
+```
+
+Be careful not to send duplicate deactivation on ordinary rerenders; tests should assert at most one deactivation for unmount.
+
+- [ ] **Step 11: Return wake state and actions**
+
+Add to the hook return object:
+
+```ts
+wakeArmed,
+wakeDetectorState,
+wakeWarning,
+sessionWakeBehavior,
+wakeTriggerPhrases,
+toggleWakeArmed,
+stopWakeListening,
+setSessionWakeBehavior,
+```
+
+- [ ] **Step 12: Run controller tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Commit**
+
+Run:
+
+```bash
+git add apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+git commit -m "feat(persona): wire wake activation controller"
+```
+
+## Task 6: Persona Live UI And Route Wiring
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+- [ ] **Step 1: Add failing voice card tests**
+
+In `apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx`, update the default props with wake fields:
+
+```ts
+wakeArmed: false,
+wakeDetectorState: "idle",
+wakeWarning: null,
+wakeTriggerPhrases: ["hey helper"],
+sessionWakeBehavior: "one_shot",
+onToggleWakeArmed: vi.fn(),
+onSessionWakeBehaviorChange: vi.fn()
+```
+
+Add tests:
+
+```ts
+it("renders wake phrase controls and current saved wake phrases", () => {
+  render(<AssistantVoiceCard {...defaultVoiceCardProps()} />)
+  expect(screen.getByTestId("live-wake-toggle")).toHaveTextContent(/listen for wake phrase/i)
+  expect(screen.getByTestId("live-wake-phrases")).toHaveTextContent("hey helper")
+})
+
+it("blocks wake toggle display when no saved wake phrases are configured", () => {
+  render(<AssistantVoiceCard {...defaultVoiceCardProps()} wakeTriggerPhrases={[]} />)
+  expect(screen.getByTestId("live-wake-toggle")).toBeDisabled()
+  expect(screen.getByText(/add a trigger phrase/i)).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Add failing route test**
+
+In `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`, add or extend a Persona Live test so the mocked profile response has:
+
+```ts
+voice_defaults: {
+  voice_chat_trigger_phrases: ["saved wake phrase"],
+  wake_behavior: "continuous"
+}
+```
+
+Set global voice chat trigger phrases in the test to a different fallback if the harness exposes it, then assert the controller/card receives or renders `saved wake phrase`, not the fallback phrase.
+
+- [ ] **Step 3: Run failing UI route tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx ../packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: FAIL because wake props and route wiring do not exist yet.
+
+- [ ] **Step 4: Add wake props and UI**
+
+In `apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx`, import:
+
+```ts
+import type { PersonaWakeBehavior } from "@/hooks/useResolvedPersonaVoiceDefaults"
+import type { WakeDetectorState } from "@/hooks/personaWakeDetector"
+```
+
+Extend props:
+
+```ts
+wakeArmed: boolean
+wakeDetectorState: WakeDetectorState
+wakeWarning: string | null
+wakeTriggerPhrases: string[]
+sessionWakeBehavior: PersonaWakeBehavior
+onToggleWakeArmed: () => void
+onSessionWakeBehaviorChange: (next: PersonaWakeBehavior) => void
+```
+
+Add a compact wake control section near the top of the card:
+
+```tsx
+<div className="mt-3 rounded-md border border-border bg-surface2 p-3 text-xs text-text">
+  <div className="flex flex-wrap items-center justify-between gap-2">
+    <div>
+      <Typography.Text strong>Wake phrase</Typography.Text>
+      <Typography.Text type="secondary" className="mt-1 block text-xs">
+        Active only while this Persona Live surface is open.
+      </Typography.Text>
+    </div>
+    <Button
+      data-testid="live-wake-toggle"
+      size="small"
+      type={wakeArmed ? "default" : "primary"}
+      disabled={sessionControlsDisabled || wakeTriggerPhrases.length === 0}
+      onClick={onToggleWakeArmed}
+    >
+      {wakeArmed ? "Stop wake listening" : "Listen for wake phrase"}
+    </Button>
+  </div>
+  <div className="mt-2 grid gap-2 sm:grid-cols-3">
+    <div>
+      <div className="text-text-muted">Saved wake phrases</div>
+      <div data-testid="live-wake-phrases">
+        {wakeTriggerPhrases.length > 0 ? wakeTriggerPhrases.join(", ") : "Add a trigger phrase in voice defaults."}
+      </div>
+    </div>
+    <div>
+      <div className="text-text-muted">Wake state</div>
+      <div data-testid="live-wake-state">{wakeArmed ? wakeDetectorState : "idle"}</div>
+    </div>
+    <div>
+      <div className="text-text-muted">After wake</div>
+      <Select
+        data-testid="live-wake-behavior"
+        size="small"
+        value={sessionWakeBehavior}
+        disabled={sessionControlsDisabled}
+        onChange={onSessionWakeBehaviorChange}
+        options={[
+          { value: "one_shot", label: "One turn" },
+          { value: "continuous", label: "Continuous" },
+          { value: "push_to_talk_after_wake", label: "Push to talk" }
+        ]}
+      />
+    </div>
+  </div>
+  {wakeWarning ? <Alert className="mt-2" type="warning" showIcon message={wakeWarning} /> : null}
+</div>
+```
+
+Add `Alert` and `Select` to the existing Ant Design import.
+
+- [ ] **Step 5: Wire raw saved phrases in the route**
+
+In `apps/packages/ui/src/routes/sidepanel-persona.tsx`, add a local normalizer near other small route helpers:
+
+```ts
+const normalizeWakeTriggerPhrases = (phrases?: string[] | null): string[] => {
+  const seen = new Set<string>()
+  const next: string[] = []
+  for (const phrase of phrases || []) {
+    const trimmed = String(phrase || "").trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    next.push(trimmed)
+  }
+  return next
+}
+```
+
+Add memoized raw saved phrases:
+
+```ts
+const wakeTriggerPhrases = React.useMemo(
+  () =>
+    normalizeWakeTriggerPhrases(
+      savedPersonaVoiceDefaults?.voice_chat_trigger_phrases
+    ),
+  [savedPersonaVoiceDefaults]
+)
+```
+
+Do not derive wake phrases from `liveSessionVoiceDefaultsBaseline`; that value is a session snapshot and can become stale after profile saves. Wake arming should reflect the selected profile's current saved trigger phrases.
+
+Pass them into the controller:
+
+```ts
+const liveVoiceController = usePersonaLiveVoiceController({
+  ws,
+  connected,
+  sessionId,
+  personaId,
+  resolvedDefaults: resolvedLivePersonaVoiceDefaults,
+  canUseServerStt,
+  wakeTriggerPhrases
+})
+```
+
+Pass returned wake values into `AssistantVoiceCard`.
+
+- [ ] **Step 6: Stop wake mode on route/session actions**
+
+Before actions that intentionally change the active live persona session, call:
+
+```ts
+void liveVoiceController.stopWakeListening("persona_switch")
+```
+
+Use `route_leave` only in hook unmount cleanup. Use `stop_live_voice` when a user action stops live voice but does not leave the route.
+
+- [ ] **Step 7: Run UI route tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx ../packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat(persona): add wake controls to live voice"
+```
+
+## Task 7: Documentation And Final Verification
+
+**Files:**
+- Modify if clean: `Docs/Design/Personas.md`
+- Or create: `Docs/Design/Persona_Wake_Word_Support.md`
+- Verify touched files from Tasks 1 through 6.
+
+- [ ] **Step 1: Check documentation working tree state**
+
+Run:
+
+```bash
+git status --short Docs/Design/Personas.md
+```
+
+Expected: If this shows unrelated user changes, do not edit `Docs/Design/Personas.md`.
+
+- [ ] **Step 2: Add V1 limitations documentation**
+
+If `Docs/Design/Personas.md` is clean, add a short `Wake Phrase Support` section there.
+
+If it is dirty with unrelated changes, create `Docs/Design/Persona_Wake_Word_Support.md` containing:
+
+```md
+# Persona Wake Phrase Support
+
+Persona Live wake phrase support is manually armed per session. V1 uses the selected persona profile's saved `voice_chat_trigger_phrases` as wake phrases and detects them in the active browser or extension surface before sending a scoped `wake_activation` frame to `/api/v1/persona/stream`.
+
+V1 is not true background always-on listening. Wake listening is visible, manually armed, and only active while the Persona Live surface is open and the browser speech recognition API is available. Pre-wake audio is not sent to the tldw server.
+```
+
+- [ ] **Step 3: Run backend focused tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/Persona/test_persona_ws.py -q -k "voice_defaults or wake_activation or wake_deactivation or persona_audio_chunk_vad_auto_commit_ignores_missing_trigger_phrase"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run frontend focused tests**
+
+Run:
+
+```bash
+cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx ../packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts ../packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx ../packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx ../packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx ../packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Compile touched backend files**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m py_compile tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 6: Run Bandit on touched backend files**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_persona_wake_word.json
+```
+
+Expected: exit code 0 or only pre-existing findings outside changed lines. Inspect `/tmp/bandit_persona_wake_word.json` before proceeding.
+
+- [ ] **Step 7: Run whitespace diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 8: Commit docs and final verification fixes**
+
+Run:
+
+```bash
+git add Docs/Design/Persona_Wake_Word_Support.md Docs/Design/Personas.md
+git commit -m "docs(persona): document wake phrase limitations"
+```
+
+If only one docs file exists or changed, stage only that file. Do not stage unrelated pre-existing edits.
+
+## Final Review Checklist
+
+- [ ] `wake_behavior` is saved as nullable profile data and resolves to `one_shot` in the frontend.
+- [ ] Wake arming uses raw saved selected-profile trigger phrases, not global fallback phrases.
+- [ ] Browser detector is unavailable-safe and can be replaced by a future native companion.
+- [ ] `wake_activation` validates both saved profile phrases and current session runtime phrases.
+- [ ] Trigger phrase gating remains unchanged outside active wake windows.
+- [ ] One-shot and push-to-talk wake activations expire after a turn or no-command timeout.
+- [ ] Continuous wake activation clears on deactivation, session close, persona switch, or route leave.
+- [ ] Frontend stops detector before Persona Live mic capture.
+- [ ] UI states are visible for idle, listening, detected, unavailable, and error.
+- [ ] No pre-wake transcript is persisted or sent as a persona turn.
+- [ ] Focused tests, backend compile, Bandit, and `git diff --check` have been run.
+
+## Execution Notes
+
+- Use `superpowers:test-driven-development` for each task.
+- Use `superpowers:systematic-debugging` if a test fails unexpectedly.
+- Use `superpowers:verification-before-completion` before claiming implementation complete.
+- Use `superpowers:requesting-code-review` before merging or opening a PR.
+- Keep commits small and in the order listed above.
+- Do not use `--no-verify`.
+- Do not stage unrelated changes in `Docs/Design/Personas.md`.

--- a/Docs/superpowers/specs/2026-04-30-persona-wake-word-support-design.md
+++ b/Docs/superpowers/specs/2026-04-30-persona-wake-word-support-design.md
@@ -1,0 +1,380 @@
+# Persona Wake Word Support Design
+
+Date: 2026-04-30
+Status: Approved for planning
+Owner: Codex brainstorming pass
+
+## Summary
+
+Add wake-word support to Persona Live without creating a parallel persona runtime.
+
+V1 wake mode is manually armed from an active Persona Live surface. A client-side `WakeDetector` listens for the selected persona's existing `voice_chat_trigger_phrases`, then activates the existing `/api/v1/persona/stream` live voice flow. The first detector implementation uses browser-side transcript matching where the browser/device supports it. A later native/local companion can implement the same wake activation contract without changing persona profile semantics or the persona websocket turn executor.
+
+## Goals
+
+- Let users arm wake listening for the current Persona Live session.
+- Reuse existing persona trigger phrases as wake phrases in V1.
+- Let each persona define the default post-wake behavior.
+- Keep actual persona turns on the existing persona websocket path.
+- Keep V1 honest about browser and extension lifecycle limits.
+- Preserve a clean extension point for a future native/local companion.
+- Avoid automatic background listening in V1.
+
+## Non-Goals
+
+- Do not add server-side always-on audio streaming for wake detection.
+- Do not add a separate wake phrase model in V1.
+- Do not create a second persona or assistant runtime.
+- Do not make wake listening start automatically when the app or extension starts.
+- Do not solve native packaging, platform startup, or OS-level microphone permissions in V1.
+- Do not make generic `/api/v1/audio/*` voice chat a persona wake runtime.
+
+## Existing Context
+
+The current backend already has a persona live voice path:
+
+- `/api/v1/persona/stream` accepts persona websocket traffic.
+- `voice_config` stores session-scoped live voice runtime preferences.
+- `audio_chunk` feeds persona live STT and VAD.
+- `voice_commit` and VAD auto-commit route spoken turns through the persona turn flow.
+- Server-side trigger phrase gating strips configured trigger phrases before creating a persona turn.
+- Persona turns use existing policy, scope, memory, tool planning, assistant deltas, TTS, and analytics.
+
+The current persona profile schema already includes `voice_chat_trigger_phrases` under persona voice defaults. Those phrases should be reused as wake phrases in V1. Wake arming should use the selected persona profile's saved trigger phrases only; it should not invent global fallback wake phrases.
+
+## Key Design Decisions
+
+### 1. Wake Detection Is Client/Device Side
+
+V1 wake detection happens in the active frontend or extension surface, not on the server.
+
+This means the backend does not receive continuous pre-wake microphone audio. The frontend only opens or activates the normal persona voice flow after local wake detection.
+
+### 2. Manual Session Arming Only
+
+Wake listening starts only after the user explicitly arms it in Persona Live.
+
+Disarming, leaving the route, closing the session, switching personas, losing microphone permission, or auth failure must stop wake listening. V1 must never auto-arm based only on saved persona defaults.
+
+### 3. Reuse `voice_chat_trigger_phrases`
+
+V1 treats existing persona trigger phrases as wake phrases.
+
+This keeps the mental model simple:
+
+- The same phrase wakes the persona locally.
+- The same phrase remains the server-side guard for non-wake voice commits.
+
+Separate wake phrases can be added later if the native companion needs richer routing, but V1 should avoid that extra model.
+
+### 4. Add A WakeDetector Interface
+
+The frontend should define a detector abstraction instead of binding Persona Live directly to one browser API.
+
+The first implementation is `BrowserTranscriptWakeDetector`, which listens in the active browser context and matches normalized transcript text against the configured trigger phrases.
+
+Future implementations can include:
+
+- a native/local companion bridge
+- a dedicated wake-word model
+- an extension-specific offscreen-document detector where supported
+
+### 5. Persona Profiles Own Default Wake Behavior
+
+Each persona should store a default post-wake behavior under voice defaults:
+
+- `one_shot`
+- `continuous`
+- `push_to_talk_after_wake`
+
+The current live session can override the behavior temporarily, but that override should not persist unless the user explicitly saves it in profile settings.
+
+## Data Model
+
+Extend `PersonaVoiceDefaults` with:
+
+```python
+wake_behavior: Literal["one_shot", "continuous", "push_to_talk_after_wake"] | None
+```
+
+Default resolution should be:
+
+1. explicit persona `voice_defaults.wake_behavior`
+2. fixed fallback of `one_shot`
+
+The field is nullable so existing profiles remain valid and so unsaved profiles can inherit the product default.
+
+Do not add separate `wake_phrases` in V1. Continue to use `voice_chat_trigger_phrases`.
+
+## Frontend Components
+
+### WakeDetector Interface
+
+The interface should be small and implementation-neutral:
+
+```ts
+type WakeDetectorState =
+  | "idle"
+  | "starting"
+  | "listening"
+  | "detected"
+  | "unavailable"
+  | "error";
+
+interface WakeDetector {
+  isAvailable(): Promise<boolean>;
+  start(config: WakeDetectorConfig): Promise<void>;
+  stop(): Promise<void>;
+}
+
+interface WakeDetectorConfig {
+  phrases: string[];
+  locale?: string;
+  onWake: (event: WakeDetectedEvent) => void;
+  onStateChange?: (state: WakeDetectorState) => void;
+  onError?: (error: WakeDetectorError) => void;
+}
+```
+
+`WakeDetectedEvent` should include the matched phrase, the heard transcript if available, a timestamp, and the detector kind. The heard transcript is diagnostic in V1; it should not directly become a persona turn.
+
+### BrowserTranscriptWakeDetector
+
+The V1 detector should:
+
+- normalize phrase and transcript text before matching
+- ignore empty phrase lists
+- debounce repeated wake events while a turn is active
+- expose unavailable/error states without breaking normal Persona Live
+- stop cleanly on disarm or route/session teardown
+
+The implementation can use browser speech recognition where available. The UI must describe it as browser/device-side wake listening, not guaranteed offline recognition, because browser speech APIs vary by platform and may use browser-managed services.
+
+### Persona Live Controller
+
+`usePersonaLiveVoiceController` should own:
+
+- `armedForWake`
+- detector availability
+- detector state
+- wake behavior for the current session
+- wake activation handoff into the existing live voice flow
+
+The controller should not create a second persona session manager. It should continue to use the existing persona websocket session for actual turns.
+
+### Persona Live UI
+
+The Live UI should add:
+
+- an explicit `Listen for wake phrase` arm/disarm control
+- visible armed/listening/detected/error state
+- current wake phrases
+- a blocked state when no trigger phrases are configured
+- a session-local wake behavior selector
+- a clear indication that V1 wake listening works only while the Persona Live surface is active
+
+Profile settings should add the persistent default wake behavior near existing voice defaults.
+
+## Runtime Flow
+
+### Arming
+
+1. User opens Persona Live and selects a persona.
+2. UI resolves voice defaults and trigger phrases.
+3. User toggles `Listen for wake phrase`.
+4. If there are no trigger phrases, arming is blocked.
+5. If the detector is unavailable, UI shows a recoverable unavailable state.
+6. If available, the detector starts and the UI shows an armed/listening state.
+
+### Wake Detection
+
+1. Detector hears a transcript locally.
+2. Detector matches one configured trigger phrase.
+3. Controller debounces duplicate detections.
+4. Controller ensures the persona websocket session is connected.
+5. Controller sends or refreshes `voice_config`.
+6. Controller sends a `wake_activation` frame with the matched phrase, detector kind, timestamp, and selected wake behavior.
+7. Controller applies the current wake behavior.
+
+### Wake Activation Frame
+
+Add a small persona websocket frame for V1:
+
+```json
+{
+  "type": "wake_activation",
+  "session_id": "<persona-session-id>",
+  "matched_phrase": "hey helper",
+  "detector_kind": "browser_transcript",
+  "wake_behavior": "one_shot",
+  "detected_at_ms": 1714500000000
+}
+```
+
+The server should store this as session-local runtime state. It is not a persisted memory, not a command, and not an authorization grant.
+
+The server should accept `wake_activation` only when all of these are true:
+
+- `session_id` normalizes to an existing or creatable session for the authenticated user.
+- `wake_behavior` is one of `one_shot`, `continuous`, or `push_to_talk_after_wake`.
+- `matched_phrase` is non-empty.
+- `matched_phrase` matches one of the current session `voice_runtime.trigger_phrases`.
+
+If validation fails, the server should emit a non-fatal `WAKE_ACTIVATION_REJECTED` notice and leave trigger phrase gating unchanged.
+
+While a valid wake activation is active, the next committed voice turn does not need to contain the trigger phrase. This is required because pre-wake audio stays local and the post-wake server transcript normally starts after the wake phrase. Outside an active wake activation, existing server-side trigger phrase gating still applies.
+
+For `one_shot` and `push_to_talk_after_wake`, the wake activation expires after the next successful committed turn, after a short no-command timeout, or when the user disarms/stops the session. The no-command timeout should default to 30 seconds and be configurable. For `continuous`, the wake activation remains active until the user stops live voice, disarms wake mode, switches personas, or the session closes.
+
+The local detector transcript remains diagnostic. V1 captures the user command after wake activation through the existing persona live STT/VAD or manual send flow, so users may need a short post-wake pause or cue before speaking the command.
+
+### Wake Deactivation Frame
+
+Add a matching explicit deactivation frame:
+
+```json
+{
+  "type": "wake_deactivation",
+  "session_id": "<persona-session-id>",
+  "reason": "disarmed"
+}
+```
+
+Allowed reasons should include `disarmed`, `stop_live_voice`, `persona_switch`, `route_leave`, and `session_close`.
+
+The frontend should send `wake_deactivation` before disarming, stopping live voice, switching personas, or leaving the route when the websocket is still open. The server should also clear wake activation state during websocket cleanup, even if no deactivation frame arrives.
+
+### Post-Wake Behaviors
+
+`one_shot`:
+
+- Capture the post-wake utterance.
+- Send one turn through the existing persona voice path.
+- Return to wake listening after the assistant turn completes if the session remains armed.
+
+`continuous`:
+
+- Enter the normal Persona Live voice loop after wake.
+- Keep listening and auto-committing until the user stops live voice, disarms wake mode, or the session ends.
+- Send `wake_deactivation` before returning to armed-idle or closed state while the websocket remains open.
+
+`push_to_talk_after_wake`:
+
+- Wake opens or focuses the session.
+- UI exposes manual listen/send controls.
+- Continuous microphone capture does not start automatically after wake.
+
+## Backend Responsibilities
+
+The backend should remain additive:
+
+- Validate and persist `voice_defaults.wake_behavior`.
+- Return the resolved/saved field in persona profile responses.
+- Accept `wake_activation` websocket frames and store active wake state in session-local runtime preferences.
+- Accept `wake_deactivation` websocket frames and clear active wake state for the session.
+- Keep existing server-side trigger phrase gating on committed transcripts when no wake activation is active.
+- Let active wake state bypass trigger phrase gating only for the scoped post-wake behavior window.
+- Keep persona policy, scope, tool planning, memory, and TTS behavior unchanged.
+
+The server should not authorize actions based on `wake_behavior` or `wake_activation`. They are UI/runtime behavior settings, not permission grants.
+
+## Native Companion Compatibility
+
+The future companion should call the same conceptual activation contract:
+
+- persona id
+- session id or request to create/focus a session
+- matched phrase
+- detector kind
+- timestamp
+- desired wake behavior
+
+The frontend can initially handle this through an internal controller method that sends the persona websocket `wake_activation` frame. If a companion is added later, that method can be exposed through a local bridge without changing the persona profile data model.
+
+## Error Handling
+
+- No trigger phrases: block arming and provide a setup path to voice defaults.
+- Detector unavailable: show wake listening unavailable; normal Persona Live remains usable.
+- Microphone permission denied: stop detector and show a permission error.
+- Wake detected while a turn is active: ignore or debounce the duplicate wake.
+- Websocket connect failure after wake: show a recoverable connection error and return to armed-idle or disarmed state based on controller policy.
+- Server rejects the committed transcript because no trigger phrase remains and no wake activation is active: show the existing ignored/no-command notice and return to wake listening if still armed.
+- Server rejects `wake_activation`: keep normal trigger phrase gating, show a recoverable wake activation error, and return to armed wake listening if still armed.
+- Wake activation expires before the post-wake utterance is committed: return to armed wake listening and require a fresh wake phrase.
+- Persona switch: stop detector before changing active persona/session state.
+- Route leave or session close: stop detector and release microphone resources.
+
+## Privacy And Security
+
+V1 must be explicit that wake listening is manually armed and active only while the Persona Live surface is active.
+
+Privacy requirements:
+
+- No automatic arming.
+- No pre-wake audio sent to the tldw server.
+- Visible armed/listening state.
+- Stop detector on teardown and permission loss.
+- Do not persist raw wake transcripts unless they become normal persona turns after the persona voice turn path accepts them.
+
+Security requirements:
+
+- Existing persona websocket auth remains authoritative.
+- Server-side trigger phrase gating remains a guard outside active wake windows.
+- `wake_behavior` and `wake_activation` must not bypass persona policy or scope rules.
+- The native companion design must not embed long-lived secrets in detector events.
+
+## Testing Strategy
+
+Backend:
+
+- `PersonaVoiceDefaults` accepts valid `wake_behavior` values.
+- invalid `wake_behavior` values are rejected.
+- profile create/update/read preserves `wake_behavior`.
+- existing profiles without `wake_behavior` still validate.
+- websocket `wake_activation` allows the next post-wake voice turn to omit the trigger phrase.
+- invalid `wake_activation` frames are rejected without disabling trigger phrase gating.
+- websocket `wake_deactivation` clears continuous wake activation while the socket stays open.
+- websocket trigger phrase gating still rejects transcripts without trigger phrases when no wake activation is active.
+- `one_shot` wake activation expires after one committed voice turn.
+- `continuous` wake activation expires on explicit stop/disarm/session close.
+- persona websocket behavior remains unchanged for typed and spoken turns.
+
+Frontend:
+
+- `BrowserTranscriptWakeDetector` normalizes and matches configured phrases.
+- detector reports unavailable when the browser API is absent.
+- arming is blocked when no trigger phrases are configured.
+- disarm stops the detector.
+- persona switch stops the detector and reloads phrases.
+- duplicate wake events are debounced while a turn is active.
+- wake activation sends a `wake_activation` frame before post-wake capture starts.
+- wake listening suspends during post-wake Persona Live microphone capture to avoid microphone contention and duplicate wake events.
+- wake deactivation sends a `wake_deactivation` frame before continuous active mode is stopped while the socket remains open.
+- `one_shot` returns to armed wake listening after completion.
+- `continuous` enters the live voice loop after wake.
+- `push_to_talk_after_wake` focuses the session without starting continuous capture.
+- profile settings persist the default wake behavior.
+
+E2E or smoke:
+
+- active Persona Live session can be armed.
+- wake phrase detection activates a persona turn.
+- browser unsupported state degrades cleanly.
+- route leave stops armed listening.
+
+## Rollout Plan
+
+1. Add backend schema and persistence for `wake_behavior`.
+2. Add the frontend `WakeDetector` interface and detector unit tests.
+3. Implement `BrowserTranscriptWakeDetector`.
+4. Add Persona Live manual arm/disarm UI and blocked/unavailable states.
+5. Wire wake activation into the existing persona live voice controller.
+6. Add profile editor support for default wake behavior.
+7. Add focused backend, frontend, and smoke coverage.
+8. Document V1 limitations and the future native companion integration point.
+
+## Open Implementation Notes
+
+- The implementation plan should inspect current frontend file names before assigning exact paths, because the repository has both current app routes and historical design docs for Persona Garden.
+- The first shipping detector should be feature-detected at runtime rather than assumed available.
+- The UI should avoid calling V1 "true background always-on" because browser and extension lifecycles cannot guarantee that behavior.

--- a/Docs/superpowers/specs/2026-04-30-persona-wake-word-support-design.md
+++ b/Docs/superpowers/specs/2026-04-30-persona-wake-word-support-design.md
@@ -106,6 +106,8 @@ The field is nullable so existing profiles remain valid and so unsaved profiles 
 
 Do not add separate `wake_phrases` in V1. Continue to use `voice_chat_trigger_phrases`.
 
+Wake arming must use the raw saved persona profile phrases, not the broader resolved Persona Live defaults. Existing non-wake Persona Live behavior may continue to use fallback trigger phrases if that is already supported, but wake mode must not arm from global voice-chat fallback phrases.
+
 ## Frontend Components
 
 ### WakeDetector Interface
@@ -136,7 +138,7 @@ interface WakeDetectorConfig {
 }
 ```
 
-`WakeDetectedEvent` should include the matched phrase, the heard transcript if available, a timestamp, and the detector kind. The heard transcript is diagnostic in V1; it should not directly become a persona turn.
+`WakeDetectedEvent` should include the canonical configured phrase that matched, the heard transcript if available, a timestamp, and the detector kind. The heard transcript is diagnostic in V1; it should not directly become a persona turn.
 
 ### BrowserTranscriptWakeDetector
 
@@ -162,6 +164,8 @@ The implementation can use browser speech recognition where available. The UI mu
 
 The controller should not create a second persona session manager. It should continue to use the existing persona websocket session for actual turns.
 
+Wake mode should pass the controller a separate `wakeTriggerPhrases` value derived from `profile.voice_defaults.voice_chat_trigger_phrases`. Do not derive wake arming from `resolvedDefaults.voiceChatTriggerPhrases`, because that value may include global fallback phrases used by ordinary live voice.
+
 ### Persona Live UI
 
 The Live UI should add:
@@ -180,7 +184,7 @@ Profile settings should add the persistent default wake behavior near existing v
 ### Arming
 
 1. User opens Persona Live and selects a persona.
-2. UI resolves voice defaults and trigger phrases.
+2. UI resolves live voice defaults and separately reads saved persona wake trigger phrases.
 3. User toggles `Listen for wake phrase`.
 4. If there are no trigger phrases, arming is blocked.
 5. If the detector is unavailable, UI shows a recoverable unavailable state.
@@ -192,8 +196,8 @@ Profile settings should add the persistent default wake behavior near existing v
 2. Detector matches one configured trigger phrase.
 3. Controller debounces duplicate detections.
 4. Controller ensures the persona websocket session is connected.
-5. Controller sends or refreshes `voice_config`.
-6. Controller sends a `wake_activation` frame with the matched phrase, detector kind, timestamp, and selected wake behavior.
+5. Controller sends or refreshes `voice_config` with the saved persona wake trigger phrases for this wake-armed session.
+6. Controller sends a `wake_activation` frame with the canonical matched phrase, detector kind, timestamp, and selected wake behavior.
 7. Controller applies the current wake behavior.
 
 ### Wake Activation Frame
@@ -215,10 +219,14 @@ The server should store this as session-local runtime state. It is not a persist
 
 The server should accept `wake_activation` only when all of these are true:
 
-- `session_id` normalizes to an existing or creatable session for the authenticated user.
+- `session_id` normalizes to an existing session for the authenticated user.
+- The session has current `voice_runtime.trigger_phrases` from a prior `voice_config`.
+- The server can resolve the session's persona profile for the authenticated user.
 - `wake_behavior` is one of `one_shot`, `continuous`, or `push_to_talk_after_wake`.
 - `matched_phrase` is non-empty.
-- `matched_phrase` matches one of the current session `voice_runtime.trigger_phrases`.
+- `matched_phrase` is the canonical configured phrase after detector normalization, not the raw recognized text.
+- `matched_phrase` matches one of the saved persona profile `voice_defaults.voice_chat_trigger_phrases`.
+- `matched_phrase` is also present in the current session `voice_runtime.trigger_phrases`, so the active runtime state and saved persona wake phrases agree.
 
 If validation fails, the server should emit a non-fatal `WAKE_ACTIVATION_REJECTED` notice and leave trigger phrase gating unchanged.
 
@@ -269,9 +277,10 @@ The frontend should send `wake_deactivation` before disarming, stopping live voi
 The backend should remain additive:
 
 - Validate and persist `voice_defaults.wake_behavior`.
-- Return the resolved/saved field in persona profile responses.
+- Return the saved nullable `voice_defaults.wake_behavior` in persona profile responses; frontend resolution applies the `one_shot` fallback.
 - Accept `wake_activation` websocket frames and store active wake state in session-local runtime preferences.
 - Accept `wake_deactivation` websocket frames and clear active wake state for the session.
+- Validate wake activation phrases against the saved persona profile, not only client-supplied `voice_config`.
 - Keep existing server-side trigger phrase gating on committed transcripts when no wake activation is active.
 - Let active wake state bypass trigger phrase gating only for the scoped post-wake behavior window.
 - Keep persona policy, scope, tool planning, memory, and TTS behavior unchanged.
@@ -333,6 +342,7 @@ Backend:
 - existing profiles without `wake_behavior` still validate.
 - websocket `wake_activation` allows the next post-wake voice turn to omit the trigger phrase.
 - invalid `wake_activation` frames are rejected without disabling trigger phrase gating.
+- `wake_activation` is rejected when `matched_phrase` exists only in client-supplied runtime config and not in saved persona profile trigger phrases.
 - websocket `wake_deactivation` clears continuous wake activation while the socket stays open.
 - websocket trigger phrase gating still rejects transcripts without trigger phrases when no wake activation is active.
 - `one_shot` wake activation expires after one committed voice turn.

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
@@ -11,6 +11,7 @@ import {
 import {
   PERSONA_TURN_DETECTION_BALANCED_DEFAULTS,
   type PersonaConfirmationMode,
+  type PersonaWakeBehavior,
   type PersonaVoiceDefaults,
   useResolvedPersonaVoiceDefaults
 } from "@/hooks/useResolvedPersonaVoiceDefaults"
@@ -42,6 +43,7 @@ type AssistantDefaultsFormState = {
   ttsProvider: string
   ttsVoice: string
   confirmationMode: PersonaConfirmationMode
+  wakeBehavior: PersonaWakeBehavior
   triggerPhrasesText: string
   autoResume: boolean | null
   bargeIn: boolean | null
@@ -58,6 +60,7 @@ const DEFAULT_FORM_STATE: AssistantDefaultsFormState = {
   ttsProvider: "",
   ttsVoice: "",
   confirmationMode: "destructive_only",
+  wakeBehavior: "one_shot",
   triggerPhrasesText: "",
   autoResume: null,
   bargeIn: null,
@@ -92,6 +95,7 @@ const buildFormState = (
   ttsProvider: normalizeText(voiceDefaults?.tts_provider),
   ttsVoice: normalizeText(voiceDefaults?.tts_voice),
   confirmationMode: voiceDefaults?.confirmation_mode || "destructive_only",
+  wakeBehavior: voiceDefaults?.wake_behavior || "one_shot",
   triggerPhrasesText: (voiceDefaults?.voice_chat_trigger_phrases || []).join("\n"),
   autoResume:
     typeof voiceDefaults?.auto_resume === "boolean"
@@ -129,6 +133,7 @@ const buildPayload = (
   tts_provider: normalizeText(formState.ttsProvider) || null,
   tts_voice: normalizeText(formState.ttsVoice) || null,
   confirmation_mode: formState.confirmationMode,
+  wake_behavior: formState.wakeBehavior,
   voice_chat_trigger_phrases: normalizePhrases(formState.triggerPhrasesText),
   auto_resume: formState.autoResume,
   barge_in: formState.bargeIn,
@@ -471,6 +476,29 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
           </select>
         </label>
 
+        <label className="flex flex-col gap-1 text-sm text-text">
+          <span>
+            {t("sidepanel:personaGarden.profile.assistantDefaults.wakeBehavior", {
+              defaultValue: "Wake behavior"
+            })}
+          </span>
+          <select
+            id="persona-assistant-defaults-wake-behavior"
+            className="rounded-md border border-border bg-surface2 px-3 py-2 text-sm text-text"
+            value={formState.wakeBehavior}
+            onChange={(event) =>
+              updateField("wakeBehavior", event.target.value as PersonaWakeBehavior)
+            }
+            disabled={!selectedPersonaId || loading || saving}
+          >
+            <option value="one_shot">One turn after wake</option>
+            <option value="continuous">Continuous after wake</option>
+            <option value="push_to_talk_after_wake">
+              Push to talk after wake
+            </option>
+          </select>
+        </label>
+
         <div className="flex flex-col gap-3 rounded-md border border-border bg-surface2 px-3 py-2 text-sm text-text">
           <label className="flex flex-col gap-1">
             <span>
@@ -609,6 +637,10 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
           <div>
             <dt className="text-xs text-text-muted">Confirmation mode</dt>
             <dd>{resolvedDefaults.confirmationMode}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-text-muted">Wake behavior</dt>
+            <dd>{resolvedDefaults.wakeBehavior}</dd>
           </div>
           <div>
             <dt className="text-xs text-text-muted">Auto-resume</dt>

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
@@ -476,7 +476,10 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
           </select>
         </label>
 
-        <label className="flex flex-col gap-1 text-sm text-text">
+        <label
+          htmlFor="persona-assistant-defaults-wake-behavior"
+          className="flex flex-col gap-1 text-sm text-text"
+        >
           <span>
             {t("sidepanel:personaGarden.profile.assistantDefaults.wakeBehavior", {
               defaultValue: "Wake behavior"

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
@@ -1,11 +1,15 @@
 import React from "react"
-import { Button, Checkbox, Tag, Typography } from "antd"
+import { Alert, Button, Checkbox, Select, Tag, Typography } from "antd"
 
 import {
   PersonaTurnDetectionControls,
   type PersonaTurnDetectionPreset
 } from "@/components/PersonaGarden/PersonaTurnDetectionControls"
-import type { ResolvedPersonaVoiceDefaults } from "@/hooks/useResolvedPersonaVoiceDefaults"
+import type { WakeDetectorState } from "@/hooks/personaWakeDetector"
+import type {
+  PersonaWakeBehavior,
+  ResolvedPersonaVoiceDefaults
+} from "@/hooks/useResolvedPersonaVoiceDefaults"
 import type {
   PersonaLiveVoiceRecoveryMode,
   PersonaLiveVoiceState
@@ -30,6 +34,11 @@ type AssistantVoiceCardProps = {
   savingCurrentSettingsAsDefaults?: boolean
   sessionAutoResume: boolean
   sessionBargeIn: boolean
+  wakeArmed?: boolean
+  wakeDetectorState?: WakeDetectorState
+  wakeWarning?: string | null
+  wakeTriggerPhrases?: string[]
+  sessionWakeBehavior?: PersonaWakeBehavior
   autoCommitEnabled?: boolean
   vadPreset?: PersonaTurnDetectionPreset
   vadThreshold?: number
@@ -40,6 +49,8 @@ type AssistantVoiceCardProps = {
   onSendNow: () => void
   onSessionAutoResumeChange: (next: boolean) => void
   onSessionBargeInChange: (next: boolean) => void
+  onToggleWakeArmed?: () => void
+  onSessionWakeBehaviorChange?: (next: PersonaWakeBehavior) => void
   onAutoCommitEnabledChange?: (next: boolean) => void
   onVadPresetChange?: (next: Exclude<PersonaTurnDetectionPreset, "custom">) => void
   onVadThresholdChange?: (next: number) => void
@@ -77,6 +88,11 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
   savingCurrentSettingsAsDefaults = false,
   sessionAutoResume,
   sessionBargeIn,
+  wakeArmed = false,
+  wakeDetectorState = "idle",
+  wakeWarning = null,
+  wakeTriggerPhrases = [],
+  sessionWakeBehavior = "one_shot",
   autoCommitEnabled = true,
   vadPreset = "balanced",
   vadThreshold = 0.5,
@@ -87,6 +103,8 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
   onSendNow,
   onSessionAutoResumeChange,
   onSessionBargeInChange,
+  onToggleWakeArmed = () => undefined,
+  onSessionWakeBehaviorChange = () => undefined,
   onAutoCommitEnabledChange = () => undefined,
   onVadPresetChange = () => undefined,
   onVadThresholdChange = () => undefined,
@@ -102,6 +120,13 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
   onReconnectPersonaSession
 }) => {
   const sessionControlsDisabled = !connected
+  const normalizedWakeTriggerPhrases = React.useMemo(
+    () =>
+      (wakeTriggerPhrases || [])
+        .map((phrase) => String(phrase || "").trim())
+        .filter(Boolean),
+    [wakeTriggerPhrases]
+  )
   const turnDetectionDisabled = sessionControlsDisabled || manualModeRequired
   const turnDetectionHelperText = !connected
     ? "Connect to tune live turn detection for this session."
@@ -187,6 +212,62 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
         >
           Barge-in (session only)
         </Checkbox>
+      </div>
+
+      <div className="mt-3 rounded-md border border-border bg-surface2 p-3 text-xs text-text">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <Typography.Text strong>Wake phrase</Typography.Text>
+            <Typography.Text type="secondary" className="mt-1 block text-xs">
+              Active only while this Persona Live surface is open.
+            </Typography.Text>
+          </div>
+          <Button
+            data-testid="live-wake-toggle"
+            size="small"
+            type={wakeArmed ? "default" : "primary"}
+            disabled={
+              sessionControlsDisabled || normalizedWakeTriggerPhrases.length === 0
+            }
+            onClick={onToggleWakeArmed}
+          >
+            {wakeArmed ? "Stop wake listening" : "Listen for wake phrase"}
+          </Button>
+        </div>
+        <div className="mt-2 grid gap-2 sm:grid-cols-3">
+          <div>
+            <div className="text-text-muted">Saved wake phrases</div>
+            <div data-testid="live-wake-phrases">
+              {normalizedWakeTriggerPhrases.length > 0
+                ? normalizedWakeTriggerPhrases.join(", ")
+                : "Add a trigger phrase in voice defaults."}
+            </div>
+          </div>
+          <div>
+            <div className="text-text-muted">Wake state</div>
+            <div data-testid="live-wake-state">
+              {wakeArmed ? wakeDetectorState : "idle"}
+            </div>
+          </div>
+          <div>
+            <div className="text-text-muted">After wake</div>
+            <Select
+              data-testid="live-wake-behavior"
+              size="small"
+              value={sessionWakeBehavior}
+              disabled={sessionControlsDisabled}
+              onChange={onSessionWakeBehaviorChange}
+              options={[
+                { value: "one_shot", label: "One turn" },
+                { value: "continuous", label: "Continuous" },
+                { value: "push_to_talk_after_wake", label: "Push to talk" }
+              ]}
+            />
+          </div>
+        </div>
+        {wakeWarning ? (
+          <Alert className="mt-2" type="warning" showIcon message={wakeWarning} />
+        ) : null}
       </div>
 
       <PersonaTurnDetectionControls

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
@@ -91,8 +91,8 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
   wakeArmed = false,
   wakeDetectorState = "idle",
   wakeWarning = null,
-  wakeTriggerPhrases = [],
-  sessionWakeBehavior = "one_shot",
+  wakeTriggerPhrases,
+  sessionWakeBehavior,
   autoCommitEnabled = true,
   vadPreset = "balanced",
   vadThreshold = 0.5,
@@ -120,12 +120,16 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
   onReconnectPersonaSession
 }) => {
   const sessionControlsDisabled = !connected
+  const effectiveWakeTriggerPhrases =
+    wakeTriggerPhrases ?? resolvedDefaults.voiceChatTriggerPhrases
+  const effectiveSessionWakeBehavior =
+    sessionWakeBehavior ?? resolvedDefaults.wakeBehavior
   const normalizedWakeTriggerPhrases = React.useMemo(
     () =>
-      (wakeTriggerPhrases || [])
+      (effectiveWakeTriggerPhrases || [])
         .map((phrase) => String(phrase || "").trim())
         .filter(Boolean),
-    [wakeTriggerPhrases]
+    [effectiveWakeTriggerPhrases]
   )
   const turnDetectionDisabled = sessionControlsDisabled || manualModeRequired
   const turnDetectionHelperText = !connected
@@ -254,7 +258,7 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
             <Select
               data-testid="live-wake-behavior"
               size="small"
-              value={sessionWakeBehavior}
+              value={effectiveSessionWakeBehavior}
               disabled={sessionControlsDisabled}
               onChange={onSessionWakeBehaviorChange}
               options={[

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
@@ -294,6 +294,10 @@ describe("AssistantDefaultsPanel", () => {
       expect(screen.getByLabelText("STT language")).toHaveValue("en-US")
       expect(screen.getByLabelText("STT model")).toHaveValue("whisper-1")
       expect(screen.getByLabelText("Wake behavior")).toHaveValue("continuous")
+      expect(screen.getByLabelText("Wake behavior").closest("label")).toHaveAttribute(
+        "for",
+        "persona-assistant-defaults-wake-behavior"
+      )
     })
     expect(screen.getByText("Turn detection defaults")).toBeInTheDocument()
     expect(screen.getByTestId("assistant-defaults-vad-auto-commit")).toBeChecked()

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     ttsVoice: "af_heart",
     confirmationMode: "destructive_only" as const,
     voiceChatTriggerPhrases: ["hey helper"],
+    wakeBehavior: "one_shot" as const,
     autoResume: true,
     bargeIn: false,
     autoCommitEnabled: true,
@@ -81,6 +82,12 @@ vi.mock("@/hooks/useResolvedPersonaVoiceDefaults", () => ({
     voiceChatTriggerPhrases: Array.isArray(voiceDefaults?.voice_chat_trigger_phrases)
       ? voiceDefaults.voice_chat_trigger_phrases.map((phrase) => String(phrase))
       : mocks.resolvedDefaults.voiceChatTriggerPhrases,
+    wakeBehavior:
+      voiceDefaults?.wake_behavior === "continuous" ||
+      voiceDefaults?.wake_behavior === "push_to_talk_after_wake" ||
+      voiceDefaults?.wake_behavior === "one_shot"
+        ? voiceDefaults.wake_behavior
+        : mocks.resolvedDefaults.wakeBehavior,
     autoResume:
       typeof voiceDefaults?.auto_resume === "boolean"
         ? voiceDefaults.auto_resume
@@ -209,6 +216,7 @@ describe("AssistantDefaultsPanel", () => {
       ttsVoice: "af_heart",
       confirmationMode: "destructive_only",
       voiceChatTriggerPhrases: ["hey helper"],
+      wakeBehavior: "one_shot",
       autoResume: true,
       bargeIn: false,
       autoCommitEnabled: true,
@@ -233,6 +241,7 @@ describe("AssistantDefaultsPanel", () => {
               tts_voice: "af_heart",
               confirmation_mode: "destructive_only",
               voice_chat_trigger_phrases: ["hey helper"],
+              wake_behavior: "continuous",
               auto_resume: true,
               barge_in: false,
               auto_commit_enabled: true,
@@ -284,6 +293,7 @@ describe("AssistantDefaultsPanel", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("STT language")).toHaveValue("en-US")
       expect(screen.getByLabelText("STT model")).toHaveValue("whisper-1")
+      expect(screen.getByLabelText("Wake behavior")).toHaveValue("continuous")
     })
     expect(screen.getByText("Turn detection defaults")).toBeInTheDocument()
     expect(screen.getByTestId("assistant-defaults-vad-auto-commit")).toBeChecked()
@@ -311,6 +321,9 @@ describe("AssistantDefaultsPanel", () => {
     })
     fireEvent.change(screen.getByLabelText("Trigger phrases"), {
       target: { value: "bonjour helper\nhey garden, start research" }
+    })
+    fireEvent.change(screen.getByLabelText("Wake behavior"), {
+      target: { value: "push_to_talk_after_wake" }
     })
     fireEvent.change(screen.getByLabelText("Auto-resume"), {
       target: { value: "false" }
@@ -353,6 +366,7 @@ describe("AssistantDefaultsPanel", () => {
                 "bonjour helper",
                 "hey garden, start research"
               ],
+              wake_behavior: "push_to_talk_after_wake",
               auto_resume: false,
               barge_in: true,
               auto_commit_enabled: false,

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
@@ -13,6 +13,7 @@ const createResolvedDefaults = (): React.ComponentProps<
     ttsProvider: "openai",
     ttsVoice: "alloy",
     confirmationMode: "destructive_only",
+    wakeBehavior: "one_shot",
     voiceChatTriggerPhrases: ["hey helper"],
     autoResume: true,
     bargeIn: false,
@@ -40,6 +41,11 @@ const defaultVoiceCardProps = (): React.ComponentProps<typeof AssistantVoiceCard
   textOnlyDueToTtsFailure: false,
   sessionAutoResume: true,
   sessionBargeIn: false,
+  wakeArmed: false,
+  wakeDetectorState: "idle",
+  wakeWarning: null,
+  wakeTriggerPhrases: ["hey helper"],
+  sessionWakeBehavior: "one_shot",
   autoCommitEnabled: true,
   vadPreset: "balanced",
   vadThreshold: 0.5,
@@ -50,6 +56,8 @@ const defaultVoiceCardProps = (): React.ComponentProps<typeof AssistantVoiceCard
   onSendNow: vi.fn(),
   onSessionAutoResumeChange: vi.fn(),
   onSessionBargeInChange: vi.fn(),
+  onToggleWakeArmed: vi.fn(),
+  onSessionWakeBehaviorChange: vi.fn(),
   onAutoCommitEnabledChange: vi.fn(),
   onVadPresetChange: vi.fn(),
   onVadThresholdChange: vi.fn(),
@@ -138,6 +146,30 @@ describe("AssistantVoiceCard", () => {
 
     fireEvent.click(screen.getByTestId("live-vad-preset-fast"))
     expect(props.onVadPresetChange).toHaveBeenCalledWith("fast")
+  })
+
+  it("renders wake phrase controls and current saved wake phrases", () => {
+    const props = defaultVoiceCardProps()
+
+    render(<AssistantVoiceCard {...props} />)
+
+    expect(screen.getByTestId("live-wake-toggle")).toHaveTextContent(
+      /listen for wake phrase/i
+    )
+    expect(screen.getByTestId("live-wake-phrases")).toHaveTextContent("hey helper")
+
+    fireEvent.click(screen.getByTestId("live-wake-toggle"))
+    expect(props.onToggleWakeArmed).toHaveBeenCalledTimes(1)
+  })
+
+  it("blocks wake toggle display when no saved wake phrases are configured", () => {
+    const props = defaultVoiceCardProps()
+    props.wakeTriggerPhrases = []
+
+    render(<AssistantVoiceCard {...props} />)
+
+    expect(screen.getByTestId("live-wake-toggle")).toBeDisabled()
+    expect(screen.getByText(/add a trigger phrase/i)).toBeInTheDocument()
   })
 
   it("shows the advanced drawer and current runtime values", () => {

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
@@ -162,6 +162,24 @@ describe("AssistantVoiceCard", () => {
     expect(props.onToggleWakeArmed).toHaveBeenCalledTimes(1)
   })
 
+  it("uses resolved wake defaults when session wake props are omitted", () => {
+    const props = defaultVoiceCardProps()
+    props.resolvedDefaults = {
+      ...props.resolvedDefaults,
+      voiceChatTriggerPhrases: ["fallback wake"],
+      wakeBehavior: "continuous"
+    }
+    props.wakeTriggerPhrases = undefined
+    props.sessionWakeBehavior = undefined
+
+    render(<AssistantVoiceCard {...props} />)
+
+    expect(screen.getByTestId("live-wake-phrases")).toHaveTextContent(
+      "fallback wake"
+    )
+    expect(screen.getByTestId("live-wake-behavior")).toHaveTextContent("Continuous")
+  })
+
   it("blocks wake toggle display when no saved wake phrases are configured", () => {
     const props = defaultVoiceCardProps()
     props.wakeTriggerPhrases = []

--- a/apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  BrowserTranscriptWakeDetector,
+  findCanonicalWakePhrase,
+  normalizeWakePhraseText
+} from "../personaWakeDetector"
+
+type MockRecognitionInstance = {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  onresult: ((event: { results: Array<Array<{ transcript: string }>> }) => void) | null
+  onerror: ((event: { error?: string; message?: string }) => void) | null
+  onend: (() => void) | null
+  start: ReturnType<typeof vi.fn>
+  stop: ReturnType<typeof vi.fn>
+}
+
+const installMockRecognition = () => {
+  const instances: MockRecognitionInstance[] = []
+
+  class MockRecognition {
+    continuous = false
+    interimResults = false
+    lang = ""
+    onresult: MockRecognitionInstance["onresult"] = null
+    onerror: MockRecognitionInstance["onerror"] = null
+    onend: MockRecognitionInstance["onend"] = null
+    start = vi.fn()
+    stop = vi.fn()
+
+    constructor() {
+      instances.push(this)
+    }
+  }
+
+  ;(window as any).SpeechRecognition = MockRecognition
+  ;(window as any).webkitSpeechRecognition = undefined
+
+  return {
+    instances,
+    get current() {
+      const instance = instances.at(-1)
+      if (!instance) {
+        throw new Error("Expected SpeechRecognition to be constructed")
+      }
+      return instance
+    }
+  }
+}
+
+describe("personaWakeDetector", () => {
+  afterEach(() => {
+    ;(window as any).SpeechRecognition = undefined
+    ;(window as any).webkitSpeechRecognition = undefined
+  })
+
+  it("normalizes phrase text for matching", () => {
+    expect(normalizeWakePhraseText("  Hey,   Helper! ")).toBe("hey helper")
+  })
+
+  it("matches whole normalized phrase sequences", () => {
+    expect(
+      findCanonicalWakePhrase("um hey helper please wake up", ["Hey Helper"])
+    ).toBe("Hey Helper")
+    expect(findCanonicalWakePhrase("the helper is nearby", ["hey helper"])).toBeNull()
+  })
+
+  it("reports unavailable when SpeechRecognition is absent", async () => {
+    ;(window as any).SpeechRecognition = undefined
+    ;(window as any).webkitSpeechRecognition = undefined
+
+    const detector = new BrowserTranscriptWakeDetector()
+    await expect(detector.isAvailable()).resolves.toBe(false)
+  })
+
+  it("starts browser recognition and emits wake events for matched transcripts", async () => {
+    const recognition = installMockRecognition()
+    const onWake = vi.fn()
+    const onStateChange = vi.fn()
+    const detector = new BrowserTranscriptWakeDetector()
+
+    await detector.start({
+      phrases: ["Hey Helper"],
+      locale: "fr-FR",
+      onWake,
+      onStateChange
+    })
+
+    expect(onStateChange).toHaveBeenNthCalledWith(1, "starting")
+    expect(onStateChange).toHaveBeenNthCalledWith(2, "listening")
+    expect(recognition.current.continuous).toBe(true)
+    expect(recognition.current.interimResults).toBe(true)
+    expect(recognition.current.lang).toBe("fr-FR")
+    expect(recognition.current.start).toHaveBeenCalledTimes(1)
+
+    recognition.current.onresult?.({
+      results: [[{ transcript: "noise hey helper do the thing" }]]
+    })
+
+    expect(onStateChange).toHaveBeenLastCalledWith("detected")
+    expect(onWake).toHaveBeenCalledWith(
+      expect.objectContaining({
+        canonicalPhrase: "Hey Helper",
+        transcript: "noise hey helper do the thing",
+        detectorKind: "browser_transcript"
+      })
+    )
+
+    await detector.stop()
+    expect(recognition.current.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not start recognition when no wake phrases are configured", async () => {
+    const recognition = installMockRecognition()
+    const onStateChange = vi.fn()
+    const detector = new BrowserTranscriptWakeDetector()
+
+    await detector.start({
+      phrases: [" ", ""],
+      onWake: vi.fn(),
+      onStateChange
+    })
+
+    expect(onStateChange).toHaveBeenCalledWith("unavailable")
+    expect(recognition.instances).toHaveLength(0)
+  })
+})

--- a/apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
@@ -134,6 +134,33 @@ describe("personaWakeDetector", () => {
     await detector.stop()
   })
 
+  it("does not restart browser recognition after fatal recognition errors", async () => {
+    const recognition = installMockRecognition()
+    const onError = vi.fn()
+    const onStateChange = vi.fn()
+    const detector = new BrowserTranscriptWakeDetector()
+
+    await detector.start({
+      phrases: ["Hey Helper"],
+      onWake: vi.fn(),
+      onError,
+      onStateChange
+    })
+
+    recognition.current.onerror?.({
+      error: "not-allowed",
+      message: "permission denied"
+    })
+
+    expect(onStateChange).toHaveBeenLastCalledWith("error")
+    expect(onError).toHaveBeenCalledWith({
+      code: "not-allowed",
+      message: "permission denied"
+    })
+    expect(recognition.current.onend).toBeNull()
+    expect(recognition.current.start).toHaveBeenCalledTimes(1)
+  })
+
   it("does not start recognition when no wake phrases are configured", async () => {
     const recognition = installMockRecognition()
     const onStateChange = vi.fn()

--- a/apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
@@ -112,6 +112,25 @@ describe("personaWakeDetector", () => {
     expect(recognition.current.stop).toHaveBeenCalledTimes(1)
   })
 
+  it("restarts browser recognition when it ends while still active", async () => {
+    const recognition = installMockRecognition()
+    const onStateChange = vi.fn()
+    const detector = new BrowserTranscriptWakeDetector()
+
+    await detector.start({
+      phrases: ["Hey Helper"],
+      onWake: vi.fn(),
+      onStateChange
+    })
+
+    recognition.current.onend?.()
+
+    expect(recognition.current.start).toHaveBeenCalledTimes(2)
+    expect(onStateChange).toHaveBeenLastCalledWith("listening")
+
+    await detector.stop()
+  })
+
   it("does not start recognition when no wake phrases are configured", async () => {
     const recognition = installMockRecognition()
     const onStateChange = vi.fn()

--- a/apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts
@@ -110,6 +110,9 @@ describe("personaWakeDetector", () => {
 
     await detector.stop()
     expect(recognition.current.stop).toHaveBeenCalledTimes(1)
+    expect(recognition.current.onresult).toBeNull()
+    expect(recognition.current.onerror).toBeNull()
+    expect(recognition.current.onend).toBeNull()
   })
 
   it("restarts browser recognition when it ends while still active", async () => {

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import type { WakeDetector, WakeDetectorConfig } from "../personaWakeDetector"
 import { usePersonaLiveVoiceController } from "../usePersonaLiveVoiceController"
 
 const hookMocks = vi.hoisted(() => ({
@@ -102,6 +103,7 @@ describe("usePersonaLiveVoiceController", () => {
     ttsProvider: "openai",
     ttsVoice: "alloy",
     confirmationMode: "destructive_only" as const,
+    wakeBehavior: "one_shot" as const,
     voiceChatTriggerPhrases: ["hey helper"],
     autoResume: true,
     bargeIn: false,
@@ -114,6 +116,29 @@ describe("usePersonaLiveVoiceController", () => {
 
   const getSentPayloads = (ws: WebSocket & { send: ReturnType<typeof vi.fn> }) =>
     ws.send.mock.calls.map(([payload]) => JSON.parse(String(payload)))
+
+  const createWakeDetectorHarness = () => {
+    let config: WakeDetectorConfig | null = null
+    const detector: WakeDetector = {
+      isAvailable: vi.fn(async () => true),
+      start: vi.fn(async (nextConfig) => {
+        config = nextConfig
+        nextConfig.onStateChange?.("listening")
+      }),
+      stop: vi.fn(async () => undefined)
+    }
+    return {
+      detector,
+      fireWake: (canonicalPhrase = "hey helper") => {
+        config?.onWake({
+          canonicalPhrase,
+          transcript: `${canonicalPhrase} status`,
+          detectedAtMs: 1714500000000,
+          detectorKind: "browser_transcript"
+        })
+      }
+    }
+  }
 
   it("sends persona-scoped voice_config when the live websocket is connected", async () => {
     const ws = {
@@ -184,6 +209,222 @@ describe("usePersonaLiveVoiceController", () => {
     expect(controller.minSilenceMs).toBe(250)
     expect(controller.turnStopSecs).toBe(0.2)
     expect(controller.minUtteranceSecs).toBe(0.4)
+  })
+
+  it("blocks wake arming when the selected profile has no saved trigger phrases", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: [],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+
+    expect(wakeHarness.detector.start).not.toHaveBeenCalled()
+    expect(result.current.wakeWarning).toMatch(/trigger phrase/i)
+  })
+
+  it("starts the wake detector with raw saved phrases", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+
+    expect(wakeHarness.detector.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phrases: ["hey helper"]
+      })
+    )
+    expect(result.current.wakeArmed).toBe(true)
+    expect(result.current.wakeDetectorState).toBe("listening")
+  })
+
+  it("sends wake activation when the detector hears a configured phrase", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    ;(ws as WebSocket & { send: ReturnType<typeof vi.fn> }).send.mockClear()
+
+    act(() => {
+      wakeHarness.fireWake()
+    })
+
+    expect(getSentPayloads(ws as WebSocket & { send: ReturnType<typeof vi.fn> })).toEqual(
+      expect.arrayContaining([
+        {
+          type: "wake_activation",
+          session_id: "sess-1",
+          matched_phrase: "hey helper",
+          detector_kind: "browser_transcript",
+          wake_behavior: "one_shot",
+          detected_at_ms: 1714500000000
+        }
+      ])
+    )
+  })
+
+  it("sends wake deactivation when wake listening is disarmed", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    ;(ws as WebSocket & { send: ReturnType<typeof vi.fn> }).send.mockClear()
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+
+    expect(getSentPayloads(ws as WebSocket & { send: ReturnType<typeof vi.fn> })).toEqual([
+      {
+        type: "wake_deactivation",
+        session_id: "sess-1",
+        reason: "disarmed"
+      }
+    ])
+    expect(wakeHarness.detector.stop).toHaveBeenCalled()
+    expect(result.current.wakeArmed).toBe(false)
+  })
+
+  it("sends wake deactivation on unmount when wake listening is armed", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result, unmount } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    ;(ws as WebSocket & { send: ReturnType<typeof vi.fn> }).send.mockClear()
+
+    unmount()
+
+    expect(getSentPayloads(ws as WebSocket & { send: ReturnType<typeof vi.fn> })).toEqual([
+      {
+        type: "wake_deactivation",
+        session_id: "sess-1",
+        reason: "route_leave"
+      }
+    ])
+  })
+
+  it("stops the wake detector before live mic capture starts", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    const stopCallsBeforeMic = vi.mocked(wakeHarness.detector.stop).mock.calls.length
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+
+    expect(vi.mocked(wakeHarness.detector.stop).mock.calls.length).toBe(
+      stopCallsBeforeMic + 1
+    )
+    expect(hookMocks.micStart).toHaveBeenCalled()
+    expect(result.current.wakeArmed).toBe(true)
   })
 
   it("marks the preset as custom after an advanced runtime edit", () => {

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -427,6 +427,96 @@ describe("usePersonaLiveVoiceController", () => {
     expect(result.current.wakeArmed).toBe(true)
   })
 
+  it("restarts wake listening after manually stopped mic capture while armed", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    expect(wakeHarness.detector.start).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await result.current.startListening()
+    })
+    await waitFor(() => {
+      expect(result.current.isListening).toBe(true)
+    })
+
+    act(() => {
+      result.current.stopListening()
+    })
+
+    await waitFor(() => {
+      expect(wakeHarness.detector.start).toHaveBeenCalledTimes(2)
+    })
+    expect(result.current.wakeArmed).toBe(true)
+  })
+
+  it("restarts wake listening after push-to-talk wake turn finishes", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+    const pushToTalkDefaults = {
+      ...resolvedDefaults,
+      autoResume: false,
+      wakeBehavior: "push_to_talk_after_wake" as const
+    }
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults: pushToTalkDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    expect(wakeHarness.detector.start).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      wakeHarness.fireWake()
+    })
+
+    act(() => {
+      result.current.handlePayload({
+        event: "notice",
+        reason_code: "TTS_UNAVAILABLE_TEXT_ONLY",
+        message: "text only"
+      })
+    })
+
+    await waitFor(() => {
+      expect(wakeHarness.detector.start).toHaveBeenCalledTimes(2)
+    })
+    expect(result.current.wakeArmed).toBe(true)
+  })
+
   it("marks the preset as custom after an advanced runtime edit", () => {
     const ws = {
       readyState: WebSocket.OPEN,

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -167,7 +167,8 @@ describe("usePersonaLiveVoiceController", () => {
           voice: {
             trigger_phrases: ["hey helper"],
             auto_resume: true,
-            barge_in: false
+            barge_in: false,
+            wake_behavior: "one_shot"
           },
           stt: {
             language: "en-US",
@@ -310,11 +311,50 @@ describe("usePersonaLiveVoiceController", () => {
           session_id: "sess-1",
           matched_phrase: "hey helper",
           detector_kind: "browser_transcript",
-          wake_behavior: "one_shot",
           detected_at_ms: 1714500000000
         }
       ])
     )
+  })
+
+  it("keeps wake armed when activation send fails", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn((payload: string) => {
+        const parsed = JSON.parse(String(payload))
+        if (parsed.type === "wake_activation") {
+          throw new Error("socket send failed")
+        }
+      })
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    vi.mocked(wakeHarness.detector.stop).mockClear()
+
+    act(() => {
+      wakeHarness.fireWake()
+    })
+
+    expect(result.current.wakeArmed).toBe(true)
+    expect(result.current.wakeWarning).toMatch(/activation could not be sent/i)
+    expect(wakeHarness.detector.stop).not.toHaveBeenCalled()
+    expect(hookMocks.micStart).not.toHaveBeenCalled()
   })
 
   it("sends wake deactivation when wake listening is disarmed", async () => {
@@ -391,6 +431,114 @@ describe("usePersonaLiveVoiceController", () => {
         reason: "route_leave"
       }
     ])
+  })
+
+  it("sends wake deactivation for the previous session on persona switch", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result, rerender } = renderHook(
+      ({
+        sessionId,
+        personaId
+      }: {
+        sessionId: string
+        personaId: string
+      }) =>
+        usePersonaLiveVoiceController({
+          ws,
+          connected: true,
+          sessionId,
+          personaId,
+          resolvedDefaults,
+          canUseServerStt: true,
+          wakeTriggerPhrases: ["hey helper"],
+          wakeDetectorFactory: () => wakeHarness.detector
+        }),
+      {
+        initialProps: {
+          sessionId: "sess-old",
+          personaId: "persona-1"
+        }
+      }
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    ;(ws as WebSocket & { send: ReturnType<typeof vi.fn> }).send.mockClear()
+
+    rerender({
+      sessionId: "sess-new",
+      personaId: "persona-2"
+    })
+
+    await waitFor(() => {
+      expect(getSentPayloads(ws as WebSocket & { send: ReturnType<typeof vi.fn> })).toEqual(
+        expect.arrayContaining([
+          {
+            type: "wake_deactivation",
+            session_id: "sess-old",
+            reason: "persona_switch"
+          }
+        ])
+      )
+    })
+  })
+
+  it("cancels stale wake starts when disarmed before availability resolves", async () => {
+    let resolveAvailable: ((available: boolean) => void) | null = null
+    const detector: WakeDetector = {
+      isAvailable: vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveAvailable = resolve
+          })
+      ),
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined)
+    }
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => detector
+      })
+    )
+
+    let armPromise: Promise<void> = Promise.resolve()
+    act(() => {
+      armPromise = result.current.toggleWakeArmed()
+    })
+
+    await waitFor(() => {
+      expect(result.current.wakeArmed).toBe(true)
+    })
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+
+    await act(async () => {
+      resolveAvailable?.(true)
+      await armPromise
+    })
+
+    expect(detector.start).not.toHaveBeenCalled()
+    expect(result.current.wakeArmed).toBe(false)
   })
 
   it("stops the wake detector before live mic capture starts", async () => {

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -125,7 +125,9 @@ describe("usePersonaLiveVoiceController", () => {
         config = nextConfig
         nextConfig.onStateChange?.("listening")
       }),
-      stop: vi.fn(async () => undefined)
+      stop: vi.fn(async () => {
+        config = null
+      })
     }
     return {
       detector,

--- a/apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx
@@ -73,6 +73,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
         tts_provider: "openai",
         confirmation_mode: "always",
         voice_chat_trigger_phrases: ["bonjour helper"],
+        wake_behavior: "continuous",
         auto_resume: false,
         auto_commit_enabled: false,
         vad_threshold: 0.61,
@@ -89,6 +90,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
       ttsVoice: "alloy",
       confirmationMode: "always",
       voiceChatTriggerPhrases: ["bonjour helper"],
+      wakeBehavior: "continuous",
       autoResume: false,
       bargeIn: false,
       autoCommitEnabled: false,
@@ -115,6 +117,7 @@ describe("useResolvedPersonaVoiceDefaults", () => {
       ttsVoice: "voice-eleven",
       confirmationMode: "destructive_only",
       voiceChatTriggerPhrases: ["okay helper", "status check"],
+      wakeBehavior: "one_shot",
       autoResume: false,
       bargeIn: true,
       autoCommitEnabled: true,
@@ -134,5 +137,16 @@ describe("useResolvedPersonaVoiceDefaults", () => {
 
     expect(result.current.ttsProvider).toBe("tldw")
     expect(result.current.ttsVoice).toBe("Bella")
+    expect(result.current.wakeBehavior).toBe("one_shot")
+  })
+
+  it("resolves explicit persona wake behavior", () => {
+    const { result } = renderHook(() =>
+      useResolvedPersonaVoiceDefaults({
+        wake_behavior: "push_to_talk_after_wake"
+      })
+    )
+
+    expect(result.current.wakeBehavior).toBe("push_to_talk_after_wake")
   })
 })

--- a/apps/packages/ui/src/hooks/personaWakeDetector.ts
+++ b/apps/packages/ui/src/hooks/personaWakeDetector.ts
@@ -154,6 +154,20 @@ export class BrowserTranscriptWakeDetector implements WakeDetector {
     recognition.onend = () => {
       if (this.active) {
         config.onStateChange?.("idle")
+        try {
+          recognition.start()
+          config.onStateChange?.("listening")
+        } catch (error) {
+          this.active = false
+          config.onStateChange?.("error")
+          config.onError?.({
+            code: "restart_failed",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Wake detector could not restart."
+          })
+        }
       }
     }
     recognition.start()

--- a/apps/packages/ui/src/hooks/personaWakeDetector.ts
+++ b/apps/packages/ui/src/hooks/personaWakeDetector.ts
@@ -110,6 +110,13 @@ export class BrowserTranscriptWakeDetector implements WakeDetector {
   private recognition: SpeechRecognitionLike | null = null
   private active = false
 
+  private clearRecognitionHandlers(recognition: SpeechRecognitionLike | null): void {
+    if (!recognition) return
+    recognition.onresult = null
+    recognition.onerror = null
+    recognition.onend = null
+  }
+
   async isAvailable(): Promise<boolean> {
     return Boolean(getSpeechRecognitionCtor())
   }
@@ -182,6 +189,8 @@ export class BrowserTranscriptWakeDetector implements WakeDetector {
       recognition?.stop()
     } catch {
       // SpeechRecognition implementations throw when stop races with end.
+    } finally {
+      this.clearRecognitionHandlers(recognition)
     }
   }
 }

--- a/apps/packages/ui/src/hooks/personaWakeDetector.ts
+++ b/apps/packages/ui/src/hooks/personaWakeDetector.ts
@@ -1,0 +1,173 @@
+export type WakeDetectorState =
+  | "idle"
+  | "starting"
+  | "listening"
+  | "detected"
+  | "unavailable"
+  | "error"
+
+export type WakeDetectorKind = "browser_transcript"
+
+export type WakeDetectedEvent = {
+  canonicalPhrase: string
+  transcript: string
+  detectedAtMs: number
+  detectorKind: WakeDetectorKind
+}
+
+export type WakeDetectorError = {
+  message: string
+  code?: string
+}
+
+export type WakeDetectorConfig = {
+  phrases: string[]
+  locale?: string
+  onWake: (event: WakeDetectedEvent) => void
+  onStateChange?: (state: WakeDetectorState) => void
+  onError?: (error: WakeDetectorError) => void
+}
+
+export interface WakeDetector {
+  isAvailable(): Promise<boolean>
+  start(config: WakeDetectorConfig): Promise<void>
+  stop(): Promise<void>
+}
+
+type SpeechRecognitionAlternativeLike = {
+  transcript?: string
+}
+
+type SpeechRecognitionResultLike = ArrayLike<SpeechRecognitionAlternativeLike>
+
+type SpeechRecognitionEventLike = {
+  results?: ArrayLike<SpeechRecognitionResultLike>
+}
+
+type SpeechRecognitionErrorEventLike = {
+  error?: string
+  message?: string
+}
+
+type SpeechRecognitionLike = {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null
+  onend: (() => void) | null
+  start: () => void
+  stop: () => void
+}
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike
+
+type SpeechRecognitionWindow = Window & {
+  SpeechRecognition?: SpeechRecognitionCtor
+  webkitSpeechRecognition?: SpeechRecognitionCtor
+}
+
+const getSpeechRecognitionCtor = (): SpeechRecognitionCtor | null => {
+  if (typeof window === "undefined") return null
+  const scopedWindow = window as SpeechRecognitionWindow
+  return scopedWindow.SpeechRecognition || scopedWindow.webkitSpeechRecognition || null
+}
+
+export const normalizeWakePhraseText = (value: unknown): string =>
+  String(value || "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+
+export const findCanonicalWakePhrase = (
+  transcript: unknown,
+  phrases: string[]
+): string | null => {
+  const normalizedTranscript = ` ${normalizeWakePhraseText(transcript)} `
+  if (!normalizedTranscript.trim()) return null
+  for (const phrase of phrases || []) {
+    const normalizedPhrase = normalizeWakePhraseText(phrase)
+    if (!normalizedPhrase) continue
+    if (normalizedTranscript.includes(` ${normalizedPhrase} `)) {
+      return String(phrase || "").trim()
+    }
+  }
+  return null
+}
+
+const buildTranscript = (event: SpeechRecognitionEventLike): string =>
+  Array.from(event.results || [])
+    .map((result) => result?.[0]?.transcript || "")
+    .join(" ")
+
+const normalizeWakePhrases = (phrases: string[]): string[] =>
+  (phrases || [])
+    .map((phrase) => String(phrase || "").trim())
+    .filter(Boolean)
+
+export class BrowserTranscriptWakeDetector implements WakeDetector {
+  private recognition: SpeechRecognitionLike | null = null
+  private active = false
+
+  async isAvailable(): Promise<boolean> {
+    return Boolean(getSpeechRecognitionCtor())
+  }
+
+  async start(config: WakeDetectorConfig): Promise<void> {
+    await this.stop()
+    const Ctor = getSpeechRecognitionCtor()
+    const phrases = normalizeWakePhrases(config.phrases)
+    if (!Ctor || phrases.length === 0) {
+      config.onStateChange?.("unavailable")
+      return
+    }
+
+    config.onStateChange?.("starting")
+
+    const recognition = new Ctor()
+    this.recognition = recognition
+    this.active = true
+    recognition.continuous = true
+    recognition.interimResults = true
+    recognition.lang = config.locale || "en-US"
+    recognition.onresult = (event) => {
+      if (!this.active) return
+      const transcript = buildTranscript(event)
+      const canonicalPhrase = findCanonicalWakePhrase(transcript, phrases)
+      if (!canonicalPhrase) return
+      config.onStateChange?.("detected")
+      config.onWake({
+        canonicalPhrase,
+        transcript,
+        detectedAtMs: Date.now(),
+        detectorKind: "browser_transcript"
+      })
+    }
+    recognition.onerror = (event) => {
+      config.onStateChange?.("error")
+      config.onError?.({
+        code: String(event?.error || ""),
+        message: String(event?.message || event?.error || "Wake detector error")
+      })
+    }
+    recognition.onend = () => {
+      if (this.active) {
+        config.onStateChange?.("idle")
+      }
+    }
+    recognition.start()
+    config.onStateChange?.("listening")
+  }
+
+  async stop(): Promise<void> {
+    this.active = false
+    const recognition = this.recognition
+    this.recognition = null
+    try {
+      recognition?.stop()
+    } catch {
+      // SpeechRecognition implementations throw when stop races with end.
+    }
+  }
+}

--- a/apps/packages/ui/src/hooks/personaWakeDetector.ts
+++ b/apps/packages/ui/src/hooks/personaWakeDetector.ts
@@ -106,6 +106,14 @@ const normalizeWakePhrases = (phrases: string[]): string[] =>
     .map((phrase) => String(phrase || "").trim())
     .filter(Boolean)
 
+const FATAL_SPEECH_RECOGNITION_ERRORS = new Set([
+  "audio-capture",
+  "bad-grammar",
+  "language-not-supported",
+  "not-allowed",
+  "service-not-allowed"
+])
+
 export class BrowserTranscriptWakeDetector implements WakeDetector {
   private recognition: SpeechRecognitionLike | null = null
   private active = false
@@ -139,7 +147,7 @@ export class BrowserTranscriptWakeDetector implements WakeDetector {
     recognition.interimResults = true
     recognition.lang = config.locale || "en-US"
     recognition.onresult = (event) => {
-      if (!this.active) return
+      if (!this.active || this.recognition !== recognition) return
       const transcript = buildTranscript(event)
       const canonicalPhrase = findCanonicalWakePhrase(transcript, phrases)
       if (!canonicalPhrase) return
@@ -152,14 +160,24 @@ export class BrowserTranscriptWakeDetector implements WakeDetector {
       })
     }
     recognition.onerror = (event) => {
+      if (!this.active || this.recognition !== recognition) return
+      const code = String(event?.error || "")
+      const fatal = FATAL_SPEECH_RECOGNITION_ERRORS.has(code)
+      if (fatal) {
+        this.active = false
+        this.recognition = null
+      }
       config.onStateChange?.("error")
       config.onError?.({
-        code: String(event?.error || ""),
+        code,
         message: String(event?.message || event?.error || "Wake detector error")
       })
+      if (fatal) {
+        this.clearRecognitionHandlers(recognition)
+      }
     }
     recognition.onend = () => {
-      if (this.active) {
+      if (this.active && this.recognition === recognition) {
         config.onStateChange?.("idle")
         try {
           recognition.start()

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -29,6 +29,7 @@ type PersonaWakeStopReason =
   | "route_leave"
   | "stop_live_voice"
   | "persona_switch"
+  | "tab_switch"
 
 type UsePersonaLiveVoiceControllerArgs = {
   ws: WebSocket | null
@@ -167,11 +168,13 @@ export const usePersonaLiveVoiceController = ({
   const wakeDetectorRef = React.useRef<WakeDetector | null>(null)
   const wakeArmedRef = React.useRef(false)
   const wakeActiveRef = React.useRef(false)
+  const wakeStartTokenRef = React.useRef(0)
   const stopWakeListeningRef = React.useRef<
-    (reason?: PersonaWakeStopReason) => Promise<void>
+    (reason?: PersonaWakeStopReason, targetSessionId?: string) => Promise<void>
   >(async () => undefined)
   const restartWakeListeningRef = React.useRef<(() => void) | null>(null)
   const personaSessionKeyRef = React.useRef(`${personaId}:${sessionId}`)
+  const personaSessionIdRef = React.useRef(sessionId)
 
   const activeProvider = React.useMemo(
     () => normalizeTtsProvider(resolvedDefaults.ttsProvider),
@@ -348,10 +351,10 @@ export const usePersonaLiveVoiceController = ({
   )
 
   const sendWakeActivation = React.useCallback(
-    (event: WakeDetectedEvent) => {
+    (event: WakeDetectedEvent): boolean => {
       if (!connected || !sessionId || !ws || ws.readyState !== WebSocket.OPEN) {
         setWakeWarning("Wake phrase heard, but Persona Live is not connected.")
-        return
+        return false
       }
 
       try {
@@ -361,25 +364,27 @@ export const usePersonaLiveVoiceController = ({
             session_id: sessionId,
             matched_phrase: event.canonicalPhrase,
             detector_kind: event.detectorKind,
-            wake_behavior: sessionWakeBehavior,
             detected_at_ms: event.detectedAtMs
           })
         )
+        return true
       } catch {
         setWakeWarning("Wake phrase heard, but activation could not be sent.")
+        return false
       }
     },
-    [connected, sessionId, sessionWakeBehavior, ws]
+    [connected, sessionId, ws]
   )
 
   const sendWakeDeactivation = React.useCallback(
-    (reason: PersonaWakeStopReason) => {
-      if (!sessionId || !ws || ws.readyState !== WebSocket.OPEN) return
+    (reason: PersonaWakeStopReason, targetSessionId = sessionId) => {
+      const normalizedSessionId = String(targetSessionId || "").trim()
+      if (!normalizedSessionId || !ws || ws.readyState !== WebSocket.OPEN) return
       try {
         ws.send(
           JSON.stringify({
             type: "wake_deactivation",
-            session_id: sessionId,
+            session_id: normalizedSessionId,
             reason
           })
         )
@@ -451,7 +456,12 @@ export const usePersonaLiveVoiceController = ({
   ])
 
   const suspendWakeDetectorForLiveCapture = React.useCallback(async () => {
-    if (!wakeArmedRef.current || !wakeDetectorRef.current) return
+    if (!wakeArmedRef.current) return
+    wakeStartTokenRef.current += 1
+    if (!wakeDetectorRef.current) {
+      setWakeDetectorState("idle")
+      return
+    }
     try {
       await wakeDetectorRef.current.stop()
     } finally {
@@ -461,12 +471,16 @@ export const usePersonaLiveVoiceController = ({
   }, [])
 
   const stopWakeListening = React.useCallback(
-    async (reason: PersonaWakeStopReason = "disarmed") => {
+    async (
+      reason: PersonaWakeStopReason = "disarmed",
+      targetSessionId?: string
+    ) => {
+      wakeStartTokenRef.current += 1
       wakeArmedRef.current = false
       wakeActiveRef.current = false
       const detector = wakeDetectorRef.current
       wakeDetectorRef.current = null
-      sendWakeDeactivation(reason)
+      sendWakeDeactivation(reason, targetSessionId)
       try {
         await detector?.stop()
       } finally {
@@ -558,11 +572,14 @@ export const usePersonaLiveVoiceController = ({
 
   React.useEffect(() => {
     const nextKey = `${personaId}:${sessionId}`
-    if (personaSessionKeyRef.current === nextKey) return
-    personaSessionKeyRef.current = nextKey
+    const previousKey = personaSessionKeyRef.current
+    const previousSessionId = personaSessionIdRef.current
+    if (previousKey === nextKey) return
     if (wakeArmedRef.current) {
-      void stopWakeListeningRef.current("persona_switch")
+      void stopWakeListeningRef.current("persona_switch", previousSessionId)
     }
+    personaSessionKeyRef.current = nextKey
+    personaSessionIdRef.current = sessionId
   }, [personaId, sessionId])
 
   React.useEffect(() => {
@@ -662,20 +679,37 @@ export const usePersonaLiveVoiceController = ({
       return
     }
 
+    const startToken = wakeStartTokenRef.current + 1
+    wakeStartTokenRef.current = startToken
+    const isCurrentStart = () => wakeStartTokenRef.current === startToken
+    wakeArmedRef.current = true
+    wakeActiveRef.current = false
+    setWakeArmed(true)
+    setWakeWarning(null)
+    setWakeDetectorState("starting")
+
     const detector = wakeDetectorFactory?.() || new BrowserTranscriptWakeDetector()
     const available = await detector.isAvailable()
+    if (!isCurrentStart()) {
+      await detector.stop()
+      return
+    }
     if (!available) {
+      wakeArmedRef.current = false
+      wakeActiveRef.current = false
+      setWakeArmed(false)
       setWakeDetectorState("unavailable")
       setWakeWarning("Wake listening is unavailable in this browser context.")
       return
     }
 
     await wakeDetectorRef.current?.stop()
+    if (!isCurrentStart()) {
+      await detector.stop()
+      return
+    }
     wakeDetectorRef.current = detector
     wakeActiveRef.current = false
-    wakeArmedRef.current = true
-    setWakeArmed(true)
-    setWakeWarning(null)
 
     try {
       await detector.start({
@@ -684,17 +718,29 @@ export const usePersonaLiveVoiceController = ({
         onStateChange: setWakeDetectorState,
         onError: (error) => setWakeWarning(error.message),
         onWake: (event) => {
+          if (!isCurrentStart() || wakeDetectorRef.current !== detector) return
           if (wakeActiveRef.current) return
           wakeActiveRef.current = true
+          const activationSent = sendWakeActivation(event)
+          if (!activationSent) {
+            wakeActiveRef.current = false
+            return
+          }
           wakeDetectorRef.current = null
           void detector.stop()
-          sendWakeActivation(event)
           if (sessionWakeBehavior !== "push_to_talk_after_wake") {
             void startListening()
           }
         }
       })
+      if (!isCurrentStart()) {
+        if (wakeDetectorRef.current === detector) {
+          wakeDetectorRef.current = null
+        }
+        await detector.stop()
+      }
     } catch (error) {
+      if (!isCurrentStart()) return
       wakeArmedRef.current = false
       wakeActiveRef.current = false
       wakeDetectorRef.current = null
@@ -963,7 +1009,8 @@ export const usePersonaLiveVoiceController = ({
           voice: {
             trigger_phrases: resolvedDefaults.voiceChatTriggerPhrases,
             auto_resume: sessionAutoResume,
-            barge_in: sessionBargeIn
+            barge_in: sessionBargeIn,
+            wake_behavior: sessionWakeBehavior
           },
           stt: {
             language: resolvedDefaults.sttLanguage,
@@ -997,6 +1044,7 @@ export const usePersonaLiveVoiceController = ({
     minUtteranceSecs,
     sessionAutoResume,
     sessionBargeIn,
+    sessionWakeBehavior,
     sessionId,
     ws
   ])

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -2,7 +2,16 @@ import React from "react"
 import { useAudioSourceCatalog } from "@/hooks/useAudioSourceCatalog"
 import { useAudioSourcePreferences } from "@/hooks/useAudioSourcePreferences"
 import { useMicStream } from "@/hooks/useMicStream"
-import type { ResolvedPersonaVoiceDefaults } from "@/hooks/useResolvedPersonaVoiceDefaults"
+import {
+  BrowserTranscriptWakeDetector,
+  type WakeDetectedEvent,
+  type WakeDetector,
+  type WakeDetectorState
+} from "@/hooks/personaWakeDetector"
+import type {
+  PersonaWakeBehavior,
+  ResolvedPersonaVoiceDefaults
+} from "@/hooks/useResolvedPersonaVoiceDefaults"
 import { useStreamingAudioPlayer } from "@/hooks/useStreamingAudioPlayer"
 import { arrayBufferToBase64 } from "@/utils/compress"
 
@@ -15,6 +24,11 @@ export type PersonaLiveVoiceState =
 
 export type PersonaLiveVoiceRecoveryMode = "none" | "listening_stuck" | "thinking_stuck"
 export type PersonaLiveVadPreset = "conservative" | "balanced" | "fast" | "custom"
+type PersonaWakeStopReason =
+  | "disarmed"
+  | "route_leave"
+  | "stop_live_voice"
+  | "persona_switch"
 
 type UsePersonaLiveVoiceControllerArgs = {
   ws: WebSocket | null
@@ -23,6 +37,8 @@ type UsePersonaLiveVoiceControllerArgs = {
   personaId: string
   resolvedDefaults: ResolvedPersonaVoiceDefaults
   canUseServerStt: boolean
+  wakeTriggerPhrases?: string[]
+  wakeDetectorFactory?: () => WakeDetector
 }
 
 type PersonaLiveVoicePayload = Record<string, unknown> | null | undefined
@@ -90,7 +106,9 @@ export const usePersonaLiveVoiceController = ({
   sessionId,
   personaId,
   resolvedDefaults,
-  canUseServerStt
+  canUseServerStt,
+  wakeTriggerPhrases = [],
+  wakeDetectorFactory
 }: UsePersonaLiveVoiceControllerArgs) => {
   const [state, setState] = React.useState<PersonaLiveVoiceState>("idle")
   const [heardText, setHeardText] = React.useState("")
@@ -130,6 +148,12 @@ export const usePersonaLiveVoiceController = ({
     isSettled: hasAudioCatalogSettled
   } = useAudioSourceCatalog()
   const [pendingStartRequest, setPendingStartRequest] = React.useState(false)
+  const [wakeArmed, setWakeArmed] = React.useState(false)
+  const [wakeDetectorState, setWakeDetectorState] =
+    React.useState<WakeDetectorState>("idle")
+  const [wakeWarning, setWakeWarning] = React.useState<string | null>(null)
+  const [sessionWakeBehavior, setSessionWakeBehavior] =
+    React.useState<PersonaWakeBehavior>(resolvedDefaults.wakeBehavior)
 
   const heardTranscriptRef = React.useRef("")
   const manualModeRequiredRef = React.useRef(false)
@@ -140,6 +164,14 @@ export const usePersonaLiveVoiceController = ({
   const browserUtteranceActiveRef = React.useRef(false)
   const listeningRecoveryTimeoutRef = React.useRef<number | null>(null)
   const thinkingRecoveryTimeoutRef = React.useRef<number | null>(null)
+  const wakeDetectorRef = React.useRef<WakeDetector | null>(null)
+  const wakeArmedRef = React.useRef(false)
+  const wakeActiveRef = React.useRef(false)
+  const stopWakeListeningRef = React.useRef<
+    (reason?: PersonaWakeStopReason) => Promise<void>
+  >(async () => undefined)
+  const restartWakeListeningRef = React.useRef<(() => void) | null>(null)
+  const personaSessionKeyRef = React.useRef(`${personaId}:${sessionId}`)
 
   const activeProvider = React.useMemo(
     () => normalizeTtsProvider(resolvedDefaults.ttsProvider),
@@ -315,6 +347,49 @@ export const usePersonaLiveVoiceController = ({
     [armThinkingRecovery, clearTransientWarning, connected, handleVoiceError, sessionId, ws]
   )
 
+  const sendWakeActivation = React.useCallback(
+    (event: WakeDetectedEvent) => {
+      if (!connected || !sessionId || !ws || ws.readyState !== WebSocket.OPEN) {
+        setWakeWarning("Wake phrase heard, but Persona Live is not connected.")
+        return
+      }
+
+      try {
+        ws.send(
+          JSON.stringify({
+            type: "wake_activation",
+            session_id: sessionId,
+            matched_phrase: event.canonicalPhrase,
+            detector_kind: event.detectorKind,
+            wake_behavior: sessionWakeBehavior,
+            detected_at_ms: event.detectedAtMs
+          })
+        )
+      } catch {
+        setWakeWarning("Wake phrase heard, but activation could not be sent.")
+      }
+    },
+    [connected, sessionId, sessionWakeBehavior, ws]
+  )
+
+  const sendWakeDeactivation = React.useCallback(
+    (reason: PersonaWakeStopReason) => {
+      if (!sessionId || !ws || ws.readyState !== WebSocket.OPEN) return
+      try {
+        ws.send(
+          JSON.stringify({
+            type: "wake_deactivation",
+            session_id: sessionId,
+            reason
+          })
+        )
+      } catch {
+        // Ignore transient websocket send errors during teardown.
+      }
+    },
+    [sessionId, ws]
+  )
+
   const { start: startMicStream, stop: stopMicStream, active: micActive } = useMicStream(
     (chunk) => {
       if (!connected || !sessionId || !ws || ws.readyState !== WebSocket.OPEN) return
@@ -375,7 +450,46 @@ export const usePersonaLiveVoiceController = ({
     ws
   ])
 
+  const suspendWakeDetectorForLiveCapture = React.useCallback(async () => {
+    if (!wakeArmedRef.current || !wakeDetectorRef.current) return
+    try {
+      await wakeDetectorRef.current.stop()
+    } finally {
+      wakeDetectorRef.current = null
+      setWakeDetectorState("idle")
+    }
+  }, [])
+
+  const stopWakeListening = React.useCallback(
+    async (reason: PersonaWakeStopReason = "disarmed") => {
+      wakeArmedRef.current = false
+      wakeActiveRef.current = false
+      const detector = wakeDetectorRef.current
+      wakeDetectorRef.current = null
+      sendWakeDeactivation(reason)
+      try {
+        await detector?.stop()
+      } finally {
+        setWakeDetectorState("idle")
+        setWakeArmed(false)
+      }
+    },
+    [sendWakeDeactivation]
+  )
+
   const finishVoiceTurn = React.useCallback(() => {
+    if (
+      wakeArmedRef.current &&
+      wakeActiveRef.current &&
+      sessionWakeBehavior === "one_shot"
+    ) {
+      wakeActiveRef.current = false
+      pendingResumeRef.current = false
+      setPendingStartRequest(false)
+      setState("idle")
+      restartWakeListeningRef.current?.()
+      return
+    }
     if (sessionAutoResume && canUseServerStt && connected) {
       if (liveVoiceSourceReady) {
         setPendingStartRequest(false)
@@ -391,7 +505,14 @@ export const usePersonaLiveVoiceController = ({
     pendingResumeRef.current = false
     setPendingStartRequest(false)
     setState("idle")
-  }, [canUseServerStt, connected, liveVoiceSourceReady, sessionAutoResume, startMicCapture])
+  }, [
+    canUseServerStt,
+    connected,
+    liveVoiceSourceReady,
+    sessionAutoResume,
+    sessionWakeBehavior,
+    startMicCapture
+  ])
 
   const resetTurn = React.useCallback(() => {
     clearListeningRecoveryTimeout()
@@ -425,6 +546,23 @@ export const usePersonaLiveVoiceController = ({
     }
     armThinkingRecovery()
   }, [armThinkingRecovery, state])
+
+  React.useEffect(() => {
+    wakeArmedRef.current = wakeArmed
+  }, [wakeArmed])
+
+  React.useEffect(() => {
+    stopWakeListeningRef.current = stopWakeListening
+  }, [stopWakeListening])
+
+  React.useEffect(() => {
+    const nextKey = `${personaId}:${sessionId}`
+    if (personaSessionKeyRef.current === nextKey) return
+    personaSessionKeyRef.current = nextKey
+    if (wakeArmedRef.current) {
+      void stopWakeListeningRef.current("persona_switch")
+    }
+  }, [personaId, sessionId])
 
   React.useEffect(() => {
     manualModeRequiredRef.current = manualModeRequired
@@ -497,6 +635,7 @@ export const usePersonaLiveVoiceController = ({
     }
 
     setPendingStartRequest(false)
+    await suspendWakeDetectorForLiveCapture()
     await startMicCapture()
   }, [
     canUseServerStt,
@@ -509,8 +648,83 @@ export const usePersonaLiveVoiceController = ({
     state,
     startMicCapture,
     stopCurrentPlayback,
+    suspendWakeDetectorForLiveCapture,
     ws
   ])
+
+  const startWakeListening = React.useCallback(async () => {
+    const phrases = (wakeTriggerPhrases || [])
+      .map((phrase) => String(phrase || "").trim())
+      .filter(Boolean)
+    if (phrases.length === 0) {
+      setWakeWarning("Add a persona trigger phrase before arming wake listening.")
+      return
+    }
+
+    const detector = wakeDetectorFactory?.() || new BrowserTranscriptWakeDetector()
+    const available = await detector.isAvailable()
+    if (!available) {
+      setWakeDetectorState("unavailable")
+      setWakeWarning("Wake listening is unavailable in this browser context.")
+      return
+    }
+
+    await wakeDetectorRef.current?.stop()
+    wakeDetectorRef.current = detector
+    wakeActiveRef.current = false
+    wakeArmedRef.current = true
+    setWakeArmed(true)
+    setWakeWarning(null)
+
+    try {
+      await detector.start({
+        phrases,
+        locale: resolvedDefaults.sttLanguage,
+        onStateChange: setWakeDetectorState,
+        onError: (error) => setWakeWarning(error.message),
+        onWake: (event) => {
+          if (wakeActiveRef.current) return
+          wakeActiveRef.current = true
+          wakeDetectorRef.current = null
+          void detector.stop()
+          sendWakeActivation(event)
+          if (sessionWakeBehavior !== "push_to_talk_after_wake") {
+            void startListening()
+          }
+        }
+      })
+    } catch (error) {
+      wakeArmedRef.current = false
+      wakeActiveRef.current = false
+      wakeDetectorRef.current = null
+      setWakeArmed(false)
+      setWakeDetectorState("error")
+      setWakeWarning(
+        error instanceof Error ? error.message : "Wake listening could not start."
+      )
+    }
+  }, [
+    resolvedDefaults.sttLanguage,
+    sendWakeActivation,
+    sessionWakeBehavior,
+    startListening,
+    wakeDetectorFactory,
+    wakeTriggerPhrases
+  ])
+
+  const toggleWakeArmed = React.useCallback(async () => {
+    if (wakeArmedRef.current) {
+      await stopWakeListening("disarmed")
+      return
+    }
+    await startWakeListening()
+  }, [startWakeListening, stopWakeListening])
+
+  React.useEffect(() => {
+    restartWakeListeningRef.current = () => {
+      void startWakeListening()
+    }
+  }, [startWakeListening])
 
   const stopListening = React.useCallback(() => {
     if (!micActive && !pendingStartRequest) return
@@ -602,6 +816,7 @@ export const usePersonaLiveVoiceController = ({
   React.useEffect(() => {
     setSessionAutoResume(resolvedDefaults.autoResume)
     setSessionBargeIn(resolvedDefaults.bargeIn)
+    setSessionWakeBehavior(resolvedDefaults.wakeBehavior)
     setAutoCommitEnabled(resolvedDefaults.autoCommitEnabled)
     setVadThreshold(resolvedDefaults.vadThreshold)
     setMinSilenceMs(resolvedDefaults.minSilenceMs)
@@ -612,6 +827,7 @@ export const usePersonaLiveVoiceController = ({
     textOnlyDueToTtsFailureRef.current = false
     setTextOnlyDueToTtsFailure(false)
     setWarning(null)
+    setWakeWarning(null)
     setHeardText("")
     heardTranscriptRef.current = ""
     setLastCommittedText("")
@@ -639,6 +855,7 @@ export const usePersonaLiveVoiceController = ({
     resolvedDefaults.autoCommitEnabled,
     resolvedDefaults.autoResume,
     resolvedDefaults.bargeIn,
+    resolvedDefaults.wakeBehavior,
     resolvedDefaults.minSilenceMs,
     resolvedDefaults.minUtteranceSecs,
     resolvedDefaults.turnStopSecs,
@@ -650,6 +867,7 @@ export const usePersonaLiveVoiceController = ({
 
   React.useEffect(() => {
     if (!connected) {
+      setSessionWakeBehavior(resolvedDefaults.wakeBehavior)
       setAutoCommitEnabled(resolvedDefaults.autoCommitEnabled)
       setVadThreshold(resolvedDefaults.vadThreshold)
       setMinSilenceMs(resolvedDefaults.minSilenceMs)
@@ -661,6 +879,7 @@ export const usePersonaLiveVoiceController = ({
       setListeningRecoveryCount(0)
       setThinkingRecoveryCount(0)
       setActiveToolStatus("")
+      setWakeWarning(null)
       setListeningRecoveryRestartKey(0)
       setThinkingRecoveryArmed(false)
       setThinkingRecoveryRestartKey(0)
@@ -684,6 +903,7 @@ export const usePersonaLiveVoiceController = ({
     resolvedDefaults.minUtteranceSecs,
     resolvedDefaults.turnStopSecs,
     resolvedDefaults.vadThreshold,
+    resolvedDefaults.wakeBehavior,
     stopMicStream,
     stopCurrentPlayback
   ])
@@ -789,6 +1009,14 @@ export const usePersonaLiveVoiceController = ({
     }
   }, [clearAwaitingTtsTimeout, clearListeningRecoveryTimeout, clearThinkingRecoveryTimeout, stopMicStream, stopCurrentPlayback])
 
+  React.useEffect(() => {
+    return () => {
+      if (wakeArmedRef.current) {
+        void stopWakeListeningRef.current("route_leave")
+      }
+    }
+  }, [])
+
   const handlePayload = React.useCallback(
     (payload: PersonaLiveVoicePayload) => {
       const eventType = String(payload?.event || payload?.type || "").trim().toLowerCase()
@@ -878,6 +1106,22 @@ export const usePersonaLiveVoiceController = ({
 
       if (eventType === "notice") {
         const reasonCode = String(payload?.reason_code || "").trim().toUpperCase()
+        if (reasonCode === "WAKE_ACTIVATION_ACCEPTED") {
+          setWakeWarning(null)
+          return
+        }
+        if (reasonCode === "WAKE_ACTIVATION_REJECTED") {
+          wakeActiveRef.current = false
+          setWakeWarning(String(payload?.message || "Wake activation was rejected."))
+          if (wakeArmedRef.current) {
+            void startWakeListening()
+          }
+          return
+        }
+        if (reasonCode === "WAKE_DEACTIVATED") {
+          wakeActiveRef.current = false
+          return
+        }
         if (reasonCode === "VOICE_TURN_PROCESSING") {
           if (state === "thinking") {
             armThinkingRecovery()
@@ -945,6 +1189,10 @@ export const usePersonaLiveVoiceController = ({
           setWarning(
             String(payload?.message || "No trigger phrase was heard, so the transcript was ignored.")
           )
+          if (wakeArmedRef.current) {
+            wakeActiveRef.current = false
+            void startWakeListening()
+          }
           setState(micActive ? "listening" : "idle")
           return
         }
@@ -958,6 +1206,10 @@ export const usePersonaLiveVoiceController = ({
                 "The trigger phrase was removed, but no spoken command remained."
             )
           )
+          if (wakeArmedRef.current) {
+            wakeActiveRef.current = false
+            void startWakeListening()
+          }
           setState(micActive ? "listening" : "idle")
           return
         }
@@ -979,6 +1231,7 @@ export const usePersonaLiveVoiceController = ({
       micActive,
       playBrowserSpeech,
       activeToolStatus,
+      startWakeListening,
       state,
       stopMicStream,
       textOnlyDueToTtsFailure
@@ -1007,6 +1260,11 @@ export const usePersonaLiveVoiceController = ({
     lastCommittedText,
     activeToolStatus,
     warning,
+    wakeArmed,
+    wakeDetectorState,
+    wakeWarning,
+    sessionWakeBehavior,
+    wakeTriggerPhrases,
     manualModeRequired,
     canSendNow: Boolean(String(heardText || heardTranscriptRef.current || "").trim()),
     speechAvailable: canUseServerStt,
@@ -1023,12 +1281,15 @@ export const usePersonaLiveVoiceController = ({
     startListening,
     stopListening,
     toggleListening,
+    toggleWakeArmed,
+    stopWakeListening,
     sendCurrentTranscriptNow,
     keepListening,
     waitOnRecovery,
     resetTurn,
     setSessionAutoResume,
     setSessionBargeIn,
+    setSessionWakeBehavior,
     setAutoCommitEnabled,
     setVadPreset,
     setVadThreshold,

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -481,7 +481,8 @@ export const usePersonaLiveVoiceController = ({
     if (
       wakeArmedRef.current &&
       wakeActiveRef.current &&
-      sessionWakeBehavior === "one_shot"
+      (sessionWakeBehavior === "one_shot" ||
+        sessionWakeBehavior === "push_to_talk_after_wake")
     ) {
       wakeActiveRef.current = false
       pendingResumeRef.current = false
@@ -737,6 +738,9 @@ export const usePersonaLiveVoiceController = ({
       stopMicStream()
     }
     setState("idle")
+    if (wakeArmedRef.current && !wakeActiveRef.current && !wakeDetectorRef.current) {
+      restartWakeListeningRef.current?.()
+    }
   }, [
     clearListeningRecoveryTimeout,
     clearThinkingRecovery,

--- a/apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx
+++ b/apps/packages/ui/src/hooks/useResolvedPersonaVoiceDefaults.tsx
@@ -13,12 +13,18 @@ export type PersonaConfirmationMode =
   | "destructive_only"
   | "never"
 
+export type PersonaWakeBehavior =
+  | "one_shot"
+  | "continuous"
+  | "push_to_talk_after_wake"
+
 export type PersonaVoiceDefaults = {
   stt_language?: string | null
   stt_model?: string | null
   tts_provider?: string | null
   tts_voice?: string | null
   confirmation_mode?: PersonaConfirmationMode | null
+  wake_behavior?: PersonaWakeBehavior | null
   voice_chat_trigger_phrases?: string[]
   auto_resume?: boolean | null
   barge_in?: boolean | null
@@ -35,6 +41,7 @@ export type ResolvedPersonaVoiceDefaults = {
   ttsProvider: string
   ttsVoice: string
   confirmationMode: PersonaConfirmationMode
+  wakeBehavior: PersonaWakeBehavior
   voiceChatTriggerPhrases: string[]
   autoResume: boolean
   bargeIn: boolean
@@ -48,6 +55,7 @@ export type ResolvedPersonaVoiceDefaults = {
 const DEFAULT_STT_LANGUAGE = "en-US"
 const DEFAULT_OPENAI_VOICE = "alloy"
 const DEFAULT_CONFIRMATION_MODE: PersonaConfirmationMode = "destructive_only"
+const DEFAULT_WAKE_BEHAVIOR: PersonaWakeBehavior = "one_shot"
 export const PERSONA_TURN_DETECTION_BALANCED_DEFAULTS = {
   autoCommitEnabled: true,
   vadThreshold: 0.5,
@@ -72,6 +80,15 @@ const normalizePhrases = (value: string[] | null | undefined): string[] => {
   }
   return next
 }
+
+const normalizeWakeBehavior = (
+  value: PersonaWakeBehavior | null | undefined
+): PersonaWakeBehavior =>
+  value === "continuous" ||
+  value === "push_to_talk_after_wake" ||
+  value === "one_shot"
+    ? value
+    : DEFAULT_WAKE_BEHAVIOR
 
 const resolveDefaultTtsVoice = (
   provider: string,
@@ -137,6 +154,7 @@ export const useResolvedPersonaVoiceDefaults = (
         ),
       confirmationMode:
         personaVoiceDefaults?.confirmation_mode || DEFAULT_CONFIRMATION_MODE,
+      wakeBehavior: normalizeWakeBehavior(personaVoiceDefaults?.wake_behavior),
       voiceChatTriggerPhrases:
         personaTriggerPhrases.length > 0
           ? personaTriggerPhrases

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -3998,6 +3998,81 @@ describe("SidepanelPersona", () => {
     })
   })
 
+  it("renders wake controls from the selected profile's saved trigger phrases", async () => {
+    mocks.location.search = "?persona_id=research_assistant&tab=live"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: "persona-key"
+    })
+    mocks.capabilitiesState.capabilities = {
+      hasPersona: true,
+      hasPersonalization: true,
+      hasAudio: true
+    } as any
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "research_assistant", name: "Research Assistant" }]
+        })
+      }
+      if (path.includes("/persona/profiles/research_assistant/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "research_assistant",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/research_assistant/state")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "research_assistant",
+            soul_md: null,
+            identity_md: null,
+            heartbeat_md: null
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/research_assistant")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "research_assistant",
+            use_persona_state_context_default: true,
+            voice_defaults: {
+              voice_chat_trigger_phrases: ["saved wake phrase"],
+              wake_behavior: "continuous"
+            }
+          })
+        })
+      }
+      if (path.includes("/persona/sessions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitForLiveSessionPanel()
+
+    expect(screen.getByTestId("live-wake-phrases")).toHaveTextContent(
+      "saved wake phrase"
+    )
+    expect(screen.getByTestId("live-wake-behavior")).toHaveTextContent("Continuous")
+  })
+
   it("hydrates persisted session preferences when connecting to a resumed session", async () => {
     mocks.getConfig.mockResolvedValue({
       serverUrl: "http://127.0.0.1:8000",

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -4073,6 +4073,135 @@ describe("SidepanelPersona", () => {
     expect(screen.getByTestId("live-wake-behavior")).toHaveTextContent("Continuous")
   })
 
+  it("stops wake listening when leaving the Live tab", async () => {
+    const originalSpeechRecognition = (window as any).SpeechRecognition
+    class MockSpeechRecognition {
+      continuous = false
+      interimResults = false
+      lang = ""
+      onresult: ((event: any) => void) | null = null
+      onerror: ((event: any) => void) | null = null
+      onend: (() => void) | null = null
+      start = vi.fn()
+      stop = vi.fn()
+    }
+    ;(window as any).SpeechRecognition = MockSpeechRecognition
+
+    try {
+      mocks.location.search = "?persona_id=research_assistant&tab=live"
+      mocks.getConfig.mockResolvedValue({
+        serverUrl: "http://127.0.0.1:8000",
+        authMode: "single-user",
+        apiKey: "persona-key"
+      })
+      mocks.capabilitiesState.capabilities = {
+        hasPersona: true,
+        hasPersonalization: true,
+        hasAudio: true
+      } as any
+      mocks.fetchWithAuth.mockImplementation((path: string) => {
+        if (path.includes("/persona/catalog")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => [{ id: "research_assistant", name: "Research Assistant" }]
+          })
+        }
+        if (path.includes("/persona/profiles/research_assistant/voice-analytics")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              persona_id: "research_assistant",
+              summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+            })
+          })
+        }
+        if (path.includes("/persona/profiles/research_assistant/state")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              persona_id: "research_assistant",
+              soul_md: null,
+              identity_md: null,
+              heartbeat_md: null
+            })
+          })
+        }
+        if (path.includes("/persona/profiles/research_assistant")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "research_assistant",
+              use_persona_state_context_default: true,
+              voice_defaults: {
+                voice_chat_trigger_phrases: ["saved wake phrase"],
+                wake_behavior: "continuous"
+              }
+            })
+          })
+        }
+        if (path.includes("/persona/sessions/sess-tab-switch")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ preferences: {} })
+          })
+        }
+        if (path === "/api/v1/persona/session") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ session_id: "sess-tab-switch" })
+          })
+        }
+        if (path.includes("/persona/sessions")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => []
+          })
+        }
+        return Promise.resolve({
+          ok: false,
+          error: `unhandled path: ${path}`,
+          json: async () => ({})
+        })
+      })
+
+      render(<SidepanelPersona />)
+
+      await waitForLiveSessionPanel()
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }))
+      await waitFor(() => {
+        expect(MockWebSocket.instances).toHaveLength(1)
+      })
+      const ws = MockWebSocket.instances[0]
+      ws.emitOpen()
+      await waitFor(() => {
+        expect(
+          getSentPayloads(ws).some((payload) => payload.type === "voice_config")
+        ).toBe(true)
+      })
+
+      fireEvent.click(screen.getByTestId("live-wake-toggle"))
+      await waitFor(() => {
+        expect(screen.getByTestId("live-wake-state")).toHaveTextContent("listening")
+      })
+      ws.send.mockClear()
+
+      fireEvent.click(screen.getByRole("tab", { name: "Profiles" }))
+
+      await waitFor(() => {
+        expect(getSentPayloads(ws)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "wake_deactivation",
+              reason: "tab_switch"
+            })
+          ])
+        )
+      })
+    } finally {
+      ;(window as any).SpeechRecognition = originalSpeechRecognition
+    }
+  })
+
   it("hydrates persisted session preferences when connecting to a resumed session", async () => {
     mocks.getConfig.mockResolvedValue({
       serverUrl: "http://127.0.0.1:8000",

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -124,6 +124,18 @@ const LazyVoiceExamplesPanel = React.lazy(() =>
   }))
 )
 
+const normalizeWakeTriggerPhrases = (phrases?: string[] | null): string[] => {
+  const seen = new Set<string>()
+  const next: string[] = []
+  for (const phrase of phrases || []) {
+    const trimmed = String(phrase || "").trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    next.push(trimmed)
+  }
+  return next
+}
+
 const SidepanelPersona = ({
   mode = "persona",
   shell = "sidepanel"
@@ -522,6 +534,13 @@ const SidepanelPersona = ({
   const resolvedLivePersonaVoiceDefaults = useResolvedPersonaVoiceDefaults(
     connected ? liveSessionVoiceDefaultsBaseline : savedPersonaVoiceDefaults
   )
+  const wakeTriggerPhrases = React.useMemo(
+    () =>
+      normalizeWakeTriggerPhrases(
+        savedPersonaVoiceDefaults?.voice_chat_trigger_phrases
+      ),
+    [savedPersonaVoiceDefaults]
+  )
   const livePersonaId = connected ? activeSessionPersonaId || selectedPersonaId : selectedPersonaId
   const liveVoiceController = usePersonaLiveVoiceController({
     ws: wsRef.current,
@@ -529,7 +548,8 @@ const SidepanelPersona = ({
     sessionId: sessionId || "",
     personaId: String(livePersonaId || "").trim(),
     resolvedDefaults: resolvedLivePersonaVoiceDefaults,
-    canUseServerStt: Boolean(capabilities?.hasAudio)
+    canUseServerStt: Boolean(capabilities?.hasAudio),
+    wakeTriggerPhrases
   })
   liveVoiceControllerRef.current = liveVoiceController
 
@@ -663,6 +683,7 @@ const SidepanelPersona = ({
 
   const handleReconnectPersonaSessionFromRecovery = React.useCallback(() => {
     if (connecting) return
+    void liveVoiceController.stopWakeListening("stop_live_voice")
     liveVoiceController.resetTurn()
     triggerRecoveryReconnect()
     disconnect({ force: true })
@@ -896,7 +917,10 @@ const SidepanelPersona = ({
           value={selectedPersonaId}
           disabled={connected}
           aria-label={t("sidepanel:persona.select", "Select persona")}
-          onChange={(value) => handlePersonaSelectionChange(String(value))}
+          onChange={(value) => {
+            void liveVoiceController.stopWakeListening("persona_switch")
+            handlePersonaSelectionChange(String(value))
+          }}
           options={catalog.map((persona) => ({
             label: persona.name || persona.id,
             value: persona.id
@@ -911,7 +935,10 @@ const SidepanelPersona = ({
         value={resumeSessionId || "__new__"}
         aria-label={t("sidepanel:persona.resume", "Resume session")}
         disabled={connected}
-        onChange={(value) => handleResumeSessionSelectionChange(String(value))}
+        onChange={(value) => {
+          void liveVoiceController.stopWakeListening("persona_switch")
+          handleResumeSessionSelectionChange(String(value))
+        }}
         options={[
           { label: t("sidepanel:persona.newSession", "New session"), value: "__new__" },
           ...sessionHistory.map((session) => ({
@@ -978,6 +1005,7 @@ const SidepanelPersona = ({
           type="primary"
           loading={connecting}
           onClick={() => {
+            void liveVoiceController.stopWakeListening("persona_switch")
             void connect()
           }}
         >
@@ -985,6 +1013,7 @@ const SidepanelPersona = ({
         </Button>
       ) : (
         <Button size="small" onClick={() => {
+          void liveVoiceController.stopWakeListening("stop_live_voice")
           disconnect()
         }}>
           {t("sidepanel:persona.disconnect", "Disconnect")}
@@ -1025,6 +1054,11 @@ const SidepanelPersona = ({
       savingCurrentSettingsAsDefaults={savingLiveVoiceDefaults}
       sessionAutoResume={liveVoiceController.sessionAutoResume}
       sessionBargeIn={liveVoiceController.sessionBargeIn}
+      wakeArmed={liveVoiceController.wakeArmed}
+      wakeDetectorState={liveVoiceController.wakeDetectorState}
+      wakeWarning={liveVoiceController.wakeWarning}
+      wakeTriggerPhrases={liveVoiceController.wakeTriggerPhrases}
+      sessionWakeBehavior={liveVoiceController.sessionWakeBehavior}
       autoCommitEnabled={liveVoiceController.autoCommitEnabled}
       vadPreset={liveVoiceController.vadPreset}
       vadThreshold={liveVoiceController.vadThreshold}
@@ -1035,6 +1069,8 @@ const SidepanelPersona = ({
       onSendNow={liveVoiceController.sendCurrentTranscriptNow}
       onSessionAutoResumeChange={liveVoiceController.setSessionAutoResume}
       onSessionBargeInChange={liveVoiceController.setSessionBargeIn}
+      onToggleWakeArmed={liveVoiceController.toggleWakeArmed}
+      onSessionWakeBehaviorChange={liveVoiceController.setSessionWakeBehavior}
       onAutoCommitEnabledChange={liveVoiceController.setAutoCommitEnabled}
       onVadPresetChange={liveVoiceController.setVadPreset}
       onVadThresholdChange={liveVoiceController.setVadThreshold}

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -906,6 +906,16 @@ const SidepanelPersona = ({
     }
     openSettings()
   }
+  const handlePersonaTabChange = React.useCallback(
+    (key: string) => {
+      const nextTab = key as PersonaGardenTabKey
+      if (activeTabRef.current === "live" && nextTab !== "live") {
+        void liveVoiceController.stopWakeListening("tab_switch")
+      }
+      setActiveTab(nextTab)
+    },
+    [liveVoiceController]
+  )
 
   // ── JSX: live session controls ──
   const liveSessionControls = (
@@ -2076,7 +2086,7 @@ const SidepanelPersona = ({
           ) : (
             <PersonaGardenTabs
               activeKey={activeTab}
-              onChange={(key) => setActiveTab(key as PersonaGardenTabKey)}
+              onChange={handlePersonaTabChange}
               items={tabItems}
             />
           )}

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -9,6 +9,7 @@ import binascii
 import contextlib
 import hashlib
 import json
+import os
 import re
 import threading
 import time
@@ -204,6 +205,14 @@ _PERSONA_RUNTIME_MODES = {"session_scoped", "persistent_scoped"}
 _PERSONA_WS_REQUIRED_NOTICE_LEVELS = {"info", "warning", "error"}
 _PERSONA_WS_ALLOWED_STEP_TYPES = {"mcp_tool", "skill", "rag_query", "final_answer"}
 _PERSONA_LIVE_PROCESSING_NOTICE_DELAY_S = 2.0
+_PERSONA_WAKE_BEHAVIORS = {"one_shot", "continuous", "push_to_talk_after_wake"}
+_PERSONA_WAKE_DEACTIVATION_REASONS = {
+    "disarmed",
+    "stop_live_voice",
+    "persona_switch",
+    "route_leave",
+    "session_close",
+}
 _PERSONA_CONNECTION_MEMORY_TYPE = "persona_connection"
 _PERSONA_CONNECTION_ALLOWED_AUTH_TYPES = {"none", "bearer", "api_key", "basic", "custom_header"}
 _PERSONA_CONNECTION_TEST_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"}
@@ -2502,6 +2511,37 @@ def _apply_persona_live_trigger_phrases(
         cleaned = pattern.sub(" ", cleaned)
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     return True, cleaned
+
+
+def _get_persona_wake_no_command_timeout_s() -> float:
+    try:
+        return max(
+            1.0,
+            min(300.0, float(os.getenv("PERSONA_WAKE_NO_COMMAND_TIMEOUT_S", "30"))),
+        )
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _normalize_persona_wake_phrase(value: object) -> str:
+    text = re.sub(r"[^\w\s]+", " ", str(value or "").strip().lower())
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _match_persona_wake_phrase(
+    matched_phrase: object,
+    configured_phrases: list[str] | None,
+) -> str | None:
+    normalized_match = _normalize_persona_wake_phrase(matched_phrase)
+    if not normalized_match:
+        return None
+    for phrase in configured_phrases or []:
+        candidate = str(phrase or "").strip()
+        if not candidate:
+            continue
+        if _normalize_persona_wake_phrase(candidate) == normalized_match:
+            return candidate
+    return None
 
 
 async def _generate_tts_audio_chunks(
@@ -5003,6 +5043,7 @@ async def persona_stream(
     auth_watchdog_stop: asyncio.Event | None = None
     auth_revoked_event: asyncio.Event | None = None
     persona_live_stt_state_by_session: dict[str, dict[str, Any]] = {}
+    persona_live_wake_state_by_session: dict[str, dict[str, Any]] = {}
     persona_live_summary_sessions_seen: set[str] = set()
     try:
         user_id, credentials_supplied, auth_ok = await _resolve_authenticated_user_id(ws, token=token, api_key=api_key)
@@ -5491,6 +5532,46 @@ async def persona_stream(
                     turn_detector.reset()
             voice_transcript_buffer_by_session.pop(session_id, None)
 
+        def _clear_persona_live_wake_state(session_id: str) -> None:
+            persona_live_wake_state_by_session.pop(session_id, None)
+
+        def _get_active_persona_live_wake_state(session_id: str) -> dict[str, Any] | None:
+            state = persona_live_wake_state_by_session.get(session_id)
+            if not isinstance(state, dict):
+                return None
+            expires_at = state.get("expires_at_monotonic")
+            if isinstance(expires_at, (int, float)) and time.monotonic() > float(expires_at):
+                _clear_persona_live_wake_state(session_id)
+                return None
+            return state
+
+        def _get_saved_wake_phrases_for_session(session_id: str) -> list[str]:
+            runtime_context = _load_persona_policy_rules_for_session(
+                persona_scope_db,
+                session_id=session_id,
+                user_id=authenticated_user_id,
+            )
+            if not bool(runtime_context.get("session_exists")):
+                return []
+            runtime_persona_id = str(runtime_context.get("persona_id") or "").strip()
+            if not runtime_persona_id or persona_scope_db is None:
+                return []
+            profile = persona_scope_db.get_persona_profile(
+                runtime_persona_id,
+                user_id=authenticated_user_id,
+                include_deleted=False,
+            )
+            if not isinstance(profile, dict):
+                return []
+            voice_defaults = profile.get("voice_defaults")
+            if not isinstance(voice_defaults, dict):
+                return []
+            return [
+                str(phrase or "").strip()
+                for phrase in voice_defaults.get("voice_chat_trigger_phrases") or []
+                if str(phrase or "").strip()
+            ]
+
         def _get_or_create_persona_live_stt_state(
             session_id: str,
         ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
@@ -5741,10 +5822,15 @@ async def persona_stream(
                 if isinstance(voice_runtime, dict)
                 else []
             )
-            trigger_matched, cleaned_transcript = _apply_persona_live_trigger_phrases(
-                transcript,
-                trigger_phrases=trigger_phrases,
-            )
+            wake_state = _get_active_persona_live_wake_state(session_id)
+            if wake_state:
+                trigger_matched = True
+                cleaned_transcript = str(transcript or "").strip()
+            else:
+                trigger_matched, cleaned_transcript = _apply_persona_live_trigger_phrases(
+                    transcript,
+                    trigger_phrases=trigger_phrases,
+                )
             if not trigger_matched:
                 await _emit_notice(
                     session_id=session_id,
@@ -5785,6 +5871,11 @@ async def persona_stream(
                 voice_runtime=voice_runtime if isinstance(voice_runtime, dict) else None,
                 commit_source=commit_source,
             )
+            if wake_state and wake_state.get("wake_behavior") in {
+                "one_shot",
+                "push_to_talk_after_wake",
+            }:
+                _clear_persona_live_wake_state(session_id)
             _reset_persona_live_active_turn(session_id)
             _schedule_persona_live_processing_notice(session_id)
             await _handle_persona_live_turn(
@@ -6947,12 +7038,97 @@ async def persona_stream(
                     session_id=session_id,
                     voice_runtime=voice_runtime,
                 )
+                _clear_persona_live_wake_state(session_id)
                 _cleanup_persona_live_stt_state(session_id)
                 await _emit_notice(
                     session_id=session_id,
                     level="info",
                     message="Voice runtime updated for this live session.",
                     reason_code="VOICE_CONFIG_UPDATED",
+                )
+            elif mtype == "wake_activation":
+                original_session_id = msg.get("session_id")
+                session_id = _normalize_ws_identifier(original_session_id, fallback="")
+                if not session_id:
+                    await _emit_notice(
+                        session_id=default_session_id,
+                        level="error",
+                        message="session_id is required",
+                        reason_code="SESSION_ID_REQUIRED",
+                    )
+                    continue
+                wake_behavior = str(msg.get("wake_behavior") or "one_shot").strip()
+                matched_phrase = str(msg.get("matched_phrase") or "").strip()
+                detector_kind = _bounded_label(
+                    msg.get("detector_kind"),
+                    allowed={"browser_transcript", "native_companion", "test"},
+                    fallback="browser_transcript",
+                )
+                saved_phrases = _get_saved_wake_phrases_for_session(session_id)
+                runtime_preferences = session_manager.get_preferences(
+                    session_id=session_id,
+                    user_id=connection_user_id,
+                )
+                voice_runtime = runtime_preferences.get("voice_runtime")
+                runtime_phrases = (
+                    list(voice_runtime.get("trigger_phrases") or [])
+                    if isinstance(voice_runtime, dict)
+                    else []
+                )
+                saved_match = _match_persona_wake_phrase(matched_phrase, saved_phrases)
+                runtime_match = _match_persona_wake_phrase(matched_phrase, runtime_phrases)
+                if (
+                    wake_behavior not in _PERSONA_WAKE_BEHAVIORS
+                    or not saved_match
+                    or not runtime_match
+                ):
+                    await _emit_notice(
+                        session_id=session_id,
+                        level="warning",
+                        reason_code="WAKE_ACTIVATION_REJECTED",
+                        message="Wake activation was rejected for this persona session.",
+                    )
+                    continue
+
+                expires_at: float | None = None
+                if wake_behavior in {"one_shot", "push_to_talk_after_wake"}:
+                    expires_at = time.monotonic() + _get_persona_wake_no_command_timeout_s()
+                persona_live_wake_state_by_session[session_id] = {
+                    "wake_behavior": wake_behavior,
+                    "matched_phrase": saved_match,
+                    "detector_kind": detector_kind,
+                    "expires_at_monotonic": expires_at,
+                }
+                await _emit_notice(
+                    session_id=session_id,
+                    level="info",
+                    reason_code="WAKE_ACTIVATION_ACCEPTED",
+                    message="Wake activation accepted for this live session.",
+                    wake_behavior=wake_behavior,
+                    detector_kind=detector_kind,
+                )
+            elif mtype == "wake_deactivation":
+                session_id = _normalize_ws_identifier(msg.get("session_id"), fallback="")
+                if not session_id:
+                    await _emit_notice(
+                        session_id=default_session_id,
+                        level="error",
+                        message="session_id is required",
+                        reason_code="SESSION_ID_REQUIRED",
+                    )
+                    continue
+                reason = _bounded_label(
+                    msg.get("reason"),
+                    allowed=_PERSONA_WAKE_DEACTIVATION_REASONS,
+                    fallback="disarmed",
+                )
+                _clear_persona_live_wake_state(session_id)
+                await _emit_notice(
+                    session_id=session_id,
+                    level="info",
+                    reason_code="WAKE_DEACTIVATED",
+                    message="Wake activation cleared for this live session.",
+                    reason=reason,
                 )
             elif mtype == "voice_commit":
                 original_session_id = msg.get("session_id")
@@ -7623,6 +7799,7 @@ async def persona_stream(
             )
         for session_id in list(persona_live_stt_state_by_session.keys()):
             _cleanup_persona_live_stt_state(session_id)
+        persona_live_wake_state_by_session.clear()
         if stream is not None:
             with contextlib.suppress(Exception):
                 await stream.stop()

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -210,6 +210,7 @@ _PERSONA_WAKE_DEACTIVATION_REASONS = {
     "disarmed",
     "stop_live_voice",
     "persona_switch",
+    "tab_switch",
     "route_leave",
     "session_close",
 }
@@ -6954,6 +6955,11 @@ async def persona_stream(
                 "trigger_phrases": normalized_trigger_phrases,
                 "auto_resume": _coerce_bool(voice_payload.get("auto_resume"), default=False),
                 "barge_in": _coerce_bool(voice_payload.get("barge_in"), default=False),
+                "wake_behavior": _bounded_label(
+                    voice_payload.get("wake_behavior"),
+                    allowed=_PERSONA_WAKE_BEHAVIORS,
+                    fallback="one_shot",
+                ),
                 "stt_language": str(stt_payload.get("language") or "").strip() or None,
                 "stt_model": str(stt_payload.get("model") or "").strip() or None,
                 "enable_vad": _coerce_bool(stt_payload.get("enable_vad"), default=True),
@@ -7062,7 +7068,6 @@ async def persona_stream(
                         reason_code="SESSION_ID_REQUIRED",
                     )
                     continue
-                wake_behavior = str(msg.get("wake_behavior") or "one_shot").strip()
                 matched_phrase = str(msg.get("matched_phrase") or "").strip()
                 detector_kind = _bounded_label(
                     msg.get("detector_kind"),
@@ -7080,13 +7085,16 @@ async def persona_stream(
                     if isinstance(voice_runtime, dict)
                     else []
                 )
+                wake_behavior = _bounded_label(
+                    voice_runtime.get("wake_behavior")
+                    if isinstance(voice_runtime, dict)
+                    else None,
+                    allowed=_PERSONA_WAKE_BEHAVIORS,
+                    fallback="one_shot",
+                )
                 saved_match = _match_persona_wake_phrase(matched_phrase, saved_phrases)
                 runtime_match = _match_persona_wake_phrase(matched_phrase, runtime_phrases)
-                if (
-                    wake_behavior not in _PERSONA_WAKE_BEHAVIORS
-                    or not saved_match
-                    or not runtime_match
-                ):
+                if not saved_match or not runtime_match:
                     await _emit_notice(
                         session_id=session_id,
                         level="warning",

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2514,6 +2514,7 @@ def _apply_persona_live_trigger_phrases(
 
 
 def _get_persona_wake_no_command_timeout_s() -> float:
+    """Return the bounded wake activation grace period for one-shot wake modes."""
     try:
         return max(
             1.0,
@@ -2524,6 +2525,7 @@ def _get_persona_wake_no_command_timeout_s() -> float:
 
 
 def _normalize_persona_wake_phrase(value: object) -> str:
+    """Normalize wake phrases so client-reported matches can be compared safely."""
     text = re.sub(r"[^\w\s]+|_", " ", str(value or "").strip().lower())
     return re.sub(r"\s+", " ", text).strip()
 
@@ -2532,6 +2534,7 @@ def _match_persona_wake_phrase(
     matched_phrase: object,
     configured_phrases: list[str] | None,
 ) -> str | None:
+    """Return the configured phrase matching a client wake activation, if any."""
     normalized_match = _normalize_persona_wake_phrase(matched_phrase)
     if not normalized_match:
         return None

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -2524,7 +2524,7 @@ def _get_persona_wake_no_command_timeout_s() -> float:
 
 
 def _normalize_persona_wake_phrase(value: object) -> str:
-    text = re.sub(r"[^\w\s]+", " ", str(value or "").strip().lower())
+    text = re.sub(r"[^\w\s]+|_", " ", str(value or "").strip().lower())
     return re.sub(r"\s+", " ", text).strip()
 
 
@@ -5545,8 +5545,9 @@ async def persona_stream(
                 return None
             return state
 
-        def _get_saved_wake_phrases_for_session(session_id: str) -> list[str]:
-            runtime_context = _load_persona_policy_rules_for_session(
+        async def _get_saved_wake_phrases_for_session(session_id: str) -> list[str]:
+            runtime_context = await asyncio.to_thread(
+                _load_persona_policy_rules_for_session,
                 persona_scope_db,
                 session_id=session_id,
                 user_id=authenticated_user_id,
@@ -5556,7 +5557,8 @@ async def persona_stream(
             runtime_persona_id = str(runtime_context.get("persona_id") or "").strip()
             if not runtime_persona_id or persona_scope_db is None:
                 return []
-            profile = persona_scope_db.get_persona_profile(
+            profile = await asyncio.to_thread(
+                persona_scope_db.get_persona_profile,
                 runtime_persona_id,
                 user_id=authenticated_user_id,
                 include_deleted=False,
@@ -7064,7 +7066,7 @@ async def persona_stream(
                     allowed={"browser_transcript", "native_companion", "test"},
                     fallback="browser_transcript",
                 )
-                saved_phrases = _get_saved_wake_phrases_for_session(session_id)
+                saved_phrases = await _get_saved_wake_phrases_for_session(session_id)
                 runtime_preferences = session_manager.get_preferences(
                     session_id=session_id,
                     user_id=connection_user_id,

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -18,6 +18,7 @@ PersonaExemplarKind = Literal["style", "catchphrase", "boundary", "scenario_demo
 PersonaExemplarSourceType = Literal["manual", "transcript_import", "character_seed", "generated_candidate"]
 PersonaExemplarReviewAction = Literal["approve", "reject"]
 PersonaConfirmationMode = Literal["always", "destructive_only", "never"]
+PersonaWakeBehavior = Literal["one_shot", "continuous", "push_to_talk_after_wake"]
 PersonaSetupStatus = Literal["not_started", "in_progress", "completed"]
 PersonaSetupStep = Literal["archetype", "persona", "voice", "commands", "safety", "test"]
 PersonaSetupTestType = Literal["dry_run", "live_session"]
@@ -126,6 +127,7 @@ class PersonaVoiceDefaults(BaseModel):
     tts_voice: str | None = None
     confirmation_mode: PersonaConfirmationMode | None = None
     voice_chat_trigger_phrases: list[str] = Field(default_factory=list)
+    wake_behavior: PersonaWakeBehavior | None = None
     auto_resume: bool | None = None
     barge_in: bool | None = None
     auto_commit_enabled: bool | None = None

--- a/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
@@ -459,6 +459,7 @@ def test_persona_profile_voice_defaults_roundtrip(persona_db: CharactersRAGDB):
                     "tts_voice": "af_heart",
                     "confirmation_mode": "always",
                     "voice_chat_trigger_phrases": ["hey helper", "okay helper"],
+                    "wake_behavior": "continuous",
                     "auto_resume": True,
                     "barge_in": False,
                     "auto_commit_enabled": True,
@@ -478,6 +479,7 @@ def test_persona_profile_voice_defaults_roundtrip(persona_db: CharactersRAGDB):
             "hey helper",
             "okay helper",
         ]
+        assert payload["voice_defaults"]["wake_behavior"] == "continuous"
         assert payload["voice_defaults"]["auto_commit_enabled"] is True
         assert payload["voice_defaults"]["vad_threshold"] == 0.35
         assert payload["voice_defaults"]["min_silence_ms"] == 150
@@ -489,6 +491,7 @@ def test_persona_profile_voice_defaults_roundtrip(persona_db: CharactersRAGDB):
         fetched_payload = fetched.json()
         assert fetched_payload["voice_defaults"]["tts_provider"] == "tldw"
         assert fetched_payload["voice_defaults"]["tts_voice"] == "af_heart"
+        assert fetched_payload["voice_defaults"]["wake_behavior"] == "continuous"
         assert fetched_payload["voice_defaults"]["auto_resume"] is True
         assert fetched_payload["voice_defaults"]["barge_in"] is False
         assert fetched_payload["voice_defaults"]["auto_commit_enabled"] is True
@@ -504,6 +507,7 @@ def test_persona_profile_voice_defaults_roundtrip(persona_db: CharactersRAGDB):
                     "stt_language": "fr-FR",
                     "confirmation_mode": "destructive_only",
                     "voice_chat_trigger_phrases": ["bonjour helper"],
+                    "wake_behavior": "push_to_talk_after_wake",
                     "auto_resume": False,
                     "barge_in": True,
                     "auto_commit_enabled": False,
@@ -521,6 +525,10 @@ def test_persona_profile_voice_defaults_roundtrip(persona_db: CharactersRAGDB):
         assert updated_payload["voice_defaults"]["voice_chat_trigger_phrases"] == [
             "bonjour helper"
         ]
+        assert (
+            updated_payload["voice_defaults"]["wake_behavior"]
+            == "push_to_talk_after_wake"
+        )
         assert updated_payload["voice_defaults"]["auto_resume"] is False
         assert updated_payload["voice_defaults"]["barge_in"] is True
         assert updated_payload["voice_defaults"]["auto_commit_enabled"] is False
@@ -528,6 +536,23 @@ def test_persona_profile_voice_defaults_roundtrip(persona_db: CharactersRAGDB):
         assert updated_payload["voice_defaults"]["min_silence_ms"] == 640
         assert updated_payload["voice_defaults"]["turn_stop_secs"] == 0.48
         assert updated_payload["voice_defaults"]["min_utterance_secs"] == 0.82
+
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_persona_profile_voice_defaults_rejects_invalid_wake_behavior(
+    persona_db: CharactersRAGDB,
+):
+    with _client_for_user(1, persona_db) as client:
+        created = client.post(
+            "/api/v1/persona/profiles",
+            json={
+                "name": "Bad Wake Helper",
+                "mode": "persistent_scoped",
+                "voice_defaults": {"wake_behavior": "always_on_background"},
+            },
+        )
+        assert created.status_code == 422, created.text
 
     fastapi_app.dependency_overrides.clear()
 

--- a/tldw_Server_API/tests/Persona/test_persona_ws.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws.py
@@ -3,6 +3,7 @@ import base64
 import json
 import queue
 import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -91,6 +92,7 @@ def _seed_persona_session(
     use_persona_state_context_default: bool = True,
     scope_snapshot_json: dict | None = None,
     preferences_json: dict | None = None,
+    voice_defaults: dict | None = None,
 ) -> None:
     from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 
@@ -106,6 +108,7 @@ def _seed_persona_session(
                 "name": "Research Assistant",
                 "mode": mode,
                 "system_prompt": "Helper",
+                "voice_defaults": dict(voice_defaults or {}),
                 "is_active": True,
                 "use_persona_state_context_default": bool(use_persona_state_context_default),
             }
@@ -2223,6 +2226,512 @@ def test_persona_voice_commit_uses_transcriber_snapshot_when_client_omits_transc
             assert plan.get("steps")
             assert fake_transcriber.initialize_called is True
             assert fake_transcriber.reset_called is True
+
+
+class _WakeFakePersonaTranscriber:
+    def __init__(self, transcript: str):
+        self.transcript = transcript
+        self.initialize_called = False
+
+    def initialize(self):
+        self.initialize_called = True
+
+    async def process_audio_chunk(self, audio_data: bytes):
+        return {
+            "type": "partial",
+            "text": self.transcript,
+            "is_final": False,
+        }
+
+    def get_full_transcript(self) -> str:
+        return self.transcript
+
+    def reset(self):
+        return None
+
+    def cleanup(self):
+        return None
+
+
+class _WakeFakeTurnDetector:
+    def __init__(self):
+        self.available = True
+        self.unavailable_reason = None
+        self.last_trigger_at = None
+        self._triggered = False
+
+    def observe(self, audio_data: bytes) -> bool:
+        if self._triggered:
+            return False
+        self._triggered = True
+        self.last_trigger_at = 123.456
+        return True
+
+    def reset(self):
+        self._triggered = False
+
+
+def _install_wake_voice_fakes(monkeypatch, transcript: str):
+    fake_transcriber = _WakeFakePersonaTranscriber(transcript)
+    fake_turn_detector = _WakeFakeTurnDetector()
+    monkeypatch.setattr(
+        persona_ep,
+        "_create_persona_live_stt_transcriber",
+        lambda *args, **kwargs: fake_transcriber,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        persona_ep,
+        "_create_persona_live_turn_detector",
+        lambda *args, **kwargs: fake_turn_detector,
+        raising=False,
+    )
+    return fake_transcriber, fake_turn_detector
+
+
+def test_persona_wake_activation_allows_next_voice_turn_without_trigger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_valid",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "voice_config",
+                        "session_id": "sess_wake_valid",
+                        "voice": {"trigger_phrases": ["hey helper"]},
+                        "stt": {"enable_vad": True},
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_CONFIG_UPDATED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "wake_activation",
+                        "session_id": "sess_wake_valid",
+                        "matched_phrase": "hey helper",
+                        "detector_kind": "browser_transcript",
+                        "wake_behavior": "one_shot",
+                        "detected_at_ms": 1714500000000,
+                    }
+                )
+            )
+            accepted = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED",
+            )
+            assert accepted.get("session_id") == "sess_wake_valid"
+
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode(
+                "ascii"
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "audio_chunk",
+                        "session_id": "sess_wake_valid",
+                        "audio_format": "pcm16",
+                        "bytes_base64": audio_payload,
+                    }
+                )
+            )
+            plan = _recv_until(ws, lambda d: d.get("event") == "tool_plan")
+            assert plan.get("session_id") == "sess_wake_valid"
+
+
+def _assert_wake_activation_rejected_keeps_trigger_gate(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    session_id: str,
+    saved_phrases: list[str],
+    runtime_phrases: list[str],
+    matched_phrase: str,
+    wake_behavior: str = "one_shot",
+) -> None:
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id=session_id,
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": saved_phrases,
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode(
+                "ascii"
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "voice_config",
+                        "session_id": session_id,
+                        "voice": {"trigger_phrases": runtime_phrases},
+                        "stt": {"model": "whisper-1", "language": "en-US"},
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_CONFIG_UPDATED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "wake_activation",
+                        "session_id": session_id,
+                        "matched_phrase": matched_phrase,
+                        "detector_kind": "browser_transcript",
+                        "wake_behavior": wake_behavior,
+                        "detected_at_ms": 1714500000000,
+                    }
+                )
+            )
+            rejected = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_REJECTED",
+            )
+            assert rejected.get("session_id") == session_id
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "audio_chunk",
+                        "session_id": session_id,
+                        "audio_format": "pcm16",
+                        "bytes_base64": audio_payload,
+                    }
+                )
+            )
+            ignored = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TRIGGER_NOT_HEARD",
+            )
+            assert ignored.get("session_id") == session_id
+
+
+def test_persona_wake_activation_rejects_phrase_not_saved_in_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _assert_wake_activation_rejected_keeps_trigger_gate(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="sess_wake_reject_saved",
+        saved_phrases=["hey helper"],
+        runtime_phrases=["runtime only"],
+        matched_phrase="runtime only",
+    )
+
+
+def test_persona_wake_activation_rejects_phrase_missing_from_runtime_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _assert_wake_activation_rejected_keeps_trigger_gate(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="sess_wake_reject_runtime",
+        saved_phrases=["hey helper"],
+        runtime_phrases=["okay helper"],
+        matched_phrase="hey helper",
+    )
+
+
+def test_persona_wake_activation_rejects_invalid_wake_behavior(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _assert_wake_activation_rejected_keeps_trigger_gate(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        session_id="sess_wake_reject_behavior",
+        saved_phrases=["hey helper"],
+        runtime_phrases=["hey helper"],
+        matched_phrase="hey helper",
+        wake_behavior="always_on_background",
+    )
+
+
+def test_persona_wake_deactivation_restores_trigger_gating(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_deactivated",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "continuous",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode(
+                "ascii"
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "voice_config",
+                        "session_id": "sess_wake_deactivated",
+                        "voice": {"trigger_phrases": ["hey helper"]},
+                        "stt": {"model": "whisper-1", "language": "en-US"},
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_CONFIG_UPDATED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "wake_activation",
+                        "session_id": "sess_wake_deactivated",
+                        "matched_phrase": "hey helper",
+                        "detector_kind": "browser_transcript",
+                        "wake_behavior": "continuous",
+                        "detected_at_ms": 1714500000000,
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "wake_deactivation",
+                        "session_id": "sess_wake_deactivated",
+                        "reason": "disarmed",
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_DEACTIVATED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "audio_chunk",
+                        "session_id": "sess_wake_deactivated",
+                        "audio_format": "pcm16",
+                        "bytes_base64": audio_payload,
+                    }
+                )
+            )
+            ignored = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TRIGGER_NOT_HEARD",
+            )
+            assert ignored.get("session_id") == "sess_wake_deactivated"
+
+
+def test_persona_wake_activation_one_shot_expires_after_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_one_shot",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode(
+                "ascii"
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "voice_config",
+                        "session_id": "sess_wake_one_shot",
+                        "voice": {"trigger_phrases": ["hey helper"]},
+                        "stt": {"model": "whisper-1", "language": "en-US"},
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_CONFIG_UPDATED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "wake_activation",
+                        "session_id": "sess_wake_one_shot",
+                        "matched_phrase": "hey helper",
+                        "detector_kind": "browser_transcript",
+                        "wake_behavior": "one_shot",
+                        "detected_at_ms": 1714500000000,
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "audio_chunk",
+                        "session_id": "sess_wake_one_shot",
+                        "audio_format": "pcm16",
+                        "bytes_base64": audio_payload,
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TURN_COMMITTED",
+            )
+            _ = _recv_until(ws, lambda d: d.get("event") == "tool_plan")
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "audio_chunk",
+                        "session_id": "sess_wake_one_shot",
+                        "audio_format": "pcm16",
+                        "bytes_base64": audio_payload,
+                    }
+                )
+            )
+            ignored = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TRIGGER_NOT_HEARD",
+            )
+            assert ignored.get("session_id") == "sess_wake_one_shot"
+
+
+def test_persona_wake_activation_expires_after_no_command_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    monkeypatch.setattr(persona_ep, "_get_persona_wake_no_command_timeout_s", lambda: 0.01)
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_timeout",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            audio_payload = base64.b64encode(b"\x00\x00\xff\x7f\x00\x80").decode(
+                "ascii"
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "voice_config",
+                        "session_id": "sess_wake_timeout",
+                        "voice": {"trigger_phrases": ["hey helper"]},
+                        "stt": {"model": "whisper-1", "language": "en-US"},
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_CONFIG_UPDATED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "wake_activation",
+                        "session_id": "sess_wake_timeout",
+                        "matched_phrase": "hey helper",
+                        "detector_kind": "browser_transcript",
+                        "wake_behavior": "one_shot",
+                        "detected_at_ms": 1714500000000,
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED",
+            )
+            time.sleep(0.02)
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "audio_chunk",
+                        "session_id": "sess_wake_timeout",
+                        "audio_format": "pcm16",
+                        "bytes_base64": audio_payload,
+                    }
+                )
+            )
+            ignored = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_TRIGGER_NOT_HEARD",
+            )
+            assert ignored.get("session_id") == "sess_wake_timeout"
 
 
 def test_persona_audio_chunk_vad_auto_commit_routes_stripped_transcript_to_plan(monkeypatch):

--- a/tldw_Server_API/tests/Persona/test_persona_ws.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws.py
@@ -2541,19 +2541,60 @@ def test_persona_wake_activation_rejects_phrase_missing_from_runtime_config(
     )
 
 
-def test_persona_wake_activation_rejects_invalid_wake_behavior(
+def test_persona_wake_activation_ignores_client_supplied_wake_behavior(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    _assert_wake_activation_rejected_keeps_trigger_gate(
-        tmp_path=tmp_path,
-        monkeypatch=monkeypatch,
-        session_id="sess_wake_reject_behavior",
-        saved_phrases=["hey helper"],
-        runtime_phrases=["hey helper"],
-        matched_phrase="hey helper",
-        wake_behavior="always_on_background",
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_server_behavior",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "one_shot",
+        },
     )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "voice_config",
+                        "session_id": "sess_wake_server_behavior",
+                        "voice": {
+                            "trigger_phrases": ["hey helper"],
+                            "wake_behavior": "one_shot",
+                        },
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_CONFIG_UPDATED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "wake_activation",
+                        "session_id": "sess_wake_server_behavior",
+                        "matched_phrase": "hey helper",
+                        "detector_kind": "browser_transcript",
+                        "wake_behavior": "continuous",
+                    }
+                )
+            )
+            accepted = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED",
+            )
+            assert accepted.get("wake_behavior") == "one_shot"
 
 
 def test_persona_wake_deactivation_restores_trigger_gating(
@@ -2584,7 +2625,10 @@ def test_persona_wake_deactivation_restores_trigger_gating(
                     {
                         "type": "voice_config",
                         "session_id": "sess_wake_deactivated",
-                        "voice": {"trigger_phrases": ["hey helper"]},
+                        "voice": {
+                            "trigger_phrases": ["hey helper"],
+                            "wake_behavior": "continuous",
+                        },
                         "stt": {"model": "whisper-1", "language": "en-US"},
                     }
                 )

--- a/tldw_Server_API/tests/Persona/test_persona_ws.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws.py
@@ -2289,6 +2289,14 @@ def _install_wake_voice_fakes(monkeypatch, transcript: str):
     return fake_transcriber, fake_turn_detector
 
 
+def test_persona_wake_phrase_normalization_treats_underscores_as_separators():
+    assert persona_ep._normalize_persona_wake_phrase("hey_tldw") == "hey tldw"
+    assert (
+        persona_ep._match_persona_wake_phrase("hey tldw", ["hey_tldw"])
+        == "hey_tldw"
+    )
+
+
 def test_persona_wake_activation_allows_next_voice_turn_without_trigger(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2358,6 +2366,68 @@ def test_persona_wake_activation_allows_next_voice_turn_without_trigger(
             )
             plan = _recv_until(ws, lambda d: d.get("event") == "tool_plan")
             assert plan.get("session_id") == "sess_wake_valid"
+
+
+def test_persona_wake_activation_saved_phrase_lookup_is_offloaded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    offloaded_calls: list[str] = []
+
+    async def _fake_to_thread(func, *args, **kwargs):
+        offloaded_calls.append(getattr(func, "__name__", str(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(persona_ep.asyncio, "to_thread", _fake_to_thread)
+    _install_wake_voice_fakes(monkeypatch, "summarize the current note")
+    _seed_persona_session(
+        tmp_path,
+        monkeypatch,
+        user_id="1",
+        session_id="sess_wake_offload",
+        mode="session_scoped",
+        voice_defaults={
+            "voice_chat_trigger_phrases": ["hey helper"],
+            "wake_behavior": "one_shot",
+        },
+    )
+
+    with TestClient(fastapi_app) as c:
+        with c.websocket_connect("/api/v1/persona/stream") as ws:
+            _ = json.loads(ws.receive_text())
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "voice_config",
+                        "session_id": "sess_wake_offload",
+                        "voice": {"trigger_phrases": ["hey helper"]},
+                    }
+                )
+            )
+            _ = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "VOICE_CONFIG_UPDATED",
+            )
+            ws.send_text(
+                json.dumps(
+                    {
+                        "type": "wake_activation",
+                        "session_id": "sess_wake_offload",
+                        "matched_phrase": "hey helper",
+                        "wake_behavior": "one_shot",
+                    }
+                )
+            )
+            accepted = _recv_until(
+                ws,
+                lambda d: d.get("event") == "notice"
+                and d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED",
+            )
+            assert accepted.get("session_id") == "sess_wake_offload"
+
+    assert "_load_persona_policy_rules_for_session" in offloaded_calls
+    assert "get_persona_profile" in offloaded_calls
 
 
 def _assert_wake_activation_rejected_keeps_trigger_gate(

--- a/tldw_Server_API/tests/Persona/test_persona_ws.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws.py
@@ -2271,7 +2271,10 @@ class _WakeFakeTurnDetector:
         self._triggered = False
 
 
-def _install_wake_voice_fakes(monkeypatch, transcript: str):
+def _install_wake_voice_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    transcript: str,
+) -> tuple[_WakeFakePersonaTranscriber, _WakeFakeTurnDetector]:
     fake_transcriber = _WakeFakePersonaTranscriber(transcript)
     fake_turn_detector = _WakeFakeTurnDetector()
     monkeypatch.setattr(


### PR DESCRIPTION
## Change summary

TODO: Human requester must replace or approve this section before merge per the AI-generated PR change summary policy.

AI-authored draft:
- Persist persona wake behavior defaults and validate websocket wake activations against the selected persona profile plus active voice runtime configuration.
- Add a browser transcript wake detector and Persona Live controller wiring so wake listening is manually armed, visible, and scoped to the open live surface.
- Add Persona Live wake controls and document V1 limitations: no true background always-on mode and no pre-wake audio sent to the server.

## Test Plan

- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/Persona/test_persona_ws.py -q -k "voice_defaults or wake_activation or wake_deactivation or persona_audio_chunk_vad_auto_commit_ignores_missing_trigger_phrase"
- [x] bunx vitest run ../packages/ui/src/hooks/__tests__/useResolvedPersonaVoiceDefaults.test.tsx ../packages/ui/src/hooks/__tests__/personaWakeDetector.test.ts ../packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx ../packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx ../packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx ../packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
- [x] git diff --check
- [x] python -m bandit -r tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /tmp/bandit_persona_wake_word.json