### PR TITLE
refactor(workers): register usage aggregators

### DIFF
--- a/tldw_Server_API/app/services/llm_usage_aggregator.py
+++ b/tldw_Server_API/app/services/llm_usage_aggregator.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from typing import Any
 
 from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.usage_repo import AuthnzUsageRepo
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+from tldw_Server_API.app.services.lifecycle_workers import (
+    ShutdownPhase,
+    start_stop_event_worker,
+)
 
 _LLM_USAGE_AGGREGATOR_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -63,11 +68,31 @@ async def _aggregator_loop(stop_event: asyncio.Event):
         logger.bind(error_type=type(e).__name__).warning("LLM usage aggregator loop exited")
 
 
-async def start_llm_usage_aggregator() -> asyncio.Task | None:
-    """Start background LLM aggregator if enabled; return task or None."""
+async def start_llm_usage_aggregator(
+    *,
+    worker_inventory: Any | None = None,
+) -> asyncio.Task | None:
+    """Start background LLM usage aggregation if enabled.
+
+    With ``worker_inventory``, register the loop with lifecycle worker
+    management while retaining the legacy stop-event task attribute used by
+    ``stop_llm_usage_aggregator``. Without inventory, create the legacy local
+    task.
+    """
     settings = get_settings()
     if not getattr(settings, "LLM_USAGE_AGGREGATOR_ENABLED", True):
         return None
+    if worker_inventory is not None:
+        task, stop_event = await start_stop_event_worker(
+            worker_inventory,
+            name="llm_usage_aggregator",
+            task_name="llm_usage_aggregator",
+            coroutine_factory=_aggregator_loop,
+            category="usage",
+            shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        )
+        task._tldw_stop_event = stop_event  # type: ignore[attr-defined]
+        return task
     stop_event = asyncio.Event()
     task = asyncio.create_task(_aggregator_loop(stop_event))
     task._tldw_stop_event = stop_event  # type: ignore[attr-defined]

--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -107,6 +107,7 @@ async def shutdown_post_worker_services(
     )
     usage_shutdown_handles = await _stop_usage_aggregators(
         coordinated_legacy_component_names=coordinated_legacy_component_names,
+        stopped_background_worker_names=stopped_background_worker_names,
         usage_task=usage_task,
         llm_usage_task=llm_usage_task,
         guard_exceptions=guard_exceptions,
@@ -300,8 +301,8 @@ async def run_shutdown_post_worker_services(
             embeddings_compactor_task=embeddings_compactor_task,
             embeddings_compactor_stop_event=embeddings_compactor_stop_event,
             websub_renewal_task=_fallback_if_not_stopped("websub_renewal_task", websub_renewal_task),
-            usage_task=usage_task,
-            llm_usage_task=llm_usage_task,
+            usage_task=_fallback_if_not_stopped("usage_aggregator", usage_task),
+            llm_usage_task=_fallback_if_not_stopped("llm_usage_aggregator", llm_usage_task),
             jobs_metrics_task=_fallback_if_not_stopped("jobs_metrics_task", jobs_metrics_task),
             loop_lag_task=loop_lag_task,
             jobs_metrics_reconcile_task=_fallback_if_not_stopped(

--- a/tldw_Server_API/app/services/shutdown_usage_aggregators.py
+++ b/tldw_Server_API/app/services/shutdown_usage_aggregators.py
@@ -19,12 +19,17 @@ class UsageAggregatorShutdownHandles:
 async def stop_usage_aggregators(
     *,
     coordinated_legacy_component_names: set[str],
+    stopped_background_worker_names: set[str] | None = None,
     usage_task: Any | None,
     llm_usage_task: Any | None,
     guard_exceptions: tuple[type[BaseException], ...],
 ) -> UsageAggregatorShutdownHandles:
     """Stop usage and LLM usage aggregators while preserving legacy fallback semantics."""
-    if "usage_aggregator" not in coordinated_legacy_component_names and usage_task:
+    stopped_background_worker_names = stopped_background_worker_names or set()
+
+    if "usage_aggregator" in stopped_background_worker_names:
+        usage_task = None
+    elif "usage_aggregator" not in coordinated_legacy_component_names and usage_task:
         try:
             await _stop_usage_aggregator_service(usage_task)
             usage_task = None
@@ -35,7 +40,9 @@ async def stop_usage_aggregators(
                 pass
             usage_task = None
 
-    if "llm_usage_aggregator" not in coordinated_legacy_component_names and llm_usage_task:
+    if "llm_usage_aggregator" in stopped_background_worker_names:
+        llm_usage_task = None
+    elif "llm_usage_aggregator" not in coordinated_legacy_component_names and llm_usage_task:
         try:
             await _stop_llm_usage_aggregator_service(llm_usage_task)
             llm_usage_task = None

--- a/tldw_Server_API/app/services/startup_auxiliary_services.py
+++ b/tldw_Server_API/app/services/startup_auxiliary_services.py
@@ -31,12 +31,21 @@ class AuxiliaryStartupHandles:
     llm_usage_task: Any | None = None
 
 
-async def start_auxiliary_services(app_settings: Mapping[str, Any]) -> AuxiliaryStartupHandles:
-    """Start the small auxiliary startup slice and return explicit task handles."""
+async def start_auxiliary_services(
+    app_settings: Mapping[str, Any],
+    *,
+    worker_inventory: Any | None = None,
+) -> AuxiliaryStartupHandles:
+    """Start auxiliary services and return explicit task handles.
+
+    When ``worker_inventory`` is provided, usage aggregators are registered
+    with lifecycle worker management. Passing ``None`` preserves the legacy
+    direct-task path in the downstream aggregator startup helpers.
+    """
     claims_alerts_task = await _start_claims_alerts_scheduler()
     claims_review_metrics_task = await _start_claims_review_metrics_scheduler()
-    usage_task = await _start_usage_aggregator()
-    llm_usage_task = await _start_llm_usage_aggregator()
+    usage_task = await _start_usage_aggregator(worker_inventory=worker_inventory)
+    llm_usage_task = await _start_llm_usage_aggregator(worker_inventory=worker_inventory)
     await _start_personalization_consolidation(app_settings)
     return AuxiliaryStartupHandles(
         claims_alerts_task=claims_alerts_task,
@@ -68,12 +77,16 @@ async def _start_claims_review_metrics_scheduler() -> Any | None:
         return None
 
 
-async def _start_usage_aggregator() -> Any | None:
+async def _start_usage_aggregator(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
+    """Start usage aggregation through lifecycle inventory or legacy task mode."""
     try:
         if _env_flag_enabled("DISABLE_USAGE_AGGREGATOR"):
             logger.info("Usage aggregator disabled via DISABLE_USAGE_AGGREGATOR")
             return None
-        task = await _start_usage_aggregator_service()
+        task = await _start_usage_aggregator_service(worker_inventory=worker_inventory)
         if task:
             logger.info("Usage aggregator started")
         return task
@@ -82,12 +95,16 @@ async def _start_usage_aggregator() -> Any | None:
         return None
 
 
-async def _start_llm_usage_aggregator() -> Any | None:
+async def _start_llm_usage_aggregator(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
+    """Start LLM usage aggregation through lifecycle inventory or legacy task mode."""
     try:
         if _env_flag_enabled("DISABLE_LLM_USAGE_AGGREGATOR"):
             logger.info("LLM usage aggregator disabled via DISABLE_LLM_USAGE_AGGREGATOR")
             return None
-        task = await _start_llm_usage_aggregator_service()
+        task = await _start_llm_usage_aggregator_service(worker_inventory=worker_inventory)
         if task:
             logger.info("LLM usage aggregator started")
         return task
@@ -126,16 +143,16 @@ async def _start_claims_review_metrics_scheduler_service() -> Any | None:
     return await start_claims_review_metrics_scheduler()
 
 
-async def _start_usage_aggregator_service() -> Any | None:
+async def _start_usage_aggregator_service(**kwargs: Any) -> Any | None:
     from tldw_Server_API.app.services.usage_aggregator import start_usage_aggregator
 
-    return await start_usage_aggregator()
+    return await start_usage_aggregator(**kwargs)
 
 
-async def _start_llm_usage_aggregator_service() -> Any | None:
+async def _start_llm_usage_aggregator_service(**kwargs: Any) -> Any | None:
     from tldw_Server_API.app.services.llm_usage_aggregator import start_llm_usage_aggregator
 
-    return await start_llm_usage_aggregator()
+    return await start_llm_usage_aggregator(**kwargs)
 
 
 def _get_consolidation_service() -> Any:

--- a/tldw_Server_API/app/services/startup_service_groups.py
+++ b/tldw_Server_API/app/services/startup_service_groups.py
@@ -74,12 +74,16 @@ async def start_service_groups(
         )
     if worker_inventory is None:
         claims_task = await _start_claims_rebuild_worker(app_settings)
+        auxiliary_startup_handles = await _start_auxiliary_services(app_settings)
     else:
         claims_task = await _start_claims_rebuild_worker(
             app_settings,
             worker_inventory=worker_inventory,
         )
-    auxiliary_startup_handles = await _start_auxiliary_services(app_settings)
+        auxiliary_startup_handles = await _start_auxiliary_services(
+            app_settings,
+            worker_inventory=worker_inventory,
+        )
     infra_startup_handles = await _start_infra_services(
         run_pg_rls_auto_ensure=run_pg_rls_auto_ensure,
         worker_inventory=worker_inventory,
@@ -156,12 +160,12 @@ async def _start_claims_rebuild_worker(app_settings: Any, **kwargs: Any) -> Any:
     return await start_claims_rebuild_worker(app_settings, **kwargs)
 
 
-async def _start_auxiliary_services(app_settings: Any):
+async def _start_auxiliary_services(app_settings: Any, **kwargs: Any) -> Any:
     from tldw_Server_API.app.services.startup_auxiliary_services import (
         start_auxiliary_services,
     )
 
-    return await start_auxiliary_services(app_settings)
+    return await start_auxiliary_services(app_settings, **kwargs)
 
 
 async def _start_infra_services(**kwargs):

--- a/tldw_Server_API/app/services/usage_aggregator.py
+++ b/tldw_Server_API/app/services/usage_aggregator.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from typing import Any
 
 from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.usage_repo import AuthnzUsageRepo
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+from tldw_Server_API.app.services.lifecycle_workers import (
+    ShutdownPhase,
+    start_stop_event_worker,
+)
 
 _USAGE_AGGREGATOR_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -63,11 +68,30 @@ async def _aggregator_loop(stop_event: asyncio.Event):
         logger.bind(error_type=type(e).__name__).warning("Usage aggregator loop exited")
 
 
-async def start_usage_aggregator() -> asyncio.Task | None:
-    """Start background aggregator if enabled; return task or None."""
+async def start_usage_aggregator(
+    *,
+    worker_inventory: Any | None = None,
+) -> asyncio.Task | None:
+    """Start background usage aggregation if enabled.
+
+    With ``worker_inventory``, register the loop with lifecycle worker
+    management while retaining the legacy stop-event task attribute used by
+    ``stop_usage_aggregator``. Without inventory, create the legacy local task.
+    """
     settings = get_settings()
     if not getattr(settings, "USAGE_LOG_ENABLED", False):
         return None
+    if worker_inventory is not None:
+        task, stop_event = await start_stop_event_worker(
+            worker_inventory,
+            name="usage_aggregator",
+            task_name="usage_aggregator",
+            coroutine_factory=_aggregator_loop,
+            category="usage",
+            shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        )
+        task._tldw_stop_event = stop_event  # type: ignore[attr-defined]
+        return task
     stop_event = asyncio.Event()
     task = asyncio.create_task(_aggregator_loop(stop_event))
     # Attach a helper to task for stopping

--- a/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
+++ b/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
@@ -1452,8 +1452,9 @@ def test_lifespan_shutdown_delegates_transition_handoff(
     fake_storage_cleanup_service = object()
     recorded_calls: list[dict[str, object]] = []
 
-    async def _fake_start_auxiliary_services(_app_settings):
+    async def _fake_start_auxiliary_services(_app_settings, **kwargs):
         del _app_settings
+        assert kwargs["worker_inventory"] is not None
         return startup_auxiliary_services.AuxiliaryStartupHandles(
             usage_task=fake_usage_task,
             llm_usage_task=fake_llm_usage_task,
@@ -2597,7 +2598,8 @@ def test_shutdown_skipped_best_effort_component_falls_back_to_direct_stop(
 
     usage_task_holder: dict[str, _DummyUsageTask] = {}
 
-    async def _fake_start_usage_aggregator() -> _DummyUsageTask:
+    async def _fake_start_usage_aggregator(**kwargs) -> _DummyUsageTask:
+        assert kwargs["worker_inventory"] is not None
         task = _DummyUsageTask()
         usage_task_holder["task"] = task
         return task

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -130,6 +130,7 @@ async def test_shutdown_post_worker_services_runs_helpers_in_order_and_returns_h
         workflows_gc_stop_event="workflows-gc-stop",
         workflows_maint_task="workflows-maint-task",
         workflows_maint_stop_event="workflows-maint-stop",
+        stopped_background_worker_names={"usage_aggregator"},
         guard_exceptions=guard_exceptions,
     )
 
@@ -146,6 +147,7 @@ async def test_shutdown_post_worker_services_runs_helpers_in_order_and_returns_h
     assert calls[0][1]["claims_task"] == "claims-task"
     assert calls[1][1]["jobs_notifications_bridge_task"] == "bridge-task"
     assert calls[2][1]["coordinated_legacy_component_names"] is coordinated_legacy_component_names
+    assert calls[2][1]["stopped_background_worker_names"] == {"usage_aggregator"}
     assert calls[3][1]["workflows_sched_task"] == "workflows-sched-task"
     assert calls[4][1]["jobs_metrics_task"] == "jobs-metrics-task"
     assert calls[5][1]["jobs_metrics_reconcile_task"] == "jobs-metrics-reconcile-task"
@@ -708,6 +710,8 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
         guard_exceptions=(RuntimeError,),
         stopped_background_worker_names={
             "claims_rebuild",
+            "usage_aggregator",
+            "llm_usage_aggregator",
             "jobs_metrics_task",
             "jobs_metrics_reconcile_task",
             "jobs_crypto_rotate_task",
@@ -725,8 +729,8 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
     assert handles.embeddings_compactor_task == "compactor-input"
     assert handles.embeddings_compactor_stop_event == "compactor-stop-input"
     assert handles.websub_renewal_task is None
-    assert handles.usage_task == "usage-input"
-    assert handles.llm_usage_task == "llm-input"
+    assert handles.usage_task is None
+    assert handles.llm_usage_task is None
     assert handles.jobs_metrics_task is None
     assert handles.loop_lag_task == "loop-lag-input"
     assert handles.jobs_metrics_reconcile_task is None

--- a/tldw_Server_API/tests/Services/test_shutdown_usage_aggregators.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_usage_aggregators.py
@@ -67,6 +67,32 @@ async def test_stop_usage_aggregators_skips_coordinated_components(
 
 
 @pytest.mark.asyncio
+async def test_stop_usage_aggregators_skips_background_stopped_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shutdown_usage = _import_shutdown_usage_aggregators()
+    calls: list[object] = []
+
+    async def _record_stop(task):
+        calls.append(task)
+
+    monkeypatch.setattr(shutdown_usage, "_stop_usage_aggregator_service", _record_stop)
+    monkeypatch.setattr(shutdown_usage, "_stop_llm_usage_aggregator_service", _record_stop)
+
+    handles = await shutdown_usage.stop_usage_aggregators(
+        coordinated_legacy_component_names=set(),
+        stopped_background_worker_names={"usage_aggregator", "llm_usage_aggregator"},
+        usage_task="usage-task",
+        llm_usage_task="llm-task",
+        guard_exceptions=(RuntimeError,),
+    )
+
+    assert calls == []
+    assert handles.usage_task is None
+    assert handles.llm_usage_task is None
+
+
+@pytest.mark.asyncio
 async def test_stop_usage_aggregators_cancels_usage_task_on_guard_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_startup_auxiliary_services.py
+++ b/tldw_Server_API/tests/Services/test_startup_auxiliary_services.py
@@ -30,11 +30,13 @@ async def test_start_auxiliary_services_combines_handles_and_starts_personalizat
         calls.append("claims-review")
         return "claims-review-task"
 
-    async def _fake_usage():
+    async def _fake_usage(**kwargs: object) -> str:
+        assert kwargs == {"worker_inventory": None}
         calls.append("usage")
         return "usage-task"
 
-    async def _fake_llm_usage():
+    async def _fake_llm_usage(**kwargs: object) -> str:
+        assert kwargs == {"worker_inventory": None}
         calls.append("llm-usage")
         return "llm-usage-task"
 
@@ -66,6 +68,47 @@ async def test_start_auxiliary_services_combines_handles_and_starts_personalizat
 
 
 @pytest.mark.asyncio
+async def test_start_auxiliary_services_passes_worker_inventory_to_usage_aggregators(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_aux = _import_startup_auxiliary_services()
+    worker_inventory = object()
+    seen_inventory: list[object] = []
+
+    async def _fake_claims_alerts():
+        return None
+
+    async def _fake_claims_review():
+        return None
+
+    async def _fake_usage(**kwargs: object) -> str:
+        seen_inventory.append(kwargs["worker_inventory"])
+        return "usage-task"
+
+    async def _fake_llm_usage(**kwargs: object) -> str:
+        seen_inventory.append(kwargs["worker_inventory"])
+        return "llm-usage-task"
+
+    async def _fake_personalization(_app_settings):
+        return None
+
+    monkeypatch.setattr(startup_aux, "_start_claims_alerts_scheduler", _fake_claims_alerts)
+    monkeypatch.setattr(startup_aux, "_start_claims_review_metrics_scheduler", _fake_claims_review)
+    monkeypatch.setattr(startup_aux, "_start_usage_aggregator", _fake_usage)
+    monkeypatch.setattr(startup_aux, "_start_llm_usage_aggregator", _fake_llm_usage)
+    monkeypatch.setattr(startup_aux, "_start_personalization_consolidation", _fake_personalization)
+
+    handles = await startup_aux.start_auxiliary_services(
+        {},
+        worker_inventory=worker_inventory,
+    )
+
+    assert seen_inventory == [worker_inventory, worker_inventory]
+    assert handles.usage_task == "usage-task"
+    assert handles.llm_usage_task == "llm-usage-task"
+
+
+@pytest.mark.asyncio
 async def test_start_usage_aggregator_skips_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -84,7 +127,8 @@ async def test_start_llm_usage_aggregator_starts_when_enabled(
 ) -> None:
     startup_aux = _import_startup_auxiliary_services()
 
-    async def _fake_start():
+    async def _fake_start(**kwargs: object) -> str:
+        assert kwargs == {"worker_inventory": None}
         return "llm-usage-task"
 
     monkeypatch.setattr(startup_aux, "_env_flag_enabled", lambda key: False)

--- a/tldw_Server_API/tests/Services/test_startup_service_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_service_groups.py
@@ -28,7 +28,7 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
     worker_inventory = object()
     worker_inventory_ref = worker_inventory
 
-    async def _record_runtime_monitors(*, worker_inventory):
+    async def _record_runtime_monitors(*, worker_inventory: object) -> SimpleNamespace:
         assert worker_inventory is worker_inventory_ref
         calls.append("runtime")
         return SimpleNamespace(
@@ -38,7 +38,7 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
             loop_lag_task="loop-lag-task",
         )
 
-    async def _record_optional_workers(*, worker_inventory):
+    async def _record_optional_workers(*, worker_inventory: object) -> SimpleNamespace:
         assert worker_inventory is worker_inventory_ref
         calls.append("optional")
         return SimpleNamespace(
@@ -60,14 +60,21 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
             jobs_integrity_task="integrity-task",
         )
 
-    async def _record_claims_rebuild_worker(seen_app_settings, **kwargs):
+    async def _record_claims_rebuild_worker(
+        seen_app_settings: object,
+        **kwargs: object,
+    ) -> str:
         assert seen_app_settings is app_settings
         assert kwargs == {"worker_inventory": worker_inventory_ref}
         calls.append("claims")
         return "claims-task"
 
-    async def _record_auxiliary_services(seen_app_settings):
+    async def _record_auxiliary_services(
+        seen_app_settings: object,
+        **kwargs: object,
+    ) -> SimpleNamespace:
         assert seen_app_settings is app_settings
+        assert kwargs == {"worker_inventory": worker_inventory_ref}
         calls.append("auxiliary")
         return SimpleNamespace(
             claims_alerts_task="claims-alerts-task",
@@ -76,7 +83,11 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
             llm_usage_task="llm-usage-task",
         )
 
-    async def _record_infra_services(*, run_pg_rls_auto_ensure, worker_inventory):
+    async def _record_infra_services(
+        *,
+        run_pg_rls_auto_ensure: object,
+        worker_inventory: object,
+    ) -> SimpleNamespace:
         assert run_pg_rls_auto_ensure is run_pg_rls_auto_ensure_ref
         assert worker_inventory is worker_inventory_ref
         calls.append("infra")
@@ -85,7 +96,10 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
             tts_history_cleanup_stop_event="tts-history-stop",
         )
 
-    async def _record_maintenance_schedulers(*, worker_inventory=None):
+    async def _record_maintenance_schedulers(
+        *,
+        worker_inventory: object | None = None,
+    ) -> SimpleNamespace:
         assert worker_inventory is worker_inventory_ref
         calls.append("maintenance")
         return SimpleNamespace(
@@ -101,10 +115,10 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
 
     async def _record_connectors_startup(
         *,
-        app,
-        owned_job_pollers,
-        register_owned_job_poller,
-    ):
+        app: object,
+        owned_job_pollers: list[object],
+        register_owned_job_poller: object,
+    ) -> SimpleNamespace:
         assert app is app_ref
         assert owned_job_pollers is owned_job_pollers_ref
         assert register_owned_job_poller is register_owned_job_poller_ref

--- a/tldw_Server_API/tests/Usage/test_llm_usage_aggregator.py
+++ b/tldw_Server_API/tests/Usage/test_llm_usage_aggregator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 from datetime import datetime, timezone
+from types import SimpleNamespace
 import uuid
 import pytest
 
@@ -114,6 +115,49 @@ async def _insert_llm_log(pool, *, user_id, operation, provider, model, status, 
             "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
             user_id, "/x", operation, provider, model, status, latency_ms, pt, ct, pt+ct, cost, "USD", 0
         )
+
+
+@pytest.mark.asyncio
+async def test_start_llm_usage_aggregator_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.services.llm_usage_aggregator as llm_usage_aggregator
+
+    class _Settings:
+        LLM_USAGE_AGGREGATOR_ENABLED = True
+
+    worker_inventory = object()
+    task = SimpleNamespace()
+    stop_event = object()
+    calls: list[dict[str, object]] = []
+
+    async def _fake_start_stop_event_worker(
+        inventory: object,
+        **kwargs: object,
+    ) -> tuple[SimpleNamespace, object]:
+        calls.append({"inventory": inventory, **kwargs})
+        return task, stop_event
+
+    monkeypatch.setattr(llm_usage_aggregator, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(
+        llm_usage_aggregator,
+        "start_stop_event_worker",
+        _fake_start_stop_event_worker,
+    )
+
+    returned_task = await llm_usage_aggregator.start_llm_usage_aggregator(
+        worker_inventory=worker_inventory,
+    )
+
+    assert returned_task is task
+    assert getattr(returned_task, "_tldw_stop_event") is stop_event
+    assert len(calls) == 1
+    assert calls[0]["inventory"] is worker_inventory
+    assert calls[0]["name"] == "llm_usage_aggregator"
+    assert calls[0]["task_name"] == "llm_usage_aggregator"
+    assert calls[0]["category"] == "usage"
+    assert calls[0]["shutdown_phase"] == llm_usage_aggregator.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+    assert callable(calls[0]["coroutine_factory"])
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Usage/test_usage_aggregator.py
+++ b/tldw_Server_API/tests/Usage/test_usage_aggregator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 from datetime import datetime, timezone
 
 import pytest
@@ -92,6 +93,49 @@ async def _insert_log(pool, *, user_id, status, latency_ms, bytes_val):
             bytes_val,
             None,
         )
+
+
+@pytest.mark.asyncio
+async def test_start_usage_aggregator_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.services.usage_aggregator as usage_aggregator
+
+    class _Settings:
+        USAGE_LOG_ENABLED = True
+
+    worker_inventory = object()
+    task = SimpleNamespace()
+    stop_event = object()
+    calls: list[dict[str, object]] = []
+
+    async def _fake_start_stop_event_worker(
+        inventory: object,
+        **kwargs: object,
+    ) -> tuple[SimpleNamespace, object]:
+        calls.append({"inventory": inventory, **kwargs})
+        return task, stop_event
+
+    monkeypatch.setattr(usage_aggregator, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(
+        usage_aggregator,
+        "start_stop_event_worker",
+        _fake_start_stop_event_worker,
+    )
+
+    returned_task = await usage_aggregator.start_usage_aggregator(
+        worker_inventory=worker_inventory,
+    )
+
+    assert returned_task is task
+    assert getattr(returned_task, "_tldw_stop_event") is stop_event
+    assert len(calls) == 1
+    assert calls[0]["inventory"] is worker_inventory
+    assert calls[0]["name"] == "usage_aggregator"
+    assert calls[0]["task_name"] == "usage_aggregator"
+    assert calls[0]["category"] == "usage"
+    assert calls[0]["shutdown_phase"] == usage_aggregator.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+    assert callable(calls[0]["coroutine_factory"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of #1114.

Change summary:
- Registers the Usage and LLM usage aggregators with the lifecycle WorkerRegistry when startup receives a worker inventory.
- Preserves the existing no-inventory legacy startup path for direct task handles and stop events.
- Propagates worker_inventory through startup service groups and auxiliary service startup.
- Clears legacy usage handles when the background-worker shutdown phase already stopped those components.

Why this shape:
- Usage aggregation is another recurring stop-event loop, so routing it through lifecycle_workers keeps shutdown phase semantics centralized instead of adding another one-off branch.
- The legacy no-inventory path stays intact so isolated tests and direct service use do not need a WorkerInventory fixture.
- The post-worker shutdown fallback now treats usage aggregators like the other migrated background workers and avoids double-stopping skipped/stopped components.

Verification:
- RED first: focused registry/shutdown tests failed before implementation.
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q => 55 passed.
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_auxiliary_services.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_shutdown_usage_aggregators.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_lifespan_worker_runtime_state.py tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py tldw_Server_API/tests/Usage/test_usage_aggregator.py tldw_Server_API/tests/Usage/test_llm_usage_aggregator.py -q => 50 passed, 1 skipped.
- git diff --check => clean.
- Bandit app touched scope => 0 findings.
- Bandit touched tests with B101,B108 skipped => 0 findings; B108 is skipped for existing sanitizer assertions that intentionally contain /tmp secret-like strings.

AI-authored PR note:
- This PR was generated by Codex. Per project policy, a human-owned Change summary is still required before merge if this PR is accepted.