### PR TITLE
refactor(workers): register claims rebuild lifecycle

### DIFF
--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -93,7 +93,7 @@ async def shutdown_post_worker_services(
         return stop_event
 
     claims_shutdown_handles = await _shutdown_claims_maintenance_tasks(
-        claims_task=claims_task,
+        claims_task=_task_if_not_stopped("claims_rebuild", claims_task),
         jobs_prune_task=jobs_prune_task,
         files_export_gc_task=files_export_gc_task,
         notifications_prune_task=notifications_prune_task,
@@ -292,7 +292,7 @@ async def run_shutdown_post_worker_services(
     except guard_exceptions as exc:
         logger.debug(f"Post-worker services skipped: {exc}")
         return PostWorkerShutdownHandles(
-            claims_task=claims_task,
+            claims_task=_fallback_if_not_stopped("claims_rebuild", claims_task),
             jobs_prune_task=jobs_prune_task,
             files_export_gc_task=files_export_gc_task,
             notifications_prune_task=notifications_prune_task,

--- a/tldw_Server_API/app/services/startup_claims_rebuild.py
+++ b/tldw_Server_API/app/services/startup_claims_rebuild.py
@@ -11,6 +11,11 @@ from typing import Any
 
 from loguru import logger
 
+from tldw_Server_API.app.services.lifecycle_workers import (
+    ShutdownPhase,
+    start_stop_event_worker,
+)
+
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
     OSError,
@@ -20,7 +25,11 @@ _STARTUP_GUARD_EXCEPTIONS = (
 )
 
 
-async def start_claims_rebuild_worker(app_settings: Mapping[str, Any]) -> Any | None:
+async def start_claims_rebuild_worker(
+    app_settings: Mapping[str, Any],
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     """Start the claims rebuild worker when enabled."""
     try:
         enabled = bool(app_settings.get("CLAIMS_REBUILD_ENABLED", False))
@@ -30,27 +39,63 @@ async def start_claims_rebuild_worker(app_settings: Mapping[str, Any]) -> Any | 
 
         interval_sec = int(app_settings.get("CLAIMS_REBUILD_INTERVAL_SEC", 3600))
         policy = str(app_settings.get("CLAIMS_REBUILD_POLICY", "missing")).lower()
+
+        if worker_inventory is not None:
+            task, _registered_stop_event = await start_stop_event_worker(
+                worker_inventory,
+                name="claims_rebuild",
+                task_name="claims_task",
+                coroutine_factory=lambda registered_stop_event: _run_claims_rebuild_loop(
+                    app_settings,
+                    stop_event=registered_stop_event,
+                    interval_sec=interval_sec,
+                    policy=policy,
+                ),
+                category="claims",
+                shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            )
+            return task
+
         stop_event = asyncio.Event()
-
-        async def _claims_rebuild_loop() -> None:
-            logger.info(f"Starting claims rebuild worker (every {interval_sec}s, policy={policy})")
-            service = _get_claims_rebuild_service()
-            while not stop_event.is_set():
-                try:
-                    run_claims_rebuild_iteration(app_settings, service, policy=policy)
-                except _STARTUP_GUARD_EXCEPTIONS as exc:
-                    logger.warning(f"Claims rebuild loop error: {exc}")
-                try:
-                    await asyncio.wait_for(stop_event.wait(), timeout=interval_sec)
-                except asyncio.TimeoutError:
-                    continue
-
-        task = asyncio.create_task(_claims_rebuild_loop())
+        task = asyncio.create_task(
+            _run_claims_rebuild_loop(
+                app_settings,
+                stop_event=stop_event,
+                interval_sec=interval_sec,
+                policy=policy,
+            )
+        )
         setattr(task, "_tldw_claims_rebuild_stop_event", stop_event)
         return task
     except _STARTUP_GUARD_EXCEPTIONS as exc:
         logger.warning(f"Failed to start claims rebuild worker: {exc}")
         return None
+
+
+async def _run_claims_rebuild_loop(
+    app_settings: Mapping[str, Any],
+    *,
+    stop_event: asyncio.Event,
+    interval_sec: int,
+    policy: str,
+) -> None:
+    """Run claims rebuild iterations until the lifecycle stop event is set.
+
+    The loop performs one bounded rebuild scan per interval and exits when the
+    caller-owned stop event is signaled by either the managed lifecycle worker
+    registry or the legacy direct-task shutdown path.
+    """
+    logger.info(f"Starting claims rebuild worker (every {interval_sec}s, policy={policy})")
+    service = _get_claims_rebuild_service()
+    while not stop_event.is_set():
+        try:
+            run_claims_rebuild_iteration(app_settings, service, policy=policy)
+        except _STARTUP_GUARD_EXCEPTIONS as exc:
+            logger.warning(f"Claims rebuild loop error: {exc}")
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_sec)
+        except asyncio.TimeoutError:
+            continue
 
 
 def run_claims_rebuild_iteration(

--- a/tldw_Server_API/app/services/startup_service_groups.py
+++ b/tldw_Server_API/app/services/startup_service_groups.py
@@ -72,7 +72,13 @@ async def start_service_groups(
         optional_worker_handles = await _start_optional_workers(
             worker_inventory=worker_inventory,
         )
-    claims_task = await _start_claims_rebuild_worker(app_settings)
+    if worker_inventory is None:
+        claims_task = await _start_claims_rebuild_worker(app_settings)
+    else:
+        claims_task = await _start_claims_rebuild_worker(
+            app_settings,
+            worker_inventory=worker_inventory,
+        )
     auxiliary_startup_handles = await _start_auxiliary_services(app_settings)
     infra_startup_handles = await _start_infra_services(
         run_pg_rls_auto_ensure=run_pg_rls_auto_ensure,
@@ -142,12 +148,12 @@ async def _start_optional_workers(**kwargs: Any) -> Any:
     return await start_optional_workers(**kwargs)
 
 
-async def _start_claims_rebuild_worker(app_settings: Any):
+async def _start_claims_rebuild_worker(app_settings: Any, **kwargs: Any) -> Any:
     from tldw_Server_API.app.services.startup_claims_rebuild import (
         start_claims_rebuild_worker,
     )
 
-    return await start_claims_rebuild_worker(app_settings)
+    return await start_claims_rebuild_worker(app_settings, **kwargs)
 
 
 async def _start_auxiliary_services(app_settings: Any):

--- a/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
+++ b/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
@@ -475,7 +475,8 @@ def test_lifespan_shutdown_cancels_claims_and_maintenance_tasks(
             observed[flag_key] = True
             raise
 
-    async def _fake_start_claims_rebuild_worker(_app_settings):
+    async def _fake_start_claims_rebuild_worker(_app_settings, **kwargs):
+        assert kwargs["worker_inventory"] is not None
         return asyncio.create_task(_wait_forever("claims_cancelled"), name="claims_task")
 
     async def _fake_start_maintenance_schedulers():

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -533,6 +533,123 @@ async def test_run_shutdown_post_worker_services_delegates_and_returns_handles(
 
 
 @pytest.mark.asyncio
+async def test_shutdown_post_worker_services_skips_claims_after_background_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_post_worker_services as shutdown_services
+
+    recorded_claims_kwargs: dict[str, object] = {}
+
+    async def _record_claims(**kwargs):
+        recorded_claims_kwargs.update(kwargs)
+        return SimpleNamespace(
+            claims_task=kwargs["claims_task"],
+            jobs_prune_task=kwargs["jobs_prune_task"],
+            files_export_gc_task=kwargs["files_export_gc_task"],
+            notifications_prune_task=kwargs["notifications_prune_task"],
+        )
+
+    async def _record_notifications(**kwargs):
+        return SimpleNamespace(
+            jobs_notifications_bridge_task=kwargs["jobs_notifications_bridge_task"],
+            embeddings_compactor_task=kwargs["embeddings_compactor_task"],
+            embeddings_compactor_stop_event=kwargs["embeddings_compactor_stop_event"],
+            websub_renewal_task=kwargs["websub_renewal_task"],
+        )
+
+    async def _record_usage(**kwargs):
+        return SimpleNamespace(
+            usage_task=kwargs["usage_task"],
+            llm_usage_task=kwargs["llm_usage_task"],
+        )
+
+    async def _record_noop(**kwargs):
+        del kwargs
+
+    async def _record_runtime(**kwargs):
+        return SimpleNamespace(
+            jobs_metrics_task=kwargs["jobs_metrics_task"],
+            loop_lag_task=kwargs["loop_lag_task"],
+        )
+
+    async def _record_reconcile(**kwargs):
+        return SimpleNamespace(
+            jobs_metrics_reconcile_task=kwargs["jobs_metrics_reconcile_task"],
+            jobs_metrics_reconcile_stop=kwargs["jobs_metrics_reconcile_stop"],
+        )
+
+    async def _record_optional(**kwargs):
+        return SimpleNamespace(
+            jobs_crypto_rotate_task=kwargs["jobs_crypto_rotate_task"],
+            jobs_integrity_task=kwargs["jobs_integrity_task"],
+            jobs_webhooks_task=kwargs["jobs_webhooks_task"],
+            meetings_webhook_dlq_task=kwargs["meetings_webhook_dlq_task"],
+            workflows_dlq_task=kwargs["workflows_dlq_task"],
+            workflows_gc_task=kwargs["workflows_gc_task"],
+            workflows_maint_task=kwargs["workflows_maint_task"],
+        )
+
+    monkeypatch.setattr(shutdown_services, "_shutdown_claims_maintenance_tasks", _record_claims)
+    monkeypatch.setattr(
+        shutdown_services,
+        "_shutdown_notifications_compactor_websub_workers",
+        _record_notifications,
+    )
+    monkeypatch.setattr(shutdown_services, "_stop_usage_aggregators", _record_usage)
+    monkeypatch.setattr(shutdown_services, "_stop_recurring_schedulers", _record_noop)
+    monkeypatch.setattr(shutdown_services, "_shutdown_runtime_monitors", _record_runtime)
+    monkeypatch.setattr(shutdown_services, "_shutdown_jobs_metrics_reconcile", _record_reconcile)
+    monkeypatch.setattr(shutdown_services, "_shutdown_personalization_consolidation", _record_noop)
+    monkeypatch.setattr(shutdown_services, "_shutdown_optional_workers", _record_optional)
+
+    handles = await shutdown_services.shutdown_post_worker_services(
+        claims_task="claims-task",
+        jobs_prune_task="jobs-prune-task",
+        files_export_gc_task="files-gc-task",
+        notifications_prune_task="notifications-prune-task",
+        jobs_notifications_bridge_task=None,
+        embeddings_compactor_task=None,
+        embeddings_compactor_stop_event=None,
+        websub_renewal_task=None,
+        coordinated_legacy_component_names=set(),
+        usage_task=None,
+        llm_usage_task=None,
+        workflows_sched_task=None,
+        reading_digest_sched_task=None,
+        admin_backup_sched_task=None,
+        companion_reflection_sched_task=None,
+        reminders_sched_task=None,
+        connectors_sync_sched_task=None,
+        jobs_metrics_task=None,
+        jobs_metrics_stop_event=None,
+        loop_lag_task=None,
+        loop_lag_stop_event=None,
+        jobs_metrics_reconcile_task=None,
+        jobs_metrics_reconcile_stop=None,
+        jobs_crypto_rotate_task=None,
+        jobs_crypto_rotate_stop_event=None,
+        jobs_integrity_task=None,
+        jobs_integrity_stop_event=None,
+        jobs_webhooks_task=None,
+        jobs_webhooks_stop_event=None,
+        meetings_webhook_dlq_task=None,
+        meetings_webhook_dlq_stop_event=None,
+        workflows_dlq_task=None,
+        workflows_dlq_stop_event=None,
+        workflows_gc_task=None,
+        workflows_gc_stop_event=None,
+        workflows_maint_task=None,
+        workflows_maint_stop_event=None,
+        guard_exceptions=(RuntimeError,),
+        stopped_background_worker_names={"claims_rebuild"},
+    )
+
+    assert recorded_claims_kwargs["claims_task"] is None
+    assert handles.claims_task is None
+    assert handles.jobs_prune_task == "jobs-prune-task"
+
+
+@pytest.mark.asyncio
 async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stopped_background_handles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -590,6 +707,7 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
         workflows_maint_stop_event="maint-stop-input",
         guard_exceptions=(RuntimeError,),
         stopped_background_worker_names={
+            "claims_rebuild",
             "jobs_metrics_task",
             "jobs_metrics_reconcile_task",
             "jobs_crypto_rotate_task",
@@ -599,7 +717,7 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
     )
 
     assert log_messages == ["Post-worker services skipped: post-worker boom"]
-    assert handles.claims_task == "claims-input"
+    assert handles.claims_task is None
     assert handles.jobs_prune_task == "prune-input"
     assert handles.files_export_gc_task == "files-input"
     assert handles.notifications_prune_task == "notifications-input"

--- a/tldw_Server_API/tests/Services/test_startup_claims_rebuild.py
+++ b/tldw_Server_API/tests/Services/test_startup_claims_rebuild.py
@@ -54,6 +54,45 @@ async def test_start_claims_rebuild_worker_creates_task_when_enabled(
     assert getattr(task, "_tldw_claims_rebuild_stop_event") is not None
 
 
+@pytest.mark.asyncio
+async def test_start_claims_rebuild_worker_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_claims = _import_startup_claims_rebuild()
+    worker_inventory = object()
+    task = object()
+    stop_event = object()
+    calls: list[dict[str, object]] = []
+
+    async def _fake_start_stop_event_worker(inventory, **kwargs):
+        calls.append({"inventory": inventory, **kwargs})
+        return task, stop_event
+
+    monkeypatch.setattr(
+        startup_claims,
+        "start_stop_event_worker",
+        _fake_start_stop_event_worker,
+    )
+
+    returned_task = await startup_claims.start_claims_rebuild_worker(
+        {
+            "CLAIMS_REBUILD_ENABLED": True,
+            "CLAIMS_REBUILD_INTERVAL_SEC": 17,
+            "CLAIMS_REBUILD_POLICY": "stale",
+        },
+        worker_inventory=worker_inventory,
+    )
+
+    assert returned_task is task
+    assert len(calls) == 1
+    assert calls[0]["inventory"] is worker_inventory
+    assert calls[0]["name"] == "claims_rebuild"
+    assert calls[0]["task_name"] == "claims_task"
+    assert calls[0]["category"] == "claims"
+    assert calls[0]["shutdown_phase"] == startup_claims.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+    assert callable(calls[0]["coroutine_factory"])
+
+
 def test_run_claims_rebuild_iteration_submits_selected_media_ids(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_startup_service_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_service_groups.py
@@ -60,8 +60,9 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
             jobs_integrity_task="integrity-task",
         )
 
-    async def _record_claims_rebuild_worker(seen_app_settings):
+    async def _record_claims_rebuild_worker(seen_app_settings, **kwargs):
         assert seen_app_settings is app_settings
+        assert kwargs == {"worker_inventory": worker_inventory_ref}
         calls.append("claims")
         return "claims-task"
 


### PR DESCRIPTION
Part of #1114.

## Change summary
- Registers the Claims rebuild loop through the lifecycle WorkerRegistry when a worker inventory is available.
- Preserves the legacy no-inventory stop-event task path for direct callers/tests.
- Marks the worker as category `claims` in the `background_worker_shutdown` phase so it stays out of job-poller quiesce.
- Filters `claims_task` from legacy post-worker shutdown when the background phase already stopped it.

## Verification
- Red checks: new registry and post-worker suppression tests failed before implementation.
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_claims_rebuild.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_shutdown_claims_maintenance_tasks.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_lifespan_worker_runtime_state.py -q` => 26 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q` => 55 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py -q` => 24 passed
- `git diff --check` => clean
- Bandit app scope => zero findings
- Bandit touched test scope with `B101,B108` skipped => zero findings; `B108` is an existing literal `/tmp/media.db` test fixture, not introduced by this slice

## Merge note
AI-authored PR: per project policy, a human requester must add a human-written Change summary before merge.