### PR TITLE
ci(sandbox): add vz_linux host-gated smoke

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -39,4 +39,5 @@ jobs:
             .github/workflows/frontend-ux-gates.yml \
             .github/workflows/publish-ghcr-main.yml \
             .github/workflows/publish-docker.yml \
-            .github/workflows/sbom.yml
+            .github/workflows/sbom.yml \
+            .github/workflows/vz-linux-host-gated.yml

--- a/.github/workflows/vz-linux-host-gated.yml
+++ b/.github/workflows/vz-linux-host-gated.yml
@@ -1,0 +1,104 @@
+name: VZ Linux Host-Gated Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      bundle_path:
+        description: Path to the canonical vz_linux bundle on the self-hosted runner
+        required: false
+        type: string
+      entitlements_path:
+        description: Optional helper entitlements plist path on the self-hosted runner
+        required: false
+        type: string
+      skip_sign:
+        description: Skip ad hoc helper signing
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: '17 10 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vz-linux-host-gated-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  vz-linux-host-gated-smoke:
+    name: VZ Linux real execution smoke
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY == '1' }}
+    runs-on: [self-hosted, macOS, ARM64, vz-linux]
+    timeout-minutes: 120
+    env:
+      PYTHONPATH: .
+      TEST_MODE: '0'
+      TLDW_VZ_HOST_E2E_BUNDLE_PATH: ${{ inputs.bundle_path || vars.TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH }}
+      TLDW_VZ_HOST_E2E_ENTITLEMENTS_PATH: ${{ inputs.entitlements_path || vars.TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH }}
+      TLDW_VZ_HOST_E2E_SKIP_SIGN: ${{ inputs.skip_sign || vars.TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN || 'false' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Verify prepared Apple Silicon host
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(uname -s)" = "Darwin"
+          test "$(uname -m)" = "arm64"
+          command -v swift
+          xcrun --find codesign
+          if [[ -z "${TLDW_VZ_HOST_E2E_BUNDLE_PATH:-}" ]]; then
+            echo "Set workflow input bundle_path or repository variable TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH" >&2
+            exit 1
+          fi
+          if [[ ! -d "${TLDW_VZ_HOST_E2E_BUNDLE_PATH}" ]]; then
+            echo "Bundle path does not exist or is not a directory: ${TLDW_VZ_HOST_E2E_BUNDLE_PATH}" >&2
+            exit 1
+          fi
+
+      - name: Setup Python and deps
+        uses: ./.github/actions/setup-python-deps
+        with:
+          python-version: '3.12'
+          use-uv: 'true'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+          extras: dev
+
+      - name: Run managed host smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          runtime_dir="${RUNNER_TEMP}/tldw-vz-helper-ci"
+          rm -rf "${runtime_dir}"
+          mkdir -p "${runtime_dir}/serial"
+          chmod 700 "${runtime_dir}"
+
+          args=(
+            --bundle "${TLDW_VZ_HOST_E2E_BUNDLE_PATH}"
+            --socket "${runtime_dir}/helper.sock"
+            --serial-log-dir "${runtime_dir}/serial"
+            --python "$(command -v python)"
+          )
+          if [[ -n "${TLDW_VZ_HOST_E2E_ENTITLEMENTS_PATH:-}" ]]; then
+            args+=(--entitlements "${TLDW_VZ_HOST_E2E_ENTITLEMENTS_PATH}")
+          fi
+          case "${TLDW_VZ_HOST_E2E_SKIP_SIGN:-false}" in
+            1|true|TRUE|True|yes|YES|Yes)
+              args+=(--skip-sign)
+              ;;
+          esac
+
+          bash tools/vz-linux-image/scripts/run-host-e2e-smoke.sh "${args[@]}"
+
+      - name: Upload helper logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vz-linux-host-gated-helper-logs
+          path: ${{ runner.temp }}/tldw-vz-helper-ci/**
+          if-no-files-found: ignore

--- a/.github/workflows/vz-linux-host-gated.yml
+++ b/.github/workflows/vz-linux-host-gated.yml
@@ -35,9 +35,9 @@ jobs:
     env:
       PYTHONPATH: .
       TEST_MODE: '0'
-      TLDW_VZ_HOST_E2E_BUNDLE_PATH: ${{ inputs.bundle_path || vars.TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH }}
-      TLDW_VZ_HOST_E2E_ENTITLEMENTS_PATH: ${{ inputs.entitlements_path || vars.TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH }}
-      TLDW_VZ_HOST_E2E_SKIP_SIGN: ${{ inputs.skip_sign || vars.TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN || 'false' }}
+      TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH: ${{ inputs.bundle_path || vars.TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH }}
+      TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH: ${{ inputs.entitlements_path || vars.TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH }}
+      TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN: ${{ inputs.skip_sign || vars.TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN || 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -50,12 +50,12 @@ jobs:
           test "$(uname -m)" = "arm64"
           command -v swift
           xcrun --find codesign
-          if [[ -z "${TLDW_VZ_HOST_E2E_BUNDLE_PATH:-}" ]]; then
+          if [[ -z "${TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH:-}" ]]; then
             echo "Set workflow input bundle_path or repository variable TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH" >&2
             exit 1
           fi
-          if [[ ! -d "${TLDW_VZ_HOST_E2E_BUNDLE_PATH}" ]]; then
-            echo "Bundle path does not exist or is not a directory: ${TLDW_VZ_HOST_E2E_BUNDLE_PATH}" >&2
+          if [[ ! -d "${TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH}" ]]; then
+            echo "Bundle path does not exist or is not a directory: ${TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH}" >&2
             exit 1
           fi
 
@@ -80,15 +80,15 @@ jobs:
           chmod 700 "${runtime_dir}/serial"
 
           args=(
-            --bundle "${TLDW_VZ_HOST_E2E_BUNDLE_PATH}"
+            --bundle "${TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH}"
             --socket "${runtime_dir}/helper.sock"
             --serial-log-dir "${runtime_dir}/serial"
             --python "$(command -v python)"
           )
-          if [[ -n "${TLDW_VZ_HOST_E2E_ENTITLEMENTS_PATH:-}" ]]; then
-            args+=(--entitlements "${TLDW_VZ_HOST_E2E_ENTITLEMENTS_PATH}")
+          if [[ -n "${TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH:-}" ]]; then
+            args+=(--entitlements "${TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH}")
           fi
-          case "${TLDW_VZ_HOST_E2E_SKIP_SIGN:-false}" in
+          case "${TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN:-false}" in
             1|true|TRUE|True|yes|YES|Yes)
               args+=(--skip-sign)
               ;;

--- a/.github/workflows/vz-linux-host-gated.yml
+++ b/.github/workflows/vz-linux-host-gated.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   vz-linux-host-gated-smoke:
     name: VZ Linux real execution smoke
-    if: ${{ github.event_name == 'workflow_dispatch' || vars.TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY == '1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || vars.TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY == '1') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
     runs-on: [self-hosted, macOS, ARM64, vz-linux]
     timeout-minutes: 120
     env:
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload helper logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: vz-linux-host-gated-helper-logs
           path: ${{ runner.temp }}/tldw-vz-helper-ci/**

--- a/.github/workflows/vz-linux-host-gated.yml
+++ b/.github/workflows/vz-linux-host-gated.yml
@@ -77,6 +77,7 @@ jobs:
           rm -rf "${runtime_dir}"
           mkdir -p "${runtime_dir}/serial"
           chmod 700 "${runtime_dir}"
+          chmod 700 "${runtime_dir}/serial"
 
           args=(
             --bundle "${TLDW_VZ_HOST_E2E_BUNDLE_PATH}"

--- a/.github/workflows/vz-linux-host-gated.yml
+++ b/.github/workflows/vz-linux-host-gated.yml
@@ -37,7 +37,7 @@ jobs:
       TEST_MODE: '0'
       TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH: ${{ inputs.bundle_path || vars.TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH }}
       TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH: ${{ inputs.entitlements_path || vars.TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH }}
-      TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN: ${{ inputs.skip_sign || vars.TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN || 'false' }}
+      TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN: ${{ inputs.skip_sign == null && (vars.TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN || 'false') || inputs.skip_sign }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/Docs/Design/2026-05-01-vz-linux-host-gated-ci-design.md
+++ b/Docs/Design/2026-05-01-vz-linux-host-gated-ci-design.md
@@ -1,0 +1,56 @@
+# vz_linux Host-Gated CI Design
+
+**Date:** 2026-05-01
+**Status:** Implementation slice
+
+## Goal
+
+Add a repeatable CI entrypoint for the real `vz_linux` macOS execution path
+without making normal CI depend on Apple Silicon hardware.
+
+The workflow should prove the same path operators run locally:
+
+- prepared Apple silicon macOS host
+- canonical `vz_linux` bundle already present on that host
+- Swift helper build and optional ad hoc signing
+- helper daemon startup over an owner-private Unix socket
+- helper bundle smoke
+- real ephemeral `vz_linux` execution
+- same-session VM reuse
+- helper shutdown and log collection
+
+## Approach
+
+Add a dedicated GitHub Actions workflow that runs only on self-hosted runners
+with labels:
+
+- `self-hosted`
+- `macOS`
+- `ARM64`
+- `vz-linux`
+
+The workflow supports manual dispatch with a `bundle_path` input. A scheduled
+trigger is present but the job is skipped unless repository variable
+`TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY=1` is set. That preserves portable
+default CI while allowing a prepared private runner to catch regressions.
+
+The workflow delegates to the existing operator smoke script instead of
+duplicating helper lifecycle logic. This keeps one source of truth for build,
+sign, start, real execution, session reuse, cleanup, and logs.
+
+## Non-Goals
+
+- Provisioning the Apple Silicon runner.
+- Building the canonical Debian bundle in CI.
+- Installing launchd services automatically.
+- Requiring this workflow as a branch-protection gate.
+- Adding APFS clone provisioning or network allowlist enforcement.
+
+## Success Criteria
+
+- Normal hosted CI remains portable.
+- Operators can run the workflow manually against a prepared host bundle.
+- Nightly runs are opt-in through a repository variable.
+- Workflow shape is covered by a static infrastructure test.
+- Operator docs describe runner labels, required repository variables, and the
+  exact smoke path used by CI.

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -366,6 +366,42 @@ That keeps the smoke path synchronous and prevents it from silently using the
 fake helper contract. On unprepared hosts, the module should skip with explicit
 helper-or-template reasons instead of reporting a fake pass.
 
+## Host-Gated CI
+
+Real `vz_linux` execution cannot run on the default hosted CI fleet because it
+requires Apple silicon macOS plus a prepared Virtualization.framework helper and
+canonical bundle. The repo therefore keeps normal CI portable and adds a
+separate host-gated workflow:
+
+- `.github/workflows/vz-linux-host-gated.yml`
+- runner labels: `self-hosted`, `macOS`, `ARM64`, `vz-linux`
+- manual trigger: `workflow_dispatch`
+- scheduled trigger: present, but skipped unless
+  `TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY=1`
+
+Required host/repository configuration:
+
+- a self-hosted Apple silicon macOS runner with the labels above
+- SwiftPM and Xcode command line tools available to the runner
+- a canonical `vz_linux` bundle already present on the runner
+- workflow input `bundle_path` or repository variable
+  `TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH`
+- optional repository variable `TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH`
+- optional repository variable `TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN=true`
+
+The workflow calls the same operator smoke script documented above:
+
+```bash
+bash tools/vz-linux-image/scripts/run-host-e2e-smoke.sh \
+  --bundle "$TLDW_VZ_HOST_E2E_BUNDLE_PATH" \
+  --socket "$RUNNER_TEMP/tldw-vz-helper-ci/helper.sock" \
+  --serial-log-dir "$RUNNER_TEMP/tldw-vz-helper-ci/serial"
+```
+
+That keeps CI aligned with local operator behavior instead of creating a second
+helper lifecycle path. The job uploads helper logs from the runner temp
+directory even when the smoke fails.
+
 ## Helper Daemon Smoke
 
 There is also an opt-in cross-language smoke test for the first-party helper daemon:

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -399,7 +399,7 @@ The workflow calls the same operator smoke script documented above:
 
 ```bash
 bash tools/vz-linux-image/scripts/run-host-e2e-smoke.sh \
-  --bundle "$TLDW_VZ_HOST_E2E_BUNDLE_PATH" \
+  --bundle "$TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH" \
   --socket "$RUNNER_TEMP/tldw-vz-helper-ci/helper.sock" \
   --serial-log-dir "$RUNNER_TEMP/tldw-vz-helper-ci/serial"
 ```

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -390,6 +390,11 @@ Required host/repository configuration:
 - optional repository variable `TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH`
 - optional repository variable `TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN=true`
 
+The self-hosted job is branch-gated to `main` and `dev` so a manual dispatch
+does not accidentally execute arbitrary feature-branch code on the prepared
+host. External actions in this workflow are pinned to immutable SHAs because
+they execute on the self-hosted runner.
+
 The workflow calls the same operator smoke script documented above:
 
 ```bash

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -317,9 +317,10 @@ tools/macos-vz-helper/scripts/vz-helperctl.py smoke \
 
 The wrapper delegates to `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh`
 with the managed helper defaults. That lower-level script validates the bundle,
-builds the Swift helper when the binary is missing, optionally ad hoc signs it
-with the supplied entitlements, runs the helper-daemon smoke, starts one helper
-daemon for real `vz_linux` E2E, verifies ephemeral execution, verifies
+builds the Swift helper when the binary is missing, ad hoc signs it with the
+supplied entitlements unless the helper is already signed with
+`com.apple.security.virtualization`, runs the helper-daemon smoke, starts one
+helper daemon for real `vz_linux` E2E, verifies ephemeral execution, verifies
 same-session VM reuse, and stops the helper on exit.
 
 The lower-level fallback remains available when operators need to bypass the

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -43,7 +43,7 @@ def test_vz_linux_host_gated_workflow_targets_prepared_apple_silicon_runner() ->
 
     assert job["runs-on"] == ["self-hosted", "macOS", "ARM64", "vz-linux"]  # nosec B101
     assert job["timeout-minutes"] <= 120  # nosec B101
-    assert "TLDW_VZ_HOST_E2E_BUNDLE_PATH" in job["env"]  # nosec B101
+    assert "TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH" in job["env"]  # nosec B101
 
 
 def test_vz_linux_host_gated_workflow_rejects_untrusted_refs() -> None:
@@ -66,7 +66,7 @@ def test_vz_linux_host_gated_workflow_uses_operator_smoke_script() -> None:
     assert "--bundle" in run_blocks  # nosec B101
     assert "--python" in run_blocks  # nosec B101
     assert 'chmod 700 "${runtime_dir}/serial"' in run_blocks  # nosec B101
-    assert "TLDW_VZ_HOST_E2E_BUNDLE_PATH" in run_blocks  # nosec B101
+    assert "TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH" in run_blocks  # nosec B101
 
 
 def test_vz_linux_host_gated_workflow_pins_external_actions() -> None:

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -46,6 +46,18 @@ def test_vz_linux_host_gated_workflow_targets_prepared_apple_silicon_runner() ->
     assert "TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH" in job["env"]  # nosec B101
 
 
+def test_vz_linux_host_gated_workflow_preserves_explicit_skip_sign_false() -> None:
+    """Manual skip_sign=false should override a true repository variable."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["vz-linux-host-gated-smoke"]
+    skip_sign_expr = job["env"]["TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN"]
+    truthy_fallback = "inputs.skip_sign || vars.TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN"
+
+    assert "inputs.skip_sign == null" in skip_sign_expr  # nosec B101
+    assert "vars.TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN || 'false'" in skip_sign_expr  # nosec B101
+    assert truthy_fallback not in skip_sign_expr  # nosec B101
+
+
 def test_vz_linux_host_gated_workflow_rejects_untrusted_refs() -> None:
     """Manual self-hosted runs must not execute arbitrary feature-branch code."""
     workflow = _load_workflow()

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -1,6 +1,9 @@
+"""Contract tests for the Apple Silicon host-gated vz_linux workflow."""
+
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -9,12 +12,14 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "vz-linux-host-gated.yml"
 
 
-def _load_workflow() -> dict:
+def _load_workflow() -> dict[str, Any]:
+    """Load the workflow YAML while preserving the parsed structure for assertions."""
     with WORKFLOW_PATH.open("r", encoding="utf-8") as handle:
         return yaml.safe_load(handle)
 
 
-def _workflow_triggers(workflow: dict) -> dict:
+def _workflow_triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the workflow trigger map despite PyYAML's YAML 1.1 boolean key parsing."""
     # PyYAML's YAML 1.1 resolver parses an unquoted "on" key as True.
     triggers = workflow.get("on", workflow.get(True))
     assert isinstance(triggers, dict)  # nosec B101
@@ -22,6 +27,7 @@ def _workflow_triggers(workflow: dict) -> dict:
 
 
 def test_vz_linux_host_gated_workflow_is_manual_and_nightly() -> None:
+    """The real VZ workflow should remain manual/nightly instead of normal CI."""
     workflow = _load_workflow()
     triggers = _workflow_triggers(workflow)
 
@@ -31,6 +37,7 @@ def test_vz_linux_host_gated_workflow_is_manual_and_nightly() -> None:
 
 
 def test_vz_linux_host_gated_workflow_targets_prepared_apple_silicon_runner() -> None:
+    """The job must target only prepared self-hosted Apple Silicon VZ runners."""
     workflow = _load_workflow()
     job = workflow["jobs"]["vz-linux-host-gated-smoke"]
 
@@ -39,7 +46,18 @@ def test_vz_linux_host_gated_workflow_targets_prepared_apple_silicon_runner() ->
     assert "TLDW_VZ_HOST_E2E_BUNDLE_PATH" in job["env"]  # nosec B101
 
 
+def test_vz_linux_host_gated_workflow_rejects_untrusted_refs() -> None:
+    """Manual self-hosted runs must not execute arbitrary feature-branch code."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["vz-linux-host-gated-smoke"]
+
+    assert "refs/heads/main" in job["if"]  # nosec B101
+    assert "refs/heads/dev" in job["if"]  # nosec B101
+    assert "github.ref" in job["if"]  # nosec B101
+
+
 def test_vz_linux_host_gated_workflow_uses_operator_smoke_script() -> None:
+    """The workflow should delegate real VM work to the repo's operator smoke script."""
     workflow = _load_workflow()
     steps = workflow["jobs"]["vz-linux-host-gated-smoke"]["steps"]
     run_blocks = "\n".join(str(step.get("run", "")) for step in steps)
@@ -49,3 +67,13 @@ def test_vz_linux_host_gated_workflow_uses_operator_smoke_script() -> None:
     assert "--python" in run_blocks  # nosec B101
     assert 'chmod 700 "${runtime_dir}/serial"' in run_blocks  # nosec B101
     assert "TLDW_VZ_HOST_E2E_BUNDLE_PATH" in run_blocks  # nosec B101
+
+
+def test_vz_linux_host_gated_workflow_pins_external_actions() -> None:
+    """The self-hosted workflow should use immutable SHAs for third-party actions."""
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["vz-linux-host-gated-smoke"]["steps"]
+    uses_entries = [str(step.get("uses", "")) for step in steps if step.get("uses")]
+
+    assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" in uses_entries  # nosec B101
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in uses_entries  # nosec B101

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "vz-linux-host-gated.yml"
+
+
+def _load_workflow() -> dict:
+    with WORKFLOW_PATH.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _workflow_triggers(workflow: dict) -> dict:
+    # PyYAML's YAML 1.1 resolver parses an unquoted "on" key as True.
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict)  # nosec B101
+    return triggers
+
+
+def test_vz_linux_host_gated_workflow_is_manual_and_nightly() -> None:
+    workflow = _load_workflow()
+    triggers = _workflow_triggers(workflow)
+
+    assert "workflow_dispatch" in triggers  # nosec B101
+    assert "schedule" in triggers  # nosec B101
+    assert triggers["workflow_dispatch"]["inputs"]["bundle_path"]["required"] is False  # nosec B101
+
+
+def test_vz_linux_host_gated_workflow_targets_prepared_apple_silicon_runner() -> None:
+    workflow = _load_workflow()
+    job = workflow["jobs"]["vz-linux-host-gated-smoke"]
+
+    assert job["runs-on"] == ["self-hosted", "macOS", "ARM64", "vz-linux"]  # nosec B101
+    assert job["timeout-minutes"] <= 120  # nosec B101
+    assert "TLDW_VZ_HOST_E2E_BUNDLE_PATH" in job["env"]  # nosec B101
+
+
+def test_vz_linux_host_gated_workflow_uses_operator_smoke_script() -> None:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["vz-linux-host-gated-smoke"]["steps"]
+    run_blocks = "\n".join(str(step.get("run", "")) for step in steps)
+
+    assert "tools/vz-linux-image/scripts/run-host-e2e-smoke.sh" in run_blocks  # nosec B101
+    assert "--bundle" in run_blocks  # nosec B101
+    assert "--python" in run_blocks  # nosec B101
+    assert "TLDW_VZ_HOST_E2E_BUNDLE_PATH" in run_blocks  # nosec B101

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -47,4 +47,5 @@ def test_vz_linux_host_gated_workflow_uses_operator_smoke_script() -> None:
     assert "tools/vz-linux-image/scripts/run-host-e2e-smoke.sh" in run_blocks  # nosec B101
     assert "--bundle" in run_blocks  # nosec B101
     assert "--python" in run_blocks  # nosec B101
+    assert 'chmod 700 "${runtime_dir}/serial"' in run_blocks  # nosec B101
     assert "TLDW_VZ_HOST_E2E_BUNDLE_PATH" in run_blocks  # nosec B101

--- a/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_daemon_host_gated.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_daemon_host_gated.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess  # nosec B404 - subprocess is required to launch the repo-local helper daemon in this opt-in smoke test.
 import sys
 import tempfile
@@ -53,14 +54,14 @@ def _require_canonical_bundle_smoke() -> Path:
 def test_macos_helper_daemon_smoke_over_real_unix_socket(monkeypatch, tmp_path: Path) -> None:
     binary_path = _require_helper_daemon_smoke()
     monkeypatch.delenv("TEST_MODE", raising=False)
-    socket_fd, socket_name = tempfile.mkstemp(  # nosec B108 - AF_UNIX paths must stay short on macOS, so this smoke test intentionally allocates under /tmp.
-        prefix="macos-vz-helper-smoke-",
-        suffix=".sock",
-        dir="/tmp",  # nosec B108
+    socket_dir = Path(
+        tempfile.mkdtemp(  # nosec B108 - AF_UNIX paths must stay short on macOS, so this smoke test intentionally allocates a private directory under /tmp.
+            prefix="macos-vz-helper-smoke-",
+            dir="/tmp",  # nosec B108
+        )
     )
-    os.close(socket_fd)
-    socket_path = Path(socket_name)
-    socket_path.unlink(missing_ok=True)
+    socket_dir.chmod(0o700)
+    socket_path = socket_dir / "helper.sock"
     template_path = tmp_path / "template.img"
     template_path.write_bytes(b"")
 
@@ -120,21 +121,21 @@ def test_macos_helper_daemon_smoke_over_real_unix_socket(monkeypatch, tmp_path: 
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=5)
-        socket_path.unlink(missing_ok=True)
+        shutil.rmtree(socket_dir, ignore_errors=True)
 
 
 def test_macos_helper_daemon_canonical_bundle_boot_smoke(monkeypatch, tmp_path: Path) -> None:
     binary_path = _require_helper_daemon_smoke()
     bundle_path = _require_canonical_bundle_smoke()
     monkeypatch.delenv("TEST_MODE", raising=False)
-    socket_fd, socket_name = tempfile.mkstemp(  # nosec B108 - AF_UNIX paths must stay short on macOS, so this smoke test intentionally allocates under /tmp.
-        prefix="macos-vz-helper-bundle-",
-        suffix=".sock",
-        dir="/tmp",  # nosec B108
+    socket_dir = Path(
+        tempfile.mkdtemp(  # nosec B108 - AF_UNIX paths must stay short on macOS, so this smoke test intentionally allocates a private directory under /tmp.
+            prefix="macos-vz-helper-bundle-",
+            dir="/tmp",  # nosec B108
+        )
     )
-    os.close(socket_fd)
-    socket_path = Path(socket_name)
-    socket_path.unlink(missing_ok=True)
+    socket_dir.chmod(0o700)
+    socket_path = socket_dir / "helper.sock"
 
     env = os.environ.copy()
     env["TLDW_SANDBOX_MACOS_HELPER_SOCKET"] = str(socket_path)
@@ -215,7 +216,7 @@ def test_macos_helper_daemon_canonical_bundle_boot_smoke(monkeypatch, tmp_path: 
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=5)
-        socket_path.unlink(missing_ok=True)
+        shutil.rmtree(socket_dir, ignore_errors=True)
         if cleanup_error is not None:
             warnings.warn(
                 f"failed to terminate helper smoke vm {created_vm_id}: {cleanup_error}",

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -215,6 +215,15 @@ Use the direct module command for focused helper or bundle validation. Use
 `run-host-e2e-smoke.sh` for the full operator workflow because it also covers
 real sandbox execution and session VM reuse.
 
+The same script is the entrypoint for the host-gated GitHub Actions workflow at
+`.github/workflows/vz-linux-host-gated.yml`. That workflow is intentionally
+limited to prepared self-hosted Apple silicon runners labeled
+`self-hosted`, `macOS`, `ARM64`, and `vz-linux`; normal hosted CI does not run
+real VZ execution. Set repository variable
+`TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY=1` to enable the scheduled run, and
+set `TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH` or pass the manual `bundle_path` input
+to point at the canonical bundle on the runner.
+
 ## Image Store Registration
 
 Canonical bundles can be registered in the sandbox image store for durable local

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -220,7 +220,9 @@ The same script is the entrypoint for the host-gated GitHub Actions workflow at
 `.github/workflows/vz-linux-host-gated.yml`. That workflow is intentionally
 limited to prepared self-hosted Apple silicon runners labeled
 `self-hosted`, `macOS`, `ARM64`, and `vz-linux`; normal hosted CI does not run
-real VZ execution. Set repository variable
+real VZ execution. The job is branch-gated to `main` and `dev` so manual
+dispatch cannot run arbitrary feature-branch code on the self-hosted host. Set
+repository variable
 `TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY=1` to enable the scheduled run, and
 set `TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH` or pass the manual `bundle_path` input
 to point at the canonical bundle on the runner.

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -192,10 +192,11 @@ chmod 700 "${runtime_dir}"
 ```
 
 On a prepared Apple silicon macOS host, that script builds the Swift helper
-when needed, optionally signs it with `--entitlements`, runs the helper-daemon
-bundle smoke, starts a helper daemon for the Python sandbox runtime, runs real
-`vz_linux` ephemeral execution, verifies same-session VM reuse, and stops the
-helper on exit.
+when needed, signs it with `--entitlements` unless the helper is already signed
+with `com.apple.security.virtualization`, runs the helper-daemon bundle smoke,
+starts a helper daemon for the Python sandbox runtime, runs real `vz_linux`
+ephemeral execution, verifies same-session VM reuse, and stops the helper on
+exit.
 
 The helper refuses sockets whose parent directory is not owner-only. Do not put
 the helper socket directly under `/tmp`; use the script defaults or create a

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -30,7 +30,7 @@ Options:
   --socket PATH          Host-side helper AF_UNIX socket path
   --serial-log-dir PATH  Directory for helper VM serial logs
   --helper PATH          Helper binary path
-  --entitlements PATH    Entitlements plist for ad hoc codesigning
+  --entitlements PATH    Entitlements plist for ad hoc codesigning unless the helper is already signed
   --python PATH          Python executable for pytest
   --skip-build           Do not build the helper even if the binary is missing
   --skip-sign            Do not codesign the helper
@@ -236,12 +236,36 @@ prepare_private_socket_parent() {
   fi
 }
 
+prepare_private_serial_log_dir() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  if [[ -L "${SERIAL_LOG_DIR}" ]]; then
+    die "serial log directory is a symlink: ${SERIAL_LOG_DIR}"
+  fi
+  if [[ -e "${SERIAL_LOG_DIR}" && ! -d "${SERIAL_LOG_DIR}" ]]; then
+    die "serial log path is not a directory: ${SERIAL_LOG_DIR}"
+  fi
+  if [[ -d "${SERIAL_LOG_DIR}" ]]; then
+    if ! directory_is_owner_private "${SERIAL_LOG_DIR}"; then
+      die "serial log directory must be owner-only: ${SERIAL_LOG_DIR}"
+    fi
+    return 0
+  fi
+  mkdir -p "${SERIAL_LOG_DIR}"
+  chmod 700 "${SERIAL_LOG_DIR}"
+  if ! directory_is_owner_private "${SERIAL_LOG_DIR}"; then
+    die "serial log directory must be owner-only: ${SERIAL_LOG_DIR}"
+  fi
+}
+
 run_helper_daemon_smoke() {
   run_cmd env \
     TLDW_SANDBOX_MACOS_HELPER_DAEMON_SMOKE=1 \
     TLDW_SANDBOX_VZ_LINUX_BUNDLE_SMOKE=1 \
     TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH="${BUNDLE_PATH}" \
     TLDW_SANDBOX_MACOS_HELPER_BINARY="${HELPER_PATH}" \
+    TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR="${SERIAL_LOG_DIR}" \
     "${PYTHON_BIN}" -m pytest \
     "${REPO_ROOT}/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_daemon_host_gated.py" \
     -q -rs
@@ -258,7 +282,6 @@ start_helper_for_real_e2e() {
 
   prepare_private_socket_parent
   prepare_socket_path
-  mkdir -p "${SERIAL_LOG_DIR}"
   env \
     TLDW_SANDBOX_MACOS_HELPER_SOCKET="${SOCKET_PATH}" \
     TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR="${SERIAL_LOG_DIR}" \
@@ -312,6 +335,7 @@ cd "${REPO_ROOT}"
 build_helper_if_needed
 sign_helper_if_requested
 require_helper_binary
+prepare_private_serial_log_dir
 run_helper_daemon_smoke
 start_helper_for_real_e2e
 wait_for_helper_socket

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -76,6 +76,7 @@ def test_host_e2e_smoke_script_dry_run_prints_helper_and_pytest_commands(tmp_pat
     assert f"TLDW_SANDBOX_MACOS_HELPER_SOCKET={socket_path}" in result.stdout
     assert f"TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH={bundle}" in result.stdout
     assert f"TLDW_SANDBOX_VZ_LINUX_E2E_BASE_IMAGE={bundle}" in result.stdout
+    assert f"TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR={serial_log_dir}" in result.stdout  # nosec B101
     assert "test_macos_virtualization_helper_daemon_host_gated.py" in result.stdout
     assert "test_vz_linux_real_host_e2e.py" in result.stdout
     assert not serial_log_dir.exists()
@@ -200,6 +201,49 @@ def test_host_e2e_smoke_script_refuses_non_private_socket_parent(tmp_path: Path)
 
     assert result.returncode != 0
     assert "helper socket directory must be owner-only" in result.stderr
+
+
+def test_host_e2e_smoke_script_refuses_non_private_serial_log_directory(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    socket_dir = tmp_path / "private-runtime"
+    socket_dir.mkdir(mode=0o700)
+    socket_dir.chmod(0o700)
+    serial_log_dir = tmp_path / "public-serial"
+    serial_log_dir.mkdir(mode=0o755)
+    serial_log_dir.chmod(0o755)
+    fake_python = tmp_path / "fake-python"
+    fake_helper = tmp_path / "fake-helper"
+    fake_python.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.exit(0 if sys.argv[1:3] == ['-m', 'pytest'] else 2)\n",
+        encoding="utf-8",
+    )
+    fake_helper.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    fake_python.chmod(0o755)
+    fake_helper.chmod(0o755)
+
+    result = _run_smoke_script(
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(fake_helper),
+        "--socket",
+        str(socket_dir / "helper.sock"),
+        "--serial-log-dir",
+        str(serial_log_dir),
+        "--python",
+        str(fake_python),
+        "--skip-build",
+        "--skip-sign",
+        env_overrides={"TLDW_HOST_E2E_SMOKE_SKIP_SOCKET_WAIT": "1"},
+    )
+
+    assert result.returncode != 0  # nosec B101
+    assert "serial log directory must be owner-only" in result.stderr  # nosec B101
 
 
 def test_host_e2e_smoke_script_refuses_regular_file_socket_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a manual/nightly self-hosted Apple Silicon workflow for real `vz_linux` execution smoke.
- Delegate CI execution to the existing `tools/vz-linux-image/scripts/run-host-e2e-smoke.sh` operator path instead of duplicating helper lifecycle logic.
- Document runner labels, bundle/entitlements variables, nightly opt-in behavior, and add a static workflow contract test.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py -q`
- [x] `git diff --check`
- [x] YAML parse check for `.github/workflows/vz-linux-host-gated.yml` and `.github/workflows/actionlint.yml`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -f json -o /tmp/bandit_vz_host_gated_ci.json`
- [ ] Real host-gated VZ smoke, requires prepared Apple Silicon self-hosted runner and canonical bundle
- [ ] Local `actionlint`, unavailable in this environment; workflow is now included in the repo actionlint target list

## Change summary
TODO: maintainer-authored summary required before merge by the AI-generated PR policy.