### PR TITLE
refactor(workers): register core jobs poller

### DIFF
--- a/tldw_Server_API/app/services/startup_primary_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_primary_jobs_pollers.py
@@ -11,6 +11,8 @@ from typing import Any, Callable
 
 from loguru import logger
 
+from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase
+
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
     OSError,
@@ -43,6 +45,7 @@ async def start_primary_jobs_pollers(
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[[str, str], bool],
     sidecar_mode: bool,
+    worker_inventory: Any | None = None,
 ) -> PrimaryJobsPollerHandles:
     """Start the first owned jobs pollers and return their handles."""
 
@@ -51,6 +54,7 @@ async def start_primary_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         sidecar_mode=sidecar_mode,
+        worker_inventory=worker_inventory,
     )
     files_jobs_stop_event, files_jobs_task = await _start_files_jobs_worker(
         app=app,
@@ -96,6 +100,7 @@ async def _start_core_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     sidecar_mode: bool,
+    worker_inventory: Any | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         backend = (os.getenv("CHATBOOKS_JOBS_BACKEND") or os.getenv("TLDW_JOBS_BACKEND") or "").lower()
@@ -106,6 +111,18 @@ async def _start_core_jobs_worker(
         if not is_core or not core_worker_enabled:
             logger.info("Core Jobs worker (Chatbooks) disabled by backend selection or flag")
             return None, None
+
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="core_jobs_task",
+                task_name="core_jobs_task",
+                coroutine_factory=_run_chatbooks_core_jobs_worker_service,
+                timeout_sec=5.0,
+                category="jobs",
+                shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+            )
+            logger.info("Core Jobs worker (Chatbooks) started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_chatbooks_core_jobs_worker_service(stop_event))

--- a/tldw_Server_API/app/services/startup_primary_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_primary_jobs_pollers.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 
 from loguru import logger
 
-from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase
+from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase, WorkerRegistry
 
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
@@ -45,7 +45,7 @@ async def start_primary_jobs_pollers(
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[[str, str], bool],
     sidecar_mode: bool,
-    worker_inventory: Any | None = None,
+    worker_inventory: WorkerRegistry | None = None,
 ) -> PrimaryJobsPollerHandles:
     """Start the first owned jobs pollers and return their handles."""
 
@@ -100,7 +100,7 @@ async def _start_core_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     sidecar_mode: bool,
-    worker_inventory: Any | None = None,
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         backend = (os.getenv("CHATBOOKS_JOBS_BACKEND") or os.getenv("TLDW_JOBS_BACKEND") or "").lower()

--- a/tldw_Server_API/app/services/startup_worker_groups.py
+++ b/tldw_Server_API/app/services/startup_worker_groups.py
@@ -5,11 +5,11 @@ Startup worker-group orchestration extracted from the application lifespan.
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping
+from typing import Any, Callable
 
 from loguru import logger
-
 
 _TRUTHY_ENV_VALUES = {"true", "1", "yes", "y", "on"}
 
@@ -120,6 +120,7 @@ async def start_worker_groups(
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=_should_start_worker,
         sidecar_mode=sidecar_mode,
+        worker_inventory=worker_inventory,
     )
     study_privilege_jobs_poller_handles = await _start_study_privilege_jobs_pollers(
         app=app,

--- a/tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
@@ -5,7 +5,6 @@ import sys
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -66,6 +65,39 @@ async def test_start_primary_jobs_pollers_combines_handles_in_order(
 
 
 @pytest.mark.asyncio
+async def test_start_primary_jobs_pollers_passes_inventory_to_core_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_primary_jobs_pollers()
+    worker_inventory = object()
+    captured_kwargs: dict[str, object] = {}
+
+    async def _record_core(**kwargs):
+        captured_kwargs.update(kwargs)
+        return ("core-stop", "core-task")
+
+    async def _record_worker(**kwargs):
+        del kwargs
+        return (None, None)
+
+    monkeypatch.setattr(startup_pollers, "_start_core_jobs_worker", _record_core)
+    monkeypatch.setattr(startup_pollers, "_start_files_jobs_worker", _record_worker)
+    monkeypatch.setattr(startup_pollers, "_start_data_tables_jobs_worker", _record_worker)
+    monkeypatch.setattr(startup_pollers, "_start_prompt_studio_jobs_worker", _record_worker)
+
+    await startup_pollers.start_primary_jobs_pollers(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=lambda *args, **kwargs: None,
+        should_start_worker=lambda *args, **kwargs: False,
+        sidecar_mode=False,
+        worker_inventory=worker_inventory,
+    )
+
+    assert captured_kwargs["worker_inventory"] is worker_inventory
+
+
+@pytest.mark.asyncio
 async def test_start_core_jobs_worker_skips_in_sidecar_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -83,6 +115,56 @@ async def test_start_core_jobs_worker_skips_in_sidecar_mode(
 
     assert stop_event is None
     assert task is None
+
+
+@pytest.mark.asyncio
+async def test_start_core_jobs_worker_registers_with_worker_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_primary_jobs_pollers()
+    registrations: list[dict[str, object]] = []
+
+    class _FakeWorkerInventory:
+        async def register_custom(self, **kwargs: object) -> tuple[str, str]:
+            registrations.append(kwargs)
+            return "core-task", "core-stop"
+
+    monkeypatch.setenv("CHATBOOKS_JOBS_BACKEND", "core")
+    monkeypatch.setenv("CHATBOOKS_CORE_WORKER_ENABLED", "true")
+    monkeypatch.setattr(
+        startup_pollers,
+        "_make_event",
+        lambda: (_ for _ in ()).throw(AssertionError("legacy event path should not run")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_create_task",
+        lambda coro: (_ for _ in ()).throw(AssertionError("legacy task path should not run")),
+    )
+
+    def _register_owned_job_poller(*args, **kwargs):
+        raise AssertionError("legacy poller registration should not run")
+
+    stop_event, task = await startup_pollers._start_core_jobs_worker(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=_register_owned_job_poller,
+        sidecar_mode=False,
+        worker_inventory=_FakeWorkerInventory(),
+    )
+
+    assert stop_event == "core-stop"
+    assert task == "core-task"
+    assert registrations == [
+        {
+            "name": "core_jobs_task",
+            "task_name": "core_jobs_task",
+            "coroutine_factory": startup_pollers._run_chatbooks_core_jobs_worker_service,
+            "timeout_sec": 5.0,
+            "category": "jobs",
+            "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
@@ -72,11 +72,11 @@ async def test_start_primary_jobs_pollers_passes_inventory_to_core_worker(
     worker_inventory = object()
     captured_kwargs: dict[str, object] = {}
 
-    async def _record_core(**kwargs):
+    async def _record_core(**kwargs: object) -> tuple[str, str]:
         captured_kwargs.update(kwargs)
         return ("core-stop", "core-task")
 
-    async def _record_worker(**kwargs):
+    async def _record_worker(**kwargs: object) -> tuple[None, None]:
         del kwargs
         return (None, None)
 

--- a/tldw_Server_API/tests/Services/test_startup_worker_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_groups.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 import pytest
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -52,8 +51,10 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
         register_owned_job_poller,
         should_start_worker,
         sidecar_mode,
+        worker_inventory,
     ):
         assert sidecar_mode is False
+        assert worker_inventory is worker_inventory_ref
         assert should_start_worker("FILES_JOBS_WORKER_ENABLED", "files") is False
         calls.append("primary")
         return SimpleNamespace(


### PR DESCRIPTION
## Change summary
TODO (human): explain what changed and why these implementation choices were made before merge.

## Summary
- Thread the lifecycle worker inventory into primary job poller startup.
- Register the Chatbooks core jobs poller via the worker registry when inventory is available.
- Preserve the custom backend/sidecar enablement logic and the legacy direct registration fallback.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_startup_tail_finalization.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py tldw_Server_API/tests/Services/test_shutdown_job_poller_handoff.py tldw_Server_API/tests/Services/test_shutdown_core_jobs_worker.py tldw_Server_API/tests/Services/test_shutdown_primary_late_stop_workers.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_primary_jobs_pollers.py tldw_Server_API/app/services/startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_primary_jobs_pollers.py tldw_Server_API/app/services/startup_worker_groups.py -f json -o /tmp/bandit_core_jobs_worker_registry.json
- [x] git diff --check

Part of #1114