### PR TITLE
fix(persona): surface wake rejection diagnostics

### DIFF
--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -357,6 +357,92 @@ describe("usePersonaLiveVoiceController", () => {
     expect(hookMocks.micStart).not.toHaveBeenCalled()
   })
 
+  it("surfaces a profile-specific wake rejection reason from the server", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+
+    act(() => {
+      wakeHarness.fireWake("runtime only")
+    })
+
+    act(() => {
+      result.current.handlePayload({
+        event: "notice",
+        reason_code: "WAKE_ACTIVATION_REJECTED",
+        wake_rejection_reason: "not_saved_in_profile",
+        message: "Wake activation was rejected for this persona session."
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.wakeWarning).toMatch(/saved trigger phrase/i)
+    })
+    expect(result.current.wakeArmed).toBe(true)
+  })
+
+  it("surfaces a runtime wake configuration rejection reason from the server", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => wakeHarness.detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+
+    act(() => {
+      wakeHarness.fireWake("hey helper")
+    })
+
+    act(() => {
+      result.current.handlePayload({
+        event: "notice",
+        reason_code: "WAKE_ACTIVATION_REJECTED",
+        wake_rejection_reason: "missing_from_runtime_config",
+        message: "Wake activation was rejected for this persona session."
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.wakeWarning).toMatch(/live voice configuration/i)
+    })
+    expect(result.current.wakeArmed).toBe(true)
+  })
+
   it("sends wake deactivation when wake listening is disarmed", async () => {
     const wakeHarness = createWakeDetectorHarness()
     const ws = {

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -101,6 +101,32 @@ const formatActiveToolStatus = (tool: unknown, why: unknown): string => {
   return `Running ${toolName}: ${whyText}`
 }
 
+const formatWakeActivationRejectedMessage = (
+  payload: PersonaLiveVoicePayload
+): string => {
+  const reason = String(payload?.wake_rejection_reason || "").trim()
+  if (reason === "not_saved_in_profile") {
+    return (
+      "Wake phrase was heard, but it is not a saved trigger phrase for this " +
+      "persona. Add it to the selected persona's trigger phrases, then arm " +
+      "wake listening again."
+    )
+  }
+  if (reason === "missing_from_runtime_config") {
+    return (
+      "Wake phrase was heard, but the live voice configuration did not load " +
+      "that saved trigger phrase. Reconnect Persona Live or save voice defaults again."
+    )
+  }
+  if (reason === "phrase_not_configured") {
+    return (
+      "Wake phrase was heard, but it is not configured for this Persona Live " +
+      "session. Check the selected persona's saved trigger phrases."
+    )
+  }
+  return String(payload?.message || "Wake activation was rejected.")
+}
+
 export const usePersonaLiveVoiceController = ({
   ws,
   connected,
@@ -670,7 +696,9 @@ export const usePersonaLiveVoiceController = ({
     ws
   ])
 
-  const startWakeListening = React.useCallback(async () => {
+  const startWakeListening = React.useCallback(async (
+    options: { preserveWarning?: boolean } = {}
+  ) => {
     const phrases = (wakeTriggerPhrases || [])
       .map((phrase) => String(phrase || "").trim())
       .filter(Boolean)
@@ -685,7 +713,9 @@ export const usePersonaLiveVoiceController = ({
     wakeArmedRef.current = true
     wakeActiveRef.current = false
     setWakeArmed(true)
-    setWakeWarning(null)
+    if (!options.preserveWarning) {
+      setWakeWarning(null)
+    }
     setWakeDetectorState("starting")
 
     const detector = wakeDetectorFactory?.() || new BrowserTranscriptWakeDetector()
@@ -1164,9 +1194,9 @@ export const usePersonaLiveVoiceController = ({
         }
         if (reasonCode === "WAKE_ACTIVATION_REJECTED") {
           wakeActiveRef.current = false
-          setWakeWarning(String(payload?.message || "Wake activation was rejected."))
+          setWakeWarning(formatWakeActivationRejectedMessage(payload))
           if (wakeArmedRef.current) {
-            void startWakeListening()
+            void startWakeListening({ preserveWarning: true })
           }
           return
         }

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -101,30 +101,27 @@ const formatActiveToolStatus = (tool: unknown, why: unknown): string => {
   return `Running ${toolName}: ${whyText}`
 }
 
+const WAKE_REJECTION_MESSAGES: Record<string, string> = {
+  not_saved_in_profile:
+    "Wake phrase was heard, but it is not a saved trigger phrase for this " +
+    "persona. Add it to the selected persona's trigger phrases, then arm " +
+    "wake listening again.",
+  missing_from_runtime_config:
+    "Wake phrase was heard, but the live voice configuration did not load " +
+    "that saved trigger phrase. Reconnect Persona Live or save voice defaults again.",
+  phrase_not_configured:
+    "Wake phrase was heard, but it is not configured for this Persona Live " +
+    "session. Check the selected persona's saved trigger phrases."
+}
+
 const formatWakeActivationRejectedMessage = (
   payload: PersonaLiveVoicePayload
 ): string => {
   const reason = String(payload?.wake_rejection_reason || "").trim()
-  if (reason === "not_saved_in_profile") {
-    return (
-      "Wake phrase was heard, but it is not a saved trigger phrase for this " +
-      "persona. Add it to the selected persona's trigger phrases, then arm " +
-      "wake listening again."
-    )
-  }
-  if (reason === "missing_from_runtime_config") {
-    return (
-      "Wake phrase was heard, but the live voice configuration did not load " +
-      "that saved trigger phrase. Reconnect Persona Live or save voice defaults again."
-    )
-  }
-  if (reason === "phrase_not_configured") {
-    return (
-      "Wake phrase was heard, but it is not configured for this Persona Live " +
-      "session. Check the selected persona's saved trigger phrases."
-    )
-  }
-  return String(payload?.message || "Wake activation was rejected.")
+  return (
+    WAKE_REJECTION_MESSAGES[reason] ||
+    String(payload?.message || "Wake activation was rejected.")
+  )
 }
 
 export const usePersonaLiveVoiceController = ({

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -7096,28 +7096,15 @@ async def persona_stream(
                 runtime_match = _match_persona_wake_phrase(matched_phrase, runtime_phrases)
                 if not saved_match or not runtime_match:
                     wake_rejection_reason = "phrase_not_configured"
-                    wake_rejection_message = (
-                        "Wake activation was rejected for this persona session."
-                    )
                     if not saved_match and runtime_match:
                         wake_rejection_reason = "not_saved_in_profile"
-                        wake_rejection_message = (
-                            "Wake phrase is not saved on this persona profile. "
-                            "Add it to the selected persona's trigger phrases before "
-                            "arming wake listening."
-                        )
                     elif saved_match and not runtime_match:
                         wake_rejection_reason = "missing_from_runtime_config"
-                        wake_rejection_message = (
-                            "Wake phrase is saved on the profile, but this live "
-                            "session did not load it. Reconnect Persona Live or save "
-                            "voice defaults again."
-                        )
                     await _emit_notice(
                         session_id=session_id,
                         level="warning",
                         reason_code="WAKE_ACTIVATION_REJECTED",
-                        message=wake_rejection_message,
+                        message="Wake activation was rejected for this persona session.",
                         wake_rejection_reason=wake_rejection_reason,
                     )
                     continue

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -7095,11 +7095,30 @@ async def persona_stream(
                 saved_match = _match_persona_wake_phrase(matched_phrase, saved_phrases)
                 runtime_match = _match_persona_wake_phrase(matched_phrase, runtime_phrases)
                 if not saved_match or not runtime_match:
+                    wake_rejection_reason = "phrase_not_configured"
+                    wake_rejection_message = (
+                        "Wake activation was rejected for this persona session."
+                    )
+                    if not saved_match and runtime_match:
+                        wake_rejection_reason = "not_saved_in_profile"
+                        wake_rejection_message = (
+                            "Wake phrase is not saved on this persona profile. "
+                            "Add it to the selected persona's trigger phrases before "
+                            "arming wake listening."
+                        )
+                    elif saved_match and not runtime_match:
+                        wake_rejection_reason = "missing_from_runtime_config"
+                        wake_rejection_message = (
+                            "Wake phrase is saved on the profile, but this live "
+                            "session did not load it. Reconnect Persona Live or save "
+                            "voice defaults again."
+                        )
                     await _emit_notice(
                         session_id=session_id,
                         level="warning",
                         reason_code="WAKE_ACTIVATION_REJECTED",
-                        message="Wake activation was rejected for this persona session.",
+                        message=wake_rejection_message,
+                        wake_rejection_reason=wake_rejection_reason,
                     )
                     continue
 

--- a/tldw_Server_API/tests/Persona/test_persona_ws.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws.py
@@ -2444,6 +2444,7 @@ def _assert_wake_activation_rejected_keeps_trigger_gate(
     expected_rejection_reason: str,
     wake_behavior: str = "one_shot",
 ) -> None:
+    """Assert rejected wake phrases keep trigger gating and emit the expected reason."""
     _install_wake_voice_fakes(monkeypatch, "summarize the current note")
     _seed_persona_session(
         tmp_path,

--- a/tldw_Server_API/tests/Persona/test_persona_ws.py
+++ b/tldw_Server_API/tests/Persona/test_persona_ws.py
@@ -2441,6 +2441,7 @@ def _assert_wake_activation_rejected_keeps_trigger_gate(
     saved_phrases: list[str],
     runtime_phrases: list[str],
     matched_phrase: str,
+    expected_rejection_reason: str,
     wake_behavior: str = "one_shot",
 ) -> None:
     _install_wake_voice_fakes(monkeypatch, "summarize the current note")
@@ -2495,6 +2496,7 @@ def _assert_wake_activation_rejected_keeps_trigger_gate(
                 and d.get("reason_code") == "WAKE_ACTIVATION_REJECTED",
             )
             assert rejected.get("session_id") == session_id
+            assert rejected.get("wake_rejection_reason") == expected_rejection_reason
             ws.send_text(
                 json.dumps(
                     {
@@ -2524,6 +2526,7 @@ def test_persona_wake_activation_rejects_phrase_not_saved_in_profile(
         saved_phrases=["hey helper"],
         runtime_phrases=["runtime only"],
         matched_phrase="runtime only",
+        expected_rejection_reason="not_saved_in_profile",
     )
 
 
@@ -2538,6 +2541,7 @@ def test_persona_wake_activation_rejects_phrase_missing_from_runtime_config(
         saved_phrases=["hey helper"],
         runtime_phrases=["okay helper"],
         matched_phrase="hey helper",
+        expected_rejection_reason="missing_from_runtime_config",
     )
 
 
@@ -3558,6 +3562,7 @@ def test_persona_voice_config_stores_runtime_preferences(monkeypatch):
         "trigger_phrases": ["hey helper", "ok helper"],
         "auto_resume": True,
         "barge_in": False,
+        "wake_behavior": "one_shot",
         "stt_language": "en-US",
         "stt_model": "whisper-1",
         "enable_vad": True,


### PR DESCRIPTION
## Change summary

TODO (human): Replace this with a human-owned summary explaining what changed and why these implementation choices were made.

## What changed

- Added structured `wake_rejection_reason` metadata to rejected Persona Live wake activations.
- Mapped wake rejection reasons in the Persona Live controller to actionable user-facing wake warnings.
- Preserved wake warnings while automatically restarting wake listening after a rejection.
- Updated persona websocket coverage for the current `wake_behavior` runtime payload.

## Verification

- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_ws.py -q`
- `bun run test src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx`
- `git diff --check`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/persona.py -f json -o /private/tmp/bandit_persona_wake_diagnostics.json`
