### PR TITLE
refactor(workers): register auxiliary optional worker lifecycle

### DIFF
--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -193,14 +193,29 @@ async def shutdown_post_worker_services(
             "jobs_webhooks_task",
             jobs_webhooks_stop_event,
         ),
-        meetings_webhook_dlq_task=meetings_webhook_dlq_task,
-        meetings_webhook_dlq_stop_event=meetings_webhook_dlq_stop_event,
-        workflows_dlq_task=workflows_dlq_task,
-        workflows_dlq_stop_event=workflows_dlq_stop_event,
-        workflows_gc_task=workflows_gc_task,
-        workflows_gc_stop_event=workflows_gc_stop_event,
-        workflows_maint_task=workflows_maint_task,
-        workflows_maint_stop_event=workflows_maint_stop_event,
+        meetings_webhook_dlq_task=_task_if_not_stopped(
+            "meetings_webhook_dlq_task",
+            meetings_webhook_dlq_task,
+        ),
+        meetings_webhook_dlq_stop_event=_stop_event_if_not_stopped(
+            "meetings_webhook_dlq_task",
+            meetings_webhook_dlq_stop_event,
+        ),
+        workflows_dlq_task=_task_if_not_stopped("workflows_dlq_task", workflows_dlq_task),
+        workflows_dlq_stop_event=_stop_event_if_not_stopped(
+            "workflows_dlq_task",
+            workflows_dlq_stop_event,
+        ),
+        workflows_gc_task=_task_if_not_stopped("workflows_gc_task", workflows_gc_task),
+        workflows_gc_stop_event=_stop_event_if_not_stopped(
+            "workflows_gc_task",
+            workflows_gc_stop_event,
+        ),
+        workflows_maint_task=_task_if_not_stopped("workflows_maint_task", workflows_maint_task),
+        workflows_maint_stop_event=_stop_event_if_not_stopped(
+            "workflows_maint_task",
+            workflows_maint_stop_event,
+        ),
         guard_exceptions=guard_exceptions,
     )
     return PostWorkerShutdownHandles(
@@ -364,10 +379,16 @@ async def run_shutdown_post_worker_services(
                 jobs_integrity_task,
             ),
             jobs_webhooks_task=_fallback_if_not_stopped("jobs_webhooks_task", jobs_webhooks_task),
-            meetings_webhook_dlq_task=meetings_webhook_dlq_task,
-            workflows_dlq_task=workflows_dlq_task,
-            workflows_gc_task=workflows_gc_task,
-            workflows_maint_task=workflows_maint_task,
+            meetings_webhook_dlq_task=_fallback_if_not_stopped(
+                "meetings_webhook_dlq_task",
+                meetings_webhook_dlq_task,
+            ),
+            workflows_dlq_task=_fallback_if_not_stopped("workflows_dlq_task", workflows_dlq_task),
+            workflows_gc_task=_fallback_if_not_stopped("workflows_gc_task", workflows_gc_task),
+            workflows_maint_task=_fallback_if_not_stopped(
+                "workflows_maint_task",
+                workflows_maint_task,
+            ),
         )
 
 

--- a/tldw_Server_API/app/services/startup_optional_workers.py
+++ b/tldw_Server_API/app/services/startup_optional_workers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -21,6 +22,8 @@ _STARTUP_GUARD_EXCEPTIONS = (
     TypeError,
     ValueError,
 )
+
+OptionalWorkerCoroutineFactory = Callable[[asyncio.Event], Awaitable[Any]]
 
 
 @dataclass
@@ -50,29 +53,30 @@ async def start_optional_workers(
     worker_inventory: Any | None = None,
 ) -> OptionalWorkerStartupHandles:
     """Start optional stop-event workers and return the task/stop handles."""
-    if worker_inventory is None:
-        jobs_metrics_reconcile_stop, jobs_metrics_reconcile_task = await _start_jobs_metrics_reconcile_worker()
-        jobs_crypto_rotate_stop_event, jobs_crypto_rotate_task = await _start_jobs_crypto_rotate_worker()
-    else:
-        jobs_metrics_reconcile_stop, jobs_metrics_reconcile_task = await _start_jobs_metrics_reconcile_worker(
-            worker_inventory=worker_inventory,
-        )
-        jobs_crypto_rotate_stop_event, jobs_crypto_rotate_task = await _start_jobs_crypto_rotate_worker(
-            worker_inventory=worker_inventory,
-        )
+    jobs_metrics_reconcile_stop, jobs_metrics_reconcile_task = await _start_jobs_metrics_reconcile_worker(
+        worker_inventory=worker_inventory,
+    )
+    jobs_crypto_rotate_stop_event, jobs_crypto_rotate_task = await _start_jobs_crypto_rotate_worker(
+        worker_inventory=worker_inventory,
+    )
     jobs_webhooks_stop_event, jobs_webhooks_task = await _start_jobs_webhooks_worker(
         worker_inventory=worker_inventory,
     )
-    meetings_webhook_dlq_stop_event, meetings_webhook_dlq_task = await _start_meetings_webhook_dlq_worker()
-    workflows_dlq_stop_event, workflows_dlq_task = await _start_workflows_webhook_dlq_worker()
-    workflows_gc_stop_event, workflows_gc_task = await _start_workflows_artifact_gc_worker()
-    workflows_maint_stop_event, workflows_maint_task = await _start_workflows_db_maintenance_worker()
-    if worker_inventory is None:
-        jobs_integrity_stop_event, jobs_integrity_task = await _start_jobs_integrity_sweeper()
-    else:
-        jobs_integrity_stop_event, jobs_integrity_task = await _start_jobs_integrity_sweeper(
-            worker_inventory=worker_inventory,
-        )
+    meetings_webhook_dlq_stop_event, meetings_webhook_dlq_task = await _start_meetings_webhook_dlq_worker(
+        worker_inventory=worker_inventory,
+    )
+    workflows_dlq_stop_event, workflows_dlq_task = await _start_workflows_webhook_dlq_worker(
+        worker_inventory=worker_inventory,
+    )
+    workflows_gc_stop_event, workflows_gc_task = await _start_workflows_artifact_gc_worker(
+        worker_inventory=worker_inventory,
+    )
+    workflows_maint_stop_event, workflows_maint_task = await _start_workflows_db_maintenance_worker(
+        worker_inventory=worker_inventory,
+    )
+    jobs_integrity_stop_event, jobs_integrity_task = await _start_jobs_integrity_sweeper(
+        worker_inventory=worker_inventory,
+    )
     return OptionalWorkerStartupHandles(
         jobs_metrics_reconcile_stop=jobs_metrics_reconcile_stop,
         jobs_metrics_reconcile_task=jobs_metrics_reconcile_task,
@@ -105,6 +109,8 @@ async def _start_jobs_metrics_reconcile_worker(
     *,
     worker_inventory: Any | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the jobs metrics reconcile worker through inventory or legacy handles."""
+
     try:
         if not _env_flag_enabled("JOBS_METRICS_RECONCILE_ENABLE"):
             logger.info("Jobs metrics reconcile worker disabled by flag (JOBS_METRICS_RECONCILE_ENABLE)")
@@ -138,6 +144,8 @@ async def _start_jobs_crypto_rotate_worker(
     *,
     worker_inventory: Any | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the jobs crypto rotation worker through inventory or legacy handles."""
+
     try:
         if not _env_flag_enabled("JOBS_CRYPTO_ROTATE_SERVICE_ENABLED"):
             logger.info("Jobs crypto rotate worker disabled by flag")
@@ -206,11 +214,25 @@ async def _start_jobs_webhooks_worker(
         return None, None
 
 
-async def _start_meetings_webhook_dlq_worker() -> tuple[Any | None, Any | None]:
+async def _start_meetings_webhook_dlq_worker(
+    *,
+    worker_inventory: Any | None = None,
+) -> tuple[Any | None, Any | None]:
+    """Start the meetings webhook DLQ worker through inventory or legacy handles."""
+
     try:
         if not _env_flag_enabled("MEETINGS_WEBHOOK_DLQ_ENABLED"):
             logger.info("Meetings webhook DLQ worker disabled by flag")
             return None, None
+        if worker_inventory is not None:
+            stop_event, task = await _start_registered_optional_worker(
+                worker_inventory=worker_inventory,
+                name="meetings_webhook_dlq_task",
+                coroutine_factory=_run_meetings_webhook_dlq_worker_service,
+                category="meetings",
+            )
+            logger.info("Meetings webhook DLQ worker started with explicit stop_event signal")
+            return stop_event, task
         stop_event = _make_event()
         task = _create_task(_run_meetings_webhook_dlq_worker_service(stop_event))
         logger.info("Meetings webhook DLQ worker started with explicit stop_event signal")
@@ -220,11 +242,25 @@ async def _start_meetings_webhook_dlq_worker() -> tuple[Any | None, Any | None]:
         return None, None
 
 
-async def _start_workflows_webhook_dlq_worker() -> tuple[Any | None, Any | None]:
+async def _start_workflows_webhook_dlq_worker(
+    *,
+    worker_inventory: Any | None = None,
+) -> tuple[Any | None, Any | None]:
+    """Start the workflows webhook DLQ worker through inventory or legacy handles."""
+
     try:
         if not _env_flag_enabled("WORKFLOWS_WEBHOOK_DLQ_ENABLED"):
             logger.info("Workflows webhook DLQ worker disabled by flag")
             return None, None
+        if worker_inventory is not None:
+            stop_event, task = await _start_registered_optional_worker(
+                worker_inventory=worker_inventory,
+                name="workflows_dlq_task",
+                coroutine_factory=_run_workflows_webhook_dlq_worker_service,
+                category="workflows",
+            )
+            logger.info("Workflows webhook DLQ worker started with explicit stop_event signal")
+            return stop_event, task
         stop_event = _make_event()
         task = _create_task(_run_workflows_webhook_dlq_worker_service(stop_event))
         logger.info("Workflows webhook DLQ worker started with explicit stop_event signal")
@@ -234,11 +270,25 @@ async def _start_workflows_webhook_dlq_worker() -> tuple[Any | None, Any | None]
         return None, None
 
 
-async def _start_workflows_artifact_gc_worker() -> tuple[Any | None, Any | None]:
+async def _start_workflows_artifact_gc_worker(
+    *,
+    worker_inventory: Any | None = None,
+) -> tuple[Any | None, Any | None]:
+    """Start the workflows artifact GC worker through inventory or legacy handles."""
+
     try:
         if not _env_flag_enabled("WORKFLOWS_ARTIFACT_GC_ENABLED"):
             logger.info("Workflows artifact GC worker disabled by flag")
             return None, None
+        if worker_inventory is not None:
+            stop_event, task = await _start_registered_optional_worker(
+                worker_inventory=worker_inventory,
+                name="workflows_gc_task",
+                coroutine_factory=_run_workflows_artifact_gc_worker_service,
+                category="workflows",
+            )
+            logger.info("Workflows artifact GC worker started with explicit stop_event signal")
+            return stop_event, task
         stop_event = _make_event()
         task = _create_task(_run_workflows_artifact_gc_worker_service(stop_event))
         logger.info("Workflows artifact GC worker started with explicit stop_event signal")
@@ -248,11 +298,25 @@ async def _start_workflows_artifact_gc_worker() -> tuple[Any | None, Any | None]
         return None, None
 
 
-async def _start_workflows_db_maintenance_worker() -> tuple[Any | None, Any | None]:
+async def _start_workflows_db_maintenance_worker(
+    *,
+    worker_inventory: Any | None = None,
+) -> tuple[Any | None, Any | None]:
+    """Start the workflows DB maintenance worker through inventory or legacy handles."""
+
     try:
         if not _env_flag_enabled("WORKFLOWS_DB_MAINTENANCE_ENABLED"):
             logger.info("Workflows DB maintenance worker disabled by flag")
             return None, None
+        if worker_inventory is not None:
+            stop_event, task = await _start_registered_optional_worker(
+                worker_inventory=worker_inventory,
+                name="workflows_maint_task",
+                coroutine_factory=_run_workflows_db_maintenance_worker_service,
+                category="workflows",
+            )
+            logger.info("Workflows DB maintenance worker started with explicit stop_event signal")
+            return stop_event, task
         stop_event = _make_event()
         task = _create_task(_run_workflows_db_maintenance_worker_service(stop_event))
         logger.info("Workflows DB maintenance worker started with explicit stop_event signal")
@@ -266,6 +330,8 @@ async def _start_jobs_integrity_sweeper(
     *,
     worker_inventory: Any | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the jobs integrity sweeper through inventory or legacy handles."""
+
     try:
         if not _env_flag_enabled("JOBS_INTEGRITY_SWEEP_ENABLED"):
             logger.info("Jobs integrity sweeper disabled by flag")
@@ -293,6 +359,31 @@ async def _start_jobs_integrity_sweeper(
     except _STARTUP_GUARD_EXCEPTIONS as exc:
         logger.warning(f"Failed to start Jobs integrity sweeper: {exc}")
         return None, None
+
+
+async def _start_registered_optional_worker(
+    *,
+    worker_inventory: Any,
+    name: str,
+    coroutine_factory: OptionalWorkerCoroutineFactory,
+    category: str,
+) -> tuple[Any, Any]:
+    """Register an optional stop-event worker with the lifecycle inventory."""
+
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ShutdownPhase,
+        start_stop_event_worker,
+    )
+
+    task, stop_event = await start_stop_event_worker(
+        worker_inventory,
+        name=name,
+        task_name=name,
+        coroutine_factory=coroutine_factory,
+        category=category,
+        shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+    )
+    return stop_event, task
 
 
 def _run_jobs_metrics_reconcile_service(stop_event: Any) -> Any:

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -302,6 +302,142 @@ async def test_shutdown_post_worker_services_skips_jobs_webhooks_after_backgroun
 
 
 @pytest.mark.asyncio
+async def test_shutdown_post_worker_services_skips_auxiliary_optional_workers_after_background_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_post_worker_services as shutdown_services
+
+    optional_kwargs: dict[str, object] = {}
+
+    async def _claims(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            claims_task=kwargs["claims_task"],
+            jobs_prune_task=kwargs["jobs_prune_task"],
+            files_export_gc_task=kwargs["files_export_gc_task"],
+            notifications_prune_task=kwargs["notifications_prune_task"],
+        )
+
+    async def _notifications(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_notifications_bridge_task=kwargs["jobs_notifications_bridge_task"],
+            embeddings_compactor_task=kwargs["embeddings_compactor_task"],
+            embeddings_compactor_stop_event=kwargs["embeddings_compactor_stop_event"],
+            websub_renewal_task=kwargs["websub_renewal_task"],
+        )
+
+    async def _usage(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            usage_task=kwargs["usage_task"],
+            llm_usage_task=kwargs["llm_usage_task"],
+        )
+
+    async def _recurring(**kwargs: object) -> None:
+        return None
+
+    async def _runtime(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_metrics_task=kwargs["jobs_metrics_task"],
+            loop_lag_task=kwargs["loop_lag_task"],
+        )
+
+    async def _reconcile(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            jobs_metrics_reconcile_task=kwargs["jobs_metrics_reconcile_task"],
+            jobs_metrics_reconcile_stop=kwargs["jobs_metrics_reconcile_stop"],
+        )
+
+    async def _personalization(**kwargs: object) -> None:
+        return None
+
+    async def _optional(**kwargs: object) -> SimpleNamespace:
+        optional_kwargs.update(kwargs)
+        return SimpleNamespace(
+            jobs_crypto_rotate_task=kwargs["jobs_crypto_rotate_task"],
+            jobs_integrity_task=kwargs["jobs_integrity_task"],
+            jobs_webhooks_task=kwargs["jobs_webhooks_task"],
+            meetings_webhook_dlq_task=kwargs["meetings_webhook_dlq_task"],
+            workflows_dlq_task=kwargs["workflows_dlq_task"],
+            workflows_gc_task=kwargs["workflows_gc_task"],
+            workflows_maint_task=kwargs["workflows_maint_task"],
+        )
+
+    monkeypatch.setattr(shutdown_services, "_shutdown_claims_maintenance_tasks", _claims)
+    monkeypatch.setattr(
+        shutdown_services,
+        "_shutdown_notifications_compactor_websub_workers",
+        _notifications,
+    )
+    monkeypatch.setattr(shutdown_services, "_stop_usage_aggregators", _usage)
+    monkeypatch.setattr(shutdown_services, "_stop_recurring_schedulers", _recurring)
+    monkeypatch.setattr(shutdown_services, "_shutdown_runtime_monitors", _runtime)
+    monkeypatch.setattr(shutdown_services, "_shutdown_jobs_metrics_reconcile", _reconcile)
+    monkeypatch.setattr(shutdown_services, "_shutdown_personalization_consolidation", _personalization)
+    monkeypatch.setattr(shutdown_services, "_shutdown_optional_workers", _optional)
+
+    handles = await shutdown_services.shutdown_post_worker_services(
+        claims_task=None,
+        jobs_prune_task=None,
+        files_export_gc_task=None,
+        notifications_prune_task=None,
+        jobs_notifications_bridge_task=None,
+        embeddings_compactor_task=None,
+        embeddings_compactor_stop_event=None,
+        websub_renewal_task=None,
+        coordinated_legacy_component_names=set(),
+        usage_task=None,
+        llm_usage_task=None,
+        workflows_sched_task=None,
+        reading_digest_sched_task=None,
+        admin_backup_sched_task=None,
+        companion_reflection_sched_task=None,
+        reminders_sched_task=None,
+        connectors_sync_sched_task=None,
+        jobs_metrics_task=None,
+        jobs_metrics_stop_event=None,
+        loop_lag_task=None,
+        loop_lag_stop_event=None,
+        jobs_metrics_reconcile_task=None,
+        jobs_metrics_reconcile_stop=None,
+        jobs_crypto_rotate_task="crypto-task",
+        jobs_crypto_rotate_stop_event="crypto-stop",
+        jobs_integrity_task="integrity-task",
+        jobs_integrity_stop_event="integrity-stop",
+        jobs_webhooks_task="webhooks-task",
+        jobs_webhooks_stop_event="webhooks-stop",
+        meetings_webhook_dlq_task="meetings-task",
+        meetings_webhook_dlq_stop_event="meetings-stop",
+        workflows_dlq_task="workflows-dlq-task",
+        workflows_dlq_stop_event="workflows-dlq-stop",
+        workflows_gc_task="workflows-gc-task",
+        workflows_gc_stop_event="workflows-gc-stop",
+        workflows_maint_task="workflows-maint-task",
+        workflows_maint_stop_event="workflows-maint-stop",
+        guard_exceptions=(RuntimeError,),
+        stopped_background_worker_names={
+            "meetings_webhook_dlq_task",
+            "workflows_dlq_task",
+            "workflows_gc_task",
+            "workflows_maint_task",
+        },
+    )
+
+    assert optional_kwargs["jobs_webhooks_task"] == "webhooks-task"
+    assert optional_kwargs["meetings_webhook_dlq_task"] is None
+    assert optional_kwargs["meetings_webhook_dlq_stop_event"] is None
+    assert optional_kwargs["workflows_dlq_task"] is None
+    assert optional_kwargs["workflows_dlq_stop_event"] is None
+    assert optional_kwargs["workflows_gc_task"] is None
+    assert optional_kwargs["workflows_gc_stop_event"] is None
+    assert optional_kwargs["workflows_maint_task"] is None
+    assert optional_kwargs["workflows_maint_stop_event"] is None
+    assert handles.jobs_webhooks_task == "webhooks-task"
+    assert handles.meetings_webhook_dlq_task is None
+    assert handles.workflows_dlq_task is None
+    assert handles.workflows_gc_task is None
+    assert handles.workflows_maint_task is None
+
+
+@pytest.mark.asyncio
 async def test_shutdown_post_worker_services_skips_compactor_and_websub_after_background_phase(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -983,6 +1119,10 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
             "jobs_crypto_rotate_task",
             "jobs_integrity_task",
             "websub_renewal_task",
+            "meetings_webhook_dlq_task",
+            "workflows_dlq_task",
+            "workflows_gc_task",
+            "workflows_maint_task",
         },
     )
 
@@ -1004,7 +1144,7 @@ async def test_run_shutdown_post_worker_services_guard_failure_suppresses_stoppe
     assert handles.jobs_crypto_rotate_task is None
     assert handles.jobs_integrity_task is None
     assert handles.jobs_webhooks_task == "webhooks-input"
-    assert handles.meetings_webhook_dlq_task == "meetings-input"
-    assert handles.workflows_dlq_task == "dlq-input"
-    assert handles.workflows_gc_task == "gc-input"
-    assert handles.workflows_maint_task == "maint-input"
+    assert handles.meetings_webhook_dlq_task is None
+    assert handles.workflows_dlq_task is None
+    assert handles.workflows_gc_task is None
+    assert handles.workflows_maint_task is None

--- a/tldw_Server_API/tests/Services/test_startup_optional_workers.py
+++ b/tldw_Server_API/tests/Services/test_startup_optional_workers.py
@@ -4,9 +4,8 @@ import asyncio
 import importlib
 import sys
 
-from fastapi import FastAPI
 import pytest
-
+from fastapi import FastAPI
 
 pytestmark = pytest.mark.unit
 
@@ -23,11 +22,13 @@ async def test_start_optional_workers_combines_handles_in_order(
     startup_workers = _import_startup_optional_workers()
     calls: list[str] = []
 
-    async def _record_jobs_metrics():
+    async def _record_jobs_metrics(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        assert worker_inventory is None
         calls.append("jobs-metrics")
         return ("jobs-metrics-stop", "jobs-metrics-task")
 
-    async def _record_jobs_crypto():
+    async def _record_jobs_crypto(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        assert worker_inventory is None
         calls.append("jobs-crypto")
         return ("jobs-crypto-stop", "jobs-crypto-task")
 
@@ -36,23 +37,28 @@ async def test_start_optional_workers_combines_handles_in_order(
         calls.append("jobs-webhooks")
         return ("jobs-webhooks-stop", "jobs-webhooks-task")
 
-    async def _record_meetings_dlq():
+    async def _record_meetings_dlq(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        assert worker_inventory is None
         calls.append("meetings-dlq")
         return ("meetings-dlq-stop", "meetings-dlq-task")
 
-    async def _record_workflows_dlq():
+    async def _record_workflows_dlq(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        assert worker_inventory is None
         calls.append("workflows-dlq")
         return ("workflows-dlq-stop", "workflows-dlq-task")
 
-    async def _record_workflows_gc():
+    async def _record_workflows_gc(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        assert worker_inventory is None
         calls.append("workflows-gc")
         return ("workflows-gc-stop", "workflows-gc-task")
 
-    async def _record_workflows_maint():
+    async def _record_workflows_maint(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        assert worker_inventory is None
         calls.append("workflows-maint")
         return ("workflows-maint-stop", "workflows-maint-task")
 
-    async def _record_jobs_integrity():
+    async def _record_jobs_integrity(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        assert worker_inventory is None
         calls.append("jobs-integrity")
         return ("jobs-integrity-stop", "jobs-integrity-task")
 
@@ -161,6 +167,172 @@ async def test_start_jobs_webhooks_worker_registers_background_inventory_when_en
                 "has_stop_event": True,
                 "timeout_sec": 5.0,
                 "category": "jobs",
+                "shutdown_phase": "background_worker_shutdown",
+            }
+        ]
+        assert app.state._tldw_shutdown_job_poller_inventory == []
+    finally:
+        if stop_event is not None:
+            stop_event.set()
+        if task is not None:
+            await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_start_optional_workers_passes_inventory_to_auxiliary_optional_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_workers = _import_startup_optional_workers()
+    worker_inventory = object()
+    calls: list[tuple[str, object | None]] = []
+
+    async def _record_jobs_metrics(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        calls.append(("jobs-metrics", worker_inventory))
+        return ("jobs-metrics-stop", "jobs-metrics-task")
+
+    async def _record_jobs_crypto(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        calls.append(("jobs-crypto", worker_inventory))
+        return ("jobs-crypto-stop", "jobs-crypto-task")
+
+    async def _record_jobs_webhooks(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        calls.append(("jobs-webhooks", worker_inventory))
+        return ("jobs-webhooks-stop", "jobs-webhooks-task")
+
+    async def _record_meetings_dlq(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        calls.append(("meetings-dlq", worker_inventory))
+        return ("meetings-dlq-stop", "meetings-dlq-task")
+
+    async def _record_workflows_dlq(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        calls.append(("workflows-dlq", worker_inventory))
+        return ("workflows-dlq-stop", "workflows-dlq-task")
+
+    async def _record_workflows_gc(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        calls.append(("workflows-gc", worker_inventory))
+        return ("workflows-gc-stop", "workflows-gc-task")
+
+    async def _record_workflows_maint(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        calls.append(("workflows-maint", worker_inventory))
+        return ("workflows-maint-stop", "workflows-maint-task")
+
+    async def _record_jobs_integrity(*, worker_inventory: object | None = None) -> tuple[str, str]:
+        calls.append(("jobs-integrity", worker_inventory))
+        return ("jobs-integrity-stop", "jobs-integrity-task")
+
+    monkeypatch.setattr(startup_workers, "_start_jobs_metrics_reconcile_worker", _record_jobs_metrics)
+    monkeypatch.setattr(startup_workers, "_start_jobs_crypto_rotate_worker", _record_jobs_crypto)
+    monkeypatch.setattr(startup_workers, "_start_jobs_webhooks_worker", _record_jobs_webhooks)
+    monkeypatch.setattr(startup_workers, "_start_meetings_webhook_dlq_worker", _record_meetings_dlq)
+    monkeypatch.setattr(startup_workers, "_start_workflows_webhook_dlq_worker", _record_workflows_dlq)
+    monkeypatch.setattr(startup_workers, "_start_workflows_artifact_gc_worker", _record_workflows_gc)
+    monkeypatch.setattr(startup_workers, "_start_workflows_db_maintenance_worker", _record_workflows_maint)
+    monkeypatch.setattr(startup_workers, "_start_jobs_integrity_sweeper", _record_jobs_integrity)
+
+    handles = await startup_workers.start_optional_workers(worker_inventory=worker_inventory)
+
+    assert calls == [
+        ("jobs-metrics", worker_inventory),
+        ("jobs-crypto", worker_inventory),
+        ("jobs-webhooks", worker_inventory),
+        ("meetings-dlq", worker_inventory),
+        ("workflows-dlq", worker_inventory),
+        ("workflows-gc", worker_inventory),
+        ("workflows-maint", worker_inventory),
+        ("jobs-integrity", worker_inventory),
+    ]
+    assert handles.meetings_webhook_dlq_task == "meetings-dlq-task"
+    assert handles.workflows_dlq_task == "workflows-dlq-task"
+    assert handles.workflows_gc_task == "workflows-gc-task"
+    assert handles.workflows_maint_task == "workflows-maint-task"
+
+
+@pytest.mark.parametrize(
+    (
+        "helper_name",
+        "env_key",
+        "service_name",
+        "worker_name",
+        "category",
+    ),
+    [
+        (
+            "_start_meetings_webhook_dlq_worker",
+            "MEETINGS_WEBHOOK_DLQ_ENABLED",
+            "_run_meetings_webhook_dlq_worker_service",
+            "meetings_webhook_dlq_task",
+            "meetings",
+        ),
+        (
+            "_start_workflows_webhook_dlq_worker",
+            "WORKFLOWS_WEBHOOK_DLQ_ENABLED",
+            "_run_workflows_webhook_dlq_worker_service",
+            "workflows_dlq_task",
+            "workflows",
+        ),
+        (
+            "_start_workflows_artifact_gc_worker",
+            "WORKFLOWS_ARTIFACT_GC_ENABLED",
+            "_run_workflows_artifact_gc_worker_service",
+            "workflows_gc_task",
+            "workflows",
+        ),
+        (
+            "_start_workflows_db_maintenance_worker",
+            "WORKFLOWS_DB_MAINTENANCE_ENABLED",
+            "_run_workflows_db_maintenance_worker_service",
+            "workflows_maint_task",
+            "workflows",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_start_auxiliary_optional_worker_registers_background_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    helper_name: str,
+    env_key: str,
+    service_name: str,
+    worker_name: str,
+    category: str,
+) -> None:
+    startup_workers = _import_startup_optional_workers()
+    from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase, WorkerRegistry
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    observed_stop_events: list[asyncio.Event] = []
+
+    async def _fake_worker(stop_event: asyncio.Event) -> None:
+        observed_stop_events.append(stop_event)
+        await stop_event.wait()
+
+    monkeypatch.setenv(env_key, "true")
+    monkeypatch.setattr(startup_workers, service_name, _fake_worker)
+
+    stop_event = None
+    task = None
+    try:
+        stop_event, task = await getattr(startup_workers, helper_name)(
+            worker_inventory=worker_inventory,
+        )
+        await asyncio.sleep(0)
+
+        assert stop_event is not None
+        assert task is not None
+        assert task.get_name() == worker_name
+        assert observed_stop_events == [stop_event]
+        assert len(worker_inventory.handles) == 1
+        handle = worker_inventory.handles[0]
+        assert handle.name == worker_name
+        assert handle.task is task
+        assert handle.stop_event is stop_event
+        assert handle.category == category
+        assert handle.shutdown_phase is ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+        assert app.state._tldw_shutdown_worker_inventory == [
+            {
+                "name": worker_name,
+                "task_name": worker_name,
+                "has_stop_event": True,
+                "timeout_sec": 5.0,
+                "category": category,
                 "shutdown_phase": "background_worker_shutdown",
             }
         ]


### PR DESCRIPTION
Part of #1114.

## Change summary

Human-authored Change summary required before merge per repo policy.

## AI-authored implementation notes

- Registers the remaining auxiliary optional stop-event workers with the lifecycle inventory when a `WorkerRegistry` is available: meetings webhook DLQ, workflows webhook DLQ, workflows artifact GC, and workflows DB maintenance.
- Keeps the legacy no-inventory startup path intact, so direct helper calls and existing tests can still use the old stop-event task behavior.
- Suppresses the later direct optional-worker shutdown path, including guarded fallback handling, after the background-worker phase has already stopped these handles.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_optional_workers.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_shutdown_optional_workers.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_startup_delegates_service_tail tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_startup_delegates_owned_job_pollers tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_lifespan_startup_publishes_first_batch_background_worker_inventory tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_background_workers_do_not_enter_job_poller_quiesce -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_optional_workers.py tldw_Server_API/app/services/shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_startup_optional_workers.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_optional_workers.py tldw_Server_API/app/services/shutdown_post_worker_services.py -f json -o /tmp/bandit_auxiliary_optional_workers_1114.json`
- `git diff --check`
