### PR TITLE
fix(persona): require saved wake phrases in live card

### DIFF
--- a/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantVoiceCard.tsx
@@ -120,8 +120,7 @@ export const AssistantVoiceCard: React.FC<AssistantVoiceCardProps> = ({
   onReconnectPersonaSession
 }) => {
   const sessionControlsDisabled = !connected
-  const effectiveWakeTriggerPhrases =
-    wakeTriggerPhrases ?? resolvedDefaults.voiceChatTriggerPhrases
+  const effectiveWakeTriggerPhrases = wakeTriggerPhrases ?? []
   const effectiveSessionWakeBehavior =
     sessionWakeBehavior ?? resolvedDefaults.wakeBehavior
   const normalizedWakeTriggerPhrases = React.useMemo(

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx
@@ -162,7 +162,7 @@ describe("AssistantVoiceCard", () => {
     expect(props.onToggleWakeArmed).toHaveBeenCalledTimes(1)
   })
 
-  it("uses resolved wake defaults when session wake props are omitted", () => {
+  it("does not arm wake from resolved fallback trigger phrases when session wake props are omitted", () => {
     const props = defaultVoiceCardProps()
     props.resolvedDefaults = {
       ...props.resolvedDefaults,
@@ -175,8 +175,9 @@ describe("AssistantVoiceCard", () => {
     render(<AssistantVoiceCard {...props} />)
 
     expect(screen.getByTestId("live-wake-phrases")).toHaveTextContent(
-      "fallback wake"
+      /add a trigger phrase/i
     )
+    expect(screen.getByTestId("live-wake-toggle")).toBeDisabled()
     expect(screen.getByTestId("live-wake-behavior")).toHaveTextContent("Continuous")
   })
 


### PR DESCRIPTION
## Change summary

TODO (human): Replace this with a human-owned summary explaining what changed and why these implementation choices were made.

## What changed

- Removed the live voice card fallback that treated resolved/global trigger phrases as wake phrases when raw saved wake phrases were not provided.
- Updated the focused component test to enforce that omitted wake phrase props leave wake arming blocked.
- Kept session wake behavior fallback intact so only wake phrase arming is tightened.

## Verification

- `bun run test src/components/PersonaGarden/__tests__/LiveSessionPanel.test.tsx`
- `bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t wake`
- `git diff --check`

## Notes

- Frontend-only change; no backend files were touched, so Bandit was not applicable for this slice.
