### PR TITLE
refactor(workers): register recurring scheduler lifecycle

### DIFF
--- a/tldw_Server_API/app/services/lifecycle_workers.py
+++ b/tldw_Server_API/app/services/lifecycle_workers.py
@@ -32,6 +32,7 @@ class ManagedWorker:
     name: str
     task: asyncio.Task[Any]
     stop_event: asyncio.Event | None = None
+    shutdown_callback: Callable[[], Awaitable[None]] | None = None
     timeout_sec: float = 5.0
     category: str | None = None
     shutdown_phase: ShutdownPhase = ShutdownPhase.JOB_POLLER_QUIESCE
@@ -173,6 +174,38 @@ async def stop_registered_workers(
 ) -> None:
     """Stop registered workers concurrently and publish stopped worker names."""
 
+    async def _request_worker_stop(handle: ManagedWorker) -> None:
+        if handle.stop_event is not None:
+            handle.stop_event.set()
+            return
+        if handle.shutdown_callback is not None:
+            try:
+                await asyncio.wait_for(handle.shutdown_callback(), timeout=handle.timeout_sec)
+                return
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "App Shutdown: Timed out waiting for {} {} shutdown callback after {}s; cancelling",
+                    log_label,
+                    handle.name,
+                    handle.timeout_sec,
+                )
+            except Exception as exc:  # noqa: BLE001 - shutdown hooks must not block teardown.
+                logger.warning(
+                    "App Shutdown: {} {} shutdown callback failed: {}",
+                    log_label,
+                    handle.name,
+                    exc,
+                )
+        try:
+            handle.task.cancel()
+        except Exception as exc:  # noqa: BLE001 - cancel hooks can raise arbitrary errors.
+            logger.warning(
+                "App Shutdown: {} {} cancel request failed: {}",
+                log_label,
+                handle.name,
+                exc,
+            )
+
     async def _await_worker_shutdown(handle: ManagedWorker) -> bool:
         try:
             await asyncio.wait_for(asyncio.shield(handle.task), timeout=handle.timeout_sec)
@@ -212,19 +245,10 @@ async def stop_registered_workers(
             )
         return bool(handle.task.done())
 
-    for handle in handles:
-        if handle.stop_event is not None:
-            handle.stop_event.set()
-        else:
-            try:
-                handle.task.cancel()
-            except Exception as exc:  # noqa: BLE001 - cancel hooks can raise arbitrary errors.
-                logger.warning(
-                    "App Shutdown: {} {} cancel request failed: {}",
-                    log_label,
-                    handle.name,
-                    exc,
-                )
+    await asyncio.gather(
+        *(_request_worker_stop(handle) for handle in handles),
+        return_exceptions=False,
+    )
 
     stopped_results = await asyncio.gather(
         *(_await_worker_shutdown(handle) for handle in handles),

--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -125,12 +125,30 @@ async def shutdown_post_worker_services(
         guard_exceptions=guard_exceptions,
     )
     await _stop_recurring_schedulers(
-        workflows_sched_task=workflows_sched_task,
-        reading_digest_sched_task=reading_digest_sched_task,
-        admin_backup_sched_task=admin_backup_sched_task,
-        companion_reflection_sched_task=companion_reflection_sched_task,
-        reminders_sched_task=reminders_sched_task,
-        connectors_sync_sched_task=connectors_sync_sched_task,
+        workflows_sched_task=_task_if_not_stopped(
+            "workflows_sched_task",
+            workflows_sched_task,
+        ),
+        reading_digest_sched_task=_task_if_not_stopped(
+            "reading_digest_sched_task",
+            reading_digest_sched_task,
+        ),
+        admin_backup_sched_task=_task_if_not_stopped(
+            "admin_backup_sched_task",
+            admin_backup_sched_task,
+        ),
+        companion_reflection_sched_task=_task_if_not_stopped(
+            "companion_reflection_sched_task",
+            companion_reflection_sched_task,
+        ),
+        reminders_sched_task=_task_if_not_stopped(
+            "reminders_sched_task",
+            reminders_sched_task,
+        ),
+        connectors_sync_sched_task=_task_if_not_stopped(
+            "connectors_sync_sched_task",
+            connectors_sync_sched_task,
+        ),
     )
     runtime_monitor_shutdown_handles = await _shutdown_runtime_monitors(
         jobs_metrics_task=_task_if_not_stopped("jobs_metrics_task", jobs_metrics_task),

--- a/tldw_Server_API/app/services/startup_recurring_schedulers.py
+++ b/tldw_Server_API/app/services/startup_recurring_schedulers.py
@@ -4,7 +4,9 @@ Recurring-scheduler startup helpers extracted from the application lifespan.
 
 from __future__ import annotations
 
+import asyncio
 import os
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -20,6 +22,13 @@ _STARTUP_GUARD_EXCEPTIONS = (
     TypeError,
     ValueError,
 )
+_SCHEDULER_ROLLBACK_TIMEOUT_SEC = 1.0
+
+SchedulerHandle = Any
+SchedulerStarter = Callable[[], Awaitable[SchedulerHandle | None]]
+InventorySchedulerStarter = Callable[..., Awaitable[SchedulerHandle | None]]
+SchedulerStopper = Callable[[SchedulerHandle], Awaitable[None]]
+SchedulerShutdownCallback = Callable[[], Awaitable[None]]
 
 
 @dataclass
@@ -35,16 +44,38 @@ class RecurringSchedulerHandles:
     connectors_sync_sched_task: Any | None = None
 
 
-async def start_recurring_schedulers(*, test_mode: bool) -> RecurringSchedulerHandles:
+async def start_recurring_schedulers(
+    *,
+    test_mode: bool,
+    worker_inventory: Any | None = None,
+) -> RecurringSchedulerHandles:
     """Start the recurring scheduler batch and return explicit scheduler handles."""
     return RecurringSchedulerHandles(
         authnz_scheduler_started=await _start_authnz_scheduler(),
-        workflows_sched_task=await _start_workflows_scheduler(),
-        reading_digest_sched_task=await _start_reading_digest_scheduler(test_mode=test_mode),
-        admin_backup_sched_task=await _start_admin_backup_scheduler(),
-        companion_reflection_sched_task=await _start_companion_reflection_scheduler(),
-        reminders_sched_task=await _start_reminders_scheduler(),
-        connectors_sync_sched_task=await _start_connectors_sync_scheduler(),
+        workflows_sched_task=await _start_with_optional_inventory(
+            _start_workflows_scheduler,
+            worker_inventory,
+        ),
+        reading_digest_sched_task=await _start_reading_digest_with_optional_inventory(
+            test_mode=test_mode,
+            worker_inventory=worker_inventory,
+        ),
+        admin_backup_sched_task=await _start_with_optional_inventory(
+            _start_admin_backup_scheduler,
+            worker_inventory,
+        ),
+        companion_reflection_sched_task=await _start_with_optional_inventory(
+            _start_companion_reflection_scheduler,
+            worker_inventory,
+        ),
+        reminders_sched_task=await _start_with_optional_inventory(
+            _start_reminders_scheduler,
+            worker_inventory,
+        ),
+        connectors_sync_sched_task=await _start_with_optional_inventory(
+            _start_connectors_sync_scheduler,
+            worker_inventory,
+        ),
     )
 
 
@@ -53,6 +84,32 @@ def _env_flag(key: str, default: bool) -> bool:
     if raw is None or str(raw).strip() == "":
         return bool(default)
     return str(raw).strip().lower() in {"true", "1", "yes", "y", "on"}
+
+
+async def _start_with_optional_inventory(
+    starter: InventorySchedulerStarter,
+    worker_inventory: Any | None,
+) -> SchedulerHandle | None:
+    """Start a scheduler with inventory when the caller provided one."""
+
+    if worker_inventory is None:
+        return await starter()
+    return await starter(worker_inventory=worker_inventory)
+
+
+async def _start_reading_digest_with_optional_inventory(
+    *,
+    test_mode: bool,
+    worker_inventory: Any | None,
+) -> SchedulerHandle | None:
+    """Start the reading digest scheduler while preserving its test-mode flag."""
+
+    if worker_inventory is None:
+        return await _start_reading_digest_scheduler(test_mode=test_mode)
+    return await _start_reading_digest_scheduler(
+        test_mode=test_mode,
+        worker_inventory=worker_inventory,
+    )
 
 
 async def _start_authnz_scheduler() -> bool:
@@ -68,16 +125,26 @@ async def _start_authnz_scheduler() -> bool:
         return False
 
 
-async def _start_workflows_scheduler() -> Any | None:
+async def _start_workflows_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     return await _start_optional_scheduler(
         started_message="Workflows recurring scheduler started",
         disabled_message="Workflows recurring scheduler disabled (WORKFLOWS_SCHEDULER_ENABLED != true)",
         failure_message="Failed to start Workflows recurring scheduler: {exc}",
         starter=_start_workflows_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="workflows_sched_task",
+        stopper=_stop_workflows_scheduler_service,
     )
 
 
-async def _start_reading_digest_scheduler(*, test_mode: bool) -> Any | None:
+async def _start_reading_digest_scheduler(
+    *,
+    test_mode: bool,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     try:
         try:
             enabled = _env_flag("READING_DIGEST_SCHEDULER_ENABLED", True)
@@ -90,6 +157,12 @@ async def _start_reading_digest_scheduler(*, test_mode: bool) -> Any | None:
             return None
         task = await _start_reading_digest_scheduler_service(enabled=True)
         if task:
+            await _register_recurring_scheduler_task(
+                worker_inventory=worker_inventory,
+                task=task,
+                worker_name="reading_digest_sched_task",
+                stopper=_stop_reading_digest_scheduler_service,
+            )
             logger.info("Reading digest scheduler started")
         else:
             logger.info("Reading digest scheduler disabled (READING_DIGEST_SCHEDULER_ENABLED != true)")
@@ -99,16 +172,25 @@ async def _start_reading_digest_scheduler(*, test_mode: bool) -> Any | None:
         return None
 
 
-async def _start_admin_backup_scheduler() -> Any | None:
+async def _start_admin_backup_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     return await _start_optional_scheduler(
         started_message="Admin backup scheduler started",
         disabled_message="Admin backup scheduler disabled (ADMIN_BACKUP_SCHEDULER_ENABLED != true)",
         failure_message="Failed to start Admin backup scheduler: {exc}",
         starter=_start_admin_backup_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="admin_backup_sched_task",
+        stopper=_stop_admin_backup_scheduler_service,
     )
 
 
-async def _start_companion_reflection_scheduler() -> Any | None:
+async def _start_companion_reflection_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     try:
         try:
             enabled = _env_flag("COMPANION_REFLECTION_SCHEDULER_ENABLED", False)
@@ -121,6 +203,12 @@ async def _start_companion_reflection_scheduler() -> Any | None:
             return None
         task = await _start_companion_reflection_scheduler_service(enabled=True)
         if task:
+            await _register_recurring_scheduler_task(
+                worker_inventory=worker_inventory,
+                task=task,
+                worker_name="companion_reflection_sched_task",
+                stopper=_stop_companion_reflection_scheduler_service,
+            )
             logger.info("Companion reflection scheduler started")
         else:
             logger.info(
@@ -132,21 +220,33 @@ async def _start_companion_reflection_scheduler() -> Any | None:
         return None
 
 
-async def _start_reminders_scheduler() -> Any | None:
+async def _start_reminders_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     return await _start_optional_scheduler(
         started_message="Reminders scheduler started",
         disabled_message="Reminders scheduler disabled (REMINDERS_SCHEDULER_ENABLED != true)",
         failure_message="Failed to start Reminders scheduler: {exc}",
         starter=_start_reminders_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="reminders_sched_task",
+        stopper=_stop_reminders_scheduler_service,
     )
 
 
-async def _start_connectors_sync_scheduler() -> Any | None:
+async def _start_connectors_sync_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     return await _start_optional_scheduler(
         started_message="Connectors sync scheduler started",
         disabled_message="Connectors sync scheduler disabled (CONNECTORS_SYNC_SCHEDULER_ENABLED != true)",
         failure_message="Failed to start Connectors sync scheduler: {exc}",
         starter=_start_connectors_sync_scheduler_service,
+        worker_inventory=worker_inventory,
+        worker_name="connectors_sync_sched_task",
+        stopper=_stop_connectors_sync_scheduler_service,
     )
 
 
@@ -155,11 +255,22 @@ async def _start_optional_scheduler(
     started_message: str,
     disabled_message: str,
     failure_message: str,
-    starter,
-) -> Any | None:
+    starter: SchedulerStarter,
+    worker_inventory: Any | None = None,
+    worker_name: str | None = None,
+    stopper: SchedulerStopper | None = None,
+) -> SchedulerHandle | None:
+    """Start an optional scheduler and register it for managed shutdown."""
+
     try:
         task = await starter()
         if task:
+            await _register_recurring_scheduler_task(
+                worker_inventory=worker_inventory,
+                task=task,
+                worker_name=worker_name,
+                stopper=stopper,
+            )
             logger.info(started_message)
         else:
             logger.info(disabled_message)
@@ -167,6 +278,89 @@ async def _start_optional_scheduler(
     except _STARTUP_GUARD_EXCEPTIONS as exc:
         logger.warning(failure_message.format(exc=exc))
         return None
+
+
+async def _register_recurring_scheduler_task(
+    *,
+    worker_inventory: Any | None,
+    task: SchedulerHandle,
+    worker_name: str | None,
+    stopper: SchedulerStopper | None,
+) -> None:
+    """Register a started recurring scheduler with the lifecycle worker registry."""
+
+    if worker_inventory is None:
+        return
+    if worker_name is None or stopper is None:
+        logger.warning(
+            "Recurring scheduler registration skipped for task {}: missing worker name or stopper",
+            task,
+        )
+        return
+
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        ShutdownPhase,
+    )
+
+    try:
+        worker_inventory.register(
+            ManagedWorker(
+                name=worker_name,
+                task=task,
+                stop_event=None,
+                shutdown_callback=_build_scheduler_shutdown_callback(
+                    task=task,
+                    stopper=stopper,
+                ),
+                category="recurring-scheduler",
+                shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            )
+        )
+    except _STARTUP_GUARD_EXCEPTIONS:
+        await _cancel_unregistered_task(task)
+        raise
+
+
+def _build_scheduler_shutdown_callback(
+    *,
+    task: SchedulerHandle,
+    stopper: SchedulerStopper,
+) -> SchedulerShutdownCallback:
+    """Build a no-argument lifecycle callback for a scheduler stop function."""
+
+    async def _shutdown() -> None:
+        await stopper(task)
+
+    return _shutdown
+
+
+async def _cancel_unregistered_task(task: SchedulerHandle) -> None:
+    """Cancel a scheduler that could not be registered without blocking startup."""
+
+    try:
+        task.cancel()
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Recurring scheduler startup rollback cancel failed: {exc}")
+        return
+
+    done, pending = await asyncio.wait(
+        {task},
+        timeout=_SCHEDULER_ROLLBACK_TIMEOUT_SEC,
+    )
+    if pending:
+        logger.warning(
+            "Recurring scheduler startup rollback timed out after {}s",
+            _SCHEDULER_ROLLBACK_TIMEOUT_SEC,
+        )
+        return
+
+    try:
+        done.pop().result()
+    except asyncio.CancelledError:
+        pass
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Recurring scheduler raised during startup rollback: {exc}")
 
 
 async def _start_authnz_scheduler_service() -> None:
@@ -213,3 +407,43 @@ async def _start_connectors_sync_scheduler_service() -> Any | None:
     )
 
     return await start_connectors_sync_scheduler()
+
+
+async def _stop_workflows_scheduler_service(task: Any) -> None:
+    from tldw_Server_API.app.services.workflows_scheduler import stop_workflows_scheduler
+
+    await stop_workflows_scheduler(task)
+
+
+async def _stop_reading_digest_scheduler_service(task: Any) -> None:
+    from tldw_Server_API.app.services.reading_digest_scheduler import stop_reading_digest_scheduler
+
+    await stop_reading_digest_scheduler(task)
+
+
+async def _stop_admin_backup_scheduler_service(task: Any) -> None:
+    from tldw_Server_API.app.services.admin_backup_scheduler import stop_admin_backup_scheduler
+
+    await stop_admin_backup_scheduler(task)
+
+
+async def _stop_companion_reflection_scheduler_service(task: Any) -> None:
+    from tldw_Server_API.app.services.companion_reflection_scheduler import (
+        stop_companion_reflection_scheduler,
+    )
+
+    await stop_companion_reflection_scheduler(task)
+
+
+async def _stop_reminders_scheduler_service(task: Any | None) -> None:
+    from tldw_Server_API.app.services.reminders_scheduler import stop_reminders_scheduler
+
+    await stop_reminders_scheduler(task)
+
+
+async def _stop_connectors_sync_scheduler_service(task: Any | None) -> None:
+    from tldw_Server_API.app.services.connectors_sync_scheduler import (
+        stop_connectors_sync_scheduler,
+    )
+
+    await stop_connectors_sync_scheduler(task)

--- a/tldw_Server_API/app/services/startup_service_tail.py
+++ b/tldw_Server_API/app/services/startup_service_tail.py
@@ -91,6 +91,7 @@ async def initialize_startup_service_tail(
         startup_service_group_handles=startup_service_group_handles,
         replace_owned_job_poller_inventory=replace_owned_job_poller_inventory,
         test_mode=test_mode,
+        worker_inventory=worker_inventory,
     )
     await _report_startup_environment(
         app=app,

--- a/tldw_Server_API/app/services/startup_tail_finalization.py
+++ b/tldw_Server_API/app/services/startup_tail_finalization.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
-
 if TYPE_CHECKING:
     from tldw_Server_API.app.services.startup_recurring_schedulers import (
         RecurringSchedulerHandles,
@@ -168,7 +167,8 @@ async def finalize_startup_tail(
     startup_service_group_handles: Any,
     replace_owned_job_poller_inventory: Callable[..., None],
     test_mode: bool,
-) -> "RecurringSchedulerHandles":
+    worker_inventory: Any | None = None,
+) -> RecurringSchedulerHandles:
     replace_owned_job_poller_inventory(
         app,
         owned_job_pollers,
@@ -177,12 +177,17 @@ async def finalize_startup_tail(
             startup_service_group_handles=startup_service_group_handles,
         ),
     )
-    return await _start_recurring_schedulers(test_mode=test_mode)
+    if worker_inventory is None:
+        return await _start_recurring_schedulers(test_mode=test_mode)
+    return await _start_recurring_schedulers(
+        test_mode=test_mode,
+        worker_inventory=worker_inventory,
+    )
 
 
-async def _start_recurring_schedulers(*, test_mode: bool):
+async def _start_recurring_schedulers(**kwargs: Any) -> RecurringSchedulerHandles:
     from tldw_Server_API.app.services.startup_recurring_schedulers import (
         start_recurring_schedulers,
     )
 
-    return await start_recurring_schedulers(test_mode=test_mode)
+    return await start_recurring_schedulers(**kwargs)

--- a/tldw_Server_API/tests/Services/test_lifecycle_workers.py
+++ b/tldw_Server_API/tests/Services/test_lifecycle_workers.py
@@ -366,6 +366,110 @@ async def test_stop_registered_workers_sets_events_and_waits_concurrently() -> N
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_stop_registered_workers_awaits_custom_shutdown_callback() -> None:
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        stop_registered_workers,
+    )
+
+    app = FastAPI()
+    shutdown_calls = 0
+
+    async def _worker() -> None:
+        await asyncio.Future()
+
+    task = asyncio.create_task(_worker(), name="callback-task")
+
+    async def _shutdown_callback() -> None:
+        nonlocal shutdown_calls
+        shutdown_calls += 1
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    await asyncio.sleep(0)
+
+    await stop_registered_workers(
+        app,
+        [
+            ManagedWorker(
+                name="callback_worker",
+                task=task,
+                stop_event=None,
+                shutdown_callback=_shutdown_callback,
+                timeout_sec=1.0,
+            )
+        ],
+        stopped_names_attr="_tldw_stopped_worker_names",
+        log_label="test worker",
+    )
+
+    assert shutdown_calls == 1
+    assert task.cancelled() is True
+    assert app.state._tldw_stopped_worker_names == ["callback_worker"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stop_registered_workers_bounds_custom_shutdown_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import lifecycle_workers
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        stop_registered_workers,
+    )
+
+    app = FastAPI()
+    warnings: list[tuple[object, ...]] = []
+
+    async def _worker() -> None:
+        await asyncio.Future()
+
+    async def _shutdown_callback() -> None:
+        await asyncio.Future()
+
+    monkeypatch.setattr(
+        lifecycle_workers.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+
+    task = asyncio.create_task(_worker(), name="hung-callback-task")
+    await asyncio.sleep(0)
+
+    try:
+        await asyncio.wait_for(
+            stop_registered_workers(
+                app,
+                [
+                    ManagedWorker(
+                        name="hung_callback_worker",
+                        task=task,
+                        stop_event=None,
+                        shutdown_callback=_shutdown_callback,
+                        timeout_sec=0.01,
+                    )
+                ],
+                stopped_names_attr="_tldw_stopped_worker_names",
+                log_label="test worker",
+            ),
+            timeout=0.5,
+        )
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    assert any("shutdown callback" in str(args[0]) for args in warnings)
+    assert task.cancelled() is True
+    assert app.state._tldw_stopped_worker_names == ["hung_callback_worker"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_stop_registered_workers_logs_stopped_names_publication_guard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -557,6 +557,137 @@ async def test_shutdown_post_worker_services_skips_maintenance_tasks_after_backg
 
 
 @pytest.mark.asyncio
+async def test_shutdown_post_worker_services_skips_recurring_schedulers_after_background_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_post_worker_services as shutdown_services
+
+    recurring_kwargs: dict[str, object] = {}
+
+    async def _claims(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            claims_task=kwargs["claims_task"],
+            jobs_prune_task=kwargs["jobs_prune_task"],
+            files_export_gc_task=kwargs["files_export_gc_task"],
+            notifications_prune_task=kwargs["notifications_prune_task"],
+        )
+
+    async def _notifications(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_notifications_bridge_task=kwargs["jobs_notifications_bridge_task"],
+            embeddings_compactor_task=kwargs["embeddings_compactor_task"],
+            embeddings_compactor_stop_event=kwargs["embeddings_compactor_stop_event"],
+            websub_renewal_task=kwargs["websub_renewal_task"],
+        )
+
+    async def _usage(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            usage_task=kwargs["usage_task"],
+            llm_usage_task=kwargs["llm_usage_task"],
+        )
+
+    async def _recurring(**kwargs: object) -> None:
+        recurring_kwargs.update(kwargs)
+
+    async def _runtime(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_metrics_task=kwargs["jobs_metrics_task"],
+            loop_lag_task=kwargs["loop_lag_task"],
+        )
+
+    async def _reconcile(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_metrics_reconcile_task=kwargs["jobs_metrics_reconcile_task"],
+            jobs_metrics_reconcile_stop=kwargs["jobs_metrics_reconcile_stop"],
+        )
+
+    async def _personalization(**kwargs: object) -> None:
+        return None
+
+    async def _optional(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_crypto_rotate_task=kwargs["jobs_crypto_rotate_task"],
+            jobs_integrity_task=kwargs["jobs_integrity_task"],
+            jobs_webhooks_task=kwargs["jobs_webhooks_task"],
+            meetings_webhook_dlq_task=kwargs["meetings_webhook_dlq_task"],
+            workflows_dlq_task=kwargs["workflows_dlq_task"],
+            workflows_gc_task=kwargs["workflows_gc_task"],
+            workflows_maint_task=kwargs["workflows_maint_task"],
+        )
+
+    monkeypatch.setattr(shutdown_services, "_shutdown_claims_maintenance_tasks", _claims)
+    monkeypatch.setattr(
+        shutdown_services,
+        "_shutdown_notifications_compactor_websub_workers",
+        _notifications,
+    )
+    monkeypatch.setattr(shutdown_services, "_stop_usage_aggregators", _usage)
+    monkeypatch.setattr(shutdown_services, "_stop_recurring_schedulers", _recurring)
+    monkeypatch.setattr(shutdown_services, "_shutdown_runtime_monitors", _runtime)
+    monkeypatch.setattr(shutdown_services, "_shutdown_jobs_metrics_reconcile", _reconcile)
+    monkeypatch.setattr(shutdown_services, "_shutdown_personalization_consolidation", _personalization)
+    monkeypatch.setattr(shutdown_services, "_shutdown_optional_workers", _optional)
+
+    await shutdown_services.shutdown_post_worker_services(
+        claims_task=None,
+        jobs_prune_task=None,
+        files_export_gc_task=None,
+        notifications_prune_task=None,
+        jobs_notifications_bridge_task=None,
+        embeddings_compactor_task=None,
+        embeddings_compactor_stop_event=None,
+        websub_renewal_task=None,
+        coordinated_legacy_component_names=set(),
+        usage_task=None,
+        llm_usage_task=None,
+        workflows_sched_task="workflows-sched-task",
+        reading_digest_sched_task="reading-digest-sched-task",
+        admin_backup_sched_task="admin-backup-sched-task",
+        companion_reflection_sched_task="companion-reflection-sched-task",
+        reminders_sched_task="reminders-sched-task",
+        connectors_sync_sched_task="connectors-sync-sched-task",
+        jobs_metrics_task=None,
+        jobs_metrics_stop_event=None,
+        loop_lag_task=None,
+        loop_lag_stop_event=None,
+        jobs_metrics_reconcile_task=None,
+        jobs_metrics_reconcile_stop=None,
+        jobs_crypto_rotate_task=None,
+        jobs_crypto_rotate_stop_event=None,
+        jobs_integrity_task=None,
+        jobs_integrity_stop_event=None,
+        jobs_webhooks_task=None,
+        jobs_webhooks_stop_event=None,
+        meetings_webhook_dlq_task=None,
+        meetings_webhook_dlq_stop_event=None,
+        workflows_dlq_task=None,
+        workflows_dlq_stop_event=None,
+        workflows_gc_task=None,
+        workflows_gc_stop_event=None,
+        workflows_maint_task=None,
+        workflows_maint_stop_event=None,
+        guard_exceptions=(RuntimeError,),
+        stopped_background_worker_names={
+            "workflows_sched_task",
+            "reading_digest_sched_task",
+            "admin_backup_sched_task",
+            "companion_reflection_sched_task",
+            "reminders_sched_task",
+            "connectors_sync_sched_task",
+        },
+    )
+
+    assert recurring_kwargs == {
+        "workflows_sched_task": None,
+        "reading_digest_sched_task": None,
+        "admin_backup_sched_task": None,
+        "companion_reflection_sched_task": None,
+        "reminders_sched_task": None,
+        "connectors_sync_sched_task": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_run_shutdown_post_worker_services_delegates_and_returns_handles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py
+++ b/tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
 
 import pytest
-
+from fastapi import FastAPI
 
 pytestmark = pytest.mark.unit
 
@@ -12,6 +13,10 @@ pytestmark = pytest.mark.unit
 def _import_startup_recurring_schedulers():
     sys.modules.pop("tldw_Server_API.app.services.startup_recurring_schedulers", None)
     return importlib.import_module("tldw_Server_API.app.services.startup_recurring_schedulers")
+
+
+async def _wait_forever() -> None:
+    await asyncio.Event().wait()
 
 
 @pytest.mark.asyncio
@@ -126,3 +131,216 @@ async def test_start_companion_reflection_scheduler_starts_when_enabled(
     task = await startup_recurring._start_companion_reflection_scheduler()
 
     assert task == "companion-reflection-task"
+
+
+@pytest.mark.asyncio
+async def test_start_recurring_schedulers_registers_background_inventory_with_shutdown_callbacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_recurring = _import_startup_recurring_schedulers()
+    from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase, WorkerRegistry
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    created_tasks: list[asyncio.Task[None]] = []
+    stopped: list[str] = []
+
+    def _make_task(name: str) -> asyncio.Task[None]:
+        task = asyncio.create_task(_wait_forever(), name=name)
+        created_tasks.append(task)
+        return task
+
+    async def _fake_authnz():
+        return True
+
+    async def _fake_workflows():
+        return _make_task("workflows_recurring_scheduler")
+
+    async def _fake_reading_digest(*, enabled: bool):
+        assert enabled is True
+        return _make_task("reading_digest_scheduler")
+
+    async def _fake_admin_backup():
+        return _make_task("admin_backup_scheduler")
+
+    async def _fake_companion_reflection(*, enabled: bool):
+        assert enabled is True
+        return _make_task("companion_reflection_scheduler")
+
+    async def _fake_reminders():
+        return _make_task("reminders_scheduler")
+
+    async def _fake_connectors_sync():
+        return _make_task("connectors_sync_scheduler")
+
+    def _fake_stop(label: str):
+        async def _stop(task: asyncio.Task[None]) -> None:
+            stopped.append(label)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        return _stop
+
+    monkeypatch.setattr(startup_recurring, "_start_authnz_scheduler", _fake_authnz)
+    monkeypatch.setattr(startup_recurring, "_start_workflows_scheduler_service", _fake_workflows)
+    monkeypatch.setattr(startup_recurring, "_start_reading_digest_scheduler_service", _fake_reading_digest)
+    monkeypatch.setattr(startup_recurring, "_start_admin_backup_scheduler_service", _fake_admin_backup)
+    monkeypatch.setattr(
+        startup_recurring,
+        "_start_companion_reflection_scheduler_service",
+        _fake_companion_reflection,
+    )
+    monkeypatch.setattr(startup_recurring, "_start_reminders_scheduler_service", _fake_reminders)
+    monkeypatch.setattr(startup_recurring, "_start_connectors_sync_scheduler_service", _fake_connectors_sync)
+    monkeypatch.setattr(startup_recurring, "_env_flag", lambda key, default: True)
+    monkeypatch.setattr(startup_recurring, "_stop_workflows_scheduler_service", _fake_stop("workflows"))
+    monkeypatch.setattr(
+        startup_recurring,
+        "_stop_reading_digest_scheduler_service",
+        _fake_stop("reading-digest"),
+    )
+    monkeypatch.setattr(startup_recurring, "_stop_admin_backup_scheduler_service", _fake_stop("admin-backup"))
+    monkeypatch.setattr(
+        startup_recurring,
+        "_stop_companion_reflection_scheduler_service",
+        _fake_stop("companion-reflection"),
+    )
+    monkeypatch.setattr(startup_recurring, "_stop_reminders_scheduler_service", _fake_stop("reminders"))
+    monkeypatch.setattr(startup_recurring, "_stop_connectors_sync_scheduler_service", _fake_stop("connectors-sync"))
+
+    try:
+        handles = await startup_recurring.start_recurring_schedulers(
+            test_mode=False,
+            worker_inventory=worker_inventory,
+        )
+
+        assert handles.authnz_scheduler_started is True
+        assert handles.workflows_sched_task in created_tasks
+        assert handles.reading_digest_sched_task in created_tasks
+        assert handles.admin_backup_sched_task in created_tasks
+        assert handles.companion_reflection_sched_task in created_tasks
+        assert handles.reminders_sched_task in created_tasks
+        assert handles.connectors_sync_sched_task in created_tasks
+        assert {
+            handle.name: handle.shutdown_phase
+            for handle in worker_inventory.handles
+        } == {
+            "workflows_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "reading_digest_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "admin_backup_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "companion_reflection_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "reminders_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            "connectors_sync_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        }
+        assert all(handle.stop_event is None for handle in worker_inventory.handles)
+        assert all(handle.shutdown_callback is not None for handle in worker_inventory.handles)
+        assert {handle.category for handle in worker_inventory.handles} == {"recurring-scheduler"}
+        assert app.state._tldw_shutdown_job_poller_inventory == []
+
+        for handle in worker_inventory.handles:
+            await handle.shutdown_callback()
+
+        assert stopped == [
+            "workflows",
+            "reading-digest",
+            "admin-backup",
+            "companion-reflection",
+            "reminders",
+            "connectors-sync",
+        ]
+    finally:
+        for task in created_tasks:
+            task.cancel()
+        await asyncio.gather(*created_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_register_recurring_scheduler_task_warns_on_incomplete_inventory_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_recurring = _import_startup_recurring_schedulers()
+    from tldw_Server_API.app.services.lifecycle_workers import WorkerRegistry
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    warnings: list[tuple[object, ...]] = []
+
+    async def _stop(task: asyncio.Task[None]) -> None:
+        task.cancel()
+
+    monkeypatch.setattr(
+        startup_recurring.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+
+    task = asyncio.create_task(_wait_forever(), name="metadata-missing-scheduler")
+    try:
+        await startup_recurring._register_recurring_scheduler_task(
+            worker_inventory=worker_inventory,
+            task=task,
+            worker_name=None,
+            stopper=_stop,
+        )
+
+        assert worker_inventory.handles == []
+        assert any("registration skipped" in str(args[0]) for args in warnings)
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_register_recurring_scheduler_task_bounds_failed_registration_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_recurring = _import_startup_recurring_schedulers()
+    warnings: list[tuple[object, ...]] = []
+
+    class _FailingInventory:
+        def register(self, worker: object) -> None:
+            raise RuntimeError("inventory unavailable")
+
+    allow_cancel = False
+
+    async def _stubborn_task() -> None:
+        nonlocal allow_cancel
+        while True:
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                if allow_cancel:
+                    raise
+                continue
+
+    async def _stop(task: asyncio.Task[None]) -> None:
+        task.cancel()
+
+    monkeypatch.setattr(startup_recurring, "_SCHEDULER_ROLLBACK_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(
+        startup_recurring.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+
+    task = asyncio.create_task(_stubborn_task(), name="stubborn-rollback-scheduler")
+    try:
+        with pytest.raises(RuntimeError, match="inventory unavailable"):
+            await asyncio.wait_for(
+                startup_recurring._register_recurring_scheduler_task(
+                    worker_inventory=_FailingInventory(),
+                    task=task,
+                    worker_name="stubborn_sched_task",
+                    stopper=_stop,
+                ),
+                timeout=0.5,
+            )
+
+        assert any("startup rollback timed out" in str(args[0]) for args in warnings)
+    finally:
+        allow_cancel = True
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)

--- a/tldw_Server_API/tests/Services/test_startup_tail_finalization.py
+++ b/tldw_Server_API/tests/Services/test_startup_tail_finalization.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -143,3 +142,95 @@ async def test_finalize_startup_tail_refreshes_inventory_and_starts_recurring_sc
     assert handles.authnz_scheduler_started is True
     assert handles.workflows_sched_task == "workflows-task"
     assert handles.connectors_sync_sched_task == "connectors-sync-scheduler-task"
+
+
+@pytest.mark.asyncio
+async def test_finalize_startup_tail_passes_worker_inventory_to_recurring_schedulers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_tail = _import_startup_tail_finalization()
+    worker_inventory = object()
+    observed: dict[str, object] = {}
+
+    def _fake_replace_owned_job_poller_inventory(*args, **kwargs):
+        return None
+
+    async def _fake_start_recurring_schedulers(**kwargs):
+        observed.update(kwargs)
+        return SimpleNamespace(
+            authnz_scheduler_started=False,
+            workflows_sched_task=None,
+            reading_digest_sched_task=None,
+            admin_backup_sched_task=None,
+            companion_reflection_sched_task=None,
+            reminders_sched_task=None,
+            connectors_sync_sched_task=None,
+        )
+
+    empty_worker_group_handles = SimpleNamespace(
+        core_jobs_task=None,
+        core_jobs_stop_event=None,
+        files_jobs_task=None,
+        files_jobs_stop_event=None,
+        data_tables_jobs_task=None,
+        data_tables_jobs_stop_event=None,
+        prompt_studio_jobs_task=None,
+        prompt_studio_jobs_stop_event=None,
+        study_pack_jobs_task=None,
+        study_pack_jobs_stop_event=None,
+        study_suggestions_jobs_task=None,
+        study_suggestions_jobs_stop_event=None,
+        privilege_snapshot_task=None,
+        privilege_snapshot_stop_event=None,
+        audio_jobs_task=None,
+        audio_jobs_stop_event=None,
+        audiobook_jobs_task=None,
+        audiobook_jobs_stop_event=None,
+        presentation_render_jobs_task=None,
+        presentation_render_jobs_stop_event=None,
+        media_ingest_jobs_task=None,
+        media_ingest_jobs_stop_event=None,
+        media_ingest_heavy_jobs_task=None,
+        media_ingest_heavy_jobs_stop_event=None,
+        reading_digest_jobs_task=None,
+        reading_digest_jobs_stop_event=None,
+        vn_asset_jobs_task=None,
+        vn_asset_jobs_stop_event=None,
+        vn_asset_generation_jobs_task=None,
+        vn_asset_generation_jobs_stop_event=None,
+        companion_reflection_jobs_task=None,
+        companion_reflection_jobs_stop_event=None,
+        reminder_jobs_task=None,
+        reminder_jobs_stop_event=None,
+        admin_backup_jobs_task=None,
+        admin_backup_jobs_stop_event=None,
+        admin_byok_validation_jobs_task=None,
+        admin_byok_validation_jobs_stop_event=None,
+        admin_maintenance_rotation_jobs_task=None,
+        admin_maintenance_rotation_jobs_stop_event=None,
+        recipe_run_jobs_task=None,
+        recipe_run_jobs_stop_event=None,
+        evals_abtest_jobs_task=None,
+        evals_abtest_jobs_stop_event=None,
+    )
+
+    monkeypatch.setattr(
+        startup_tail,
+        "_start_recurring_schedulers",
+        _fake_start_recurring_schedulers,
+    )
+
+    await startup_tail.finalize_startup_tail(
+        app=object(),
+        owned_job_pollers=[],
+        startup_worker_group_handles=empty_worker_group_handles,
+        startup_service_group_handles=SimpleNamespace(
+            connectors_jobs_task=None,
+            connectors_jobs_stop_event=None,
+        ),
+        replace_owned_job_poller_inventory=_fake_replace_owned_job_poller_inventory,
+        test_mode=True,
+        worker_inventory=worker_inventory,
+    )
+
+    assert observed == {"test_mode": True, "worker_inventory": worker_inventory}


### PR DESCRIPTION
Part of #1114.

## Change summary

Human-authored Change summary required before merge per repo policy.

## AI-authored implementation notes

- Adds a `ManagedWorker.shutdown_callback` hook so lifecycle-managed workers that need service-specific shutdown can still participate in `WorkerInventory`.
- Registers the recurring scheduler batch in the background-worker shutdown phase: workflows, reading digest, admin backup, companion reflection, reminders, and connectors sync.
- Threads `worker_inventory` through the startup tail and suppresses the later direct recurring-scheduler shutdown calls after the background-worker phase has already stopped those handles.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py tldw_Server_API/tests/Services/test_startup_tail_finalization.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_shutdown_recurring_schedulers.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_startup_delegates_owned_job_pollers tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_startup_delegates_service_tail tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_lifespan_startup_publishes_first_batch_background_worker_inventory tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_background_workers_do_not_enter_job_poller_quiesce -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/lifecycle_workers.py tldw_Server_API/app/services/shutdown_post_worker_services.py tldw_Server_API/app/services/startup_recurring_schedulers.py tldw_Server_API/app/services/startup_service_tail.py tldw_Server_API/app/services/startup_tail_finalization.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py tldw_Server_API/tests/Services/test_startup_tail_finalization.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/lifecycle_workers.py tldw_Server_API/app/services/shutdown_post_worker_services.py tldw_Server_API/app/services/startup_recurring_schedulers.py tldw_Server_API/app/services/startup_service_tail.py tldw_Server_API/app/services/startup_tail_finalization.py -f json -o /tmp/bandit_recurring_schedulers_1114.json`
- `git diff --check`
