### PR TITLE
Enforce vz_linux guest output caps

### DIFF
--- a/Docs/superpowers/plans/2026-05-02-vz-guest-output-cap.md
+++ b/Docs/superpowers/plans/2026-05-02-vz-guest-output-cap.md
@@ -1,0 +1,714 @@
+# VZ Linux Guest Output Cap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce `vz_linux` output caps inside the Linux guest agent, forward the cap through the Swift helper bridge, and surface guest-side enforcement metadata without changing the public sandbox API.
+
+**Architecture:** Keep the existing Python-to-helper `exec_guest` contract and the existing guest request/response protocol shape. Python continues to choose the cap, Swift validates and forwards it, and the Go guest agent owns bounded capture plus process termination. Swift keeps host-side response capping as defense in depth and Python parses guest-prefixed counters defensively.
+
+**Tech Stack:** Go guest agent (`tools/tldw-agent`), Swift Package helper (`tools/macos-vz-helper`), Python sandbox runner/client (`tldw_Server_API/app/core/Sandbox`), pytest, Go test, Swift test.
+
+---
+
+## Preconditions
+
+- Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/vz-guest-output-cap`
+- Branch: `codex/vz-guest-output-cap`
+- Spec: `Docs/superpowers/specs/2026-05-02-vz-guest-output-cap-design.md`
+- Python venv for this nested worktree: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv`
+- Root checkout has unrelated dirty state in `Docs/Design/Agents.md`; do not touch or revert it from this worktree.
+
+## File Map
+
+- Modify: `tools/tldw-agent/internal/guest/types.go`
+  - Add `MaxOutputBytes *int` and `Details map[string]string` to guest exec request/response.
+- Modify: `tools/tldw-agent/internal/guest/exec.go`
+  - Replace unbounded `bytes.Buffer` capture with pipe-based bounded capture and output-limit cancellation.
+- Create: `tools/tldw-agent/internal/guest/process_linux.go`
+  - Linux process-group setup and termination helpers.
+- Create: `tools/tldw-agent/internal/guest/process_unsupported.go`
+  - Portable fallback process termination helpers for non-Linux builds.
+- Modify: `tools/tldw-agent/internal/guest/exec_test.go`
+  - Add unit coverage for cap enforcement, direct cap validation, UTF-8 safety, timeout distinction, and noisy-process cleanup.
+- Modify: `tools/tldw-agent/internal/guest/types_test.go`
+  - Add JSON parse/encode coverage for omitted, valid, and invalid `max_output_bytes`.
+- Modify: `tools/tldw-agent/docs/vz-linux-guest-protocol.md`
+  - Document guest `max_output_bytes` and guest-prefixed response details.
+- Modify: `tools/macos-vz-helper/Sources/Guest/VSockBridge.swift`
+  - Forward `maxOutputBytes`, decode guest details defensively, and expose details on `GuestExecResult`.
+- Modify: `tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift`
+  - Thread `maxOutputBytes` through to `GuestBridging.exec`.
+- Modify: `tools/macos-vz-helper/Sources/Server/HelperService.swift`
+  - Pass validated cap to `vmManager.execGuest` and merge only guest-prefixed detail values.
+- Modify: `tools/macos-vz-helper/Tests/TestDoubles.swift`
+  - Update test doubles for the new `GuestBridging.exec` signature.
+- Modify: `tools/macos-vz-helper/Tests/VSockBridgeTests.swift`
+  - Add request encoding and detail decoding tests.
+- Modify: `tools/macos-vz-helper/Tests/HelperServiceExecTests.swift`
+  - Add cap forwarding and guest/host detail merge tests.
+- Modify: `tools/macos-vz-helper/PROTOCOL.md`
+  - Update helper protocol wording from host-only cap to guest-forwarded cap plus host fallback.
+- Modify: `tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
+  - Add guest-prefixed output counters to `_OUTPUT_COUNTER_KEYS`.
+- Modify: `tldw_Server_API/tests/sandbox/test_vz_linux_runner.py`
+  - Add defensive parsing/resource usage tests for guest counters.
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py`
+  - Add helper-client detail pass-through tests only if current coverage does not already assert it.
+- Modify: `tools/vz-linux-image/README.md`
+  - Note that guest kill-on-cap requires rebuilding images with the updated `tldw-agent-guest`.
+
+## Task 1: Go Guest Protocol Shape
+
+**Files:**
+- Modify: `tools/tldw-agent/internal/guest/types.go`
+- Modify: `tools/tldw-agent/internal/guest/types_test.go`
+
+- [ ] **Step 1: Write failing type tests**
+
+Add tests covering omitted cap, valid cap, and explicit zero:
+
+```go
+func TestExecRequestMaxOutputBytesOptional(t *testing.T) {
+	var req ExecRequest
+	if err := json.Unmarshal([]byte(`{"protocol_version":"1","request_id":"req-1","type":"exec","argv":["/bin/echo","ok"]}`), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.MaxOutputBytes != nil {
+		t.Fatalf("expected nil MaxOutputBytes, got %v", *req.MaxOutputBytes)
+	}
+}
+
+func TestExecRequestMaxOutputBytesPreservesExplicitZero(t *testing.T) {
+	var req ExecRequest
+	if err := json.Unmarshal([]byte(`{"protocol_version":"1","request_id":"req-1","type":"exec","argv":["/bin/echo","ok"],"max_output_bytes":0}`), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.MaxOutputBytes == nil || *req.MaxOutputBytes != 0 {
+		t.Fatalf("expected explicit zero cap, got %#v", req.MaxOutputBytes)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+Run:
+
+```bash
+cd tools/tldw-agent && go test ./internal/guest -run 'TestExecRequestMaxOutputBytes' -count=1
+```
+
+Expected: fail because `ExecRequest.MaxOutputBytes` does not exist.
+
+- [ ] **Step 3: Add request/response fields**
+
+Update `ExecRequest` and `ExecResponse`:
+
+```go
+type ExecRequest struct {
+	ProtocolVersion string            `json:"protocol_version"`
+	RequestID       string            `json:"request_id"`
+	Type            string            `json:"type,omitempty"`
+	Argv            []string          `json:"argv"`
+	Cwd             string            `json:"cwd,omitempty"`
+	Env             map[string]string `json:"env,omitempty"`
+	TimeoutSec      int               `json:"timeout_sec,omitempty"`
+	MaxOutputBytes  *int              `json:"max_output_bytes,omitempty"`
+}
+
+type ExecResponse struct {
+	ProtocolVersion string            `json:"protocol_version"`
+	RequestID       string            `json:"request_id"`
+	ExitCode        int               `json:"exit_code"`
+	Stdout          string            `json:"stdout,omitempty"`
+	Stderr          string            `json:"stderr,omitempty"`
+	Details         map[string]string `json:"details,omitempty"`
+}
+```
+
+- [ ] **Step 4: Verify type tests pass**
+
+Run:
+
+```bash
+cd tools/tldw-agent && go test ./internal/guest -run 'TestExecRequestMaxOutputBytes' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/tldw-agent/internal/guest/types.go tools/tldw-agent/internal/guest/types_test.go
+git commit -m "feat(vz): extend guest exec protocol for output caps"
+```
+
+## Task 2: Go Bounded Capture And Process Termination
+
+**Files:**
+- Modify: `tools/tldw-agent/internal/guest/exec.go`
+- Create: `tools/tldw-agent/internal/guest/process_linux.go`
+- Create: `tools/tldw-agent/internal/guest/process_unsupported.go`
+- Modify: `tools/tldw-agent/internal/guest/exec_test.go`
+
+- [ ] **Step 1: Write failing tests for direct cap validation**
+
+Add tests that call `Server.Exec` with `MaxOutputBytes` set to `0` and `268435457`.
+
+Expected `ErrorResponse`:
+
+```go
+ErrorCode: "invalid_request"
+Message:   "max_output_bytes out of range"
+```
+
+- [ ] **Step 2: Write failing tests for cap exceeded metadata**
+
+Use a shell command that writes more than a small cap:
+
+```go
+capBytes := 16
+resp, execErr := server.Exec(ExecRequest{
+	ProtocolVersion: ProtocolVersion,
+	RequestID:       "req-cap",
+	Type:            "exec",
+	Argv:            []string{"/bin/sh", "-c", "i=0; while [ $i -lt 4096 ]; do printf x; i=$((i+1)); done"},
+	MaxOutputBytes:  &capBytes,
+})
+if execErr != nil {
+	t.Fatalf("Exec() unexpected error = %#v", execErr)
+}
+if len([]byte(resp.Stdout))+len([]byte(resp.Stderr)) > capBytes {
+	t.Fatalf("returned output exceeds cap")
+}
+if resp.ExitCode != 137 {
+	t.Fatalf("expected output-limit exit 137, got %d", resp.ExitCode)
+}
+if resp.Details["guest_output_limit_exceeded"] != "true" {
+	t.Fatalf("expected guest output limit metadata")
+}
+```
+
+If the shell loop is too slow on a platform, use `/usr/bin/yes` with a short timeout and expect the cap cancellation to win.
+
+- [ ] **Step 3: Write failing UTF-8 truncation test**
+
+Use multibyte output such as `printf 'éééé'`, cap to an odd byte count, and assert `utf8.ValidString(resp.Stdout)` and returned bytes are at or under the cap.
+
+- [ ] **Step 4: Run failing Go tests**
+
+Run:
+
+```bash
+cd tools/tldw-agent && go test ./internal/guest -run 'TestGuestExec.*Output|TestGuestExec.*MaxOutput|TestGuestExec.*UTF8' -count=1
+```
+
+Expected: fail because bounded capture is not implemented.
+
+- [ ] **Step 5: Add platform process helpers**
+
+Create `process_linux.go`:
+
+```go
+//go:build linux
+
+package guest
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureCommandProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func terminateCommandProcess(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	if pid > 0 {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}
+	_ = cmd.Process.Kill()
+}
+```
+
+Create `process_unsupported.go`:
+
+```go
+//go:build !linux
+
+package guest
+
+import "os/exec"
+
+func configureCommandProcessGroup(_ *exec.Cmd) {}
+
+func terminateCommandProcess(cmd *exec.Cmd) {
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}
+```
+
+- [ ] **Step 6: Implement bounded capture helper**
+
+In `exec.go`, add a small focused helper with mutex-protected shared state:
+
+```go
+type outputLimitReason string
+
+const (
+	outputLimitReasonNone   outputLimitReason = ""
+	outputLimitReasonOutput outputLimitReason = "output_limit"
+	outputLimitExitCode     int               = 137
+	maxGuestOutputBytes     int               = 256 * 1024 * 1024
+)
+
+type boundedExecOutput struct {
+	mu           sync.Mutex
+	limit        int
+	stdout       []byte
+	stderr       []byte
+	stdoutSeen   int
+	stderrSeen   int
+	exceeded     bool
+	cancelReason outputLimitReason
+	cancel       context.CancelFunc
+	kill         func()
+}
+```
+
+The writer method should:
+
+- increment observed bytes for the relevant stream
+- append only remaining budget
+- set `exceeded=true` and `cancelReason=output_limit` once
+- call cancel and kill callbacks once
+- return `len(p), nil` so `io.Copy` exits because the process is killed, not because a writer error is misinterpreted as command failure
+
+Use `strings.ToValidUTF8` and a byte-safe trim after sanitization so the final returned output remains within the cap.
+
+- [ ] **Step 7: Replace `cmd.Run()` path**
+
+Use:
+
+```go
+stdoutPipe, err := cmd.StdoutPipe()
+stderrPipe, err := cmd.StderrPipe()
+configureCommandProcessGroup(cmd)
+err = cmd.Start()
+go copy stdout
+go copy stderr
+waitErr := cmd.Wait()
+wait for copy goroutines
+```
+
+Classify results in this order:
+
+1. If timeout context won first: return `timeout_exceeded` error.
+2. If output cap won first: return normal `ExecResponse` with `ExitCode: 137`.
+3. Else preserve existing exit-code behavior for normal command failures.
+
+- [ ] **Step 8: Verify focused Go tests**
+
+Run:
+
+```bash
+cd tools/tldw-agent && go test ./internal/guest -run 'TestGuestExec.*Output|TestGuestExec.*MaxOutput|TestGuestExec.*UTF8|TestGuestServerExecutesArgvWithoutShell' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Verify broader Go guest package**
+
+Run:
+
+```bash
+cd tools/tldw-agent && go test ./internal/guest -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add tools/tldw-agent/internal/guest/exec.go tools/tldw-agent/internal/guest/process_linux.go tools/tldw-agent/internal/guest/process_unsupported.go tools/tldw-agent/internal/guest/exec_test.go
+git commit -m "feat(vz): enforce guest output caps"
+```
+
+## Task 3: Swift Helper Cap Forwarding And Detail Merge
+
+**Files:**
+- Modify: `tools/macos-vz-helper/Sources/Guest/VSockBridge.swift`
+- Modify: `tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift`
+- Modify: `tools/macos-vz-helper/Sources/Server/HelperService.swift`
+- Modify: `tools/macos-vz-helper/Tests/TestDoubles.swift`
+- Modify: `tools/macos-vz-helper/Tests/VSockBridgeTests.swift`
+- Modify: `tools/macos-vz-helper/Tests/HelperServiceExecTests.swift`
+
+- [ ] **Step 1: Write failing VSock request encoding test**
+
+In `VSockBridgeTests.swift`, assert the encoded guest request includes `"max_output_bytes":10` when `bridge.exec(..., maxOutputBytes: 10)` is called.
+
+- [ ] **Step 2: Write failing detail decoding test**
+
+Return a guest response with:
+
+```json
+"details":{"guest_output_limit_exceeded":"true","ignored_number":1}
+```
+
+Assert `GuestExecResult.details["guest_output_limit_exceeded"] == "true"` and `ignored_number` is absent.
+
+- [ ] **Step 3: Write failing HelperService merge test**
+
+Use a guest bridge double that returns large output plus guest-prefixed details. Assert helper response details contain both:
+
+- host keys: `stdout_bytes_original`, `stdout_bytes_returned`, `stdout_truncated`
+- guest keys: `guest_output_limit_exceeded`, `guest_stdout_bytes_observed`
+
+Also assert guest keys do not overwrite host keys.
+
+- [ ] **Step 4: Run failing Swift tests**
+
+Run:
+
+```bash
+cd tools/macos-vz-helper && swift test --filter 'VSockBridgeTests|HelperServiceExecTests'
+```
+
+Expected: fail because signatures/details are not implemented.
+
+- [ ] **Step 5: Update bridge types and signatures**
+
+Change `GuestExecResult`:
+
+```swift
+struct GuestExecResult {
+    let exitCode: Int
+    let stdout: String
+    let stderr: String
+    let details: [String: String]
+}
+```
+
+Add `maxOutputBytes: Int?` to `GuestBridging.exec`, `VZLinuxVMManager.execGuest`, and `VSockBridge.exec`.
+
+Add optional `maxOutputBytes` to `GuestExecRequest` with coding key `max_output_bytes`.
+
+- [ ] **Step 6: Decode guest details defensively**
+
+Implement a custom `GuestExecResponse` decoder that reads details as `[String: JSONValue]` or a permissive dictionary and keeps only string values whose keys start with `guest_`.
+
+Do not throw if `details` is missing, not an object, or contains non-string values.
+
+- [ ] **Step 7: Pass cap from HelperService**
+
+Update:
+
+```swift
+let result = try vmManager.execGuest(
+    vmID: vmID,
+    argv: argv,
+    cwd: cwd,
+    env: env,
+    timeoutSeconds: timeoutSeconds,
+    maxOutputBytes: maxOutputBytes
+)
+```
+
+Merge details:
+
+```swift
+var details = ["transport": "vsock", "vm_id": vmID]
+for (key, value) in result.details where key.hasPrefix("guest_") {
+    details[key] = value
+}
+for (key, value) in cappedOutput.details {
+    details[key] = value
+}
+```
+
+- [ ] **Step 8: Verify focused Swift tests**
+
+Run:
+
+```bash
+cd tools/macos-vz-helper && swift test --filter 'VSockBridgeTests|HelperServiceExecTests'
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Verify full Swift package**
+
+Run:
+
+```bash
+cd tools/macos-vz-helper && swift test
+```
+
+Expected: pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add tools/macos-vz-helper/Sources/Guest/VSockBridge.swift tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift tools/macos-vz-helper/Sources/Server/HelperService.swift tools/macos-vz-helper/Tests/TestDoubles.swift tools/macos-vz-helper/Tests/VSockBridgeTests.swift tools/macos-vz-helper/Tests/HelperServiceExecTests.swift
+git commit -m "feat(vz): forward output caps to guest agent"
+```
+
+## Task 4: Python Guest Counter Parsing
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_vz_linux_runner.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py` only if needed
+
+- [ ] **Step 1: Write failing runner counter test**
+
+Add a focused unit test for `_output_counters_from_details`:
+
+```python
+def test_output_counters_include_guest_enforcement_details():
+    counters = VZLinuxRunner._output_counters_from_details(
+        {
+            "guest_output_limit_bytes": "16",
+            "guest_output_limit_exceeded": "true",
+            "guest_stdout_bytes_observed": "17",
+            "guest_stderr_bytes_observed": "0",
+            "guest_stdout_bytes_returned": "16",
+            "guest_stderr_bytes_returned": "0",
+            "guest_output_kill_reason": "output_limit",
+            "ignored": "not-int",
+        }
+    )
+    assert counters["guest_output_limit_bytes"] == 16
+    assert counters["guest_output_limit_exceeded"] == 1
+    assert counters["guest_stdout_bytes_observed"] == 17
+    assert counters["guest_stdout_bytes_returned"] == 16
+    assert "guest_output_kill_reason" not in counters
+```
+
+- [ ] **Step 2: Run failing pytest**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -k output_counters
+```
+
+Expected: fail because guest keys are not in `_OUTPUT_COUNTER_KEYS`.
+
+- [ ] **Step 3: Add guest counter keys**
+
+Update `_OUTPUT_COUNTER_KEYS` with:
+
+```python
+"guest_output_limit_bytes",
+"guest_output_limit_exceeded",
+"guest_stdout_bytes_observed",
+"guest_stderr_bytes_observed",
+"guest_stdout_bytes_returned",
+"guest_stderr_bytes_returned",
+```
+
+Do not include string reason fields in `resource_usage`.
+
+- [ ] **Step 4: Verify focused pytest**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -k output_counters
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Verify helper-client pass-through if touched**
+
+If `test_macos_virtualization_helper_client.py` is changed, run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+git commit -m "feat(vz): surface guest output cap counters"
+```
+
+If `test_macos_virtualization_helper_client.py` is not touched, omit it from `git add`.
+
+## Task 5: Protocol And Operator Documentation
+
+**Files:**
+- Modify: `tools/macos-vz-helper/PROTOCOL.md`
+- Modify: `tools/tldw-agent/docs/vz-linux-guest-protocol.md`
+- Modify: `tools/vz-linux-image/README.md`
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+
+- [ ] **Step 1: Update helper protocol docs**
+
+In `tools/macos-vz-helper/PROTOCOL.md`, replace the host-only warning with:
+
+```markdown
+`max_output_bytes` is forwarded to guest agents that support guest-side output
+cap enforcement. Rebuilt guests terminate the command when the combined
+stdout/stderr observation exceeds the cap and return guest-prefixed detail
+metadata. The helper still applies host-side response capping as defense in
+depth and as fallback for older guests.
+```
+
+- [ ] **Step 2: Update guest protocol docs**
+
+Add `max_output_bytes` to the guest exec request example and add a details block to the response example with guest-prefixed keys.
+
+- [ ] **Step 3: Update image docs**
+
+In `tools/vz-linux-image/README.md`, add a short note:
+
+```markdown
+Guest-side kill-on-output-cap requires images rebuilt with the updated
+`tldw-agent-guest` binary. Older images still boot and execute, but only the
+host helper response cap is guaranteed.
+```
+
+- [ ] **Step 4: Update sandbox README**
+
+Update the `vz_linux` output cap bullet to say guest-side enforcement is available when the image contains the updated guest agent, while host-side cap remains fallback.
+
+- [ ] **Step 5: Check markdown diff**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/macos-vz-helper/PROTOCOL.md tools/tldw-agent/docs/vz-linux-guest-protocol.md tools/vz-linux-image/README.md tldw_Server_API/app/core/Sandbox/README.md
+git commit -m "docs(vz): document guest output cap enforcement"
+```
+
+## Task 6: Full Focused Verification
+
+**Files:**
+- No implementation files unless verification reveals defects.
+
+- [ ] **Step 1: Run Go guest tests**
+
+```bash
+cd tools/tldw-agent && go test ./...
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run Swift helper tests**
+
+```bash
+cd tools/macos-vz-helper && swift test
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run focused Python sandbox tests**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest -q \
+  tldw_Server_API/tests/sandbox/test_vz_linux_runner.py \
+  tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run py_compile on touched Python module**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m py_compile tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Run Bandit on touched Python scope**
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py -f json -o /tmp/bandit_vz_guest_output_cap.json
+```
+
+Expected: no new findings in touched code.
+
+- [ ] **Step 6: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 7: Commit verification-only fixes if needed**
+
+Only commit if verification forced code/doc changes:
+
+```bash
+git add <changed-files>
+git commit -m "fix(vz): harden guest output cap edge cases"
+```
+
+## Task 7: Optional Real Host Smoke
+
+**Files:**
+- No implementation files expected.
+
+- [ ] **Step 1: Confirm operator prerequisites**
+
+Confirm an Apple Silicon macOS host with:
+
+- built/signed helper
+- rebuilt Debian arm64 image containing updated `tldw-agent-guest`
+- owner-only runtime/socket/log directories
+
+- [ ] **Step 2: Run host smoke command**
+
+Use the existing smoke harness after rebuilding the image:
+
+```bash
+tools/vz-linux-image/scripts/run-host-e2e-smoke.sh --bundle <rebuilt-bundle-path>
+```
+
+Expected: existing ephemeral execution and same-session reuse pass.
+
+- [ ] **Step 3: Add cap-specific manual command if harness lacks it**
+
+If the smoke harness does not yet include a cap-exceeded command, run one manual `vz_linux` sandbox command with a very small `SANDBOX_MAX_LOG_BYTES` and noisy output, then verify:
+
+- exit code is `137`
+- `guest_output_limit_exceeded` appears in helper details/resource usage
+- a second command in the same session still executes after the capped command
+
+- [ ] **Step 4: Record results in PR**
+
+Do not commit local image artifacts. Put exact command output summary in the PR comment.
+
+## Completion Criteria
+
+- Go guest agent enforces `max_output_bytes` without unbounded output buffers.
+- Swift helper forwards `max_output_bytes` and keeps host-side capping as fallback.
+- Guest details are guest-prefixed, string-only, and defensively decoded.
+- Python runner records guest enforcement counters only as integer `resource_usage` values.
+- Protocol/operator docs distinguish rebuilt-image guest enforcement from host fallback.
+- Focused Go, Swift, Python, Bandit, py_compile, and `git diff --check` verification complete.

--- a/Docs/superpowers/specs/2026-05-02-vz-guest-output-cap-design.md
+++ b/Docs/superpowers/specs/2026-05-02-vz-guest-output-cap-design.md
@@ -56,10 +56,11 @@ validates `exec_guest.max_output_bytes`; after validation, it should pass the
 same value into `VZLinuxVMManager.execGuest`, `GuestBridging.exec`, and the
 encoded `GuestExecRequest`.
 
-The Go guest agent should add `MaxOutputBytes int` to `ExecRequest` and replace
-the current `cmd.Run()` plus unbounded stdout/stderr buffers with explicit
-`StdoutPipe` / `StderrPipe` readers and a combined bounded capture mechanism.
-The bounded capture should:
+The Go guest agent should add `MaxOutputBytes *int` to `ExecRequest` and
+replace the current `cmd.Run()` plus unbounded stdout/stderr buffers with
+explicit `StdoutPipe` / `StderrPipe` readers and a combined bounded capture
+mechanism. A pointer is required so the guest can distinguish an omitted cap
+from an explicit invalid `0`. The bounded capture should:
 
 - keep at most `max_output_bytes` returned bytes across stdout and stderr
 - track observed byte counts separately for stdout and stderr
@@ -75,8 +76,8 @@ The guest response should remain a single final response. It should add optional
 detail fields, not a stream frame protocol. If the cap is exceeded, the guest
 agent should return a normal exec response with a stable non-zero exit code when
 the process is terminated by the cap, plus metadata indicating
-`output_limit_exceeded=true`. The host should avoid turning this into a helper
-transport failure; it is a command result constrained by policy.
+`guest_output_limit_exceeded=true`. The host should avoid turning this into a
+helper transport failure; it is a command result constrained by policy.
 
 Swift helper response capping remains active. If a rebuilt guest agent enforces
 the cap, Swift details should report both guest-observed metadata and any
@@ -148,9 +149,11 @@ metadata remains the authoritative reason for the termination.
 
 ## Output Semantics
 
-When no `max_output_bytes` is provided, the guest agent keeps existing behavior
-except that implementation may still use a bounded helper internally if it
-preserves current default limits.
+When no `max_output_bytes` is provided, the guest agent keeps existing exec
+behavior and does not add a new implicit guest kill-on-cap default. This avoids
+changing lower-level guest protocol semantics for callers that do not send the
+field. The `vz_linux` Python runner is expected to send the sandbox log cap for
+normal sandbox execution.
 
 When a cap is provided:
 
@@ -201,7 +204,7 @@ rebuilt images containing the updated `tldw-agent-guest` binary.
 
 ### Go guest agent
 
-- Add `MaxOutputBytes int` and optional `Details map[string]string` to guest
+- Add `MaxOutputBytes *int` and optional `Details map[string]string` to guest
   exec request/response types.
 - Validate direct guest requests defensively with the same effective ceiling as
   the host helper, currently 256 MiB.
@@ -224,6 +227,8 @@ rebuilt images containing the updated `tldw-agent-guest` binary.
 - Encode `max_output_bytes` in `GuestExecRequest` when provided.
 - Decode optional guest response details and merge only string-valued,
   guest-prefixed keys into helper response details.
+- Decode guest details defensively so missing, malformed, or non-string detail
+  values do not fail an otherwise valid exec response.
 - Preserve host-side output counter keys for Swift-received and Swift-returned
   byte counts; do not overwrite them with guest-observed counters.
 - Keep existing helper-side `capExecOutput` behavior as fallback.
@@ -282,6 +287,8 @@ Swift helper tests:
 
 - `VSockBridge` encodes `max_output_bytes` into guest exec requests.
 - `VSockBridge` decodes optional guest details.
+- `VSockBridge` ignores non-string or malformed guest details without failing
+  the exec response.
 - `HelperService.execGuest` passes the cap to the bridge/manager.
 - `HelperService.execGuest` merges guest-prefixed metadata and still applies
   host cap without overwriting host output counters.

--- a/Docs/superpowers/specs/2026-05-02-vz-guest-output-cap-design.md
+++ b/Docs/superpowers/specs/2026-05-02-vz-guest-output-cap-design.md
@@ -57,8 +57,9 @@ same value into `VZLinuxVMManager.execGuest`, `GuestBridging.exec`, and the
 encoded `GuestExecRequest`.
 
 The Go guest agent should add `MaxOutputBytes int` to `ExecRequest` and replace
-the current unbounded stdout/stderr buffers with a combined bounded capture
-mechanism. The bounded capture should:
+the current `cmd.Run()` plus unbounded stdout/stderr buffers with explicit
+`StdoutPipe` / `StderrPipe` readers and a combined bounded capture mechanism.
+The bounded capture should:
 
 - keep at most `max_output_bytes` returned bytes across stdout and stderr
 - track observed byte counts separately for stdout and stderr
@@ -67,6 +68,7 @@ mechanism. The bounded capture should:
 - be safe for concurrent stdout and stderr writes
 - record output-cap cancellation separately from timeout cancellation
 - cancel the command context when the cap is exceeded
+- terminate the process group when supported, not just the direct child process
 - return UTF-8-safe strings in the existing `stdout` and `stderr` fields
 
 The guest response should remain a single final response. It should add optional
@@ -81,6 +83,13 @@ the cap, Swift details should report both guest-observed metadata and any
 host-side truncation metadata. If an old guest agent ignores `max_output_bytes`,
 Swift still caps the final response and details should make clear that only
 host-side truncation was observed.
+
+Guest-provided output counters must use guest-prefixed detail keys so they do
+not overwrite the existing host-side helper cap keys. The existing host keys
+such as `stdout_bytes_original`, `stderr_bytes_original`,
+`stdout_bytes_returned`, and `stderr_bytes_returned` continue to describe the
+bytes Swift received and returned after host-side capping. Guest keys describe
+what the guest agent observed before it terminated or completed the process.
 
 ## Protocol Contract
 
@@ -116,19 +125,21 @@ Guest `exec` response remains:
   "stdout": "bounded prefix...",
   "stderr": "",
   "details": {
-    "output_limit_bytes": "1048576",
-    "output_limit_enforced_by": "guest",
-    "output_limit_exceeded": "true",
-    "stdout_bytes_observed": "1048577",
-    "stderr_bytes_observed": "0",
-    "stdout_bytes_returned": "1048576",
-    "stderr_bytes_returned": "0"
+    "guest_output_limit_bytes": "1048576",
+    "guest_output_limit_exceeded": "true",
+    "guest_output_kill_reason": "output_limit",
+    "guest_stdout_bytes_observed": "1048577",
+    "guest_stderr_bytes_observed": "0",
+    "guest_stdout_bytes_returned": "1048576",
+    "guest_stderr_bytes_returned": "0"
   }
 }
 ```
 
 Detail values should remain strings for consistency with the Swift helper
-details map and existing Python parsing behavior.
+details map and existing Python parsing behavior. Boolean values should be
+encoded as `"true"` or `"false"` and parsed defensively by Python into integer
+resource usage counters where needed.
 
 When the guest agent terminates a command because of output cap enforcement, it
 should normalize the command result to exit code `137` in the response instead
@@ -153,12 +164,16 @@ When a cap is provided:
   `os/exec` may write both streams concurrently.
 - The bounded capture helper must store the first cancellation reason so timeout
   and output-cap paths do not misclassify each other.
+- The implementation should use `cmd.Start()`, concurrent pipe readers, and
+  `cmd.Wait()` rather than relying on `io.Writer` errors from `cmd.Run()` to
+  control process lifetime.
 - The guest should preserve stderr diagnostics when both streams produce output
   where practical, but exact fair-share truncation can remain host-side in this
   PR if guest-side chunk interleaving makes deterministic fair sharing costly.
 - Returned strings must not contain partial UTF-8 sequences. Invalid UTF-8 from
   guest commands should be decoded with replacement rather than crashing the
-  agent.
+  agent, but the final UTF-8 byte length after sanitization must still obey the
+  cap.
 
 The policy outcome is reported as metadata, not as a transport error. A command
 terminated for output cap should complete the `exec_guest` request and let the
@@ -172,8 +187,8 @@ host-side caps and must not claim full guest-side protection unless the response
 contains guest enforcement metadata.
 
 The Swift helper should parse response details defensively. Missing details mean
-`output_limit_enforced_by` is unknown or host-only. The Python runner should
-carry enough resource usage metadata for diagnostics and audit to distinguish:
+guest enforcement is unknown or absent. The Python runner should carry enough
+resource usage metadata for diagnostics and audit to distinguish:
 
 - guest cap enforced
 - host response cap applied
@@ -188,9 +203,16 @@ rebuilt images containing the updated `tldw-agent-guest` binary.
 
 - Add `MaxOutputBytes int` and optional `Details map[string]string` to guest
   exec request/response types.
+- Validate direct guest requests defensively with the same effective ceiling as
+  the host helper, currently 256 MiB.
 - Replace unbounded `bytes.Buffer` usage in guest exec with bounded stream
-  capture.
-- Cancel command execution when combined observed bytes exceed the cap.
+  capture driven by stdout/stderr pipes.
+- Cancel command execution and terminate the process group when combined
+  observed bytes exceed the cap.
+- Implement process-group setup and termination behind a small platform helper
+  so Go packages remain portable where possible. Linux guests should use process
+  group termination; unsupported platforms may fall back to direct process
+  termination.
 - Add focused unit tests for bounded output, process termination, timeout
   precedence, UTF-8-safe returned output, and no-cap compatibility.
 
@@ -200,8 +222,10 @@ rebuilt images containing the updated `tldw-agent-guest` binary.
 - Extend `GuestBridging.exec` and `VZLinuxVMManager.execGuest` to accept
   `maxOutputBytes`.
 - Encode `max_output_bytes` in `GuestExecRequest` when provided.
-- Decode optional guest response details and merge them into helper response
-  details with clear namespacing or stable keys.
+- Decode optional guest response details and merge only string-valued,
+  guest-prefixed keys into helper response details.
+- Preserve host-side output counter keys for Swift-received and Swift-returned
+  byte counts; do not overwrite them with guest-observed counters.
 - Keep existing helper-side `capExecOutput` behavior as fallback.
 
 ### Python sandbox runtime
@@ -209,7 +233,10 @@ rebuilt images containing the updated `tldw-agent-guest` binary.
 - Keep sending `max_output_bytes` from `VZLinuxRunner` through
   `MacOSVirtualizationHelperClient.exec_guest`.
 - Parse new helper detail keys defensively into integer `resource_usage`
-  counters.
+  counters, including `guest_output_limit_bytes`,
+  `guest_output_limit_exceeded`, `guest_stdout_bytes_observed`,
+  `guest_stderr_bytes_observed`, `guest_stdout_bytes_returned`, and
+  `guest_stderr_bytes_returned`.
 - Preserve existing host-side output and audit metadata.
 - Add tests only where Python behavior changes; avoid duplicating Go/Swift
   unit coverage in Python.
@@ -230,7 +257,7 @@ rebuilt images containing the updated `tldw-agent-guest` binary.
   malformed request reaches the guest agent despite host validation.
 - Output cap termination should not be represented as a guest protocol error.
 - Output cap termination should normalize the response exit code to `137` and
-  set `output_limit_exceeded=true`.
+  set `guest_output_limit_exceeded=true`.
 - Timeout should remain distinct from output cap termination. If both happen,
   whichever cancellation reason is observed first should determine the primary
   metadata reason, and tests should document that precedence.
@@ -245,7 +272,10 @@ Go guest-agent tests:
 - `Exec` with cap below command output returns no more than the cap.
 - `Exec` with cap below command output cancels a long-running/noisy process.
 - `Exec` metadata reports observed, returned, limit, and exceeded fields.
+- `Exec` kills or cleans up child processes through the platform process-group
+  helper on Linux.
 - `Exec` returns UTF-8-safe output when truncating multibyte text.
+- `Exec` rejects non-positive or excessive direct guest caps.
 - `Exec` timeout still reports `timeout_exceeded` when timeout wins.
 
 Swift helper tests:
@@ -253,7 +283,8 @@ Swift helper tests:
 - `VSockBridge` encodes `max_output_bytes` into guest exec requests.
 - `VSockBridge` decodes optional guest details.
 - `HelperService.execGuest` passes the cap to the bridge/manager.
-- `HelperService.execGuest` merges guest metadata and still applies host cap.
+- `HelperService.execGuest` merges guest-prefixed metadata and still applies
+  host cap without overwriting host output counters.
 - Socket-level `exec_guest` behavior remains backward compatible when guest
   details are absent.
 
@@ -263,6 +294,8 @@ Python tests:
   defensively.
 - `VZLinuxRunner` resource usage includes guest enforcement counters when
   helper details provide them.
+- `VZLinuxRunner` preserves existing host-side output counters when guest
+  enforcement counters are absent.
 - Existing host cap tests still pass when guest enforcement details are absent.
 
 Host-gated smoke follow-up:
@@ -278,9 +311,12 @@ Host-gated smoke follow-up:
 - The strongest safety guarantee requires rebuilt images. Host diagnostics
   should not imply guest enforcement for stale images.
 - Killing a process on cap can leave child processes if the command spawns its
-  own process tree. The implementation should use process-group termination on
-  supported guest platforms if practical; otherwise document the limitation and
-  rely on timeout cleanup as fallback.
+  own process tree and the platform process-group helper is unavailable. Linux
+  guest images should support process-group termination; unsupported platforms
+  should be explicitly documented as weaker.
+- Pipe readers must not deadlock when one stream hits the cap while the other is
+  still being copied. The implementation should cancel once, close/kill the
+  process, wait for both reader goroutines, then call `cmd.Wait()`.
 - Exact fair sharing between stdout and stderr is harder inside a live bounded
   writer than after both streams are buffered. Preserve host-side fair sharing
   and keep guest-side behavior simple unless tests show stderr starvation is a

--- a/Docs/superpowers/specs/2026-05-02-vz-guest-output-cap-design.md
+++ b/Docs/superpowers/specs/2026-05-02-vz-guest-output-cap-design.md
@@ -1,0 +1,296 @@
+# VZ Linux Guest Output Cap Design
+
+## Status
+
+Design approved for specification. Implementation is not started in this
+document.
+
+## Context
+
+The `vz_linux` runtime now passes `max_output_bytes` through the Python helper
+client and the Swift helper caps the helper response before returning it to
+Python. That protects the Python boundary and WebSocket publication path, but it
+does not protect the guest agent or the Swift bridge if a guest command writes
+large stdout/stderr before the helper response cap is applied.
+
+The in-repo guest agent lives under `tools/tldw-agent` and is installed into the
+Debian image by `tools/vz-linux-image/scripts/install-agent.sh`. The current
+guest exec path uses unbounded `bytes.Buffer` values for stdout and stderr. This
+slice should move the output limit enforcement closer to the process that
+produces output, while preserving the current request/response protocol shape.
+
+This work follows `Docs/Sandbox/sandbox-architecture-doctrine.md`: Python owns
+policy selection and public API behavior, the Swift helper owns the host control
+boundary, and the guest agent owns guest-local execution mechanics.
+
+## Goals
+
+- Add guest-side enforcement for the existing `exec_guest.max_output_bytes`
+  request policy.
+- Forward `max_output_bytes` from the Swift helper to the guest agent over the
+  existing vsock request/response protocol.
+- Bound guest stdout/stderr retention so the guest agent does not accumulate
+  unbounded output in memory.
+- Terminate the guest process when the combined stdout/stderr observation
+  exceeds the configured cap.
+- Preserve Swift helper-side response capping as defense in depth.
+- Surface guest enforcement metadata so operators can distinguish guest-side
+  limit enforcement from host-side fallback truncation.
+- Update protocol documentation and focused tests across Go, Swift, and Python.
+
+## Non-Goals
+
+- Do not implement incremental stdout/stderr streaming in this PR.
+- Do not change the public sandbox API shape.
+- Do not remove Swift helper-side response capping.
+- Do not change `docker`, `seatbelt`, `worktree`, `firecracker`, or `lima`
+  output semantics.
+- Do not make old VM images magically enforce guest-side caps; old guest agents
+  may ignore the new request field.
+
+## Chosen Approach
+
+Extend the existing request/response protocol with an optional
+`max_output_bytes` field on guest `exec` requests. The Swift helper already
+validates `exec_guest.max_output_bytes`; after validation, it should pass the
+same value into `VZLinuxVMManager.execGuest`, `GuestBridging.exec`, and the
+encoded `GuestExecRequest`.
+
+The Go guest agent should add `MaxOutputBytes int` to `ExecRequest` and replace
+the current unbounded stdout/stderr buffers with a combined bounded capture
+mechanism. The bounded capture should:
+
+- keep at most `max_output_bytes` returned bytes across stdout and stderr
+- track observed byte counts separately for stdout and stderr
+- track returned byte counts separately for stdout and stderr
+- mark whether the cap was exceeded
+- be safe for concurrent stdout and stderr writes
+- record output-cap cancellation separately from timeout cancellation
+- cancel the command context when the cap is exceeded
+- return UTF-8-safe strings in the existing `stdout` and `stderr` fields
+
+The guest response should remain a single final response. It should add optional
+detail fields, not a stream frame protocol. If the cap is exceeded, the guest
+agent should return a normal exec response with a stable non-zero exit code when
+the process is terminated by the cap, plus metadata indicating
+`output_limit_exceeded=true`. The host should avoid turning this into a helper
+transport failure; it is a command result constrained by policy.
+
+Swift helper response capping remains active. If a rebuilt guest agent enforces
+the cap, Swift details should report both guest-observed metadata and any
+host-side truncation metadata. If an old guest agent ignores `max_output_bytes`,
+Swift still caps the final response and details should make clear that only
+host-side truncation was observed.
+
+## Protocol Contract
+
+Host helper `exec_guest` request semantics remain unchanged externally:
+
+- `max_output_bytes` is optional.
+- Valid values are JSON integers in the existing range `1...268435456`.
+- Invalid shape returns `invalid_request`.
+- Invalid semantic values return `exec_output_limit_invalid`.
+
+Guest `exec` request gains:
+
+```json
+{
+  "protocol_version": "1",
+  "request_id": "req-1",
+  "type": "exec",
+  "argv": ["/bin/sh", "-c", "yes"],
+  "cwd": "/workspace",
+  "env": {},
+  "timeout_sec": 30,
+  "max_output_bytes": 1048576
+}
+```
+
+Guest `exec` response remains:
+
+```json
+{
+  "protocol_version": "1",
+  "request_id": "req-1",
+  "exit_code": 137,
+  "stdout": "bounded prefix...",
+  "stderr": "",
+  "details": {
+    "output_limit_bytes": "1048576",
+    "output_limit_enforced_by": "guest",
+    "output_limit_exceeded": "true",
+    "stdout_bytes_observed": "1048577",
+    "stderr_bytes_observed": "0",
+    "stdout_bytes_returned": "1048576",
+    "stderr_bytes_returned": "0"
+  }
+}
+```
+
+Detail values should remain strings for consistency with the Swift helper
+details map and existing Python parsing behavior.
+
+When the guest agent terminates a command because of output cap enforcement, it
+should normalize the command result to exit code `137` in the response instead
+of leaking platform-specific `os/exec` signal behavior such as `-1`. The
+metadata remains the authoritative reason for the termination.
+
+## Output Semantics
+
+When no `max_output_bytes` is provided, the guest agent keeps existing behavior
+except that implementation may still use a bounded helper internally if it
+preserves current default limits.
+
+When a cap is provided:
+
+- The cap applies to combined stdout and stderr bytes.
+- The guest agent should kill/cancel the command as soon as the combined
+  observed bytes exceed the cap.
+- The returned stdout/stderr bytes must not exceed the cap.
+- Observed byte counts may exceed returned byte counts by at least one byte
+  because cap detection happens while reading chunks.
+- Stdout and stderr capture must coordinate through shared state because
+  `os/exec` may write both streams concurrently.
+- The bounded capture helper must store the first cancellation reason so timeout
+  and output-cap paths do not misclassify each other.
+- The guest should preserve stderr diagnostics when both streams produce output
+  where practical, but exact fair-share truncation can remain host-side in this
+  PR if guest-side chunk interleaving makes deterministic fair sharing costly.
+- Returned strings must not contain partial UTF-8 sequences. Invalid UTF-8 from
+  guest commands should be decoded with replacement rather than crashing the
+  agent.
+
+The policy outcome is reported as metadata, not as a transport error. A command
+terminated for output cap should complete the `exec_guest` request and let the
+runner publish a failed run according to the command exit code and metadata.
+
+## Backward Compatibility
+
+Old guest agents will ignore `max_output_bytes` and may still buffer large
+stdout/stderr before responding. The PR must therefore preserve all existing
+host-side caps and must not claim full guest-side protection unless the response
+contains guest enforcement metadata.
+
+The Swift helper should parse response details defensively. Missing details mean
+`output_limit_enforced_by` is unknown or host-only. The Python runner should
+carry enough resource usage metadata for diagnostics and audit to distinguish:
+
+- guest cap enforced
+- host response cap applied
+- host response cap applied because guest enforcement metadata was missing
+
+Image-store and operator docs should state that guest kill-on-cap requires
+rebuilt images containing the updated `tldw-agent-guest` binary.
+
+## Component Changes
+
+### Go guest agent
+
+- Add `MaxOutputBytes int` and optional `Details map[string]string` to guest
+  exec request/response types.
+- Replace unbounded `bytes.Buffer` usage in guest exec with bounded stream
+  capture.
+- Cancel command execution when combined observed bytes exceed the cap.
+- Add focused unit tests for bounded output, process termination, timeout
+  precedence, UTF-8-safe returned output, and no-cap compatibility.
+
+### Swift helper
+
+- Extend `GuestExecResult` with optional detail metadata.
+- Extend `GuestBridging.exec` and `VZLinuxVMManager.execGuest` to accept
+  `maxOutputBytes`.
+- Encode `max_output_bytes` in `GuestExecRequest` when provided.
+- Decode optional guest response details and merge them into helper response
+  details with clear namespacing or stable keys.
+- Keep existing helper-side `capExecOutput` behavior as fallback.
+
+### Python sandbox runtime
+
+- Keep sending `max_output_bytes` from `VZLinuxRunner` through
+  `MacOSVirtualizationHelperClient.exec_guest`.
+- Parse new helper detail keys defensively into integer `resource_usage`
+  counters.
+- Preserve existing host-side output and audit metadata.
+- Add tests only where Python behavior changes; avoid duplicating Go/Swift
+  unit coverage in Python.
+
+### Documentation
+
+- Update `tools/macos-vz-helper/PROTOCOL.md` to remove the statement that
+  `max_output_bytes` is host-response-only once guest forwarding is implemented.
+- Update `tools/tldw-agent/docs/vz-linux-guest-protocol.md` with the new guest
+  request field and response details.
+- Update `tools/vz-linux-image/README.md` to note that images must be rebuilt to
+  gain guest-side kill-on-cap behavior.
+
+## Error Handling
+
+- Malformed host-side `max_output_bytes` handling remains unchanged.
+- Guest-side invalid or non-positive caps should return `invalid_request` if a
+  malformed request reaches the guest agent despite host validation.
+- Output cap termination should not be represented as a guest protocol error.
+- Output cap termination should normalize the response exit code to `137` and
+  set `output_limit_exceeded=true`.
+- Timeout should remain distinct from output cap termination. If both happen,
+  whichever cancellation reason is observed first should determine the primary
+  metadata reason, and tests should document that precedence.
+- If the guest agent fails to kill a capped process promptly, the existing
+  timeout path remains the fallback.
+
+## Testing Strategy
+
+Go guest-agent tests:
+
+- `Exec` with no cap preserves current stdout/stderr behavior.
+- `Exec` with cap below command output returns no more than the cap.
+- `Exec` with cap below command output cancels a long-running/noisy process.
+- `Exec` metadata reports observed, returned, limit, and exceeded fields.
+- `Exec` returns UTF-8-safe output when truncating multibyte text.
+- `Exec` timeout still reports `timeout_exceeded` when timeout wins.
+
+Swift helper tests:
+
+- `VSockBridge` encodes `max_output_bytes` into guest exec requests.
+- `VSockBridge` decodes optional guest details.
+- `HelperService.execGuest` passes the cap to the bridge/manager.
+- `HelperService.execGuest` merges guest metadata and still applies host cap.
+- Socket-level `exec_guest` behavior remains backward compatible when guest
+  details are absent.
+
+Python tests:
+
+- `MacOSVirtualizationHelperClient` accepts and exposes new detail counters
+  defensively.
+- `VZLinuxRunner` resource usage includes guest enforcement counters when
+  helper details provide them.
+- Existing host cap tests still pass when guest enforcement details are absent.
+
+Host-gated smoke follow-up:
+
+- After unit/integration coverage passes, rebuild the Debian arm64 image and run
+  a real `vz_linux` command that exceeds a small cap to verify the guest process
+  is terminated and session reuse still works afterward.
+
+## Risks And Review Notes
+
+- The guest protocol version remains `1`, so new fields must be optional and
+  old-agent tolerant.
+- The strongest safety guarantee requires rebuilt images. Host diagnostics
+  should not imply guest enforcement for stale images.
+- Killing a process on cap can leave child processes if the command spawns its
+  own process tree. The implementation should use process-group termination on
+  supported guest platforms if practical; otherwise document the limitation and
+  rely on timeout cleanup as fallback.
+- Exact fair sharing between stdout and stderr is harder inside a live bounded
+  writer than after both streams are buffered. Preserve host-side fair sharing
+  and keep guest-side behavior simple unless tests show stderr starvation is a
+  practical issue.
+- The details schema should stay integer/string-only so existing helper-client
+  parsing and `RunStatus.resource_usage` constraints remain stable.
+
+## Follow-Up Work
+
+- Add incremental guest stdout/stderr streaming over vsock.
+- Add guest-agent version/capability reporting to helper diagnostics so stale
+  images are obvious before execution.
+- Apply similar guest-side cap behavior to future VM runtimes.

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -66,10 +66,11 @@ Current limitations:
   Virtualization.framework configuration does not attach a network device.
 - `vz_linux` passes `SANDBOX_MAX_LOG_BYTES` to helper `exec_guest` as
   `max_output_bytes`, clamped to the helper protocol ceiling of 256 MiB, and
-  also uses the effective cap when publishing stdout/stderr frames. This bounds
-  helper-returned output and WebSocket log publication, but it is not a
-  guest-agent kill-on-cap mechanism; guest-side streaming and early termination
-  remain follow-up work.
+  also uses the effective cap when publishing stdout/stderr frames. Rebuilt
+  images with the updated `tldw-agent-guest` enforce the cap inside the guest
+  and terminate noisy commands when observed output exceeds it. The helper still
+  applies host-side response capping as defense in depth and fallback for older
+  images. Guest-side streaming remains follow-up work.
 - `vz_linux` artifact capture is bounded by `SANDBOX_MAX_ARTIFACT_FILE_BYTES`
   and `SANDBOX_MAX_ARTIFACT_TOTAL_BYTES`. Oversized or over-budget artifacts
   are skipped without failing an otherwise successful run, and aggregate skip

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -41,6 +41,12 @@ _OUTPUT_COUNTER_KEYS = frozenset(
         "stderr_bytes_returned",
         "stdout_truncated",
         "stderr_truncated",
+        "guest_output_limit_bytes",
+        "guest_output_limit_exceeded",
+        "guest_stdout_bytes_observed",
+        "guest_stderr_bytes_observed",
+        "guest_stdout_bytes_returned",
+        "guest_stderr_bytes_returned",
     }
 )
 

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -821,6 +821,27 @@ def test_vz_linux_collect_artifacts_uses_policy_caps(monkeypatch, tmp_path) -> N
     assert artifacts == {}
 
 
+def test_output_counters_include_guest_enforcement_details() -> None:
+    counters = VZLinuxRunner._output_counters_from_details(
+        {
+            "guest_output_limit_bytes": "16",
+            "guest_output_limit_exceeded": "true",
+            "guest_stdout_bytes_observed": "17",
+            "guest_stderr_bytes_observed": "0",
+            "guest_stdout_bytes_returned": "16",
+            "guest_stderr_bytes_returned": "0",
+            "guest_output_kill_reason": "output_limit",
+            "ignored": "not-int",
+        }
+    )
+
+    assert counters["guest_output_limit_bytes"] == 16
+    assert counters["guest_output_limit_exceeded"] == 1
+    assert counters["guest_stdout_bytes_observed"] == 17
+    assert counters["guest_stdout_bytes_returned"] == 16
+    assert "guest_output_kill_reason" not in counters
+
+
 def test_vz_linux_start_run_records_output_limit_counters(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
     monkeypatch.setattr(

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -200,19 +200,21 @@ guest agent:
   characters. Values cannot contain NUL.
 - `timeout_sec` must be finite, positive, and no greater than 3600 seconds.
 - `max_output_bytes`, when present, must be a JSON integer in the range
-  `1...268435456`. It caps the combined stdout/stderr bytes returned in the
-  helper response. When both streams exceed the cap and the cap is at least 2
-  bytes, each stream receives a non-empty fair share and unused stream budget may
-  be reused by the other stream.
+  `1...268435456`. It is forwarded to guest agents that support guest-side
+  output cap enforcement and also caps the combined stdout/stderr bytes returned
+  in the helper response. When both streams exceed the helper response cap and
+  the cap is at least 2 bytes, each stream receives a non-empty fair share and
+  unused stream budget may be reused by the other stream.
 
 Malformed JSON shape or missing required fields returns `invalid_request`.
 Semantic contract denials return one of `exec_argv_invalid`, `exec_cwd_invalid`,
 `exec_env_invalid`, `exec_timeout_invalid`, or `exec_output_limit_invalid`; the
 `message` field contains the stable reason.
 
-`max_output_bytes` is a host response cap only. It does not stop guest-agent or
-bridge-side buffering, and it does not kill the guest process when the cap is
-reached.
+Guest agents rebuilt with output-cap support terminate the command when the
+combined stdout/stderr observation exceeds `max_output_bytes` and return
+guest-prefixed detail metadata. The helper still applies host-side response
+capping as defense in depth and as fallback for older guest agents.
 
 Response:
 
@@ -227,6 +229,12 @@ Response:
     "transport": "vsock",
     "vm_id": "run-123",
     "output_limit_bytes": "10485760",
+    "guest_output_limit_bytes": "10485760",
+    "guest_output_limit_exceeded": "false",
+    "guest_stdout_bytes_observed": "3",
+    "guest_stderr_bytes_observed": "0",
+    "guest_stdout_bytes_returned": "3",
+    "guest_stderr_bytes_returned": "0",
     "stdout_bytes_original": "3",
     "stderr_bytes_original": "0",
     "stdout_bytes_returned": "3",
@@ -238,7 +246,8 @@ Response:
 ```
 
 Output limit detail values are encoded as strings to preserve the existing
-`details` shape.
+`details` shape. Guest-side counters use `guest_` prefixes and host-side
+response-cap counters keep the existing unprefixed keys.
 
 ### `validate_template`
 

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -248,6 +248,9 @@ Response:
 Output limit detail values are encoded as strings to preserve the existing
 `details` shape. Guest-side counters use `guest_` prefixes and host-side
 response-cap counters keep the existing unprefixed keys.
+Guest-prefixed counters are conditional: older guest agents may omit `guest_*`
+metadata and rely only on host-side fallback counters. Clients must fall back to
+the unprefixed keys when `guest_*` keys are absent during mixed-version rollouts.
 
 ### `validate_template`
 

--- a/tools/macos-vz-helper/Sources/Guest/VSockBridge.swift
+++ b/tools/macos-vz-helper/Sources/Guest/VSockBridge.swift
@@ -10,6 +10,7 @@ struct GuestExecResult {
     let exitCode: Int
     let stdout: String
     let stderr: String
+    let details: [String: String]
 }
 
 protocol GuestBridging: GuestReadinessBridging {
@@ -18,7 +19,8 @@ protocol GuestBridging: GuestReadinessBridging {
         argv: [String],
         cwd: String,
         env: [String: String],
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int?
     ) throws -> GuestExecResult
 }
 
@@ -50,6 +52,7 @@ private struct GuestExecRequest: Encodable {
     let cwd: String
     let env: [String: String]
     let timeoutSeconds: Int
+    let maxOutputBytes: Int?
 
     private enum CodingKeys: String, CodingKey {
         case protocolVersion = "protocol_version"
@@ -59,6 +62,7 @@ private struct GuestExecRequest: Encodable {
         case cwd
         case env
         case timeoutSeconds = "timeout_sec"
+        case maxOutputBytes = "max_output_bytes"
     }
 }
 
@@ -82,6 +86,7 @@ private struct GuestExecResponse: Decodable {
     let exitCode: Int
     let stdout: String
     let stderr: String
+    let details: [String: String]
 
     private enum CodingKeys: String, CodingKey {
         case protocolVersion = "protocol_version"
@@ -89,6 +94,7 @@ private struct GuestExecResponse: Decodable {
         case exitCode = "exit_code"
         case stdout
         case stderr
+        case details
     }
 
     init(from decoder: Decoder) throws {
@@ -98,6 +104,22 @@ private struct GuestExecResponse: Decodable {
         exitCode = try container.decode(Int.self, forKey: .exitCode)
         stdout = try container.decodeIfPresent(String.self, forKey: .stdout) ?? ""
         stderr = try container.decodeIfPresent(String.self, forKey: .stderr) ?? ""
+        let decodedDetails = (try? container.decodeIfPresent([String: StringOnlyDetailValue].self, forKey: .details)) ?? [:]
+        details = decodedDetails.reduce(into: [String: String]()) { result, item in
+            guard item.key.hasPrefix("guest_"), let value = item.value.value else {
+                return
+            }
+            result[item.key] = value
+        }
+    }
+}
+
+private struct StringOnlyDetailValue: Decodable {
+    let value: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try? container.decode(String.self)
     }
 }
 
@@ -148,7 +170,8 @@ final class VSockBridge: GuestBridging {
         argv: [String],
         cwd: String,
         env: [String: String],
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int? = nil
     ) throws -> GuestExecResult {
         let requestID = UUID().uuidString
         let requestData = try encoder.encode(
@@ -159,7 +182,8 @@ final class VSockBridge: GuestBridging {
                 argv: argv,
                 cwd: cwd,
                 env: env,
-                timeoutSeconds: Int(timeoutSeconds.rounded(.up))
+                timeoutSeconds: Int(timeoutSeconds.rounded(.up)),
+                maxOutputBytes: maxOutputBytes
             )
         )
         let responseData = try transport.sendExecRequest(
@@ -175,7 +199,8 @@ final class VSockBridge: GuestBridging {
         return GuestExecResult(
             exitCode: response.exitCode,
             stdout: response.stdout,
-            stderr: response.stderr
+            stderr: response.stderr,
+            details: response.details
         )
     }
 

--- a/tools/macos-vz-helper/Sources/Guest/VSockBridge.swift
+++ b/tools/macos-vz-helper/Sources/Guest/VSockBridge.swift
@@ -173,6 +173,9 @@ final class VSockBridge: GuestBridging {
         timeoutSeconds: TimeInterval,
         maxOutputBytes: Int? = nil
     ) throws -> GuestExecResult {
+        if let maxOutputBytes, maxOutputBytes < 0 {
+            throw GuestBridgeError.guestProtocolError("invalid_max_output_bytes")
+        }
         let requestID = UUID().uuidString
         let requestData = try encoder.encode(
             GuestExecRequest(

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -184,7 +184,8 @@ final class HelperService {
             argv: argv,
             cwd: cwd,
             env: env,
-            timeoutSeconds: timeoutSeconds
+            timeoutSeconds: timeoutSeconds,
+            maxOutputBytes: maxOutputBytes
         )
         let cappedOutput = capExecOutput(
             stdout: result.stdout,
@@ -192,6 +193,9 @@ final class HelperService {
             maxOutputBytes: maxOutputBytes
         )
         var details = ["transport": "vsock", "vm_id": vmID]
+        for (key, value) in result.details where key.hasPrefix("guest_") {
+            details[key] = value
+        }
         for (key, value) in cappedOutput.details {
             details[key] = value
         }

--- a/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
+++ b/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
@@ -78,7 +78,8 @@ final class VZLinuxVMManager {
         argv: [String],
         cwd: String,
         env: [String: String],
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int? = nil
     ) throws -> GuestExecResult {
         guard let record = registry.status(vmID: vmID), record.healthy else {
             throw GuestBridgeError.guestExecNotImplemented
@@ -88,7 +89,8 @@ final class VZLinuxVMManager {
             argv: argv,
             cwd: cwd,
             env: env,
-            timeoutSeconds: timeoutSeconds
+            timeoutSeconds: timeoutSeconds,
+            maxOutputBytes: maxOutputBytes
         )
     }
 }

--- a/tools/macos-vz-helper/Tests/HelperServiceExecTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceExecTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import MacOSVZHelperDaemon
 
 final class RecordingGuestBridge: GuestBridging {
-    private(set) var lastExec: (vmID: String, argv: [String], cwd: String, env: [String: String], timeout: TimeInterval)?
+    private(set) var lastExec: (vmID: String, argv: [String], cwd: String, env: [String: String], timeout: TimeInterval, maxOutputBytes: Int?)?
 
     func waitUntilReady(vmID: String, timeoutSeconds: TimeInterval) throws {}
 
@@ -12,20 +12,23 @@ final class RecordingGuestBridge: GuestBridging {
         argv: [String],
         cwd: String,
         env: [String: String],
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int?
     ) throws -> GuestExecResult {
-        lastExec = (vmID, argv, cwd, env, timeoutSeconds)
-        return GuestExecResult(exitCode: 0, stdout: "ok\n", stderr: "")
+        lastExec = (vmID, argv, cwd, env, timeoutSeconds, maxOutputBytes)
+        return GuestExecResult(exitCode: 0, stdout: "ok\n", stderr: "", details: [:])
     }
 }
 
 final class StaticOutputGuestBridge: GuestBridging {
     let stdout: String
     let stderr: String
+    let details: [String: String]
 
-    init(stdout: String, stderr: String) {
+    init(stdout: String, stderr: String, details: [String: String] = [:]) {
         self.stdout = stdout
         self.stderr = stderr
+        self.details = details
     }
 
     func waitUntilReady(vmID: String, timeoutSeconds: TimeInterval) throws {}
@@ -35,9 +38,10 @@ final class StaticOutputGuestBridge: GuestBridging {
         argv: [String],
         cwd: String,
         env: [String: String],
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int?
     ) throws -> GuestExecResult {
-        return GuestExecResult(exitCode: 0, stdout: stdout, stderr: stderr)
+        return GuestExecResult(exitCode: 0, stdout: stdout, stderr: stderr, details: details)
     }
 }
 
@@ -78,6 +82,40 @@ final class StaticOutputGuestBridge: GuestBridging {
     #expect(guestBridge.lastExec?.cwd == "/workspace")
     #expect(guestBridge.lastExec?.env == ["FOO": "1"])
     #expect(guestBridge.lastExec?.timeout == 15)
+    #expect(guestBridge.lastExec?.maxOutputBytes == nil)
+}
+
+@Test func helperServiceExecGuestPassesOutputCapToGuestBridge() throws {
+    let registry = VMRegistry()
+    let guestBridge = RecordingGuestBridge()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: guestBridge
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    _ = try service.createVM(
+        vmID: "vm-exec-cap-forward",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/workspace",
+        readinessTimeoutSeconds: 5
+    )
+
+    _ = try service.execGuest(
+        vmID: "vm-exec-cap-forward",
+        argv: ["/bin/echo", "ok"],
+        cwd: "/workspace",
+        env: [:],
+        timeoutSeconds: 15,
+        maxOutputBytes: 10
+    )
+
+    #expect(guestBridge.lastExec?.maxOutputBytes == 10)
 }
 
 @Test func helperServiceExecGuestCapsReturnedOutputAndRecordsDetails() throws {
@@ -117,6 +155,50 @@ final class StaticOutputGuestBridge: GuestBridging {
     #expect(response.details["stderr_bytes_original"] == "100")
     #expect(response.details["stdout_truncated"] == "true")
     #expect(response.details["stderr_truncated"] == "true")
+}
+
+@Test func helperServiceExecGuestMergesGuestDetailsWithoutOverwritingHostCounters() throws {
+    let registry = VMRegistry()
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: StaticOutputGuestBridge(
+            stdout: String(repeating: "o", count: 100),
+            stderr: "",
+            details: [
+                "guest_output_limit_exceeded": "true",
+                "guest_stdout_bytes_observed": "101",
+                "stdout_bytes_original": "wrong",
+            ]
+        )
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    _ = try service.createVM(
+        vmID: "vm-exec-guest-details",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/workspace",
+        readinessTimeoutSeconds: 5
+    )
+
+    let response = try service.execGuest(
+        vmID: "vm-exec-guest-details",
+        argv: ["/bin/echo", "ok"],
+        cwd: "/workspace",
+        env: [:],
+        timeoutSeconds: 15,
+        maxOutputBytes: 10
+    )
+
+    #expect(response.details["guest_output_limit_exceeded"] == "true")
+    #expect(response.details["guest_stdout_bytes_observed"] == "101")
+    #expect(response.details["stdout_bytes_original"] == "100")
+    #expect(response.details["stdout_bytes_returned"] == "10")
+    #expect(response.details["stdout_truncated"] == "true")
 }
 
 @Test func helperServiceExecGuestCapsOutputAtUtf8Boundary() throws {

--- a/tools/macos-vz-helper/Tests/TestDoubles.swift
+++ b/tools/macos-vz-helper/Tests/TestDoubles.swift
@@ -28,9 +28,10 @@ final class ReadyGuestBridge: GuestBridging {
         argv: [String],
         cwd: String,
         env: [String : String],
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int?
     ) throws -> GuestExecResult {
-        GuestExecResult(exitCode: 0, stdout: "", stderr: "")
+        GuestExecResult(exitCode: 0, stdout: "", stderr: "", details: [:])
     }
 }
 
@@ -50,7 +51,8 @@ final class FailingGuestBridge: GuestBridging {
         argv: [String],
         cwd: String,
         env: [String : String],
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int?
     ) throws -> GuestExecResult {
         throw error
     }

--- a/tools/macos-vz-helper/Tests/VSockBridgeTests.swift
+++ b/tools/macos-vz-helper/Tests/VSockBridgeTests.swift
@@ -99,6 +99,29 @@ final class RecordingGuestTransport: GuestTransporting {
     #expect(result.details["host_key"] == nil)
 }
 
+@Test func vsockBridgeRejectsNegativeMaxOutputBytesBeforeEncoding() throws {
+    let transport = RecordingGuestTransport()
+    let bridge = VSockBridge(transport: transport)
+
+    do {
+        _ = try bridge.exec(
+            vmID: "vm-negative-cap",
+            argv: ["/bin/echo", "ok"],
+            cwd: "/workspace",
+            env: [:],
+            timeoutSeconds: 15,
+            maxOutputBytes: -1
+        )
+        Issue.record("expected negative maxOutputBytes to be rejected")
+    } catch GuestBridgeError.guestProtocolError(let reason) {
+        #expect(reason == "invalid_max_output_bytes")
+    } catch {
+        Issue.record("expected guestProtocolError, got \(error)")
+    }
+
+    #expect(transport.execPayload == nil)
+}
+
 @Test func vsockBridgeTreatsMissingExecStreamsAsEmptyStrings() throws {
     let transport = RecordingGuestTransport()
     transport.execResponseFactory = { payload in

--- a/tools/macos-vz-helper/Tests/VSockBridgeTests.swift
+++ b/tools/macos-vz-helper/Tests/VSockBridgeTests.swift
@@ -55,17 +55,48 @@ final class RecordingGuestTransport: GuestTransporting {
         argv: ["/bin/echo", "ok"],
         cwd: "/workspace",
         env: ["FOO": "1"],
-        timeoutSeconds: 15
+        timeoutSeconds: 15,
+        maxOutputBytes: 10
     )
 
     #expect(result.exitCode == 0)
     #expect(result.stdout == "ok\n")
     #expect(result.stderr == "")
+    #expect(result.details.isEmpty)
     #expect(transport.execVMID == "vm-exec")
     #expect(transport.execTimeout == 15)
     #expect(transport.execPayload?["type"] as? String == "exec")
+    #expect(transport.execPayload?["max_output_bytes"] as? Int == 10)
     let argv = transport.execPayload?["argv"] as? [String]
     #expect(argv == ["/bin/echo", "ok"])
+}
+
+@Test func vsockBridgeDecodesGuestPrefixedDetailsDefensively() throws {
+    let transport = RecordingGuestTransport()
+    transport.execResponseFactory = { payload in
+        let requestID = payload["request_id"] as? String ?? ""
+        return Data(
+            """
+            {"protocol_version":"1","request_id":"\(requestID)","exit_code":137,"stdout":"x","stderr":"","details":{"guest_output_limit_exceeded":"true","guest_stdout_bytes_observed":"17","ignored_number":1,"host_key":"wrong"}}
+            """.utf8
+        )
+    }
+    let bridge = VSockBridge(transport: transport)
+
+    let result = try bridge.exec(
+        vmID: "vm-exec-details",
+        argv: ["/bin/echo", "ok"],
+        cwd: "/workspace",
+        env: [:],
+        timeoutSeconds: 15,
+        maxOutputBytes: 10
+    )
+
+    #expect(result.exitCode == 137)
+    #expect(result.details["guest_output_limit_exceeded"] == "true")
+    #expect(result.details["guest_stdout_bytes_observed"] == "17")
+    #expect(result.details["ignored_number"] == nil)
+    #expect(result.details["host_key"] == nil)
 }
 
 @Test func vsockBridgeTreatsMissingExecStreamsAsEmptyStrings() throws {

--- a/tools/tldw-agent/docs/vz-linux-guest-protocol.md
+++ b/tools/tldw-agent/docs/vz-linux-guest-protocol.md
@@ -122,9 +122,15 @@ This document defines the first guest protocol used between the Swift
   "env": {
     "EXAMPLE": "1"
   },
-  "timeout_sec": 30
+  "timeout_sec": 30,
+  "max_output_bytes": 1048576
 }
 ```
+
+`max_output_bytes` is optional. When present, it is a combined stdout/stderr
+byte cap. The guest agent terminates the process when observed output exceeds
+the cap, returns only a bounded UTF-8-safe prefix, and reports guest-prefixed
+detail metadata.
 
 ### Exec response
 
@@ -134,9 +140,21 @@ This document defines the first guest protocol used between the Swift
   "request_id": "req-1",
   "exit_code": 0,
   "stdout": "ok\n",
-  "stderr": ""
+  "stderr": "",
+  "details": {
+    "guest_output_limit_bytes": "1048576",
+    "guest_output_limit_exceeded": "false",
+    "guest_stdout_bytes_observed": "3",
+    "guest_stderr_bytes_observed": "0",
+    "guest_stdout_bytes_returned": "3",
+    "guest_stderr_bytes_returned": "0"
+  }
 }
 ```
+
+When output cap enforcement terminates the command, the response uses exit code
+`137` and sets `guest_output_limit_exceeded` to `"true"` with
+`guest_output_kill_reason` set to `"output_limit"`.
 
 ### Error response
 

--- a/tools/tldw-agent/internal/guest/exec.go
+++ b/tools/tldw-agent/internal/guest/exec.go
@@ -34,17 +34,18 @@ const (
 )
 
 type boundedExecOutput struct {
-	mu           sync.Mutex
-	limit        int
-	stdout       []byte
-	stderr       []byte
-	stdoutSeen   int
-	stderrSeen   int
-	exceeded     bool
-	cancelReason outputLimitReason
-	timeoutCtx   context.Context
-	cancel       context.CancelFunc
-	kill         func()
+	mu            sync.Mutex
+	limit         int
+	stdout        []byte
+	stderr        []byte
+	stdoutSeen    int
+	stderrSeen    int
+	exceeded      bool
+	killConfirmed bool
+	cancelReason  outputLimitReason
+	timeoutCtx    context.Context
+	cancel        context.CancelFunc
+	kill          func() bool
 }
 
 type boundedStreamWriter struct {
@@ -164,8 +165,8 @@ func runExecWithOutputLimit(
 		timeoutCtx:   timeoutCtx,
 		cancel:       outputCancel,
 	}
-	limiter.kill = func() {
-		terminateCommandProcess(cmd)
+	limiter.kill = func() bool {
+		return terminateCommandProcess(cmd)
 	}
 
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -202,7 +203,19 @@ func runExecWithOutputLimit(
 	wg.Wait()
 
 	limiter.recordTimeoutIfDeadlineExceeded()
-	stdout, stderr, details, reason := limiter.response()
+	stdout, stderr, details, reason, killConfirmed := limiter.response()
+	return buildLimitedExecResponse(req, stdout, stderr, details, reason, killConfirmed, waitErr)
+}
+
+func buildLimitedExecResponse(
+	req ExecRequest,
+	stdout string,
+	stderr string,
+	details map[string]string,
+	reason outputLimitReason,
+	killConfirmed bool,
+	waitErr error,
+) (*ExecResponse, *ErrorResponse) {
 	if reason == outputLimitReasonTimeout {
 		return nil, &ErrorResponse{
 			ProtocolVersion: ProtocolVersion,
@@ -211,25 +224,27 @@ func runExecWithOutputLimit(
 			Message:         "guest exec timed out",
 		}
 	}
+
 	if reason == outputLimitReasonOutput {
-		return &ExecResponse{
-			ProtocolVersion: ProtocolVersion,
-			RequestID:       req.RequestID,
-			ExitCode:        outputLimitExitCode,
-			Stdout:          stdout,
-			Stderr:          stderr,
-			Details:         details,
-		}, nil
+		if killConfirmed || waitErrIndicatesForcedTermination(waitErr) {
+			return &ExecResponse{
+				ProtocolVersion: ProtocolVersion,
+				RequestID:       req.RequestID,
+				ExitCode:        outputLimitExitCode,
+				Stdout:          stdout,
+				Stderr:          stderr,
+				Details:         details,
+			}, nil
+		}
+		delete(details, "guest_output_kill_reason")
+		if errors.Is(waitErr, context.Canceled) {
+			waitErr = nil
+		}
 	}
 
-	exitCode := 0
-	if waitErr != nil {
-		var exitErr *exec.ExitError
-		if errors.As(waitErr, &exitErr) {
-			exitCode = exitErr.ExitCode()
-		} else {
-			return nil, execFailedResponse(req.RequestID, waitErr)
-		}
+	exitCode, execErr := exitCodeFromWaitErr(req.RequestID, waitErr)
+	if execErr != nil {
+		return nil, execErr
 	}
 
 	return &ExecResponse{
@@ -240,6 +255,22 @@ func runExecWithOutputLimit(
 		Stderr:          stderr,
 		Details:         details,
 	}, nil
+}
+
+func exitCodeFromWaitErr(requestID string, waitErr error) (int, *ErrorResponse) {
+	if waitErr == nil {
+		return 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+	return 0, execFailedResponse(requestID, waitErr)
+}
+
+func waitErrIndicatesForcedTermination(waitErr error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(waitErr, &exitErr) && exitErr.ExitCode() < 0
 }
 
 func execFailedResponse(requestID string, err error) *ErrorResponse {
@@ -303,11 +334,15 @@ func (b *boundedExecOutput) write(stream outputStream, chunk []byte) {
 	b.mu.Unlock()
 
 	if shouldCancel {
+		killConfirmed := false
+		if kill != nil {
+			killConfirmed = kill()
+		}
 		if cancel != nil {
 			cancel()
 		}
-		if kill != nil {
-			kill()
+		if killConfirmed {
+			b.recordKillConfirmed()
 		}
 	}
 }
@@ -323,11 +358,17 @@ func (b *boundedExecOutput) recordTimeoutIfDeadlineExceeded() {
 	b.mu.Unlock()
 }
 
+func (b *boundedExecOutput) recordKillConfirmed() {
+	b.mu.Lock()
+	b.killConfirmed = true
+	b.mu.Unlock()
+}
+
 func (b *boundedExecOutput) timeoutDeadlineExceeded() bool {
 	return b.timeoutCtx != nil && errors.Is(b.timeoutCtx.Err(), context.DeadlineExceeded)
 }
 
-func (b *boundedExecOutput) response() (string, string, map[string]string, outputLimitReason) {
+func (b *boundedExecOutput) response() (string, string, map[string]string, outputLimitReason, bool) {
 	b.mu.Lock()
 	stdoutBytes := append([]byte(nil), b.stdout...)
 	stderrBytes := append([]byte(nil), b.stderr...)
@@ -335,6 +376,7 @@ func (b *boundedExecOutput) response() (string, string, map[string]string, outpu
 	stderrSeen := b.stderrSeen
 	exceeded := b.exceeded
 	reason := b.cancelReason
+	killConfirmed := b.killConfirmed
 	limit := b.limit
 	b.mu.Unlock()
 
@@ -355,7 +397,7 @@ func (b *boundedExecOutput) response() (string, string, map[string]string, outpu
 	if reason != outputLimitReasonNone {
 		details["guest_output_kill_reason"] = string(reason)
 	}
-	return stdout, stderr, details, reason
+	return stdout, stderr, details, reason, killConfirmed
 }
 
 func sanitizeUTF8WithinLimit(value []byte, maxBytes int) string {

--- a/tools/tldw-agent/internal/guest/exec.go
+++ b/tools/tldw-agent/internal/guest/exec.go
@@ -4,10 +4,51 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 )
+
+const (
+	maxGuestOutputBytes = 256 * 1024 * 1024
+	outputLimitExitCode = 137
+)
+
+type outputLimitReason string
+
+const (
+	outputLimitReasonNone   outputLimitReason = ""
+	outputLimitReasonOutput outputLimitReason = "output_limit"
+)
+
+type outputStream int
+
+const (
+	outputStreamStdout outputStream = iota
+	outputStreamStderr
+)
+
+type boundedExecOutput struct {
+	mu           sync.Mutex
+	limit        int
+	stdout       []byte
+	stderr       []byte
+	stdoutSeen   int
+	stderrSeen   int
+	exceeded     bool
+	cancelReason outputLimitReason
+	cancel       context.CancelFunc
+	kill         func()
+}
+
+type boundedStreamWriter struct {
+	output *boundedExecOutput
+	stream outputStream
+}
 
 func (s *Server) Exec(req ExecRequest) (*ExecResponse, *ErrorResponse) {
 	if len(req.Argv) == 0 {
@@ -38,12 +79,25 @@ func (s *Server) Exec(req ExecRequest) (*ExecResponse, *ErrorResponse) {
 		timeout = time.Duration(req.TimeoutSec) * time.Second
 	}
 
+	if req.MaxOutputBytes != nil && (*req.MaxOutputBytes <= 0 || *req.MaxOutputBytes > maxGuestOutputBytes) {
+		return nil, &ErrorResponse{
+			ProtocolVersion: ProtocolVersion,
+			RequestID:       req.RequestID,
+			ErrorCode:       "invalid_request",
+			Message:         "max_output_bytes out of range",
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, req.Argv[0], req.Argv[1:]...)
 	cmd.Dir = cwd
 	cmd.Env = append(os.Environ(), flattenEnv(req.Env)...)
+
+	if req.MaxOutputBytes != nil {
+		return runExecWithOutputLimit(ctx, cancel, cmd, req, *req.MaxOutputBytes)
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -82,6 +136,209 @@ func (s *Server) Exec(req ExecRequest) (*ExecResponse, *ErrorResponse) {
 		Stdout:          stdout.String(),
 		Stderr:          stderr.String(),
 	}, nil
+}
+
+func runExecWithOutputLimit(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	cmd *exec.Cmd,
+	req ExecRequest,
+	maxOutputBytes int,
+) (*ExecResponse, *ErrorResponse) {
+	limiter := &boundedExecOutput{
+		limit:        maxOutputBytes,
+		cancelReason: outputLimitReasonNone,
+		cancel:       cancel,
+	}
+	limiter.kill = func() {
+		terminateCommandProcess(cmd)
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, execFailedResponse(req.RequestID, err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, execFailedResponse(req.RequestID, err)
+	}
+
+	configureCommandProcessGroup(cmd)
+	cmd.Cancel = func() error {
+		terminateCommandProcess(cmd)
+		return nil
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, execFailedResponse(req.RequestID, err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(boundedStreamWriter{output: limiter, stream: outputStreamStdout}, stdoutPipe)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(boundedStreamWriter{output: limiter, stream: outputStreamStderr}, stderrPipe)
+	}()
+
+	waitErr := cmd.Wait()
+	wg.Wait()
+
+	stdout, stderr, details, exceeded := limiter.response()
+	if exceeded {
+		return &ExecResponse{
+			ProtocolVersion: ProtocolVersion,
+			RequestID:       req.RequestID,
+			ExitCode:        outputLimitExitCode,
+			Stdout:          stdout,
+			Stderr:          stderr,
+			Details:         details,
+		}, nil
+	}
+
+	if ctx.Err() != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return nil, &ErrorResponse{
+			ProtocolVersion: ProtocolVersion,
+			RequestID:       req.RequestID,
+			ErrorCode:       "timeout_exceeded",
+			Message:         "guest exec timed out",
+		}
+	}
+
+	exitCode := 0
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return nil, execFailedResponse(req.RequestID, waitErr)
+		}
+	}
+
+	return &ExecResponse{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       req.RequestID,
+		ExitCode:        exitCode,
+		Stdout:          stdout,
+		Stderr:          stderr,
+		Details:         details,
+	}, nil
+}
+
+func execFailedResponse(requestID string, err error) *ErrorResponse {
+	return &ErrorResponse{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       requestID,
+		ErrorCode:       "exec_failed",
+		Message:         err.Error(),
+	}
+}
+
+func (w boundedStreamWriter) Write(p []byte) (int, error) {
+	if w.output == nil {
+		return len(p), nil
+	}
+	w.output.write(w.stream, p)
+	return len(p), nil
+}
+
+func (b *boundedExecOutput) write(stream outputStream, chunk []byte) {
+	if len(chunk) == 0 {
+		return
+	}
+
+	var shouldCancel bool
+	b.mu.Lock()
+	switch stream {
+	case outputStreamStdout:
+		b.stdoutSeen += len(chunk)
+	case outputStreamStderr:
+		b.stderrSeen += len(chunk)
+	}
+
+	remaining := b.limit - len(b.stdout) - len(b.stderr)
+	if remaining > 0 {
+		retained := chunk
+		if len(retained) > remaining {
+			retained = retained[:remaining]
+		}
+		switch stream {
+		case outputStreamStdout:
+			b.stdout = append(b.stdout, retained...)
+		case outputStreamStderr:
+			b.stderr = append(b.stderr, retained...)
+		}
+	}
+
+	if b.stdoutSeen+b.stderrSeen > b.limit && !b.exceeded {
+		b.exceeded = true
+		b.cancelReason = outputLimitReasonOutput
+		shouldCancel = true
+	}
+	cancel := b.cancel
+	kill := b.kill
+	b.mu.Unlock()
+
+	if shouldCancel {
+		if cancel != nil {
+			cancel()
+		}
+		if kill != nil {
+			kill()
+		}
+	}
+}
+
+func (b *boundedExecOutput) response() (string, string, map[string]string, bool) {
+	b.mu.Lock()
+	stdoutBytes := append([]byte(nil), b.stdout...)
+	stderrBytes := append([]byte(nil), b.stderr...)
+	stdoutSeen := b.stdoutSeen
+	stderrSeen := b.stderrSeen
+	exceeded := b.exceeded
+	reason := b.cancelReason
+	limit := b.limit
+	b.mu.Unlock()
+
+	stdout := sanitizeUTF8WithinLimit(stdoutBytes, limit)
+	remaining := limit - len([]byte(stdout))
+	if remaining < 0 {
+		remaining = 0
+	}
+	stderr := sanitizeUTF8WithinLimit(stderrBytes, remaining)
+	details := map[string]string{
+		"guest_output_limit_bytes":    strconv.Itoa(limit),
+		"guest_output_limit_exceeded": strconv.FormatBool(exceeded),
+		"guest_stdout_bytes_observed": strconv.Itoa(stdoutSeen),
+		"guest_stderr_bytes_observed": strconv.Itoa(stderrSeen),
+		"guest_stdout_bytes_returned": strconv.Itoa(len([]byte(stdout))),
+		"guest_stderr_bytes_returned": strconv.Itoa(len([]byte(stderr))),
+	}
+	if reason != outputLimitReasonNone {
+		details["guest_output_kill_reason"] = string(reason)
+	}
+	return stdout, stderr, details, exceeded
+}
+
+func sanitizeUTF8WithinLimit(value []byte, maxBytes int) string {
+	if maxBytes <= 0 || len(value) == 0 {
+		return ""
+	}
+	if len(value) > maxBytes {
+		value = value[:maxBytes]
+	}
+	text := strings.ToValidUTF8(string(value), "")
+	for len([]byte(text)) > maxBytes {
+		runes := []rune(text)
+		if len(runes) == 0 {
+			return ""
+		}
+		text = string(runes[:len(runes)-1])
+	}
+	return text
 }
 
 func flattenEnv(values map[string]string) []string {

--- a/tools/tldw-agent/internal/guest/exec.go
+++ b/tools/tldw-agent/internal/guest/exec.go
@@ -365,15 +365,7 @@ func sanitizeUTF8WithinLimit(value []byte, maxBytes int) string {
 	if len(value) > maxBytes {
 		value = value[:maxBytes]
 	}
-	text := strings.ToValidUTF8(string(value), "")
-	for len([]byte(text)) > maxBytes {
-		runes := []rune(text)
-		if len(runes) == 0 {
-			return ""
-		}
-		text = string(runes[:len(runes)-1])
-	}
-	return text
+	return strings.ToValidUTF8(string(value), "")
 }
 
 func flattenEnv(values map[string]string) []string {

--- a/tools/tldw-agent/internal/guest/exec.go
+++ b/tools/tldw-agent/internal/guest/exec.go
@@ -21,8 +21,9 @@ const (
 type outputLimitReason string
 
 const (
-	outputLimitReasonNone   outputLimitReason = ""
-	outputLimitReasonOutput outputLimitReason = "output_limit"
+	outputLimitReasonNone    outputLimitReason = ""
+	outputLimitReasonOutput  outputLimitReason = "output_limit"
+	outputLimitReasonTimeout outputLimitReason = "timeout"
 )
 
 type outputStream int
@@ -41,6 +42,7 @@ type boundedExecOutput struct {
 	stderrSeen   int
 	exceeded     bool
 	cancelReason outputLimitReason
+	timeoutCtx   context.Context
 	cancel       context.CancelFunc
 	kill         func()
 }
@@ -88,16 +90,20 @@ func (s *Server) Exec(req ExecRequest) (*ExecResponse, *ErrorResponse) {
 		}
 	}
 
+	if req.MaxOutputBytes != nil {
+		timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), timeout)
+		defer timeoutCancel()
+		execCtx, outputCancel := context.WithCancel(timeoutCtx)
+		defer outputCancel()
+
+		cmd := buildExecCommand(execCtx, req, cwd)
+		return runExecWithOutputLimit(timeoutCtx, outputCancel, cmd, req, *req.MaxOutputBytes)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, req.Argv[0], req.Argv[1:]...)
-	cmd.Dir = cwd
-	cmd.Env = append(os.Environ(), flattenEnv(req.Env)...)
-
-	if req.MaxOutputBytes != nil {
-		return runExecWithOutputLimit(ctx, cancel, cmd, req, *req.MaxOutputBytes)
-	}
+	cmd := buildExecCommand(ctx, req, cwd)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -138,9 +144,16 @@ func (s *Server) Exec(req ExecRequest) (*ExecResponse, *ErrorResponse) {
 	}, nil
 }
 
+func buildExecCommand(ctx context.Context, req ExecRequest, cwd string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, req.Argv[0], req.Argv[1:]...)
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), flattenEnv(req.Env)...)
+	return cmd
+}
+
 func runExecWithOutputLimit(
-	ctx context.Context,
-	cancel context.CancelFunc,
+	timeoutCtx context.Context,
+	outputCancel context.CancelFunc,
 	cmd *exec.Cmd,
 	req ExecRequest,
 	maxOutputBytes int,
@@ -148,7 +161,8 @@ func runExecWithOutputLimit(
 	limiter := &boundedExecOutput{
 		limit:        maxOutputBytes,
 		cancelReason: outputLimitReasonNone,
-		cancel:       cancel,
+		timeoutCtx:   timeoutCtx,
+		cancel:       outputCancel,
 	}
 	limiter.kill = func() {
 		terminateCommandProcess(cmd)
@@ -187,8 +201,17 @@ func runExecWithOutputLimit(
 	waitErr := cmd.Wait()
 	wg.Wait()
 
-	stdout, stderr, details, exceeded := limiter.response()
-	if exceeded {
+	limiter.recordTimeoutIfDeadlineExceeded()
+	stdout, stderr, details, reason := limiter.response()
+	if reason == outputLimitReasonTimeout {
+		return nil, &ErrorResponse{
+			ProtocolVersion: ProtocolVersion,
+			RequestID:       req.RequestID,
+			ErrorCode:       "timeout_exceeded",
+			Message:         "guest exec timed out",
+		}
+	}
+	if reason == outputLimitReasonOutput {
 		return &ExecResponse{
 			ProtocolVersion: ProtocolVersion,
 			RequestID:       req.RequestID,
@@ -197,15 +220,6 @@ func runExecWithOutputLimit(
 			Stderr:          stderr,
 			Details:         details,
 		}, nil
-	}
-
-	if ctx.Err() != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return nil, &ErrorResponse{
-			ProtocolVersion: ProtocolVersion,
-			RequestID:       req.RequestID,
-			ErrorCode:       "timeout_exceeded",
-			Message:         "guest exec timed out",
-		}
 	}
 
 	exitCode := 0
@@ -273,10 +287,16 @@ func (b *boundedExecOutput) write(stream outputStream, chunk []byte) {
 		}
 	}
 
-	if b.stdoutSeen+b.stderrSeen > b.limit && !b.exceeded {
+	if b.stdoutSeen+b.stderrSeen > b.limit {
 		b.exceeded = true
-		b.cancelReason = outputLimitReasonOutput
-		shouldCancel = true
+		if b.cancelReason == outputLimitReasonNone {
+			if b.timeoutDeadlineExceeded() {
+				b.cancelReason = outputLimitReasonTimeout
+			} else {
+				b.cancelReason = outputLimitReasonOutput
+				shouldCancel = true
+			}
+		}
 	}
 	cancel := b.cancel
 	kill := b.kill
@@ -292,7 +312,22 @@ func (b *boundedExecOutput) write(stream outputStream, chunk []byte) {
 	}
 }
 
-func (b *boundedExecOutput) response() (string, string, map[string]string, bool) {
+func (b *boundedExecOutput) recordTimeoutIfDeadlineExceeded() {
+	if !b.timeoutDeadlineExceeded() {
+		return
+	}
+	b.mu.Lock()
+	if b.cancelReason == outputLimitReasonNone {
+		b.cancelReason = outputLimitReasonTimeout
+	}
+	b.mu.Unlock()
+}
+
+func (b *boundedExecOutput) timeoutDeadlineExceeded() bool {
+	return b.timeoutCtx != nil && errors.Is(b.timeoutCtx.Err(), context.DeadlineExceeded)
+}
+
+func (b *boundedExecOutput) response() (string, string, map[string]string, outputLimitReason) {
 	b.mu.Lock()
 	stdoutBytes := append([]byte(nil), b.stdout...)
 	stderrBytes := append([]byte(nil), b.stderr...)
@@ -320,7 +355,7 @@ func (b *boundedExecOutput) response() (string, string, map[string]string, bool)
 	if reason != outputLimitReasonNone {
 		details["guest_output_kill_reason"] = string(reason)
 	}
-	return stdout, stderr, details, exceeded
+	return stdout, stderr, details, reason
 }
 
 func sanitizeUTF8WithinLimit(value []byte, maxBytes int) string {

--- a/tools/tldw-agent/internal/guest/exec_test.go
+++ b/tools/tldw-agent/internal/guest/exec_test.go
@@ -1,6 +1,10 @@
 package guest
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
 
 func TestGuestServerRejectsEmptyArgv(t *testing.T) {
 	root := t.TempDir()
@@ -22,5 +26,94 @@ func TestGuestServerRejectsEmptyArgv(t *testing.T) {
 	}
 	if execErr.Message == "" {
 		t.Fatal("expected non-empty error message")
+	}
+}
+
+func TestGuestServerRejectsInvalidMaxOutputBytes(t *testing.T) {
+	root := t.TempDir()
+	server, err := NewServer(root)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	for _, capBytes := range []int{0, 256*1024*1024 + 1} {
+		resp, execErr := server.Exec(ExecRequest{
+			ProtocolVersion: ProtocolVersion,
+			RequestID:       "req-invalid-cap",
+			Type:            "exec",
+			Argv:            []string{"/bin/echo", "ok"},
+			MaxOutputBytes:  &capBytes,
+		})
+		if execErr == nil {
+			t.Fatalf("expected error response for cap %d, got nil and response %#v", capBytes, resp)
+		}
+		if execErr.ErrorCode != "invalid_request" {
+			t.Fatalf("expected invalid_request for cap %d, got %q", capBytes, execErr.ErrorCode)
+		}
+		if execErr.Message != "max_output_bytes out of range" {
+			t.Fatalf("expected max_output_bytes out of range, got %q", execErr.Message)
+		}
+	}
+}
+
+func TestGuestServerExecStopsAtMaxOutputBytes(t *testing.T) {
+	root := t.TempDir()
+	server, err := NewServer(root)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	capBytes := 16
+	resp, execErr := server.Exec(ExecRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "req-cap",
+		Type:            "exec",
+		Argv:            []string{"/bin/sh", "-c", "i=0; while [ $i -lt 4096 ]; do printf x; i=$((i+1)); done"},
+		MaxOutputBytes:  &capBytes,
+	})
+	if execErr != nil {
+		t.Fatalf("Exec() unexpected error = %#v", execErr)
+	}
+	if got := len([]byte(resp.Stdout)) + len([]byte(resp.Stderr)); got > capBytes {
+		t.Fatalf("returned output exceeds cap: got %d, cap %d", got, capBytes)
+	}
+	if resp.ExitCode != 137 {
+		t.Fatalf("expected output-limit exit 137, got %d", resp.ExitCode)
+	}
+	if resp.Details["guest_output_limit_exceeded"] != "true" {
+		t.Fatalf("expected guest output limit metadata, got %#v", resp.Details)
+	}
+	if resp.Details["guest_output_limit_bytes"] != "16" {
+		t.Fatalf("expected limit detail 16, got %#v", resp.Details)
+	}
+}
+
+func TestGuestServerExecOutputCapKeepsUTF8Valid(t *testing.T) {
+	root := t.TempDir()
+	server, err := NewServer(root)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	capBytes := 5
+	resp, execErr := server.Exec(ExecRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "req-utf8",
+		Type:            "exec",
+		Argv:            []string{"/bin/sh", "-c", "printf 'éééé'"},
+		MaxOutputBytes:  &capBytes,
+	})
+	if execErr != nil {
+		t.Fatalf("Exec() unexpected error = %#v", execErr)
+	}
+	output := resp.Stdout + resp.Stderr
+	if !utf8.ValidString(output) {
+		t.Fatalf("expected valid UTF-8 output, got %q", output)
+	}
+	if len([]byte(output)) > capBytes {
+		t.Fatalf("returned output exceeds cap: got %d, cap %d", len([]byte(output)), capBytes)
+	}
+	if strings.Contains(output, "\uFFFD") {
+		t.Fatalf("expected truncation without replacement characters, got %q", output)
 	}
 }

--- a/tools/tldw-agent/internal/guest/exec_test.go
+++ b/tools/tldw-agent/internal/guest/exec_test.go
@@ -133,16 +133,20 @@ func TestBoundedExecOutputTimeoutWinsOverPostTimeoutDrain(t *testing.T) {
 		cancel: func() {
 			cancelCalled = true
 		},
-		kill: func() {
+		kill: func() bool {
 			t.Fatal("post-timeout drain should not invoke output-limit kill")
+			return false
 		},
 	}
 
 	limiter.write(outputStreamStdout, []byte("exceeds-cap"))
-	stdout, stderr, details, reason := limiter.response()
+	stdout, stderr, details, reason, killConfirmed := limiter.response()
 
 	if cancelCalled {
 		t.Fatal("post-timeout drain should not invoke output-limit cancel")
+	}
+	if killConfirmed {
+		t.Fatal("post-timeout drain should not record output-limit kill")
 	}
 	if reason != outputLimitReasonTimeout {
 		t.Fatalf("expected timeout reason to win, got %q", reason)
@@ -155,5 +159,32 @@ func TestBoundedExecOutputTimeoutWinsOverPostTimeoutDrain(t *testing.T) {
 	}
 	if len([]byte(stdout))+len([]byte(stderr)) > 4 {
 		t.Fatalf("returned output exceeds cap: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestLimitedExecResponsePreservesCompletedExitCodeWhenOutputExceeded(t *testing.T) {
+	resp, execErr := buildLimitedExecResponse(
+		ExecRequest{ProtocolVersion: ProtocolVersion, RequestID: "req-completed"},
+		"xxxx",
+		"",
+		map[string]string{
+			"guest_output_limit_exceeded": "true",
+			"guest_output_kill_reason":    string(outputLimitReasonOutput),
+		},
+		outputLimitReasonOutput,
+		false,
+		context.Canceled,
+	)
+	if execErr != nil {
+		t.Fatalf("unexpected error response: %#v", execErr)
+	}
+	if resp.ExitCode != 0 {
+		t.Fatalf("expected completed command exit code 0, got %d", resp.ExitCode)
+	}
+	if resp.Details["guest_output_limit_exceeded"] != "true" {
+		t.Fatalf("expected output limit metadata, got %#v", resp.Details)
+	}
+	if _, ok := resp.Details["guest_output_kill_reason"]; ok {
+		t.Fatalf("expected kill reason to be omitted when no process kill is proven, got %#v", resp.Details)
 	}
 }

--- a/tools/tldw-agent/internal/guest/exec_test.go
+++ b/tools/tldw-agent/internal/guest/exec_test.go
@@ -1,8 +1,10 @@
 package guest
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 )
 
@@ -115,5 +117,43 @@ func TestGuestServerExecOutputCapKeepsUTF8Valid(t *testing.T) {
 	}
 	if strings.Contains(output, "\uFFFD") {
 		t.Fatalf("expected truncation without replacement characters, got %q", output)
+	}
+}
+
+func TestBoundedExecOutputTimeoutWinsOverPostTimeoutDrain(t *testing.T) {
+	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer timeoutCancel()
+	<-timeoutCtx.Done()
+
+	cancelCalled := false
+	limiter := &boundedExecOutput{
+		limit:        4,
+		cancelReason: outputLimitReasonNone,
+		timeoutCtx:   timeoutCtx,
+		cancel: func() {
+			cancelCalled = true
+		},
+		kill: func() {
+			t.Fatal("post-timeout drain should not invoke output-limit kill")
+		},
+	}
+
+	limiter.write(outputStreamStdout, []byte("exceeds-cap"))
+	stdout, stderr, details, reason := limiter.response()
+
+	if cancelCalled {
+		t.Fatal("post-timeout drain should not invoke output-limit cancel")
+	}
+	if reason != outputLimitReasonTimeout {
+		t.Fatalf("expected timeout reason to win, got %q", reason)
+	}
+	if details["guest_output_kill_reason"] != string(outputLimitReasonTimeout) {
+		t.Fatalf("expected timeout kill reason detail, got %#v", details)
+	}
+	if details["guest_output_limit_exceeded"] != "true" {
+		t.Fatalf("expected exceeded detail to remain true after drain, got %#v", details)
+	}
+	if len([]byte(stdout))+len([]byte(stderr)) > 4 {
+		t.Fatalf("returned output exceeds cap: stdout=%q stderr=%q", stdout, stderr)
 	}
 }

--- a/tools/tldw-agent/internal/guest/process_linux.go
+++ b/tools/tldw-agent/internal/guest/process_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package guest
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureCommandProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func terminateCommandProcess(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	if pid > 0 {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}
+	_ = cmd.Process.Kill()
+}

--- a/tools/tldw-agent/internal/guest/process_linux.go
+++ b/tools/tldw-agent/internal/guest/process_linux.go
@@ -11,13 +11,17 @@ func configureCommandProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-func terminateCommandProcess(cmd *exec.Cmd) {
+func terminateCommandProcess(cmd *exec.Cmd) bool {
 	if cmd == nil || cmd.Process == nil {
-		return
+		return false
 	}
+	terminated := false
 	pid := cmd.Process.Pid
 	if pid > 0 {
-		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		terminated = syscall.Kill(-pid, syscall.SIGKILL) == nil
 	}
-	_ = cmd.Process.Kill()
+	if cmd.Process.Kill() == nil {
+		terminated = true
+	}
+	return terminated
 }

--- a/tools/tldw-agent/internal/guest/process_unsupported.go
+++ b/tools/tldw-agent/internal/guest/process_unsupported.go
@@ -6,8 +6,9 @@ import "os/exec"
 
 func configureCommandProcessGroup(_ *exec.Cmd) {}
 
-func terminateCommandProcess(cmd *exec.Cmd) {
+func terminateCommandProcess(cmd *exec.Cmd) bool {
 	if cmd != nil && cmd.Process != nil {
-		_ = cmd.Process.Kill()
+		return cmd.Process.Kill() == nil
 	}
+	return false
 }

--- a/tools/tldw-agent/internal/guest/process_unsupported.go
+++ b/tools/tldw-agent/internal/guest/process_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package guest
+
+import "os/exec"
+
+func configureCommandProcessGroup(_ *exec.Cmd) {}
+
+func terminateCommandProcess(cmd *exec.Cmd) {
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/tools/tldw-agent/internal/guest/types.go
+++ b/tools/tldw-agent/internal/guest/types.go
@@ -72,14 +72,16 @@ type ExecRequest struct {
 	Cwd             string            `json:"cwd,omitempty"`
 	Env             map[string]string `json:"env,omitempty"`
 	TimeoutSec      int               `json:"timeout_sec,omitempty"`
+	MaxOutputBytes  *int              `json:"max_output_bytes,omitempty"`
 }
 
 type ExecResponse struct {
-	ProtocolVersion string `json:"protocol_version"`
-	RequestID       string `json:"request_id"`
-	ExitCode        int    `json:"exit_code"`
-	Stdout          string `json:"stdout,omitempty"`
-	Stderr          string `json:"stderr,omitempty"`
+	ProtocolVersion string            `json:"protocol_version"`
+	RequestID       string            `json:"request_id"`
+	ExitCode        int               `json:"exit_code"`
+	Stdout          string            `json:"stdout,omitempty"`
+	Stderr          string            `json:"stderr,omitempty"`
+	Details         map[string]string `json:"details,omitempty"`
 }
 
 type ErrorResponse struct {

--- a/tools/tldw-agent/internal/guest/types_test.go
+++ b/tools/tldw-agent/internal/guest/types_test.go
@@ -1,6 +1,9 @@
 package guest
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestParseExecRequest(t *testing.T) {
 	req := ExecRequest{
@@ -21,5 +24,25 @@ func TestParseExecRequest(t *testing.T) {
 	}
 	if req.Cwd != "/workspace" {
 		t.Fatalf("expected cwd /workspace, got %q", req.Cwd)
+	}
+}
+
+func TestExecRequestMaxOutputBytesOptional(t *testing.T) {
+	var req ExecRequest
+	if err := json.Unmarshal([]byte(`{"protocol_version":"1","request_id":"req-1","type":"exec","argv":["/bin/echo","ok"]}`), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.MaxOutputBytes != nil {
+		t.Fatalf("expected nil MaxOutputBytes, got %v", *req.MaxOutputBytes)
+	}
+}
+
+func TestExecRequestMaxOutputBytesPreservesExplicitZero(t *testing.T) {
+	var req ExecRequest
+	if err := json.Unmarshal([]byte(`{"protocol_version":"1","request_id":"req-1","type":"exec","argv":["/bin/echo","ok"],"max_output_bytes":0}`), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.MaxOutputBytes == nil || *req.MaxOutputBytes != 0 {
+		t.Fatalf("expected explicit zero cap, got %#v", req.MaxOutputBytes)
 	}
 }

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -175,6 +175,10 @@ The install script now also stages `/workspace`, installs `workspace.mount`,
 and enables both `workspace.mount` and `tldw-agent-guest.service` by creating
 the expected `multi-user.target.wants/` symlinks inside the rootfs.
 
+Guest-side kill-on-output-cap requires images rebuilt with the updated
+`tldw-agent-guest` binary. Older images still boot and execute, but only the
+host helper response cap is guaranteed.
+
 ## Helper Smoke
 
 The canonical bundle can also drive the repeatable host-side E2E smoke:


### PR DESCRIPTION
## Change summary
TODO: Human-authored summary required before merge.

## Summary
- Adds guest-agent `max_output_bytes` support with bounded stdout/stderr capture, output-limit termination metadata, and guest-prefixed cap counters.
- Forwards helper `exec_guest.max_output_bytes` through the Swift vsock bridge while preserving host-side output capping as a fallback.
- Surfaces guest output cap counters in `vz_linux` resource usage and updates the helper, guest-agent, image, and sandbox docs.

## Test Plan
- [x] `git diff --check`
- [x] `GOCACHE=/private/tmp/tldw-go-cache-vz-guest-output-cap go test ./internal/guest -count=1`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_client.py`
- [x] `CLANG_MODULE_CACHE_PATH=/private/tmp/tldw-swift-module-cache-vz-guest-output-cap SWIFTPM_MODULECACHE_OVERRIDE=/private/tmp/tldw-swift-module-cache-vz-guest-output-cap swift test --filter VSockBridgeTests`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py -f json -o /tmp/bandit_vz_guest_output_cap.json` (0 findings)
