### PR TITLE
refactor(workers): register TTS history cleanup lifecycle

### DIFF
--- a/tldw_Server_API/app/services/startup_infra_services.py
+++ b/tldw_Server_API/app/services/startup_infra_services.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 from loguru import logger
 
 from tldw_Server_API.app.core.testing import env_flag_enabled as _env_flag_enabled
+from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase
 
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
@@ -39,11 +40,14 @@ class ConnectorsStartupHandles:
 
 async def start_infra_services(
     *,
-    run_pg_rls_auto_ensure,
+    run_pg_rls_auto_ensure: Callable[[Any], Any],
+    worker_inventory: Any | None = None,
 ) -> InfraStartupHandles:
     """Start the small infrastructure startup slice and return explicit handles."""
     await _maybe_ensure_pg_rls(run_pg_rls_auto_ensure)
-    tts_history_cleanup_task, tts_history_cleanup_stop_event = await _start_tts_history_cleanup_worker()
+    tts_history_cleanup_task, tts_history_cleanup_stop_event = await _start_tts_history_cleanup_worker(
+        worker_inventory=worker_inventory,
+    )
     return InfraStartupHandles(
         tts_history_cleanup_task=tts_history_cleanup_task,
         tts_history_cleanup_stop_event=tts_history_cleanup_stop_event,
@@ -68,7 +72,7 @@ async def start_connectors_startup(
     )
 
 
-async def _maybe_ensure_pg_rls(run_pg_rls_auto_ensure) -> None:
+async def _maybe_ensure_pg_rls(run_pg_rls_auto_ensure: Callable[[Any], Any]) -> None:
     """Apply optional PostgreSQL RLS policies when enabled by env."""
     try:
         if not _env_flag_enabled("RAG_ENSURE_PG_RLS"):
@@ -88,11 +92,29 @@ async def _maybe_ensure_pg_rls(run_pg_rls_auto_ensure) -> None:
         logger.warning(f"Failed to apply PG RLS policies automatically: {exc}")
 
 
-async def _start_tts_history_cleanup_worker() -> tuple[Any | None, Any | None]:
+async def _start_tts_history_cleanup_worker(
+    *,
+    worker_inventory: Any | None = None,
+) -> tuple[Any | None, Any | None]:
     """Start the TTS history cleanup worker and return task/stop handles."""
     try:
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="tts_history_cleanup_task",
+                task_name="tts_history_cleanup_task",
+                coroutine_factory=_run_tts_history_cleanup_loop,
+                timeout_sec=5.0,
+                category="maintenance",
+                shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            )
+            logger.info("TTS history cleanup worker started")
+            return task, stop_event
+
         stop_event = asyncio.Event()
-        task = asyncio.create_task(_run_tts_history_cleanup_loop(stop_event))
+        task = asyncio.create_task(
+            _run_tts_history_cleanup_loop(stop_event),
+            name="tts_history_cleanup_task",
+        )
         logger.info("TTS history cleanup worker started")
         return task, stop_event
     except _STARTUP_GUARD_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/services/startup_service_groups.py
+++ b/tldw_Server_API/app/services/startup_service_groups.py
@@ -55,7 +55,7 @@ async def start_service_groups(
     *,
     app: Any,
     app_settings: Any,
-    run_pg_rls_auto_ensure: Callable[[], Any],
+    run_pg_rls_auto_ensure: Callable[[Any], Any],
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     worker_inventory: Any | None = None,
@@ -75,6 +75,7 @@ async def start_service_groups(
     auxiliary_startup_handles = await _start_auxiliary_services(app_settings)
     infra_startup_handles = await _start_infra_services(
         run_pg_rls_auto_ensure=run_pg_rls_auto_ensure,
+        worker_inventory=worker_inventory,
     )
     maintenance_scheduler_handles = await _start_maintenance_schedulers()
     connectors_startup_handles = await _start_connectors_startup(

--- a/tldw_Server_API/app/services/tts_history_cleanup_service.py
+++ b/tldw_Server_API/app/services/tts_history_cleanup_service.py
@@ -159,7 +159,14 @@ async def run_tts_history_cleanup_loop(stop_event: asyncio.Event | None = None) 
         return
 
     interval_sec = max(60, interval_hours * 3600)
-    await asyncio.sleep(min(interval_sec, 60))
+    initial_delay = min(interval_sec, 60)
+    if stop_event is not None:
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(stop_event.wait(), timeout=initial_delay)
+        if stop_event.is_set():
+            return
+    else:
+        await asyncio.sleep(initial_delay)
 
     while True:
         if stop_event is not None and stop_event.is_set():

--- a/tldw_Server_API/tests/Services/test_startup_infra_services.py
+++ b/tldw_Server_API/tests/Services/test_startup_infra_services.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import sys
 from types import SimpleNamespace
 
 import pytest
-
 
 pytestmark = pytest.mark.unit
 
@@ -26,7 +26,8 @@ async def test_start_infra_services_runs_pg_rls_then_tts(
         calls.append("pg-rls")
         assert run_pg_rls_auto_ensure is not None
 
-    async def _fake_tts():
+    async def _fake_tts(*, worker_inventory):
+        assert worker_inventory is None
         calls.append("tts")
         return ("tts-task", "tts-stop")
 
@@ -69,7 +70,8 @@ async def test_start_tts_history_cleanup_worker_creates_task(
     async def _fake_runner(stop_event):
         return stop_event
 
-    def _record_create_task(coro):
+    def _record_create_task(coro, *, name=None):
+        assert name == "tts_history_cleanup_task"
         task = SimpleNamespace(coro=coro, cancel=lambda: None)
         created_tasks.append(task)
         coro.close()
@@ -82,6 +84,37 @@ async def test_start_tts_history_cleanup_worker_creates_task(
 
     assert task is created_tasks[0]
     assert stop_event is not None
+
+
+@pytest.mark.asyncio
+async def test_start_tts_history_cleanup_worker_registers_background_inventory() -> None:
+    startup_infra = _import_startup_infra_services()
+    registrations: list[dict[str, object]] = []
+
+    class _FakeInventory:
+        async def register_custom(self, **kwargs):
+            registrations.append(kwargs)
+            coroutine = kwargs["coroutine_factory"](startup_infra.asyncio.Event())
+            assert inspect.isawaitable(coroutine)
+            coroutine.close()
+            return "tts-task", "tts-stop"
+
+    task, stop_event = await startup_infra._start_tts_history_cleanup_worker(
+        worker_inventory=_FakeInventory(),
+    )
+
+    assert task == "tts-task"
+    assert stop_event == "tts-stop"
+    assert registrations == [
+        {
+            "name": "tts_history_cleanup_task",
+            "task_name": "tts_history_cleanup_task",
+            "coroutine_factory": startup_infra._run_tts_history_cleanup_loop,
+            "timeout_sec": 5.0,
+            "category": "maintenance",
+            "shutdown_phase": startup_infra.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_service_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_service_groups.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -27,7 +26,8 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
     register_owned_job_poller = object()
     run_pg_rls_auto_ensure = object()
 
-    async def _record_runtime_monitors():
+    async def _record_runtime_monitors(*, worker_inventory):
+        assert worker_inventory is worker_inventory_ref
         calls.append("runtime")
         return SimpleNamespace(
             jobs_metrics_stop_event="jobs-metrics-stop",
@@ -36,7 +36,8 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
             loop_lag_task="loop-lag-task",
         )
 
-    async def _record_optional_workers():
+    async def _record_optional_workers(*, worker_inventory):
+        assert worker_inventory is worker_inventory_ref
         calls.append("optional")
         return SimpleNamespace(
             jobs_metrics_reconcile_stop="reconcile-stop",
@@ -72,8 +73,9 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
             llm_usage_task="llm-usage-task",
         )
 
-    async def _record_infra_services(*, run_pg_rls_auto_ensure):
+    async def _record_infra_services(*, run_pg_rls_auto_ensure, worker_inventory):
         assert run_pg_rls_auto_ensure is run_pg_rls_auto_ensure_ref
+        assert worker_inventory is worker_inventory_ref
         calls.append("infra")
         return SimpleNamespace(
             tts_history_cleanup_task="tts-history-task",
@@ -112,6 +114,7 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
     owned_job_pollers_ref = owned_job_pollers
     register_owned_job_poller_ref = register_owned_job_poller
     run_pg_rls_auto_ensure_ref = run_pg_rls_auto_ensure
+    worker_inventory_ref = object()
 
     monkeypatch.setattr(startup_groups, "_start_runtime_monitors", _record_runtime_monitors)
     monkeypatch.setattr(startup_groups, "_start_optional_workers", _record_optional_workers)
@@ -131,6 +134,7 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
         run_pg_rls_auto_ensure=run_pg_rls_auto_ensure,
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
+        worker_inventory=worker_inventory_ref,
     )
 
     assert calls == [

--- a/tldw_Server_API/tests/Services/test_tts_history_cleanup_service.py
+++ b/tldw_Server_API/tests/Services/test_tts_history_cleanup_service.py
@@ -5,7 +5,6 @@ from loguru import logger
 
 from tldw_Server_API.app.services import tts_history_cleanup_service as cleanup
 
-
 pytestmark = pytest.mark.unit
 
 _LEAK = "not-an-int /tmp/secret-token"
@@ -200,6 +199,37 @@ async def test_cleanup_loop_disabled_when_retention_and_rows_nonpositive(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_cleanup_loop_honors_stop_event_during_initial_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_event = cleanup.asyncio.Event()
+    events: list[object] = []
+
+    monkeypatch.setattr(cleanup, "_resolve_cleanup_settings", lambda: (1, 30, 100))
+
+    async def _fail_sleep(_seconds: float) -> None:
+        raise AssertionError("initial delay should wait on the stop event")
+
+    async def _fake_wait_for(coro, timeout: float):
+        events.append(("wait_for", timeout))
+        stop_event.set()
+        await coro
+        return True
+
+    monkeypatch.setattr(cleanup.asyncio, "sleep", _fail_sleep)
+    monkeypatch.setattr(cleanup.asyncio, "wait_for", _fake_wait_for)
+    monkeypatch.setattr(
+        cleanup.DatabasePaths,
+        "get_media_db_path",
+        lambda _uid: (_ for _ in ()).throw(AssertionError("cleanup should not run")),
+    )
+
+    await cleanup.run_tts_history_cleanup_loop(stop_event=stop_event)
+
+    assert events == [("wait_for", 60)]
+
+
+@pytest.mark.asyncio
 async def test_cleanup_loop_uses_create_media_database_for_sqlite_users(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -218,7 +248,16 @@ async def test_cleanup_loop_uses_create_media_database_for_sqlite_users(
     async def _fake_sleep(_seconds: float) -> None:
         return None
 
+    initial_wait_seen = False
+
     async def _fake_wait_for(coro, timeout: float):
+        nonlocal initial_wait_seen
+        if not initial_wait_seen:
+            initial_wait_seen = True
+            events.append(("initial_wait_for", timeout))
+            if hasattr(coro, "close"):
+                coro.close()
+            raise cleanup.asyncio.TimeoutError
         events.append(("wait_for", timeout))
         stop_event.set()
         await coro
@@ -252,6 +291,7 @@ async def test_cleanup_loop_uses_create_media_database_for_sqlite_users(
     await cleanup.run_tts_history_cleanup_loop(stop_event=stop_event)
 
     assert events == [
+        ("initial_wait_for", 60),
         ("create", "tts_history_cleanup", str(user_db_paths["1"])),
         ("close", "probe"),
         ("create", "tts_history_cleanup", str(user_db_paths["11"])),
@@ -291,7 +331,16 @@ async def test_cleanup_loop_uses_create_media_database_for_postgres(
     async def _fake_sleep(_seconds: float) -> None:
         return None
 
+    initial_wait_seen = False
+
     async def _fake_wait_for(coro, timeout: float):
+        nonlocal initial_wait_seen
+        if not initial_wait_seen:
+            initial_wait_seen = True
+            events.append(("initial_wait_for", timeout))
+            if hasattr(coro, "close"):
+                coro.close()
+            raise cleanup.asyncio.TimeoutError
         events.append(("wait_for", timeout))
         stop_event.set()
         await coro
@@ -315,6 +364,7 @@ async def test_cleanup_loop_uses_create_media_database_for_postgres(
     await cleanup.run_tts_history_cleanup_loop(stop_event=stop_event)
 
     assert events == [
+        ("initial_wait_for", 60),
         ("create", "tts_history_cleanup", str(probe_path)),
         ("purge_with_db", probe_db, ["7", "8"], 14, 55),
         ("close", "probe"),
@@ -336,7 +386,15 @@ async def test_cleanup_loop_failure_log_is_sanitized(
     async def _fake_sleep(_seconds: float) -> None:
         return None
 
+    initial_wait_seen = False
+
     async def _fake_wait_for(coro, timeout: float):
+        nonlocal initial_wait_seen
+        if not initial_wait_seen:
+            initial_wait_seen = True
+            if hasattr(coro, "close"):
+                coro.close()
+            raise cleanup.asyncio.TimeoutError
         stop_event.set()
         await coro
         return True


### PR DESCRIPTION
## Change summary

Part of #1114.

This migrates the TTS history cleanup background task into the shared lifecycle worker inventory when that inventory is available. It registers the task as `category="maintenance"` with `ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN`, keeping it out of the job-poller lease quiesce path while still making startup and shutdown ownership explicit.

The legacy direct `asyncio.create_task` path remains in place for callers that do not provide a worker inventory. The cleanup loop also now observes the stop event during its initial delay, so normal shutdown can stop it promptly instead of waiting on or cancelling the startup sleep.

## Verification

Red tests were run first:

- `python -m pytest tldw_Server_API/tests/Services/test_startup_infra_services.py::test_start_tts_history_cleanup_worker_registers_background_inventory tldw_Server_API/tests/Services/test_startup_service_groups.py::test_start_service_groups_runs_helpers_in_order_and_returns_handles -q`
  - Failed as expected before implementation because the startup helpers did not accept/pass `worker_inventory`.
- `python -m pytest tldw_Server_API/tests/Services/test_tts_history_cleanup_service.py::test_cleanup_loop_honors_stop_event_during_initial_delay -q`
  - Failed as expected before implementation because the initial cleanup delay used plain `asyncio.sleep`.

Final checks:

- `python -m pytest tldw_Server_API/tests/Services/test_startup_infra_services.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_tts_history_cleanup_service.py -q`
  - 33 passed, 5 warnings.
- `python -m pytest tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py -q`
  - 24 passed, 9 warnings.
- `git diff --check`
  - Passed.
- `git diff --cached --check`
  - Passed.
- `python -m bandit -r tldw_Server_API/app/services/startup_infra_services.py tldw_Server_API/app/services/startup_service_groups.py tldw_Server_API/app/services/tts_history_cleanup_service.py -f json -o /tmp/bandit_tts_history_worker_registry_app.json`
  - Passed; no findings.
- `python -m bandit -r tldw_Server_API/tests/Services/test_startup_infra_services.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_tts_history_cleanup_service.py -s B101,B108 -f json -o /tmp/bandit_tts_history_worker_registry_tests_skip_b101_b108.json`
  - Passed. `B101` is skipped for pytest assertions, and `B108` is skipped for pre-existing hardcoded `/tmp/...` strings used by sanitation tests.
