### PR TITLE
docs(sandbox): capture Apple container prior art

### DIFF
--- a/Docs/Design/2026-04-27-vz-linux-operator-image-store-design.md
+++ b/Docs/Design/2026-04-27-vz-linux-operator-image-store-design.md
@@ -42,6 +42,14 @@ The script should not hide failures. If helper build, signing, validation, VM bo
 
 Harden `tldw_Server_API/app/core/Sandbox/image_store.py` into a small filesystem-backed manifest store. The store should remain simple and local, not a full image registry.
 
+The Apple [`container`](https://github.com/apple/container) and
+[`containerization`](https://github.com/apple/containerization) projects are
+relevant prior art for this layer because they use OCI-compatible images for
+macOS-hosted Linux VM workloads. This design still keeps the near-term
+repo-owned bundle format, but future image-store changes should avoid
+assumptions that would block OCI manifests, layer digests, registry provenance,
+or a later `vz_oci_linux` runtime from reusing the same run/session/audit model.
+
 The store layout should be deterministic:
 
 ```text

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -19,6 +19,32 @@ This is not yet a guide for shipping the full macOS runtime roadmap. The current
 - The VM-oriented runtimes assume Apple `Virtualization.framework`
 - `vz_linux` and `vz_macos` preflights fail closed when the host is not macOS or not Apple silicon
 
+## Apple Container Prior Art
+
+Apple's [`container`](https://github.com/apple/container) CLI is relevant prior
+art for `vz_linux` because it runs Linux containers as lightweight per-workload
+VMs on Apple silicon and uses the same family of macOS building blocks this
+subsystem targets:
+`Virtualization.framework`, vmnet, `launchd`, helper services, unified logging,
+OCI-compatible images, and guest control over vsock.
+
+It is not an operator prerequisite for `tldw_server`. Operators should not need
+to install or run Apple's `container` CLI for the current `vz_linux` path.
+Near-term work should instead use it as a comparison point for:
+
+- helper lifecycle and service decomposition
+- image-store layout, digests, provenance, and future OCI compatibility
+- optimized Linux kernel/rootfs choices for faster VM startup
+- vmnet-backed networking only when a reviewed network policy needs it
+- guest init/agent readiness contracts over vsock
+
+Direct reuse of Apple's lower-level
+[`containerization`](https://github.com/apple/containerization) Swift package
+should be decided in a focused implementation plan, not introduced
+incidentally. Any adoption must preserve the repo-owned helper protocol, admin
+diagnostics, fail-closed policy admission, the intended macOS support window,
+and the separate `seatbelt` and `vz_macos` runtime tracks.
+
 ## Trust-Level Policy
 
 - `untrusted`:

--- a/Docs/Sandbox/sandbox-architecture-doctrine.md
+++ b/Docs/Sandbox/sandbox-architecture-doctrine.md
@@ -33,9 +33,50 @@ This doctrine synthesizes lessons from:
 - Nono
 - CUA/Lume
 - CodeRunner
+- Apple [`container`](https://github.com/apple/container) and
+  [`containerization`](https://github.com/apple/containerization)
 
 It encodes the parts that are useful as enduring subsystem rules rather than
 copying any one implementation wholesale.
+
+## Apple Container Prior-Art Guidance
+
+Apple's [`container`](https://github.com/apple/container) and
+[`containerization`](https://github.com/apple/containerization) projects are
+first-party prior art for macOS-hosted Linux workloads, not a drop-in
+replacement for this sandbox subsystem. They validate several choices this
+subsystem already depends on:
+
+- Apple silicon as the primary serious macOS VM target
+- per-workload lightweight Linux VMs instead of one shared Linux VM
+- `Virtualization.framework` as the VM control surface
+- host services managed through `launchd`, XPC-style helper boundaries, and
+  unified logging
+- OCI-compatible image flow for portable Linux workload artifacts
+- vmnet-backed networking when network access is intentionally enabled
+- a guest init/control service over vsock
+
+Future macOS VM plans should compare against this prior art before inventing
+new helper, image, network, or guest-control mechanics. That comparison must be
+bounded by this repo's sandbox contract:
+
+- Python still owns admission, run/session identity, policy, artifacts, queueing,
+  and audit.
+- The host helper still owns live VM truth and must expose a stable repo-owned
+  protocol.
+- The guest agent still owns in-guest execution readiness and must remain
+  versioned separately from the host helper protocol.
+- `untrusted` workloads still require VM-grade isolation and fail-closed
+  admission.
+- `seatbelt` and future `vz_macos` work must not be forced through a
+  Linux-container abstraction.
+
+Do not require the `container` CLI to be installed for the sandbox module.
+Direct Swift package reuse from `containerization` is allowed only after a
+focused evaluation shows that it preserves the runtime contract, works on the
+intended macOS support window, accounts for upstream source-stability risk, and
+reduces custom code without weakening diagnostics, audit, or security
+reviewability.
 
 ## Non-Negotiable Boundaries
 
@@ -70,6 +111,13 @@ VM-backed runtimes should preserve three distinct layers:
 
 Host-local runtimes like `seatbelt` may not need a guest layer, but they still
 must keep execution logic outside policy description and diagnostics logic.
+
+Host-side helpers should be decomposed by trust boundary and operational
+responsibility rather than growing into one ambient daemon. Apple `container`
+is useful prior art here: image/content management, network management, and
+per-workload runtime management can have distinct lifecycle and permission
+profiles. This repo should adopt that shape only when a split materially
+improves safety, diagnostics, or operator control.
 
 ## Layered Readiness Model
 
@@ -164,6 +212,16 @@ Canonical artifacts should have stronger validation and deterministic metadata.
 Compatibility paths may exist, but their weaker validation strength should be
 reported explicitly.
 
+The long-term canonical Linux artifact path should be OCI-aware even if the
+current implementation remains a repo-owned bundle format. Image-store metadata
+should be structured so templates can later map to OCI manifests, layers,
+digests, registry provenance, or a dedicated `vz_oci_linux` runtime without
+rewriting run/session/audit semantics.
+
+The current bundle path remains valid for near-term `vz_linux` work. Do not
+switch to OCI or `containerization` as a side effect of unrelated helper,
+diagnostics, or policy hardening.
+
 ### Reproducible Builder Outputs
 
 Repo-owned builders should emit inspectable outputs and provenance metadata.
@@ -184,6 +242,7 @@ Builder outputs should emit deterministic metadata such as:
 - profile
 - kernel package or image family
 - selected package set or source artifact paths
+- OCI source image, manifest digest, or registry provenance when applicable
 
 Cryptographic signing or attestation can layer on top later, but provenance
 metadata is mandatory even before signing exists.
@@ -209,6 +268,19 @@ policy description distinct.
 - policy/profile decisions should live in one auditable source of truth
 - security-relevant config should be explicit and reviewable
 - ambient environment variables should not become the long-term policy model
+
+### Network Policy Doctrine
+
+VM networking must be explicit policy, not an implementation side effect.
+Apple `container` shows that vmnet can provide a first-party macOS networking
+surface for Linux VMs, but this subsystem's strict baseline remains no attached
+guest network for `vz_linux` unless a policy implementation can prove and
+diagnose the requested guarantee.
+
+`deny_all` should continue to mean no guest network device unless a runtime has
+a separately reviewed enforcement layer. Future allowlist work must expose
+host/helper truth in diagnostics and must not silently downgrade to best-effort
+networking.
 
 ## Lifecycle And Recovery Doctrine
 

--- a/Docs/Sandbox/sandbox-architecture-doctrine.md
+++ b/Docs/Sandbox/sandbox-architecture-doctrine.md
@@ -45,7 +45,7 @@ Apple's [`container`](https://github.com/apple/container) and
 [`containerization`](https://github.com/apple/containerization) projects are
 first-party prior art for macOS-hosted Linux workloads, not a drop-in
 replacement for this sandbox subsystem. They validate several choices this
-subsystem already depends on:
+subsystem has adopted as foundational principles:
 
 - Apple silicon as the primary serious macOS VM target
 - per-workload lightweight Linux VMs instead of one shared Linux VM


### PR DESCRIPTION
## Summary
- Add Apple container/containerization as explicit macOS sandbox prior art in the architecture doctrine.
- Clarify that Apple's container CLI is not an operator prerequisite for current vz_linux usage.
- Preserve the current bundle path while steering future image-store work toward OCI-compatible metadata seams.

## Change summary
TODO: human-authored summary required before merge.

## Test Plan
- [x] git diff --check HEAD~1..HEAD