### PR TITLE
refactor(workers): register loop lag watchdog

### DIFF
--- a/tldw_Server_API/app/services/shutdown_post_worker_services.py
+++ b/tldw_Server_API/app/services/shutdown_post_worker_services.py
@@ -156,8 +156,11 @@ async def shutdown_post_worker_services(
             "jobs_metrics_task",
             jobs_metrics_stop_event,
         ),
-        loop_lag_task=loop_lag_task,
-        loop_lag_stop_event=loop_lag_stop_event,
+        loop_lag_task=_task_if_not_stopped("loop_lag_task", loop_lag_task),
+        loop_lag_stop_event=_stop_event_if_not_stopped(
+            "loop_lag_task",
+            loop_lag_stop_event,
+        ),
         guard_exceptions=guard_exceptions,
     )
     jobs_metrics_reconcile_shutdown_handles = await _shutdown_jobs_metrics_reconcile(
@@ -361,7 +364,7 @@ async def run_shutdown_post_worker_services(
             usage_task=_fallback_if_not_stopped("usage_aggregator", usage_task),
             llm_usage_task=_fallback_if_not_stopped("llm_usage_aggregator", llm_usage_task),
             jobs_metrics_task=_fallback_if_not_stopped("jobs_metrics_task", jobs_metrics_task),
-            loop_lag_task=loop_lag_task,
+            loop_lag_task=_fallback_if_not_stopped("loop_lag_task", loop_lag_task),
             jobs_metrics_reconcile_task=_fallback_if_not_stopped(
                 "jobs_metrics_reconcile_task",
                 jobs_metrics_reconcile_task,

--- a/tldw_Server_API/app/services/startup_runtime_monitors.py
+++ b/tldw_Server_API/app/services/startup_runtime_monitors.py
@@ -45,12 +45,9 @@ async def start_runtime_monitors(
         jobs_metrics_stop_event, jobs_metrics_task = await _start_jobs_metrics_gauge_worker(
             worker_inventory=worker_inventory,
         )
-    if worker_inventory is None:
-        loop_lag_stop_event, loop_lag_task = await _start_loop_lag_watchdog()
-    else:
-        loop_lag_stop_event, loop_lag_task = await _start_loop_lag_watchdog(
-            worker_inventory=worker_inventory,
-        )
+    loop_lag_stop_event, loop_lag_task = await _start_loop_lag_watchdog(
+        worker_inventory=worker_inventory,
+    )
     return RuntimeMonitorHandles(
         jobs_metrics_stop_event=jobs_metrics_stop_event,
         jobs_metrics_task=jobs_metrics_task,
@@ -105,6 +102,13 @@ async def _start_loop_lag_watchdog(
     *,
     worker_inventory: Any | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the event-loop lag watchdog directly or through worker inventory.
+
+    The monitor is skipped when EVENT_LOOP_LAG_WATCHDOG_ENABLED is disabled.
+    When a worker inventory is supplied, the watchdog is registered as a
+    background-phase custom worker so WorkerRegistry owns shutdown; otherwise
+    this helper preserves the legacy explicit stop-event/task handles.
+    """
     try:
         if not _env_flag_enabled("EVENT_LOOP_LAG_WATCHDOG_ENABLED"):
             logger.info("Event loop lag watchdog disabled by flag")

--- a/tldw_Server_API/app/services/startup_runtime_monitors.py
+++ b/tldw_Server_API/app/services/startup_runtime_monitors.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from tldw_Server_API.app.core.testing import env_flag_enabled as _env_flag_enabled
 from tldw_Server_API.app.core.testing import is_truthy as _is_truthy
+from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase
 
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
@@ -44,7 +45,12 @@ async def start_runtime_monitors(
         jobs_metrics_stop_event, jobs_metrics_task = await _start_jobs_metrics_gauge_worker(
             worker_inventory=worker_inventory,
         )
-    loop_lag_stop_event, loop_lag_task = await _start_loop_lag_watchdog()
+    if worker_inventory is None:
+        loop_lag_stop_event, loop_lag_task = await _start_loop_lag_watchdog()
+    else:
+        loop_lag_stop_event, loop_lag_task = await _start_loop_lag_watchdog(
+            worker_inventory=worker_inventory,
+        )
     return RuntimeMonitorHandles(
         jobs_metrics_stop_event=jobs_metrics_stop_event,
         jobs_metrics_task=jobs_metrics_task,
@@ -95,11 +101,25 @@ async def _start_jobs_metrics_gauge_worker(
         return None, None
 
 
-async def _start_loop_lag_watchdog() -> tuple[Any | None, Any | None]:
+async def _start_loop_lag_watchdog(
+    *,
+    worker_inventory: Any | None = None,
+) -> tuple[Any | None, Any | None]:
     try:
         if not _env_flag_enabled("EVENT_LOOP_LAG_WATCHDOG_ENABLED"):
             logger.info("Event loop lag watchdog disabled by flag")
             return None, None
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="loop_lag_task",
+                task_name="loop_lag_watchdog",
+                coroutine_factory=_run_loop_lag_watchdog_service,
+                timeout_sec=2.0,
+                category="monitoring",
+                shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+            )
+            logger.info("Event loop lag watchdog started")
+            return stop_event, task
         stop_event = _make_event()
         task = _create_task(_run_loop_lag_watchdog_service(stop_event))
         logger.info("Event loop lag watchdog started")

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -176,6 +176,88 @@ async def test_shutdown_post_worker_services_runs_helpers_in_order_and_returns_h
 
 
 @pytest.mark.asyncio
+async def test_shutdown_post_worker_services_skips_loop_lag_after_background_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_post_worker_services as shutdown_services
+
+    runtime_kwargs: dict[str, object] = {}
+
+    async def _namespace(**kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(**kwargs)
+
+    async def _record_runtime(**kwargs: object) -> SimpleNamespace:
+        runtime_kwargs.update(kwargs)
+        return SimpleNamespace(
+            jobs_metrics_task=kwargs["jobs_metrics_task"],
+            loop_lag_task=kwargs["loop_lag_task"],
+        )
+
+    monkeypatch.setattr(shutdown_services, "_shutdown_claims_maintenance_tasks", _namespace)
+    monkeypatch.setattr(
+        shutdown_services,
+        "_shutdown_notifications_compactor_websub_workers",
+        _namespace,
+    )
+    monkeypatch.setattr(shutdown_services, "_stop_usage_aggregators", _namespace)
+    monkeypatch.setattr(shutdown_services, "_stop_recurring_schedulers", _namespace)
+    monkeypatch.setattr(shutdown_services, "_shutdown_runtime_monitors", _record_runtime)
+    monkeypatch.setattr(shutdown_services, "_shutdown_jobs_metrics_reconcile", _namespace)
+    monkeypatch.setattr(
+        shutdown_services,
+        "_shutdown_personalization_consolidation",
+        _namespace,
+    )
+    monkeypatch.setattr(shutdown_services, "_shutdown_optional_workers", _namespace)
+
+    handles = await shutdown_services.shutdown_post_worker_services(
+        claims_task=None,
+        jobs_prune_task=None,
+        files_export_gc_task=None,
+        notifications_prune_task=None,
+        jobs_notifications_bridge_task=None,
+        embeddings_compactor_task=None,
+        embeddings_compactor_stop_event=None,
+        websub_renewal_task=None,
+        coordinated_legacy_component_names=set(),
+        usage_task=None,
+        llm_usage_task=None,
+        workflows_sched_task=None,
+        reading_digest_sched_task=None,
+        admin_backup_sched_task=None,
+        companion_reflection_sched_task=None,
+        reminders_sched_task=None,
+        connectors_sync_sched_task=None,
+        jobs_metrics_task=None,
+        jobs_metrics_stop_event=None,
+        loop_lag_task="loop-lag-task",
+        loop_lag_stop_event="loop-lag-stop",
+        jobs_metrics_reconcile_task=None,
+        jobs_metrics_reconcile_stop=None,
+        jobs_crypto_rotate_task=None,
+        jobs_crypto_rotate_stop_event=None,
+        jobs_integrity_task=None,
+        jobs_integrity_stop_event=None,
+        jobs_webhooks_task=None,
+        jobs_webhooks_stop_event=None,
+        meetings_webhook_dlq_task=None,
+        meetings_webhook_dlq_stop_event=None,
+        workflows_dlq_task=None,
+        workflows_dlq_stop_event=None,
+        workflows_gc_task=None,
+        workflows_gc_stop_event=None,
+        workflows_maint_task=None,
+        workflows_maint_stop_event=None,
+        stopped_background_worker_names={"loop_lag_task"},
+        guard_exceptions=(RuntimeError,),
+    )
+
+    assert runtime_kwargs["loop_lag_task"] is None
+    assert runtime_kwargs["loop_lag_stop_event"] is None
+    assert handles.loop_lag_task is None
+
+
+@pytest.mark.asyncio
 async def test_shutdown_post_worker_services_skips_jobs_webhooks_after_background_phase(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
@@ -258,6 +258,63 @@ async def test_shutdown_post_worker_services_skips_loop_lag_after_background_pha
 
 
 @pytest.mark.asyncio
+async def test_run_shutdown_post_worker_services_fallback_skips_stopped_loop_lag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_post_worker_services as shutdown_services
+
+    async def _raise_shutdown_error(**kwargs: object) -> None:
+        raise RuntimeError("shutdown failed")
+
+    monkeypatch.setattr(shutdown_services, "shutdown_post_worker_services", _raise_shutdown_error)
+
+    handles = await shutdown_services.run_shutdown_post_worker_services(
+        claims_task=None,
+        jobs_prune_task=None,
+        files_export_gc_task=None,
+        notifications_prune_task=None,
+        jobs_notifications_bridge_task=None,
+        embeddings_compactor_task=None,
+        embeddings_compactor_stop_event=None,
+        websub_renewal_task=None,
+        coordinated_legacy_component_names=set(),
+        usage_task=None,
+        llm_usage_task=None,
+        workflows_sched_task=None,
+        reading_digest_sched_task=None,
+        admin_backup_sched_task=None,
+        companion_reflection_sched_task=None,
+        reminders_sched_task=None,
+        connectors_sync_sched_task=None,
+        jobs_metrics_task="jobs-metrics-input",
+        jobs_metrics_stop_event=None,
+        loop_lag_task="loop-lag-input",
+        loop_lag_stop_event=None,
+        jobs_metrics_reconcile_task=None,
+        jobs_metrics_reconcile_stop=None,
+        jobs_crypto_rotate_task=None,
+        jobs_crypto_rotate_stop_event=None,
+        jobs_integrity_task=None,
+        jobs_integrity_stop_event=None,
+        jobs_webhooks_task=None,
+        jobs_webhooks_stop_event=None,
+        meetings_webhook_dlq_task=None,
+        meetings_webhook_dlq_stop_event=None,
+        workflows_dlq_task=None,
+        workflows_dlq_stop_event=None,
+        workflows_gc_task=None,
+        workflows_gc_stop_event=None,
+        workflows_maint_task=None,
+        workflows_maint_stop_event=None,
+        stopped_background_worker_names={"loop_lag_task"},
+        guard_exceptions=(RuntimeError,),
+    )
+
+    assert handles.jobs_metrics_task == "jobs-metrics-input"
+    assert handles.loop_lag_task is None
+
+
+@pytest.mark.asyncio
 async def test_shutdown_post_worker_services_skips_jobs_webhooks_after_background_phase(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_startup_runtime_monitors.py
+++ b/tldw_Server_API/tests/Services/test_startup_runtime_monitors.py
@@ -24,7 +24,7 @@ async def test_start_runtime_monitors_combines_handles_in_order(
         calls.append("jobs-metrics")
         return ("jobs-metrics-stop", "jobs-metrics-task")
 
-    async def _record_loop_lag():
+    async def _record_loop_lag(*, worker_inventory: object | None = None) -> tuple[str, str]:
         calls.append("loop-lag")
         return ("loop-lag-stop", "loop-lag-task")
 
@@ -48,11 +48,11 @@ async def test_start_runtime_monitors_passes_inventory_to_registered_monitors(
     worker_inventory = object()
     calls: list[str] = []
 
-    async def _record_jobs_metrics(*, worker_inventory: object):
+    async def _record_jobs_metrics(*, worker_inventory: object) -> tuple[object, str]:
         calls.append("jobs-metrics")
         return (worker_inventory, "jobs-metrics-task")
 
-    async def _record_loop_lag(*, worker_inventory: object):
+    async def _record_loop_lag(*, worker_inventory: object) -> tuple[object, str]:
         calls.append("loop-lag")
         return (worker_inventory, "loop-lag-task")
 

--- a/tldw_Server_API/tests/Services/test_startup_runtime_monitors.py
+++ b/tldw_Server_API/tests/Services/test_startup_runtime_monitors.py
@@ -5,7 +5,6 @@ import sys
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -39,6 +38,32 @@ async def test_start_runtime_monitors_combines_handles_in_order(
     assert handles.jobs_metrics_task == "jobs-metrics-task"
     assert handles.loop_lag_stop_event == "loop-lag-stop"
     assert handles.loop_lag_task == "loop-lag-task"
+
+
+@pytest.mark.asyncio
+async def test_start_runtime_monitors_passes_inventory_to_registered_monitors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_monitors = _import_startup_runtime_monitors()
+    worker_inventory = object()
+    calls: list[str] = []
+
+    async def _record_jobs_metrics(*, worker_inventory: object):
+        calls.append("jobs-metrics")
+        return (worker_inventory, "jobs-metrics-task")
+
+    async def _record_loop_lag(*, worker_inventory: object):
+        calls.append("loop-lag")
+        return (worker_inventory, "loop-lag-task")
+
+    monkeypatch.setattr(startup_monitors, "_start_jobs_metrics_gauge_worker", _record_jobs_metrics)
+    monkeypatch.setattr(startup_monitors, "_start_loop_lag_watchdog", _record_loop_lag)
+
+    handles = await startup_monitors.start_runtime_monitors(worker_inventory=worker_inventory)
+
+    assert calls == ["jobs-metrics", "loop-lag"]
+    assert handles.jobs_metrics_stop_event is worker_inventory
+    assert handles.loop_lag_stop_event is worker_inventory
 
 
 @pytest.mark.asyncio
@@ -84,6 +109,48 @@ async def test_start_loop_lag_watchdog_skips_when_disabled(
 
     assert stop_event is None
     assert task is None
+
+
+@pytest.mark.asyncio
+async def test_start_loop_lag_watchdog_registers_background_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_monitors = _import_startup_runtime_monitors()
+    registrations: list[dict[str, object]] = []
+
+    class _FakeWorkerInventory:
+        async def register_custom(self, **kwargs: object) -> tuple[str, str]:
+            registrations.append(kwargs)
+            return "loop-lag-task", "loop-lag-stop"
+
+    monkeypatch.setenv("EVENT_LOOP_LAG_WATCHDOG_ENABLED", "true")
+    monkeypatch.setattr(
+        startup_monitors,
+        "_make_event",
+        lambda: (_ for _ in ()).throw(AssertionError("legacy event path should not run")),
+    )
+    monkeypatch.setattr(
+        startup_monitors,
+        "_create_task",
+        lambda coro: (_ for _ in ()).throw(AssertionError("legacy task path should not run")),
+    )
+
+    stop_event, task = await startup_monitors._start_loop_lag_watchdog(
+        worker_inventory=_FakeWorkerInventory(),
+    )
+
+    assert stop_event == "loop-lag-stop"
+    assert task == "loop-lag-task"
+    assert registrations == [
+        {
+            "name": "loop_lag_task",
+            "task_name": "loop_lag_watchdog",
+            "coroutine_factory": startup_monitors._run_loop_lag_watchdog_service,
+            "timeout_sec": 2.0,
+            "category": "monitoring",
+            "shutdown_phase": startup_monitors.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change summary
TODO (human): explain what changed and why these implementation choices were made before merge.

## Summary
- Register the event-loop lag watchdog through the lifecycle worker inventory when a worker registry is available.
- Preserve the legacy direct startup path for compatibility when no inventory is supplied.
- Skip the late direct shutdown path once lifecycle shutdown has already stopped the watchdog.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_runtime_monitors.py tldw_Server_API/tests/Services/test_startup_service_groups.py tldw_Server_API/tests/Services/test_startup_service_tail.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_shutdown_runtime_monitors.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_runtime_monitors.py tldw_Server_API/app/services/shutdown_post_worker_services.py tldw_Server_API/tests/Services/test_startup_runtime_monitors.py tldw_Server_API/tests/Services/test_shutdown_post_worker_services.py
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_runtime_monitors.py tldw_Server_API/app/services/shutdown_post_worker_services.py -f json -o /tmp/bandit_loop_lag_worker_registry.json
- [x] git diff --check

Part of #1114