### PR TITLE
refactor(workers): register embeddings compactor lifecycle

### DIFF
--- a/tldw_Server_API/app/services/shutdown_notifications_compactor_websub_workers.py
+++ b/tldw_Server_API/app/services/shutdown_notifications_compactor_websub_workers.py
@@ -81,6 +81,8 @@ async def _shutdown_embeddings_vector_compactor_worker(
             logger.info("Embeddings Vector Compactor stopped via stop_event")
         else:
             await _cancel_and_wait_for_task(task, guard_exceptions=guard_exceptions)
+    except asyncio.CancelledError:
+        logger.info("Embeddings Vector Compactor was already cancelled")
     except fallback_exceptions:
         await _cancel_and_wait_for_task(task, guard_exceptions=guard_exceptions)
 

--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -100,8 +100,14 @@ async def shutdown_post_worker_services(
     )
     notifications_shutdown_handles = await _shutdown_notifications_compactor_websub_workers(
         jobs_notifications_bridge_task=jobs_notifications_bridge_task,
-        embeddings_compactor_task=embeddings_compactor_task,
-        embeddings_compactor_stop_event=embeddings_compactor_stop_event,
+        embeddings_compactor_task=_task_if_not_stopped(
+            "embeddings_compactor_task",
+            embeddings_compactor_task,
+        ),
+        embeddings_compactor_stop_event=_stop_event_if_not_stopped(
+            "embeddings_compactor_task",
+            embeddings_compactor_stop_event,
+        ),
         websub_renewal_task=_task_if_not_stopped("websub_renewal_task", websub_renewal_task),
         guard_exceptions=guard_exceptions,
     )
@@ -298,8 +304,14 @@ async def run_shutdown_post_worker_services(
             files_export_gc_task=files_export_gc_task,
             notifications_prune_task=notifications_prune_task,
             jobs_notifications_bridge_task=jobs_notifications_bridge_task,
-            embeddings_compactor_task=embeddings_compactor_task,
-            embeddings_compactor_stop_event=embeddings_compactor_stop_event,
+            embeddings_compactor_task=_fallback_if_not_stopped(
+                "embeddings_compactor_task",
+                embeddings_compactor_task,
+            ),
+            embeddings_compactor_stop_event=_fallback_if_not_stopped(
+                "embeddings_compactor_task",
+                embeddings_compactor_stop_event,
+            ),
             websub_renewal_task=_fallback_if_not_stopped("websub_renewal_task", websub_renewal_task),
             usage_task=_fallback_if_not_stopped("usage_aggregator", usage_task),
             llm_usage_task=_fallback_if_not_stopped("llm_usage_aggregator", llm_usage_task),

--- a/tldw_Server_API/app/services/startup_compactor_websub_workers.py
+++ b/tldw_Server_API/app/services/startup_compactor_websub_workers.py
@@ -38,7 +38,9 @@ async def start_compactor_websub_workers(
 ) -> CompactorWebsubStartupHandles:
     """Start the embeddings compactor and WebSub renewal worker."""
 
-    embeddings_compactor_stop_event, embeddings_compactor_task = await _start_embeddings_vector_compactor()
+    embeddings_compactor_stop_event, embeddings_compactor_task = await _start_embeddings_vector_compactor(
+        worker_inventory=worker_inventory,
+    )
     websub_renewal_task = await _start_websub_renewal_worker(
         should_start_worker=should_start_worker,
         worker_inventory=worker_inventory,
@@ -59,12 +61,39 @@ def _create_task(awaitable: Any, *, name: str | None = None) -> Any:
     return asyncio.create_task(awaitable, name=name)
 
 
-async def _start_embeddings_vector_compactor() -> tuple[Any | None, Any | None]:
+async def _start_embeddings_vector_compactor(
+    *,
+    worker_inventory: Any | None = None,
+) -> tuple[Any | None, Any | None]:
+    """Start the embeddings vector compactor when enabled.
+
+    When a worker inventory is available, register the compactor as a
+    background-shutdown worker and return ``(stop_event, task)`` for legacy
+    state compatibility. Without an inventory, create the legacy stop
+    event/task pair directly.
+    """
     try:
         enabled = os.getenv("EMBEDDINGS_COMPACTOR_ENABLED", "false").lower() in _TRUTHY_ENV_VALUES
         if not enabled:
             logger.info("Embeddings Vector Compactor disabled by flag (EMBEDDINGS_COMPACTOR_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            from tldw_Server_API.app.services.lifecycle_workers import (
+                ShutdownPhase,
+                start_stop_event_worker,
+            )
+
+            task, stop_event = await start_stop_event_worker(
+                worker_inventory,
+                name="embeddings_compactor_task",
+                task_name="embeddings_compactor_task",
+                coroutine_factory=_run_embeddings_vector_compactor_service,
+                category="embeddings",
+                shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            )
+            logger.info("Embeddings Vector Compactor started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_embeddings_vector_compactor_service(stop_event))

--- a/tldw_Server_API/tests/Services/test_shutdown_notifications_compactor_websub_workers.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_notifications_compactor_websub_workers.py
@@ -141,6 +141,30 @@ async def test_shutdown_embeddings_vector_compactor_worker_cancels_on_guard_exce
 
 
 @pytest.mark.asyncio
+async def test_shutdown_embeddings_vector_compactor_worker_treats_cancelled_wait_as_stopped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shutdown_workers = _import_shutdown_notifications_compactor_websub_workers()
+    task = _FakeTask()
+    stop_event = _FakeStopEvent()
+
+    async def _cancelled_wait(_task, *, timeout):
+        del timeout
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(shutdown_workers, "_wait_for_task", _cancelled_wait)
+
+    await shutdown_workers._shutdown_embeddings_vector_compactor_worker(
+        task=task,
+        stop_event=stop_event,
+        guard_exceptions=(RuntimeError,),
+    )
+
+    assert stop_event.is_set is True
+    assert task.cancelled is False
+
+
+@pytest.mark.asyncio
 async def test_shutdown_embeddings_vector_compactor_worker_cancels_on_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -303,7 +303,7 @@ async def test_shutdown_post_worker_services_skips_jobs_webhooks_after_backgroun
 
 
 @pytest.mark.asyncio
-async def test_shutdown_post_worker_services_skips_websub_after_background_phase(
+async def test_shutdown_post_worker_services_skips_compactor_and_websub_after_background_phase(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from tldw_Server_API.app.services import shutdown_post_worker_services as shutdown_services
@@ -414,14 +414,19 @@ async def test_shutdown_post_worker_services_skips_websub_after_background_phase
         workflows_maint_task=None,
         workflows_maint_stop_event=None,
         guard_exceptions=(RuntimeError,),
-        stopped_background_worker_names={"websub_renewal_task"},
+        stopped_background_worker_names={
+            "embeddings_compactor_task",
+            "websub_renewal_task",
+        },
     )
 
     assert notification_kwargs["jobs_notifications_bridge_task"] == "bridge-task"
-    assert notification_kwargs["embeddings_compactor_task"] == "compactor-task"
+    assert notification_kwargs["embeddings_compactor_task"] is None
+    assert notification_kwargs["embeddings_compactor_stop_event"] is None
     assert notification_kwargs["websub_renewal_task"] is None
     assert handles.jobs_notifications_bridge_task == "bridge-task"
-    assert handles.embeddings_compactor_task == "compactor-task"
+    assert handles.embeddings_compactor_task is None
+    assert handles.embeddings_compactor_stop_event is None
     assert handles.websub_renewal_task is None
 
 
@@ -710,6 +715,7 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
         guard_exceptions=(RuntimeError,),
         stopped_background_worker_names={
             "claims_rebuild",
+            "embeddings_compactor_task",
             "usage_aggregator",
             "llm_usage_aggregator",
             "jobs_metrics_task",
@@ -726,8 +732,8 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
     assert handles.files_export_gc_task == "files-input"
     assert handles.notifications_prune_task == "notifications-input"
     assert handles.jobs_notifications_bridge_task == "bridge-input"
-    assert handles.embeddings_compactor_task == "compactor-input"
-    assert handles.embeddings_compactor_stop_event == "compactor-stop-input"
+    assert handles.embeddings_compactor_task is None
+    assert handles.embeddings_compactor_stop_event is None
     assert handles.websub_renewal_task is None
     assert handles.usage_task is None
     assert handles.llm_usage_task is None

--- a/tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py
+++ b/tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py
@@ -26,7 +26,7 @@ async def test_start_compactor_websub_workers_combines_handles_in_order(
     calls: list[str] = []
 
     async def _record_compactor(**kwargs):
-        del kwargs
+        assert kwargs == {"worker_inventory": None}
         calls.append("compactor")
         return ("compactor-stop", "compactor-task")
 
@@ -79,6 +79,72 @@ async def test_start_embeddings_vector_compactor_starts_when_enabled(
     assert task == "compactor-task"
     assert captured_stop_events == ["compactor-stop"]
     assert created_coroutines == ["compactor-coro"]
+
+
+@pytest.mark.asyncio
+async def test_start_embeddings_vector_compactor_registers_background_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_workers = _import_startup_compactor_websub_workers()
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ShutdownPhase,
+        WorkerRegistry,
+    )
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    observed_stop_events: list[asyncio.Event] = []
+
+    async def _fake_compactor(stop_event: asyncio.Event) -> None:
+        observed_stop_events.append(stop_event)
+        await stop_event.wait()
+
+    monkeypatch.setattr(
+        startup_workers.os,
+        "getenv",
+        lambda key, default=None: "true" if key == "EMBEDDINGS_COMPACTOR_ENABLED" else default,
+    )
+    monkeypatch.setattr(
+        startup_workers,
+        "_run_embeddings_vector_compactor_service",
+        _fake_compactor,
+    )
+
+    stop_event = None
+    task = None
+    try:
+        stop_event, task = await startup_workers._start_embeddings_vector_compactor(
+            worker_inventory=worker_inventory,
+        )
+        await asyncio.sleep(0)
+
+        assert stop_event is not None
+        assert task is not None
+        assert task.get_name() == "embeddings_compactor_task"
+        assert observed_stop_events == [stop_event]
+        assert len(worker_inventory.handles) == 1
+        handle = worker_inventory.handles[0]
+        assert handle.name == "embeddings_compactor_task"
+        assert handle.task is task
+        assert handle.stop_event is stop_event
+        assert handle.category == "embeddings"
+        assert handle.shutdown_phase is ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+        assert app.state._tldw_shutdown_worker_inventory == [
+            {
+                "name": "embeddings_compactor_task",
+                "task_name": "embeddings_compactor_task",
+                "has_stop_event": True,
+                "timeout_sec": 5.0,
+                "category": "embeddings",
+                "shutdown_phase": "background_worker_shutdown",
+            }
+        ]
+        assert app.state._tldw_shutdown_job_poller_inventory == []
+    finally:
+        if stop_event is not None:
+            stop_event.set()
+        if task is not None:
+            await asyncio.wait_for(task, timeout=1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of #1114.

Change summary
- Registers the embeddings vector compactor through WorkerRegistry when a lifecycle inventory is available.
- Keeps the legacy returned stop_event/task handles so existing startup runtime state stays compatible.
- Suppresses the late post-worker compactor shutdown path when the background-worker phase already stopped the registered compactor.

Why this shape
- Matches the existing WebSub registration pattern in the same startup helper.
- Keeps compactor shutdown in the background-worker phase without double-stopping it later in the post-worker tail.

Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_shutdown_notifications_compactor_websub_workers.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -q
- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_compactor_websub_workers.py tldw_Server_API/app/services/shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_startup_compactor_websub_workers.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py --skip B101 -f json -o /tmp/bandit_embeddings_compactor_worker_registry_1114.json

AI-authored PR note
This PR was generated by Codex. Per project policy, a human-owned Change summary is still required before merge if this PR is accepted.