### PR TITLE
refactor(workers): register ephemeral cleanup lifecycle

### DIFF
--- a/tldw_Server_API/app/services/lifespan_shutdown_sequence.py
+++ b/tldw_Server_API/app/services/lifespan_shutdown_sequence.py
@@ -92,9 +92,7 @@ async def run_lifespan_shutdown_sequence(
             stopped_names_attr="_tldw_shutdown_stopped_background_worker_names",
             log_label="background worker",
         )
-        stopped_background_worker_names = set(
-            getattr(app.state, "_tldw_shutdown_stopped_background_worker_names", [])
-        )
+        stopped_background_worker_names = set(getattr(app.state, "_tldw_shutdown_stopped_background_worker_names", []))
 
     from tldw_Server_API.app.services.shutdown_coordinated_legacy_components import (
         run_shutdown_coordinated_legacy_components,
@@ -108,9 +106,7 @@ async def run_lifespan_shutdown_sequence(
         import_exceptions=import_exceptions,
         stopped_background_worker_names=stopped_background_worker_names,
     )
-    coordinated_legacy_component_names = (
-        coordinated_legacy_shutdown_handles.coordinated_legacy_component_names
-    )
+    coordinated_legacy_component_names = coordinated_legacy_shutdown_handles.coordinated_legacy_component_names
 
     from tldw_Server_API.app.services.shutdown_pre_worker_cleanup import (
         run_shutdown_pre_worker_cleanup,

--- a/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
@@ -33,9 +33,15 @@ async def shutdown_pre_worker_cleanup(
     stopped_background_worker_names: set[str] | None = None,
 ) -> PreWorkerCleanupHandles:
     """Run the cleanup/reset shutdown slice that precedes the worker helpers."""
+    stopped_background_worker_names = stopped_background_worker_names or set()
+    cleanup_task_for_shutdown = _unless_background_stopped(
+        "ephemeral_cleanup_task",
+        cleanup_task,
+        stopped_background_worker_names,
+    )
     await _shutdown_pre_worker_cleanup(
         app=app,
-        cleanup_task=cleanup_task,
+        cleanup_task=cleanup_task_for_shutdown,
         chatbooks_cleanup_task=chatbooks_cleanup_task,
         chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
         storage_cleanup_service=storage_cleanup_service,
@@ -44,7 +50,7 @@ async def shutdown_pre_worker_cleanup(
         stopped_background_worker_names=stopped_background_worker_names,
     )
     return PreWorkerCleanupHandles(
-        cleanup_task=cleanup_task,
+        cleanup_task=cleanup_task_for_shutdown,
         chatbooks_cleanup_task=chatbooks_cleanup_task,
         chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
         storage_cleanup_service=storage_cleanup_service,
@@ -63,6 +69,7 @@ async def run_shutdown_pre_worker_cleanup(
     stopped_background_worker_names: set[str] | None = None,
 ) -> PreWorkerCleanupHandles:
     """Run pre-worker cleanup with main-lifespan fallback behavior."""
+    stopped_background_worker_names = stopped_background_worker_names or set()
     try:
         return await shutdown_pre_worker_cleanup(
             app=app,
@@ -77,7 +84,11 @@ async def run_shutdown_pre_worker_cleanup(
     except guard_exceptions as exc:
         logger.debug(f"Pre-worker cleanup skipped: {exc}")
         return PreWorkerCleanupHandles(
-            cleanup_task=cleanup_task,
+            cleanup_task=_unless_background_stopped(
+                "ephemeral_cleanup_task",
+                cleanup_task,
+                stopped_background_worker_names,
+            ),
             chatbooks_cleanup_task=chatbooks_cleanup_task,
             chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
             storage_cleanup_service=storage_cleanup_service,
@@ -123,6 +134,17 @@ async def _shutdown_pre_worker_cleanup(
     await _reset_authnz_rate_limiter_singleton(
         guard_exceptions=guard_exceptions,
     )
+
+
+def _unless_background_stopped(
+    name: str,
+    value: Any | None,
+    stopped_background_worker_names: set[str],
+) -> Any | None:
+    """Suppress legacy handles already stopped by the background-worker registry."""
+    if name in stopped_background_worker_names:
+        return None
+    return value
 
 
 async def _cancel_deferred_startup_task(

--- a/tldw_Server_API/app/services/startup_cleanup_workers.py
+++ b/tldw_Server_API/app/services/startup_cleanup_workers.py
@@ -44,7 +44,10 @@ async def start_cleanup_workers(
     worker_inventory: Any | None = None,
 ) -> CleanupWorkerHandles:
     """Start the small cleanup-worker startup slice and return explicit handles."""
-    cleanup_task = await _start_ephemeral_cleanup_worker(app_settings)
+    cleanup_task = await _start_ephemeral_cleanup_worker(
+        app_settings,
+        worker_inventory=worker_inventory,
+    )
     secondary = await _start_secondary_cleanup_workers(
         test_mode=test_mode,
         worker_inventory=worker_inventory,
@@ -74,51 +77,93 @@ async def _start_secondary_cleanup_workers(
     )
 
 
-async def _start_ephemeral_cleanup_worker(app_settings: Mapping[str, Any]) -> Any | None:
+async def _start_ephemeral_cleanup_worker(
+    app_settings: Mapping[str, Any],
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     """Start the ephemeral collections cleanup loop when enabled."""
     try:
-        single_uid = int(app_settings.get("SINGLE_USER_FIXED_ID", "1"))
-        db_path = str(_get_evaluations_db_path(single_uid))
+        single_uid, db_path, interval_sec = _resolve_ephemeral_cleanup_config(app_settings)
         enabled = _settings_truthy(app_settings.get("EPHEMERAL_CLEANUP_ENABLED", True))
-        interval_sec = int(app_settings.get("EPHEMERAL_CLEANUP_INTERVAL_SEC", 1800))
-
-        async def _ephemeral_cleanup_loop() -> None:
-            logger.info(f"Starting ephemeral collections cleanup worker (every {interval_sec}s)")
-            db = _create_evaluations_db(db_path)
-            adapter = _create_vector_store_adapter(app_settings, str(app_settings.get("SINGLE_USER_FIXED_ID", "1")))
-            await _maybe_await(getattr(adapter, "initialize", lambda: None)())
-            while True:
-                try:
-                    enabled_dyn = _settings_truthy(app_settings.get("EPHEMERAL_CLEANUP_ENABLED", True))
-                    interval_dyn = int(app_settings.get("EPHEMERAL_CLEANUP_INTERVAL_SEC", interval_sec))
-                    if not enabled_dyn:
-                        await asyncio.sleep(interval_sec)
-                        continue
-                    expired = db.list_expired_ephemeral_collections()
-                    if expired:
-                        deleted = 0
-                        for collection_name in expired:
-                            try:
-                                await _maybe_await(adapter.delete_collection(collection_name))
-                                db.mark_ephemeral_deleted(collection_name)
-                                deleted += 1
-                            except _STARTUP_GUARD_EXCEPTIONS as exc:
-                                logger.warning(f"Ephemeral cleanup: failed to delete {collection_name}: {exc}")
-                        if deleted:
-                            logger.info(
-                                f"Ephemeral cleanup: deleted {deleted}/{len(expired)} expired collections"
-                            )
-                except _STARTUP_GUARD_EXCEPTIONS as exc:
-                    logger.warning(f"Ephemeral cleanup loop error: {exc}")
-                await asyncio.sleep(interval_dyn)
 
         if enabled:
-            return asyncio.create_task(_ephemeral_cleanup_loop())
+            if worker_inventory is not None:
+                task, _stop_event = await start_stop_event_worker(
+                    worker_inventory,
+                    name="ephemeral_cleanup_task",
+                    task_name="ephemeral_cleanup_task",
+                    coroutine_factory=lambda stop_event: _run_ephemeral_cleanup_loop(
+                        app_settings,
+                        single_uid=single_uid,
+                        db_path=db_path,
+                        interval_sec=interval_sec,
+                        stop_event=stop_event,
+                    ),
+                    category="cleanup",
+                    shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+                )
+                return task
+            return asyncio.create_task(
+                _run_ephemeral_cleanup_loop(
+                    app_settings,
+                    single_uid=single_uid,
+                    db_path=db_path,
+                    interval_sec=interval_sec,
+                ),
+                name="ephemeral_cleanup_task",
+            )
         logger.info("Ephemeral cleanup worker disabled by settings")
         return None
     except _STARTUP_GUARD_EXCEPTIONS as exc:
         logger.warning(f"Failed to start ephemeral cleanup worker: {exc}")
         return None
+
+
+async def _run_ephemeral_cleanup_loop(
+    app_settings: Mapping[str, Any],
+    *,
+    single_uid: int | None = None,
+    db_path: str | None = None,
+    interval_sec: int | None = None,
+    stop_event: Any | None = None,
+) -> None:
+    """Run ephemeral collection cleanup until cancelled or the stop event is set."""
+    if _stop_requested(stop_event):
+        return
+
+    if single_uid is None or db_path is None or interval_sec is None:
+        single_uid, db_path, interval_sec = _resolve_ephemeral_cleanup_config(app_settings)
+    user_id = str(single_uid)
+    logger.info(f"Starting ephemeral collections cleanup worker (every {interval_sec}s)")
+    db = _create_evaluations_db(db_path)
+    adapter = _create_vector_store_adapter(app_settings, user_id)
+    await _maybe_await(getattr(adapter, "initialize", lambda: None)())
+    while not _stop_requested(stop_event):
+        sleep_for = interval_sec
+        try:
+            enabled_dyn = _settings_truthy(app_settings.get("EPHEMERAL_CLEANUP_ENABLED", True))
+            interval_dyn = int(app_settings.get("EPHEMERAL_CLEANUP_INTERVAL_SEC", interval_sec))
+            sleep_for = interval_dyn if enabled_dyn else interval_sec
+            if enabled_dyn:
+                expired = db.list_expired_ephemeral_collections()
+                if expired:
+                    deleted = 0
+                    for collection_name in expired:
+                        if _stop_requested(stop_event):
+                            logger.info("Ephemeral cleanup: stop requested; exiting delete batch early")
+                            break
+                        try:
+                            await _maybe_await(adapter.delete_collection(collection_name))
+                            db.mark_ephemeral_deleted(collection_name)
+                            deleted += 1
+                        except _STARTUP_GUARD_EXCEPTIONS as exc:
+                            logger.warning(f"Ephemeral cleanup: failed to delete {collection_name}: {exc}")
+                    if deleted:
+                        logger.info(f"Ephemeral cleanup: deleted {deleted}/{len(expired)} expired collections")
+        except _STARTUP_GUARD_EXCEPTIONS as exc:
+            logger.warning(f"Ephemeral cleanup loop error: {exc}")
+        await _sleep_or_stop(stop_event, sleep_for)
 
 
 async def _start_chatbooks_cleanup_worker(
@@ -183,10 +228,43 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
+def _stop_requested(stop_event: Any | None) -> bool:
+    """Return whether a lifecycle stop event has been signaled."""
+    if stop_event is None:
+        return False
+    is_set = getattr(stop_event, "is_set", None)
+    if not callable(is_set):
+        return False
+    return bool(is_set())
+
+
+async def _sleep_or_stop(stop_event: Any | None, delay: int) -> None:
+    """Sleep for delay seconds, returning early when a stop event is signaled."""
+    if stop_event is None:
+        await asyncio.sleep(delay)
+        return
+    wait = getattr(stop_event, "wait", None)
+    if not callable(wait):
+        await asyncio.sleep(delay)
+        return
+    try:
+        await asyncio.wait_for(wait(), timeout=delay)
+    except asyncio.TimeoutError:
+        pass
+
+
 def _settings_truthy(value: Any) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in _TRUTHY_VALUES
     return bool(value)
+
+
+def _resolve_ephemeral_cleanup_config(app_settings: Mapping[str, Any]) -> tuple[int, str, int]:
+    """Resolve and validate the ephemeral cleanup user, DB path, and interval."""
+    single_uid = int(app_settings.get("SINGLE_USER_FIXED_ID", "1"))
+    db_path = str(_get_evaluations_db_path(single_uid))
+    interval_sec = int(app_settings.get("EPHEMERAL_CLEANUP_INTERVAL_SEC", 1800))
+    return single_uid, db_path, interval_sec
 
 
 def _create_evaluations_db(db_path: str) -> Any:

--- a/tldw_Server_API/app/services/startup_worker_groups.py
+++ b/tldw_Server_API/app/services/startup_worker_groups.py
@@ -164,59 +164,41 @@ async def start_worker_groups(
         prompt_studio_jobs_task=primary_jobs_poller_handles.prompt_studio_jobs_task,
         study_pack_jobs_stop_event=study_privilege_jobs_poller_handles.study_pack_jobs_stop_event,
         study_pack_jobs_task=study_privilege_jobs_poller_handles.study_pack_jobs_task,
-        study_suggestions_jobs_stop_event=(
-            study_privilege_jobs_poller_handles.study_suggestions_jobs_stop_event
-        ),
+        study_suggestions_jobs_stop_event=(study_privilege_jobs_poller_handles.study_suggestions_jobs_stop_event),
         study_suggestions_jobs_task=study_privilege_jobs_poller_handles.study_suggestions_jobs_task,
         privilege_snapshot_stop_event=study_privilege_jobs_poller_handles.privilege_snapshot_stop_event,
         privilege_snapshot_task=study_privilege_jobs_poller_handles.privilege_snapshot_task,
-        embeddings_compactor_stop_event=(
-            compactor_websub_startup_handles.embeddings_compactor_stop_event
-        ),
+        embeddings_compactor_stop_event=(compactor_websub_startup_handles.embeddings_compactor_stop_event),
         embeddings_compactor_task=compactor_websub_startup_handles.embeddings_compactor_task,
         websub_renewal_task=compactor_websub_startup_handles.websub_renewal_task,
         audio_jobs_stop_event=content_jobs_poller_handles.audio_jobs_stop_event,
         audio_jobs_task=content_jobs_poller_handles.audio_jobs_task,
         audiobook_jobs_stop_event=content_jobs_poller_handles.audiobook_jobs_stop_event,
         audiobook_jobs_task=content_jobs_poller_handles.audiobook_jobs_task,
-        presentation_render_jobs_stop_event=(
-            content_jobs_poller_handles.presentation_render_jobs_stop_event
-        ),
+        presentation_render_jobs_stop_event=(content_jobs_poller_handles.presentation_render_jobs_stop_event),
         presentation_render_jobs_task=content_jobs_poller_handles.presentation_render_jobs_task,
         media_ingest_jobs_stop_event=content_jobs_poller_handles.media_ingest_jobs_stop_event,
         media_ingest_jobs_task=content_jobs_poller_handles.media_ingest_jobs_task,
-        media_ingest_heavy_jobs_stop_event=(
-            content_jobs_poller_handles.media_ingest_heavy_jobs_stop_event
-        ),
+        media_ingest_heavy_jobs_stop_event=(content_jobs_poller_handles.media_ingest_heavy_jobs_stop_event),
         media_ingest_heavy_jobs_task=content_jobs_poller_handles.media_ingest_heavy_jobs_task,
         reading_digest_jobs_stop_event=content_jobs_poller_handles.reading_digest_jobs_stop_event,
         reading_digest_jobs_task=content_jobs_poller_handles.reading_digest_jobs_task,
         vn_asset_jobs_stop_event=content_jobs_poller_handles.vn_asset_jobs_stop_event,
         vn_asset_jobs_task=content_jobs_poller_handles.vn_asset_jobs_task,
-        vn_asset_generation_jobs_stop_event=(
-            content_jobs_poller_handles.vn_asset_generation_jobs_stop_event
-        ),
-        vn_asset_generation_jobs_task=(
-            content_jobs_poller_handles.vn_asset_generation_jobs_task
-        ),
-        companion_reflection_jobs_stop_event=(
-            content_jobs_poller_handles.companion_reflection_jobs_stop_event
-        ),
+        vn_asset_generation_jobs_stop_event=(content_jobs_poller_handles.vn_asset_generation_jobs_stop_event),
+        vn_asset_generation_jobs_task=(content_jobs_poller_handles.vn_asset_generation_jobs_task),
+        companion_reflection_jobs_stop_event=(content_jobs_poller_handles.companion_reflection_jobs_stop_event),
         companion_reflection_jobs_task=content_jobs_poller_handles.companion_reflection_jobs_task,
         reminder_jobs_stop_event=sidecar_owned_jobs_poller_handles.reminder_jobs_stop_event,
         reminder_jobs_task=sidecar_owned_jobs_poller_handles.reminder_jobs_task,
         admin_backup_jobs_stop_event=sidecar_owned_jobs_poller_handles.admin_backup_jobs_stop_event,
         admin_backup_jobs_task=sidecar_owned_jobs_poller_handles.admin_backup_jobs_task,
-        admin_byok_validation_jobs_stop_event=(
-            sidecar_owned_jobs_poller_handles.admin_byok_validation_jobs_stop_event
-        ),
+        admin_byok_validation_jobs_stop_event=(sidecar_owned_jobs_poller_handles.admin_byok_validation_jobs_stop_event),
         admin_byok_validation_jobs_task=sidecar_owned_jobs_poller_handles.admin_byok_validation_jobs_task,
         admin_maintenance_rotation_jobs_stop_event=(
             sidecar_owned_jobs_poller_handles.admin_maintenance_rotation_jobs_stop_event
         ),
-        admin_maintenance_rotation_jobs_task=(
-            sidecar_owned_jobs_poller_handles.admin_maintenance_rotation_jobs_task
-        ),
+        admin_maintenance_rotation_jobs_task=(sidecar_owned_jobs_poller_handles.admin_maintenance_rotation_jobs_task),
         recipe_run_jobs_stop_event=sidecar_owned_jobs_poller_handles.recipe_run_jobs_stop_event,
         recipe_run_jobs_task=sidecar_owned_jobs_poller_handles.recipe_run_jobs_task,
         jobs_notifications_bridge_task=notifications_abtest_startup_handles.jobs_notifications_bridge_task,

--- a/tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
+++ b/tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
@@ -104,6 +104,25 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
         calls.append(("pollers", kwargs))
         return SimpleNamespace(should_run_late_stop=True)
 
+    async def _fake_stop_registered_workers(
+        app: FastAPI,
+        handles: list[object],
+        *,
+        stopped_names_attr: str,
+        log_label: str,
+    ) -> None:
+        calls.append(
+            (
+                "stop-background",
+                {
+                    "handles": handles,
+                    "stopped_names_attr": stopped_names_attr,
+                    "log_label": log_label,
+                },
+            )
+        )
+        setattr(app.state, stopped_names_attr, ["chatbooks_cleanup", "ephemeral_cleanup_task"])
+
     async def _fake_coordinated_shutdown(**kwargs):
         calls.append(("coordinated", kwargs))
         return SimpleNamespace(
@@ -112,7 +131,10 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
 
     async def _fake_pre_worker_cleanup(**kwargs):
         calls.append(("pre", kwargs))
-        assert kwargs["stopped_background_worker_names"] == {"chatbooks_cleanup"}
+        assert kwargs["stopped_background_worker_names"] == {
+            "chatbooks_cleanup",
+            "ephemeral_cleanup_task",
+        }
         return SimpleNamespace(
             cleanup_task="cleanup-after",
             chatbooks_cleanup_task="chatbooks-after",
@@ -150,10 +172,6 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
             files_export_gc_task="files-gc-final",
         )
 
-    async def _fake_stop_registered_workers(app, handles, *, stopped_names_attr, log_label):
-        del handles, log_label
-        setattr(app.state, stopped_names_attr, ["chatbooks_cleanup"])
-
     monkeypatch.setattr(
         shutdown_transition_handoff,
         "shutdown_transition_handoff",
@@ -163,6 +181,11 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
         shutdown_job_poller_handoff,
         "run_shutdown_job_poller_handoff",
         _fake_job_poller_handoff,
+    )
+    monkeypatch.setattr(
+        lifespan_shutdown_sequence,
+        "stop_registered_workers",
+        _fake_stop_registered_workers,
     )
     monkeypatch.setattr(
         shutdown_coordinated_legacy_components,
@@ -194,12 +217,6 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
         "shutdown_final_cleanup_tail",
         _fake_final_cleanup,
     )
-    monkeypatch.setattr(
-        lifespan_shutdown_sequence,
-        "stop_registered_workers",
-        _fake_stop_registered_workers,
-    )
-
     await lifespan_shutdown_sequence.run_lifespan_shutdown_sequence(
         app=app,
         worker_runtime=worker_runtime,
@@ -225,6 +242,7 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
         "transition",
         "pollers",
         "segment",
+        "stop-background",
         "coordinated",
         "pre",
         "primary",
@@ -236,18 +254,22 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
     assert calls[1][1]["usage_task"] == "usage-start"
     assert calls[2][1]["owned_job_pollers"] == ["poller-a"]
     assert calls[3][1]["segment_name"] == "background_worker_shutdown"
-    assert calls[4][1]["legacy_shutdown_plan"] == ["transition-plan"]
-    assert calls[4][1]["stopped_background_worker_names"] == {"chatbooks_cleanup"}
-    assert calls[5][1]["coordinated_legacy_component_names"] == {"usage_aggregator"}
-    assert calls[6][1]["should_run_late_stop"] is True
+    assert calls[4][1]["stopped_names_attr"] == "_tldw_shutdown_stopped_background_worker_names"
+    assert calls[5][1]["legacy_shutdown_plan"] == ["transition-plan"]
+    assert calls[6][1]["coordinated_legacy_component_names"] == {"usage_aggregator"}
+    assert calls[6][1]["stopped_background_worker_names"] == {
+        "chatbooks_cleanup",
+        "ephemeral_cleanup_task",
+    }
     assert calls[7][1]["should_run_late_stop"] is True
-    assert calls[8][1]["claims_task"] == "claims-start"
-    assert calls[9][1]["authnz_scheduler_started"] is True
-    assert calls[9][1]["db_pool"] == "db-pool"
-    assert calls[9][1]["session_manager"] == "session-manager"
-    assert calls[9][1]["heavy_startup_handles"] == "heavy-handles"
-    assert calls[9][1]["in_pytest_for_db_pool_shutdown"] is True
-    assert calls[9][1]["in_pytest_for_tts_shutdown"] is True
+    assert calls[8][1]["should_run_late_stop"] is True
+    assert calls[9][1]["claims_task"] == "claims-start"
+    assert calls[10][1]["authnz_scheduler_started"] is True
+    assert calls[10][1]["db_pool"] == "db-pool"
+    assert calls[10][1]["session_manager"] == "session-manager"
+    assert calls[10][1]["heavy_startup_handles"] == "heavy-handles"
+    assert calls[10][1]["in_pytest_for_db_pool_shutdown"] is True
+    assert calls[10][1]["in_pytest_for_tts_shutdown"] is True
     assert worker_runtime.cleanup_task == "cleanup-after"
     assert worker_runtime.chatbooks_cleanup_task == "chatbooks-after"
     assert worker_runtime.storage_cleanup_service == "storage-after"

--- a/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
+++ b/tldw_Server_API/tests/Services/test_main_lifecycle_contract.py
@@ -154,7 +154,9 @@ def test_apply_shutdown_transition_gate_logs_guard_failures(
 
     monkeypatch.setattr(main_module, "get_or_create_lifecycle_state", _raise_lifecycle_state)
     monkeypatch.setattr(main_module, "mark_lifecycle_shutdown", _raise_mark_shutdown)
-    monkeypatch.setattr(main_module.logger, "debug", lambda message, *args, **kwargs: debug_messages.append(str(message)))
+    monkeypatch.setattr(
+        main_module.logger, "debug", lambda message, *args, **kwargs: debug_messages.append(str(message))
+    )
     monkeypatch.setattr(
         main_module.logger,
         "warning",
@@ -788,9 +790,7 @@ def test_lifespan_startup_delegates_worker_bootstrap(
     assert recorded_calls[0]["route_enabled"] is main_module.route_enabled
     assert recorded_calls[0]["run_pg_rls_auto_ensure"] is main_module._run_pg_rls_auto_ensure
     assert recorded_calls[0]["register_owned_job_poller"] is main_module._register_owned_job_poller
-    assert recorded_calls[0]["replace_owned_job_poller_inventory"] is (
-        main_module._replace_owned_job_poller_inventory
-    )
+    assert recorded_calls[0]["replace_owned_job_poller_inventory"] is (main_module._replace_owned_job_poller_inventory)
     assert "publish_shutdown_job_poller_inventory" not in recorded_calls[0]
     assert recorded_calls[0]["logger"] is main_module.logger
     assert recorded_calls[0]["startup_api_key_log_value"] is main_module._startup_api_key_log_value
@@ -948,9 +948,7 @@ def test_lifespan_startup_delegates_service_tail(
     assert isinstance(recorded_calls[0]["owned_job_pollers"], list)
     assert recorded_calls[0]["register_owned_job_poller"] is main_module._register_owned_job_poller
     assert recorded_calls[0]["run_pg_rls_auto_ensure"] is main_module._run_pg_rls_auto_ensure
-    assert recorded_calls[0]["replace_owned_job_poller_inventory"] is (
-        main_module._replace_owned_job_poller_inventory
-    )
+    assert recorded_calls[0]["replace_owned_job_poller_inventory"] is (main_module._replace_owned_job_poller_inventory)
     assert isinstance(
         recorded_calls[0]["startup_worker_group_handles"],
         object,
@@ -1386,11 +1384,11 @@ def test_lifespan_shutdown_delegates_pre_worker_cleanup(
     recorded_calls: list[dict[str, object]] = []
 
     async def _fake_start_cleanup_workers(
-        app_settings,
+        app_settings: object,
         *,
         test_mode: bool,
-        worker_inventory,
-    ):
+        worker_inventory: object,
+    ) -> startup_cleanup_workers.CleanupWorkerHandles:
         del app_settings, test_mode
         assert worker_inventory is not None
         return startup_cleanup_workers.CleanupWorkerHandles(
@@ -1461,11 +1459,11 @@ def test_lifespan_shutdown_delegates_transition_handoff(
         )
 
     async def _fake_start_cleanup_workers(
-        app_settings,
+        app_settings: object,
         *,
         test_mode: bool,
-        worker_inventory,
-    ):
+        worker_inventory: object,
+    ) -> startup_cleanup_workers.CleanupWorkerHandles:
         del app_settings, test_mode
         assert worker_inventory is not None
         return startup_cleanup_workers.CleanupWorkerHandles(
@@ -2384,6 +2382,7 @@ def test_shutdown_falls_back_to_direct_drain_when_transition_gate_component_fail
         "set_acquire_gate",
         classmethod(_record_gate),
     )
+
     def _failing_transition_stop() -> None:
         raise RuntimeError("shadow transition component failed")
 
@@ -2521,9 +2520,7 @@ def test_shutdown_migrated_legacy_slice_uses_prod_drain_profile(
             ),
         ]
 
-    fake_shutdown_legacy_adapters = types.ModuleType(
-        "tldw_Server_API.app.services.shutdown_legacy_adapters"
-    )
+    fake_shutdown_legacy_adapters = types.ModuleType("tldw_Server_API.app.services.shutdown_legacy_adapters")
     fake_shutdown_legacy_adapters.LegacyShutdownContext = shutdown_legacy_adapters.LegacyShutdownContext
     fake_shutdown_legacy_adapters.build_legacy_shutdown_plan = _fake_build_legacy_shutdown_plan
     fake_shutdown_legacy_adapters.register_legacy_shutdown_components = (
@@ -2562,9 +2559,7 @@ def test_shutdown_migrated_legacy_slice_uses_prod_drain_profile(
         "lifecycle_gate",
     ]
     expected_transport_names = getattr(app.state, "_tldw_shutdown_transport_component_names", [])
-    migrated_registered_names = [
-        component.name for component in _SpyShutdownCoordinator.instances[1].registered
-    ]
+    migrated_registered_names = [component.name for component in _SpyShutdownCoordinator.instances[1].registered]
     assert migrated_registered_names == expected_migrated_names + expected_transport_names
     assert "lifecycle_gate" not in migrated_registered_names
 
@@ -2680,9 +2675,7 @@ def test_shutdown_skipped_best_effort_component_falls_back_to_direct_stop(
             ),
         ]
 
-    fake_shutdown_legacy_adapters = types.ModuleType(
-        "tldw_Server_API.app.services.shutdown_legacy_adapters"
-    )
+    fake_shutdown_legacy_adapters = types.ModuleType("tldw_Server_API.app.services.shutdown_legacy_adapters")
     fake_shutdown_legacy_adapters.LegacyShutdownContext = shutdown_legacy_adapters.LegacyShutdownContext
     fake_shutdown_legacy_adapters.build_legacy_shutdown_plan = _fake_build_legacy_shutdown_plan
     fake_shutdown_legacy_adapters.register_legacy_shutdown_components = (

--- a/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import sys
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -10,7 +11,7 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def _import_shutdown_pre_worker_cleanup():
+def _import_shutdown_pre_worker_cleanup() -> Any:
     sys.modules.pop("tldw_Server_API.app.services.shutdown_pre_worker_cleanup", None)
     return importlib.import_module("tldw_Server_API.app.services.shutdown_pre_worker_cleanup")
 
@@ -55,7 +56,7 @@ async def test_shutdown_pre_worker_cleanup_returns_handles(
     shutdown_cleanup = _import_shutdown_pre_worker_cleanup()
     calls: list[dict[str, object]] = []
 
-    async def _record_shutdown(**kwargs):
+    async def _record_shutdown(**kwargs: object) -> None:
         calls.append(kwargs)
 
     monkeypatch.setattr(shutdown_cleanup, "_shutdown_pre_worker_cleanup", _record_shutdown)
@@ -120,6 +121,36 @@ async def test_shutdown_pre_worker_cleanup_cancels_deferred_and_cleanup_tasks_an
     assert deferred_task.cancelled is True
     assert cleanup_task.cancelled is True
     assert reset_calls == ["cleanup", "storage", "auth"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_pre_worker_cleanup_skips_background_stopped_ephemeral_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shutdown_cleanup = _import_shutdown_pre_worker_cleanup()
+    cleanup_task = _FakeTask()
+    app = SimpleNamespace(state=SimpleNamespace(bg_tasks={}))
+
+    async def _noop() -> None:
+        return None
+
+    monkeypatch.setattr(shutdown_cleanup, "_reset_cleanup_service", _noop)
+    monkeypatch.setattr(shutdown_cleanup, "_reset_storage_service", _noop)
+    monkeypatch.setattr(shutdown_cleanup, "_reset_authnz_rate_limiter", _noop)
+
+    handles = await shutdown_cleanup.shutdown_pre_worker_cleanup(
+        app=app,
+        cleanup_task=cleanup_task,
+        chatbooks_cleanup_task=None,
+        chatbooks_cleanup_stop_event=None,
+        storage_cleanup_service=None,
+        coordinated_legacy_component_names=set(),
+        guard_exceptions=(RuntimeError,),
+        stopped_background_worker_names={"ephemeral_cleanup_task"},
+    )
+
+    assert cleanup_task.cancelled is False
+    assert handles.cleanup_task is None
 
 
 @pytest.mark.asyncio
@@ -305,7 +336,7 @@ async def test_run_shutdown_pre_worker_cleanup_delegates_and_returns_handles(
         storage_cleanup_service=storage_cleanup_service,
     )
 
-    async def _fake_shutdown_pre_worker_cleanup(**kwargs):
+    async def _fake_shutdown_pre_worker_cleanup(**kwargs: object) -> Any:
         recorded_calls.append(kwargs)
         return expected_handles
 
@@ -322,6 +353,7 @@ async def test_run_shutdown_pre_worker_cleanup_delegates_and_returns_handles(
         chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
         storage_cleanup_service=storage_cleanup_service,
         coordinated_legacy_component_names={"usage_aggregator"},
+        stopped_background_worker_names={"ephemeral_cleanup_task"},
         guard_exceptions=(RuntimeError,),
     )
 
@@ -333,6 +365,7 @@ async def test_run_shutdown_pre_worker_cleanup_delegates_and_returns_handles(
     assert recorded_calls[0]["chatbooks_cleanup_stop_event"] is chatbooks_cleanup_stop_event
     assert recorded_calls[0]["storage_cleanup_service"] is storage_cleanup_service
     assert recorded_calls[0]["coordinated_legacy_component_names"] == {"usage_aggregator"}
+    assert recorded_calls[0]["stopped_background_worker_names"] == {"ephemeral_cleanup_task"}
 
 
 @pytest.mark.asyncio
@@ -346,7 +379,7 @@ async def test_run_shutdown_pre_worker_cleanup_logs_and_returns_original_handles
     storage_cleanup_service = object()
     debug_messages: list[str] = []
 
-    async def _raise_guard_failure(**_kwargs):
+    async def _raise_guard_failure(**_kwargs: object) -> None:
         raise RuntimeError("pre-worker unavailable")
 
     monkeypatch.setattr(
@@ -367,10 +400,11 @@ async def test_run_shutdown_pre_worker_cleanup_logs_and_returns_original_handles
         chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
         storage_cleanup_service=storage_cleanup_service,
         coordinated_legacy_component_names=set(),
+        stopped_background_worker_names={"ephemeral_cleanup_task"},
         guard_exceptions=(RuntimeError,),
     )
 
-    assert handles.cleanup_task is cleanup_task
+    assert handles.cleanup_task is None
     assert handles.chatbooks_cleanup_task is chatbooks_cleanup_task
     assert handles.chatbooks_cleanup_stop_event is chatbooks_cleanup_stop_event
     assert handles.storage_cleanup_service is storage_cleanup_service

--- a/tldw_Server_API/tests/Services/test_startup_cleanup_workers.py
+++ b/tldw_Server_API/tests/Services/test_startup_cleanup_workers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -10,7 +13,7 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def _import_startup_cleanup_workers():
+def _import_startup_cleanup_workers() -> Any:
     sys.modules.pop("tldw_Server_API.app.services.startup_cleanup_workers", None)
     return importlib.import_module("tldw_Server_API.app.services.startup_cleanup_workers")
 
@@ -22,17 +25,22 @@ async def test_start_cleanup_workers_combines_all_handles(
     startup_cleanup = _import_startup_cleanup_workers()
     calls: list[str] = []
 
-    async def _fake_ephemeral(app_settings):
+    async def _fake_ephemeral(
+        app_settings: dict[str, str],
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
+        assert worker_inventory is None
         calls.append("ephemeral")
         assert app_settings["SINGLE_USER_FIXED_ID"] == "7"
         return "ephemeral-task"
 
-    async def _fake_chatbooks(*, worker_inventory=None):
+    async def _fake_chatbooks(*, worker_inventory: object | None = None) -> tuple[str, str]:
         assert worker_inventory is None
         calls.append("chatbooks")
         return ("chatbooks-task", "chatbooks-stop")
 
-    async def _fake_storage(*, test_mode: bool):
+    async def _fake_storage(*, test_mode: bool) -> str:
         calls.append("storage")
         assert test_mode is True
         return "storage-service"
@@ -54,22 +62,27 @@ async def test_start_cleanup_workers_combines_all_handles(
 
 
 @pytest.mark.asyncio
-async def test_start_cleanup_workers_passes_worker_inventory_to_chatbooks(
+async def test_start_cleanup_workers_passes_worker_inventory_to_registered_cleanup_workers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     startup_cleanup = _import_startup_cleanup_workers()
     worker_inventory = object()
     calls: list[tuple[str, object | None]] = []
 
-    async def _fake_ephemeral(app_settings):
-        del app_settings
-        return None
+    async def _fake_ephemeral(
+        app_settings: dict[str, str],
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
+        assert app_settings["SINGLE_USER_FIXED_ID"] == "7"
+        calls.append(("ephemeral", worker_inventory))
+        return "ephemeral-task"
 
-    async def _fake_chatbooks(*, worker_inventory=None):
+    async def _fake_chatbooks(*, worker_inventory: object | None = None) -> tuple[str, str]:
         calls.append(("chatbooks", worker_inventory))
         return ("chatbooks-task", "chatbooks-stop")
 
-    async def _fake_storage(*, test_mode: bool):
+    async def _fake_storage(*, test_mode: bool) -> None:
         assert test_mode is True
         return None
 
@@ -83,7 +96,8 @@ async def test_start_cleanup_workers_passes_worker_inventory_to_chatbooks(
         worker_inventory=worker_inventory,
     )
 
-    assert calls == [("chatbooks", worker_inventory)]
+    assert calls == [("ephemeral", worker_inventory), ("chatbooks", worker_inventory)]
+    assert handles.cleanup_task == "ephemeral-task"
     assert handles.chatbooks_cleanup_task == "chatbooks-task"
     assert handles.chatbooks_cleanup_stop_event == "chatbooks-stop"
 
@@ -95,12 +109,12 @@ async def test_start_chatbooks_cleanup_worker_starts_when_interval_positive(
     startup_cleanup = _import_startup_cleanup_workers()
     monkeypatch.setenv("CHATBOOKS_CLEANUP_INTERVAL_SEC", "30")
     started_with: list[object] = []
-    created_tasks = []
+    created_tasks: list[SimpleNamespace] = []
 
-    async def _fake_runner(stop_event):
+    async def _fake_runner(stop_event: object) -> None:
         started_with.append(stop_event)
 
-    def _record_create_task(coro, *, name=None):
+    def _record_create_task(coro: Any, *, name: str | None = None) -> SimpleNamespace:
         task = SimpleNamespace(coro=coro, name=name, cancel=lambda: None)
         created_tasks.append(task)
         coro.close()
@@ -126,7 +140,10 @@ async def test_start_chatbooks_cleanup_worker_registers_background_inventory(
     task = object()
     stop_event = object()
 
-    async def _fake_start_stop_event_worker(inventory, **kwargs):
+    async def _fake_start_stop_event_worker(
+        inventory: object,
+        **kwargs: object,
+    ) -> tuple[object, object]:
         calls.append({"inventory": inventory, **kwargs})
         return task, stop_event
 
@@ -199,20 +216,24 @@ async def test_start_storage_cleanup_worker_starts_enabled_service(
 @pytest.mark.asyncio
 async def test_start_ephemeral_cleanup_worker_creates_task_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
+    tmp_path: Path,
 ) -> None:
     startup_cleanup = _import_startup_cleanup_workers()
-    created_tasks = []
+    created_tasks: list[SimpleNamespace] = []
 
-    def _record_create_task(coro):
-        task = SimpleNamespace(coro=coro, cancel=lambda: None)
+    def _record_create_task(coro: Any, *, name: str | None = None) -> SimpleNamespace:
+        task = SimpleNamespace(coro=coro, name=name, cancel=lambda: None)
         created_tasks.append(task)
         coro.close()
         return task
 
     monkeypatch.setattr(startup_cleanup.asyncio, "create_task", _record_create_task)
     monkeypatch.setattr(startup_cleanup, "_create_evaluations_db", lambda db_path: SimpleNamespace())
-    monkeypatch.setattr(startup_cleanup, "_create_vector_store_adapter", lambda settings, user_id: SimpleNamespace(initialize=lambda: None))
+    monkeypatch.setattr(
+        startup_cleanup,
+        "_create_vector_store_adapter",
+        lambda settings, user_id: SimpleNamespace(initialize=lambda: None),
+    )
     monkeypatch.setattr(
         startup_cleanup,
         "_get_evaluations_db_path",
@@ -224,6 +245,114 @@ async def test_start_ephemeral_cleanup_worker_creates_task_when_enabled(
     )
 
     assert task is created_tasks[0]
+
+
+@pytest.mark.asyncio
+async def test_start_ephemeral_cleanup_worker_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_cleanup = _import_startup_cleanup_workers()
+    worker_inventory = object()
+    task = object()
+    stop_event = object()
+    calls: list[dict[str, object]] = []
+
+    async def _fake_start_stop_event_worker(
+        inventory: object,
+        **kwargs: object,
+    ) -> tuple[object, object]:
+        calls.append({"inventory": inventory, **kwargs})
+        return task, stop_event
+
+    monkeypatch.setattr(startup_cleanup, "start_stop_event_worker", _fake_start_stop_event_worker)
+    monkeypatch.setattr(startup_cleanup, "_create_evaluations_db", lambda db_path: SimpleNamespace())
+    monkeypatch.setattr(
+        startup_cleanup,
+        "_create_vector_store_adapter",
+        lambda settings, user_id: SimpleNamespace(initialize=lambda: None),
+    )
+    monkeypatch.setattr(
+        startup_cleanup,
+        "_get_evaluations_db_path",
+        lambda user_id: f"evals-{user_id}.db",
+    )
+
+    returned_task = await startup_cleanup._start_ephemeral_cleanup_worker(
+        {"SINGLE_USER_FIXED_ID": "11", "EPHEMERAL_CLEANUP_ENABLED": True},
+        worker_inventory=worker_inventory,
+    )
+
+    assert returned_task is task
+    assert len(calls) == 1
+    assert calls[0]["inventory"] is worker_inventory
+    assert calls[0]["name"] == "ephemeral_cleanup_task"
+    assert calls[0]["task_name"] == "ephemeral_cleanup_task"
+    assert calls[0]["category"] == "cleanup"
+    assert calls[0]["shutdown_phase"] == startup_cleanup.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+    assert callable(calls[0]["coroutine_factory"])
+
+
+@pytest.mark.asyncio
+async def test_run_ephemeral_cleanup_loop_exits_when_stop_event_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_cleanup = _import_startup_cleanup_workers()
+    stop_event = asyncio.Event()
+    stop_event.set()
+
+    def _fail_create_evaluations_db(_db_path: str) -> None:
+        raise AssertionError("cleanup loop should not initialize DB after stop")
+
+    monkeypatch.setattr(startup_cleanup, "_create_evaluations_db", _fail_create_evaluations_db)
+
+    await startup_cleanup._run_ephemeral_cleanup_loop(
+        {"SINGLE_USER_FIXED_ID": "11", "EPHEMERAL_CLEANUP_INTERVAL_SEC": 1},
+        stop_event=stop_event,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_ephemeral_cleanup_loop_stops_delete_batch_after_stop_request(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    startup_cleanup = _import_startup_cleanup_workers()
+    stop_event = asyncio.Event()
+    deleted: list[str] = []
+    marked: list[str] = []
+
+    class _FakeDB:
+        def list_expired_ephemeral_collections(self) -> list[str]:
+            return ["expired-a", "expired-b"]
+
+        def mark_ephemeral_deleted(self, collection_name: str) -> None:
+            marked.append(collection_name)
+
+    class _FakeAdapter:
+        def initialize(self) -> None:
+            return None
+
+        async def delete_collection(self, collection_name: str) -> None:
+            deleted.append(collection_name)
+            stop_event.set()
+
+    monkeypatch.setattr(startup_cleanup, "_create_evaluations_db", lambda db_path: _FakeDB())
+    monkeypatch.setattr(
+        startup_cleanup,
+        "_create_vector_store_adapter",
+        lambda settings, user_id: _FakeAdapter(),
+    )
+
+    await startup_cleanup._run_ephemeral_cleanup_loop(
+        {"SINGLE_USER_FIXED_ID": "11", "EPHEMERAL_CLEANUP_INTERVAL_SEC": 1},
+        single_uid=11,
+        db_path=str(tmp_path / "evals.db"),
+        interval_sec=1,
+        stop_event=stop_event,
+    )
+
+    assert deleted == ["expired-a"]
+    assert marked == ["expired-a"]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_worker_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_groups.py
@@ -28,7 +28,12 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
     worker_inventory = object()
     worker_inventory_ref = worker_inventory
 
-    async def _record_cleanup_workers(*, app_settings, test_mode, worker_inventory=None):
+    async def _record_cleanup_workers(
+        *,
+        app_settings: dict[str, str],
+        test_mode: bool,
+        worker_inventory: object | None = None,
+    ) -> SimpleNamespace:
         assert app_settings == {"SINGLE_USER_FIXED_ID": "7"}
         assert test_mode is True
         assert worker_inventory is worker_inventory_ref
@@ -159,6 +164,7 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
 
     monkeypatch.setenv("AUDIO_JOBS_WORKER_ENABLED", "1")
     monkeypatch.delenv("TLDW_WORKERS_SIDECAR_MODE", raising=False)
+    worker_inventory_ref = worker_inventory
     monkeypatch.setattr(startup_groups, "_start_cleanup_workers", _record_cleanup_workers)
     monkeypatch.setattr(startup_groups, "_start_primary_jobs_pollers", _record_primary_jobs_pollers)
     monkeypatch.setattr(
@@ -187,9 +193,7 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
         app=app,
         app_settings={"SINGLE_USER_FIXED_ID": "7"},
         test_mode=True,
-        route_enabled=lambda route_key, *, default_stable=True: route_enabled_calls.append(
-            (route_key, default_stable)
-        ),
+        route_enabled=lambda route_key, *, default_stable=True: route_enabled_calls.append((route_key, default_stable)),
         startup_guard_exceptions=(RuntimeError,),
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,


### PR DESCRIPTION
Part of #1114.

Change summary:
- Registers the ephemeral cleanup loop with the lifecycle WorkerRegistry when startup has a worker inventory.
- Extracts the inline ephemeral cleanup loop into a reusable stop-event aware coroutine while preserving the legacy direct task path when no inventory is available.
- Propagates worker_inventory through startup worker bootstrap and worker groups into cleanup startup.
- Passes background-worker stopped names into pre-worker cleanup so the legacy cleanup cancellation path does not double-handle an already-stopped ephemeral cleanup worker.

Why this shape:
- Ephemeral cleanup is one of the custom async loops called out in #1114, so registering it exercises the custom loop path without changing the storage/chatbooks cleanup service ownership.
- The stop-event-aware loop lets WorkerRegistry perform graceful background-worker shutdown instead of relying only on pre-worker cancellation.
- The legacy no-inventory path remains intact for direct unit tests and isolated startup use.

Verification:
- RED first: new inventory propagation, WorkerRegistry registration, stopped-background skip, and lifespan handoff tests failed before implementation.
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_cleanup_workers.py tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_lifespan_worker_runtime_state.py -q => 81 passed.
- git diff --check => clean.
- Bandit app touched scope => 0 findings.
- Bandit touched tests with B101 skipped => 0 findings.

AI-authored PR note:
- This PR was generated by Codex. Per project policy, a human-owned Change summary is still required before merge if this PR is accepted.