### PR TITLE
refactor(workers): register Chatbooks cleanup lifecycle

### DIFF
--- a/tldw_Server_API/app/services/lifespan_shutdown_sequence.py
+++ b/tldw_Server_API/app/services/lifespan_shutdown_sequence.py
@@ -106,6 +106,7 @@ async def run_lifespan_shutdown_sequence(
         run_coordinated_shutdown=run_coordinated_shutdown,
         startup_guard_exceptions=startup_guard_exceptions,
         import_exceptions=import_exceptions,
+        stopped_background_worker_names=stopped_background_worker_names,
     )
     coordinated_legacy_component_names = (
         coordinated_legacy_shutdown_handles.coordinated_legacy_component_names
@@ -123,6 +124,7 @@ async def run_lifespan_shutdown_sequence(
         storage_cleanup_service=worker_runtime.storage_cleanup_service,
         coordinated_legacy_component_names=coordinated_legacy_component_names,
         guard_exceptions=startup_guard_exceptions,
+        stopped_background_worker_names=stopped_background_worker_names,
     )
     worker_runtime.apply_pre_worker_cleanup_handles(pre_worker_cleanup_handles)
 

--- a/tldw_Server_API/app/services/shutdown_coordinated_legacy_components.py
+++ b/tldw_Server_API/app/services/shutdown_coordinated_legacy_components.py
@@ -24,6 +24,7 @@ async def shutdown_coordinated_legacy_components(
     run_coordinated_shutdown: Callable[[Any, list[Any]], Awaitable[set[str]]],
     startup_guard_exceptions: tuple[type[BaseException], ...],
     import_exceptions: tuple[type[BaseException], ...],
+    stopped_background_worker_names: set[str] | None = None,
 ) -> CoordinatedLegacyShutdownHandles:
     """Run the non-transition legacy components through the coordinated shutdown path."""
     coordinated_legacy_component_names = await _shutdown_coordinated_legacy_components(
@@ -32,6 +33,7 @@ async def shutdown_coordinated_legacy_components(
         run_coordinated_shutdown=run_coordinated_shutdown,
         startup_guard_exceptions=startup_guard_exceptions,
         import_exceptions=import_exceptions,
+        stopped_background_worker_names=stopped_background_worker_names,
     )
     return CoordinatedLegacyShutdownHandles(
         coordinated_legacy_component_names=coordinated_legacy_component_names,
@@ -45,6 +47,7 @@ async def run_shutdown_coordinated_legacy_components(
     run_coordinated_shutdown: Callable[[Any, list[Any]], Awaitable[set[str]]],
     startup_guard_exceptions: tuple[type[BaseException], ...],
     import_exceptions: tuple[type[BaseException], ...],
+    stopped_background_worker_names: set[str] | None = None,
 ) -> CoordinatedLegacyShutdownHandles:
     """Run coordinated legacy shutdown with main-lifespan fallback behavior."""
     try:
@@ -54,6 +57,7 @@ async def run_shutdown_coordinated_legacy_components(
             run_coordinated_shutdown=run_coordinated_shutdown,
             startup_guard_exceptions=startup_guard_exceptions,
             import_exceptions=import_exceptions,
+            stopped_background_worker_names=stopped_background_worker_names,
         )
     except (startup_guard_exceptions + import_exceptions) as exc:
         logger.debug(f"Legacy coordinator shutdown skipped: {exc}")
@@ -67,13 +71,16 @@ async def _shutdown_coordinated_legacy_components(
     run_coordinated_shutdown: Callable[[Any, list[Any]], Awaitable[set[str]]],
     startup_guard_exceptions: tuple[type[BaseException], ...],
     import_exceptions: tuple[type[BaseException], ...],
+    stopped_background_worker_names: set[str] | None = None,
 ) -> set[str]:
     del startup_guard_exceptions, import_exceptions
+    stopped_background_worker_names = stopped_background_worker_names or set()
 
     non_transition_legacy_shutdown_plan = [
         component
         for component in legacy_shutdown_plan
         if getattr(getattr(component, "phase", None), "value", None) != "transition"
+        and getattr(component, "name", None) not in stopped_background_worker_names
     ]
     return await run_coordinated_shutdown(
         app,

--- a/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
@@ -30,6 +30,7 @@ async def shutdown_pre_worker_cleanup(
     storage_cleanup_service: Any | None,
     coordinated_legacy_component_names: set[str],
     guard_exceptions: tuple[type[BaseException], ...],
+    stopped_background_worker_names: set[str] | None = None,
 ) -> PreWorkerCleanupHandles:
     """Run the cleanup/reset shutdown slice that precedes the worker helpers."""
     await _shutdown_pre_worker_cleanup(
@@ -40,6 +41,7 @@ async def shutdown_pre_worker_cleanup(
         storage_cleanup_service=storage_cleanup_service,
         coordinated_legacy_component_names=coordinated_legacy_component_names,
         guard_exceptions=guard_exceptions,
+        stopped_background_worker_names=stopped_background_worker_names,
     )
     return PreWorkerCleanupHandles(
         cleanup_task=cleanup_task,
@@ -58,6 +60,7 @@ async def run_shutdown_pre_worker_cleanup(
     storage_cleanup_service: Any | None,
     coordinated_legacy_component_names: set[str],
     guard_exceptions: tuple[type[BaseException], ...],
+    stopped_background_worker_names: set[str] | None = None,
 ) -> PreWorkerCleanupHandles:
     """Run pre-worker cleanup with main-lifespan fallback behavior."""
     try:
@@ -69,6 +72,7 @@ async def run_shutdown_pre_worker_cleanup(
             storage_cleanup_service=storage_cleanup_service,
             coordinated_legacy_component_names=coordinated_legacy_component_names,
             guard_exceptions=guard_exceptions,
+            stopped_background_worker_names=stopped_background_worker_names,
         )
     except guard_exceptions as exc:
         logger.debug(f"Pre-worker cleanup skipped: {exc}")
@@ -89,14 +93,19 @@ async def _shutdown_pre_worker_cleanup(
     storage_cleanup_service: Any | None,
     coordinated_legacy_component_names: set[str],
     guard_exceptions: tuple[type[BaseException], ...],
+    stopped_background_worker_names: set[str] | None = None,
 ) -> None:
+    stopped_background_worker_names = stopped_background_worker_names or set()
     await _cancel_deferred_startup_task(
         app=app,
         guard_exceptions=guard_exceptions,
     )
     if cleanup_task:
         cleanup_task.cancel()
-    if "chatbooks_cleanup" not in coordinated_legacy_component_names:
+    if (
+        "chatbooks_cleanup" not in coordinated_legacy_component_names
+        and "chatbooks_cleanup" not in stopped_background_worker_names
+    ):
         if chatbooks_cleanup_stop_event:
             chatbooks_cleanup_stop_event.set()
         if chatbooks_cleanup_task:

--- a/tldw_Server_API/app/services/startup_cleanup_workers.py
+++ b/tldw_Server_API/app/services/startup_cleanup_workers.py
@@ -12,6 +12,11 @@ from typing import Any, Mapping
 
 from loguru import logger
 
+from tldw_Server_API.app.services.worker_registry import (
+    ShutdownPhase,
+    start_stop_event_worker,
+)
+
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
     OSError,
@@ -36,10 +41,14 @@ async def start_cleanup_workers(
     app_settings: Mapping[str, Any],
     *,
     test_mode: bool,
+    worker_inventory: Any | None = None,
 ) -> CleanupWorkerHandles:
     """Start the small cleanup-worker startup slice and return explicit handles."""
     cleanup_task = await _start_ephemeral_cleanup_worker(app_settings)
-    secondary = await _start_secondary_cleanup_workers(test_mode=test_mode)
+    secondary = await _start_secondary_cleanup_workers(
+        test_mode=test_mode,
+        worker_inventory=worker_inventory,
+    )
     return CleanupWorkerHandles(
         cleanup_task=cleanup_task,
         chatbooks_cleanup_task=secondary.chatbooks_cleanup_task,
@@ -48,9 +57,15 @@ async def start_cleanup_workers(
     )
 
 
-async def _start_secondary_cleanup_workers(*, test_mode: bool) -> CleanupWorkerHandles:
+async def _start_secondary_cleanup_workers(
+    *,
+    test_mode: bool,
+    worker_inventory: Any | None = None,
+) -> CleanupWorkerHandles:
     """Start cleanup workers whose enablement is driven by process env."""
-    chatbooks_cleanup_task, chatbooks_cleanup_stop_event = await _start_chatbooks_cleanup_worker()
+    chatbooks_cleanup_task, chatbooks_cleanup_stop_event = await _start_chatbooks_cleanup_worker(
+        worker_inventory=worker_inventory,
+    )
     storage_cleanup_service = await _start_storage_cleanup_worker(test_mode=test_mode)
     return CleanupWorkerHandles(
         chatbooks_cleanup_task=chatbooks_cleanup_task,
@@ -106,13 +121,29 @@ async def _start_ephemeral_cleanup_worker(app_settings: Mapping[str, Any]) -> An
         return None
 
 
-async def _start_chatbooks_cleanup_worker() -> tuple[Any | None, Any | None]:
+async def _start_chatbooks_cleanup_worker(
+    *,
+    worker_inventory: Any | None = None,
+) -> tuple[Any | None, Any | None]:
     """Start the scheduled chatbooks cleanup worker when enabled."""
     try:
         interval_sec = int(os.getenv("CHATBOOKS_CLEANUP_INTERVAL_SEC", "0") or "0")
         if interval_sec > 0:
-            stop_event = asyncio.Event()
-            task = asyncio.create_task(_run_chatbooks_cleanup_loop(stop_event))
+            if worker_inventory is not None:
+                task, stop_event = await start_stop_event_worker(
+                    worker_inventory,
+                    name="chatbooks_cleanup",
+                    task_name="chatbooks_cleanup_task",
+                    coroutine_factory=_run_chatbooks_cleanup_loop,
+                    category="cleanup",
+                    shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+                )
+            else:
+                stop_event = asyncio.Event()
+                task = asyncio.create_task(
+                    _run_chatbooks_cleanup_loop(stop_event),
+                    name="chatbooks_cleanup_task",
+                )
             logger.info("Chatbooks cleanup worker started")
             return task, stop_event
         logger.info("Chatbooks cleanup worker disabled by settings")

--- a/tldw_Server_API/app/services/startup_worker_bootstrap.py
+++ b/tldw_Server_API/app/services/startup_worker_bootstrap.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from tldw_Server_API.app.services.lifecycle_workers import WorkerRegistry
+from tldw_Server_API.app.services.worker_registry import WorkerRegistry
 
 
 @dataclass
@@ -72,6 +72,7 @@ async def initialize_startup_worker_bootstrap(
         startup_service_tail_handles=startup_service_tail_handles,
         worker_inventory=worker_inventory,
     )
+
 
 def _load_app_settings():
     from tldw_Server_API.app.core.config import settings as app_settings

--- a/tldw_Server_API/app/services/startup_worker_groups.py
+++ b/tldw_Server_API/app/services/startup_worker_groups.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 
 from loguru import logger
 
@@ -75,7 +75,7 @@ class StartupWorkerGroupHandles:
 async def start_worker_groups(
     *,
     app: Any,
-    app_settings: Any,
+    app_settings: Mapping[str, Any],
     test_mode: bool,
     route_enabled: Callable[..., bool],
     startup_guard_exceptions: tuple[type[BaseException], ...],
@@ -87,6 +87,7 @@ async def start_worker_groups(
     cleanup_worker_handles = await _start_cleanup_workers(
         app_settings=app_settings,
         test_mode=test_mode,
+        worker_inventory=worker_inventory,
     )
 
     def _env_flag(key: str, default: bool) -> bool:
@@ -224,10 +225,19 @@ async def start_worker_groups(
     )
 
 
-async def _start_cleanup_workers(*, app_settings: Any, test_mode: bool):
+async def _start_cleanup_workers(
+    *,
+    app_settings: Mapping[str, Any],
+    test_mode: bool,
+    worker_inventory: Any | None = None,
+) -> Any:
     from tldw_Server_API.app.services.startup_cleanup_workers import start_cleanup_workers
 
-    return await start_cleanup_workers(app_settings, test_mode=test_mode)
+    return await start_cleanup_workers(
+        app_settings,
+        test_mode=test_mode,
+        worker_inventory=worker_inventory,
+    )
 
 
 async def _start_primary_jobs_pollers(**kwargs):

--- a/tldw_Server_API/app/services/worker_registry.py
+++ b/tldw_Server_API/app/services/worker_registry.py
@@ -6,6 +6,7 @@ from tldw_Server_API.app.services.lifecycle_workers import (
     ManagedWorker,
     ShutdownPhase,
     WorkerRegistry,
+    start_stop_event_worker,
 )
 
-__all__ = ["ManagedWorker", "ShutdownPhase", "WorkerRegistry"]
+__all__ = ["ManagedWorker", "ShutdownPhase", "WorkerRegistry", "start_stop_event_worker"]

--- a/tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
+++ b/tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
@@ -22,9 +22,7 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
     from tldw_Server_API.app.services import shutdown_pre_worker_cleanup
     from tldw_Server_API.app.services import shutdown_primary_late_stop_workers
     from tldw_Server_API.app.services import shutdown_transition_handoff
-    from tldw_Server_API.app.services.lifespan_shutdown_sequence import (
-        run_lifespan_shutdown_sequence,
-    )
+    from tldw_Server_API.app.services import lifespan_shutdown_sequence
     from tldw_Server_API.app.services.lifespan_worker_runtime_state import (
         LifespanWorkerRuntimeState,
     )
@@ -114,6 +112,7 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
 
     async def _fake_pre_worker_cleanup(**kwargs):
         calls.append(("pre", kwargs))
+        assert kwargs["stopped_background_worker_names"] == {"chatbooks_cleanup"}
         return SimpleNamespace(
             cleanup_task="cleanup-after",
             chatbooks_cleanup_task="chatbooks-after",
@@ -150,6 +149,10 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
             authnz_scheduler_started=False,
             files_export_gc_task="files-gc-final",
         )
+
+    async def _fake_stop_registered_workers(app, handles, *, stopped_names_attr, log_label):
+        del handles, log_label
+        setattr(app.state, stopped_names_attr, ["chatbooks_cleanup"])
 
     monkeypatch.setattr(
         shutdown_transition_handoff,
@@ -191,8 +194,13 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
         "shutdown_final_cleanup_tail",
         _fake_final_cleanup,
     )
+    monkeypatch.setattr(
+        lifespan_shutdown_sequence,
+        "stop_registered_workers",
+        _fake_stop_registered_workers,
+    )
 
-    await run_lifespan_shutdown_sequence(
+    await lifespan_shutdown_sequence.run_lifespan_shutdown_sequence(
         app=app,
         worker_runtime=worker_runtime,
         readiness_state={"ready": True},
@@ -229,6 +237,7 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
     assert calls[2][1]["owned_job_pollers"] == ["poller-a"]
     assert calls[3][1]["segment_name"] == "background_worker_shutdown"
     assert calls[4][1]["legacy_shutdown_plan"] == ["transition-plan"]
+    assert calls[4][1]["stopped_background_worker_names"] == {"chatbooks_cleanup"}
     assert calls[5][1]["coordinated_legacy_component_names"] == {"usage_aggregator"}
     assert calls[6][1]["should_run_late_stop"] is True
     assert calls[7][1]["should_run_late_stop"] is True

--- a/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
+++ b/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
@@ -1384,8 +1384,14 @@ def test_lifespan_shutdown_delegates_pre_worker_cleanup(
     fake_storage_cleanup_service = object()
     recorded_calls: list[dict[str, object]] = []
 
-    async def _fake_start_cleanup_workers(_app_settings, *, test_mode: bool):
-        del _app_settings, test_mode
+    async def _fake_start_cleanup_workers(
+        app_settings,
+        *,
+        test_mode: bool,
+        worker_inventory,
+    ):
+        del app_settings, test_mode
+        assert worker_inventory is not None
         return startup_cleanup_workers.CleanupWorkerHandles(
             cleanup_task=fake_cleanup_task,
             chatbooks_cleanup_task=fake_chatbooks_cleanup_task,
@@ -1423,6 +1429,8 @@ def test_lifespan_shutdown_delegates_pre_worker_cleanup(
     assert recorded_calls[0]["chatbooks_cleanup_stop_event"] is fake_chatbooks_cleanup_stop_event
     assert recorded_calls[0]["storage_cleanup_service"] is fake_storage_cleanup_service
     assert isinstance(recorded_calls[0]["coordinated_legacy_component_names"], set)
+    assert isinstance(recorded_calls[0]["stopped_background_worker_names"], set)
+    assert "chatbooks_cleanup" not in recorded_calls[0]["stopped_background_worker_names"]
     assert recorded_calls[0]["guard_exceptions"] == main_module._STARTUP_GUARD_EXCEPTIONS
 
 
@@ -1450,8 +1458,14 @@ def test_lifespan_shutdown_delegates_transition_handoff(
             llm_usage_task=fake_llm_usage_task,
         )
 
-    async def _fake_start_cleanup_workers(_app_settings, *, test_mode: bool):
-        del _app_settings, test_mode
+    async def _fake_start_cleanup_workers(
+        app_settings,
+        *,
+        test_mode: bool,
+        worker_inventory,
+    ):
+        del app_settings, test_mode
+        assert worker_inventory is not None
         return startup_cleanup_workers.CleanupWorkerHandles(
             chatbooks_cleanup_task=fake_chatbooks_cleanup_task,
             chatbooks_cleanup_stop_event=fake_chatbooks_cleanup_stop_event,

--- a/tldw_Server_API/tests/Services/test_shutdown_coordinated_legacy_components.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_coordinated_legacy_components.py
@@ -79,6 +79,41 @@ async def test_shutdown_coordinated_legacy_components_returns_handles_and_filter
 
 
 @pytest.mark.asyncio
+async def test_shutdown_coordinated_legacy_components_filters_stopped_background_workers() -> None:
+    shutdown_legacy = _import_shutdown_coordinated_legacy_components()
+    calls: list[list[ShutdownComponent]] = []
+    legacy_shutdown_plan = [
+        _component(
+            "chatbooks_cleanup",
+            phase=ShutdownPhase.WORKERS,
+            policy=ShutdownPolicy.PROD_DRAIN,
+        ),
+        _component(
+            "usage_aggregator",
+            phase=ShutdownPhase.RESOURCES,
+            policy=ShutdownPolicy.BEST_EFFORT,
+        ),
+    ]
+
+    async def _fake_run_coordinated_shutdown(_app_obj, non_transition_plan):
+        calls.append(non_transition_plan)
+        return {component.name for component in non_transition_plan}
+
+    handles = await shutdown_legacy.shutdown_coordinated_legacy_components(
+        app="app",
+        legacy_shutdown_plan=legacy_shutdown_plan,
+        run_coordinated_shutdown=_fake_run_coordinated_shutdown,
+        startup_guard_exceptions=(RuntimeError,),
+        import_exceptions=(ImportError,),
+        stopped_background_worker_names={"chatbooks_cleanup"},
+    )
+
+    assert len(calls) == 1
+    assert [component.name for component in calls[0]] == ["usage_aggregator"]
+    assert handles.coordinated_legacy_component_names == {"usage_aggregator"}
+
+
+@pytest.mark.asyncio
 async def test_shutdown_coordinated_legacy_components_propagates_guard_exception() -> None:
     shutdown_legacy = _import_shutdown_coordinated_legacy_components()
 

--- a/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
@@ -193,6 +193,36 @@ async def test_shutdown_pre_worker_cleanup_skips_coordinated_chatbooks_and_stora
 
 
 @pytest.mark.asyncio
+async def test_shutdown_pre_worker_cleanup_skips_stopped_background_chatbooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shutdown_cleanup = _import_shutdown_pre_worker_cleanup()
+    stop_event = _FakeStopEvent()
+    chatbooks_task = _FakeTask()
+
+    async def _noop() -> None:
+        return None
+
+    monkeypatch.setattr(shutdown_cleanup, "_reset_cleanup_service", _noop)
+    monkeypatch.setattr(shutdown_cleanup, "_reset_storage_service", _noop)
+    monkeypatch.setattr(shutdown_cleanup, "_reset_authnz_rate_limiter", _noop)
+
+    await shutdown_cleanup._shutdown_pre_worker_cleanup(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        cleanup_task=None,
+        chatbooks_cleanup_task=chatbooks_task,
+        chatbooks_cleanup_stop_event=stop_event,
+        storage_cleanup_service=None,
+        coordinated_legacy_component_names=set(),
+        stopped_background_worker_names={"chatbooks_cleanup"},
+        guard_exceptions=(RuntimeError,),
+    )
+
+    assert stop_event.is_set is False
+    assert chatbooks_task.cancelled is False
+
+
+@pytest.mark.asyncio
 async def test_shutdown_pre_worker_cleanup_swallows_guard_exceptions_from_local_guarded_steps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_startup_cleanup_workers.py
+++ b/tldw_Server_API/tests/Services/test_startup_cleanup_workers.py
@@ -27,7 +27,8 @@ async def test_start_cleanup_workers_combines_all_handles(
         assert app_settings["SINGLE_USER_FIXED_ID"] == "7"
         return "ephemeral-task"
 
-    async def _fake_chatbooks():
+    async def _fake_chatbooks(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("chatbooks")
         return ("chatbooks-task", "chatbooks-stop")
 
@@ -53,6 +54,41 @@ async def test_start_cleanup_workers_combines_all_handles(
 
 
 @pytest.mark.asyncio
+async def test_start_cleanup_workers_passes_worker_inventory_to_chatbooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_cleanup = _import_startup_cleanup_workers()
+    worker_inventory = object()
+    calls: list[tuple[str, object | None]] = []
+
+    async def _fake_ephemeral(app_settings):
+        del app_settings
+        return None
+
+    async def _fake_chatbooks(*, worker_inventory=None):
+        calls.append(("chatbooks", worker_inventory))
+        return ("chatbooks-task", "chatbooks-stop")
+
+    async def _fake_storage(*, test_mode: bool):
+        assert test_mode is True
+        return None
+
+    monkeypatch.setattr(startup_cleanup, "_start_ephemeral_cleanup_worker", _fake_ephemeral)
+    monkeypatch.setattr(startup_cleanup, "_start_chatbooks_cleanup_worker", _fake_chatbooks)
+    monkeypatch.setattr(startup_cleanup, "_start_storage_cleanup_worker", _fake_storage)
+
+    handles = await startup_cleanup.start_cleanup_workers(
+        {"SINGLE_USER_FIXED_ID": "7"},
+        test_mode=True,
+        worker_inventory=worker_inventory,
+    )
+
+    assert calls == [("chatbooks", worker_inventory)]
+    assert handles.chatbooks_cleanup_task == "chatbooks-task"
+    assert handles.chatbooks_cleanup_stop_event == "chatbooks-stop"
+
+
+@pytest.mark.asyncio
 async def test_start_chatbooks_cleanup_worker_starts_when_interval_positive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -64,8 +100,8 @@ async def test_start_chatbooks_cleanup_worker_starts_when_interval_positive(
     async def _fake_runner(stop_event):
         started_with.append(stop_event)
 
-    def _record_create_task(coro):
-        task = SimpleNamespace(coro=coro, cancel=lambda: None)
+    def _record_create_task(coro, *, name=None):
+        task = SimpleNamespace(coro=coro, name=name, cancel=lambda: None)
         created_tasks.append(task)
         coro.close()
         return task
@@ -76,7 +112,43 @@ async def test_start_chatbooks_cleanup_worker_starts_when_interval_positive(
     task, stop_event = await startup_cleanup._start_chatbooks_cleanup_worker()
 
     assert task is created_tasks[0]
+    assert created_tasks[0].name == "chatbooks_cleanup_task"
     assert stop_event is not None
+
+
+@pytest.mark.asyncio
+async def test_start_chatbooks_cleanup_worker_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_cleanup = _import_startup_cleanup_workers()
+    monkeypatch.setenv("CHATBOOKS_CLEANUP_INTERVAL_SEC", "30")
+    calls: list[dict[str, object]] = []
+    task = object()
+    stop_event = object()
+
+    async def _fake_start_stop_event_worker(inventory, **kwargs):
+        calls.append({"inventory": inventory, **kwargs})
+        return task, stop_event
+
+    worker_inventory = object()
+    monkeypatch.setattr(startup_cleanup, "start_stop_event_worker", _fake_start_stop_event_worker)
+
+    returned_task, returned_stop_event = await startup_cleanup._start_chatbooks_cleanup_worker(
+        worker_inventory=worker_inventory,
+    )
+
+    assert returned_task is task
+    assert returned_stop_event is stop_event
+    assert calls == [
+        {
+            "inventory": worker_inventory,
+            "name": "chatbooks_cleanup",
+            "task_name": "chatbooks_cleanup_task",
+            "coroutine_factory": startup_cleanup._run_chatbooks_cleanup_loop,
+            "category": "cleanup",
+            "shutdown_phase": startup_cleanup.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -127,6 +199,7 @@ async def test_start_storage_cleanup_worker_starts_enabled_service(
 @pytest.mark.asyncio
 async def test_start_ephemeral_cleanup_worker_creates_task_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     startup_cleanup = _import_startup_cleanup_workers()
     created_tasks = []
@@ -140,7 +213,11 @@ async def test_start_ephemeral_cleanup_worker_creates_task_when_enabled(
     monkeypatch.setattr(startup_cleanup.asyncio, "create_task", _record_create_task)
     monkeypatch.setattr(startup_cleanup, "_create_evaluations_db", lambda db_path: SimpleNamespace())
     monkeypatch.setattr(startup_cleanup, "_create_vector_store_adapter", lambda settings, user_id: SimpleNamespace(initialize=lambda: None))
-    monkeypatch.setattr(startup_cleanup, "_get_evaluations_db_path", lambda user_id: f"/tmp/evals-{user_id}.db")
+    monkeypatch.setattr(
+        startup_cleanup,
+        "_get_evaluations_db_path",
+        lambda user_id: str(tmp_path / f"evals-{user_id}.db"),
+    )
 
     task = await startup_cleanup._start_ephemeral_cleanup_worker(
         {"SINGLE_USER_FIXED_ID": "11", "EPHEMERAL_CLEANUP_ENABLED": True, "EPHEMERAL_CLEANUP_INTERVAL_SEC": 9}

--- a/tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py
@@ -64,6 +64,7 @@ async def test_initialize_startup_worker_bootstrap_runs_helpers_in_order_and_ret
     assert calls[1][1]["worker_inventory"].handles is calls[1][1]["owned_job_pollers"]
     assert calls[1][1]["register_owned_job_poller"] == "register-poller"
     assert calls[1][1]["startup_guard_exceptions"] == (RuntimeError,)
+    assert calls[1][1]["worker_inventory"].handles is calls[1][1]["owned_job_pollers"]
     assert calls[2][1]["app"] == "app"
     assert calls[2][1]["app_settings"] == "settings"
     assert calls[2][1]["run_pg_rls_auto_ensure"] == "run-pg-ensure"

--- a/tldw_Server_API/tests/Services/test_startup_worker_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_groups.py
@@ -25,10 +25,13 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
     app = object()
     owned_job_pollers: list[object] = []
     register_owned_job_poller = object()
+    worker_inventory = object()
+    worker_inventory_ref = worker_inventory
 
-    async def _record_cleanup_workers(*, app_settings, test_mode):
+    async def _record_cleanup_workers(*, app_settings, test_mode, worker_inventory=None):
         assert app_settings == {"SINGLE_USER_FIXED_ID": "7"}
         assert test_mode is True
+        assert worker_inventory is worker_inventory_ref
         calls.append("cleanup")
         return SimpleNamespace(
             cleanup_task="cleanup-task",
@@ -79,7 +82,7 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
 
     async def _record_compactor_websub_workers(*, should_start_worker, worker_inventory):
         assert should_start_worker("AUDIO_JOBS_WORKER_ENABLED", "audio-jobs") is True
-        assert worker_inventory == "worker-inventory"
+        assert worker_inventory is worker_inventory_ref
         calls.append("compactor")
         return SimpleNamespace(
             embeddings_compactor_stop_event="embeddings-stop",
@@ -190,7 +193,7 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
         startup_guard_exceptions=(RuntimeError,),
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
-        worker_inventory="worker-inventory",
+        worker_inventory=worker_inventory,
     )
 
     assert calls == [


### PR DESCRIPTION
Part of #1114.

## Summary
- Register the Chatbooks cleanup loop with the lifecycle `WorkerRegistry` when a worker inventory is available, using `category="cleanup"` and the `background_worker_shutdown` phase.
- Keep the legacy no-inventory `asyncio.create_task` path intact for isolated callers.
- Publish stopped background-worker names into the coordinated legacy and pre-worker cleanup phases so lifecycle-stopped Chatbooks cleanup is not stopped a second time.
- Keep Chatbooks cleanup out of the job-poller quiesce phase; only job-poller-phase handles continue publishing to `_tldw_shutdown_job_poller_inventory`.

## Change summary
This moves the Chatbooks cleanup loop into the lifecycle-managed background-worker shutdown path without changing its enablement flag or loop implementation. The branch keeps the old task and stop-event handles visible because existing shutdown code still builds legacy shutdown plans from those handles; the new stopped-name handoff is what prevents double stop/cancel once the lifecycle registry has already stopped the worker. That keeps the migration incremental and avoids tying a non-job cleanup worker to the job-poller lease/quiesce flow.

## Verification
- Red tests first failed on missing `worker_inventory` propagation, missing Chatbooks lifecycle registration, and missing stopped-background-worker filtering.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_cleanup_workers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_shutdown_coordinated_legacy_components.py tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py tldw_Server_API/tests/Services/test_shutdown_transition_handoff.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -q` -> 42 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py -q` -> 24 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q` -> 55 passed
- `git diff --check origin/dev...HEAD`
- Bandit app scope: no findings
- Bandit touched-test scope with `B101` skipped: no findings
