### PR TITLE
fix(vz-helper): recover after timed-out exec responses

### DIFF
--- a/tools/macos-vz-helper/Sources/Guest/VSockSession.swift
+++ b/tools/macos-vz-helper/Sources/Guest/VSockSession.swift
@@ -22,6 +22,8 @@ private struct VSockPendingRequest {
     var result: Result<Data, Error>?
 }
 
+private let maxAbandonedExecRequestIDs = 128
+
 final class VSockSession {
     let vmID: String
     let connectionToken: String
@@ -33,6 +35,8 @@ final class VSockSession {
     private var ready = false
     private var readinessError: Error?
     private var pendingRequest: VSockPendingRequest?
+    private var abandonedRequestIDs: Set<String> = []
+    private var abandonedRequestIDOrder: [String] = []
     private var readinessWaiters: [DispatchSemaphore] = []
 
     init(
@@ -53,6 +57,8 @@ final class VSockSession {
         channel = newChannel
         ready = false
         readinessError = nil
+        abandonedRequestIDs.removeAll()
+        abandonedRequestIDOrder.removeAll()
         lock.unlock()
 
         previousChannel?.close()
@@ -124,7 +130,8 @@ final class VSockSession {
 
         let timedOut = waiter.wait(timeout: .now() + timeoutSeconds) == .timedOut
         if timedOut {
-            completePendingRequest(with: .failure(VSockSessionError.requestTimedOut(requestID)))
+            markPendingRequestTimedOut(requestID)
+            throw VSockSessionError.requestTimedOut(requestID)
         }
 
         let result = try lock.withLock { () throws -> Result<Data, Error> in
@@ -267,14 +274,22 @@ final class VSockSession {
         let requestID = try requireString("request_id", in: payload)
 
         var pending: VSockPendingRequest?
+        var shouldIgnoreLateResponse = false
         lock.lock()
         if let current = pendingRequest, current.requestID == requestID {
             var updated = current
             updated.result = .success(line)
             pendingRequest = updated
             pending = updated
+        } else if abandonedRequestIDs.remove(requestID) != nil {
+            abandonedRequestIDOrder.removeAll { $0 == requestID }
+            shouldIgnoreLateResponse = true
         }
         lock.unlock()
+
+        if shouldIgnoreLateResponse {
+            return
+        }
 
         guard let pending else {
             throw VSockSessionError.invalidMessage(requestID)
@@ -293,6 +308,25 @@ final class VSockSession {
         }
         lock.unlock()
         pending?.semaphore.signal()
+    }
+
+    private func markPendingRequestTimedOut(_ requestID: String) {
+        lock.lock()
+        if let current = pendingRequest, current.requestID == requestID {
+            pendingRequest = nil
+            rememberAbandonedRequestID(requestID)
+        }
+        lock.unlock()
+    }
+
+    private func rememberAbandonedRequestID(_ requestID: String) {
+        if abandonedRequestIDs.insert(requestID).inserted {
+            abandonedRequestIDOrder.append(requestID)
+        }
+        while abandonedRequestIDOrder.count > maxAbandonedExecRequestIDs {
+            let evictedRequestID = abandonedRequestIDOrder.removeFirst()
+            abandonedRequestIDs.remove(evictedRequestID)
+        }
     }
 
     private func validateControlMessage(_ payload: [String: Any], requireToken: Bool) throws {

--- a/tools/macos-vz-helper/Sources/Guest/VSockSession.swift
+++ b/tools/macos-vz-helper/Sources/Guest/VSockSession.swift
@@ -57,8 +57,6 @@ final class VSockSession {
         channel = newChannel
         ready = false
         readinessError = nil
-        abandonedRequestIDs.removeAll()
-        abandonedRequestIDOrder.removeAll()
         lock.unlock()
 
         previousChannel?.close()
@@ -282,7 +280,9 @@ final class VSockSession {
             pendingRequest = updated
             pending = updated
         } else if abandonedRequestIDs.remove(requestID) != nil {
-            abandonedRequestIDOrder.removeAll { $0 == requestID }
+            if let index = abandonedRequestIDOrder.firstIndex(of: requestID) {
+                abandonedRequestIDOrder.remove(at: index)
+            }
             shouldIgnoreLateResponse = true
         }
         lock.unlock()

--- a/tools/macos-vz-helper/Tests/VSockSessionManagerTests.swift
+++ b/tools/macos-vz-helper/Tests/VSockSessionManagerTests.swift
@@ -180,3 +180,70 @@ final class InMemoryVSockChannel: VSockChanneling {
     #expect(result.exitCode == 0)
     #expect(result.stdout == "ok\n")
 }
+
+@Test func vsockSessionIgnoresLateResponseAfterReconnectFollowingExecTimeout() throws {
+    let manager = VSockSessionManager()
+    _ = manager.prepareSession(
+        vmID: "vm-timeout-reconnect",
+        connectionToken: "token-timeout-reconnect",
+        port: 1024,
+        workspaceRoot: "/workspace"
+    )
+    let firstChannel = InMemoryVSockChannel()
+
+    #expect(manager.accept(channel: firstChannel, for: "vm-timeout-reconnect") == true)
+    firstChannel.push(
+        json: #"{"protocol_version":"1","request_id":"req-handshake-1","type":"handshake","vm_id":"vm-timeout-reconnect","connection_token":"token-timeout-reconnect"}"#
+    )
+    firstChannel.push(
+        json: #"{"protocol_version":"1","request_id":"req-ready-1","type":"ready"}"#
+    )
+
+    let bridge = VSockBridge(transport: manager)
+    try bridge.waitUntilReady(vmID: "vm-timeout-reconnect", timeoutSeconds: 0.1)
+
+    #expect(throws: VSockSessionError.self) {
+        _ = try bridge.exec(
+            vmID: "vm-timeout-reconnect",
+            argv: ["/bin/sh", "-c", "sleep 2"],
+            cwd: "/workspace",
+            env: [:],
+            timeoutSeconds: 0.01
+        )
+    }
+    let timedOutRequestID = firstChannel.writes.last?["request_id"] as? String ?? ""
+
+    let secondChannel = InMemoryVSockChannel()
+    secondChannel.onWrite = { payload in
+        guard payload["type"] as? String == "exec" else {
+            return
+        }
+        let requestID = payload["request_id"] as? String ?? ""
+        secondChannel.push(
+            json: #"{"protocol_version":"1","request_id":"\#(requestID)","exit_code":0,"stdout":"ok\n","stderr":""}"#
+        )
+    }
+    #expect(manager.accept(channel: secondChannel, for: "vm-timeout-reconnect") == true)
+    secondChannel.push(
+        json: #"{"protocol_version":"1","request_id":"req-handshake-2","type":"handshake","vm_id":"vm-timeout-reconnect","connection_token":"token-timeout-reconnect"}"#
+    )
+    secondChannel.push(
+        json: #"{"protocol_version":"1","request_id":"req-ready-2","type":"ready"}"#
+    )
+    try bridge.waitUntilReady(vmID: "vm-timeout-reconnect", timeoutSeconds: 0.1)
+
+    firstChannel.push(
+        json: #"{"protocol_version":"1","request_id":"\#(timedOutRequestID)","exit_code":0,"stdout":"late\n","stderr":""}"#
+    )
+
+    let result = try bridge.exec(
+        vmID: "vm-timeout-reconnect",
+        argv: ["/bin/echo", "ok"],
+        cwd: "/workspace",
+        env: [:],
+        timeoutSeconds: 0.1
+    )
+
+    #expect(result.exitCode == 0)
+    #expect(result.stdout == "ok\n")
+}

--- a/tools/macos-vz-helper/Tests/VSockSessionManagerTests.swift
+++ b/tools/macos-vz-helper/Tests/VSockSessionManagerTests.swift
@@ -122,3 +122,61 @@ final class InMemoryVSockChannel: VSockChanneling {
     #expect(channel.writes.count == 3)
     #expect(channel.writes.last?["type"] as? String == "exec")
 }
+
+@Test func vsockSessionIgnoresLateResponseAfterExecTimeout() throws {
+    let manager = VSockSessionManager()
+    _ = manager.prepareSession(
+        vmID: "vm-timeout",
+        connectionToken: "token-timeout",
+        port: 1024,
+        workspaceRoot: "/workspace"
+    )
+    let channel = InMemoryVSockChannel()
+    var respondToExec = false
+    channel.onWrite = { payload in
+        guard payload["type"] as? String == "exec", respondToExec else {
+            return
+        }
+        let requestID = payload["request_id"] as? String ?? ""
+        channel.push(
+            json: #"{"protocol_version":"1","request_id":"\#(requestID)","exit_code":0,"stdout":"ok\n","stderr":""}"#
+        )
+    }
+
+    #expect(manager.accept(channel: channel, for: "vm-timeout") == true)
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-handshake","type":"handshake","vm_id":"vm-timeout","connection_token":"token-timeout"}"#
+    )
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-ready","type":"ready"}"#
+    )
+
+    let bridge = VSockBridge(transport: manager)
+    try bridge.waitUntilReady(vmID: "vm-timeout", timeoutSeconds: 0.1)
+
+    #expect(throws: VSockSessionError.self) {
+        _ = try bridge.exec(
+            vmID: "vm-timeout",
+            argv: ["/bin/sh", "-c", "sleep 2"],
+            cwd: "/workspace",
+            env: [:],
+            timeoutSeconds: 0.01
+        )
+    }
+    let timedOutRequestID = channel.writes.last?["request_id"] as? String ?? ""
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"\#(timedOutRequestID)","exit_code":0,"stdout":"late\n","stderr":""}"#
+    )
+
+    respondToExec = true
+    let result = try bridge.exec(
+        vmID: "vm-timeout",
+        argv: ["/bin/echo", "ok"],
+        cwd: "/workspace",
+        env: [:],
+        timeoutSeconds: 0.1
+    )
+
+    #expect(result.exitCode == 0)
+    #expect(result.stdout == "ok\n")
+}

--- a/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+++ b/tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
@@ -259,6 +259,15 @@ prepare_private_serial_log_dir() {
   fi
 }
 
+prepare_runtime_paths() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    return 0
+  fi
+  prepare_private_socket_parent
+  prepare_socket_path
+  prepare_private_serial_log_dir
+}
+
 run_helper_daemon_smoke() {
   run_cmd env \
     TLDW_SANDBOX_MACOS_HELPER_DAEMON_SMOKE=1 \
@@ -335,7 +344,7 @@ cd "${REPO_ROOT}"
 build_helper_if_needed
 sign_helper_if_requested
 require_helper_binary
-prepare_private_serial_log_dir
+prepare_runtime_paths
 run_helper_daemon_smoke
 start_helper_for_real_e2e
 wait_for_helper_socket

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -152,7 +152,10 @@ def test_host_e2e_smoke_script_default_runtime_dir_is_private_for_real_run(tmp_p
     )
 
     assert result.returncode == 0, result.stderr
-    socket_match = re.search(r"TLDW_SANDBOX_MACOS_HELPER_SOCKET=([^ ]+/helper\.sock)", result.stdout)
+    socket_match = re.search(
+        r"TLDW_SANDBOX_MACOS_HELPER_SOCKET=([^ ]+/helper\.sock)",
+        result.stdout,
+    )
     assert socket_match is not None
     runtime_dir = Path(socket_match.group(1)).parent
     assert runtime_dir.exists()

--- a/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
+++ b/tools/vz-linux-image/tests/test_host_e2e_smoke_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -105,6 +106,60 @@ def test_host_e2e_smoke_script_default_socket_uses_private_runtime_dir(tmp_path:
     assert "/helper.sock" in result.stdout
     assert "TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR=" in result.stdout
     assert "/serial" in result.stdout
+
+
+def test_host_e2e_smoke_script_default_runtime_dir_is_private_for_real_run(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    fake_python = tmp_path / "fake-python"
+    fake_helper = tmp_path / "fake-helper"
+    fake_python.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.exit(0 if sys.argv[1:3] == ['-m', 'pytest'] else 2)\n",
+        encoding="utf-8",
+    )
+    fake_helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import signal\n"
+        "import sys\n"
+        "import time\n"
+        "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+        "while True:\n"
+        "    time.sleep(0.1)\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_helper.chmod(0o755)
+
+    result = _run_smoke_script(
+        "--bundle",
+        str(bundle),
+        "--helper",
+        str(fake_helper),
+        "--python",
+        str(fake_python),
+        "--skip-build",
+        "--skip-sign",
+        env_overrides={
+            "TMPDIR": str(tmp_dir),
+            "TLDW_HOST_E2E_SMOKE_SKIP_SOCKET_WAIT": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    socket_match = re.search(r"TLDW_SANDBOX_MACOS_HELPER_SOCKET=([^ ]+/helper\.sock)", result.stdout)
+    assert socket_match is not None
+    runtime_dir = Path(socket_match.group(1)).parent
+    assert runtime_dir.exists()
+    assert runtime_dir.stat().st_mode & 0o077 == 0
+    serial_dir = runtime_dir / "serial"
+    assert serial_dir.exists()
+    assert serial_dir.stat().st_mode & 0o077 == 0
 
 
 def test_host_e2e_smoke_script_removes_stale_socket_before_helper_start(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Track timed-out VSock exec request IDs so late guest responses are ignored instead of poisoning session readiness.
- Bound the abandoned-request cache and add a regression covering timeout -> late response -> subsequent exec recovery.
- Harden the host E2E smoke script default runtime path so the generated socket parent is owner-private before use.

## Verification
- swift test --package-path tools/macos-vz-helper --filter vsockSessionIgnoresLateResponseAfterExecTimeout
- swift test --package-path tools/macos-vz-helper --filter VSock
- swift test --package-path tools/macos-vz-helper
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tools/vz-linux-image/tests/test_host_e2e_smoke_script.py -q
- bash -n tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tools/vz-linux-image/tests/test_host_e2e_smoke_script.py --skip B101,B108,B404,B603 -f json -o /private/tmp/bandit_vz_helper_timeout_recovery_filtered.json
- tools/vz-linux-image/scripts/run-host-e2e-smoke.sh --bundle /private/tmp/tldw-vz-linux-build-20260502112846/bundle --skip-build --entitlements /private/tmp/tldw-vz-helper-entitlements.plist --python /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python

## Change summary
Human-authored summary pending.