### PR TITLE
Surface vz_linux guest capability readiness metadata

### DIFF
--- a/Docs/Plans/2026-05-02-vz-guest-capability-readiness-plan.md
+++ b/Docs/Plans/2026-05-02-vz-guest-capability-readiness-plan.md
@@ -1,0 +1,51 @@
+# VZ Guest Capability Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Surface `vz_linux` guest-agent version, workspace root, and optional capability metadata in helper VM readiness/status responses.
+
+**Architecture:** Extend the existing guest handshake with optional capabilities while preserving protocol version `1` and old guest compatibility. Store the parsed metadata in the Swift helper session/registry path and expose it through the existing VM `details` maps used by `create_vm`, `get_vm_status`, and `list_vms`. Treat the metadata as diagnostics/readiness information only; do not use it for security enforcement in this slice.
+
+**Tech Stack:** Swift helper daemon, Go `tools/tldw-agent` guest protocol, existing helper protocol JSON details, Swift Testing, Go tests.
+
+---
+
+## Stage 1: Lock Swift Session Metadata Behavior
+**Goal:** Prove the helper records optional guest capabilities and handles old guests as unknown.
+**Success Criteria:** `VSockSessionManager` exposes parsed guest version/workspace/capability state after handshake, and missing or malformed capabilities do not fail readiness.
+**Tests:** `swift test --package-path tools/macos-vz-helper --filter VSockSessionManagerTests`
+**Status:** Complete
+
+- [x] Add failing tests for capability-present, capability-missing, and malformed capability handshakes.
+- [x] Implement a small `GuestAgentInfo` model and session/manager accessors.
+- [x] Run the focused Swift session tests until green.
+
+## Stage 2: Surface Metadata Through VM Status
+**Goal:** Include guest readiness metadata in VM `details` without changing the helper protocol shape.
+**Success Criteria:** `create_vm`, `get_vm_status`, and `list_vms` include deterministic `guest_*` detail keys when guest info is known, and report capability state as unknown for old guests.
+**Tests:** `swift test --package-path tools/macos-vz-helper --filter HelperServiceVMTests`
+**Status:** Complete
+
+- [x] Add failing helper service tests for guest details in create/status/list replies.
+- [x] Persist guest info in `VMRecord` via `VZLinuxVMManager` after readiness.
+- [x] Format details with stable strings: `guest_version`, `guest_workspace_root`, `guest_capabilities_known`, and `guest_capabilities`.
+
+## Stage 3: Advertise Capabilities From the Guest Agent
+**Goal:** Have new `tldw-agent` builds send explicit capabilities while old images remain compatible.
+**Success Criteria:** The initial guest handshake includes a stable capability list; existing host validation still accepts older handshakes.
+**Tests:** `cd tools/tldw-agent && go test ./internal/guest`
+**Status:** Complete
+
+- [x] Add failing Go test coverage for handshake capability emission.
+- [x] Add `capabilities` to `HandshakeRequest`.
+- [x] Send a sorted V1 capability list from `VSockClient.sendHandshake`.
+
+## Stage 4: Document and Verify
+**Goal:** Document the optional metadata contract and run focused verification.
+**Success Criteria:** Protocol docs mention optional capabilities and status details; focused Swift and Go tests pass; whitespace/security checks are clean.
+**Tests:** `git diff --check`; focused Swift/Go test commands above.
+**Status:** Complete
+
+- [x] Update guest protocol and helper docs.
+- [x] Run focused tests and `git diff --check`.
+- [x] Run Bandit on touched Python paths only if Python files are changed.

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -71,6 +71,11 @@ Current limitations:
   and terminate noisy commands when observed output exceeds it. The helper still
   applies host-side response capping as defense in depth and fallback for older
   images. Guest-side streaming remains follow-up work.
+- `vz_linux` helper VM status details include guest-agent readiness metadata
+  when available: `guest_version`, `guest_workspace_root`,
+  `guest_capabilities_known`, and `guest_capabilities`. These fields are
+  diagnostic only; old images that omit capabilities remain compatible and are
+  reported as capability-unknown.
 - `vz_linux` artifact capture is bounded by `SANDBOX_MAX_ARTIFACT_FILE_BYTES`
   and `SANDBOX_MAX_ARTIFACT_TOTAL_BYTES`. Oversized or over-budget artifacts
   are skipped without failing an otherwise successful run, and aggregate skip

--- a/tools/macos-vz-helper/PROTOCOL.md
+++ b/tools/macos-vz-helper/PROTOCOL.md
@@ -92,7 +92,11 @@ Every failure response should include:
   },
   "details": {
     "transport": "vsock",
-    "network_policy": "deny_all"
+    "network_policy": "deny_all",
+    "guest_version": "1.0.0",
+    "guest_workspace_root": "/workspace",
+    "guest_capabilities_known": "true",
+    "guest_capabilities": "exec,output_cap_v1"
   }
 }
 ```
@@ -157,7 +161,11 @@ Response:
   },
   "details": {
     "transport": "vsock",
-    "network_policy": "deny_all"
+    "network_policy": "deny_all",
+    "guest_version": "1.0.0",
+    "guest_workspace_root": "/workspace",
+    "guest_capabilities_known": "true",
+    "guest_capabilities": "exec,output_cap_v1"
   }
 }
 ```
@@ -296,7 +304,11 @@ the unprefixed keys when `guest_*` keys are absent during mixed-version rollouts
       },
       "details": {
         "transport": "vsock",
-        "network_policy": "deny_all"
+        "network_policy": "deny_all",
+        "guest_version": "1.0.0",
+        "guest_workspace_root": "/workspace",
+        "guest_capabilities_known": "true",
+        "guest_capabilities": "exec,output_cap_v1"
       }
     }
   ]
@@ -315,6 +327,11 @@ the unprefixed keys when `guest_*` keys are absent during mixed-version rollouts
 - `vz_linux` helper VM creation accepts only `network_policy=deny_all` until a
   separately verified allowlist implementation exists. The accepted policy is
   echoed in VM metadata and status details.
+- `vz_linux` guest-agent readiness metadata is additive in protocol version `1`.
+  `guest_version`, `guest_workspace_root`, `guest_capabilities_known`, and
+  `guest_capabilities` are diagnostic details only. Older guests may omit
+  capabilities, in which case helpers report `guest_capabilities_known=false`
+  instead of failing VM readiness.
 - Template validation must report `boot_mode` and `validation_strength` when the
   helper can resolve the template successfully.
 - Python remains the source of truth for sandbox sessions; the helper only reports

--- a/tools/macos-vz-helper/Sources/Guest/GuestAgentInfo.swift
+++ b/tools/macos-vz-helper/Sources/Guest/GuestAgentInfo.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct GuestAgentInfo: Equatable {
+    let guestVersion: String?
+    let workspaceRoot: String?
+    let capabilities: [String]
+    let capabilitiesKnown: Bool
+}

--- a/tools/macos-vz-helper/Sources/Guest/VSockBridge.swift
+++ b/tools/macos-vz-helper/Sources/Guest/VSockBridge.swift
@@ -4,6 +4,7 @@ let guestProtocolVersion = "1"
 
 protocol GuestReadinessBridging {
     func waitUntilReady(vmID: String, timeoutSeconds: TimeInterval) throws
+    func guestInfo(vmID: String) -> GuestAgentInfo?
 }
 
 struct GuestExecResult {
@@ -140,6 +141,7 @@ private struct GuestErrorResponse: Decodable {
 protocol GuestTransporting {
     func waitUntilGuestReady(vmID: String, timeoutSeconds: TimeInterval) throws
     func sendExecRequest(vmID: String, requestData: Data, timeoutSeconds: TimeInterval) throws -> Data
+    func guestInfo(vmID: String) -> GuestAgentInfo?
 }
 
 private final class UnimplementedGuestTransport: GuestTransporting {
@@ -149,6 +151,10 @@ private final class UnimplementedGuestTransport: GuestTransporting {
 
     func sendExecRequest(vmID: String, requestData: Data, timeoutSeconds: TimeInterval) throws -> Data {
         throw GuestBridgeError.guestExecNotImplemented
+    }
+
+    func guestInfo(vmID: String) -> GuestAgentInfo? {
+        nil
     }
 }
 
@@ -163,6 +169,10 @@ final class VSockBridge: GuestBridging {
 
     func waitUntilReady(vmID: String, timeoutSeconds: TimeInterval) throws {
         try transport.waitUntilGuestReady(vmID: vmID, timeoutSeconds: timeoutSeconds)
+    }
+
+    func guestInfo(vmID: String) -> GuestAgentInfo? {
+        transport.guestInfo(vmID: vmID)
     }
 
     func exec(

--- a/tools/macos-vz-helper/Sources/Guest/VSockSession.swift
+++ b/tools/macos-vz-helper/Sources/Guest/VSockSession.swift
@@ -38,6 +38,7 @@ final class VSockSession {
     private var abandonedRequestIDs: Set<String> = []
     private var abandonedRequestIDOrder: [String] = []
     private var readinessWaiters: [DispatchSemaphore] = []
+    private var guestInfo: GuestAgentInfo?
 
     init(
         vmID: String,
@@ -152,6 +153,12 @@ final class VSockSession {
         }
     }
 
+    func currentGuestInfo() -> GuestAgentInfo? {
+        lock.withLock {
+            guestInfo
+        }
+    }
+
     private func currentReadinessResult() -> Result<Void, Error>? {
         lock.withLock {
             if ready {
@@ -215,6 +222,7 @@ final class VSockSession {
 
     private func handleHandshake(_ payload: [String: Any]) throws {
         try validateControlMessage(payload, requireToken: true)
+        let parsedGuestInfo = parseGuestInfo(from: payload)
         try writeJSONObject([
             "protocol_version": guestProtocolVersion,
             "request_id": try requireString("request_id", in: payload),
@@ -222,6 +230,37 @@ final class VSockSession {
             "status": "accepted",
             "vm_id": vmID,
         ])
+        lock.withLock {
+            guestInfo = parsedGuestInfo
+        }
+    }
+
+    private func parseGuestInfo(from payload: [String: Any]) -> GuestAgentInfo {
+        let capabilities = parseGuestCapabilities(from: payload)
+        return GuestAgentInfo(
+            guestVersion: optionalString("guest_version", in: payload),
+            workspaceRoot: optionalString("workspace_root", in: payload),
+            capabilities: capabilities.values,
+            capabilitiesKnown: capabilities.known
+        )
+    }
+
+    private func parseGuestCapabilities(from payload: [String: Any]) -> (known: Bool, values: [String]) {
+        guard let rawCapabilities = payload["capabilities"] else {
+            return (false, [])
+        }
+        guard let values = rawCapabilities as? [Any] else {
+            return (false, [])
+        }
+
+        var capabilities = Set<String>()
+        for value in values {
+            guard let capability = value as? String, !capability.isEmpty else {
+                return (false, [])
+            }
+            capabilities.insert(capability)
+        }
+        return (true, capabilities.sorted())
     }
 
     private func handleReconnect(_ payload: [String: Any]) throws {
@@ -375,6 +414,13 @@ final class VSockSession {
     private func requireString(_ key: String, in object: [String: Any]) throws -> String {
         guard let value = object[key] as? String, !value.isEmpty else {
             throw VSockSessionError.invalidMessage(key)
+        }
+        return value
+    }
+
+    private func optionalString(_ key: String, in object: [String: Any]) -> String? {
+        guard let value = object[key] as? String, !value.isEmpty else {
+            return nil
         }
         return value
     }

--- a/tools/macos-vz-helper/Sources/Guest/VSockSession.swift
+++ b/tools/macos-vz-helper/Sources/Guest/VSockSession.swift
@@ -23,6 +23,8 @@ private struct VSockPendingRequest {
 }
 
 private let maxAbandonedExecRequestIDs = 128
+private let maxGuestCapabilityCount = 128
+private let maxGuestCapabilityBytes = 256
 
 final class VSockSession {
     let vmID: String
@@ -249,13 +251,16 @@ final class VSockSession {
         guard let rawCapabilities = payload["capabilities"] else {
             return (false, [])
         }
-        guard let values = rawCapabilities as? [Any] else {
+        guard let values = rawCapabilities as? [Any], values.count <= maxGuestCapabilityCount else {
             return (false, [])
         }
 
         var capabilities = Set<String>()
+        capabilities.reserveCapacity(values.count)
         for value in values {
-            guard let capability = value as? String, !capability.isEmpty else {
+            guard let capability = value as? String,
+                  !capability.isEmpty,
+                  capability.utf8.count <= maxGuestCapabilityBytes else {
                 return (false, [])
             }
             capabilities.insert(capability)

--- a/tools/macos-vz-helper/Sources/Guest/VSockSessionManager.swift
+++ b/tools/macos-vz-helper/Sources/Guest/VSockSessionManager.swift
@@ -36,6 +36,13 @@ final class VSockSessionManager: GuestTransporting {
         return try session.sendExecRequest(requestData, timeoutSeconds: timeoutSeconds)
     }
 
+    func guestInfo(vmID: String) -> GuestAgentInfo? {
+        guard let session = try? requireSession(vmID: vmID) else {
+            return nil
+        }
+        return session.currentGuestInfo()
+    }
+
     func accept(channel: VSockChanneling, for vmID: String) -> Bool {
         do {
             let session = try requireSession(vmID: vmID)

--- a/tools/macos-vz-helper/Sources/Protocol/Response.swift
+++ b/tools/macos-vz-helper/Sources/Protocol/Response.swift
@@ -126,17 +126,20 @@ struct VMRecord {
     let state: String
     let healthy: Bool
     let metadata: VMOwnershipMetadata
+    let guestInfo: GuestAgentInfo?
 
     init(
         vmID: String,
         state: String,
         healthy: Bool,
-        metadata: VMOwnershipMetadata = .unknown
+        metadata: VMOwnershipMetadata = .unknown,
+        guestInfo: GuestAgentInfo? = nil
     ) {
         self.vmID = vmID
         self.state = state
         self.healthy = healthy
         self.metadata = metadata
+        self.guestInfo = guestInfo
     }
 }
 

--- a/tools/macos-vz-helper/Sources/Server/HelperService.swift
+++ b/tools/macos-vz-helper/Sources/Server/HelperService.swift
@@ -249,10 +249,23 @@ final class HelperService {
     }
 
     private func vmDetails(for record: VMRecord) -> [String: String] {
-        [
+        var details = [
             "transport": "vsock",
             "network_policy": record.metadata.networkPolicy.isEmpty ? "deny_all" : record.metadata.networkPolicy,
         ]
+        if let guestInfo = record.guestInfo {
+            details["guest_capabilities_known"] = guestInfo.capabilitiesKnown ? "true" : "false"
+            if let guestVersion = guestInfo.guestVersion {
+                details["guest_version"] = guestVersion
+            }
+            if let workspaceRoot = guestInfo.workspaceRoot {
+                details["guest_workspace_root"] = workspaceRoot
+            }
+            if guestInfo.capabilitiesKnown {
+                details["guest_capabilities"] = guestInfo.capabilities.joined(separator: ",")
+            }
+        }
+        return details
     }
 
     private func validateExecGuestContract(

--- a/tools/macos-vz-helper/Sources/VM/VMRegistry.swift
+++ b/tools/macos-vz-helper/Sources/VM/VMRegistry.swift
@@ -4,15 +4,23 @@ final class VMRegistry {
     private var records: [String: VMRecord] = [:]
     private let lock = NSLock()
 
-    func upsert(vmID: String, state: String, healthy: Bool, metadata: VMOwnershipMetadata? = nil) {
+    func upsert(
+        vmID: String,
+        state: String,
+        healthy: Bool,
+        metadata: VMOwnershipMetadata? = nil,
+        guestInfo: GuestAgentInfo? = nil
+    ) {
         lock.lock()
         defer { lock.unlock() }
-        let existingMetadata = records[vmID]?.metadata ?? .unknown
+        let existing = records[vmID]
+        let existingMetadata = existing?.metadata ?? .unknown
         records[vmID] = VMRecord(
             vmID: vmID,
             state: state,
             healthy: healthy,
-            metadata: metadata ?? existingMetadata
+            metadata: metadata ?? existingMetadata,
+            guestInfo: guestInfo ?? existing?.guestInfo
         )
     }
 

--- a/tools/macos-vz-helper/Sources/VM/VMRegistry.swift
+++ b/tools/macos-vz-helper/Sources/VM/VMRegistry.swift
@@ -9,18 +9,20 @@ final class VMRegistry {
         state: String,
         healthy: Bool,
         metadata: VMOwnershipMetadata? = nil,
-        guestInfo: GuestAgentInfo? = nil
+        guestInfo: GuestAgentInfo? = nil,
+        preserveGuestInfo: Bool = true
     ) {
         lock.lock()
         defer { lock.unlock() }
         let existing = records[vmID]
         let existingMetadata = existing?.metadata ?? .unknown
+        let resolvedGuestInfo = guestInfo ?? (preserveGuestInfo ? existing?.guestInfo : nil)
         records[vmID] = VMRecord(
             vmID: vmID,
             state: state,
             healthy: healthy,
             metadata: metadata ?? existingMetadata,
-            guestInfo: guestInfo ?? existing?.guestInfo
+            guestInfo: resolvedGuestInfo
         )
     }
 

--- a/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
+++ b/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
@@ -50,12 +50,14 @@ final class VZLinuxVMManager {
                 startupTimeoutSeconds: readinessTimeoutSeconds
             )
             try guestBridge.waitUntilReady(vmID: vmID, timeoutSeconds: readinessTimeoutSeconds)
-            registry.upsert(vmID: vmID, state: "running", healthy: true)
+            let guestInfo = guestBridge.guestInfo(vmID: vmID)
+            registry.upsert(vmID: vmID, state: "running", healthy: true, guestInfo: guestInfo)
             return registry.status(vmID: vmID) ?? VMRecord(
                 vmID: vmID,
                 state: "running",
                 healthy: true,
-                metadata: metadata
+                metadata: metadata,
+                guestInfo: guestInfo
             )
         } catch {
             try? bootDriver.stop(vmID: vmID)

--- a/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
+++ b/tools/macos-vz-helper/Sources/VM/VZLinuxVMManager.swift
@@ -41,7 +41,13 @@ final class VZLinuxVMManager {
         readinessTimeoutSeconds: TimeInterval,
         metadata: VMOwnershipMetadata = .unknown
     ) throws -> VMRecord {
-        registry.upsert(vmID: vmID, state: "booting", healthy: false, metadata: metadata)
+        registry.upsert(
+            vmID: vmID,
+            state: "booting",
+            healthy: false,
+            metadata: metadata,
+            preserveGuestInfo: false
+        )
         do {
             try bootDriver.boot(
                 vmID: vmID,
@@ -51,7 +57,13 @@ final class VZLinuxVMManager {
             )
             try guestBridge.waitUntilReady(vmID: vmID, timeoutSeconds: readinessTimeoutSeconds)
             let guestInfo = guestBridge.guestInfo(vmID: vmID)
-            registry.upsert(vmID: vmID, state: "running", healthy: true, guestInfo: guestInfo)
+            registry.upsert(
+                vmID: vmID,
+                state: "running",
+                healthy: true,
+                guestInfo: guestInfo,
+                preserveGuestInfo: false
+            )
             return registry.status(vmID: vmID) ?? VMRecord(
                 vmID: vmID,
                 state: "running",

--- a/tools/macos-vz-helper/Tests/HelperServiceExecTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceExecTests.swift
@@ -7,6 +7,10 @@ final class RecordingGuestBridge: GuestBridging {
 
     func waitUntilReady(vmID: String, timeoutSeconds: TimeInterval) throws {}
 
+    func guestInfo(vmID: String) -> GuestAgentInfo? {
+        nil
+    }
+
     func exec(
         vmID: String,
         argv: [String],
@@ -32,6 +36,10 @@ final class StaticOutputGuestBridge: GuestBridging {
     }
 
     func waitUntilReady(vmID: String, timeoutSeconds: TimeInterval) throws {}
+
+    func guestInfo(vmID: String) -> GuestAgentInfo? {
+        nil
+    }
 
     func exec(
         vmID: String,

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -26,6 +26,74 @@ import Testing
     #expect(response.details["transport"] == "vsock")
 }
 
+@Test func helperServiceSurfacesGuestAgentDetailsInCreateStatusAndList() throws {
+    let registry = VMRegistry()
+    let guestInfo = GuestAgentInfo(
+        guestVersion: "1.0.0",
+        workspaceRoot: "/workspace",
+        capabilities: ["exec", "output_cap_v1"],
+        capabilitiesKnown: true
+    )
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge(info: guestInfo)
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    let response = try service.createVM(
+        vmID: "vm-guest-details",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        readinessTimeoutSeconds: 5
+    )
+    let status = service.getVMStatus(vmID: "vm-guest-details")
+    let listed = service.listVMs().vms.first
+
+    for details in [response.details, status?.details, listed?.details] {
+        #expect(details?["guest_version"] == "1.0.0")
+        #expect(details?["guest_workspace_root"] == "/workspace")
+        #expect(details?["guest_capabilities_known"] == "true")
+        #expect(details?["guest_capabilities"] == "exec,output_cap_v1")
+    }
+}
+
+@Test func helperServiceSurfacesUnknownCapabilitiesForOlderGuests() throws {
+    let registry = VMRegistry()
+    let guestInfo = GuestAgentInfo(
+        guestVersion: "0.9.0",
+        workspaceRoot: "/workspace",
+        capabilities: [],
+        capabilitiesKnown: false
+    )
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge(info: guestInfo)
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    let response = try service.createVM(
+        vmID: "vm-old-guest-details",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        readinessTimeoutSeconds: 5
+    )
+
+    #expect(response.details["guest_version"] == "0.9.0")
+    #expect(response.details["guest_workspace_root"] == "/workspace")
+    #expect(response.details["guest_capabilities_known"] == "false")
+    #expect(response.details["guest_capabilities"] == nil)
+}
+
 @Test func helperServiceCreateVMReturnsOwnershipMetadata() throws {
     let registry = VMRegistry()
     let manager = VZLinuxVMManager(

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -87,11 +87,15 @@ import Testing
         workspacePath: "/tmp/workspace",
         readinessTimeoutSeconds: 5
     )
+    let status = service.getVMStatus(vmID: "vm-old-guest-details")
+    let listed = service.listVMs().vms.first
 
-    #expect(response.details["guest_version"] == "0.9.0")
-    #expect(response.details["guest_workspace_root"] == "/workspace")
-    #expect(response.details["guest_capabilities_known"] == "false")
-    #expect(response.details["guest_capabilities"] == nil)
+    for details in [response.details, status?.details, listed?.details] {
+        #expect(details?["guest_version"] == "0.9.0")
+        #expect(details?["guest_workspace_root"] == "/workspace")
+        #expect(details?["guest_capabilities_known"] == "false")
+        #expect(details?["guest_capabilities"] == nil)
+    }
 }
 
 @Test func helperServiceClearsStaleGuestDetailsWhenVMIDIsReusedWithoutInfo() throws {

--- a/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
+++ b/tools/macos-vz-helper/Tests/HelperServiceVMTests.swift
@@ -94,6 +94,43 @@ import Testing
     #expect(response.details["guest_capabilities"] == nil)
 }
 
+@Test func helperServiceClearsStaleGuestDetailsWhenVMIDIsReusedWithoutInfo() throws {
+    let registry = VMRegistry()
+    registry.upsert(
+        vmID: "vm-reused",
+        state: "running",
+        healthy: true,
+        guestInfo: GuestAgentInfo(
+            guestVersion: "stale",
+            workspaceRoot: "/stale",
+            capabilities: ["stale_capability"],
+            capabilitiesKnown: true
+        )
+    )
+    let manager = VZLinuxVMManager(
+        registry: registry,
+        bootDriver: RecordingBootDriver(),
+        guestBridge: ReadyGuestBridge()
+    )
+    let service = HelperService(
+        hostFacts: HostFacts(isMacOS: true, isAppleSilicon: true),
+        registry: registry,
+        vmManager: manager
+    )
+
+    let response = try service.createVM(
+        vmID: "vm-reused",
+        templatePath: "/tmp/template.img",
+        workspacePath: "/tmp/workspace",
+        readinessTimeoutSeconds: 5
+    )
+
+    #expect(response.details["guest_version"] == nil)
+    #expect(response.details["guest_workspace_root"] == nil)
+    #expect(response.details["guest_capabilities_known"] == nil)
+    #expect(response.details["guest_capabilities"] == nil)
+}
+
 @Test func helperServiceCreateVMReturnsOwnershipMetadata() throws {
     let registry = VMRegistry()
     let manager = VZLinuxVMManager(

--- a/tools/macos-vz-helper/Tests/TestDoubles.swift
+++ b/tools/macos-vz-helper/Tests/TestDoubles.swift
@@ -21,7 +21,17 @@ final class RecordingBootDriver: VZBootDriving {
 }
 
 final class ReadyGuestBridge: GuestBridging {
+    private let info: GuestAgentInfo?
+
+    init(info: GuestAgentInfo? = nil) {
+        self.info = info
+    }
+
     func waitUntilReady(vmID: String, timeoutSeconds: TimeInterval) throws {}
+
+    func guestInfo(vmID: String) -> GuestAgentInfo? {
+        info
+    }
 
     func exec(
         vmID: String,
@@ -44,6 +54,10 @@ final class FailingGuestBridge: GuestBridging {
 
     func waitUntilReady(vmID: String, timeoutSeconds: TimeInterval) throws {
         throw error
+    }
+
+    func guestInfo(vmID: String) -> GuestAgentInfo? {
+        nil
     }
 
     func exec(

--- a/tools/macos-vz-helper/Tests/VSockBridgeTests.swift
+++ b/tools/macos-vz-helper/Tests/VSockBridgeTests.swift
@@ -26,6 +26,10 @@ final class RecordingGuestTransport: GuestTransporting {
         execPayload = payload
         return execResponseFactory?(payload) ?? Data()
     }
+
+    func guestInfo(vmID: String) -> GuestAgentInfo? {
+        nil
+    }
 }
 
 @Test func vsockBridgeEncodesReadyRequestsAndAcceptsReadyResponses() throws {

--- a/tools/macos-vz-helper/Tests/VSockSessionManagerTests.swift
+++ b/tools/macos-vz-helper/Tests/VSockSessionManagerTests.swift
@@ -56,6 +56,90 @@ final class InMemoryVSockChannel: VSockChanneling {
     #expect(channel.writes.last?["workspace_root"] as? String == "/workspace")
 }
 
+@Test func vsockSessionManagerReportsGuestInfoFromHandshakeCapabilities() throws {
+    let manager = VSockSessionManager()
+    _ = manager.prepareSession(
+        vmID: "vm-capabilities",
+        connectionToken: "token-capabilities",
+        port: 1024,
+        workspaceRoot: "/workspace"
+    )
+    let channel = InMemoryVSockChannel()
+
+    #expect(manager.accept(channel: channel, for: "vm-capabilities") == true)
+
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-handshake","type":"handshake","vm_id":"vm-capabilities","connection_token":"token-capabilities","guest_version":"1.0.0","workspace_root":"/workspace","capabilities":["output_cap_v1","exec","exec"]}"#
+    )
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-ready","type":"ready"}"#
+    )
+
+    try manager.waitUntilGuestReady(vmID: "vm-capabilities", timeoutSeconds: 0.1)
+
+    let info = manager.guestInfo(vmID: "vm-capabilities")
+    #expect(info?.guestVersion == "1.0.0")
+    #expect(info?.workspaceRoot == "/workspace")
+    #expect(info?.capabilitiesKnown == true)
+    #expect(info?.capabilities == ["exec", "output_cap_v1"])
+}
+
+@Test func vsockSessionManagerReportsUnknownCapabilitiesForOlderGuests() throws {
+    let manager = VSockSessionManager()
+    _ = manager.prepareSession(
+        vmID: "vm-old-guest",
+        connectionToken: "token-old-guest",
+        port: 1024,
+        workspaceRoot: "/workspace"
+    )
+    let channel = InMemoryVSockChannel()
+
+    #expect(manager.accept(channel: channel, for: "vm-old-guest") == true)
+
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-handshake","type":"handshake","vm_id":"vm-old-guest","connection_token":"token-old-guest","guest_version":"0.9.0","workspace_root":"/workspace"}"#
+    )
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-ready","type":"ready"}"#
+    )
+
+    try manager.waitUntilGuestReady(vmID: "vm-old-guest", timeoutSeconds: 0.1)
+
+    let info = manager.guestInfo(vmID: "vm-old-guest")
+    #expect(info?.guestVersion == "0.9.0")
+    #expect(info?.workspaceRoot == "/workspace")
+    #expect(info?.capabilitiesKnown == false)
+    #expect(info?.capabilities == [String]())
+}
+
+@Test func vsockSessionManagerTreatsMalformedCapabilitiesAsUnknown() throws {
+    let manager = VSockSessionManager()
+    _ = manager.prepareSession(
+        vmID: "vm-malformed-capabilities",
+        connectionToken: "token-malformed-capabilities",
+        port: 1024,
+        workspaceRoot: "/workspace"
+    )
+    let channel = InMemoryVSockChannel()
+
+    #expect(manager.accept(channel: channel, for: "vm-malformed-capabilities") == true)
+
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-handshake","type":"handshake","vm_id":"vm-malformed-capabilities","connection_token":"token-malformed-capabilities","guest_version":"1.0.0","workspace_root":"/workspace","capabilities":["exec",1]}"#
+    )
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-ready","type":"ready"}"#
+    )
+
+    try manager.waitUntilGuestReady(vmID: "vm-malformed-capabilities", timeoutSeconds: 0.1)
+
+    let info = manager.guestInfo(vmID: "vm-malformed-capabilities")
+    #expect(info?.guestVersion == "1.0.0")
+    #expect(info?.workspaceRoot == "/workspace")
+    #expect(info?.capabilitiesKnown == false)
+    #expect(info?.capabilities == [String]())
+}
+
 @Test func vsockSessionManagerRejectsWrongConnectionToken() throws {
     let manager = VSockSessionManager()
     _ = manager.prepareSession(

--- a/tools/macos-vz-helper/Tests/VSockSessionManagerTests.swift
+++ b/tools/macos-vz-helper/Tests/VSockSessionManagerTests.swift
@@ -140,6 +140,60 @@ final class InMemoryVSockChannel: VSockChanneling {
     #expect(info?.capabilities == [String]())
 }
 
+@Test func vsockSessionManagerTreatsTooManyCapabilitiesAsUnknown() throws {
+    let manager = VSockSessionManager()
+    _ = manager.prepareSession(
+        vmID: "vm-too-many-capabilities",
+        connectionToken: "token-too-many-capabilities",
+        port: 1024,
+        workspaceRoot: "/workspace"
+    )
+    let channel = InMemoryVSockChannel()
+    let capabilities = (0..<129).map { #""cap-\#($0)""# }.joined(separator: ",")
+
+    #expect(manager.accept(channel: channel, for: "vm-too-many-capabilities") == true)
+
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-handshake","type":"handshake","vm_id":"vm-too-many-capabilities","connection_token":"token-too-many-capabilities","guest_version":"1.0.0","workspace_root":"/workspace","capabilities":[\#(capabilities)]}"#
+    )
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-ready","type":"ready"}"#
+    )
+
+    try manager.waitUntilGuestReady(vmID: "vm-too-many-capabilities", timeoutSeconds: 0.1)
+
+    let info = manager.guestInfo(vmID: "vm-too-many-capabilities")
+    #expect(info?.capabilitiesKnown == false)
+    #expect(info?.capabilities == [String]())
+}
+
+@Test func vsockSessionManagerTreatsOversizedCapabilitiesAsUnknown() throws {
+    let manager = VSockSessionManager()
+    _ = manager.prepareSession(
+        vmID: "vm-oversized-capabilities",
+        connectionToken: "token-oversized-capabilities",
+        port: 1024,
+        workspaceRoot: "/workspace"
+    )
+    let channel = InMemoryVSockChannel()
+    let capability = String(repeating: "x", count: 257)
+
+    #expect(manager.accept(channel: channel, for: "vm-oversized-capabilities") == true)
+
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-handshake","type":"handshake","vm_id":"vm-oversized-capabilities","connection_token":"token-oversized-capabilities","guest_version":"1.0.0","workspace_root":"/workspace","capabilities":["\#(capability)"]}"#
+    )
+    channel.push(
+        json: #"{"protocol_version":"1","request_id":"req-ready","type":"ready"}"#
+    )
+
+    try manager.waitUntilGuestReady(vmID: "vm-oversized-capabilities", timeoutSeconds: 0.1)
+
+    let info = manager.guestInfo(vmID: "vm-oversized-capabilities")
+    #expect(info?.capabilitiesKnown == false)
+    #expect(info?.capabilities == [String]())
+}
+
 @Test func vsockSessionManagerRejectsWrongConnectionToken() throws {
     let manager = VSockSessionManager()
     _ = manager.prepareSession(

--- a/tools/tldw-agent/docs/vz-linux-guest-protocol.md
+++ b/tools/tldw-agent/docs/vz-linux-guest-protocol.md
@@ -26,9 +26,15 @@ This document defines the first guest protocol used between the Swift
   "vm_id": "vm-1",
   "connection_token": "token-1",
   "guest_version": "1.0.0",
-  "workspace_root": "/workspace"
+  "workspace_root": "/workspace",
+  "capabilities": ["exec", "output_cap_v1"]
 }
 ```
+
+`guest_version`, `workspace_root`, and `capabilities` are optional readiness
+metadata. New guests should send a stable, sorted capability list; hosts must
+accept older guests that omit it and treat capabilities as unknown rather than
+failing the handshake.
 
 ### Handshake ack
 

--- a/tools/tldw-agent/internal/guest/types.go
+++ b/tools/tldw-agent/internal/guest/types.go
@@ -3,13 +3,14 @@ package guest
 const ProtocolVersion = "1"
 
 type HandshakeRequest struct {
-	ProtocolVersion string `json:"protocol_version"`
-	RequestID       string `json:"request_id"`
-	Type            string `json:"type"`
-	VMID            string `json:"vm_id"`
-	ConnectionToken string `json:"connection_token"`
-	GuestVersion    string `json:"guest_version,omitempty"`
-	WorkspaceRoot   string `json:"workspace_root,omitempty"`
+	ProtocolVersion string   `json:"protocol_version"`
+	RequestID       string   `json:"request_id"`
+	Type            string   `json:"type"`
+	VMID            string   `json:"vm_id"`
+	ConnectionToken string   `json:"connection_token"`
+	GuestVersion    string   `json:"guest_version,omitempty"`
+	WorkspaceRoot   string   `json:"workspace_root,omitempty"`
+	Capabilities    []string `json:"capabilities,omitempty"`
 }
 
 type HandshakeAck struct {

--- a/tools/tldw-agent/internal/guest/vsock_client.go
+++ b/tools/tldw-agent/internal/guest/vsock_client.go
@@ -127,6 +127,7 @@ func (c *VSockClient) sendHandshake(conn io.Writer, reader *bufio.Reader) error 
 		ConnectionToken: c.cfg.ConnectionToken,
 		GuestVersion:    c.cfg.GuestVersion,
 		WorkspaceRoot:   c.cfg.WorkspaceRoot,
+		Capabilities:    guestCapabilities(),
 	}); err != nil {
 		return err
 	}
@@ -208,6 +209,10 @@ func (c *VSockClient) sendReady(conn io.Writer, reader *bufio.Reader, server *Se
 		return fmt.Errorf("workspace root mismatch: %s", response.WorkspaceRoot)
 	}
 	return nil
+}
+
+func guestCapabilities() []string {
+	return []string{"exec", "output_cap_v1"}
 }
 
 func loadVSockClientConfigFromEnv() (VSockClientConfig, error) {

--- a/tools/tldw-agent/internal/guest/vsock_client_test.go
+++ b/tools/tldw-agent/internal/guest/vsock_client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"reflect"
 	"testing"
 )
 
@@ -64,6 +65,11 @@ func TestGuestVSockClientSendsHandshakeAndReady(t *testing.T) {
 		}
 		if handshake.ConnectionToken != "token-handshake" {
 			done <- errUnexpectedValue("connection_token", handshake.ConnectionToken)
+			return
+		}
+		expectedCapabilities := []string{"exec", "output_cap_v1"}
+		if !reflect.DeepEqual(handshake.Capabilities, expectedCapabilities) {
+			done <- errUnexpectedValue("capabilities", handshake.Capabilities)
 			return
 		}
 		if err := writeJSONLine(helperConn, HandshakeAck{


### PR DESCRIPTION
## Change summary
TODO: human-authored change summary required before merge.

## Summary
- Adds optional guest-agent capability metadata to the vz_linux guest handshake while preserving protocol v1 compatibility.
- Stores parsed guest readiness metadata in the Swift helper session/registry path and surfaces it through VM details for create/status/list responses.
- Documents the optional guest capability contract and old-guest unknown-capability behavior.

## Test plan
- swift test --package-path tools/macos-vz-helper
- cd tools/tldw-agent && go test ./internal/guest
- git diff --check origin/dev...HEAD

## Notes
- Real VZ smoke was not run for this slice; observing new capabilities in a live VM requires rebuilding the guest image.