### PR TITLE
refactor(workers): register storage cleanup lifecycle

### DIFF
--- a/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
@@ -121,13 +121,21 @@ async def _shutdown_pre_worker_cleanup(
             chatbooks_cleanup_stop_event.set()
         if chatbooks_cleanup_task:
             chatbooks_cleanup_task.cancel()
-    if storage_cleanup_service and "storage_cleanup_service" not in coordinated_legacy_component_names:
+    storage_cleanup_stopped_by_background = "storage_cleanup_service" in stopped_background_worker_names
+    if (
+        storage_cleanup_service
+        and "storage_cleanup_service" not in coordinated_legacy_component_names
+        and not storage_cleanup_stopped_by_background
+    ):
         try:
             await storage_cleanup_service.stop()
             logger.info("Storage cleanup worker stopped")
         except guard_exceptions:
             pass
-    if "storage_cleanup_service" not in coordinated_legacy_component_names:
+    if (
+        "storage_cleanup_service" not in coordinated_legacy_component_names
+        and not storage_cleanup_stopped_by_background
+    ):
         await _reset_storage_service_singletons(
             guard_exceptions=guard_exceptions,
         )

--- a/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
@@ -132,10 +132,7 @@ async def _shutdown_pre_worker_cleanup(
             logger.info("Storage cleanup worker stopped")
         except guard_exceptions:
             pass
-    if (
-        "storage_cleanup_service" not in coordinated_legacy_component_names
-        and not storage_cleanup_stopped_by_background
-    ):
+    if "storage_cleanup_service" not in coordinated_legacy_component_names:
         await _reset_storage_service_singletons(
             guard_exceptions=guard_exceptions,
         )

--- a/tldw_Server_API/app/services/startup_cleanup_workers.py
+++ b/tldw_Server_API/app/services/startup_cleanup_workers.py
@@ -240,6 +240,7 @@ async def _register_storage_cleanup_service(
     worker_inventory: Any,
     storage_cleanup_service: Any,
 ) -> None:
+    """Register a started storage cleanup service with lifecycle inventory."""
     task = _get_storage_cleanup_task(storage_cleanup_service)
     if task is None:
         logger.warning("Storage cleanup worker started without a task handle; lifecycle inventory skipped")
@@ -261,6 +262,7 @@ async def _register_storage_cleanup_service(
 
 
 def _get_storage_cleanup_task(storage_cleanup_service: Any) -> Any | None:
+    """Return the public or legacy background task handle from the cleanup service."""
     task = getattr(storage_cleanup_service, "task", None)
     if task is not None:
         return task
@@ -268,6 +270,7 @@ def _get_storage_cleanup_task(storage_cleanup_service: Any) -> Any | None:
 
 
 async def _stop_started_storage_cleanup_service(storage_cleanup_service: Any) -> None:
+    """Best-effort rollback for a service that started but failed inventory registration."""
     try:
         await storage_cleanup_service.stop()
     except _STARTUP_GUARD_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/services/startup_cleanup_workers.py
+++ b/tldw_Server_API/app/services/startup_cleanup_workers.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 from loguru import logger
 
 from tldw_Server_API.app.services.worker_registry import (
+    ManagedWorker,
     ShutdownPhase,
     start_stop_event_worker,
 )
@@ -69,7 +71,10 @@ async def _start_secondary_cleanup_workers(
     chatbooks_cleanup_task, chatbooks_cleanup_stop_event = await _start_chatbooks_cleanup_worker(
         worker_inventory=worker_inventory,
     )
-    storage_cleanup_service = await _start_storage_cleanup_worker(test_mode=test_mode)
+    storage_cleanup_service = await _start_storage_cleanup_worker(
+        test_mode=test_mode,
+        worker_inventory=worker_inventory,
+    )
     return CleanupWorkerHandles(
         chatbooks_cleanup_task=chatbooks_cleanup_task,
         chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
@@ -198,7 +203,11 @@ async def _start_chatbooks_cleanup_worker(
         return None, None
 
 
-async def _start_storage_cleanup_worker(*, test_mode: bool) -> Any | None:
+async def _start_storage_cleanup_worker(
+    *,
+    test_mode: bool,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     """Start the storage cleanup worker when enabled by the current mode/env."""
     try:
         storage_cleanup_default = "false" if test_mode else "true"
@@ -212,6 +221,11 @@ async def _start_storage_cleanup_worker(*, test_mode: bool) -> Any | None:
         if storage_cleanup_enabled:
             storage_cleanup_service = _get_storage_cleanup_service()
             await storage_cleanup_service.start()
+            if worker_inventory is not None:
+                await _register_storage_cleanup_service(
+                    worker_inventory=worker_inventory,
+                    storage_cleanup_service=storage_cleanup_service,
+                )
             logger.info("Storage cleanup worker started")
             return storage_cleanup_service
         logger.info("Storage cleanup worker disabled by settings")
@@ -219,6 +233,45 @@ async def _start_storage_cleanup_worker(*, test_mode: bool) -> Any | None:
     except _STARTUP_GUARD_EXCEPTIONS as exc:
         logger.warning(f"Failed to start storage cleanup worker: {exc}")
         return None
+
+
+async def _register_storage_cleanup_service(
+    *,
+    worker_inventory: Any,
+    storage_cleanup_service: Any,
+) -> None:
+    task = _get_storage_cleanup_task(storage_cleanup_service)
+    if task is None:
+        logger.warning("Storage cleanup worker started without a task handle; lifecycle inventory skipped")
+        return
+    try:
+        worker_inventory.register(
+            ManagedWorker(
+                name="storage_cleanup_service",
+                task=task,
+                stop_event=None,
+                shutdown_callback=storage_cleanup_service.stop,
+                category="cleanup",
+                shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            )
+        )
+    except _STARTUP_GUARD_EXCEPTIONS:
+        await _stop_started_storage_cleanup_service(storage_cleanup_service)
+        raise
+
+
+def _get_storage_cleanup_task(storage_cleanup_service: Any) -> Any | None:
+    task = getattr(storage_cleanup_service, "task", None)
+    if task is not None:
+        return task
+    return getattr(storage_cleanup_service, "_task", None)
+
+
+async def _stop_started_storage_cleanup_service(storage_cleanup_service: Any) -> None:
+    try:
+        await storage_cleanup_service.stop()
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Storage cleanup startup rollback stop failed: {exc}")
 
 
 async def _maybe_await(value: Any) -> Any:

--- a/tldw_Server_API/app/services/storage_cleanup_service.py
+++ b/tldw_Server_API/app/services/storage_cleanup_service.py
@@ -378,7 +378,8 @@ class StorageCleanupService:
                 stop_event=self._stop_event,
                 interval_seconds=self.interval,
                 temp_retention_hours=self.temp_retention_hours,
-            )
+            ),
+            name="storage_cleanup_service",
         )
         logger.info(f"StorageCleanupService started (interval: {self.interval}s)")
 

--- a/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
@@ -253,7 +253,7 @@ async def test_shutdown_pre_worker_cleanup_skips_stopped_background_chatbooks(
 
 
 @pytest.mark.asyncio
-async def test_shutdown_pre_worker_cleanup_skips_background_stopped_storage_cleanup(
+async def test_shutdown_pre_worker_cleanup_resets_singletons_for_background_stopped_storage_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     shutdown_cleanup = _import_shutdown_pre_worker_cleanup()
@@ -285,7 +285,7 @@ async def test_shutdown_pre_worker_cleanup_skips_background_stopped_storage_clea
     )
 
     assert storage_cleanup_service.stopped is False
-    assert reset_calls == ["auth"]
+    assert reset_calls == ["cleanup", "storage", "auth"]
     assert handles.storage_cleanup_service is storage_cleanup_service
 
 

--- a/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -251,6 +250,43 @@ async def test_shutdown_pre_worker_cleanup_skips_stopped_background_chatbooks(
 
     assert stop_event.is_set is False
     assert chatbooks_task.cancelled is False
+
+
+@pytest.mark.asyncio
+async def test_shutdown_pre_worker_cleanup_skips_background_stopped_storage_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shutdown_cleanup = _import_shutdown_pre_worker_cleanup()
+    storage_cleanup_service = _FakeStorageCleanupService()
+    reset_calls: list[str] = []
+
+    async def _record_cleanup() -> None:
+        reset_calls.append("cleanup")
+
+    async def _record_storage() -> None:
+        reset_calls.append("storage")
+
+    async def _record_auth() -> None:
+        reset_calls.append("auth")
+
+    monkeypatch.setattr(shutdown_cleanup, "_reset_cleanup_service", _record_cleanup)
+    monkeypatch.setattr(shutdown_cleanup, "_reset_storage_service", _record_storage)
+    monkeypatch.setattr(shutdown_cleanup, "_reset_authnz_rate_limiter", _record_auth)
+
+    handles = await shutdown_cleanup.shutdown_pre_worker_cleanup(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        cleanup_task=None,
+        chatbooks_cleanup_task=None,
+        chatbooks_cleanup_stop_event=None,
+        storage_cleanup_service=storage_cleanup_service,
+        coordinated_legacy_component_names=set(),
+        guard_exceptions=(RuntimeError,),
+        stopped_background_worker_names={"storage_cleanup_service"},
+    )
+
+    assert storage_cleanup_service.stopped is False
+    assert reset_calls == ["auth"]
+    assert handles.storage_cleanup_service is storage_cleanup_service
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_cleanup_workers.py
+++ b/tldw_Server_API/tests/Services/test_startup_cleanup_workers.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-
+from fastapi import FastAPI
 
 pytestmark = pytest.mark.unit
 
@@ -40,7 +40,12 @@ async def test_start_cleanup_workers_combines_all_handles(
         calls.append("chatbooks")
         return ("chatbooks-task", "chatbooks-stop")
 
-    async def _fake_storage(*, test_mode: bool) -> str:
+    async def _fake_storage(
+        *,
+        test_mode: bool,
+        worker_inventory: object | None = None,
+    ) -> str:
+        assert worker_inventory is None
         calls.append("storage")
         assert test_mode is True
         return "storage-service"
@@ -82,8 +87,13 @@ async def test_start_cleanup_workers_passes_worker_inventory_to_registered_clean
         calls.append(("chatbooks", worker_inventory))
         return ("chatbooks-task", "chatbooks-stop")
 
-    async def _fake_storage(*, test_mode: bool) -> None:
+    async def _fake_storage(
+        *,
+        test_mode: bool,
+        worker_inventory: object | None = None,
+    ) -> None:
         assert test_mode is True
+        calls.append(("storage", worker_inventory))
         return None
 
     monkeypatch.setattr(startup_cleanup, "_start_ephemeral_cleanup_worker", _fake_ephemeral)
@@ -96,7 +106,11 @@ async def test_start_cleanup_workers_passes_worker_inventory_to_registered_clean
         worker_inventory=worker_inventory,
     )
 
-    assert calls == [("ephemeral", worker_inventory), ("chatbooks", worker_inventory)]
+    assert calls == [
+        ("ephemeral", worker_inventory),
+        ("chatbooks", worker_inventory),
+        ("storage", worker_inventory),
+    ]
     assert handles.cleanup_task == "ephemeral-task"
     assert handles.chatbooks_cleanup_task == "chatbooks-task"
     assert handles.chatbooks_cleanup_stop_event == "chatbooks-stop"
@@ -211,6 +225,72 @@ async def test_start_storage_cleanup_worker_starts_enabled_service(
 
     assert service is not None
     assert started == ["start"]
+
+
+@pytest.mark.asyncio
+async def test_start_storage_cleanup_worker_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_cleanup = _import_startup_cleanup_workers()
+    from tldw_Server_API.app.services.worker_registry import WorkerRegistry
+
+    class _FakeService:
+        def __init__(self) -> None:
+            self.stop_event = asyncio.Event()
+            self.task: asyncio.Task[None] | None = None
+            self.stop_calls = 0
+
+        async def _run(self) -> None:
+            await self.stop_event.wait()
+
+        async def start(self) -> None:
+            self.task = asyncio.create_task(self._run(), name="storage_cleanup_service")
+
+        async def stop(self) -> None:
+            self.stop_calls += 1
+            self.stop_event.set()
+            if self.task is not None:
+                await asyncio.wait_for(self.task, timeout=1)
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    service = _FakeService()
+    monkeypatch.setenv("STORAGE_CLEANUP_ENABLED", "true")
+    monkeypatch.setattr(startup_cleanup, "_get_storage_cleanup_service", lambda: service)
+
+    try:
+        returned_service = await startup_cleanup._start_storage_cleanup_worker(
+            test_mode=False,
+            worker_inventory=worker_inventory,
+        )
+
+        assert returned_service is service
+        assert service.task is not None
+        assert len(worker_inventory.handles) == 1
+        handle = worker_inventory.handles[0]
+        assert handle.name == "storage_cleanup_service"
+        assert handle.task is service.task
+        assert handle.stop_event is None
+        assert handle.shutdown_callback is not None
+        assert handle.category == "cleanup"
+        assert handle.shutdown_phase is startup_cleanup.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+        assert app.state._tldw_shutdown_worker_inventory == [
+            {
+                "name": "storage_cleanup_service",
+                "task_name": "storage_cleanup_service",
+                "has_stop_event": False,
+                "timeout_sec": 5.0,
+                "category": "cleanup",
+                "shutdown_phase": "background_worker_shutdown",
+            }
+        ]
+        assert app.state._tldw_shutdown_job_poller_inventory == []
+
+        await handle.shutdown_callback()
+        assert service.stop_calls == 1
+    finally:
+        if service.task is not None and not service.task.done():
+            await service.stop()
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Storage/test_storage_cleanup_service.py
+++ b/tldw_Server_API/tests/Storage/test_storage_cleanup_service.py
@@ -5,6 +5,7 @@ Focus on expired-file cleanup:
 - Usage decrement via unregister_generated_file
 - Safe path resolution prevents traversal deletes
 """
+import asyncio
 import contextlib
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -206,3 +207,27 @@ def test_mark_tts_history_artifact_deleted_uses_managed_media_database(
             },
         ),
     ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_storage_cleanup_service_names_background_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_cleanup_loop(
+        *,
+        stop_event: asyncio.Event,
+        interval_seconds: int | None,
+        temp_retention_hours: int,
+    ) -> None:
+        await stop_event.wait()
+
+    monkeypatch.setattr(cleanup, "run_storage_cleanup_loop", _fake_cleanup_loop)
+    service = cleanup.StorageCleanupService(interval_seconds=1)
+
+    await service.start()
+    try:
+        assert service._task is not None
+        assert service._task.get_name() == "storage_cleanup_service"
+    finally:
+        await service.stop()


### PR DESCRIPTION
Part of #1114.

## Change summary

Human-authored Change summary required before merge per repo policy.

## AI-authored implementation notes

- Registers `storage_cleanup_service` as a background-worker lifecycle handle after the storage cleanup service starts and exposes its task handle.
- Uses the lifecycle shutdown callback hook to stop the storage cleanup service during background-worker shutdown.
- Suppresses the later pre-worker storage stop/reset path when the background-worker phase already stopped the storage cleanup service.
- Names the real storage cleanup task so diagnostic lifecycle inventory reports the same task name as the worker handle.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_cleanup_workers.py tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py tldw_Server_API/tests/Services/test_shutdown_coordinated_legacy_components.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_startup_delegates_worker_groups tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_shutdown_delegates_pre_worker_cleanup tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_background_workers_do_not_enter_job_poller_quiesce tldw_Server_API/tests/Storage/test_storage_cleanup_service.py -q` (42 passed, 9 warnings)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_cleanup_workers.py tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py tldw_Server_API/app/services/storage_cleanup_service.py tldw_Server_API/tests/Services/test_startup_cleanup_workers.py tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py tldw_Server_API/tests/Storage/test_storage_cleanup_service.py` (passed)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_cleanup_workers.py tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py tldw_Server_API/app/services/storage_cleanup_service.py -f json -o /tmp/bandit_storage_cleanup_1114.json` (0 results, 0 errors)
- `git diff --check` (passed)
