### PR TITLE
refactor(workers): register maintenance scheduler lifecycle

### DIFF
--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -94,9 +94,15 @@ async def shutdown_post_worker_services(
 
     claims_shutdown_handles = await _shutdown_claims_maintenance_tasks(
         claims_task=_task_if_not_stopped("claims_rebuild", claims_task),
-        jobs_prune_task=jobs_prune_task,
-        files_export_gc_task=files_export_gc_task,
-        notifications_prune_task=notifications_prune_task,
+        jobs_prune_task=_task_if_not_stopped("jobs_prune_task", jobs_prune_task),
+        files_export_gc_task=_task_if_not_stopped(
+            "files_export_gc_task",
+            files_export_gc_task,
+        ),
+        notifications_prune_task=_task_if_not_stopped(
+            "notifications_prune_task",
+            notifications_prune_task,
+        ),
     )
     notifications_shutdown_handles = await _shutdown_notifications_compactor_websub_workers(
         jobs_notifications_bridge_task=jobs_notifications_bridge_task,
@@ -300,9 +306,15 @@ async def run_shutdown_post_worker_services(
         logger.debug(f"Post-worker services skipped: {exc}")
         return PostWorkerShutdownHandles(
             claims_task=_fallback_if_not_stopped("claims_rebuild", claims_task),
-            jobs_prune_task=jobs_prune_task,
-            files_export_gc_task=files_export_gc_task,
-            notifications_prune_task=notifications_prune_task,
+            jobs_prune_task=_fallback_if_not_stopped("jobs_prune_task", jobs_prune_task),
+            files_export_gc_task=_fallback_if_not_stopped(
+                "files_export_gc_task",
+                files_export_gc_task,
+            ),
+            notifications_prune_task=_fallback_if_not_stopped(
+                "notifications_prune_task",
+                notifications_prune_task,
+            ),
             jobs_notifications_bridge_task=jobs_notifications_bridge_task,
             embeddings_compactor_task=_fallback_if_not_stopped(
                 "embeddings_compactor_task",

--- a/tldw_Server_API/app/services/startup_maintenance_schedulers.py
+++ b/tldw_Server_API/app/services/startup_maintenance_schedulers.py
@@ -49,8 +49,12 @@ async def start_maintenance_schedulers(
 ) -> MaintenanceSchedulerHandles:
     """Start the env-gated maintenance scheduler batch and return explicit task handles."""
     return MaintenanceSchedulerHandles(
-        quality_eval_task=await _start_quality_eval_scheduler(),
-        outputs_purge_task=await _start_outputs_purge_scheduler(),
+        quality_eval_task=await _start_quality_eval_scheduler(
+            worker_inventory=worker_inventory,
+        ),
+        outputs_purge_task=await _start_outputs_purge_scheduler(
+            worker_inventory=worker_inventory,
+        ),
         kanban_activity_cleanup_task=await _start_kanban_activity_cleanup_scheduler(
             worker_inventory=worker_inventory,
         ),
@@ -60,9 +64,15 @@ async def start_maintenance_schedulers(
         kanban_purge_task=await _start_kanban_purge_scheduler(
             worker_inventory=worker_inventory,
         ),
-        files_export_gc_task=await _start_file_artifacts_export_gc_scheduler(),
-        notifications_prune_task=await _start_notifications_prune_scheduler(),
-        jobs_prune_task=await _start_jobs_prune_scheduler(),
+        files_export_gc_task=await _start_file_artifacts_export_gc_scheduler(
+            worker_inventory=worker_inventory,
+        ),
+        notifications_prune_task=await _start_notifications_prune_scheduler(
+            worker_inventory=worker_inventory,
+        ),
+        jobs_prune_task=await _start_jobs_prune_scheduler(
+            worker_inventory=worker_inventory,
+        ),
     )
 
 
@@ -70,23 +80,33 @@ def _env_enabled(key: str) -> bool:
     return _is_truthy(os.getenv(key, "false"))
 
 
-async def _start_quality_eval_scheduler() -> Any | None:
+async def _start_quality_eval_scheduler(
+    *,
+    worker_inventory: WorkerInventory | None = None,
+) -> Any | None:
     return await _start_env_gated_task(
         env_key="RAG_QUALITY_EVAL_ENABLED",
         disabled_message="RAG quality eval scheduler disabled (RAG_QUALITY_EVAL_ENABLED != true)",
         started_message="RAG quality eval scheduler started",
         failure_message="Failed to start RAG quality eval scheduler: {exc}",
         starter=_start_quality_eval_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="quality_eval_task",
     )
 
 
-async def _start_outputs_purge_scheduler() -> Any | None:
+async def _start_outputs_purge_scheduler(
+    *,
+    worker_inventory: WorkerInventory | None = None,
+) -> Any | None:
     return await _start_env_gated_task(
         env_key="OUTPUTS_PURGE_ENABLED",
         disabled_message="Outputs purge scheduler disabled (OUTPUTS_PURGE_ENABLED != true)",
         started_message="Outputs purge scheduler started",
         failure_message="Failed to start Outputs purge scheduler: {exc}",
         starter=_start_outputs_purge_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="outputs_purge_task",
     )
 
 
@@ -141,33 +161,48 @@ async def _start_kanban_purge_scheduler(
     )
 
 
-async def _start_file_artifacts_export_gc_scheduler() -> Any | None:
+async def _start_file_artifacts_export_gc_scheduler(
+    *,
+    worker_inventory: WorkerInventory | None = None,
+) -> Any | None:
     return await _start_env_gated_task(
         env_key="FILES_EXPORT_GC_ENABLED",
         disabled_message="File artifacts export GC scheduler disabled (FILES_EXPORT_GC_ENABLED != true)",
         started_message="File artifacts export GC scheduler started",
         failure_message="Failed to start File artifacts export GC scheduler: {exc}",
         starter=_start_file_artifacts_export_gc_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="files_export_gc_task",
     )
 
 
-async def _start_notifications_prune_scheduler() -> Any | None:
+async def _start_notifications_prune_scheduler(
+    *,
+    worker_inventory: WorkerInventory | None = None,
+) -> Any | None:
     return await _start_env_gated_task(
         env_key="NOTIFICATIONS_PRUNE_ENABLED",
         disabled_message="Notifications prune scheduler disabled (NOTIFICATIONS_PRUNE_ENABLED != true)",
         started_message="Notifications prune scheduler started",
         failure_message="Failed to start Notifications prune scheduler: {exc}",
         starter=_start_notifications_prune_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="notifications_prune_task",
     )
 
 
-async def _start_jobs_prune_scheduler() -> Any | None:
+async def _start_jobs_prune_scheduler(
+    *,
+    worker_inventory: WorkerInventory | None = None,
+) -> Any | None:
     return await _start_env_gated_task(
         env_key="JOBS_PRUNE_ENFORCE",
         disabled_message="Jobs prune scheduler disabled (JOBS_PRUNE_ENFORCE != true)",
         started_message="Jobs prune scheduler started",
         failure_message="Failed to start Jobs prune scheduler: {exc}",
         starter=_start_jobs_prune_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="jobs_prune_task",
     )
 
 
@@ -184,7 +219,7 @@ async def _start_env_gated_task(
     """Start one env-gated scheduler and optionally register it for managed shutdown.
 
     Scheduler startup failures return ``None``. Inventory registration failures
-    are logged without hiding a successfully started task handle.
+    roll back the started task so unregistered maintenance work does not leak.
     """
 
     try:
@@ -193,27 +228,59 @@ async def _start_env_gated_task(
             return None
         task = await starter()
         if task:
-            if worker_inventory is not None and worker_name is not None:
-                try:
-                    worker_inventory.register(
-                        ManagedWorker(
-                            name=worker_name,
-                            task=task,
-                            stop_event=None,
-                            timeout_sec=5.0,
-                            category="maintenance",
-                            shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
-                        )
-                    )
-                except _STARTUP_GUARD_EXCEPTIONS as exc:
-                    logger.warning(
-                        f"Started {worker_name} but failed to register it in worker inventory: {exc}"
-                    )
+            await _register_maintenance_scheduler_task(
+                worker_inventory=worker_inventory,
+                task=task,
+                worker_name=worker_name,
+            )
             logger.info(started_message)
         return task
     except _STARTUP_GUARD_EXCEPTIONS as exc:
         logger.warning(failure_message.format(exc=exc))
         return None
+
+
+async def _register_maintenance_scheduler_task(
+    *,
+    worker_inventory: WorkerInventory | None,
+    task: Any,
+    worker_name: str | None,
+) -> None:
+    if worker_inventory is None or worker_name is None:
+        return
+
+    try:
+        worker_inventory.register(
+            ManagedWorker(
+                name=worker_name,
+                task=task,
+                stop_event=None,
+                category="maintenance",
+                shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            )
+        )
+    except _STARTUP_GUARD_EXCEPTIONS:
+        await _cancel_unregistered_task(task)
+        raise
+
+
+async def _cancel_unregistered_task(task: Any, *, timeout: float = 1.0) -> None:
+    try:
+        task.cancel()
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Maintenance scheduler startup rollback cancel failed: {exc}")
+        return
+    try:
+        await asyncio.wait_for(task, timeout=timeout)
+    except asyncio.CancelledError:
+        pass
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Maintenance scheduler did not cancel within {}s during startup rollback",
+            timeout,
+        )
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Maintenance scheduler raised during startup rollback: {exc}")
 
 
 async def _start_quality_eval_scheduler_service() -> Any | None:

--- a/tldw_Server_API/app/services/startup_service_groups.py
+++ b/tldw_Server_API/app/services/startup_service_groups.py
@@ -88,12 +88,9 @@ async def start_service_groups(
         run_pg_rls_auto_ensure=run_pg_rls_auto_ensure,
         worker_inventory=worker_inventory,
     )
-    if worker_inventory is None:
-        maintenance_scheduler_handles = await _start_maintenance_schedulers()
-    else:
-        maintenance_scheduler_handles = await _start_maintenance_schedulers(
-            worker_inventory=worker_inventory,
-        )
+    maintenance_scheduler_handles = await _start_maintenance_schedulers(
+        worker_inventory=worker_inventory,
+    )
     connectors_startup_handles = await _start_connectors_startup(
         app=app,
         owned_job_pollers=owned_job_pollers,

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -431,6 +430,133 @@ async def test_shutdown_post_worker_services_skips_compactor_and_websub_after_ba
 
 
 @pytest.mark.asyncio
+async def test_shutdown_post_worker_services_skips_maintenance_tasks_after_background_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_post_worker_services as shutdown_services
+
+    claims_kwargs: dict[str, object] = {}
+
+    async def _claims(**kwargs: object) -> SimpleNamespace:
+        claims_kwargs.update(kwargs)
+        return SimpleNamespace(
+            claims_task=kwargs["claims_task"],
+            jobs_prune_task=kwargs["jobs_prune_task"],
+            files_export_gc_task=kwargs["files_export_gc_task"],
+            notifications_prune_task=kwargs["notifications_prune_task"],
+        )
+
+    async def _notifications(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_notifications_bridge_task=kwargs["jobs_notifications_bridge_task"],
+            embeddings_compactor_task=kwargs["embeddings_compactor_task"],
+            embeddings_compactor_stop_event=kwargs["embeddings_compactor_stop_event"],
+            websub_renewal_task=kwargs["websub_renewal_task"],
+        )
+
+    async def _usage(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            usage_task=kwargs["usage_task"],
+            llm_usage_task=kwargs["llm_usage_task"],
+        )
+
+    async def _recurring(**kwargs: object) -> None:
+        return None
+
+    async def _runtime(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_metrics_task=kwargs["jobs_metrics_task"],
+            loop_lag_task=kwargs["loop_lag_task"],
+        )
+
+    async def _reconcile(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_metrics_reconcile_task=kwargs["jobs_metrics_reconcile_task"],
+            jobs_metrics_reconcile_stop=kwargs["jobs_metrics_reconcile_stop"],
+        )
+
+    async def _personalization(**kwargs: object) -> None:
+        return None
+
+    async def _optional(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_crypto_rotate_task=kwargs["jobs_crypto_rotate_task"],
+            jobs_integrity_task=kwargs["jobs_integrity_task"],
+            jobs_webhooks_task=kwargs["jobs_webhooks_task"],
+            meetings_webhook_dlq_task=kwargs["meetings_webhook_dlq_task"],
+            workflows_dlq_task=kwargs["workflows_dlq_task"],
+            workflows_gc_task=kwargs["workflows_gc_task"],
+            workflows_maint_task=kwargs["workflows_maint_task"],
+        )
+
+    monkeypatch.setattr(shutdown_services, "_shutdown_claims_maintenance_tasks", _claims)
+    monkeypatch.setattr(
+        shutdown_services,
+        "_shutdown_notifications_compactor_websub_workers",
+        _notifications,
+    )
+    monkeypatch.setattr(shutdown_services, "_stop_usage_aggregators", _usage)
+    monkeypatch.setattr(shutdown_services, "_stop_recurring_schedulers", _recurring)
+    monkeypatch.setattr(shutdown_services, "_shutdown_runtime_monitors", _runtime)
+    monkeypatch.setattr(shutdown_services, "_shutdown_jobs_metrics_reconcile", _reconcile)
+    monkeypatch.setattr(shutdown_services, "_shutdown_personalization_consolidation", _personalization)
+    monkeypatch.setattr(shutdown_services, "_shutdown_optional_workers", _optional)
+
+    handles = await shutdown_services.shutdown_post_worker_services(
+        claims_task=None,
+        jobs_prune_task="jobs-prune-task",
+        files_export_gc_task="files-gc-task",
+        notifications_prune_task="notifications-prune-task",
+        jobs_notifications_bridge_task=None,
+        embeddings_compactor_task=None,
+        embeddings_compactor_stop_event=None,
+        websub_renewal_task=None,
+        coordinated_legacy_component_names=set(),
+        usage_task=None,
+        llm_usage_task=None,
+        workflows_sched_task=None,
+        reading_digest_sched_task=None,
+        admin_backup_sched_task=None,
+        companion_reflection_sched_task=None,
+        reminders_sched_task=None,
+        connectors_sync_sched_task=None,
+        jobs_metrics_task=None,
+        jobs_metrics_stop_event=None,
+        loop_lag_task=None,
+        loop_lag_stop_event=None,
+        jobs_metrics_reconcile_task=None,
+        jobs_metrics_reconcile_stop=None,
+        jobs_crypto_rotate_task=None,
+        jobs_crypto_rotate_stop_event=None,
+        jobs_integrity_task=None,
+        jobs_integrity_stop_event=None,
+        jobs_webhooks_task=None,
+        jobs_webhooks_stop_event=None,
+        meetings_webhook_dlq_task=None,
+        meetings_webhook_dlq_stop_event=None,
+        workflows_dlq_task=None,
+        workflows_dlq_stop_event=None,
+        workflows_gc_task=None,
+        workflows_gc_stop_event=None,
+        workflows_maint_task=None,
+        workflows_maint_stop_event=None,
+        guard_exceptions=(RuntimeError,),
+        stopped_background_worker_names={
+            "jobs_prune_task",
+            "files_export_gc_task",
+            "notifications_prune_task",
+        },
+    )
+
+    assert claims_kwargs["jobs_prune_task"] is None
+    assert claims_kwargs["files_export_gc_task"] is None
+    assert claims_kwargs["notifications_prune_task"] is None
+    assert handles.jobs_prune_task is None
+    assert handles.files_export_gc_task is None
+    assert handles.notifications_prune_task is None
+
+
+@pytest.mark.asyncio
 async def test_run_shutdown_post_worker_services_delegates_and_returns_handles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -715,6 +841,9 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
         guard_exceptions=(RuntimeError,),
         stopped_background_worker_names={
             "claims_rebuild",
+            "jobs_prune_task",
+            "files_export_gc_task",
+            "notifications_prune_task",
             "embeddings_compactor_task",
             "usage_aggregator",
             "llm_usage_aggregator",
@@ -728,9 +857,9 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
 
     assert log_messages == ["Post-worker services skipped: post-worker boom"]
     assert handles.claims_task is None
-    assert handles.jobs_prune_task == "prune-input"
-    assert handles.files_export_gc_task == "files-input"
-    assert handles.notifications_prune_task == "notifications-input"
+    assert handles.jobs_prune_task is None
+    assert handles.files_export_gc_task is None
+    assert handles.notifications_prune_task is None
     assert handles.jobs_notifications_bridge_task == "bridge-input"
     assert handles.embeddings_compactor_task is None
     assert handles.embeddings_compactor_stop_event is None

--- a/tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py
+++ b/tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
 
 import pytest
+from fastapi import FastAPI
 
 pytestmark = pytest.mark.unit
 
@@ -13,6 +15,10 @@ def _import_startup_maintenance_schedulers():
     return importlib.import_module("tldw_Server_API.app.services.startup_maintenance_schedulers")
 
 
+async def _wait_forever() -> None:
+    await asyncio.Event().wait()
+
+
 @pytest.mark.asyncio
 async def test_start_maintenance_schedulers_combines_handles(
     monkeypatch: pytest.MonkeyPatch,
@@ -20,11 +26,13 @@ async def test_start_maintenance_schedulers_combines_handles(
     startup_maintenance = _import_startup_maintenance_schedulers()
     calls: list[str] = []
 
-    async def _fake_quality():
+    async def _fake_quality(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("quality")
         return "quality-task"
 
-    async def _fake_outputs():
+    async def _fake_outputs(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("outputs")
         return "outputs-task"
 
@@ -43,15 +51,18 @@ async def test_start_maintenance_schedulers_combines_handles(
         calls.append("kanban-purge")
         return "kanban-purge-task"
 
-    async def _fake_files_gc():
+    async def _fake_files_gc(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("files-gc")
         return "files-gc-task"
 
-    async def _fake_notifications():
+    async def _fake_notifications(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("notifications")
         return "notifications-task"
 
-    async def _fake_jobs_prune():
+    async def _fake_jobs_prune(*, worker_inventory=None):
+        assert worker_inventory is None
         calls.append("jobs-prune")
         return "jobs-prune-task"
 
@@ -94,11 +105,19 @@ async def test_start_maintenance_schedulers_passes_worker_inventory_to_registere
     worker_inventory = object()
     calls: list[tuple[str, object | None]] = []
 
-    async def _fake_quality() -> None:
-        return None
+    async def _fake_quality(
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
+        calls.append(("quality", worker_inventory))
+        return "quality-task"
 
-    async def _fake_outputs() -> None:
-        return None
+    async def _fake_outputs(
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
+        calls.append(("outputs", worker_inventory))
+        return "outputs-task"
 
     async def _fake_kanban_activity(
         *,
@@ -121,14 +140,26 @@ async def test_start_maintenance_schedulers_passes_worker_inventory_to_registere
         calls.append(("kanban-purge", worker_inventory))
         return "kanban-purge-task"
 
-    async def _fake_files_gc() -> None:
-        return None
+    async def _fake_files_gc(
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
+        calls.append(("files-gc", worker_inventory))
+        return "files-gc-task"
 
-    async def _fake_notifications() -> None:
-        return None
+    async def _fake_notifications(
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
+        calls.append(("notifications", worker_inventory))
+        return "notifications-task"
 
-    async def _fake_jobs_prune() -> None:
-        return None
+    async def _fake_jobs_prune(
+        *,
+        worker_inventory: object | None = None,
+    ) -> str:
+        calls.append(("jobs-prune", worker_inventory))
+        return "jobs-prune-task"
 
     monkeypatch.setattr(startup_maintenance, "_start_quality_eval_scheduler", _fake_quality)
     monkeypatch.setattr(startup_maintenance, "_start_outputs_purge_scheduler", _fake_outputs)
@@ -144,13 +175,23 @@ async def test_start_maintenance_schedulers_passes_worker_inventory_to_registere
     )
 
     assert calls == [
+        ("quality", worker_inventory),
+        ("outputs", worker_inventory),
         ("kanban-activity", worker_inventory),
         ("ingestion-sources", worker_inventory),
         ("kanban-purge", worker_inventory),
+        ("files-gc", worker_inventory),
+        ("notifications", worker_inventory),
+        ("jobs-prune", worker_inventory),
     ]
+    assert handles.quality_eval_task == "quality-task"
+    assert handles.outputs_purge_task == "outputs-task"
     assert handles.kanban_activity_cleanup_task == "kanban-activity-task"
     assert handles.ingestion_sources_cleanup_task == "ingestion-sources-task"
     assert handles.kanban_purge_task == "kanban-purge-task"
+    assert handles.files_export_gc_task == "files-gc-task"
+    assert handles.notifications_prune_task == "notifications-task"
+    assert handles.jobs_prune_task == "jobs-prune-task"
 
 
 @pytest.mark.asyncio
@@ -277,11 +318,12 @@ async def test_kanban_maintenance_schedulers_register_background_inventory(
 
 
 @pytest.mark.asyncio
-async def test_start_env_gated_task_returns_task_when_inventory_registration_fails(
+async def test_start_env_gated_task_rolls_back_when_inventory_registration_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     startup_maintenance = _import_startup_maintenance_schedulers()
     task = object()
+    cancelled_tasks: list[object] = []
 
     class _FailingInventory:
         def register(self, worker):
@@ -290,7 +332,11 @@ async def test_start_env_gated_task_returns_task_when_inventory_registration_fai
     async def _fake_start():
         return task
 
+    async def _fake_cancel(seen_task):
+        cancelled_tasks.append(seen_task)
+
     monkeypatch.setattr(startup_maintenance, "_env_enabled", lambda key: True)
+    monkeypatch.setattr(startup_maintenance, "_cancel_unregistered_task", _fake_cancel)
 
     started_task = await startup_maintenance._start_env_gated_task(
         env_key="KANBAN_PURGE_ENABLED",
@@ -302,4 +348,132 @@ async def test_start_env_gated_task_returns_task_when_inventory_registration_fai
         worker_name="kanban_purge_scheduler",
     )
 
-    assert started_task is task
+    assert started_task is None
+    assert cancelled_tasks == [task]
+
+
+@pytest.mark.asyncio
+async def test_cancel_unregistered_task_bounds_rollback_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_maintenance = _import_startup_maintenance_schedulers()
+    waits: list[tuple[object, float]] = []
+    warnings: list[tuple[str, tuple[object, ...]]] = []
+
+    class _Task:
+        def __init__(self) -> None:
+            self.cancelled = False
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    async def _timeout_wait(task: object, *, timeout: float) -> None:
+        waits.append((task, timeout))
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(startup_maintenance.asyncio, "wait_for", _timeout_wait)
+    monkeypatch.setattr(
+        startup_maintenance.logger,
+        "warning",
+        lambda message, *args: warnings.append((message, args)),
+    )
+
+    task = _Task()
+    await startup_maintenance._cancel_unregistered_task(task, timeout=0.25)
+
+    assert task.cancelled is True
+    assert waits == [(task, 0.25)]
+    assert warnings == [
+        (
+            "Maintenance scheduler did not cancel within {}s during startup rollback",
+            (0.25,),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_remaining_maintenance_schedulers_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_maintenance = _import_startup_maintenance_schedulers()
+    from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase, WorkerRegistry
+
+    selected_envs = {
+        "RAG_QUALITY_EVAL_ENABLED",
+        "OUTPUTS_PURGE_ENABLED",
+        "FILES_EXPORT_GC_ENABLED",
+        "NOTIFICATIONS_PRUNE_ENABLED",
+        "JOBS_PRUNE_ENFORCE",
+    }
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    created_tasks: list[asyncio.Task[None]] = []
+
+    def _make_task(name: str) -> asyncio.Task[None]:
+        task = asyncio.create_task(_wait_forever(), name=name)
+        created_tasks.append(task)
+        return task
+
+    async def _fake_quality():
+        return _make_task("rag_quality_eval_scheduler")
+
+    async def _fake_outputs():
+        return _make_task("outputs_purge_scheduler")
+
+    async def _fake_files_gc():
+        return _make_task("file_artifacts_export_gc")
+
+    async def _fake_notifications():
+        return _make_task("notifications_prune_scheduler")
+
+    async def _fake_jobs_prune():
+        return _make_task("jobs_prune_scheduler")
+
+    monkeypatch.setattr(startup_maintenance, "_env_enabled", lambda key: key in selected_envs)
+    monkeypatch.setattr(startup_maintenance, "_start_quality_eval_scheduler_service", _fake_quality)
+    monkeypatch.setattr(startup_maintenance, "_start_outputs_purge_scheduler_service", _fake_outputs)
+    monkeypatch.setattr(startup_maintenance, "_start_file_artifacts_export_gc_scheduler_service", _fake_files_gc)
+    monkeypatch.setattr(startup_maintenance, "_start_notifications_prune_scheduler_service", _fake_notifications)
+    monkeypatch.setattr(startup_maintenance, "_start_jobs_prune_scheduler_service", _fake_jobs_prune)
+
+    try:
+        handles = await startup_maintenance.start_maintenance_schedulers(
+            worker_inventory=worker_inventory,
+        )
+
+        assert handles.quality_eval_task in created_tasks
+        assert handles.outputs_purge_task in created_tasks
+        assert handles.kanban_activity_cleanup_task is None
+        assert handles.ingestion_sources_cleanup_task is None
+        assert handles.kanban_purge_task is None
+        assert handles.files_export_gc_task in created_tasks
+        assert handles.notifications_prune_task in created_tasks
+        assert handles.jobs_prune_task in created_tasks
+
+        assert {
+            handle.name: handle.shutdown_phase
+            for handle in worker_inventory.handles
+        } == {
+            "quality_eval_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "outputs_purge_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "files_export_gc_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "notifications_prune_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "jobs_prune_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        }
+        assert {handle.stop_event for handle in worker_inventory.handles} == {None}
+        assert {handle.category for handle in worker_inventory.handles} == {"maintenance"}
+        assert app.state._tldw_shutdown_job_poller_inventory == []
+        assert {
+            entry["name"]: entry["shutdown_phase"]
+            for entry in app.state._tldw_shutdown_worker_inventory
+        } == {
+            "quality_eval_task": "background_worker_shutdown",
+            "outputs_purge_task": "background_worker_shutdown",
+            "files_export_gc_task": "background_worker_shutdown",
+            "notifications_prune_task": "background_worker_shutdown",
+            "jobs_prune_task": "background_worker_shutdown",
+        }
+    finally:
+        for task in created_tasks:
+            task.cancel()
+        await asyncio.gather(*created_tasks, return_exceptions=True)

--- a/tldw_Server_API/tests/Services/test_startup_service_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_service_groups.py
@@ -174,14 +174,14 @@ async def test_start_service_groups_runs_helpers_in_order_and_returns_handles(
 
 
 @pytest.mark.asyncio
-async def test_start_service_groups_keeps_no_arg_maintenance_compatibility(
+async def test_start_service_groups_passes_worker_inventory_to_maintenance_schedulers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     startup_groups = _import_startup_service_groups()
-    calls: list[str] = []
+    worker_inventory = object()
+    maintenance_kwargs: dict[str, object] = {}
 
-    async def _record_runtime_monitors():
-        calls.append("runtime")
+    async def _record_runtime_monitors(*, worker_inventory: object) -> SimpleNamespace:
         return SimpleNamespace(
             jobs_metrics_stop_event=None,
             jobs_metrics_task=None,
@@ -189,8 +189,7 @@ async def test_start_service_groups_keeps_no_arg_maintenance_compatibility(
             loop_lag_task=None,
         )
 
-    async def _record_optional_workers():
-        calls.append("optional")
+    async def _record_optional_workers(*, worker_inventory: object) -> SimpleNamespace:
         return SimpleNamespace(
             jobs_metrics_reconcile_stop=None,
             jobs_metrics_reconcile_task=None,
@@ -210,12 +209,16 @@ async def test_start_service_groups_keeps_no_arg_maintenance_compatibility(
             jobs_integrity_task=None,
         )
 
-    async def _record_claims_rebuild_worker(app_settings):
-        calls.append("claims")
+    async def _record_claims_rebuild_worker(
+        _app_settings: object,
+        **_kwargs: object,
+    ) -> None:
         return None
 
-    async def _record_auxiliary_services(app_settings):
-        calls.append("auxiliary")
+    async def _record_auxiliary_services(
+        _app_settings: object,
+        **_kwargs: object,
+    ) -> SimpleNamespace:
         return SimpleNamespace(
             claims_alerts_task=None,
             claims_review_metrics_task=None,
@@ -223,16 +226,14 @@ async def test_start_service_groups_keeps_no_arg_maintenance_compatibility(
             llm_usage_task=None,
         )
 
-    async def _record_infra_services(*, run_pg_rls_auto_ensure, worker_inventory=None):
-        assert worker_inventory is None
-        calls.append("infra")
+    async def _record_infra_services(**_kwargs: object) -> SimpleNamespace:
         return SimpleNamespace(
             tts_history_cleanup_task=None,
             tts_history_cleanup_stop_event=None,
         )
 
-    async def _record_maintenance_schedulers():
-        calls.append("maintenance")
+    async def _record_maintenance_schedulers(**kwargs: object) -> SimpleNamespace:
+        maintenance_kwargs.update(kwargs)
         return SimpleNamespace(
             quality_eval_task=None,
             outputs_purge_task=None,
@@ -244,13 +245,7 @@ async def test_start_service_groups_keeps_no_arg_maintenance_compatibility(
             jobs_prune_task=None,
         )
 
-    async def _record_connectors_startup(
-        *,
-        app,
-        owned_job_pollers,
-        register_owned_job_poller,
-    ):
-        calls.append("connectors")
+    async def _record_connectors_startup(**_kwargs: object) -> SimpleNamespace:
         return SimpleNamespace(
             connectors_jobs_task=None,
             connectors_jobs_stop_event=None,
@@ -273,18 +268,11 @@ async def test_start_service_groups_keeps_no_arg_maintenance_compatibility(
         app_settings={},
         run_pg_rls_auto_ensure=object(),
         owned_job_pollers=[],
-        register_owned_job_poller=lambda *args, **kwargs: None,
+        register_owned_job_poller=object(),
+        worker_inventory=worker_inventory,
     )
 
-    assert calls == [
-        "runtime",
-        "optional",
-        "claims",
-        "auxiliary",
-        "infra",
-        "maintenance",
-        "connectors",
-    ]
+    assert maintenance_kwargs == {"worker_inventory": worker_inventory}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of #1114.

## Change summary
Human-authored Change summary required before merge per repo policy.

## AI-authored implementation notes
- Registers RAG quality eval, outputs purge, file export GC, notifications prune, and jobs prune tasks in the lifecycle inventory as background-worker shutdown entries.
- Threads the WorkerRegistry through startup_service_groups into maintenance scheduler startup without changing Kanban or ingestion cleanup paths covered by separate PRs.
- Suppresses post-worker direct cancellation for maintenance tasks already stopped during the registry background phase.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_shutdown_claims_maintenance_tasks.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_startup_delegates_owned_job_pollers tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_startup_delegates_service_tail tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_lifespan_startup_publishes_first_batch_background_worker_inventory tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_background_workers_do_not_enter_job_poller_quiesce -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_maintenance_schedulers.py tldw_Server_API/app/services/startup_service_groups.py tldw_Server_API/app/services/shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_maintenance_schedulers.py tldw_Server_API/app/services/startup_service_groups.py tldw_Server_API/app/services/shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_startup_maintenance_schedulers.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py -f json -o /tmp/bandit_maintenance_schedulers_1114.json --skip B101
- git diff --check