### PR TITLE
refactor(workers): register authnz scheduler lifecycle

### DIFF
--- a/tldw_Server_API/app/services/lifecycle_workers.py
+++ b/tldw_Server_API/app/services/lifecycle_workers.py
@@ -30,7 +30,7 @@ class ManagedWorker:
     """Runtime handle for one lifecycle-managed worker task."""
 
     name: str
-    task: asyncio.Task[Any]
+    task: asyncio.Task[Any] | None
     stop_event: asyncio.Event | None = None
     shutdown_callback: Callable[[], Awaitable[None]] | None = None
     timeout_sec: float = 5.0
@@ -174,14 +174,18 @@ async def stop_registered_workers(
 ) -> None:
     """Stop registered workers concurrently and publish stopped worker names."""
 
-    async def _request_worker_stop(handle: ManagedWorker) -> None:
+    async def _request_worker_stop(handle: ManagedWorker) -> bool | None:
         if handle.stop_event is not None:
             handle.stop_event.set()
-            return
+            if handle.task is None:
+                return True
+            return None
         if handle.shutdown_callback is not None:
             try:
                 await asyncio.wait_for(handle.shutdown_callback(), timeout=handle.timeout_sec)
-                return
+                if handle.task is None:
+                    return True
+                return None
             except asyncio.TimeoutError:
                 logger.warning(
                     "App Shutdown: Timed out waiting for {} {} shutdown callback after {}s; cancelling",
@@ -196,6 +200,8 @@ async def stop_registered_workers(
                     handle.name,
                     exc,
                 )
+        if handle.task is None:
+            return False
         try:
             handle.task.cancel()
         except Exception as exc:  # noqa: BLE001 - cancel hooks can raise arbitrary errors.
@@ -205,8 +211,11 @@ async def stop_registered_workers(
                 handle.name,
                 exc,
             )
+        return None
 
-    async def _await_worker_shutdown(handle: ManagedWorker) -> bool:
+    async def _await_worker_shutdown(handle: ManagedWorker, stop_result: bool | None) -> bool:
+        if handle.task is None:
+            return bool(stop_result)
         try:
             await asyncio.wait_for(asyncio.shield(handle.task), timeout=handle.timeout_sec)
         except asyncio.CancelledError:
@@ -245,13 +254,16 @@ async def stop_registered_workers(
             )
         return bool(handle.task.done())
 
-    await asyncio.gather(
+    stop_results = await asyncio.gather(
         *(_request_worker_stop(handle) for handle in handles),
         return_exceptions=False,
     )
 
     stopped_results = await asyncio.gather(
-        *(_await_worker_shutdown(handle) for handle in handles),
+        *(
+            _await_worker_shutdown(handle, stop_result)
+            for handle, stop_result in zip(handles, stop_results)
+        ),
         return_exceptions=False,
     )
     try:
@@ -295,7 +307,9 @@ async def start_stop_event_worker(
     return task, stop_event
 
 
-def _task_name(task: asyncio.Task[Any]) -> str:
+def _task_name(task: asyncio.Task[Any] | None) -> str | None:
+    if task is None:
+        return None
     get_name = getattr(task, "get_name", None)
     if callable(get_name):
         return str(get_name())

--- a/tldw_Server_API/app/services/lifecycle_workers.py
+++ b/tldw_Server_API/app/services/lifecycle_workers.py
@@ -193,6 +193,15 @@ async def stop_registered_workers(
                     handle.name,
                     handle.timeout_sec,
                 )
+            except asyncio.CancelledError:
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelling():
+                    raise
+                logger.warning(
+                    "App Shutdown: {} {} shutdown callback was cancelled",
+                    log_label,
+                    handle.name,
+                )
             except Exception as exc:  # noqa: BLE001 - shutdown hooks must not block teardown.
                 logger.warning(
                     "App Shutdown: {} {} shutdown callback failed: {}",

--- a/tldw_Server_API/app/services/lifespan_shutdown_sequence.py
+++ b/tldw_Server_API/app/services/lifespan_shutdown_sequence.py
@@ -239,6 +239,7 @@ async def run_lifespan_shutdown_sequence(
         app=app,
         authnz_scheduler_started=worker_runtime.authnz_scheduler_started,
         coordinated_legacy_component_names=coordinated_legacy_component_names,
+        stopped_background_worker_names=stopped_background_worker_names,
         db_pool=db_pool,
         session_manager=session_manager,
         heavy_startup_handles=heavy_startup_handles,

--- a/tldw_Server_API/app/services/shutdown_authnz_scheduler.py
+++ b/tldw_Server_API/app/services/shutdown_authnz_scheduler.py
@@ -13,10 +13,14 @@ async def maybe_stop_authnz_scheduler(
     *,
     authnz_scheduler_started: bool,
     coordinated_legacy_component_names: set[str],
+    stopped_background_worker_names: set[str] | None = None,
     guard_exceptions: tuple[type[BaseException], ...],
     debug_log: Callable[[str], None] | None = None,
 ) -> bool:
     """Stop the AuthNZ scheduler when it was started and is not coordinator-owned."""
+    stopped_background_worker_names = stopped_background_worker_names or set()
+    if "authnz_scheduler" in stopped_background_worker_names:
+        return False
     if not authnz_scheduler_started or "authnz_scheduler" in coordinated_legacy_component_names:
         return authnz_scheduler_started
 

--- a/tldw_Server_API/app/services/shutdown_final_cleanup_tail.py
+++ b/tldw_Server_API/app/services/shutdown_final_cleanup_tail.py
@@ -18,6 +18,7 @@ async def shutdown_final_cleanup_tail(
     app: Any,
     authnz_scheduler_started: bool,
     coordinated_legacy_component_names: set[str],
+    stopped_background_worker_names: set[str] | None = None,
     db_pool: Any | None,
     session_manager: Any | None,
     heavy_startup_handles: Any | None,
@@ -32,6 +33,7 @@ async def shutdown_final_cleanup_tail(
     authnz_scheduler_started = await _maybe_stop_authnz_scheduler(
         authnz_scheduler_started=authnz_scheduler_started,
         coordinated_legacy_component_names=coordinated_legacy_component_names,
+        stopped_background_worker_names=stopped_background_worker_names,
         guard_exceptions=startup_guard_exceptions,
     )
     cleanup_timed_shutdown_handles = await _shutdown_cleanup_timed_segments(

--- a/tldw_Server_API/app/services/startup_recurring_schedulers.py
+++ b/tldw_Server_API/app/services/startup_recurring_schedulers.py
@@ -51,7 +51,9 @@ async def start_recurring_schedulers(
 ) -> RecurringSchedulerHandles:
     """Start the recurring scheduler batch and return explicit scheduler handles."""
     return RecurringSchedulerHandles(
-        authnz_scheduler_started=await _start_authnz_scheduler(),
+        authnz_scheduler_started=await _start_authnz_scheduler(
+            worker_inventory=worker_inventory,
+        ),
         workflows_sched_task=await _start_with_optional_inventory(
             _start_workflows_scheduler,
             worker_inventory,
@@ -112,17 +114,58 @@ async def _start_reading_digest_with_optional_inventory(
     )
 
 
-async def _start_authnz_scheduler() -> bool:
+async def _start_authnz_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> bool:
     try:
         if _env_flag_enabled("DISABLE_AUTHNZ_SCHEDULER"):
             logger.info("AuthNZ scheduler disabled via DISABLE_AUTHNZ_SCHEDULER env var")
             return False
         await _start_authnz_scheduler_service()
+        try:
+            await _register_authnz_scheduler(worker_inventory=worker_inventory)
+        except _STARTUP_GUARD_EXCEPTIONS:
+            await _stop_authnz_scheduler_after_registration_failure()
+            raise
         logger.info("AuthNZ scheduler started")
         return True
     except _STARTUP_GUARD_EXCEPTIONS as exc:
         logger.warning(f"Failed to start AuthNZ scheduler: {exc}")
         return False
+
+
+async def _register_authnz_scheduler(
+    *,
+    worker_inventory: Any | None,
+) -> None:
+    """Register AuthNZ scheduler as callback-only lifecycle work."""
+
+    if worker_inventory is None:
+        return
+
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        ShutdownPhase,
+    )
+
+    worker_inventory.register(
+        ManagedWorker(
+            name="authnz_scheduler",
+            task=None,
+            stop_event=None,
+            shutdown_callback=_stop_authnz_scheduler_service,
+            category="recurring-scheduler",
+            shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        )
+    )
+
+
+async def _stop_authnz_scheduler_after_registration_failure() -> None:
+    try:
+        await _stop_authnz_scheduler_service()
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"AuthNZ scheduler startup rollback stop failed: {exc}")
 
 
 async def _start_workflows_scheduler(
@@ -367,6 +410,12 @@ async def _start_authnz_scheduler_service() -> None:
     from tldw_Server_API.app.core.AuthNZ.scheduler import start_authnz_scheduler
 
     await start_authnz_scheduler()
+
+
+async def _stop_authnz_scheduler_service() -> None:
+    from tldw_Server_API.app.core.AuthNZ.scheduler import stop_authnz_scheduler
+
+    await stop_authnz_scheduler()
 
 
 async def _start_workflows_scheduler_service() -> Any | None:

--- a/tldw_Server_API/tests/Services/test_lifecycle_workers.py
+++ b/tldw_Server_API/tests/Services/test_lifecycle_workers.py
@@ -487,6 +487,48 @@ async def test_stop_registered_workers_awaits_callback_only_worker() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_stop_registered_workers_handles_cancelled_shutdown_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import lifecycle_workers
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        stop_registered_workers,
+    )
+
+    app = FastAPI()
+    warnings: list[tuple[object, ...]] = []
+
+    async def _shutdown_callback() -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        lifecycle_workers.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+
+    await stop_registered_workers(
+        app,
+        [
+            ManagedWorker(
+                name="cancelled_callback_worker",
+                task=None,
+                stop_event=None,
+                shutdown_callback=_shutdown_callback,
+                timeout_sec=1.0,
+            )
+        ],
+        stopped_names_attr="_tldw_stopped_worker_names",
+        log_label="test worker",
+    )
+
+    assert any("shutdown callback was cancelled" in str(args[0]) for args in warnings)
+    assert app.state._tldw_stopped_worker_names == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_stop_registered_workers_bounds_custom_shutdown_callback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_lifecycle_workers.py
+++ b/tldw_Server_API/tests/Services/test_lifecycle_workers.py
@@ -176,6 +176,46 @@ async def test_worker_inventory_publishes_full_and_filtered_views() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_worker_inventory_publishes_callback_only_background_worker() -> None:
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        ShutdownPhase,
+        WorkerRegistry,
+    )
+
+    app = FastAPI()
+    registry = WorkerRegistry(app)
+
+    async def _shutdown_callback() -> None:
+        return None
+
+    handle = registry.register(
+        ManagedWorker(
+            name="authnz_scheduler",
+            task=None,
+            stop_event=None,
+            shutdown_callback=_shutdown_callback,
+            category="recurring-scheduler",
+            shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        )
+    )
+
+    assert handle.task is None
+    assert app.state._tldw_shutdown_worker_inventory == [
+        {
+            "name": "authnz_scheduler",
+            "task_name": None,
+            "has_stop_event": False,
+            "timeout_sec": 5.0,
+            "category": "recurring-scheduler",
+            "shutdown_phase": "background_worker_shutdown",
+        }
+    ]
+    assert app.state._tldw_shutdown_job_poller_inventory == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_start_stop_event_worker_registers_named_task_and_stop_event() -> None:
     from tldw_Server_API.app.services.lifecycle_workers import (
         ShutdownPhase,
@@ -409,6 +449,40 @@ async def test_stop_registered_workers_awaits_custom_shutdown_callback() -> None
     assert shutdown_calls == 1
     assert task.cancelled() is True
     assert app.state._tldw_stopped_worker_names == ["callback_worker"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stop_registered_workers_awaits_callback_only_worker() -> None:
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        stop_registered_workers,
+    )
+
+    app = FastAPI()
+    shutdown_calls = 0
+
+    async def _shutdown_callback() -> None:
+        nonlocal shutdown_calls
+        shutdown_calls += 1
+
+    await stop_registered_workers(
+        app,
+        [
+            ManagedWorker(
+                name="authnz_scheduler",
+                task=None,
+                stop_event=None,
+                shutdown_callback=_shutdown_callback,
+                timeout_sec=1.0,
+            )
+        ],
+        stopped_names_attr="_tldw_stopped_worker_names",
+        log_label="test worker",
+    )
+
+    assert shutdown_calls == 1
+    assert app.state._tldw_stopped_worker_names == ["authnz_scheduler"]
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
+++ b/tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 import pytest
 from fastapi import FastAPI
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -14,15 +13,17 @@ pytestmark = pytest.mark.unit
 async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from tldw_Server_API.app.services import shutdown_coordinated_legacy_components
-    from tldw_Server_API.app.services import shutdown_final_cleanup_tail
-    from tldw_Server_API.app.services import shutdown_grouped_late_stop_workers
-    from tldw_Server_API.app.services import shutdown_job_poller_handoff
-    from tldw_Server_API.app.services import shutdown_post_worker_services
-    from tldw_Server_API.app.services import shutdown_pre_worker_cleanup
-    from tldw_Server_API.app.services import shutdown_primary_late_stop_workers
-    from tldw_Server_API.app.services import shutdown_transition_handoff
-    from tldw_Server_API.app.services import lifespan_shutdown_sequence
+    from tldw_Server_API.app.services import (
+        lifespan_shutdown_sequence,
+        shutdown_coordinated_legacy_components,
+        shutdown_final_cleanup_tail,
+        shutdown_grouped_late_stop_workers,
+        shutdown_job_poller_handoff,
+        shutdown_post_worker_services,
+        shutdown_pre_worker_cleanup,
+        shutdown_primary_late_stop_workers,
+        shutdown_transition_handoff,
+    )
     from tldw_Server_API.app.services.lifespan_worker_runtime_state import (
         LifespanWorkerRuntimeState,
     )
@@ -121,7 +122,11 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
                 },
             )
         )
-        setattr(app.state, stopped_names_attr, ["chatbooks_cleanup", "ephemeral_cleanup_task"])
+        setattr(
+            app.state,
+            stopped_names_attr,
+            ["authnz_scheduler", "chatbooks_cleanup", "ephemeral_cleanup_task"],
+        )
 
     async def _fake_coordinated_shutdown(**kwargs):
         calls.append(("coordinated", kwargs))
@@ -132,6 +137,7 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
     async def _fake_pre_worker_cleanup(**kwargs):
         calls.append(("pre", kwargs))
         assert kwargs["stopped_background_worker_names"] == {
+            "authnz_scheduler",
             "chatbooks_cleanup",
             "ephemeral_cleanup_task",
         }
@@ -258,6 +264,7 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
     assert calls[5][1]["legacy_shutdown_plan"] == ["transition-plan"]
     assert calls[6][1]["coordinated_legacy_component_names"] == {"usage_aggregator"}
     assert calls[6][1]["stopped_background_worker_names"] == {
+        "authnz_scheduler",
         "chatbooks_cleanup",
         "ephemeral_cleanup_task",
     }
@@ -265,6 +272,11 @@ async def test_run_lifespan_shutdown_sequence_runs_wrappers_in_order_and_updates
     assert calls[8][1]["should_run_late_stop"] is True
     assert calls[9][1]["claims_task"] == "claims-start"
     assert calls[10][1]["authnz_scheduler_started"] is True
+    assert calls[10][1]["stopped_background_worker_names"] == {
+        "authnz_scheduler",
+        "chatbooks_cleanup",
+        "ephemeral_cleanup_task",
+    }
     assert calls[10][1]["db_pool"] == "db-pool"
     assert calls[10][1]["session_manager"] == "session-manager"
     assert calls[10][1]["heavy_startup_handles"] == "heavy-handles"

--- a/tldw_Server_API/tests/Services/test_shutdown_authnz_scheduler.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_authnz_scheduler.py
@@ -5,7 +5,6 @@ import sys
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -56,6 +55,30 @@ async def test_maybe_stop_authnz_scheduler_skips_when_component_is_coordinated(
     )
 
     assert started is True
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_maybe_stop_authnz_scheduler_skips_when_background_stopped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shutdown_authnz = _import_shutdown_authnz_scheduler()
+    called = False
+
+    async def _fake_stop():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(shutdown_authnz, "_stop_authnz_scheduler_service", _fake_stop)
+
+    started = await shutdown_authnz.maybe_stop_authnz_scheduler(
+        authnz_scheduler_started=True,
+        coordinated_legacy_component_names=set(),
+        stopped_background_worker_names={"authnz_scheduler"},
+        guard_exceptions=(RuntimeError,),
+    )
+
+    assert started is False
     assert called is False
 
 

--- a/tldw_Server_API/tests/Services/test_shutdown_final_cleanup_tail.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_final_cleanup_tail.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -36,6 +35,7 @@ async def test_shutdown_final_cleanup_tail_runs_helpers_in_order_and_returns_han
         app="app",
         authnz_scheduler_started=True,
         coordinated_legacy_component_names={"coord"},
+        stopped_background_worker_names={"authnz_scheduler"},
         db_pool="db-pool",
         session_manager="session-manager",
         heavy_startup_handles="heavy-startup",
@@ -50,6 +50,7 @@ async def test_shutdown_final_cleanup_tail_runs_helpers_in_order_and_returns_han
     assert [name for name, _ in calls] == ["authnz", "cleanup", "post_runtime"]
     assert calls[0][1]["authnz_scheduler_started"] is True
     assert calls[0][1]["coordinated_legacy_component_names"] == {"coord"}
+    assert calls[0][1]["stopped_background_worker_names"] == {"authnz_scheduler"}
     assert calls[1][1]["authnz_scheduler_started"] is False
     assert calls[1][1]["db_pool"] == "db-pool"
     assert calls[1][1]["session_manager"] == "session-manager"

--- a/tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py
+++ b/tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py
@@ -26,7 +26,7 @@ async def test_start_recurring_schedulers_combines_handles(
     startup_recurring = _import_startup_recurring_schedulers()
     calls: list[str] = []
 
-    async def _fake_authnz(*, worker_inventory: object | None = None):
+    async def _fake_authnz(*, worker_inventory: object | None = None) -> bool:
         assert worker_inventory is None
         calls.append("authnz")
         return True

--- a/tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py
+++ b/tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py
@@ -26,7 +26,8 @@ async def test_start_recurring_schedulers_combines_handles(
     startup_recurring = _import_startup_recurring_schedulers()
     calls: list[str] = []
 
-    async def _fake_authnz():
+    async def _fake_authnz(*, worker_inventory: object | None = None):
+        assert worker_inventory is None
         calls.append("authnz")
         return True
 
@@ -144,14 +145,18 @@ async def test_start_recurring_schedulers_registers_background_inventory_with_sh
     worker_inventory = WorkerRegistry(app)
     created_tasks: list[asyncio.Task[None]] = []
     stopped: list[str] = []
+    service_calls: list[str] = []
 
     def _make_task(name: str) -> asyncio.Task[None]:
         task = asyncio.create_task(_wait_forever(), name=name)
         created_tasks.append(task)
         return task
 
-    async def _fake_authnz():
-        return True
+    async def _fake_authnz_start() -> None:
+        service_calls.append("start-authnz")
+
+    async def _fake_authnz_stop() -> None:
+        stopped.append("authnz")
 
     async def _fake_workflows():
         return _make_task("workflows_recurring_scheduler")
@@ -184,7 +189,9 @@ async def test_start_recurring_schedulers_registers_background_inventory_with_sh
 
         return _stop
 
-    monkeypatch.setattr(startup_recurring, "_start_authnz_scheduler", _fake_authnz)
+    monkeypatch.setattr(startup_recurring, "_env_flag_enabled", lambda key: False)
+    monkeypatch.setattr(startup_recurring, "_start_authnz_scheduler_service", _fake_authnz_start)
+    monkeypatch.setattr(startup_recurring, "_stop_authnz_scheduler_service", _fake_authnz_stop)
     monkeypatch.setattr(startup_recurring, "_start_workflows_scheduler_service", _fake_workflows)
     monkeypatch.setattr(startup_recurring, "_start_reading_digest_scheduler_service", _fake_reading_digest)
     monkeypatch.setattr(startup_recurring, "_start_admin_backup_scheduler_service", _fake_admin_backup)
@@ -218,6 +225,7 @@ async def test_start_recurring_schedulers_registers_background_inventory_with_sh
         )
 
         assert handles.authnz_scheduler_started is True
+        assert service_calls == ["start-authnz"]
         assert handles.workflows_sched_task in created_tasks
         assert handles.reading_digest_sched_task in created_tasks
         assert handles.admin_backup_sched_task in created_tasks
@@ -228,6 +236,7 @@ async def test_start_recurring_schedulers_registers_background_inventory_with_sh
             handle.name: handle.shutdown_phase
             for handle in worker_inventory.handles
         } == {
+            "authnz_scheduler": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
             "workflows_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
             "reading_digest_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
             "admin_backup_sched_task": ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
@@ -244,6 +253,7 @@ async def test_start_recurring_schedulers_registers_background_inventory_with_sh
             await handle.shutdown_callback()
 
         assert stopped == [
+            "authnz",
             "workflows",
             "reading-digest",
             "admin-backup",
@@ -255,6 +265,57 @@ async def test_start_recurring_schedulers_registers_background_inventory_with_sh
         for task in created_tasks:
             task.cancel()
         await asyncio.gather(*created_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_start_authnz_scheduler_registers_callback_only_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_recurring = _import_startup_recurring_schedulers()
+    from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase, WorkerRegistry
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    service_calls: list[str] = []
+
+    async def _fake_start() -> None:
+        service_calls.append("start")
+
+    async def _fake_stop() -> None:
+        service_calls.append("stop")
+
+    monkeypatch.setattr(startup_recurring, "_env_flag_enabled", lambda key: False)
+    monkeypatch.setattr(startup_recurring, "_start_authnz_scheduler_service", _fake_start)
+    monkeypatch.setattr(startup_recurring, "_stop_authnz_scheduler_service", _fake_stop)
+
+    started = await startup_recurring._start_authnz_scheduler(
+        worker_inventory=worker_inventory,
+    )
+
+    assert started is True
+    assert service_calls == ["start"]
+    assert len(worker_inventory.handles) == 1
+    handle = worker_inventory.handles[0]
+    assert handle.name == "authnz_scheduler"
+    assert handle.task is None
+    assert handle.stop_event is None
+    assert handle.shutdown_callback is not None
+    assert handle.category == "recurring-scheduler"
+    assert handle.shutdown_phase is ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+    assert app.state._tldw_shutdown_worker_inventory == [
+        {
+            "name": "authnz_scheduler",
+            "task_name": None,
+            "has_stop_event": False,
+            "timeout_sec": 5.0,
+            "category": "recurring-scheduler",
+            "shutdown_phase": "background_worker_shutdown",
+        }
+    ]
+    assert app.state._tldw_shutdown_job_poller_inventory == []
+
+    await handle.shutdown_callback()
+    assert service_calls == ["start", "stop"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of #1114.

## Change summary

Human-authored Change summary required before merge per repo policy.

## AI-authored implementation notes

- Allows `ManagedWorker` lifecycle handles to represent callback-only services that do not own a durable asyncio task.
- Registers the AuthNZ scheduler as a background-worker lifecycle handle with a shutdown callback.
- Carries background-stopped worker names through the final cleanup tail so AuthNZ is not stopped twice after registry-managed shutdown.
- Keeps AuthNZ out of the job-poller quiesce inventory by using the background-worker shutdown phase.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py tldw_Server_API/tests/Services/test_shutdown_authnz_scheduler.py tldw_Server_API/tests/Services/test_shutdown_final_cleanup_tail.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_startup_tail_finalization.py tldw_Server_API/tests/Services/test_shutdown_coordinated_legacy_components.py tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_background_workers_do_not_enter_job_poller_quiesce tldw_Server_API/tests/Services/test_main_lifecycle_contract.py::test_lifespan_shutdown_delegates_pre_worker_cleanup -q` (38 passed, 9 warnings)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_lifespan_startup_publishes_first_batch_background_worker_inventory tldw_Server_API/tests/Services/test_main_shutdown_job_pollers.py::test_background_workers_do_not_enter_job_poller_quiesce -q` (2 passed, 9 warnings)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/lifecycle_workers.py tldw_Server_API/app/services/startup_recurring_schedulers.py tldw_Server_API/app/services/shutdown_authnz_scheduler.py tldw_Server_API/app/services/shutdown_final_cleanup_tail.py tldw_Server_API/app/services/lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_startup_recurring_schedulers.py tldw_Server_API/tests/Services/test_shutdown_authnz_scheduler.py tldw_Server_API/tests/Services/test_shutdown_final_cleanup_tail.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py` (passed)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/lifecycle_workers.py tldw_Server_API/app/services/startup_recurring_schedulers.py tldw_Server_API/app/services/shutdown_authnz_scheduler.py tldw_Server_API/app/services/shutdown_final_cleanup_tail.py tldw_Server_API/app/services/lifespan_shutdown_sequence.py -f json -o /tmp/bandit_authnz_scheduler_1114.json` (0 results, 0 errors)
- `git diff --check` (passed)
