### PR TITLE
Enforce VZ Linux deny-all network policy

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -178,6 +178,13 @@ item and reports `live_vm_matches_blocked_cleanup` instead of deleting files.
 ## Networking
 
 - `deny_all` is the intended strict baseline for the new macOS runtimes.
+- `vz_linux` enforces that baseline in both layers: Python policy admission
+  rejects unsupported policies before dispatch, and the Swift helper rejects
+  direct `create_vm` requests unless `network_policy=deny_all`. The helper also
+  echoes the accepted policy in VM metadata/status details for diagnostics.
+- The current `vz_linux` Virtualization.framework configuration omits network
+  device attachment; guest command transport uses vsock rather than guest
+  network access.
 - `seatbelt` only offers a best-effort deny-all claim via seatbelt policy; discovery should not be read as VM-grade or firewall-backed network isolation.
 - `strict_allowlist_not_supported` is still the expected result for:
   - `vz_linux`

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -60,6 +60,10 @@ Current limitations:
 - `vz_linux` requires helper/template readiness and reports `execution_mode=real` when the helper-backed boot and guest execution path is available.
 - `vz_macos` still requires helper/template readiness plus `*_FAKE_EXEC=1`; otherwise discovery reports `real_execution_not_implemented`.
 - Strict allowlist networking is not implemented for `vz_linux`, `vz_macos`, or `seatbelt`.
+- `vz_linux` VM creation is fail-closed at both Python admission and helper
+  protocol layers: only `network_policy=deny_all` is accepted, and the helper
+  records the accepted policy in VM metadata/status details. The current
+  Virtualization.framework configuration does not attach a network device.
 - `seatbelt` discovery may be `available=True` while `strict_deny_all_supported=False`; deny-all is a best-effort host policy claim, not a VM-grade guarantee.
 - `seatbelt` control files and isolated `HOME`/temp dirs live outside the writable workspace and are removed after each run.
 - `seatbelt` real execution still depends on deprecated `sandbox-exec` and may be blocked by an enclosing sandbox even on macOS hosts.

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -91,6 +91,12 @@ class MacOSVirtualizationHelperClient:
         if is_truthy(os.getenv("TEST_MODE")):
             vm_name = str(request.get("vm_name") or "").strip() or "vm-test"
             runtime = str(request.get("runtime") or "").strip() or "vz_linux"
+            network_policy = self._normalize_network_policy(request.get("network_policy"))
+            if network_policy != "deny_all":
+                raise MacOSVirtualizationHelperFailure(
+                    error_code=self._network_policy_error_code(network_policy),
+                    message=network_policy,
+                )
             template_path = str(request.get("template") or request.get("template_path") or "").strip()
             raw_session_mode = request.get("session_mode")
             session_mode = _bool_field({"session_mode": raw_session_mode}, "session_mode")
@@ -110,9 +116,10 @@ class MacOSVirtualizationHelperClient:
                         "run_manifest_path": request.get("run_manifest_path") or "",
                         "planning_source": request.get("planning_source") or "",
                         "workspace_path": request.get("workspace_path") or "",
+                        "network_policy": network_policy,
                         "created_at": created_at,
                     },
-                    "details": {"runtime": runtime or None, "transport": "vsock"},
+                    "details": {"runtime": runtime or None, "transport": "vsock", "network_policy": network_policy},
                 }
             )
         payload = self._request("create_vm", request, timeout_sec=self._operation_timeout_sec(request))
@@ -130,12 +137,16 @@ class MacOSVirtualizationHelperClient:
                 reasons.append("macos_helper_missing")
             if not template_ready:
                 reasons.append("vz_linux_template_missing")
+            network_policy = self._normalize_network_policy(request.get("network_policy"))
+            if network_policy != "deny_all":
+                reasons.append(self._network_policy_error_code(network_policy))
             available = not reasons
             return {
                 "available": available,
                 "reasons": reasons,
                 "execution_mode": "real" if available else "none",
                 "transport": "vsock" if available else None,
+                "details": {"network_policy": network_policy},
             }
         parsed = parse_helper_host_validation(self._request("validate_host", request))
         return {
@@ -292,6 +303,15 @@ class MacOSVirtualizationHelperClient:
             "reasons": reasons,
             "details": {"runtime": runtime},
         }
+
+    @staticmethod
+    def _normalize_network_policy(value: Any) -> str:
+        normalized = str(value or "").strip().lower()
+        return normalized or "deny_all"
+
+    @staticmethod
+    def _network_policy_error_code(network_policy: str) -> str:
+        return "strict_allowlist_not_supported" if network_policy == "allowlist" else "unsupported_network_policy"
 
     @staticmethod
     def _read_response(client: socket.socket) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -119,7 +119,7 @@ class MacOSVirtualizationHelperClient:
                         "network_policy": network_policy,
                         "created_at": created_at,
                     },
-                    "details": {"runtime": runtime or None, "transport": "vsock", "network_policy": network_policy},
+                    "details": {"transport": "vsock", "network_policy": network_policy},
                 }
             )
         payload = self._request("create_vm", request, timeout_sec=self._operation_timeout_sec(request))
@@ -146,7 +146,7 @@ class MacOSVirtualizationHelperClient:
                 "reasons": reasons,
                 "execution_mode": "real" if available else "none",
                 "transport": "vsock" if available else None,
-                "details": {"network_policy": network_policy},
+                "details": {"runtime": "vz_linux", "network_policy": network_policy},
             }
         parsed = parse_helper_host_validation(self._request("validate_host", request))
         return {
@@ -306,11 +306,13 @@ class MacOSVirtualizationHelperClient:
 
     @staticmethod
     def _normalize_network_policy(value: Any) -> str:
+        """Normalize caller-provided network policy text for the deny-all helper contract."""
         normalized = str(value or "").strip().lower()
         return normalized or "deny_all"
 
     @staticmethod
     def _network_policy_error_code(network_policy: str) -> str:
+        """Return the stable helper error code for an unsupported normalized network policy."""
         return "strict_allowlist_not_supported" if network_policy == "allowlist" else "unsupported_network_policy"
 
     @staticmethod

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py
@@ -58,6 +58,7 @@ class HelperVMMetadata:
     run_manifest_path: str = ""
     planning_source: str = ""
     workspace_path: str = ""
+    network_policy: str = ""
     created_at: str = ""
 
     @property
@@ -80,6 +81,7 @@ def _metadata_field(payload: dict[str, Any]) -> HelperVMMetadata:
         "run_manifest_path",
         "planning_source",
         "workspace_path",
+        "network_policy",
         "created_at",
     )
     for key in string_keys:
@@ -100,6 +102,7 @@ def _metadata_field(payload: dict[str, Any]) -> HelperVMMetadata:
         run_manifest_path=_str_field(raw, "run_manifest_path").strip(),
         planning_source=_str_field(raw, "planning_source").strip(),
         workspace_path=_str_field(raw, "workspace_path").strip(),
+        network_policy=_str_field(raw, "network_policy").strip(),
         created_at=_str_field(raw, "created_at").strip(),
     )
 

--- a/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
@@ -142,7 +142,7 @@ def test_fake_helper_supports_vz_linux_vm_create_and_exec(monkeypatch) -> None:
     assert created.metadata.workspace_path == "/tmp/workspace"
     assert created.metadata.network_policy == "deny_all"
     assert created.metadata.created_at != ""
-    assert created.details["runtime"] == "vz_linux"
+    assert "runtime" not in created.details
     assert created.details["transport"] == "vsock"
     assert created.details["network_policy"] == "deny_all"
 
@@ -177,6 +177,7 @@ def test_fake_helper_validates_vz_linux_host_readiness(monkeypatch) -> None:
     assert result["available"] is True
     assert result["execution_mode"] == "real"
     assert result["reasons"] == []
+    assert result["details"] == {"runtime": "vz_linux", "network_policy": "deny_all"}
 
 
 def test_fake_helper_rejects_unsupported_vz_linux_network_policy(monkeypatch) -> None:

--- a/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
@@ -140,9 +140,11 @@ def test_fake_helper_supports_vz_linux_vm_create_and_exec(monkeypatch) -> None:
     assert created.metadata.run_manifest_path == "/tmp/image-store/runs/run-1/manifest.json"
     assert created.metadata.planning_source == "image_store"
     assert created.metadata.workspace_path == "/tmp/workspace"
+    assert created.metadata.network_policy == "deny_all"
     assert created.metadata.created_at != ""
     assert created.details["runtime"] == "vz_linux"
     assert created.details["transport"] == "vsock"
+    assert created.details["network_policy"] == "deny_all"
 
     exec_reply = client.exec_guest(
         vm_id=created.vm_id,
@@ -175,6 +177,28 @@ def test_fake_helper_validates_vz_linux_host_readiness(monkeypatch) -> None:
     assert result["available"] is True
     assert result["execution_mode"] == "real"
     assert result["reasons"] == []
+
+
+def test_fake_helper_rejects_unsupported_vz_linux_network_policy(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", "1")
+
+    client = MacOSVirtualizationHelperClient()
+    result = client.validate_vz_linux_host({"network_policy": "allowlist"})
+
+    assert result["available"] is False
+    assert "strict_allowlist_not_supported" in result["reasons"]
+    with pytest.raises(MacOSVirtualizationHelperFailure) as exc_info:
+        client.create_vm(
+            {
+                "runtime": "vz_linux",
+                "vm_name": "vz-linux-run-allowlist",
+                "network_policy": "allowlist",
+            }
+        )
+    assert exc_info.value.error_code == "strict_allowlist_not_supported"
 
 
 def test_fake_helper_validate_template_includes_boot_metadata(monkeypatch) -> None:
@@ -270,6 +294,7 @@ def test_parse_helper_vm_status_reads_metadata() -> None:
                 "session_mode": True,
                 "template_path": "/tmp/bundle",
                 "workspace_path": "/tmp/workspace",
+                "network_policy": "deny_all",
                 "created_at": "2026-04-30T18:00:00Z",
             },
         }
@@ -282,6 +307,7 @@ def test_parse_helper_vm_status_reads_metadata() -> None:
     assert result.metadata.session_mode is True
     assert result.metadata.template_path == "/tmp/bundle"
     assert result.metadata.workspace_path == "/tmp/workspace"
+    assert result.metadata.network_policy == "deny_all"
     assert result.metadata.created_at == "2026-04-30T18:00:00Z"
     assert result.metadata.has_tldw_owner is True
 
@@ -345,6 +371,7 @@ def test_fake_helper_create_vm_normalizes_string_session_mode_and_created_at(mon
 
     assert created.metadata.runtime == "vz_linux"
     assert created.metadata.session_mode is False
+    assert created.metadata.network_policy == "deny_all"
     assert created.metadata.created_at != ""
 
 

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -61,7 +61,8 @@ Every failure response should include:
   "transport": "vsock",
   "reasons": [],
   "details": {
-    "runtime": "vz_linux"
+    "runtime": "vz_linux",
+    "network_policy": "deny_all"
   }
 }
 ```
@@ -86,10 +87,12 @@ Every failure response should include:
     "run_manifest_path": "/var/lib/tldw/image-store/runs/run-123/manifest.json",
     "planning_source": "image_store",
     "workspace_path": "/tmp/tldw-vz-linux-workspace",
+    "network_policy": "deny_all",
     "created_at": "2026-04-30T18:00:00Z"
   },
   "details": {
-    "runtime": "vz_linux"
+    "transport": "vsock",
+    "network_policy": "deny_all"
   }
 }
 ```
@@ -115,6 +118,7 @@ Request:
     "run_manifest_path": "/var/lib/tldw/image-store/runs/run-123/manifest.json",
     "planning_source": "image_store",
     "workspace_path": "/tmp/tldw-vz-linux-workspace",
+    "network_policy": "deny_all",
     "timeout_sec": 300
   }
 }
@@ -126,6 +130,8 @@ identifier to persist in VM metadata, `template_path` mirrors the concrete bundl
 path when callers want it explicit, `run_manifest_path` points at the persisted
 per-run clone manifest when image-store planning is used, and `planning_source`
 identifies the planner, for example `image_store`.
+`network_policy` defaults to `deny_all`; helper-side VM creation rejects any
+other value and returns `strict_allowlist_not_supported` for `allowlist`.
 
 Response:
 
@@ -146,10 +152,12 @@ Response:
     "run_manifest_path": "/var/lib/tldw/image-store/runs/run-123/manifest.json",
     "planning_source": "image_store",
     "workspace_path": "/tmp/tldw-vz-linux-workspace",
+    "network_policy": "deny_all",
     "created_at": "2026-04-30T18:00:00Z"
   },
   "details": {
-    "transport": "vsock"
+    "transport": "vsock",
+    "network_policy": "deny_all"
   }
 }
 ```
@@ -193,10 +201,12 @@ Response:
         "run_manifest_path": "/var/lib/tldw/image-store/runs/run-123/manifest.json",
         "planning_source": "image_store",
         "workspace_path": "/tmp/tldw-vz-linux-workspace",
+        "network_policy": "deny_all",
         "created_at": "2026-04-30T18:00:00Z"
       },
       "details": {
-        "runtime": "vz_linux"
+        "transport": "vsock",
+        "network_policy": "deny_all"
       }
     }
   ]
@@ -212,6 +222,9 @@ Response:
 - The helper assigns `created_at` when VM creation metadata omits it. Python uses
   `owner=tldw`, `runtime=vz_linux`, non-empty `run_id`, and session metadata to
   decide whether orphan repair may terminate a live VM.
+- `vz_linux` helper VM creation accepts only `network_policy=deny_all` until a
+  separately verified allowlist implementation exists. The accepted policy is
+  echoed in VM metadata and status details.
 - Template validation must report `boot_mode` and `validation_strength` when the
   helper can resolve the template successfully.
 - Python remains the source of truth for sandbox sessions; the helper only reports

--- a/tools/macos-vz-helper/Sources/Protocol/Response.swift
+++ b/tools/macos-vz-helper/Sources/Protocol/Response.swift
@@ -60,6 +60,7 @@ struct VMOwnershipMetadata: Codable, Equatable {
     let planningSource: String
     let workspacePath: String
     let createdAt: String
+    let networkPolicy: String
 
     static let unknown = VMOwnershipMetadata(
         owner: "unknown",
@@ -72,7 +73,8 @@ struct VMOwnershipMetadata: Codable, Equatable {
         runManifestPath: "",
         planningSource: "",
         workspacePath: "",
-        createdAt: ""
+        createdAt: "",
+        networkPolicy: ""
     )
 
     private enum CodingKeys: String, CodingKey {
@@ -87,6 +89,35 @@ struct VMOwnershipMetadata: Codable, Equatable {
         case planningSource = "planning_source"
         case workspacePath = "workspace_path"
         case createdAt = "created_at"
+        case networkPolicy = "network_policy"
+    }
+
+    init(
+        owner: String,
+        runtime: String,
+        runID: String,
+        sessionID: String,
+        sessionMode: Bool,
+        templateID: String,
+        templatePath: String,
+        runManifestPath: String,
+        planningSource: String,
+        workspacePath: String,
+        createdAt: String,
+        networkPolicy: String = ""
+    ) {
+        self.owner = owner
+        self.runtime = runtime
+        self.runID = runID
+        self.sessionID = sessionID
+        self.sessionMode = sessionMode
+        self.templateID = templateID
+        self.templatePath = templatePath
+        self.runManifestPath = runManifestPath
+        self.planningSource = planningSource
+        self.workspacePath = workspacePath
+        self.createdAt = createdAt
+        self.networkPolicy = networkPolicy
     }
 }
 

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -5,6 +5,10 @@ struct HostFacts {
     let isAppleSilicon: Bool
 }
 
+enum HelperServiceError: Error {
+    case unsupportedNetworkPolicy(String)
+}
+
 final class HelperService {
     private let protocolVersion = "1"
     private let helperVersion = "0.1.0"
@@ -43,6 +47,7 @@ final class HelperService {
 
     func validateHost(runtime: String, networkPolicy: String) -> HelperResponse {
         var reasons: [String] = []
+        let normalizedNetworkPolicy = normalizeNetworkPolicy(networkPolicy)
         if runtime != "vz_linux" {
             reasons.append("runtime_unsupported")
         }
@@ -52,8 +57,8 @@ final class HelperService {
         if !hostFacts.isAppleSilicon {
             reasons.append("apple_silicon_required")
         }
-        if networkPolicy != "deny_all" {
-            reasons.append("strict_allowlist_not_supported")
+        if normalizedNetworkPolicy != "deny_all" {
+            reasons.append(networkPolicyErrorCode(normalizedNetworkPolicy))
         }
 
         let available = reasons.isEmpty
@@ -65,7 +70,7 @@ final class HelperService {
             executionMode: available ? "real" : "none",
             transport: available ? "vsock" : nil,
             reasons: reasons,
-            details: ["runtime": runtime],
+            details: ["runtime": runtime, "network_policy": normalizedNetworkPolicy],
             errorCode: nil,
             message: nil
         )
@@ -80,12 +85,15 @@ final class HelperService {
         templatePath: String,
         workspacePath: String,
         readinessTimeoutSeconds: TimeInterval,
-        metadata: VMOwnershipMetadata = .unknown
+        metadata: VMOwnershipMetadata = .unknown,
+        networkPolicy: String = "deny_all"
     ) throws -> HelperVMResponse {
+        let normalizedNetworkPolicy = try requireSupportedNetworkPolicy(networkPolicy)
         let normalizedMetadata = normalizeMetadata(
             metadata,
             templatePath: templatePath,
-            workspacePath: workspacePath
+            workspacePath: workspacePath,
+            networkPolicy: normalizedNetworkPolicy
         )
         let record = try vmManager.createVM(
             vmID: vmID,
@@ -100,7 +108,7 @@ final class HelperService {
             vmID: record.vmID,
             state: record.state,
             metadata: record.metadata,
-            details: ["transport": "vsock"]
+            details: vmDetails(for: record)
         )
     }
 
@@ -115,7 +123,7 @@ final class HelperService {
             state: record.state,
             healthy: record.healthy,
             metadata: record.metadata,
-            details: ["transport": "vsock"]
+            details: vmDetails(for: record)
         )
     }
 
@@ -128,7 +136,7 @@ final class HelperService {
                 state: record.state,
                 healthy: record.healthy,
                 metadata: record.metadata,
-                details: ["transport": "vsock"]
+                details: vmDetails(for: record)
             )
         }
         return HelperVMListResponse(
@@ -169,7 +177,8 @@ final class HelperService {
     private func normalizeMetadata(
         _ metadata: VMOwnershipMetadata,
         templatePath: String,
-        workspacePath: String
+        workspacePath: String,
+        networkPolicy: String
     ) -> VMOwnershipMetadata {
         VMOwnershipMetadata(
             owner: metadata.owner.isEmpty ? "unknown" : metadata.owner,
@@ -182,7 +191,32 @@ final class HelperService {
             runManifestPath: metadata.runManifestPath,
             planningSource: metadata.planningSource,
             workspacePath: metadata.workspacePath.isEmpty ? workspacePath : metadata.workspacePath,
-            createdAt: metadata.createdAt.isEmpty ? metadataDateFormatter.string(from: Date()) : metadata.createdAt
+            createdAt: metadata.createdAt.isEmpty ? metadataDateFormatter.string(from: Date()) : metadata.createdAt,
+            networkPolicy: networkPolicy
         )
+    }
+
+    private func requireSupportedNetworkPolicy(_ networkPolicy: String) throws -> String {
+        let normalized = normalizeNetworkPolicy(networkPolicy)
+        guard normalized == "deny_all" else {
+            throw HelperServiceError.unsupportedNetworkPolicy(normalized)
+        }
+        return normalized
+    }
+
+    private func normalizeNetworkPolicy(_ networkPolicy: String) -> String {
+        let normalized = networkPolicy.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty ? "deny_all" : normalized
+    }
+
+    private func networkPolicyErrorCode(_ networkPolicy: String) -> String {
+        networkPolicy == "allowlist" ? "strict_allowlist_not_supported" : "unsupported_network_policy"
+    }
+
+    private func vmDetails(for record: VMRecord) -> [String: String] {
+        [
+            "transport": "vsock",
+            "network_policy": record.metadata.networkPolicy.isEmpty ? "deny_all" : record.metadata.networkPolicy,
+        ]
     }
 }

--- a/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
+++ b/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
@@ -141,15 +141,20 @@ final class UnixSocketServer {
                 workspacePath: workspacePath,
                 createdAt: ""
             )
-            return try encoder.encode(
-                try service.createVM(
-                    vmID: request.request["vm_name"]?.stringValue ?? request.request["run_id"]?.stringValue ?? "",
-                    templatePath: templatePath,
-                    workspacePath: workspacePath,
-                    readinessTimeoutSeconds: TimeInterval(request.request["timeout_sec"]?.intValue ?? 30),
-                    metadata: metadata
+            do {
+                return try encoder.encode(
+                    try service.createVM(
+                        vmID: request.request["vm_name"]?.stringValue ?? request.request["run_id"]?.stringValue ?? "",
+                        templatePath: templatePath,
+                        workspacePath: workspacePath,
+                        readinessTimeoutSeconds: TimeInterval(request.request["timeout_sec"]?.intValue ?? 30),
+                        metadata: metadata,
+                        networkPolicy: request.request["network_policy"]?.stringValue ?? "deny_all"
+                    )
                 )
-            )
+            } catch {
+                return encodeErrorResponse(for: error)
+            }
         case "get_vm_status":
             let vmID = request.request["vm_id"]?.stringValue ?? ""
             if let status = service.getVMStatus(vmID: vmID) {
@@ -514,6 +519,8 @@ final class UnixSocketServer {
             return "helper_socket_path_too_long"
         case UnixSocketServerError.unsupportedOperation:
             return "unsupported_operation"
+        case HelperServiceError.unsupportedNetworkPolicy(let policy):
+            return policy == "allowlist" ? "strict_allowlist_not_supported" : "unsupported_network_policy"
         case VZLinuxVMManagerError.bootNotImplemented:
             return "boot_not_implemented"
         case GuestBridgeError.guestReadinessNotImplemented:

--- a/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
+++ b/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
@@ -110,12 +110,20 @@ final class UnixSocketServer {
         case "ping":
             return try encoder.encode(service.ping())
         case "validate_host":
-            return try encoder.encode(
-                service.validateHost(
-                    runtime: request.request["runtime"]?.stringValue ?? "",
-                    networkPolicy: request.request["network_policy"]?.stringValue ?? ""
+            do {
+                return try encoder.encode(
+                    service.validateHost(
+                        runtime: request.request["runtime"]?.stringValue ?? "",
+                        networkPolicy: try optionalStringField(
+                            request.request,
+                            key: "network_policy",
+                            defaultValue: "deny_all"
+                        )
+                    )
                 )
-            )
+            } catch {
+                return encodeErrorResponse(for: error)
+            }
         case "validate_template", "register_template":
             return try encoder.encode(
                 service.validateTemplate(
@@ -124,24 +132,29 @@ final class UnixSocketServer {
                 )
             )
         case "create_vm":
-            let templatePath = request.request["template"]?.stringValue
-                ?? request.request["template_path"]?.stringValue
-                ?? ""
-            let workspacePath = request.request["workspace_path"]?.stringValue ?? ""
-            let metadata = VMOwnershipMetadata(
-                owner: request.request["owner"]?.stringValue ?? "unknown",
-                runtime: request.request["runtime"]?.stringValue ?? "vz_linux",
-                runID: request.request["run_id"]?.stringValue ?? "",
-                sessionID: request.request["session_id"]?.stringValue ?? "",
-                sessionMode: request.request["session_mode"]?.boolValue ?? false,
-                templateID: request.request["template_id"]?.stringValue ?? "",
-                templatePath: templatePath,
-                runManifestPath: request.request["run_manifest_path"]?.stringValue ?? "",
-                planningSource: request.request["planning_source"]?.stringValue ?? "",
-                workspacePath: workspacePath,
-                createdAt: ""
-            )
             do {
+                let networkPolicy = try optionalStringField(
+                    request.request,
+                    key: "network_policy",
+                    defaultValue: "deny_all"
+                )
+                let templatePath = request.request["template"]?.stringValue
+                    ?? request.request["template_path"]?.stringValue
+                    ?? ""
+                let workspacePath = request.request["workspace_path"]?.stringValue ?? ""
+                let metadata = VMOwnershipMetadata(
+                    owner: request.request["owner"]?.stringValue ?? "unknown",
+                    runtime: request.request["runtime"]?.stringValue ?? "vz_linux",
+                    runID: request.request["run_id"]?.stringValue ?? "",
+                    sessionID: request.request["session_id"]?.stringValue ?? "",
+                    sessionMode: request.request["session_mode"]?.boolValue ?? false,
+                    templateID: request.request["template_id"]?.stringValue ?? "",
+                    templatePath: templatePath,
+                    runManifestPath: request.request["run_manifest_path"]?.stringValue ?? "",
+                    planningSource: request.request["planning_source"]?.stringValue ?? "",
+                    workspacePath: workspacePath,
+                    createdAt: ""
+                )
                 return try encoder.encode(
                     try service.createVM(
                         vmID: request.request["vm_name"]?.stringValue ?? request.request["run_id"]?.stringValue ?? "",
@@ -149,7 +162,7 @@ final class UnixSocketServer {
                         workspacePath: workspacePath,
                         readinessTimeoutSeconds: TimeInterval(request.request["timeout_sec"]?.intValue ?? 30),
                         metadata: metadata,
-                        networkPolicy: request.request["network_policy"]?.stringValue ?? "deny_all"
+                        networkPolicy: networkPolicy
                     )
                 )
             } catch {
@@ -509,6 +522,20 @@ final class UnixSocketServer {
         return (try? encoder.encode(response)) ?? Data("{\"protocol_version\":\"1\",\"helper_version\":\"0.1.0\",\"error_code\":\"helper_internal_error\",\"message\":\"encoding failure\"}".utf8)
     }
 
+    private func optionalStringField(
+        _ request: [String: JSONValue],
+        key: String,
+        defaultValue: String
+    ) throws -> String {
+        guard let value = request[key] else {
+            return defaultValue
+        }
+        guard let stringValue = value.stringValue else {
+            throw UnixSocketServerError.invalidRequest
+        }
+        return stringValue
+    }
+
     private func errorCode(for error: Error) -> String {
         switch error {
         case UnixSocketServerError.invalidRequest, is DecodingError:
@@ -551,6 +578,10 @@ final class UnixSocketServer {
              UnixSocketServerError.socketCreateFailed(let code),
              UnixSocketServerError.writeFailed(let code):
             return "system_error_\(code)"
+        case UnixSocketServerError.invalidRequest, is DecodingError:
+            return "invalid_request"
+        case HelperServiceError.unsupportedNetworkPolicy(let policy):
+            return policy
         default:
             return String(describing: error)
         }

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -49,7 +49,8 @@ import Testing
         runManifestPath: "/tmp/image-store/runs/run-owned/manifest.json",
         planningSource: "image_store",
         workspacePath: "/tmp/workspace",
-        createdAt: ""
+        createdAt: "",
+        networkPolicy: "allowlist"
     )
 
     let response = try service.createVM(
@@ -71,9 +72,37 @@ import Testing
     #expect(response.metadata.runManifestPath == "/tmp/image-store/runs/run-owned/manifest.json")
     #expect(response.metadata.planningSource == "image_store")
     #expect(response.metadata.workspacePath == "/tmp/workspace")
+    #expect(response.metadata.networkPolicy == "deny_all")
     #expect(response.metadata.createdAt.isEmpty == false)
     #expect(status?.metadata.runID == "run-owned")
+    #expect(status?.details["network_policy"] == "deny_all")
     #expect(listed?.metadata.runID == "run-owned")
+    #expect(listed?.details["network_policy"] == "deny_all")
+}
+
+@Test func helperServiceCreateVMRejectsUnsupportedNetworkPolicy() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    #expect(throws: HelperServiceError.self) {
+        try service.createVM(
+            vmID: "vm-allowlist",
+            templatePath: "/tmp/template.img",
+            workspacePath: "/tmp/workspace",
+            readinessTimeoutSeconds: 5,
+            networkPolicy: "allowlist"
+        )
+    }
+    #expect(registry.status(vmID: "vm-allowlist") == nil)
 }
 
 @Test func helperServiceCreateVMDefaultsMissingOwnershipMetadataToUnknown() throws {

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -93,14 +93,19 @@ import Testing
         vmManager: manager
     )
 
-    #expect(throws: HelperServiceError.self) {
-        try service.createVM(
+    do {
+        _ = try service.createVM(
             vmID: "vm-allowlist",
             templatePath: "/tmp/template.img",
             workspacePath: "/tmp/workspace",
             readinessTimeoutSeconds: 5,
             networkPolicy: "allowlist"
         )
+        Issue.record("expected unsupported network policy")
+    } catch HelperServiceError.unsupportedNetworkPolicy(let policy) {
+        #expect(policy == "allowlist")
+    } catch {
+        Issue.record("expected unsupportedNetworkPolicy, got \(error)")
     }
     #expect(registry.status(vmID: "vm-allowlist") == nil)
 }

--- a/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
+++ b/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
@@ -124,7 +124,50 @@ import Testing
     let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
 
     #expect(json?["error_code"] as? String == "strict_allowlist_not_supported")
+    #expect(json?["message"] as? String == "allowlist")
     #expect(registry.status(vmID: "vm-allowlist") == nil)
+}
+
+@Test func unixSocketServerRejectsCreateVMNonStringNetworkPolicy() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+    let server = UnixSocketServer(
+        socketPath: "/tmp/macos-vz-helper.sock",
+        service: service
+    )
+
+    let createRequest = """
+    {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-malformed-policy","template":"/tmp/template.img","workspace_path":"/workspace","network_policy":["deny_all"]}}
+    """.data(using: .utf8)!
+    let responseData = try server.handleRequestData(createRequest)
+    let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+
+    #expect(json?["error_code"] as? String == "invalid_request")
+    #expect(registry.status(vmID: "vm-malformed-policy") == nil)
+}
+
+@Test func unixSocketServerRejectsValidateHostNonStringNetworkPolicy() throws {
+    let server = UnixSocketServer(
+        socketPath: "/tmp/macos-vz-helper.sock",
+        service: HelperService(hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true))
+    )
+
+    let validateRequest = """
+    {"operation":"validate_host","protocol_version":"1","request":{"runtime":"vz_linux","network_policy":{"mode":"deny_all"}}}
+    """.data(using: .utf8)!
+    let responseData = try server.handleRequestData(validateRequest)
+    let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+
+    #expect(json?["error_code"] as? String == "invalid_request")
 }
 
 @Test func unixSocketServerServesPingOverRealSocket() throws {

--- a/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
+++ b/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
@@ -96,7 +96,35 @@ import Testing
     #expect(metadata?["run_manifest_path"] as? String == "/tmp/image-store/runs/run-owned/manifest.json")
     #expect(metadata?["planning_source"] as? String == "image_store")
     #expect(metadata?["workspace_path"] as? String == "/workspace")
+    #expect(metadata?["network_policy"] as? String == "deny_all")
     #expect((metadata?["created_at"] as? String)?.isEmpty == false)
+}
+
+@Test func unixSocketServerRejectsCreateVMUnsupportedNetworkPolicy() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+    let server = UnixSocketServer(
+        socketPath: "/tmp/macos-vz-helper.sock",
+        service: service
+    )
+
+    let createRequest = """
+    {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-allowlist","template":"/tmp/template.img","workspace_path":"/workspace","network_policy":"allowlist"}}
+    """.data(using: .utf8)!
+    let responseData = try server.handleRequestData(createRequest)
+    let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+
+    #expect(json?["error_code"] as? String == "strict_allowlist_not_supported")
+    #expect(registry.status(vmID: "vm-allowlist") == nil)
 }
 
 @Test func unixSocketServerServesPingOverRealSocket() throws {

--- a/tools/macos-vz-helper/Tests/ValidateHostTests.swift
+++ b/tools/macos-vz-helper/Tests/ValidateHostTests.swift
@@ -13,3 +13,13 @@ import Testing
     #expect(response.reasons.contains("macos_host_required"))
     #expect(response.reasons.contains("apple_silicon_required"))
 }
+
+@Test func validateHostRejectsAllowlistNetworkPolicy() throws {
+    let service = HelperService(hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true))
+
+    let response = service.validateHost(runtime: "vz_linux", networkPolicy: "allowlist")
+
+    #expect(response.available == false)
+    #expect(response.reasons.contains("strict_allowlist_not_supported"))
+    #expect(response.details["network_policy"] == "allowlist")
+}


### PR DESCRIPTION
## Summary

- What changed: TODO - human-authored change summary required before merge.
- Why: TODO - human-authored rationale required before merge.

Implementation notes:
- Enforces the current `vz_linux` network-policy contract at the Swift helper boundary: only `network_policy=deny_all` is accepted for VM creation.
- Returns structured helper errors for unsupported direct `create_vm` requests, including `strict_allowlist_not_supported` for `allowlist`.
- Rejects present-but-non-string `network_policy` values as `invalid_request` for both `validate_host` and `create_vm`.
- Records and reports the accepted network policy in VM metadata/status details and keeps Python fake-helper behavior aligned with the protocol.
- Updates helper protocol/operator docs and focused Python/Swift tests.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Commands run:
- `swift test --package-path tools/macos-vz-helper` - 56 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py tldw_Server_API/tests/sandbox/test_macos_runtime_admission.py` - 43 passed, 1 skipped
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py -f json -o /tmp/bandit_vz_network_policy_contract_review_fixes.json` - 0 findings
- `git diff --check`

## UX Audit Checklist (v2 Stage 5)

- [ ] Not applicable - no WebUI changes.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [ ] Not applicable - no Watchlists UI behavior changed.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [ ] Not applicable - no Watchlists scale behavior changed.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR; the previous behavior accepted helper-side `create_vm` requests without the explicit network-policy contract.
