### PR TITLE
refactor(workers): publish owned pollers via lifecycle inventory

### DIFF
--- a/tldw_Server_API/app/services/shutdown_owned_job_pollers.py
+++ b/tldw_Server_API/app/services/shutdown_owned_job_pollers.py
@@ -6,13 +6,18 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager, suppress
-from dataclasses import dataclass
 from typing import Any
 
 from fastapi import FastAPI
 from loguru import logger
+
+from tldw_Server_API.app.services.lifecycle_workers import (
+    ManagedWorker,
+    ShutdownPhase,
+    publish_worker_inventory,
+)
 
 
 DEFAULT_GUARD_EXCEPTIONS = (
@@ -24,36 +29,19 @@ DEFAULT_GUARD_EXCEPTIONS = (
 )
 
 
-@dataclass
-class ManagedJobPoller:
-    """Shutdown-owned in-process job poller handle."""
-
-    name: str
-    task: asyncio.Task[Any]
-    stop_event: asyncio.Event | None = None
-    timeout_sec: float = 5.0
+ManagedJobPoller = ManagedWorker
 
 
 def publish_shutdown_job_poller_inventory(
     app: FastAPI,
-    handles: list[ManagedJobPoller],
-    *,
-    guard_exceptions: tuple[type[BaseException], ...] = DEFAULT_GUARD_EXCEPTIONS,
+    handles: Sequence[ManagedJobPoller],
 ) -> None:
-    """Expose shutdown-owned job poller metadata on app.state."""
-    inventory = [
-        {
-            "name": handle.name,
-            "task_name": handle.task.get_name(),
-            "has_stop_event": handle.stop_event is not None,
-            "timeout_sec": handle.timeout_sec,
-        }
-        for handle in handles
-    ]
-    try:
-        app.state._tldw_shutdown_job_poller_inventory = inventory
-    except guard_exceptions:
-        pass
+    """Expose shutdown-owned job poller metadata on app.state.
+
+    Invalid handle shapes are programmer errors and should surface before
+    inventory publication can leave stale diagnostics on app.state.
+    """
+    publish_worker_inventory(app, handles)
 
 
 def register_owned_job_poller(
@@ -70,14 +58,24 @@ def register_owned_job_poller(
     if task is None:
         return
     handles.append(
-        ManagedJobPoller(
+        ManagedWorker(
             name=name,
             task=task,
             stop_event=stop_event,
             timeout_sec=timeout_sec,
+            shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
         )
     )
     publish_inventory(app, handles)
+
+
+def _is_job_poller_quiesce(handle: ManagedJobPoller) -> bool:
+    """Return whether a worker belongs to the job-poller quiesce phase.
+
+    ShutdownPhase is a str enum, so equality preserves compatibility with
+    legacy string phase values already stored on a handle.
+    """
+    return handle.shutdown_phase == ShutdownPhase.JOB_POLLER_QUIESCE
 
 
 def replace_owned_job_poller_inventory(
@@ -89,7 +87,11 @@ def replace_owned_job_poller_inventory(
     publish_inventory=publish_shutdown_job_poller_inventory,
 ) -> None:
     """Replace the managed job-poller inventory with the current owned poller set."""
-    handles.clear()
+    handles[:] = [
+        handle
+        for handle in handles
+        if not _is_job_poller_quiesce(handle)
+    ]
     publish_inventory(app, handles)
     for name, task, stop_event, timeout_sec in registrations:
         register_owned_job_poller_fn(

--- a/tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py
@@ -17,6 +17,120 @@ def _import_shutdown_owned_job_pollers():
     return importlib.import_module("tldw_Server_API.app.services.shutdown_owned_job_pollers")
 
 
+@pytest.mark.asyncio
+async def test_register_owned_job_poller_publishes_lifecycle_worker_inventory() -> None:
+    shutdown_pollers = _import_shutdown_owned_job_pollers()
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        ShutdownPhase,
+    )
+
+    app = FastAPI()
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(stop_event.wait(), name="core-jobs-task")
+    handles: list[object] = []
+
+    try:
+        shutdown_pollers.register_owned_job_poller(
+            app,
+            handles,
+            name="core_jobs_task",
+            task=task,
+            stop_event=stop_event,
+            timeout_sec=3.0,
+        )
+
+        assert len(handles) == 1
+        handle = handles[0]
+        assert isinstance(handle, ManagedWorker)
+        assert handle.shutdown_phase is ShutdownPhase.JOB_POLLER_QUIESCE
+        assert getattr(app.state, "_tldw_shutdown_worker_inventory") == [
+            {
+                "name": "core_jobs_task",
+                "task_name": "core-jobs-task",
+                "has_stop_event": True,
+                "timeout_sec": 3.0,
+                "category": None,
+                "shutdown_phase": "job_poller_quiesce",
+            }
+        ]
+        assert getattr(app.state, "_tldw_shutdown_job_poller_inventory") == [
+            {
+                "name": "core_jobs_task",
+                "task_name": "core-jobs-task",
+                "has_stop_event": True,
+                "timeout_sec": 3.0,
+            }
+        ]
+    finally:
+        stop_event.set()
+        await asyncio.wait_for(task, timeout=1)
+
+
+def test_publish_shutdown_job_poller_inventory_surfaces_invalid_handle_shape() -> None:
+    shutdown_pollers = _import_shutdown_owned_job_pollers()
+    app = FastAPI()
+
+    with pytest.raises(AttributeError):
+        shutdown_pollers.publish_shutdown_job_poller_inventory(app, [object()])
+
+
+@pytest.mark.asyncio
+async def test_replace_owned_job_poller_inventory_preserves_background_workers() -> None:
+    shutdown_pollers = _import_shutdown_owned_job_pollers()
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        ShutdownPhase,
+    )
+
+    app = FastAPI()
+    background_stop_event = asyncio.Event()
+    poller_stop_event = asyncio.Event()
+    background_task = asyncio.create_task(
+        background_stop_event.wait(),
+        name="background-worker",
+    )
+    poller_task = asyncio.create_task(poller_stop_event.wait(), name="poller-worker")
+    handles: list[object] = [
+        ManagedWorker(
+            name="background_worker",
+            task=background_task,
+            stop_event=background_stop_event,
+            shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        )
+    ]
+
+    try:
+        shutdown_pollers.replace_owned_job_poller_inventory(
+            app,
+            handles,
+            registrations=[
+                ("poller_worker", poller_task, poller_stop_event, 3.0),
+            ],
+        )
+
+        assert {handle.name for handle in handles} == {
+            "background_worker",
+            "poller_worker",
+        }
+        assert {entry["name"] for entry in app.state._tldw_shutdown_worker_inventory} == {
+            "background_worker",
+            "poller_worker",
+        }
+        assert app.state._tldw_shutdown_job_poller_inventory == [
+            {
+                "name": "poller_worker",
+                "task_name": "poller-worker",
+                "has_stop_event": True,
+                "timeout_sec": 3.0,
+            }
+        ]
+    finally:
+        background_stop_event.set()
+        poller_stop_event.set()
+        await asyncio.wait_for(asyncio.gather(background_task, poller_task), timeout=1)
+
+
 def test_register_and_replace_owned_job_poller_inventory_refreshes_app_state() -> None:
     shutdown_pollers = _import_shutdown_owned_job_pollers()
     app = FastAPI()


### PR DESCRIPTION
Part of #1114.

Change summary
- Align extracted owned job-poller registration with the lifecycle WorkerRegistry shape used by main.py.
- Publish owned pollers through the unified worker inventory while preserving the filtered job-poller compatibility inventory.
- Preserve background-worker handles when replacing job-poller inventory so phase ownership remains operational.

Why this shape
- Keeps existing job-poller shutdown order and lease-wait behavior intact by retaining the JOB_POLLER_QUIESCE phase.
- Removes the divergent ManagedJobPoller shape from the extracted service path, which avoids mixed inventory records as more custom workers move to WorkerRegistry.

Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_startup_owned_job_pollers.py -q
- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/shutdown_owned_job_pollers.py tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py --skip B101 -f json -o /tmp/bandit_owned_job_pollers_worker_inventory_1114.json

AI-authored PR note
This PR was generated by Codex. Per project policy, a human-owned Change summary is still required before merge if this PR is accepted.