### PR TITLE
fix(persona): stop wake listening on disconnect

### DIFF
--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -483,6 +483,59 @@ describe("usePersonaLiveVoiceController", () => {
     expect(result.current.wakeArmed).toBe(false)
   })
 
+  it("cleans up wake state when detector stop rejects during disarm", async () => {
+    const stopError = new Error("wake stop failed")
+    const detector: WakeDetector = {
+      isAvailable: vi.fn(async () => true),
+      start: vi.fn(async (nextConfig) => {
+        nextConfig.onStateChange?.("listening")
+      }),
+      stop: vi.fn(async () => {
+        throw stopError
+      })
+    }
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result } = renderHook(() =>
+      usePersonaLiveVoiceController({
+        ws,
+        connected: true,
+        sessionId: "sess-1",
+        personaId: "persona-1",
+        resolvedDefaults,
+        canUseServerStt: true,
+        wakeTriggerPhrases: ["hey helper"],
+        wakeDetectorFactory: () => detector
+      })
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    ;(ws as WebSocket & { send: ReturnType<typeof vi.fn> }).send.mockClear()
+
+    let disarmResult: unknown
+    await act(async () => {
+      disarmResult = await result.current.toggleWakeArmed()
+    })
+
+    expect(disarmResult).toBeUndefined()
+    await waitFor(() => {
+      expect(result.current.wakeArmed).toBe(false)
+    })
+    expect(result.current.wakeDetectorState).toBe("idle")
+    expect(getSentPayloads(ws as WebSocket & { send: ReturnType<typeof vi.fn> })).toEqual([
+      {
+        type: "wake_deactivation",
+        session_id: "sess-1",
+        reason: "disarmed"
+      }
+    ])
+  })
+
   it("sends wake deactivation on unmount when wake listening is armed", async () => {
     const wakeHarness = createWakeDetectorHarness()
     const ws = {

--- a/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
+++ b/apps/packages/ui/src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx
@@ -575,6 +575,53 @@ describe("usePersonaLiveVoiceController", () => {
     })
   })
 
+  it("stops armed wake listening when Persona Live disconnects", async () => {
+    const wakeHarness = createWakeDetectorHarness()
+    const ws = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn()
+    } as unknown as WebSocket
+
+    const { result, rerender } = renderHook(
+      ({ connected }: { connected: boolean }) =>
+        usePersonaLiveVoiceController({
+          ws,
+          connected,
+          sessionId: "sess-1",
+          personaId: "persona-1",
+          resolvedDefaults,
+          canUseServerStt: true,
+          wakeTriggerPhrases: ["hey helper"],
+          wakeDetectorFactory: () => wakeHarness.detector
+        }),
+      {
+        initialProps: { connected: true }
+      }
+    )
+
+    await act(async () => {
+      await result.current.toggleWakeArmed()
+    })
+    ;(ws as WebSocket & { send: ReturnType<typeof vi.fn> }).send.mockClear()
+    vi.mocked(wakeHarness.detector.stop).mockClear()
+
+    rerender({ connected: false })
+
+    await waitFor(() => {
+      expect(result.current.wakeArmed).toBe(false)
+    })
+    expect(wakeHarness.detector.stop).toHaveBeenCalledTimes(1)
+    expect(getSentPayloads(ws as WebSocket & { send: ReturnType<typeof vi.fn> })).toEqual(
+      expect.arrayContaining([
+        {
+          type: "wake_deactivation",
+          session_id: "sess-1",
+          reason: "session_close"
+        }
+      ])
+    )
+  })
+
   it("cancels stale wake starts when disarmed before availability resolves", async () => {
     let resolveAvailable: ((available: boolean) => void) | null = null
     const detector: WakeDetector = {

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -30,6 +30,7 @@ type PersonaWakeStopReason =
   | "stop_live_voice"
   | "persona_switch"
   | "tab_switch"
+  | "session_close"
 
 type UsePersonaLiveVoiceControllerArgs = {
   ws: WebSocket | null
@@ -944,6 +945,9 @@ export const usePersonaLiveVoiceController = ({
 
   React.useEffect(() => {
     if (!connected) {
+      if (wakeArmedRef.current || wakeDetectorRef.current) {
+        void stopWakeListeningRef.current("session_close")
+      }
       setSessionWakeBehavior(resolvedDefaults.wakeBehavior)
       setAutoCommitEnabled(resolvedDefaults.autoCommitEnabled)
       setVadThreshold(resolvedDefaults.vadThreshold)

--- a/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
+++ b/apps/packages/ui/src/hooks/usePersonaLiveVoiceController.tsx
@@ -507,6 +507,8 @@ export const usePersonaLiveVoiceController = ({
       sendWakeDeactivation(reason, targetSessionId)
       try {
         await detector?.stop()
+      } catch {
+        // Wake detector teardown is best-effort; state cleanup must still finish.
       } finally {
         setWakeDetectorState("idle")
         setWakeArmed(false)


### PR DESCRIPTION
## Change summary

TODO (human): Replace this with a human-owned summary explaining what changed and why these implementation choices were made.

## What changed

- Stops an armed Persona Live wake detector when the live session disconnects.
- Sends the existing backend-supported `session_close` wake deactivation reason when the websocket is still open.
- Adds focused hook coverage for the disconnect cleanup path.

## Verification

- `bun run test src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx -t "stops armed wake listening"`
- `bun run test src/hooks/__tests__/usePersonaLiveVoiceController.test.tsx`
- `bun run test src/routes/__tests__/sidepanel-persona.test.tsx -t wake`
- `git diff --check`

## Notes

- Frontend-only change; no backend files were touched, so Bandit was not applicable for this slice.
