### PR TITLE
refactor(workers): register ingestion cleanup lifecycle

### DIFF
--- a/tldw_Server_API/app/services/ingestion_sources_cleanup_service.py
+++ b/tldw_Server_API/app/services/ingestion_sources_cleanup_service.py
@@ -83,7 +83,29 @@ async def run_ingestion_sources_cleanup_loop(stop_event: asyncio.Event | None = 
                 )
         except _NONCRITICAL_EXCEPTIONS as exc:
             logger.bind(error_type=type(exc).__name__).warning("Ingestion sources cleanup loop error")
+        if await _wait_for_interval_or_stop(interval_sec, stop_event):
+            logger.info("Stopping ingestion sources cleanup worker on shutdown signal")
+            return
+
+
+async def _wait_for_interval_or_stop(
+    interval_sec: int,
+    stop_event: asyncio.Event | None,
+) -> bool:
+    """Wait for the cleanup interval or shutdown.
+
+    Returns True when ``stop_event`` fires; False means the interval elapsed.
+    """
+
+    if stop_event is None:
         await asyncio.sleep(interval_sec)
+        return False
+
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=interval_sec)
+    except asyncio.TimeoutError:
+        return False
+    return True
 
 
 async def start_ingestion_sources_cleanup_scheduler() -> asyncio.Task | None:

--- a/tldw_Server_API/app/services/startup_maintenance_schedulers.py
+++ b/tldw_Server_API/app/services/startup_maintenance_schedulers.py
@@ -4,6 +4,7 @@ Maintenance-scheduler startup helpers extracted from the application lifespan.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -12,7 +13,12 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.testing import is_truthy as _is_truthy
-from tldw_Server_API.app.services.lifecycle_workers import ManagedWorker, ShutdownPhase, WorkerInventory
+from tldw_Server_API.app.services.lifecycle_workers import (
+    ManagedWorker,
+    ShutdownPhase,
+    WorkerInventory,
+    start_stop_event_worker,
+)
 
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
@@ -48,7 +54,9 @@ async def start_maintenance_schedulers(
         kanban_activity_cleanup_task=await _start_kanban_activity_cleanup_scheduler(
             worker_inventory=worker_inventory,
         ),
-        ingestion_sources_cleanup_task=await _start_ingestion_sources_cleanup_scheduler(),
+        ingestion_sources_cleanup_task=await _start_ingestion_sources_cleanup_scheduler(
+            worker_inventory=worker_inventory,
+        ),
         kanban_purge_task=await _start_kanban_purge_scheduler(
             worker_inventory=worker_inventory,
         ),
@@ -97,7 +105,15 @@ async def _start_kanban_activity_cleanup_scheduler(
     )
 
 
-async def _start_ingestion_sources_cleanup_scheduler() -> Any | None:
+async def _start_ingestion_sources_cleanup_scheduler(
+    *,
+    worker_inventory: WorkerInventory | None = None,
+) -> Any | None:
+    async def _start_service() -> Any | None:
+        if worker_inventory is None:
+            return await _start_ingestion_sources_cleanup_scheduler_service()
+        return await _start_ingestion_sources_cleanup_registered(worker_inventory)
+
     return await _start_env_gated_task(
         env_key="INGESTION_SOURCES_CLEANUP_ENABLED",
         disabled_message=(
@@ -106,7 +122,7 @@ async def _start_ingestion_sources_cleanup_scheduler() -> Any | None:
         ),
         started_message="Ingestion source archive cleanup scheduler started",
         failure_message="Failed to start ingestion source archive cleanup scheduler: {exc}",
-        starter=_start_ingestion_sources_cleanup_scheduler_service,
+        starter=_start_service,
     )
 
 
@@ -226,6 +242,28 @@ async def _start_ingestion_sources_cleanup_scheduler_service() -> Any | None:
     )
 
     return await start_ingestion_sources_cleanup_scheduler()
+
+
+async def _start_ingestion_sources_cleanup_registered(
+    worker_inventory: WorkerInventory,
+) -> Any | None:
+    task, _stop_event = await start_stop_event_worker(
+        worker_inventory,
+        name="ingestion_sources_cleanup",
+        task_name="ingestion_sources_cleanup_task",
+        coroutine_factory=_run_ingestion_sources_cleanup_loop,
+        category="maintenance",
+        shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+    )
+    return task
+
+
+async def _run_ingestion_sources_cleanup_loop(stop_event: asyncio.Event) -> None:
+    from tldw_Server_API.app.services.ingestion_sources_cleanup_service import (
+        run_ingestion_sources_cleanup_loop,
+    )
+
+    await run_ingestion_sources_cleanup_loop(stop_event)
 
 
 async def _start_kanban_purge_scheduler_service() -> Any | None:

--- a/tldw_Server_API/tests/Ingestion_Sources/test_ingestion_sources_cleanup_service.py
+++ b/tldw_Server_API/tests/Ingestion_Sources/test_ingestion_sources_cleanup_service.py
@@ -343,6 +343,34 @@ async def test_run_cleanup_loop_failure_log_is_sanitized(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_run_cleanup_loop_honors_stop_event_during_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup_module = _load_cleanup_service_module()
+    assert cleanup_module is not None
+
+    stop_event = asyncio.Event()
+    runs = {"count": 0}
+
+    async def _run_once() -> dict[str, int]:
+        runs["count"] += 1
+        stop_event.set()
+        return {"scanned": 0, "pruned": 0, "skipped_active": 0, "failed": 0}
+
+    async def _unexpected_sleep(_seconds: float) -> None:
+        raise AssertionError("loop should wait on stop_event instead of sleeping")
+
+    monkeypatch.setenv("INGESTION_SOURCES_CLEANUP_INTERVAL_SEC", "3600")
+    monkeypatch.setattr(cleanup_module, "run_ingestion_sources_cleanup_once", _run_once, raising=False)
+    monkeypatch.setattr(cleanup_module.asyncio, "sleep", _unexpected_sleep)
+
+    await cleanup_module.run_ingestion_sources_cleanup_loop(stop_event)
+
+    assert runs == {"count": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_cleanup_scheduler_startup_accepts_single_letter_y(monkeypatch):
     cleanup_module = _load_cleanup_service_module()
     assert cleanup_module is not None

--- a/tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py
+++ b/tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py
@@ -33,7 +33,8 @@ async def test_start_maintenance_schedulers_combines_handles(
         calls.append("kanban-activity")
         return "kanban-activity-task"
 
-    async def _fake_ingestion_sources():
+    async def _fake_ingestion_sources(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("ingestion-sources")
         return "ingestion-sources-task"
 
@@ -86,37 +87,47 @@ async def test_start_maintenance_schedulers_combines_handles(
 
 
 @pytest.mark.asyncio
-async def test_start_maintenance_schedulers_passes_worker_inventory_to_kanban_helpers(
+async def test_start_maintenance_schedulers_passes_worker_inventory_to_registered_helpers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     startup_maintenance = _import_startup_maintenance_schedulers()
     worker_inventory = object()
     calls: list[tuple[str, object | None]] = []
 
-    async def _fake_quality():
+    async def _fake_quality() -> None:
         return None
 
-    async def _fake_outputs():
+    async def _fake_outputs() -> None:
         return None
 
-    async def _fake_kanban_activity(*, worker_inventory=None):
+    async def _fake_kanban_activity(
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
         calls.append(("kanban-activity", worker_inventory))
         return "kanban-activity-task"
 
-    async def _fake_ingestion_sources():
-        return None
+    async def _fake_ingestion_sources(
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
+        calls.append(("ingestion-sources", worker_inventory))
+        return "ingestion-sources-task"
 
-    async def _fake_kanban_purge(*, worker_inventory=None):
+    async def _fake_kanban_purge(
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
         calls.append(("kanban-purge", worker_inventory))
         return "kanban-purge-task"
 
-    async def _fake_files_gc():
+    async def _fake_files_gc() -> None:
         return None
 
-    async def _fake_notifications():
+    async def _fake_notifications() -> None:
         return None
 
-    async def _fake_jobs_prune():
+    async def _fake_jobs_prune() -> None:
         return None
 
     monkeypatch.setattr(startup_maintenance, "_start_quality_eval_scheduler", _fake_quality)
@@ -134,10 +145,53 @@ async def test_start_maintenance_schedulers_passes_worker_inventory_to_kanban_he
 
     assert calls == [
         ("kanban-activity", worker_inventory),
+        ("ingestion-sources", worker_inventory),
         ("kanban-purge", worker_inventory),
     ]
     assert handles.kanban_activity_cleanup_task == "kanban-activity-task"
+    assert handles.ingestion_sources_cleanup_task == "ingestion-sources-task"
     assert handles.kanban_purge_task == "kanban-purge-task"
+
+
+@pytest.mark.asyncio
+async def test_ingestion_sources_cleanup_scheduler_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_maintenance = _import_startup_maintenance_schedulers()
+    worker_inventory = object()
+    task = object()
+    stop_event = object()
+    calls: list[dict[str, object]] = []
+
+    async def _fake_start_stop_event_worker(
+        inventory: object,
+        **kwargs: object,
+    ) -> tuple[object, object]:
+        calls.append({"inventory": inventory, **kwargs})
+        return task, stop_event
+
+    monkeypatch.setattr(startup_maintenance, "_env_enabled", lambda key: True)
+    monkeypatch.setattr(
+        startup_maintenance,
+        "start_stop_event_worker",
+        _fake_start_stop_event_worker,
+    )
+
+    returned_task = await startup_maintenance._start_ingestion_sources_cleanup_scheduler(
+        worker_inventory=worker_inventory,
+    )
+
+    assert returned_task is task
+    assert calls == [
+        {
+            "inventory": worker_inventory,
+            "name": "ingestion_sources_cleanup",
+            "task_name": "ingestion_sources_cleanup_task",
+            "coroutine_factory": startup_maintenance._run_ingestion_sources_cleanup_loop,
+            "category": "maintenance",
+            "shutdown_phase": startup_maintenance.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_service_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_service_groups.py
@@ -25,8 +25,8 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
     owned_job_pollers: list[object] = []
     register_owned_job_poller = object()
     run_pg_rls_auto_ensure = object()
-
-    worker_inventory_ref = object()
+    worker_inventory = object()
+    worker_inventory_ref = worker_inventory
 
     async def _record_runtime_monitors(*, worker_inventory):
         assert worker_inventory is worker_inventory_ref
@@ -117,6 +117,7 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
     owned_job_pollers_ref = owned_job_pollers
     register_owned_job_poller_ref = register_owned_job_poller
     run_pg_rls_auto_ensure_ref = run_pg_rls_auto_ensure
+    worker_inventory_ref = worker_inventory
 
     monkeypatch.setattr(startup_groups, "_start_runtime_monitors", _record_runtime_monitors)
     monkeypatch.setattr(startup_groups, "_start_optional_workers", _record_optional_workers)


### PR DESCRIPTION
Part of #1114.

Change summary:
- Registers the ingestion source archive cleanup scheduler with the lifecycle WorkerRegistry when startup has a worker inventory.
- Keeps the legacy env-gated scheduler path for startup paths without inventory.
- Marks the worker as category=maintenance and shutdown_phase=background_worker_shutdown so it is not routed through job-poller quiesce.
- Makes the cleanup loop respond to a stop event during interval waits.

Verification:
- RED: focused regression tests failed before implementation for missing worker_inventory plumbing, missing WorkerRegistry registration, and fixed interval sleep.
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py::test_start_maintenance_schedulers_passes_worker_inventory_to_ingestion_sources tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py::test_ingestion_sources_cleanup_scheduler_registers_background_inventory tldw_Server_API/tests/Services/test_startup_service_groups.py::test_start_service_groups_runs_helpers_in_order_and_returns_handles tldw_Server_API/tests/Ingestion_Sources/test_ingestion_sources_cleanup_service.py::test_run_cleanup_loop_honors_stop_event_during_interval -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Ingestion_Sources/test_ingestion_sources_cleanup_service.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_lifespan_worker_runtime_state.py -q
- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_maintenance_schedulers.py tldw_Server_API/app/services/startup_service_groups.py tldw_Server_API/app/services/ingestion_sources_cleanup_service.py -f json -o /tmp/bandit_ingestion_sources_worker_registry_app.json
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Ingestion_Sources/test_ingestion_sources_cleanup_service.py -s B101,B108 -f json -o /tmp/bandit_ingestion_sources_worker_registry_tests.json

Bandit note:
- Test-scope Bandit without B108 skipped reports two existing hardcoded /tmp sanitation assertions in test_ingestion_sources_cleanup_service.py; no new B108 strings were added in this slice.

Merge gate note:
- This PR is AI-authored. Per project policy, the human requester still needs to add their own Change summary before merge.