### PR TITLE
refactor(workers): register claims schedulers

### DIFF
--- a/tldw_Server_API/app/services/claims_alerts_scheduler.py
+++ b/tldw_Server_API/app/services/claims_alerts_scheduler.py
@@ -29,7 +29,6 @@ from tldw_Server_API.app.core.DB_Management.media_db.api import managed_media_da
 from tldw_Server_API.app.core.testing import is_truthy
 
 _CLAIMS_ALERTS_NONCRITICAL_EXCEPTIONS = (
-    asyncio.CancelledError,
     AttributeError,
     KeyError,
     OSError,

--- a/tldw_Server_API/app/services/claims_review_metrics_scheduler.py
+++ b/tldw_Server_API/app/services/claims_review_metrics_scheduler.py
@@ -27,7 +27,6 @@ from tldw_Server_API.app.core.DB_Management.media_db.api import managed_media_da
 from tldw_Server_API.app.core.testing import is_truthy
 
 _CLAIMS_REVIEW_METRICS_NONCRITICAL_EXCEPTIONS = (
-    asyncio.CancelledError,
     AttributeError,
     KeyError,
     OSError,

--- a/tldw_Server_API/app/services/startup_auxiliary_services.py
+++ b/tldw_Server_API/app/services/startup_auxiliary_services.py
@@ -4,13 +4,16 @@ Auxiliary startup-service helpers extracted from the application lifespan.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 from loguru import logger
 
 from tldw_Server_API.app.core.config import legacy_get as _legacy_get
 from tldw_Server_API.app.core.testing import env_flag_enabled as _env_flag_enabled
+from tldw_Server_API.app.services.lifecycle_workers import ManagedWorker, ShutdownPhase
 
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
@@ -38,12 +41,17 @@ async def start_auxiliary_services(
 ) -> AuxiliaryStartupHandles:
     """Start auxiliary services and return explicit task handles.
 
-    When ``worker_inventory`` is provided, usage aggregators are registered
-    with lifecycle worker management. Passing ``None`` preserves the legacy
-    direct-task path in the downstream aggregator startup helpers.
+    When ``worker_inventory`` is provided, claims schedulers and usage
+    aggregators are registered with lifecycle worker management. Passing
+    ``None`` preserves the legacy direct-task path in downstream startup
+    helpers.
     """
-    claims_alerts_task = await _start_claims_alerts_scheduler()
-    claims_review_metrics_task = await _start_claims_review_metrics_scheduler()
+    claims_alerts_task = await _start_claims_alerts_scheduler(
+        worker_inventory=worker_inventory,
+    )
+    claims_review_metrics_task = await _start_claims_review_metrics_scheduler(
+        worker_inventory=worker_inventory,
+    )
     usage_task = await _start_usage_aggregator(worker_inventory=worker_inventory)
     llm_usage_task = await _start_llm_usage_aggregator(worker_inventory=worker_inventory)
     await _start_personalization_consolidation(app_settings)
@@ -55,10 +63,18 @@ async def start_auxiliary_services(
     )
 
 
-async def _start_claims_alerts_scheduler() -> Any | None:
+async def _start_claims_alerts_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     try:
         task = await _start_claims_alerts_scheduler_service()
         if task:
+            await _register_auxiliary_task(
+                worker_inventory=worker_inventory,
+                task=task,
+                worker_name="claims_alerts_task",
+            )
             logger.info("Claims alerts scheduler started")
         return task
     except _STARTUP_GUARD_EXCEPTIONS as exc:
@@ -66,10 +82,18 @@ async def _start_claims_alerts_scheduler() -> Any | None:
         return None
 
 
-async def _start_claims_review_metrics_scheduler() -> Any | None:
+async def _start_claims_review_metrics_scheduler(
+    *,
+    worker_inventory: Any | None = None,
+) -> Any | None:
     try:
         task = await _start_claims_review_metrics_scheduler_service()
         if task:
+            await _register_auxiliary_task(
+                worker_inventory=worker_inventory,
+                task=task,
+                worker_name="claims_review_metrics_task",
+            )
             logger.info("Claims review metrics scheduler started")
         return task
     except _STARTUP_GUARD_EXCEPTIONS as exc:
@@ -111,6 +135,48 @@ async def _start_llm_usage_aggregator(
     except _STARTUP_GUARD_EXCEPTIONS as exc:
         logger.warning(f"Failed to start LLM usage aggregator: {exc}")
         return None
+
+
+async def _register_auxiliary_task(
+    *,
+    worker_inventory: Any | None,
+    task: Any,
+    worker_name: str,
+) -> None:
+    if worker_inventory is None:
+        return
+    try:
+        worker_inventory.register(
+            ManagedWorker(
+                name=worker_name,
+                task=task,
+                stop_event=None,
+                category="auxiliary",
+                shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            )
+        )
+    except _STARTUP_GUARD_EXCEPTIONS:
+        await _cancel_unregistered_task(task)
+        raise
+
+
+async def _cancel_unregistered_task(task: Any, *, timeout: float = 1.0) -> None:
+    try:
+        task.cancel()
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Auxiliary scheduler startup rollback cancel failed: {exc}")
+        return
+    try:
+        await asyncio.wait_for(task, timeout=timeout)
+    except asyncio.CancelledError:
+        pass
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Auxiliary scheduler did not cancel within {}s during startup rollback",
+            timeout,
+        )
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Auxiliary scheduler startup rollback wait failed: {exc}")
 
 
 async def _start_personalization_consolidation(app_settings: Mapping[str, Any]) -> None:

--- a/tldw_Server_API/app/services/startup_auxiliary_services.py
+++ b/tldw_Server_API/app/services/startup_auxiliary_services.py
@@ -143,8 +143,16 @@ async def _register_auxiliary_task(
     task: Any,
     worker_name: str,
 ) -> None:
+    """Register a scheduler task for lifecycle shutdown management.
+
+    If inventory registration fails after the task has been created, the
+    task is cancelled as rollback cleanup. Rollback errors are logged without
+    replacing the original registration failure.
+    """
     if worker_inventory is None:
         return
+    inventory_handles = getattr(worker_inventory, "handles", None)
+    initial_handle_count = len(inventory_handles) if isinstance(inventory_handles, list) else None
     try:
         worker_inventory.register(
             ManagedWorker(
@@ -155,15 +163,31 @@ async def _register_auxiliary_task(
                 shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
             )
         )
-    except _STARTUP_GUARD_EXCEPTIONS:
-        await _cancel_unregistered_task(task)
+    except Exception:  # noqa: BLE001 - rollback must preserve the original registration failure.
+        if isinstance(inventory_handles, list) and initial_handle_count is not None:
+            del inventory_handles[initial_handle_count:]
+            publish = getattr(worker_inventory, "publish", None)
+            if callable(publish):
+                try:
+                    publish()
+                except Exception as exc:  # noqa: BLE001 - best-effort rollback state republish.
+                    logger.debug(f"Auxiliary scheduler inventory rollback publish failed: {exc}")
+        try:
+            await _cancel_unregistered_task(task)
+        except Exception as exc:  # noqa: BLE001 - cleanup must not shadow registration failure.
+            logger.debug(f"Auxiliary scheduler startup rollback failed: {exc}")
         raise
 
 
 async def _cancel_unregistered_task(task: Any, *, timeout: float = 1.0) -> None:
+    """Cancel a scheduler task that could not be registered with inventory.
+
+    The wait is bounded so startup rollback cannot hang indefinitely when a
+    task ignores cancellation.
+    """
     try:
         task.cancel()
-    except _STARTUP_GUARD_EXCEPTIONS as exc:
+    except Exception as exc:  # noqa: BLE001 - rollback cleanup is best effort.
         logger.debug(f"Auxiliary scheduler startup rollback cancel failed: {exc}")
         return
     try:
@@ -175,8 +199,8 @@ async def _cancel_unregistered_task(task: Any, *, timeout: float = 1.0) -> None:
             "Auxiliary scheduler did not cancel within {}s during startup rollback",
             timeout,
         )
-    except _STARTUP_GUARD_EXCEPTIONS as exc:
-        logger.debug(f"Auxiliary scheduler startup rollback wait failed: {exc}")
+    except Exception as exc:  # noqa: BLE001 - task exceptions during rollback are logged only.
+        logger.debug(f"Auxiliary scheduler raised during startup rollback: {exc}")
 
 
 async def _start_personalization_consolidation(app_settings: Mapping[str, Any]) -> None:

--- a/tldw_Server_API/tests/Services/test_claims_alerts_scheduler.py
+++ b/tldw_Server_API/tests/Services/test_claims_alerts_scheduler.py
@@ -9,7 +9,6 @@ import pytest
 
 from tldw_Server_API.app.services import claims_alerts_scheduler as service
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -223,3 +222,30 @@ async def test_start_claims_alerts_scheduler_loop_error_log_is_sanitized(
     rendered = "\n".join(logger.debugs + logger.infos + logger.warnings)
     assert "/tmp/claims-alerts-loop" not in rendered
     assert "sk-live-loop" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_start_claims_alerts_scheduler_propagates_cancelled_error_from_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls = {"count": 0}
+
+    async def _cancelled_run_once() -> int:
+        raise asyncio.CancelledError()
+
+    async def _fake_sleep(_seconds: float) -> None:
+        sleep_calls["count"] += 1
+        if sleep_calls["count"] > 1:
+            raise AssertionError("scheduler continued after cancellation")
+
+    monkeypatch.setenv("CLAIMS_ALERTS_SCHEDULER_ENABLED", "true")
+    monkeypatch.setenv("CLAIMS_ALERTS_EVAL_INTERVAL_SEC", "1")
+    monkeypatch.setattr(service, "run_claims_alerts_once", _cancelled_run_once)
+    monkeypatch.setattr(service.asyncio, "sleep", _fake_sleep)
+
+    task = await service.start_claims_alerts_scheduler()
+
+    assert task is not None
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert sleep_calls["count"] == 1

--- a/tldw_Server_API/tests/Services/test_claims_review_metrics_scheduler.py
+++ b/tldw_Server_API/tests/Services/test_claims_review_metrics_scheduler.py
@@ -11,7 +11,6 @@ import pytest
 from tldw_Server_API.app.core.DB_Management.backends.base import BackendType
 from tldw_Server_API.app.services import claims_review_metrics_scheduler as service
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -195,3 +194,30 @@ async def test_start_claims_review_metrics_scheduler_loop_error_log_is_sanitized
     assert logger.binds == [{"error_type": "RuntimeError"}]
     assert "/tmp/claims-review-loop" not in _rendered_logs(logger)
     assert "sk-live-loop" not in _rendered_logs(logger)
+
+
+@pytest.mark.asyncio
+async def test_start_claims_review_metrics_scheduler_propagates_cancelled_error_from_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls = {"count": 0}
+
+    async def _cancelled_run_once() -> int:
+        raise asyncio.CancelledError()
+
+    async def _fake_sleep(_seconds: float) -> None:
+        sleep_calls["count"] += 1
+        if sleep_calls["count"] > 1:
+            raise AssertionError("scheduler continued after cancellation")
+
+    monkeypatch.setenv("CLAIMS_REVIEW_METRICS_SCHEDULER_ENABLED", "true")
+    monkeypatch.setenv("CLAIMS_REVIEW_METRICS_INTERVAL_SEC", "1")
+    monkeypatch.setattr(service, "run_claims_review_metrics_once", _cancelled_run_once)
+    monkeypatch.setattr(service.asyncio, "sleep", _fake_sleep)
+
+    task = await service.start_claims_review_metrics_scheduler()
+
+    assert task is not None
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert sleep_calls["count"] == 1

--- a/tldw_Server_API/tests/Services/test_startup_auxiliary_services.py
+++ b/tldw_Server_API/tests/Services/test_startup_auxiliary_services.py
@@ -195,6 +195,107 @@ async def test_start_auxiliary_services_registers_claims_schedulers_with_worker_
 
 
 @pytest.mark.asyncio
+async def test_register_auxiliary_task_preserves_registration_error_when_rollback_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_aux = _import_startup_auxiliary_services()
+    task = object()
+
+    class _FailingInventory:
+        def register(self, worker: object) -> None:
+            raise AttributeError("registration failed")
+
+    async def _failing_cancel(_task: object) -> None:
+        raise LookupError("rollback failed")
+
+    monkeypatch.setattr(startup_aux, "_cancel_unregistered_task", _failing_cancel)
+
+    with pytest.raises(AttributeError, match="registration failed"):
+        await startup_aux._register_auxiliary_task(
+            worker_inventory=_FailingInventory(),
+            task=task,
+            worker_name="claims_alerts_task",
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_auxiliary_services_rolls_back_claims_task_when_inventory_register_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_aux = _import_startup_auxiliary_services()
+    from tldw_Server_API.app.services.lifecycle_workers import WorkerRegistry
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    created_tasks: list[asyncio.Task[None]] = []
+
+    async def _wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    def _make_task(name: str) -> asyncio.Task[None]:
+        task = asyncio.create_task(_wait_forever(), name=name)
+        created_tasks.append(task)
+        return task
+
+    async def _fake_claims_alerts_service() -> asyncio.Task[None]:
+        return _make_task("claims_alerts_scheduler")
+
+    def _failing_register(worker: object) -> None:
+        worker_inventory.handles.append(worker)
+        raise LookupError("registration failed")
+
+    monkeypatch.setattr(
+        startup_aux,
+        "_start_claims_alerts_scheduler_service",
+        _fake_claims_alerts_service,
+    )
+    monkeypatch.setattr(worker_inventory, "register", _failing_register)
+
+    try:
+        with pytest.raises(LookupError, match="registration failed"):
+            await startup_aux.start_auxiliary_services(
+                {},
+                worker_inventory=worker_inventory,
+            )
+
+        assert len(created_tasks) == 1
+        assert created_tasks[0].cancelled()
+        assert worker_inventory.handles == []
+    finally:
+        for task in created_tasks:
+            task.cancel()
+        await asyncio.gather(*created_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cancel_unregistered_task_swallows_task_exception_during_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_aux = _import_startup_auxiliary_services()
+    debug_messages: list[str] = []
+
+    async def _raises_on_cancel() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as exc:
+            raise LookupError("cleanup failed") from exc
+
+    monkeypatch.setattr(
+        startup_aux.logger,
+        "debug",
+        lambda message, *args: debug_messages.append(message.format(*args) if args else message),
+    )
+
+    task = asyncio.create_task(_raises_on_cancel(), name="claims_alerts_scheduler")
+    await asyncio.sleep(0)
+
+    await startup_aux._cancel_unregistered_task(task, timeout=0.25)
+
+    assert task.done()
+    assert debug_messages == ["Auxiliary scheduler raised during startup rollback: cleanup failed"]
+
+
+@pytest.mark.asyncio
 async def test_start_usage_aggregator_skips_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_startup_auxiliary_services.py
+++ b/tldw_Server_API/tests/Services/test_startup_auxiliary_services.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
-from types import SimpleNamespace
 
 import pytest
-
+from fastapi import FastAPI
 
 pytestmark = pytest.mark.unit
 
@@ -22,11 +22,13 @@ async def test_start_auxiliary_services_combines_handles_and_starts_personalizat
     startup_aux = _import_startup_auxiliary_services()
     calls: list[str] = []
 
-    async def _fake_claims_alerts():
+    async def _fake_claims_alerts(**kwargs: object) -> str:
+        assert kwargs == {"worker_inventory": None}
         calls.append("claims-alerts")
         return "claims-alerts-task"
 
-    async def _fake_claims_review():
+    async def _fake_claims_review(**kwargs: object) -> str:
+        assert kwargs == {"worker_inventory": None}
         calls.append("claims-review")
         return "claims-review-task"
 
@@ -75,10 +77,12 @@ async def test_start_auxiliary_services_passes_worker_inventory_to_usage_aggrega
     worker_inventory = object()
     seen_inventory: list[object] = []
 
-    async def _fake_claims_alerts():
+    async def _fake_claims_alerts(**kwargs: object) -> None:
+        assert kwargs == {"worker_inventory": worker_inventory}
         return None
 
-    async def _fake_claims_review():
+    async def _fake_claims_review(**kwargs: object) -> None:
+        assert kwargs == {"worker_inventory": worker_inventory}
         return None
 
     async def _fake_usage(**kwargs: object) -> str:
@@ -106,6 +110,88 @@ async def test_start_auxiliary_services_passes_worker_inventory_to_usage_aggrega
     assert seen_inventory == [worker_inventory, worker_inventory]
     assert handles.usage_task == "usage-task"
     assert handles.llm_usage_task == "llm-usage-task"
+
+
+@pytest.mark.asyncio
+async def test_start_auxiliary_services_registers_claims_schedulers_with_worker_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_aux = _import_startup_auxiliary_services()
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ShutdownPhase,
+        WorkerRegistry,
+    )
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    created_tasks: list[asyncio.Task[None]] = []
+
+    async def _wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    def _make_task(name: str) -> asyncio.Task[None]:
+        task = asyncio.create_task(_wait_forever(), name=name)
+        created_tasks.append(task)
+        return task
+
+    async def _fake_claims_alerts_service() -> asyncio.Task[None]:
+        return _make_task("claims_alerts_scheduler")
+
+    async def _fake_claims_review_service() -> asyncio.Task[None]:
+        return _make_task("claims_review_metrics_scheduler")
+
+    async def _fake_usage(**kwargs: object) -> None:
+        assert kwargs == {"worker_inventory": worker_inventory}
+
+    async def _fake_llm_usage(**kwargs: object) -> None:
+        assert kwargs == {"worker_inventory": worker_inventory}
+
+    async def _fake_personalization(_app_settings) -> None:
+        return None
+
+    monkeypatch.setattr(
+        startup_aux,
+        "_start_claims_alerts_scheduler_service",
+        _fake_claims_alerts_service,
+    )
+    monkeypatch.setattr(
+        startup_aux,
+        "_start_claims_review_metrics_scheduler_service",
+        _fake_claims_review_service,
+    )
+    monkeypatch.setattr(startup_aux, "_start_usage_aggregator", _fake_usage)
+    monkeypatch.setattr(startup_aux, "_start_llm_usage_aggregator", _fake_llm_usage)
+    monkeypatch.setattr(startup_aux, "_start_personalization_consolidation", _fake_personalization)
+
+    try:
+        handles = await startup_aux.start_auxiliary_services(
+            {},
+            worker_inventory=worker_inventory,
+        )
+
+        assert handles.claims_alerts_task is created_tasks[0]
+        assert handles.claims_review_metrics_task is created_tasks[1]
+        assert [handle.name for handle in worker_inventory.handles] == [
+            "claims_alerts_task",
+            "claims_review_metrics_task",
+        ]
+        assert [handle.task for handle in worker_inventory.handles] == created_tasks
+        assert [handle.stop_event for handle in worker_inventory.handles] == [None, None]
+        assert [handle.category for handle in worker_inventory.handles] == [
+            "auxiliary",
+            "auxiliary",
+        ]
+        assert [
+            handle.shutdown_phase for handle in worker_inventory.handles
+        ] == [
+            ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        ]
+        assert app.state._tldw_shutdown_job_poller_inventory == []
+    finally:
+        for task in created_tasks:
+            task.cancel()
+        await asyncio.gather(*created_tasks, return_exceptions=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- What changed:
  - Registers the claims alerts and claims review metrics schedulers with the lifecycle worker inventory when `worker_inventory` is available.
  - Keeps the legacy direct-task path when no inventory is provided.
  - Cancels a started claims scheduler task if inventory registration fails, avoiding an untracked background task leak.
- Why:
  - These two long-running auxiliary schedulers were still raw startup handles and were not represented in centralized background-worker shutdown.

## Change Summary

Human-authored change summary required before merge per project policy.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [ ] Docs updated (not needed: internal lifecycle refactor only)

Commands run:

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_auxiliary_services.py::test_start_auxiliary_services_registers_claims_schedulers_with_worker_inventory -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_auxiliary_services.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_auxiliary_services.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_auxiliary_services.py tldw_Server_API/tests/Services/test_startup_auxiliary_services.py`
- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_auxiliary_services.py -f json -o /tmp/bandit_claims_schedulers_worker_registry_1114.json`

## UX Audit Checklist (v2 Stage 5)

- [ ] `npm run e2e:smoke:stage5` passes (not applicable: backend lifecycle refactor)
- [ ] `npx playwright test e2e/smoke/all-pages.spec.ts --reporter=line` passes (not applicable: backend lifecycle refactor)
- [x] No listed AntD deprecations in console output: not applicable
- [x] No `Maximum update depth exceeded` warnings on audited routes: not applicable
- [x] No unresolved `{{...}}` placeholders on audited routes: not applicable
- [x] WebUI/extension parity validated for shared UI fixes: not applicable
- [x] For Flashcards UI changes: not applicable
- [x] For Flashcards drawer changes: not applicable
- [x] For Flashcards help/copy/import UX changes: not applicable

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable: no Watchlists UI behavior changed

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable: no Watchlists scale behavior changed

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this commit to restore direct claims scheduler task startup without lifecycle inventory registration.
