### PR TITLE
Harden VZ exec_guest request contract

### DIFF
--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import socket
 from datetime import datetime, timezone
@@ -26,7 +27,14 @@ from .models import (
 EXPECTED_HELPER_PROTOCOL_VERSION = "1"
 _DEFAULT_PROTOCOL_VERSION = EXPECTED_HELPER_PROTOCOL_VERSION
 _DEFAULT_SOCKET_TIMEOUT_SEC = 5.0
+_DEFAULT_EXEC_TIMEOUT_SEC = 30.0
 _HELPER_SOCKET_ENV = "TLDW_SANDBOX_MACOS_HELPER_SOCKET"
+_EXEC_WORKSPACE_ROOT = "/workspace"
+_MAX_EXEC_ARGV_COUNT = 128
+_MAX_EXEC_ARGV_BYTES = 32 * 1024
+_MAX_EXEC_ENV_COUNT = 128
+_MAX_EXEC_ENV_BYTES = 32 * 1024
+_MAX_EXEC_TIMEOUT_SEC = 3_600.0
 
 
 class MacOSVirtualizationHelperUnavailable(RuntimeError):
@@ -161,7 +169,7 @@ class MacOSVirtualizationHelperClient:
 
     def exec_guest(self, *, vm_id: str, request: dict[str, Any]) -> HelperExecReply:
         if is_truthy(os.getenv("TEST_MODE")):
-            argv = list(request.get("argv") or [])
+            argv, _cwd, _env, _timeout_sec = self._validate_exec_guest_request(request)
             stdout = b""
             if argv[:2] == ["/bin/echo", "ok"]:
                 stdout = b"ok\n"
@@ -173,7 +181,10 @@ class MacOSVirtualizationHelperClient:
         payload = self._request(
             "exec_guest",
             {"vm_id": vm_id, **dict(request)},
-            timeout_sec=self._operation_timeout_sec(request),
+            timeout_sec=self._operation_timeout_sec(
+                request,
+                default_request_timeout_sec=_DEFAULT_EXEC_TIMEOUT_SEC,
+            ),
         )
         stdout = payload.get("stdout", "")
         stderr = payload.get("stderr", "")
@@ -255,14 +266,33 @@ class MacOSVirtualizationHelperClient:
             )
         return response
 
-    def _operation_timeout_sec(self, request: dict[str, Any]) -> float:
+    def _operation_timeout_sec(
+        self,
+        request: dict[str, Any],
+        *,
+        default_request_timeout_sec: float | None = None,
+    ) -> float:
+        base_timeout = self._finite_positive_timeout(self._timeout_sec) or _DEFAULT_SOCKET_TIMEOUT_SEC
+        default_timeout = self._finite_positive_timeout(default_request_timeout_sec)
         try:
             requested = float(request.get("timeout_sec") or 0)
         except (TypeError, ValueError):
             requested = 0.0
+        if not math.isfinite(requested) or requested <= 0:
+            requested = default_timeout or 0.0
         if requested <= 0:
-            return self._timeout_sec
-        return max(self._timeout_sec, requested + 5.0)
+            return base_timeout
+        return max(base_timeout, requested + 5.0)
+
+    @staticmethod
+    def _finite_positive_timeout(value: Any) -> float | None:
+        try:
+            timeout = float(value or 0)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(timeout) or timeout <= 0:
+            return None
+        return timeout
 
     def _fake_template_reply(self, request: dict[str, Any]) -> dict[str, Any]:
         runtime = str(request.get("runtime") or "vz_linux").strip().lower() or "vz_linux"
@@ -314,6 +344,94 @@ class MacOSVirtualizationHelperClient:
     def _network_policy_error_code(network_policy: str) -> str:
         """Return the stable helper error code for an unsupported normalized network policy."""
         return "strict_allowlist_not_supported" if network_policy == "allowlist" else "unsupported_network_policy"
+
+    @classmethod
+    def _validate_exec_guest_request(
+        cls,
+        request: dict[str, Any],
+    ) -> tuple[list[str], str, dict[str, str], float]:
+        if not isinstance(request, dict):
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+
+        if "argv" not in request:
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+        raw_argv = request["argv"]
+        if not isinstance(raw_argv, list) or any(not isinstance(item, str) for item in raw_argv):
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+        argv = list(raw_argv)
+
+        raw_cwd = request.get("cwd", _EXEC_WORKSPACE_ROOT)
+        if not isinstance(raw_cwd, str):
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+        cwd = raw_cwd
+
+        raw_env = request.get("env", {})
+        if not isinstance(raw_env, dict):
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+        if any(not isinstance(key, str) or not isinstance(value, str) for key, value in raw_env.items()):
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+        env = dict(raw_env)
+
+        raw_timeout_sec = request.get("timeout_sec", _DEFAULT_EXEC_TIMEOUT_SEC)
+        if isinstance(raw_timeout_sec, bool) or not isinstance(raw_timeout_sec, (int, float)):
+            raise MacOSVirtualizationHelperFailure("invalid_request", "invalid_request")
+        timeout_sec = float(raw_timeout_sec)
+
+        cls._validate_exec_argv(argv)
+        cls._validate_exec_cwd(cwd)
+        cls._validate_exec_env(env)
+        cls._validate_exec_timeout(timeout_sec)
+        return argv, cwd, env, timeout_sec
+
+    @staticmethod
+    def _validate_exec_argv(argv: list[str]) -> None:
+        if not argv:
+            raise MacOSVirtualizationHelperFailure("exec_argv_invalid", "argv_required")
+        if len(argv) > _MAX_EXEC_ARGV_COUNT:
+            raise MacOSVirtualizationHelperFailure("exec_argv_invalid", "argv_too_large")
+        total_bytes = 0
+        for argument in argv:
+            if not argument:
+                raise MacOSVirtualizationHelperFailure("exec_argv_invalid", "argv_empty_argument")
+            if "\x00" in argument:
+                raise MacOSVirtualizationHelperFailure("exec_argv_invalid", "argv_invalid")
+            total_bytes += len(argument.encode("utf-8"))
+            if total_bytes > _MAX_EXEC_ARGV_BYTES:
+                raise MacOSVirtualizationHelperFailure("exec_argv_invalid", "argv_too_large")
+
+    @staticmethod
+    def _validate_exec_cwd(cwd: str) -> None:
+        if (
+            not cwd
+            or "\x00" in cwd
+            or (cwd != _EXEC_WORKSPACE_ROOT and not cwd.startswith(f"{_EXEC_WORKSPACE_ROOT}/"))
+            or ".." in cwd.split("/")
+        ):
+            raise MacOSVirtualizationHelperFailure("exec_cwd_invalid", "cwd_outside_workspace")
+
+    @staticmethod
+    def _validate_exec_env(env: dict[str, str]) -> None:
+        if len(env) > _MAX_EXEC_ENV_COUNT:
+            raise MacOSVirtualizationHelperFailure("exec_env_invalid", "env_too_large")
+        total_bytes = 0
+        for key, value in env.items():
+            if (
+                not key
+                or "=" in key
+                or "\x00" in key
+                or any(ord(character) < 0x20 or ord(character) == 0x7F for character in key)
+            ):
+                raise MacOSVirtualizationHelperFailure("exec_env_invalid", "env_key_invalid")
+            if "\x00" in value:
+                raise MacOSVirtualizationHelperFailure("exec_env_invalid", "env_value_invalid")
+            total_bytes += len(key.encode("utf-8")) + len(value.encode("utf-8"))
+            if total_bytes > _MAX_EXEC_ENV_BYTES:
+                raise MacOSVirtualizationHelperFailure("exec_env_invalid", "env_too_large")
+
+    @staticmethod
+    def _validate_exec_timeout(timeout_sec: float) -> None:
+        if not math.isfinite(timeout_sec) or timeout_sec <= 0 or timeout_sec > _MAX_EXEC_TIMEOUT_SEC:
+            raise MacOSVirtualizationHelperFailure("exec_timeout_invalid", "timeout_out_of_range")
 
     @staticmethod
     def _read_response(client: socket.socket) -> dict[str, Any]:

--- a/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
@@ -28,6 +28,7 @@ class _FakeClientSocket:
         self._responses = responses
         self._requests = requests
         self._buffer = b""
+        self._timeout: float | None = None
 
     def __enter__(self) -> "_FakeClientSocket":
         return self
@@ -36,7 +37,7 @@ class _FakeClientSocket:
         self.close()
 
     def settimeout(self, timeout: float) -> None:
-        del timeout
+        self._timeout = timeout
 
     def connect(self, path: str) -> None:
         if path != self._socket_path:
@@ -44,6 +45,7 @@ class _FakeClientSocket:
 
     def sendall(self, payload: bytes) -> None:
         request = json.loads(payload.decode("utf-8").strip())
+        request["_socket_timeout"] = self._timeout
         self._requests.append(request)
         operation = str(request["operation"])
         response = self._responses[operation]
@@ -154,6 +156,25 @@ def test_fake_helper_supports_vz_linux_vm_create_and_exec(monkeypatch) -> None:
     assert exec_reply.exit_code == 0
     assert exec_reply.stdout == b"ok\n"
     assert exec_reply.details["vm_id"] == "vz-linux-run-1"
+
+
+def test_fake_helper_rejects_invalid_exec_guest_contract(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+
+    client = MacOSVirtualizationHelperClient()
+    invalid_requests = [
+        ({"argv": [], "cwd": "/workspace"}, "exec_argv_invalid"),
+        ({"argv": ["/bin/echo", ""], "cwd": "/workspace"}, "exec_argv_invalid"),
+        ({"argv": ["/bin/echo"], "cwd": "/tmp"}, "exec_cwd_invalid"),
+        ({"argv": ["/bin/echo"], "cwd": "/workspace/../tmp"}, "exec_cwd_invalid"),
+        ({"argv": ["/bin/echo"], "cwd": "/workspace", "env": {"BAD=KEY": "1"}}, "exec_env_invalid"),
+        ({"argv": ["/bin/echo"], "cwd": "/workspace", "timeout_sec": 0}, "exec_timeout_invalid"),
+    ]
+
+    for request, expected_code in invalid_requests:
+        with pytest.raises(MacOSVirtualizationHelperFailure) as exc_info:
+            client.exec_guest(vm_id="vm-test", request=request)
+        assert exc_info.value.error_code == expected_code
 
 
 def test_helper_create_vm_fails_closed_without_test_mode(monkeypatch) -> None:
@@ -509,6 +530,40 @@ def test_socket_helper_supports_ping_validate_create_exec_status_and_terminate(m
     assert requests[2]["request"]["template_id"] == "vz_linux:debian-bookworm-arm64"
     assert requests[2]["request"]["run_manifest_path"] == "/tmp/image-store/runs/run-1/manifest.json"
     assert requests[2]["request"]["planning_source"] == "image_store"
+    assert requests[3]["_socket_timeout"] == 35.0
+
+
+def test_socket_helper_treats_non_finite_exec_timeout_as_missing(monkeypatch) -> None:
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    responses = [
+        {
+            "protocol_version": "1",
+            "helper_version": "0.1.0",
+            "exit_code": 0,
+            "stdout": "ok\n",
+            "stderr": "",
+            "details": {"vm_id": "vm-transport-1", "transport": "vsock"},
+        },
+        {
+            "protocol_version": "1",
+            "helper_version": "0.1.0",
+            "exit_code": 0,
+            "stdout": "ok\n",
+            "stderr": "",
+            "details": {"vm_id": "vm-transport-1", "transport": "vsock"},
+        },
+    ]
+    requests = _install_fake_helper_socket(monkeypatch, responses={"exec_guest": responses})
+
+    client = MacOSVirtualizationHelperClient()
+
+    for raw_timeout in ("inf", "nan"):
+        client.exec_guest(
+            vm_id="vm-transport-1",
+            request={"argv": ["/bin/echo", "ok"], "timeout_sec": raw_timeout},
+        )
+
+    assert [request["_socket_timeout"] for request in requests] == [35.0, 35.0]
 
 
 def test_socket_helper_raises_protocol_error_for_mismatched_protocol(monkeypatch) -> None:

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -162,6 +162,63 @@ Response:
 }
 ```
 
+### `exec_guest`
+
+Request:
+
+```json
+{
+  "operation": "exec_guest",
+  "protocol_version": "1",
+  "request": {
+    "vm_id": "run-123",
+    "argv": ["/bin/echo", "ok"],
+    "cwd": "/workspace",
+    "env": {
+      "PATH": "/usr/local/bin:/usr/bin:/bin"
+    },
+    "timeout_sec": 30
+  }
+}
+```
+
+`vm_id` and `argv` are required. `cwd` defaults to `/workspace`, `env` defaults
+to an empty object, and `timeout_sec` defaults to `30`.
+
+The helper enforces this request contract before forwarding execution to the
+guest agent:
+
+- `argv` must be a non-empty string array, cannot contain empty or NUL-bearing
+  arguments, and is capped at 128 arguments / 32 KiB total argument text.
+- `cwd` must lexically remain under `/workspace` and cannot contain `..` path
+  components. This is a helper protocol boundary, not a full guest filesystem
+  authorization model.
+- `env` must be a string-to-string object with at most 128 entries / 32 KiB
+  total text. Keys must be non-empty and cannot contain `=`, NUL, or control
+  characters. Values cannot contain NUL.
+- `timeout_sec` must be finite, positive, and no greater than 3600 seconds.
+
+Malformed JSON shape or missing required fields returns `invalid_request`.
+Semantic contract denials return one of `exec_argv_invalid`, `exec_cwd_invalid`,
+`exec_env_invalid`, or `exec_timeout_invalid`; the `message` field contains the
+stable reason.
+
+Response:
+
+```json
+{
+  "protocol_version": "1",
+  "helper_version": "0.1.0",
+  "exit_code": 0,
+  "stdout": "ok\n",
+  "stderr": "",
+  "details": {
+    "transport": "vsock",
+    "vm_id": "run-123"
+  }
+}
+```
+
 ### `validate_template`
 
 ```json

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -7,9 +7,21 @@ struct HostFacts {
 
 enum HelperServiceError: Error {
     case unsupportedNetworkPolicy(String)
+    case invalidExecArgv(String)
+    case invalidExecCwd(String)
+    case invalidExecEnv(String)
+    case invalidExecTimeout(String)
 }
 
 final class HelperService {
+    private static let execWorkspaceRoot = "/workspace"
+    private static let execWorkspaceRootPrefix = execWorkspaceRoot + "/"
+    private static let maxExecArgvCount = 128
+    private static let maxExecArgvBytes = 32 * 1024
+    private static let maxExecEnvCount = 128
+    private static let maxExecEnvBytes = 32 * 1024
+    private static let maxExecTimeoutSeconds: TimeInterval = 3_600
+
     private let protocolVersion = "1"
     private let helperVersion = "0.1.0"
     private let hostFacts: HostFacts
@@ -157,6 +169,12 @@ final class HelperService {
         env: [String: String],
         timeoutSeconds: TimeInterval
     ) throws -> HelperExecResponse {
+        try validateExecGuestContract(
+            argv: argv,
+            cwd: cwd,
+            env: env,
+            timeoutSeconds: timeoutSeconds
+        )
         let result = try vmManager.execGuest(
             vmID: vmID,
             argv: argv,
@@ -218,5 +236,91 @@ final class HelperService {
             "transport": "vsock",
             "network_policy": record.metadata.networkPolicy.isEmpty ? "deny_all" : record.metadata.networkPolicy,
         ]
+    }
+
+    private func validateExecGuestContract(
+        argv: [String],
+        cwd: String,
+        env: [String: String],
+        timeoutSeconds: TimeInterval
+    ) throws {
+        try validateExecArgv(argv)
+        try validateExecCwd(cwd)
+        try validateExecEnv(env)
+        try validateExecTimeout(timeoutSeconds)
+    }
+
+    private func validateExecArgv(_ argv: [String]) throws {
+        guard !argv.isEmpty else {
+            throw HelperServiceError.invalidExecArgv("argv_required")
+        }
+        guard argv.count <= Self.maxExecArgvCount else {
+            throw HelperServiceError.invalidExecArgv("argv_too_large")
+        }
+        var totalBytes = 0
+        for argument in argv {
+            guard !argument.isEmpty else {
+                throw HelperServiceError.invalidExecArgv("argv_empty_argument")
+            }
+            guard !containsNUL(argument) else {
+                throw HelperServiceError.invalidExecArgv("argv_invalid")
+            }
+            totalBytes += argument.utf8.count
+            guard totalBytes <= Self.maxExecArgvBytes else {
+                throw HelperServiceError.invalidExecArgv("argv_too_large")
+            }
+        }
+    }
+
+    private func validateExecCwd(_ cwd: String) throws {
+        guard !cwd.isEmpty,
+              !containsNUL(cwd),
+              cwd == Self.execWorkspaceRoot || cwd.hasPrefix(Self.execWorkspaceRootPrefix) else {
+            throw HelperServiceError.invalidExecCwd("cwd_outside_workspace")
+        }
+        let components = cwd.split(separator: "/", omittingEmptySubsequences: true)
+        guard !components.contains("..") else {
+            throw HelperServiceError.invalidExecCwd("cwd_outside_workspace")
+        }
+    }
+
+    private func validateExecEnv(_ env: [String: String]) throws {
+        guard env.count <= Self.maxExecEnvCount else {
+            throw HelperServiceError.invalidExecEnv("env_too_large")
+        }
+        var totalBytes = 0
+        for (key, value) in env {
+            guard !key.isEmpty,
+                  !key.contains("="),
+                  !containsNUL(key),
+                  !containsControlCharacter(key) else {
+                throw HelperServiceError.invalidExecEnv("env_key_invalid")
+            }
+            guard !containsNUL(value) else {
+                throw HelperServiceError.invalidExecEnv("env_value_invalid")
+            }
+            totalBytes += key.utf8.count + value.utf8.count
+            guard totalBytes <= Self.maxExecEnvBytes else {
+                throw HelperServiceError.invalidExecEnv("env_too_large")
+            }
+        }
+    }
+
+    private func validateExecTimeout(_ timeoutSeconds: TimeInterval) throws {
+        guard timeoutSeconds.isFinite,
+              timeoutSeconds > 0,
+              timeoutSeconds <= Self.maxExecTimeoutSeconds else {
+            throw HelperServiceError.invalidExecTimeout("timeout_out_of_range")
+        }
+    }
+
+    private func containsNUL(_ value: String) -> Bool {
+        value.unicodeScalars.contains { $0.value == 0 }
+    }
+
+    private func containsControlCharacter(_ value: String) -> Bool {
+        value.unicodeScalars.contains { scalar in
+            scalar.value < 0x20 || scalar.value == 0x7F
+        }
     }
 }

--- a/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
+++ b/tools/macos-vz-helper/Sources/Server/UnixSocketServer.swift
@@ -196,17 +196,36 @@ final class UnixSocketServer {
                 )
             )
         case "exec_guest":
-            let argv = (request.request["argv"]?.arrayValue ?? []).compactMap { $0.stringValue }
-            let env = request.request["env"]?.objectValue?.compactMapValues { $0.stringValue } ?? [:]
-            return try encoder.encode(
-                try service.execGuest(
-                    vmID: request.request["vm_id"]?.stringValue ?? "",
-                    argv: argv,
-                    cwd: request.request["cwd"]?.stringValue ?? "",
-                    env: env,
-                    timeoutSeconds: TimeInterval(request.request["timeout_sec"]?.intValue ?? 30)
+            do {
+                let vmID = try requiredStringField(request.request, key: "vm_id")
+                let argv = try requiredStringArrayField(request.request, key: "argv")
+                let cwd = try optionalStringField(
+                    request.request,
+                    key: "cwd",
+                    defaultValue: "/workspace"
                 )
-            )
+                let env = try optionalStringDictionaryField(
+                    request.request,
+                    key: "env",
+                    defaultValue: [:]
+                )
+                let timeoutSeconds = try optionalTimeIntervalField(
+                    request.request,
+                    key: "timeout_sec",
+                    defaultValue: 30
+                )
+                return try encoder.encode(
+                    try service.execGuest(
+                        vmID: vmID,
+                        argv: argv,
+                        cwd: cwd,
+                        env: env,
+                        timeoutSeconds: timeoutSeconds
+                    )
+                )
+            } catch {
+                return encodeErrorResponse(for: error)
+            }
         default:
             return try encoder.encode(
                 HelperErrorResponse(
@@ -536,6 +555,76 @@ final class UnixSocketServer {
         return stringValue
     }
 
+    private func requiredStringField(
+        _ request: [String: JSONValue],
+        key: String
+    ) throws -> String {
+        guard let value = request[key] else {
+            throw UnixSocketServerError.invalidRequest
+        }
+        guard let stringValue = value.stringValue else {
+            throw UnixSocketServerError.invalidRequest
+        }
+        return stringValue
+    }
+
+    private func requiredStringArrayField(
+        _ request: [String: JSONValue],
+        key: String
+    ) throws -> [String] {
+        guard let value = request[key] else {
+            throw UnixSocketServerError.invalidRequest
+        }
+        guard let arrayValue = value.arrayValue else {
+            throw UnixSocketServerError.invalidRequest
+        }
+        return try arrayValue.map { item in
+            guard let stringValue = item.stringValue else {
+                throw UnixSocketServerError.invalidRequest
+            }
+            return stringValue
+        }
+    }
+
+    private func optionalStringDictionaryField(
+        _ request: [String: JSONValue],
+        key: String,
+        defaultValue: [String: String]
+    ) throws -> [String: String] {
+        guard let value = request[key] else {
+            return defaultValue
+        }
+        guard let objectValue = value.objectValue else {
+            throw UnixSocketServerError.invalidRequest
+        }
+        var parsed: [String: String] = [:]
+        for (envKey, envValue) in objectValue {
+            guard let stringValue = envValue.stringValue else {
+                throw UnixSocketServerError.invalidRequest
+            }
+            parsed[envKey] = stringValue
+        }
+        return parsed
+    }
+
+    private func optionalTimeIntervalField(
+        _ request: [String: JSONValue],
+        key: String,
+        defaultValue: TimeInterval
+    ) throws -> TimeInterval {
+        guard let value = request[key] else {
+            return defaultValue
+        }
+        switch value {
+        case .int(let intValue):
+            return TimeInterval(intValue)
+        case .double(let doubleValue):
+            return TimeInterval(doubleValue)
+        default:
+            throw UnixSocketServerError.invalidRequest
+        }
+    }
+
     private func errorCode(for error: Error) -> String {
         switch error {
         case UnixSocketServerError.invalidRequest, is DecodingError:
@@ -548,6 +637,14 @@ final class UnixSocketServer {
             return "unsupported_operation"
         case HelperServiceError.unsupportedNetworkPolicy(let policy):
             return policy == "allowlist" ? "strict_allowlist_not_supported" : "unsupported_network_policy"
+        case HelperServiceError.invalidExecArgv:
+            return "exec_argv_invalid"
+        case HelperServiceError.invalidExecCwd:
+            return "exec_cwd_invalid"
+        case HelperServiceError.invalidExecEnv:
+            return "exec_env_invalid"
+        case HelperServiceError.invalidExecTimeout:
+            return "exec_timeout_invalid"
         case VZLinuxVMManagerError.bootNotImplemented:
             return "boot_not_implemented"
         case GuestBridgeError.guestReadinessNotImplemented:
@@ -582,6 +679,11 @@ final class UnixSocketServer {
             return "invalid_request"
         case HelperServiceError.unsupportedNetworkPolicy(let policy):
             return policy
+        case HelperServiceError.invalidExecArgv(let reason),
+             HelperServiceError.invalidExecCwd(let reason),
+             HelperServiceError.invalidExecEnv(let reason),
+             HelperServiceError.invalidExecTimeout(let reason):
+            return reason
         default:
             return String(describing: error)
         }

--- a/tools/macos-vz-helper/Tests/HelperServiceExecTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceExecTests.swift
@@ -57,3 +57,84 @@ final class RecordingGuestBridge: GuestBridging {
     #expect(guestBridge.lastExec?.env == ["FOO": "1"])
     #expect(guestBridge.lastExec?.timeout == 15)
 }
+
+@Test func helperServiceExecGuestRejectsInvalidCommandContract() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: RecordingGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    _ = try service.createVM(
+        vmID: "vm-exec-contract",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/workspace",
+        readinessTimeoutSeconds: 5
+    )
+
+    do {
+        _ = try service.execGuest(
+            vmID: "vm-exec-contract",
+            argv: [],
+            cwd: "/workspace",
+            env: [:],
+            timeoutSeconds: 15
+        )
+        Issue.record("expected empty argv to be rejected")
+    } catch HelperServiceError.invalidExecArgv(let reason) {
+        #expect(reason == "argv_required")
+    } catch {
+        Issue.record("expected invalidExecArgv, got \(error)")
+    }
+
+    do {
+        _ = try service.execGuest(
+            vmID: "vm-exec-contract",
+            argv: ["/bin/echo"],
+            cwd: "/tmp",
+            env: [:],
+            timeoutSeconds: 15
+        )
+        Issue.record("expected cwd outside workspace to be rejected")
+    } catch HelperServiceError.invalidExecCwd(let reason) {
+        #expect(reason == "cwd_outside_workspace")
+    } catch {
+        Issue.record("expected invalidExecCwd, got \(error)")
+    }
+
+    do {
+        _ = try service.execGuest(
+            vmID: "vm-exec-contract",
+            argv: ["/bin/echo"],
+            cwd: "/workspace",
+            env: ["BAD=KEY": "1"],
+            timeoutSeconds: 15
+        )
+        Issue.record("expected invalid env key to be rejected")
+    } catch HelperServiceError.invalidExecEnv(let reason) {
+        #expect(reason == "env_key_invalid")
+    } catch {
+        Issue.record("expected invalidExecEnv, got \(error)")
+    }
+
+    do {
+        _ = try service.execGuest(
+            vmID: "vm-exec-contract",
+            argv: ["/bin/echo"],
+            cwd: "/workspace",
+            env: [:],
+            timeoutSeconds: 0
+        )
+        Issue.record("expected non-positive timeout to be rejected")
+    } catch HelperServiceError.invalidExecTimeout(let reason) {
+        #expect(reason == "timeout_out_of_range")
+    } catch {
+        Issue.record("expected invalidExecTimeout, got \(error)")
+    }
+}

--- a/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
+++ b/tools/macos-vz-helper/Tests/UnixSocketServerTests.swift
@@ -50,7 +50,7 @@ import Testing
     #expect(createJSON?["state"] as? String == "running")
 
     let execRequest = """
-    {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-route","argv":["/bin/echo","ok"],"cwd":"/workspace","timeout_sec":15}}
+    {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-route","argv":["/bin/echo","ok"],"cwd":"/workspace","timeout_sec":15.5}}
     """.data(using: .utf8)!
     let execResponseData = try server.handleRequestData(execRequest)
     let execJSON = try JSONSerialization.jsonObject(with: execResponseData) as? [String: Any]
@@ -59,6 +59,110 @@ import Testing
     #expect(execJSON?["exit_code"] as? Int == 0)
     #expect(execJSON?["stdout"] as? String == "ok\n")
     #expect(guestBridge.lastExec?.vmID == "vm-route")
+    #expect(guestBridge.lastExec?.timeout == 15.5)
+}
+
+@Test func unixSocketServerRejectsMalformedExecGuestRequestShape() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: RecordingGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+    let server = UnixSocketServer(
+        socketPath: "/tmp/macos-vz-helper.sock",
+        service: service
+    )
+
+    let createRequest = """
+    {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-exec-shape","template":"/tmp/template.img","workspace_path":"/workspace"}}
+    """.data(using: .utf8)!
+    _ = try server.handleRequestData(createRequest)
+
+    let malformedRequests = [
+        """
+        {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-shape","argv":"/bin/echo","cwd":"/workspace","timeout_sec":15}}
+        """,
+        """
+        {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-shape","argv":["/bin/echo",1],"cwd":"/workspace","timeout_sec":15}}
+        """,
+        """
+        {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-shape","argv":["/bin/echo"],"cwd":["/workspace"],"timeout_sec":15}}
+        """,
+        """
+        {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-shape","argv":["/bin/echo"],"cwd":"/workspace","env":{"OK":1},"timeout_sec":15}}
+        """,
+        """
+        {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-shape","argv":["/bin/echo"],"cwd":"/workspace","timeout_sec":"15"}}
+        """,
+    ]
+
+    for request in malformedRequests {
+        let responseData = try server.handleRequestData(request.data(using: .utf8)!)
+        let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+        #expect(json?["error_code"] as? String == "invalid_request")
+    }
+}
+
+@Test func unixSocketServerRejectsInvalidExecGuestContract() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: RecordingGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+    let server = UnixSocketServer(
+        socketPath: "/tmp/macos-vz-helper.sock",
+        service: service
+    )
+
+    let createRequest = """
+    {"operation":"create_vm","protocol_version":"1","request":{"vm_name":"vm-exec-contract","template":"/tmp/template.img","workspace_path":"/workspace"}}
+    """.data(using: .utf8)!
+    _ = try server.handleRequestData(createRequest)
+
+    let invalidRequestsAndCodes = [
+        (
+            """
+            {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-contract","argv":[],"cwd":"/workspace","timeout_sec":15}}
+            """,
+            "exec_argv_invalid"
+        ),
+        (
+            """
+            {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-contract","argv":["/bin/echo"],"cwd":"/workspace/../tmp","timeout_sec":15}}
+            """,
+            "exec_cwd_invalid"
+        ),
+        (
+            """
+            {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-contract","argv":["/bin/echo"],"cwd":"/workspace","env":{"BAD=KEY":"1"},"timeout_sec":15}}
+            """,
+            "exec_env_invalid"
+        ),
+        (
+            """
+            {"operation":"exec_guest","protocol_version":"1","request":{"vm_id":"vm-exec-contract","argv":["/bin/echo"],"cwd":"/workspace","timeout_sec":0}}
+            """,
+            "exec_timeout_invalid"
+        ),
+    ]
+
+    for (request, expectedCode) in invalidRequestsAndCodes {
+        let responseData = try server.handleRequestData(request.data(using: .utf8)!)
+        let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+        #expect(json?["error_code"] as? String == expectedCode)
+    }
 }
 
 @Test func unixSocketServerForwardsCreateVMOwnershipMetadata() throws {


### PR DESCRIPTION
## Summary
- Harden the macOS VZ helper `exec_guest` contract at the Swift helper boundary with explicit argv, cwd, env, and timeout validation.
- Reject malformed socket request shapes with `invalid_request` and return stable semantic denial codes for invalid exec contract fields.
- Mirror the same contract in the Python TEST_MODE fake helper and document the protocol limits/reason codes.

## Change summary
Human-written summary to be added before merge.

## Test plan
- [x] `swift test --package-path tools/macos-vz-helper`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py tldw_Server_API/tests/sandbox/test_macos_runtime_admission.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py -f json -o /tmp/bandit_vz_exec_guest_contract.json`
- [x] `git diff --check`
