### PR TITLE
Align persona wake activation docs

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-persona-wake-word-support-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-01-persona-wake-word-support-implementation-plan.md
@@ -375,7 +375,10 @@ def test_persona_wake_activation_allows_next_voice_turn_without_trigger(
             ws.send_text(json.dumps({
                 "type": "voice_config",
                 "session_id": "sess_wake_valid",
-                "voice": {"trigger_phrases": ["hey helper"]},
+                "voice": {
+                    "trigger_phrases": ["hey helper"],
+                    "wake_behavior": "one_shot",
+                },
                 "stt": {"enable_vad": True},
             }))
             _ = _recv_until(
@@ -388,7 +391,6 @@ def test_persona_wake_activation_allows_next_voice_turn_without_trigger(
                 "session_id": "sess_wake_valid",
                 "matched_phrase": "hey helper",
                 "detector_kind": "browser_transcript",
-                "wake_behavior": "one_shot",
                 "detected_at_ms": 1714500000000,
             }))
             accepted = _recv_until(
@@ -445,7 +447,10 @@ def _assert_wake_activation_rejected_keeps_trigger_gate(
             ws.send_text(json.dumps({
                 "type": "voice_config",
                 "session_id": session_id,
-                "voice": {"trigger_phrases": runtime_phrases},
+                "voice": {
+                    "trigger_phrases": runtime_phrases,
+                    "wake_behavior": wake_behavior,
+                },
                 "stt": {"model": "whisper-1", "language": "en-US"},
             }))
             _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_CONFIG_UPDATED")
@@ -454,7 +459,6 @@ def _assert_wake_activation_rejected_keeps_trigger_gate(
                 "session_id": session_id,
                 "matched_phrase": matched_phrase,
                 "detector_kind": "browser_transcript",
-                "wake_behavior": wake_behavior,
                 "detected_at_ms": 1714500000000,
             }))
             rejected = _recv_until(
@@ -477,7 +481,7 @@ def _assert_wake_activation_rejected_keeps_trigger_gate(
             assert ignored.get("session_id") == session_id
 ```
 
-Add these three tests:
+Add these rejection tests:
 
 ```python
 def test_persona_wake_activation_rejects_phrase_not_saved_in_profile(tmp_path, monkeypatch):
@@ -500,19 +504,9 @@ def test_persona_wake_activation_rejects_phrase_missing_from_runtime_config(tmp_
         runtime_phrases=["okay helper"],
         matched_phrase="hey helper",
     )
-
-
-def test_persona_wake_activation_rejects_invalid_wake_behavior(tmp_path, monkeypatch):
-    _assert_wake_activation_rejected_keeps_trigger_gate(
-        tmp_path=tmp_path,
-        monkeypatch=monkeypatch,
-        session_id="sess_wake_reject_behavior",
-        saved_phrases=["hey helper"],
-        runtime_phrases=["hey helper"],
-        matched_phrase="hey helper",
-        wake_behavior="always_on_background",
-    )
 ```
+
+Also add a positive test proving the server derives wake behavior from `voice_config.voice.wake_behavior` and ignores any client-supplied `wake_behavior` on `wake_activation`.
 
 - [ ] **Step 4: Add failing deactivation and expiry tests**
 
@@ -540,7 +534,10 @@ def test_persona_wake_deactivation_restores_trigger_gating(tmp_path, monkeypatch
             ws.send_text(json.dumps({
                 "type": "voice_config",
                 "session_id": "sess_wake_deactivated",
-                "voice": {"trigger_phrases": ["hey helper"]},
+                "voice": {
+                    "trigger_phrases": ["hey helper"],
+                    "wake_behavior": "continuous",
+                },
                 "stt": {"model": "whisper-1", "language": "en-US"},
             }))
             _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_CONFIG_UPDATED")
@@ -549,7 +546,6 @@ def test_persona_wake_deactivation_restores_trigger_gating(tmp_path, monkeypatch
                 "session_id": "sess_wake_deactivated",
                 "matched_phrase": "hey helper",
                 "detector_kind": "browser_transcript",
-                "wake_behavior": "continuous",
                 "detected_at_ms": 1714500000000,
             }))
             _ = _recv_until(ws, lambda d: d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED")
@@ -597,7 +593,10 @@ def test_persona_wake_activation_one_shot_expires_after_commit(tmp_path, monkeyp
             ws.send_text(json.dumps({
                 "type": "voice_config",
                 "session_id": "sess_wake_one_shot",
-                "voice": {"trigger_phrases": ["hey helper"]},
+                "voice": {
+                    "trigger_phrases": ["hey helper"],
+                    "wake_behavior": "one_shot",
+                },
                 "stt": {"model": "whisper-1", "language": "en-US"},
             }))
             _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_CONFIG_UPDATED")
@@ -606,7 +605,6 @@ def test_persona_wake_activation_one_shot_expires_after_commit(tmp_path, monkeyp
                 "session_id": "sess_wake_one_shot",
                 "matched_phrase": "hey helper",
                 "detector_kind": "browser_transcript",
-                "wake_behavior": "one_shot",
                 "detected_at_ms": 1714500000000,
             }))
             _ = _recv_until(ws, lambda d: d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED")
@@ -659,7 +657,10 @@ def test_persona_wake_activation_expires_after_no_command_timeout(tmp_path, monk
             ws.send_text(json.dumps({
                 "type": "voice_config",
                 "session_id": "sess_wake_timeout",
-                "voice": {"trigger_phrases": ["hey helper"]},
+                "voice": {
+                    "trigger_phrases": ["hey helper"],
+                    "wake_behavior": "one_shot",
+                },
                 "stt": {"model": "whisper-1", "language": "en-US"},
             }))
             _ = _recv_until(ws, lambda d: d.get("reason_code") == "VOICE_CONFIG_UPDATED")
@@ -668,7 +669,6 @@ def test_persona_wake_activation_expires_after_no_command_timeout(tmp_path, monk
                 "session_id": "sess_wake_timeout",
                 "matched_phrase": "hey helper",
                 "detector_kind": "browser_transcript",
-                "wake_behavior": "one_shot",
                 "detected_at_ms": 1714500000000,
             }))
             _ = _recv_until(ws, lambda d: d.get("reason_code") == "WAKE_ACTIVATION_ACCEPTED")
@@ -841,7 +841,6 @@ elif mtype == "wake_activation":
         )
         continue
 
-    wake_behavior = str(msg.get("wake_behavior") or "one_shot").strip()
     matched_phrase = str(msg.get("matched_phrase") or "").strip()
     detector_kind = _bounded_label(
         msg.get("detector_kind"),
@@ -859,13 +858,16 @@ elif mtype == "wake_activation":
         if isinstance(voice_runtime, dict)
         else []
     )
+    wake_behavior = _bounded_label(
+        voice_runtime.get("wake_behavior")
+        if isinstance(voice_runtime, dict)
+        else None,
+        allowed=_PERSONA_WAKE_BEHAVIORS,
+        fallback="one_shot",
+    )
     saved_match = _match_persona_wake_phrase(matched_phrase, saved_phrases)
     runtime_match = _match_persona_wake_phrase(matched_phrase, runtime_phrases)
-    if (
-        wake_behavior not in _PERSONA_WAKE_BEHAVIORS
-        or not saved_match
-        or not runtime_match
-    ):
+    if not saved_match or not runtime_match:
         await _emit_notice(
             session_id=session_id,
             level="warning",
@@ -1480,7 +1482,7 @@ it("starts the wake detector with raw saved phrases", async () => {
 
 Add tests that assert:
 
-- `fireWake()` sends:
+- `fireWake()` sends activation metadata only; wake behavior is already carried by `voice_config.voice.wake_behavior`:
 
 ```ts
 {
@@ -1488,7 +1490,6 @@ Add tests that assert:
   session_id: "sess-1",
   matched_phrase: "hey helper",
   detector_kind: "browser_transcript",
-  wake_behavior: "one_shot",
   detected_at_ms: 1714500000000
 }
 ```
@@ -1571,10 +1572,9 @@ const sendWakeActivation = React.useCallback((event: WakeDetectedEvent) => {
     session_id: sessionId,
     matched_phrase: event.canonicalPhrase,
     detector_kind: event.detectorKind,
-    wake_behavior: sessionWakeBehavior,
     detected_at_ms: event.detectedAtMs
   }))
-}, [connected, sessionId, sessionWakeBehavior, ws])
+}, [connected, sessionId, ws])
 
 const sendWakeDeactivation = React.useCallback((reason: string) => {
   if (!sessionId || !ws || ws.readyState !== WebSocket.OPEN) return

--- a/Docs/superpowers/specs/2026-04-30-persona-wake-word-support-design.md
+++ b/Docs/superpowers/specs/2026-04-30-persona-wake-word-support-design.md
@@ -197,8 +197,9 @@ Profile settings should add the persistent default wake behavior near existing v
 3. Controller debounces duplicate detections.
 4. Controller ensures the persona websocket session is connected.
 5. Controller sends or refreshes `voice_config` with the saved persona wake trigger phrases for this wake-armed session.
-6. Controller sends a `wake_activation` frame with the canonical matched phrase, detector kind, timestamp, and selected wake behavior.
-7. Controller applies the current wake behavior.
+6. Controller sends a `wake_activation` frame with the canonical matched phrase, detector kind, and timestamp.
+7. Server derives the effective wake behavior from the current session `voice_runtime.wake_behavior`, which was sent through `voice_config`.
+8. Controller applies the current session-local wake behavior for UI flow.
 
 ### Wake Activation Frame
 
@@ -210,19 +211,18 @@ Add a small persona websocket frame for V1:
   "session_id": "<persona-session-id>",
   "matched_phrase": "hey helper",
   "detector_kind": "browser_transcript",
-  "wake_behavior": "one_shot",
   "detected_at_ms": 1714500000000
 }
 ```
 
-The server should store this as session-local runtime state. It is not a persisted memory, not a command, and not an authorization grant.
+The client must not be treated as authoritative for wake behavior in this frame. The selected behavior is sent through `voice_config.voice.wake_behavior`; the server normalizes that runtime value and stores it with the accepted wake activation as session-local runtime state. It is not a persisted memory, not a command, and not an authorization grant.
 
 The server should accept `wake_activation` only when all of these are true:
 
 - `session_id` normalizes to an existing session for the authenticated user.
 - The session has current `voice_runtime.trigger_phrases` from a prior `voice_config`.
+- The server can derive `voice_runtime.wake_behavior` as one of `one_shot`, `continuous`, or `push_to_talk_after_wake`, falling back to `one_shot` when unset.
 - The server can resolve the session's persona profile for the authenticated user.
-- `wake_behavior` is one of `one_shot`, `continuous`, or `push_to_talk_after_wake`.
 - `matched_phrase` is non-empty.
 - `matched_phrase` is the canonical configured phrase after detector normalization, not the raw recognized text.
 - `matched_phrase` matches one of the saved persona profile `voice_defaults.voice_chat_trigger_phrases`.
@@ -278,7 +278,7 @@ The backend should remain additive:
 
 - Validate and persist `voice_defaults.wake_behavior`.
 - Return the saved nullable `voice_defaults.wake_behavior` in persona profile responses; frontend resolution applies the `one_shot` fallback.
-- Accept `wake_activation` websocket frames and store active wake state in session-local runtime preferences.
+- Accept `wake_activation` websocket frames and store active wake state in session-local runtime preferences using server-derived `voice_runtime.wake_behavior`.
 - Accept `wake_deactivation` websocket frames and clear active wake state for the session.
 - Validate wake activation phrases against the saved persona profile, not only client-supplied `voice_config`.
 - Keep existing server-side trigger phrase gating on committed transcripts when no wake activation is active.
@@ -343,6 +343,7 @@ Backend:
 - websocket `wake_activation` allows the next post-wake voice turn to omit the trigger phrase.
 - invalid `wake_activation` frames are rejected without disabling trigger phrase gating.
 - `wake_activation` is rejected when `matched_phrase` exists only in client-supplied runtime config and not in saved persona profile trigger phrases.
+- client-supplied `wake_behavior` in `wake_activation`, if present, is ignored in favor of the server-side runtime value.
 - websocket `wake_deactivation` clears continuous wake activation while the socket stays open.
 - websocket trigger phrase gating still rejects transcripts without trigger phrases when no wake activation is active.
 - `one_shot` wake activation expires after one committed voice turn.


### PR DESCRIPTION
## Change summary

TODO: Human requester must replace or approve this section before merge per the AI-generated PR change summary policy.

AI-authored draft:
- Align the Persona wake design spec with the merged implementation: `wake_activation` carries activation metadata only, and wake behavior is derived from `voice_config.voice.wake_behavior` on the server.
- Update implementation-plan examples so future agents do not reintroduce client-trusted `wake_behavior` in activation frames.

## Test Plan

- [x] `rg -n 'selected wake behavior|wake_behavior: sessionWakeBehavior|msg\.get\("wake_behavior"|client-sent wake_behavior' Docs/superpowers/specs/2026-04-30-persona-wake-word-support-design.md Docs/superpowers/plans/2026-05-01-persona-wake-word-support-implementation-plan.md`
- [x] `git diff --check`
