### PR TITLE
refactor(workers): register Kanban maintenance schedulers

### DIFF
--- a/tldw_Server_API/app/services/startup_maintenance_schedulers.py
+++ b/tldw_Server_API/app/services/startup_maintenance_schedulers.py
@@ -11,6 +11,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.testing import is_truthy as _is_truthy
+from tldw_Server_API.app.services.lifecycle_workers import ManagedWorker, ShutdownPhase
 
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
@@ -35,14 +36,21 @@ class MaintenanceSchedulerHandles:
     jobs_prune_task: Any | None = None
 
 
-async def start_maintenance_schedulers() -> MaintenanceSchedulerHandles:
+async def start_maintenance_schedulers(
+    *,
+    worker_inventory: Any | None = None,
+) -> MaintenanceSchedulerHandles:
     """Start the env-gated maintenance scheduler batch and return explicit task handles."""
     return MaintenanceSchedulerHandles(
         quality_eval_task=await _start_quality_eval_scheduler(),
         outputs_purge_task=await _start_outputs_purge_scheduler(),
-        kanban_activity_cleanup_task=await _start_kanban_activity_cleanup_scheduler(),
+        kanban_activity_cleanup_task=await _start_kanban_activity_cleanup_scheduler(
+            worker_inventory=worker_inventory,
+        ),
         ingestion_sources_cleanup_task=await _start_ingestion_sources_cleanup_scheduler(),
-        kanban_purge_task=await _start_kanban_purge_scheduler(),
+        kanban_purge_task=await _start_kanban_purge_scheduler(
+            worker_inventory=worker_inventory,
+        ),
         files_export_gc_task=await _start_file_artifacts_export_gc_scheduler(),
         notifications_prune_task=await _start_notifications_prune_scheduler(),
         jobs_prune_task=await _start_jobs_prune_scheduler(),
@@ -73,13 +81,18 @@ async def _start_outputs_purge_scheduler() -> Any | None:
     )
 
 
-async def _start_kanban_activity_cleanup_scheduler() -> Any | None:
+async def _start_kanban_activity_cleanup_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     return await _start_env_gated_task(
         env_key="KANBAN_ACTIVITY_CLEANUP_ENABLED",
         disabled_message="Kanban activity cleanup scheduler disabled (KANBAN_ACTIVITY_CLEANUP_ENABLED != true)",
         started_message="Kanban activity cleanup scheduler started",
         failure_message="Failed to start Kanban activity cleanup scheduler: {exc}",
         starter=_start_kanban_activity_cleanup_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="kanban_activity_cleanup_scheduler",
     )
 
 
@@ -96,13 +109,18 @@ async def _start_ingestion_sources_cleanup_scheduler() -> Any | None:
     )
 
 
-async def _start_kanban_purge_scheduler() -> Any | None:
+async def _start_kanban_purge_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     return await _start_env_gated_task(
         env_key="KANBAN_PURGE_ENABLED",
         disabled_message="Kanban purge scheduler disabled (KANBAN_PURGE_ENABLED != true)",
         started_message="Kanban purge scheduler started",
         failure_message="Failed to start Kanban purge scheduler: {exc}",
         starter=_start_kanban_purge_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="kanban_purge_scheduler",
     )
 
 
@@ -143,6 +161,8 @@ async def _start_env_gated_task(
     started_message: str,
     failure_message: str,
     starter,
+    worker_inventory: Any | None = None,
+    worker_name: str | None = None,
 ) -> Any | None:
     try:
         if not _env_enabled(env_key):
@@ -150,6 +170,17 @@ async def _start_env_gated_task(
             return None
         task = await starter()
         if task:
+            if worker_inventory is not None and worker_name is not None:
+                worker_inventory.register(
+                    ManagedWorker(
+                        name=worker_name,
+                        task=task,
+                        stop_event=None,
+                        timeout_sec=5.0,
+                        category="maintenance",
+                        shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+                    )
+                )
             logger.info(started_message)
         return task
     except _STARTUP_GUARD_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/services/startup_maintenance_schedulers.py
+++ b/tldw_Server_API/app/services/startup_maintenance_schedulers.py
@@ -5,13 +5,14 @@ Maintenance-scheduler startup helpers extracted from the application lifespan.
 from __future__ import annotations
 
 import os
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
 
 from tldw_Server_API.app.core.testing import is_truthy as _is_truthy
-from tldw_Server_API.app.services.lifecycle_workers import ManagedWorker, ShutdownPhase
+from tldw_Server_API.app.services.lifecycle_workers import ManagedWorker, ShutdownPhase, WorkerInventory
 
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
@@ -38,7 +39,7 @@ class MaintenanceSchedulerHandles:
 
 async def start_maintenance_schedulers(
     *,
-    worker_inventory: Any | None = None,
+    worker_inventory: WorkerInventory | None = None,
 ) -> MaintenanceSchedulerHandles:
     """Start the env-gated maintenance scheduler batch and return explicit task handles."""
     return MaintenanceSchedulerHandles(
@@ -83,7 +84,7 @@ async def _start_outputs_purge_scheduler() -> Any | None:
 
 async def _start_kanban_activity_cleanup_scheduler(
     *,
-    worker_inventory: Any | None = None,
+    worker_inventory: WorkerInventory | None = None,
 ) -> Any | None:
     return await _start_env_gated_task(
         env_key="KANBAN_ACTIVITY_CLEANUP_ENABLED",
@@ -111,7 +112,7 @@ async def _start_ingestion_sources_cleanup_scheduler() -> Any | None:
 
 async def _start_kanban_purge_scheduler(
     *,
-    worker_inventory: Any | None = None,
+    worker_inventory: WorkerInventory | None = None,
 ) -> Any | None:
     return await _start_env_gated_task(
         env_key="KANBAN_PURGE_ENABLED",
@@ -160,10 +161,16 @@ async def _start_env_gated_task(
     disabled_message: str,
     started_message: str,
     failure_message: str,
-    starter,
-    worker_inventory: Any | None = None,
+    starter: Callable[[], Awaitable[Any | None]],
+    worker_inventory: WorkerInventory | None = None,
     worker_name: str | None = None,
 ) -> Any | None:
+    """Start one env-gated scheduler and optionally register it for managed shutdown.
+
+    Scheduler startup failures return ``None``. Inventory registration failures
+    are logged without hiding a successfully started task handle.
+    """
+
     try:
         if not _env_enabled(env_key):
             logger.info(disabled_message)
@@ -171,16 +178,21 @@ async def _start_env_gated_task(
         task = await starter()
         if task:
             if worker_inventory is not None and worker_name is not None:
-                worker_inventory.register(
-                    ManagedWorker(
-                        name=worker_name,
-                        task=task,
-                        stop_event=None,
-                        timeout_sec=5.0,
-                        category="maintenance",
-                        shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+                try:
+                    worker_inventory.register(
+                        ManagedWorker(
+                            name=worker_name,
+                            task=task,
+                            stop_event=None,
+                            timeout_sec=5.0,
+                            category="maintenance",
+                            shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+                        )
                     )
-                )
+                except _STARTUP_GUARD_EXCEPTIONS as exc:
+                    logger.warning(
+                        f"Started {worker_name} but failed to register it in worker inventory: {exc}"
+                    )
             logger.info(started_message)
         return task
     except _STARTUP_GUARD_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/services/startup_service_groups.py
+++ b/tldw_Server_API/app/services/startup_service_groups.py
@@ -4,6 +4,7 @@ Startup service-tail orchestration extracted from the application lifespan.
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -77,9 +78,12 @@ async def start_service_groups(
         run_pg_rls_auto_ensure=run_pg_rls_auto_ensure,
         worker_inventory=worker_inventory,
     )
-    maintenance_scheduler_handles = await _start_maintenance_schedulers(
-        worker_inventory=worker_inventory,
-    )
+    if worker_inventory is None:
+        maintenance_scheduler_handles = await _start_maintenance_schedulers()
+    else:
+        maintenance_scheduler_handles = await _start_maintenance_schedulers(
+            worker_inventory=worker_inventory,
+        )
     connectors_startup_handles = await _start_connectors_startup(
         app=app,
         owned_job_pollers=owned_job_pollers,
@@ -160,12 +164,40 @@ async def _start_infra_services(**kwargs):
     return await start_infra_services(**kwargs)
 
 
-async def _start_maintenance_schedulers(**kwargs):
+async def _start_maintenance_schedulers(**kwargs: Any) -> Any:
+    """Start maintenance schedulers while preserving no-arg monkeypatch compatibility."""
+
     from tldw_Server_API.app.services.startup_maintenance_schedulers import (
         start_maintenance_schedulers,
     )
 
+    if "worker_inventory" in kwargs and not _accepts_keyword(
+        start_maintenance_schedulers,
+        "worker_inventory",
+    ):
+        kwargs = {key: value for key, value in kwargs.items() if key != "worker_inventory"}
     return await start_maintenance_schedulers(**kwargs)
+
+
+def _accepts_keyword(func: Callable[..., Any], keyword: str) -> bool:
+    """Return whether a callable can accept the given keyword argument."""
+
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return True
+
+    parameter = signature.parameters.get(keyword)
+    if parameter is not None and parameter.kind in {
+        inspect.Parameter.KEYWORD_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    }:
+        return True
+
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
 
 
 async def _start_connectors_startup(**kwargs):

--- a/tldw_Server_API/app/services/startup_service_groups.py
+++ b/tldw_Server_API/app/services/startup_service_groups.py
@@ -77,7 +77,9 @@ async def start_service_groups(
         run_pg_rls_auto_ensure=run_pg_rls_auto_ensure,
         worker_inventory=worker_inventory,
     )
-    maintenance_scheduler_handles = await _start_maintenance_schedulers()
+    maintenance_scheduler_handles = await _start_maintenance_schedulers(
+        worker_inventory=worker_inventory,
+    )
     connectors_startup_handles = await _start_connectors_startup(
         app=app,
         owned_job_pollers=owned_job_pollers,
@@ -158,12 +160,12 @@ async def _start_infra_services(**kwargs):
     return await start_infra_services(**kwargs)
 
 
-async def _start_maintenance_schedulers():
+async def _start_maintenance_schedulers(**kwargs):
     from tldw_Server_API.app.services.startup_maintenance_schedulers import (
         start_maintenance_schedulers,
     )
 
-    return await start_maintenance_schedulers()
+    return await start_maintenance_schedulers(**kwargs)
 
 
 async def _start_connectors_startup(**kwargs):

--- a/tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py
+++ b/tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py
@@ -29,7 +29,8 @@ async def test_start_maintenance_schedulers_combines_handles(
         calls.append("outputs")
         return "outputs-task"
 
-    async def _fake_kanban_activity():
+    async def _fake_kanban_activity(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("kanban-activity")
         return "kanban-activity-task"
 
@@ -37,7 +38,8 @@ async def test_start_maintenance_schedulers_combines_handles(
         calls.append("ingestion-sources")
         return "ingestion-sources-task"
 
-    async def _fake_kanban_purge():
+    async def _fake_kanban_purge(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("kanban-purge")
         return "kanban-purge-task"
 
@@ -85,6 +87,61 @@ async def test_start_maintenance_schedulers_combines_handles(
 
 
 @pytest.mark.asyncio
+async def test_start_maintenance_schedulers_passes_worker_inventory_to_kanban_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_maintenance = _import_startup_maintenance_schedulers()
+    worker_inventory = object()
+    calls: list[tuple[str, object | None]] = []
+
+    async def _fake_quality():
+        return None
+
+    async def _fake_outputs():
+        return None
+
+    async def _fake_kanban_activity(*, worker_inventory=None):
+        calls.append(("kanban-activity", worker_inventory))
+        return "kanban-activity-task"
+
+    async def _fake_ingestion_sources():
+        return None
+
+    async def _fake_kanban_purge(*, worker_inventory=None):
+        calls.append(("kanban-purge", worker_inventory))
+        return "kanban-purge-task"
+
+    async def _fake_files_gc():
+        return None
+
+    async def _fake_notifications():
+        return None
+
+    async def _fake_jobs_prune():
+        return None
+
+    monkeypatch.setattr(startup_maintenance, "_start_quality_eval_scheduler", _fake_quality)
+    monkeypatch.setattr(startup_maintenance, "_start_outputs_purge_scheduler", _fake_outputs)
+    monkeypatch.setattr(startup_maintenance, "_start_kanban_activity_cleanup_scheduler", _fake_kanban_activity)
+    monkeypatch.setattr(startup_maintenance, "_start_ingestion_sources_cleanup_scheduler", _fake_ingestion_sources)
+    monkeypatch.setattr(startup_maintenance, "_start_kanban_purge_scheduler", _fake_kanban_purge)
+    monkeypatch.setattr(startup_maintenance, "_start_file_artifacts_export_gc_scheduler", _fake_files_gc)
+    monkeypatch.setattr(startup_maintenance, "_start_notifications_prune_scheduler", _fake_notifications)
+    monkeypatch.setattr(startup_maintenance, "_start_jobs_prune_scheduler", _fake_jobs_prune)
+
+    handles = await startup_maintenance.start_maintenance_schedulers(
+        worker_inventory=worker_inventory,
+    )
+
+    assert calls == [
+        ("kanban-activity", worker_inventory),
+        ("kanban-purge", worker_inventory),
+    ]
+    assert handles.kanban_activity_cleanup_task == "kanban-activity-task"
+    assert handles.kanban_purge_task == "kanban-purge-task"
+
+
+@pytest.mark.asyncio
 async def test_start_quality_eval_scheduler_skips_when_flag_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -112,3 +169,55 @@ async def test_start_jobs_prune_scheduler_starts_when_enabled(
     task = await startup_maintenance._start_jobs_prune_scheduler()
 
     assert task == "jobs-prune-task"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("starter_name", "service_name", "expected_name"),
+    [
+        (
+            "_start_kanban_activity_cleanup_scheduler",
+            "_start_kanban_activity_cleanup_scheduler_service",
+            "kanban_activity_cleanup_scheduler",
+        ),
+        (
+            "_start_kanban_purge_scheduler",
+            "_start_kanban_purge_scheduler_service",
+            "kanban_purge_scheduler",
+        ),
+    ],
+)
+async def test_kanban_maintenance_schedulers_register_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    starter_name: str,
+    service_name: str,
+    expected_name: str,
+) -> None:
+    startup_maintenance = _import_startup_maintenance_schedulers()
+    registrations = []
+    task = object()
+
+    class _FakeInventory:
+        def register(self, worker):
+            registrations.append(worker)
+            return worker
+
+    async def _fake_start():
+        return task
+
+    monkeypatch.setattr(startup_maintenance, "_env_enabled", lambda key: True)
+    monkeypatch.setattr(startup_maintenance, service_name, _fake_start)
+
+    started_task = await getattr(startup_maintenance, starter_name)(
+        worker_inventory=_FakeInventory(),
+    )
+
+    assert started_task is task
+    assert len(registrations) == 1
+    worker = registrations[0]
+    assert worker.name == expected_name
+    assert worker.task is task
+    assert worker.stop_event is None
+    assert worker.timeout_sec == 5.0
+    assert worker.category == "maintenance"
+    assert worker.shutdown_phase == startup_maintenance.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN

--- a/tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py
+++ b/tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py
@@ -5,7 +5,6 @@ import sys
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -221,3 +220,32 @@ async def test_kanban_maintenance_schedulers_register_background_inventory(
     assert worker.timeout_sec == 5.0
     assert worker.category == "maintenance"
     assert worker.shutdown_phase == startup_maintenance.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+
+
+@pytest.mark.asyncio
+async def test_start_env_gated_task_returns_task_when_inventory_registration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_maintenance = _import_startup_maintenance_schedulers()
+    task = object()
+
+    class _FailingInventory:
+        def register(self, worker):
+            raise AttributeError("registration unavailable")
+
+    async def _fake_start():
+        return task
+
+    monkeypatch.setattr(startup_maintenance, "_env_enabled", lambda key: True)
+
+    started_task = await startup_maintenance._start_env_gated_task(
+        env_key="KANBAN_PURGE_ENABLED",
+        disabled_message="disabled",
+        started_message="started",
+        failure_message="failed: {exc}",
+        starter=_fake_start,
+        worker_inventory=_FailingInventory(),
+        worker_name="kanban_purge_scheduler",
+    )
+
+    assert started_task is task

--- a/tldw_Server_API/tests/Services/test_startup_service_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_service_groups.py
@@ -155,3 +155,145 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
     assert handles.tts_history_cleanup_task == "tts-history-task"
     assert handles.jobs_prune_task == "jobs-prune-task"
     assert handles.connectors_jobs_task == "connectors-task"
+
+
+@pytest.mark.asyncio
+async def test_start_service_groups_keeps_no_arg_maintenance_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_groups = _import_startup_service_groups()
+    calls: list[str] = []
+
+    async def _record_runtime_monitors():
+        calls.append("runtime")
+        return SimpleNamespace(
+            jobs_metrics_stop_event=None,
+            jobs_metrics_task=None,
+            loop_lag_stop_event=None,
+            loop_lag_task=None,
+        )
+
+    async def _record_optional_workers():
+        calls.append("optional")
+        return SimpleNamespace(
+            jobs_metrics_reconcile_stop=None,
+            jobs_metrics_reconcile_task=None,
+            jobs_crypto_rotate_stop_event=None,
+            jobs_crypto_rotate_task=None,
+            jobs_webhooks_stop_event=None,
+            jobs_webhooks_task=None,
+            meetings_webhook_dlq_stop_event=None,
+            meetings_webhook_dlq_task=None,
+            workflows_dlq_stop_event=None,
+            workflows_dlq_task=None,
+            workflows_gc_stop_event=None,
+            workflows_gc_task=None,
+            workflows_maint_stop_event=None,
+            workflows_maint_task=None,
+            jobs_integrity_stop_event=None,
+            jobs_integrity_task=None,
+        )
+
+    async def _record_claims_rebuild_worker(app_settings):
+        calls.append("claims")
+        return None
+
+    async def _record_auxiliary_services(app_settings):
+        calls.append("auxiliary")
+        return SimpleNamespace(
+            claims_alerts_task=None,
+            claims_review_metrics_task=None,
+            usage_task=None,
+            llm_usage_task=None,
+        )
+
+    async def _record_infra_services(*, run_pg_rls_auto_ensure, worker_inventory=None):
+        assert worker_inventory is None
+        calls.append("infra")
+        return SimpleNamespace(
+            tts_history_cleanup_task=None,
+            tts_history_cleanup_stop_event=None,
+        )
+
+    async def _record_maintenance_schedulers():
+        calls.append("maintenance")
+        return SimpleNamespace(
+            quality_eval_task=None,
+            outputs_purge_task=None,
+            kanban_activity_cleanup_task=None,
+            ingestion_sources_cleanup_task=None,
+            kanban_purge_task=None,
+            files_export_gc_task=None,
+            notifications_prune_task=None,
+            jobs_prune_task=None,
+        )
+
+    async def _record_connectors_startup(
+        *,
+        app,
+        owned_job_pollers,
+        register_owned_job_poller,
+    ):
+        calls.append("connectors")
+        return SimpleNamespace(
+            connectors_jobs_task=None,
+            connectors_jobs_stop_event=None,
+        )
+
+    monkeypatch.setattr(startup_groups, "_start_runtime_monitors", _record_runtime_monitors)
+    monkeypatch.setattr(startup_groups, "_start_optional_workers", _record_optional_workers)
+    monkeypatch.setattr(startup_groups, "_start_claims_rebuild_worker", _record_claims_rebuild_worker)
+    monkeypatch.setattr(startup_groups, "_start_auxiliary_services", _record_auxiliary_services)
+    monkeypatch.setattr(startup_groups, "_start_infra_services", _record_infra_services)
+    monkeypatch.setattr(
+        startup_groups,
+        "_start_maintenance_schedulers",
+        _record_maintenance_schedulers,
+    )
+    monkeypatch.setattr(startup_groups, "_start_connectors_startup", _record_connectors_startup)
+
+    await startup_groups.start_service_groups(
+        app=object(),
+        app_settings={},
+        run_pg_rls_auto_ensure=object(),
+        owned_job_pollers=[],
+        register_owned_job_poller=lambda *args, **kwargs: None,
+    )
+
+    assert calls == [
+        "runtime",
+        "optional",
+        "claims",
+        "auxiliary",
+        "infra",
+        "maintenance",
+        "connectors",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_maintenance_schedulers_wrapper_supports_no_arg_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_groups = _import_startup_service_groups()
+    startup_maintenance = importlib.import_module(
+        "tldw_Server_API.app.services.startup_maintenance_schedulers"
+    )
+    calls: list[str] = []
+
+    async def _fake_start_maintenance_schedulers():
+        calls.append("maintenance")
+        return "maintenance-handles"
+
+    monkeypatch.setattr(
+        startup_maintenance,
+        "start_maintenance_schedulers",
+        _fake_start_maintenance_schedulers,
+    )
+
+    handles = await startup_groups._start_maintenance_schedulers(
+        worker_inventory=object(),
+    )
+
+    assert handles == "maintenance-handles"
+    assert calls == ["maintenance"]

--- a/tldw_Server_API/tests/Services/test_startup_service_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_service_groups.py
@@ -26,6 +26,8 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
     register_owned_job_poller = object()
     run_pg_rls_auto_ensure = object()
 
+    worker_inventory_ref = object()
+
     async def _record_runtime_monitors(*, worker_inventory):
         assert worker_inventory is worker_inventory_ref
         calls.append("runtime")
@@ -82,7 +84,8 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
             tts_history_cleanup_stop_event="tts-history-stop",
         )
 
-    async def _record_maintenance_schedulers():
+    async def _record_maintenance_schedulers(*, worker_inventory=None):
+        assert worker_inventory is worker_inventory_ref
         calls.append("maintenance")
         return SimpleNamespace(
             quality_eval_task="quality-task",
@@ -114,7 +117,6 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
     owned_job_pollers_ref = owned_job_pollers
     register_owned_job_poller_ref = register_owned_job_poller
     run_pg_rls_auto_ensure_ref = run_pg_rls_auto_ensure
-    worker_inventory_ref = object()
 
     monkeypatch.setattr(startup_groups, "_start_runtime_monitors", _record_runtime_monitors)
     monkeypatch.setattr(startup_groups, "_start_optional_workers", _record_optional_workers)


### PR DESCRIPTION
## Change summary

Part of #1114.

This migrates the Kanban activity cleanup scheduler and Kanban soft-delete purge scheduler into the lifecycle worker inventory when startup owns a worker inventory. Both tasks keep their existing environment-gated enablement and legacy no-inventory startup behavior, but when registered they are marked as `category="maintenance"` with `ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN`.

These scheduler tasks do not expose stop events today, so the lifecycle record intentionally stores `stop_event=None`; the background-worker shutdown phase will cancel them with the existing bounded cancellation behavior. Because their shutdown phase is not `JOB_POLLER_QUIESCE`, they stay out of the job-poller lease waiting path.

## Verification

Red tests were run first:

- `python -m pytest tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py::test_start_maintenance_schedulers_passes_worker_inventory_to_kanban_helpers tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py::test_kanban_maintenance_schedulers_register_background_inventory tldw_Server_API/tests/Services/test_startup_service_groups.py::test_start_service_groups_runs_helpers_in_order_and_returns_handles -q`
  - Failed as expected before implementation because `worker_inventory` was not accepted by the maintenance startup helpers and was not passed through service-group startup.

Final checks:

- `python -m pytest tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_kanban_activity_cleanup_service.py tldw_Server_API/tests/Services/test_kanban_purge_service.py -q`
  - 22 passed, 5 warnings.
- `python -m pytest tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py -q`
  - 24 passed, 9 warnings.
- `python -m pytest tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_lifespan_worker_runtime_state.py -q`
  - 5 passed, 5 warnings.
- `git diff --check`
  - Passed.
- `git diff --cached --check`
  - Passed.
- `python -m bandit -r tldw_Server_API/app/services/startup_maintenance_schedulers.py tldw_Server_API/app/services/startup_service_groups.py -f json -o /tmp/bandit_kanban_maintenance_worker_registry_app.json`
  - Passed; no findings.
- `python -m bandit -r tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py tldw_Server_API/tests/Services/test_startup_service_groups.py -s B101 -f json -o /tmp/bandit_kanban_maintenance_worker_registry_tests.json`
  - Passed; no findings. `B101` is skipped for pytest assertions.
