### PR TITLE
feat(sandbox): add OCI-aware image metadata scaffolding

### DIFF
--- a/Docs/Sandbox/sandbox-architecture-doctrine.md
+++ b/Docs/Sandbox/sandbox-architecture-doctrine.md
@@ -346,3 +346,8 @@ Future runtime-related plans should explicitly answer:
 - which guarantees are intentionally weaker than VM-grade isolation
 
 If a plan does not answer those questions, it is incomplete.
+
+The full-module roadmap that sequences these requirements across current and
+future runtime families is:
+
+- `Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md`

--- a/Docs/superpowers/plans/2026-05-02-oci-aware-image-store-metadata-implementation-plan.md
+++ b/Docs/superpowers/plans/2026-05-02-oci-aware-image-store-metadata-implementation-plan.md
@@ -1,0 +1,595 @@
+# OCI-Aware Image Store Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add metadata-only OCI/source provenance fields to the sandbox image store while preserving the current `tldw_bundle` boot path.
+
+**Architecture:** Keep `SandboxImageStore` as the local inventory and provenance authority, not a registry or boot validator. Add optional bounded OCI metadata to template manifests, set `artifact_format="tldw_bundle"` for canonical bundle registration, and surface the resulting template provenance through read-only macOS diagnostics. Do not change helper boot, networking, guest execution, runtime admission, or run-clone planning semantics.
+
+**Tech Stack:** Python dataclasses, JSON manifests, Pydantic response schemas, pytest, existing macOS diagnostics and image-store tests.
+
+---
+
+## Scope Guardrails
+
+This PR is intentionally metadata-only.
+
+In scope:
+
+- Persist `artifact_format` on template records.
+- Persist optional OCI/source fields on template records.
+- Keep old manifests loadable.
+- Keep `register_bundle()` callers working unchanged while writing `artifact_format="tldw_bundle"`.
+- Allow future callers to pass bounded OCI metadata into `register_template()`.
+- Expose template metadata through existing admin macOS image-store diagnostics.
+- Update tests and docs.
+
+Out of scope:
+
+- No helper protocol changes.
+- No VM boot path changes.
+- No `validate_template` changes.
+- No networking or vmnet work.
+- No guest-agent changes.
+- No runtime admission or trust-level changes.
+- No Apple `container` or `containerization` package dependency.
+- No OCI image pull/import implementation.
+
+## File Map
+
+- Modify: `tldw_Server_API/app/core/Sandbox/image_store.py`
+  - Add template metadata fields, validation helpers, manifest read/write support, and backward-compatible defaults.
+- Modify: `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+  - Include registered template metadata in `probe_image_store()` output.
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+  - Add Pydantic models for image-store template diagnostics.
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_image_store.py`
+  - Add coverage for persisted artifact format, OCI metadata, reload, and validation.
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+  - Add coverage for diagnostics surfacing template provenance.
+- Modify: `tools/vz-linux-image/README.md`
+  - Document `artifact_format="tldw_bundle"` and optional future OCI provenance fields.
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+  - Mention that image-store manifests are OCI-aware metadata scaffolding while helper boot remains bundle-backed.
+
+## Metadata Contract
+
+Add these fields to `TemplateRecord`:
+
+```python
+artifact_format: str = "unknown"
+oci_image_ref: str | None = None
+oci_platform: str | None = None
+oci_manifest_digest: str | None = None
+oci_config_digest: str | None = None
+oci_layer_digests: list[str] = field(default_factory=list)
+registry: str | None = None
+imported_at: str | None = None
+```
+
+Allowed `artifact_format` values:
+
+- `tldw_bundle`
+- `raw_artifacts`
+- `oci_image`
+- `unknown`
+
+Default behavior:
+
+- `register_bundle()` writes `artifact_format="tldw_bundle"`.
+- `register_template()` writes `artifact_format="raw_artifacts"` unless the caller passes a different allowed value.
+- Existing manifests that do not contain `artifact_format` reload as `artifact_format="unknown"`.
+- Existing manifests that do not contain OCI fields reload with `None` or `[]` defaults.
+
+Validation rules:
+
+- All optional string fields are stripped and capped to a small deterministic maximum, for example 2048 bytes.
+- Empty optional strings become `None`.
+- `artifact_format` must be one of the allowed values.
+- `oci_layer_digests` must be a list of non-empty strings and should be capped, for example maximum 128 entries.
+- Metadata validation failures raise `ImageStoreValidationError`.
+
+Schema version:
+
+- Keep `MANIFEST_SCHEMA_VERSION = 1` because this is additive and backward-compatible.
+- Do not require migrations for existing manifests.
+
+## Task 1: Add Failing Image-Store Metadata Tests
+
+**Files:**
+
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_image_store.py`
+
+**Success Criteria:** Tests fail because `TemplateRecord` and persisted manifests do not yet include artifact format or OCI metadata.
+
+- [ ] **Step 1: Add test for bundle artifact format**
+
+Add this test near `test_image_store_registers_bundle_with_build_provenance`:
+
+```python
+def test_image_store_registers_bundle_with_tldw_bundle_artifact_format(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    (bundle / "manifest.json").write_text(
+        json.dumps({"schema_version": 1, "boot_mode": "linux_direct"}),
+        encoding="utf-8",
+    )
+    store_root = tmp_path / "store"
+    store = SandboxImageStore(root_path=store_root)
+
+    template_id = store.register_bundle(
+        runtime="vz_linux",
+        template_name="debian-bookworm-arm64",
+        bundle_path=bundle,
+    )
+
+    manifest_path = store_root / "templates" / "vz_linux" / "debian-bookworm-arm64" / "manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["artifact_format"] == "tldw_bundle"
+
+    reloaded = SandboxImageStore(root_path=store_root).get_template(template_id)
+    assert reloaded is not None
+    assert reloaded.artifact_format == "tldw_bundle"
+    assert reloaded.oci_image_ref is None
+    assert reloaded.oci_layer_digests == []
+```
+
+- [ ] **Step 2: Add test for optional OCI metadata**
+
+Add this test:
+
+```python
+def test_image_store_persists_optional_oci_metadata(tmp_path: Path) -> None:
+    disk = tmp_path / "rootfs.img"
+    disk.write_bytes(b"rootfs")
+    store_root = tmp_path / "store"
+    store = SandboxImageStore(root_path=store_root)
+
+    template_id = store.register_template(
+        runtime="vz_linux",
+        template_name="oci-backed",
+        disk_paths=[str(disk)],
+        artifact_format="oci_image",
+        oci_image_ref="registry.example/tldw/sandbox:bookworm",
+        oci_platform="linux/arm64",
+        oci_manifest_digest="sha256:" + "a" * 64,
+        oci_config_digest="sha256:" + "b" * 64,
+        oci_layer_digests=["sha256:" + "c" * 64],
+        registry="registry.example",
+        imported_at="2026-05-02T00:00:00+00:00",
+    )
+
+    manifest_path = store_root / "templates" / "vz_linux" / "oci-backed" / "manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["artifact_format"] == "oci_image"
+    assert payload["oci_image_ref"] == "registry.example/tldw/sandbox:bookworm"
+    assert payload["oci_platform"] == "linux/arm64"
+    assert payload["oci_layer_digests"] == ["sha256:" + "c" * 64]
+
+    reloaded = SandboxImageStore(root_path=store_root).get_template(template_id)
+    assert reloaded is not None
+    assert reloaded.artifact_format == "oci_image"
+    assert reloaded.oci_image_ref == "registry.example/tldw/sandbox:bookworm"
+    assert reloaded.oci_platform == "linux/arm64"
+    assert reloaded.oci_manifest_digest == "sha256:" + "a" * 64
+    assert reloaded.oci_config_digest == "sha256:" + "b" * 64
+    assert reloaded.oci_layer_digests == ["sha256:" + "c" * 64]
+    assert reloaded.registry == "registry.example"
+    assert reloaded.imported_at == "2026-05-02T00:00:00+00:00"
+```
+
+- [ ] **Step 3: Add validation tests**
+
+Add focused negative tests:
+
+```python
+def test_image_store_rejects_unknown_artifact_format(tmp_path: Path) -> None:
+    disk = tmp_path / "rootfs.img"
+    disk.write_bytes(b"rootfs")
+    store = SandboxImageStore(root_path=tmp_path / "store")
+
+    with pytest.raises(ImageStoreValidationError, match="artifact_format_invalid"):
+        store.register_template(
+            runtime="vz_linux",
+            template_name="bad-format",
+            disk_paths=[str(disk)],
+            artifact_format="tarball",
+        )
+
+
+def test_image_store_rejects_invalid_oci_layer_digests(tmp_path: Path) -> None:
+    disk = tmp_path / "rootfs.img"
+    disk.write_bytes(b"rootfs")
+    store = SandboxImageStore(root_path=tmp_path / "store")
+
+    with pytest.raises(ImageStoreValidationError, match="oci_layer_digests_invalid"):
+        store.register_template(
+            runtime="vz_linux",
+            template_name="bad-oci",
+            disk_paths=[str(disk)],
+            oci_layer_digests=[""],
+        )
+```
+
+- [ ] **Step 4: Run tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_image_store.py -q
+```
+
+Expected: FAIL with missing `artifact_format`/OCI keyword support or missing `TemplateRecord` attributes.
+
+## Task 2: Implement Image-Store Metadata Persistence
+
+**Files:**
+
+- Modify: `tldw_Server_API/app/core/Sandbox/image_store.py`
+
+**Success Criteria:** Task 1 tests pass, old manifests still load, and current callers do not need changes.
+
+- [ ] **Step 1: Extend `TemplateRecord`**
+
+Add the metadata fields listed in the Metadata Contract section.
+
+- [ ] **Step 2: Add keyword-only parameters to `register_template()`**
+
+Extend the signature after `provenance`:
+
+```python
+artifact_format: str | None = None,
+oci_image_ref: str | None = None,
+oci_platform: str | None = None,
+oci_manifest_digest: str | None = None,
+oci_config_digest: str | None = None,
+oci_layer_digests: list[str] | None = None,
+registry: str | None = None,
+imported_at: str | None = None,
+```
+
+Set `artifact_format` to `raw_artifacts` when omitted.
+
+- [ ] **Step 3: Set `artifact_format="tldw_bundle"` in `register_bundle()`**
+
+Pass `artifact_format="tldw_bundle"` into `register_template()` and do not change any existing `register_bundle()` arguments.
+
+- [ ] **Step 4: Add validation helpers**
+
+Add small private helpers:
+
+```python
+_ALLOWED_ARTIFACT_FORMATS = frozenset({"tldw_bundle", "raw_artifacts", "oci_image", "unknown"})
+_MAX_METADATA_TEXT_BYTES = 2048
+_MAX_OCI_LAYER_DIGESTS = 128
+```
+
+Use helpers shaped like:
+
+```python
+def _normalize_artifact_format(self, value: str | None, *, default: str) -> str:
+    normalized = str(value if value is not None else default).strip()
+    if normalized not in _ALLOWED_ARTIFACT_FORMATS:
+        raise ImageStoreValidationError(f"artifact_format_invalid: {normalized}")
+    return normalized
+
+def _normalize_optional_metadata_text(self, value: str | None, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ImageStoreValidationError(f"{field_name}_invalid")
+    normalized = str(value).strip()
+    if not normalized:
+        return None
+    if len(normalized.encode("utf-8")) > _MAX_METADATA_TEXT_BYTES:
+        raise ImageStoreValidationError(f"{field_name}_too_long")
+    return normalized
+
+def _normalize_oci_layer_digests(self, values: list[str] | None) -> list[str]:
+    if values is None:
+        return []
+    if not isinstance(values, list) or len(values) > _MAX_OCI_LAYER_DIGESTS:
+        raise ImageStoreValidationError("oci_layer_digests_invalid")
+    normalized = []
+    for value in values:
+        item = self._normalize_optional_metadata_text(value, "oci_layer_digest")
+        if item is None:
+            raise ImageStoreValidationError("oci_layer_digests_invalid")
+        normalized.append(item)
+    return normalized
+```
+
+Keep the helpers boring. Do not implement a full OCI digest parser in this PR.
+
+- [ ] **Step 5: Write metadata fields into manifests**
+
+Update `_record_to_manifest()` to include the fields:
+
+```python
+"artifact_format": record.artifact_format,
+"oci_image_ref": record.oci_image_ref,
+"oci_platform": record.oci_platform,
+"oci_manifest_digest": record.oci_manifest_digest,
+"oci_config_digest": record.oci_config_digest,
+"oci_layer_digests": list(record.oci_layer_digests),
+"registry": record.registry,
+"imported_at": record.imported_at,
+```
+
+- [ ] **Step 6: Read metadata fields from manifests with backward-compatible defaults**
+
+Update `_read_manifest()` so missing fields do not fail:
+
+```python
+artifact_format=self._normalize_artifact_format(payload.get("artifact_format"), default="unknown"),
+oci_image_ref=self._normalize_optional_metadata_text(payload.get("oci_image_ref"), "oci_image_ref"),
+...
+oci_layer_digests=self._normalize_oci_layer_digests(payload.get("oci_layer_digests")),
+```
+
+When reading, handle invalid field types with `ImageStoreValidationError`, not raw `TypeError`/`ValueError`.
+
+- [ ] **Step 7: Run image-store tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_image_store.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/image_store.py tldw_Server_API/tests/sandbox/test_macos_image_store.py
+git commit -m "feat(sandbox): persist oci-aware image metadata"
+```
+
+## Task 3: Surface Template Metadata In Admin Diagnostics
+
+**Files:**
+
+- Modify: `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+
+**Success Criteria:** `collect_macos_diagnostics()` includes a read-only `image_store.templates` list with template artifact format and optional OCI provenance.
+
+- [ ] **Step 1: Add failing diagnostics assertions**
+
+In `test_collect_macos_diagnostics_reports_image_store_correlation`, after `image_store = data["image_store"]`, add:
+
+```python
+templates = {template["template_id"]: template for template in image_store["templates"]}
+assert templates[template_id]["artifact_format"] == "tldw_bundle"
+assert templates[template_id]["runtime"] == "vz_linux"
+assert templates[template_id]["template_name"] == "debian-bookworm-arm64"
+assert templates[template_id]["artifact_count"] == 2
+assert templates[template_id]["artifact_size_bytes"] == len(b"kernel") + len(b"rootfs")
+```
+
+Add a second focused unit test against `probe_image_store()` using `register_template(... artifact_format="oci_image", ...)` and assert the OCI fields are surfaced.
+
+- [ ] **Step 2: Run diagnostics tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py -q
+```
+
+Expected: FAIL because `templates` is missing.
+
+- [ ] **Step 3: Add Pydantic schema for template diagnostics**
+
+In `sandbox_schemas.py`, add:
+
+```python
+class SandboxAdminMacOSImageStoreTemplate(BaseModel):
+    template_id: str
+    runtime: str
+    template_name: str
+    artifact_format: str
+    source_path: str | None = None
+    artifact_count: int = 0
+    artifact_size_bytes: int = 0
+    oci_image_ref: str | None = None
+    oci_platform: str | None = None
+    oci_manifest_digest: str | None = None
+    oci_config_digest: str | None = None
+    oci_layer_digests: list[str] = Field(default_factory=list)
+    registry: str | None = None
+    imported_at: str | None = None
+    provenance: dict[str, object] = Field(default_factory=dict)
+```
+
+Add to `SandboxAdminMacOSImageStoreDiagnostics`:
+
+```python
+templates: list[SandboxAdminMacOSImageStoreTemplate] = Field(default_factory=list)
+```
+
+- [ ] **Step 4: Add diagnostics helper**
+
+In `macos_diagnostics.py`, add a private helper:
+
+```python
+def _image_store_template_item(record) -> dict[str, object]:
+    return {
+        "template_id": record.template_id,
+        "runtime": record.runtime,
+        "template_name": record.template_name,
+        "artifact_format": record.artifact_format,
+        "source_path": record.source_path,
+        "artifact_count": len(record.artifacts),
+        "artifact_size_bytes": sum(int(artifact.size_bytes) for artifact in record.artifacts),
+        "oci_image_ref": record.oci_image_ref,
+        "oci_platform": record.oci_platform,
+        "oci_manifest_digest": record.oci_manifest_digest,
+        "oci_config_digest": record.oci_config_digest,
+        "oci_layer_digests": list(record.oci_layer_digests),
+        "registry": record.registry,
+        "imported_at": record.imported_at,
+        "provenance": dict(record.provenance),
+    }
+```
+
+Use a concrete import type only if it does not introduce import cycles. A duck-typed helper is acceptable here because diagnostics already builds dict payloads.
+
+- [ ] **Step 5: Include `templates` in every `probe_image_store()` return shape**
+
+For unconfigured/missing/unavailable cases, return `"templates": []`.
+
+For the configured healthy case, add:
+
+```python
+templates = [_image_store_template_item(record) for record in store.list_templates()]
+```
+
+and include `templates` in the returned dict.
+
+- [ ] **Step 6: Run diagnostics tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/macos_diagnostics.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+git commit -m "feat(sandbox): expose image template provenance diagnostics"
+```
+
+## Task 4: Documentation Updates
+
+**Files:**
+
+- Modify: `tools/vz-linux-image/README.md`
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+
+**Success Criteria:** Operator-facing docs say current bundles are recorded as `tldw_bundle`, OCI fields are metadata-only, and helper bootability remains helper-owned.
+
+- [ ] **Step 1: Update `tools/vz-linux-image/README.md`**
+
+In the Image Store Registration section, update the final paragraph to mention:
+
+```markdown
+Canonical bundle registration writes `artifact_format="tldw_bundle"`.
+The manifest also has optional OCI/source provenance fields such as
+`oci_image_ref`, `oci_platform`, manifest/config/layer digests, `registry`, and
+`imported_at`. These fields are metadata scaffolding only; the helper still
+boots the repo-owned bundle path and remains the source of truth for bootability.
+```
+
+- [ ] **Step 2: Update Sandbox README technical notes**
+
+Extend the image-store note to say:
+
+```markdown
+Template manifests are OCI-aware metadata scaffolding: current canonical bundles
+remain `artifact_format=tldw_bundle`, while optional OCI fields can describe a
+future source image without changing helper boot.
+```
+
+- [ ] **Step 3: Run docs diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/vz-linux-image/README.md tldw_Server_API/app/core/Sandbox/README.md
+git commit -m "docs(sandbox): document oci-aware image metadata"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+
+- Check only.
+
+**Success Criteria:** Focused tests and security scan pass before PR creation.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/sandbox/test_macos_image_store.py \
+  tldw_Server_API/tests/sandbox/test_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_vz_linux_runner.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Bandit on touched Python code**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/Sandbox/image_store.py \
+  tldw_Server_API/app/core/Sandbox/macos_diagnostics.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  -f json -o /tmp/bandit_oci_image_store_metadata.json
+```
+
+Expected: JSON report writes successfully with no new findings in touched code.
+
+- [ ] **Step 3: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Inspect commit range**
+
+Run:
+
+```bash
+git log --oneline --decorate dev..HEAD
+git diff --stat dev..HEAD
+```
+
+Expected: only roadmap docs plus OCI-aware image-store metadata plan/implementation commits are present.
+
+## Implementation Notes
+
+- Keep diagnostics read-only. `probe_image_store()` must not create roots or write manifests.
+- Keep manifest output deterministic with `json.dump(..., sort_keys=True)`.
+- Do not store arbitrary nested OCI descriptors yet. The goal is provenance fields, not an OCI model.
+- Do not validate that OCI digests are reachable or present in a registry.
+- Do not add a new runtime enum or helper boot mode.
+- If reviewers ask for a schema bump, prefer explaining that fields are optional/additive and old manifests still load; bump only if incompatible validation is introduced.
+
+## Expected PR Summary
+
+This PR adds OCI-aware metadata scaffolding to the sandbox image store without changing VM boot behavior. Current canonical bundles are recorded as `artifact_format=tldw_bundle`; future OCI source information can be persisted and surfaced in admin diagnostics, but helper template validation remains the bootability authority.

--- a/Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
@@ -19,8 +19,8 @@ security-reviewable subsystem.
 
 The roadmap uses `vz_linux` as the strongest current VM-backed proving ground,
 then extracts stable contracts across Docker, Firecracker, Lima, `vz_macos`,
-and `seatbelt`. It should guide future plans without forcing every runtime to
-move at the same maturity level.
+`seatbelt`, and `worktree`. It should guide future plans without forcing every
+runtime to move at the same maturity level.
 
 ## Current Baseline
 
@@ -30,7 +30,8 @@ The sandbox module already has substantial production-shaped pieces:
   runtime discovery.
 - Orchestrator support for sessions, idempotency, queueing, artifact storage,
   and status persistence.
-- Runtimes for Docker, Firecracker, Lima, `vz_linux`, `vz_macos`, and `seatbelt`.
+- Runtimes for Docker, Firecracker, Lima, `vz_linux`, `vz_macos`, `seatbelt`,
+  and `worktree`.
 - Docker hardening defaults, limited interactivity, WebSocket resume, signed
   URLs, artifact quotas, and resource usage reporting.
 - Firecracker and Lima runtime surfaces with varying levels of real execution,
@@ -137,6 +138,21 @@ Roadmap stance:
 - align audit, cleanup, and diagnostics with shared runtime contracts where
   applicable
 
+### `worktree`
+
+Role: host-local VCS workspace isolation for trusted and standard workflows.
+
+Roadmap stance:
+
+- keep weaker guarantee claims explicit
+- never treat as VM-grade or acceptable for `untrusted`
+- preserve explicit repository allowlisting, sensitive environment stripping,
+  and Linux `unshare` readiness checks
+- align cancellation, cleanup, artifacts, audit, and diagnostics with other
+  host-local runtime contracts where applicable
+- do not make it a long-lived session reuse path until health and recovery
+  semantics are concrete
+
 ## Phased Roadmap
 
 ### Phase 0: Baseline Inventory
@@ -147,7 +163,7 @@ risks, and tests.
 Deliverables:
 
 - runtime capability matrix covering Docker, Firecracker, Lima, `vz_linux`,
-  `vz_macos`, and `seatbelt`
+  `vz_macos`, `seatbelt`, and `worktree`
 - current support states for trust levels, network policies, interactivity,
   session reuse, artifacts, cancellation, recovery, host readiness, and CI
 - docs/code drift report for Sandbox README, API quick guide, operator notes,
@@ -235,7 +251,7 @@ Deliverables:
 - cleanup/recovery contract tests for cancel, timeout, failed start, stuck run,
   and orphaned resources
 - artifact quota and log cap tests across Docker, Firecracker, Lima, `vz_linux`,
-  and `seatbelt` where applicable
+  `vz_macos`, `seatbelt`, and `worktree` where applicable
 - persistent store reconciliation rules for sessions/runs that outlive worker
   processes
 - operator repair surfaces generalized only where the ownership model is
@@ -258,8 +274,8 @@ Deliverables:
 
 - admin runtime dashboard/API model for readiness, warnings, repair plans, image
   store health, queue pressure, and CI status
-- documented operator playbooks for Docker, Firecracker, Lima, and macOS VZ
-  hosts
+- documented operator playbooks for Docker, Firecracker, Lima, host-local
+  runtimes, and macOS VZ hosts
 - startup warning and diagnostics summaries that distinguish blocking from
   non-blocking conditions
 - clear guidance for host-gated smoke, expected skips, and failure triage
@@ -307,7 +323,8 @@ gate before broader lifecycle, reliability, or security hardening expands.
 
    Add a repo-level matrix documenting each runtime's support state for trust
    levels, network policies, interactivity, sessions, artifacts, recovery, and
-   CI. Cross-check with `/api/v1/sandbox/runtimes`.
+   CI. Include `worktree` explicitly and cross-check with
+   `/api/v1/sandbox/runtimes`.
 
 3. **`vz_linux` helper lifecycle compatibility**
 
@@ -339,7 +356,8 @@ gate before broader lifecycle, reliability, or security hardening expands.
 8. **Public docs reconciliation**
 
    Align API docs, Sandbox README, Product PRD, and operator notes so they do
-   not overstate support for Firecracker, Lima, `vz_macos`, or `seatbelt`.
+   not overstate support for Firecracker, Lima, `vz_macos`, `seatbelt`, or
+   `worktree`.
 
 ## Design Risks And Mitigations
 
@@ -350,6 +368,11 @@ gate before broader lifecycle, reliability, or security hardening expands.
 
 - Risk: parity language could imply every runtime must implement every feature.
   Mitigation: parity means consistent reporting, not identical support.
+
+- Risk: host-local convenience runtimes could be mistaken for untrusted-code
+  isolation.
+  Mitigation: `seatbelt` and `worktree` stay explicitly weaker than VM-backed
+  runtimes and must not satisfy `untrusted`.
 
 - Risk: direct Apple `containerization` reuse could increase dependency and
   macOS version risk before the current helper path is stable.
@@ -372,6 +395,7 @@ gate before broader lifecycle, reliability, or security hardening expands.
 - Do not replace the current helper with Apple `container`.
 - Do not require Apple `container` for operators.
 - Do not make `seatbelt` VM-grade.
+- Do not make `worktree` VM-grade.
 - Do not attach networking for `deny_all`.
 - Do not implement `vz_macos` real execution until the shared contracts are
   stable enough to reuse.

--- a/Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md
@@ -1,0 +1,386 @@
+# Sandbox Module Roadmap Design
+
+**Status:** Proposed roadmap spec.
+**Date:** 2026-05-02.
+**Scope:** Full sandbox module: API, orchestrator, store, artifacts, streaming,
+admin surfaces, CI, security, and all current runtime families.
+
+## Related Docs
+
+- `Docs/Sandbox/sandbox-architecture-doctrine.md`
+- `Docs/Design/2026-05-02-apple-containerization-evaluation.md`
+- `tldw_Server_API/app/core/Sandbox/README.md`
+
+## Goal
+
+Create a structured 6-12 month roadmap plus an immediate PR queue for taking the
+sandbox module from feature-rich prototype paths to a stable, diagnosable, and
+security-reviewable subsystem.
+
+The roadmap uses `vz_linux` as the strongest current VM-backed proving ground,
+then extracts stable contracts across Docker, Firecracker, Lima, `vz_macos`,
+and `seatbelt`. It should guide future plans without forcing every runtime to
+move at the same maturity level.
+
+## Current Baseline
+
+The sandbox module already has substantial production-shaped pieces:
+
+- REST and WebSocket API for sessions, runs, logs, artifacts, cancellation, and
+  runtime discovery.
+- Orchestrator support for sessions, idempotency, queueing, artifact storage,
+  and status persistence.
+- Runtimes for Docker, Firecracker, Lima, `vz_linux`, `vz_macos`, and `seatbelt`.
+- Docker hardening defaults, limited interactivity, WebSocket resume, signed
+  URLs, artifact quotas, and resource usage reporting.
+- Firecracker and Lima runtime surfaces with varying levels of real execution,
+  strict admission, and host prerequisites.
+- macOS runtime doctrine, operator notes, helper protocol, image store, helper
+  lifecycle command, host-gated smoke path, reconciliation, repair, and startup
+  warnings.
+- `vz_linux` real Apple silicon VM execution with helper-backed boot, guest
+  command execution, session VM reuse, output caps, artifact audit metadata,
+  and guest capability readiness details.
+- Apple `container`/`containerization` evaluation that recommends OCI-aware
+  image-store metadata before deeper dependency or runtime rewrites.
+
+The biggest remaining risk is not lack of features. It is uneven runtime
+maturity: each runtime reports and enforces a different subset of guarantees,
+and some operational behaviors are mature only for `vz_linux`.
+
+## Strategy
+
+Use a stability-first roadmap with a parity overlay.
+
+1. Harden one VM path (`vz_linux`) until the lifecycle is boring.
+2. Extract only proven contracts into shared sandbox capability, diagnostics,
+   recovery, and security rules.
+3. Apply those shared rules to other runtimes with explicit `supported`,
+   `unsupported`, or `not_applicable` states.
+4. Keep feature expansion gated behind diagnostics, tests, and clear operator
+   behavior.
+
+This avoids two failure modes:
+
+- building abstractions from the least mature runtimes
+- overfitting the whole module to macOS-specific implementation details
+
+## Runtime Families
+
+### Docker
+
+Role: broadest default runtime and best place for fast developer feedback.
+
+Roadmap stance:
+
+- keep broad availability and interactive support
+- harden cleanup, egress allowlist, artifact caps, and resource reporting
+- do not claim VM-grade isolation for `untrusted` if the policy requires a VM
+- preserve Docker as the baseline for API behavior and fast local tests
+
+### Firecracker
+
+Role: Linux VM-grade isolation path.
+
+Roadmap stance:
+
+- make runtime discovery and host prep as clear as `vz_linux`
+- align cancellation, artifacts, metrics, and cleanup with shared contracts
+- defer advanced features until real execution parity is demonstrably stable
+
+### Lima
+
+Role: compatibility VM path, especially where first-party macOS helper support
+is unavailable or not desired.
+
+Roadmap stance:
+
+- keep fail-closed admission and explicit enforcement readiness
+- document slower lifecycle and host dependency constraints
+- avoid competing with `vz_linux` for Apple silicon production path unless a
+  concrete capability gap requires it
+
+### `vz_linux`
+
+Role: primary macOS Apple silicon VM-backed Linux sandbox path.
+
+Roadmap stance:
+
+- remain the proving ground for helper lifecycle, image-store, diagnostics,
+  guest protocol, recovery, and host-gated CI
+- keep current repo-owned bundle path while making metadata OCI-aware
+- do not require Apple `container`
+- do not attach networking under `deny_all`
+- do not replace `tldw-agent` until the current guest path is stable and a
+  focused comparison proves clear benefit
+
+### `vz_macos`
+
+Role: future macOS guest VM path.
+
+Roadmap stance:
+
+- keep scaffold honest until real execution exists
+- reuse helper-owned readiness and provenance rules from `vz_linux`
+- avoid promising parity before image/template, guest control, and isolation
+  semantics are concrete
+
+### `seatbelt`
+
+Role: host-local trusted-workflow isolation bridge.
+
+Roadmap stance:
+
+- keep weaker guarantee claims explicit
+- never treat as VM-grade or acceptable for `untrusted`
+- continue to make availability and `sandbox-exec` deprecation visible
+- align audit, cleanup, and diagnostics with shared runtime contracts where
+  applicable
+
+## Phased Roadmap
+
+### Phase 0: Baseline Inventory
+
+Goal: establish one authoritative view of current runtime capabilities, gaps,
+risks, and tests.
+
+Deliverables:
+
+- runtime capability matrix covering Docker, Firecracker, Lima, `vz_linux`,
+  `vz_macos`, and `seatbelt`
+- current support states for trust levels, network policies, interactivity,
+  session reuse, artifacts, cancellation, recovery, host readiness, and CI
+- docs/code drift report for Sandbox README, API quick guide, operator notes,
+  and runtime discovery
+- test coverage map by runtime and behavior
+
+Exit criteria:
+
+- every runtime capability is classified as `supported`, `unsupported`,
+  `scaffold`, `host_gated`, or `not_applicable`
+- public docs do not imply stronger guarantees than discovery/preflight reports
+- next PR queue is grounded in explicit gaps, not inferred roadmap memory
+
+### Phase 1: `vz_linux` Production Stability
+
+Goal: make the first-party Apple silicon Linux VM path repeatable, debuggable,
+and safe enough to serve as the VM contract reference.
+
+Deliverables:
+
+- OCI-aware image-store metadata scaffolding while keeping bundle boot unchanged
+- helper lifecycle version/compatibility checks and operator upgrade behavior
+- richer helper diagnostics for boot logs, serial logs, resource stats, and VM
+  health snapshots
+- session reuse health checks that reject stale or unhealthy VMs before reuse
+- recovery behavior for helper crash, host reboot, stale socket, stuck boot,
+  stuck readiness, and guest-agent mismatch
+- host-gated CI acceptance gates for manual and nightly real VM smoke
+
+Exit criteria:
+
+- a prepared Apple silicon host can run one command, same-session reuse, helper
+  restart/recovery, and cleanup through documented operator commands
+- diagnostics explain failures without requiring source-code inspection
+- no other runtime is required to adopt macOS-only details
+
+### Phase 2: Security Contract Hardening
+
+Goal: make isolation guarantees explicit and testable across all runtimes.
+
+Deliverables:
+
+- trust-level policy matrix for runtime eligibility and required guarantees
+- network policy matrix for `deny_all`, `allowlist`, and unsupported states
+- workspace mount and user model contract per runtime
+- artifact exposure and path-safety contract shared by all runtimes
+- helper/request allowlisting and bounded input validation requirements
+- audit event schema for lifecycle, policy decisions, artifacts, repair, and
+  admin actions
+
+Exit criteria:
+
+- `untrusted` cannot silently fall back to a weaker runtime
+- each runtime advertises and enforces only guarantees it can prove
+- security-relevant behavior has focused tests or explicit host-gated coverage
+
+### Phase 3: Runtime Parity Overlay
+
+Goal: define a shared runtime capability contract without pretending every
+runtime implements every feature.
+
+Deliverables:
+
+- normalized runtime discovery schema for capability states and reasons
+- common preflight vocabulary for missing binaries, unsupported OS, helper
+  mismatch, template missing, network unsupported, and policy denied
+- shared status/error taxonomy for cancellation, timeout, runtime unavailable,
+  policy failure, artifact truncation, and stale session
+- common shape for resource usage, image/template provenance, and execution
+  mode
+
+Exit criteria:
+
+- clients and ACP can make decisions from discovery without runtime-specific
+  string guessing
+- adding a new runtime means filling out capability contracts, not inventing
+  a parallel readiness model
+
+### Phase 4: Cross-Runtime Reliability
+
+Goal: align lifecycle behavior where runtimes already share concepts.
+
+Deliverables:
+
+- cleanup/recovery contract tests for cancel, timeout, failed start, stuck run,
+  and orphaned resources
+- artifact quota and log cap tests across Docker, Firecracker, Lima, `vz_linux`,
+  and `seatbelt` where applicable
+- persistent store reconciliation rules for sessions/runs that outlive worker
+  processes
+- operator repair surfaces generalized only where the ownership model is
+  strong enough
+- warm-pool and session reuse behavior explicitly scoped to runtimes that can
+  prove health
+
+Exit criteria:
+
+- users see consistent terminal states and error classes across runtimes
+- failed runs do not leak process/VM/container resources under normal failure
+  modes
+- repair actions stay explicit, dry-run-first, and ownership-checked
+
+### Phase 5: Operator And Admin UX
+
+Goal: make sandbox operation understandable without reading implementation code.
+
+Deliverables:
+
+- admin runtime dashboard/API model for readiness, warnings, repair plans, image
+  store health, queue pressure, and CI status
+- documented operator playbooks for Docker, Firecracker, Lima, and macOS VZ
+  hosts
+- startup warning and diagnostics summaries that distinguish blocking from
+  non-blocking conditions
+- clear guidance for host-gated smoke, expected skips, and failure triage
+
+Exit criteria:
+
+- an operator can answer "why is this runtime unavailable?" from admin surfaces
+- host preparation and smoke tests are copy/paste-safe
+- docs match current runtime discovery and preflight behavior
+
+### Phase 6: Expansion And Optimization
+
+Goal: add larger capabilities only after stable contracts exist.
+
+Candidates:
+
+- `vz_macos` real execution
+- vmnet-backed `vz_linux` allowlist networking
+- direct Apple `containerization` Swift package spike
+- APFS clone or filesystem snapshot execution
+- Firecracker real execution parity and snapshots
+- optimized Linux kernel/rootfs benchmark
+- richer guest protocol inspired by `vminitd`
+- resource stats and boot-log parity across VM runtimes
+
+Exit criteria:
+
+- each expansion has a focused design
+- dependency additions are isolated behind adapters
+- compatibility and rollback paths are explicit
+
+## Immediate PR Queue
+
+This queue starts with a low-risk metadata bridge already identified by the
+Apple containerization evaluation. PR 2 then completes the Phase 0 inventory
+gate before broader lifecycle, reliability, or security hardening expands.
+
+1. **OCI-aware image-store metadata scaffolding**
+
+   Add optional OCI/source fields to `SandboxImageStore` manifests, set
+   `artifact_format="tldw_bundle"` for current bundles, and surface artifact
+   format/provenance in diagnostics. Do not change helper boot.
+
+2. **Runtime capability inventory**
+
+   Add a repo-level matrix documenting each runtime's support state for trust
+   levels, network policies, interactivity, sessions, artifacts, recovery, and
+   CI. Cross-check with `/api/v1/sandbox/runtimes`.
+
+3. **`vz_linux` helper lifecycle compatibility**
+
+   Tighten helper version/protocol checks, startup/shutdown behavior, stale
+   socket handling, and operator status output. Keep launchd scaffolding
+   operator-first, not automatic.
+
+4. **Boot logs and resource diagnostics**
+
+   Surface serial/boot log pointers, bounded helper logs, and resource snapshots
+   in admin diagnostics, starting with `vz_linux`.
+
+5. **Cross-runtime cleanup contract tests**
+
+   Add focused tests for cancel/timeout/failed-start cleanup semantics for the
+   runtimes that can be exercised without special hosts, plus host-gated notes
+   for VM-only checks.
+
+6. **Security policy matrix**
+
+   Document and test trust-level/runtime eligibility, network semantics,
+   workspace mounts, user model, and artifact exposure by runtime.
+
+7. **Host-gated CI acceptance policy**
+
+   Clarify manual/nightly gates, expected skip behavior, artifact uploads,
+   branch allowlisting, and what counts as a blocking `vz_linux` regression.
+
+8. **Public docs reconciliation**
+
+   Align API docs, Sandbox README, Product PRD, and operator notes so they do
+   not overstate support for Firecracker, Lima, `vz_macos`, or `seatbelt`.
+
+## Design Risks And Mitigations
+
+- Risk: using `vz_linux` as the proving ground could overfit the whole sandbox
+  module to macOS.
+  Mitigation: only promote runtime-neutral contracts; keep macOS-specific
+  helper details in macOS docs and tests.
+
+- Risk: parity language could imply every runtime must implement every feature.
+  Mitigation: parity means consistent reporting, not identical support.
+
+- Risk: direct Apple `containerization` reuse could increase dependency and
+  macOS version risk before the current helper path is stable.
+  Mitigation: require a focused adapter spike before adding the package graph.
+
+- Risk: networking expansion could weaken `deny_all`.
+  Mitigation: no network device under `deny_all`; vmnet work starts as a policy
+  design with host-gated tests.
+
+- Risk: repair endpoints can become destructive.
+  Mitigation: dry-run-first, explicit mutation flags, ownership metadata checks,
+  and fail-closed behavior when helper truth is unavailable.
+
+- Risk: docs become stale faster than runtime code.
+  Mitigation: Phase 0 inventory and Phase 3 discovery schema should make docs
+  cite runtime capability states instead of hand-written assumptions.
+
+## Non-Goals
+
+- Do not replace the current helper with Apple `container`.
+- Do not require Apple `container` for operators.
+- Do not make `seatbelt` VM-grade.
+- Do not attach networking for `deny_all`.
+- Do not implement `vz_macos` real execution until the shared contracts are
+  stable enough to reuse.
+- Do not make every runtime support every feature before stabilizing how support
+  is reported.
+
+## Approval Gate
+
+Once this roadmap is approved, the next artifact should be an implementation
+plan for PR 1: OCI-aware image-store metadata scaffolding. That plan should
+remain narrow and should not change helper boot, networking, guest execution, or
+runtime admission.

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -391,12 +391,31 @@ class SandboxAdminMacOSImageStoreItem(BaseModel):
     matched_reconciliation_reason: str | None = None
 
 
+class SandboxAdminMacOSImageStoreTemplate(BaseModel):
+    template_id: str
+    runtime: str
+    template_name: str
+    artifact_format: str
+    source_path: str | None = None
+    artifact_count: int = 0
+    artifact_size_bytes: int = 0
+    oci_image_ref: str | None = None
+    oci_platform: str | None = None
+    oci_manifest_digest: str | None = None
+    oci_config_digest: str | None = None
+    oci_layer_digests: list[str] = Field(default_factory=list)
+    registry: str | None = None
+    imported_at: str | None = None
+    provenance: dict[str, object] = Field(default_factory=dict)
+
+
 class SandboxAdminMacOSImageStoreDiagnostics(BaseModel):
     configured: bool
     root_path: str | None = None
     registered_templates: int = 0
     run_manifests: int = 0
     gc_candidates: int = 0
+    templates: list[SandboxAdminMacOSImageStoreTemplate] = Field(default_factory=list)
     items: list[SandboxAdminMacOSImageStoreItem] = Field(default_factory=list)
     reasons: list[str] = Field(default_factory=list)
 

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -44,6 +44,10 @@ Trust-level rules:
   - canonical vs compatibility artifact paths
   - audit and provenance expectations
   - lifecycle and reconciliation rules
+- The full-module roadmap lives in
+  `Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md`.
+  It sequences remaining work across API, orchestrator, runtimes, security,
+  admin, and CI without treating every runtime as equally mature.
 - macOS scaffolding currently includes:
   - a Unix-socket helper client plus protocol models in `macos_virtualization/`
   - frozen helper contract docs in `tools/macos-vz-helper/`

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -117,7 +117,10 @@ Current limitations:
   planning manifests under `<root>/runs/<run_id>/manifest.json`, and exposes
   dry-run run-directory GC planning with candidate reasons that distinguish
   planning-only manifests, fully materialized inactive runs, and legacy run
-  directories without a persisted manifest.
+  directories without a persisted manifest. Template manifests are OCI-aware
+  metadata scaffolding: current canonical bundles remain
+  `artifact_format=tldw_bundle`, while optional OCI fields can describe a
+  future source image without changing helper boot.
 - When `TLDW_SANDBOX_IMAGE_STORE_ROOT` is configured, `vz_linux` can also
   resolve `spec.base_image` as a registered image-store `template_id` instead
   of a raw path, provided the template record has a stored `source_path`.

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -10,6 +10,7 @@
   - `vz_linux`
   - `vz_macos`
   - `seatbelt`
+  - `worktree`
 - Capabilities:
   - Create and destroy sessions
   - Queue runs with TTL and capacity limits
@@ -25,12 +26,14 @@
 - `vz_linux`: Apple `Virtualization.framework` Linux guest runtime on prepared Apple silicon macOS hosts, with real helper-backed boot, guest command execution, and session VM reuse when helper/template readiness passes.
 - `vz_macos`: Apple `Virtualization.framework` macOS guest scaffold on Apple silicon macOS hosts.
 - `seatbelt`: host-local process isolation runtime for conservative trusted macOS workflows, compatibility-gated by deprecated `sandbox-exec`.
+- `worktree`: host-local VCS-level isolation runtime for trusted and standard workflows, backed by temporary git worktrees and Linux `unshare` readiness checks where applicable.
 
 Trust-level rules:
 
 - `untrusted` requires a VM runtime.
 - `seatbelt` is rejected for `untrusted`.
 - `seatbelt` defaults to `trusted` only; `standard` requires `TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED=1`.
+- `worktree` supports `trusted` and `standard`, not `untrusted`.
 - `vz_linux` and `vz_macos` advertise `trusted`, `standard`, and `untrusted`.
 
 ## Technical Notes
@@ -63,7 +66,7 @@ Current limitations:
 - `vz_macos` real `Virtualization.framework` execution is not implemented yet.
 - `vz_linux` requires helper/template readiness and reports `execution_mode=real` when the helper-backed boot and guest execution path is available.
 - `vz_macos` still requires helper/template readiness plus `*_FAKE_EXEC=1`; otherwise discovery reports `real_execution_not_implemented`.
-- Strict allowlist networking is not implemented for `vz_linux`, `vz_macos`, or `seatbelt`.
+- Strict allowlist networking is not implemented for `vz_linux`, `vz_macos`, `seatbelt`, or `worktree`.
 - `vz_linux` VM creation is fail-closed at both Python admission and helper
   protocol layers: only `network_policy=deny_all` is accepted, and the helper
   records the accepted policy in VM metadata/status details. The current

--- a/tldw_Server_API/app/core/Sandbox/image_store.py
+++ b/tldw_Server_API/app/core/Sandbox/image_store.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from typing import Any
 
 MANIFEST_SCHEMA_VERSION = 1
+_ALLOWED_ARTIFACT_FORMATS = frozenset({"tldw_bundle", "raw_artifacts", "oci_image", "unknown"})
+_MAX_METADATA_TEXT_BYTES = 2048
+_MAX_OCI_LAYER_DIGESTS = 128
 
 
 class ImageStoreError(RuntimeError):
@@ -64,6 +67,14 @@ class TemplateRecord:
     provenance: dict[str, Any] = field(default_factory=dict)
     registered_at: str | None = None
     manifest_path: str | None = None
+    artifact_format: str = "unknown"
+    oci_image_ref: str | None = None
+    oci_platform: str | None = None
+    oci_manifest_digest: str | None = None
+    oci_config_digest: str | None = None
+    oci_layer_digests: list[str] = field(default_factory=list)
+    registry: str | None = None
+    imported_at: str | None = None
 
 
 @dataclass(slots=True)
@@ -110,6 +121,14 @@ class SandboxImageStore:
         source_path: str | Path | None = None,
         labels: dict[str, str] | None = None,
         provenance: dict[str, Any] | None = None,
+        artifact_format: str | None = None,
+        oci_image_ref: str | None = None,
+        oci_platform: str | None = None,
+        oci_manifest_digest: str | None = None,
+        oci_config_digest: str | None = None,
+        oci_layer_digests: list[str] | None = None,
+        registry: str | None = None,
+        imported_at: str | None = None,
         allow_existing: bool = False,
     ) -> str:
         """Register artifact paths as a durable template manifest.
@@ -143,6 +162,20 @@ class SandboxImageStore:
             provenance=dict(provenance or {}),
             registered_at=registered_at,
             manifest_path=str(manifest_path),
+            artifact_format=self._normalize_artifact_format(artifact_format, default="raw_artifacts"),
+            oci_image_ref=self._normalize_optional_metadata_text(oci_image_ref, "oci_image_ref"),
+            oci_platform=self._normalize_optional_metadata_text(oci_platform, "oci_platform"),
+            oci_manifest_digest=self._normalize_optional_metadata_text(
+                oci_manifest_digest,
+                "oci_manifest_digest",
+            ),
+            oci_config_digest=self._normalize_optional_metadata_text(
+                oci_config_digest,
+                "oci_config_digest",
+            ),
+            oci_layer_digests=self._normalize_oci_layer_digests(oci_layer_digests),
+            registry=self._normalize_optional_metadata_text(registry, "registry"),
+            imported_at=self._normalize_optional_metadata_text(imported_at, "imported_at"),
         )
         self._write_manifest(record)
         self._templates[template_id] = record
@@ -180,6 +213,7 @@ class SandboxImageStore:
             source_path=bundle,
             labels=labels,
             provenance=provenance,
+            artifact_format="tldw_bundle",
             allow_existing=allow_existing,
         )
 
@@ -461,6 +495,20 @@ class SandboxImageStore:
             provenance=dict(payload.get("provenance", {})),
             registered_at=payload.get("registered_at"),
             manifest_path=str(manifest_path),
+            artifact_format=self._normalize_artifact_format(payload.get("artifact_format"), default="unknown"),
+            oci_image_ref=self._normalize_optional_metadata_text(payload.get("oci_image_ref"), "oci_image_ref"),
+            oci_platform=self._normalize_optional_metadata_text(payload.get("oci_platform"), "oci_platform"),
+            oci_manifest_digest=self._normalize_optional_metadata_text(
+                payload.get("oci_manifest_digest"),
+                "oci_manifest_digest",
+            ),
+            oci_config_digest=self._normalize_optional_metadata_text(
+                payload.get("oci_config_digest"),
+                "oci_config_digest",
+            ),
+            oci_layer_digests=self._normalize_oci_layer_digests(payload.get("oci_layer_digests")),
+            registry=self._normalize_optional_metadata_text(payload.get("registry"), "registry"),
+            imported_at=self._normalize_optional_metadata_text(payload.get("imported_at"), "imported_at"),
         )
 
     def _validated_artifact_paths(
@@ -500,6 +548,14 @@ class SandboxImageStore:
             "template_name": record.template_name,
             "source_path": record.source_path,
             "registered_at": record.registered_at,
+            "artifact_format": record.artifact_format,
+            "oci_image_ref": record.oci_image_ref,
+            "oci_platform": record.oci_platform,
+            "oci_manifest_digest": record.oci_manifest_digest,
+            "oci_config_digest": record.oci_config_digest,
+            "oci_layer_digests": list(record.oci_layer_digests),
+            "registry": record.registry,
+            "imported_at": record.imported_at,
             "disk_paths": list(record.disk_paths),
             "artifacts": [
                 {
@@ -650,6 +706,37 @@ class SandboxImageStore:
             raise ImageStoreValidationError(f"{field_name}_required")
         if normalized in {".", ".."} or "/" in normalized or "\\" in normalized:
             raise ImageStoreValidationError(f"{field_name}_invalid")
+        return normalized
+
+    def _normalize_artifact_format(self, value: Any, *, default: str) -> str:
+        normalized = str(value if value is not None else default).strip()
+        if normalized not in _ALLOWED_ARTIFACT_FORMATS:
+            raise ImageStoreValidationError(f"artifact_format_invalid: {normalized}")
+        return normalized
+
+    def _normalize_optional_metadata_text(self, value: Any, field_name: str) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ImageStoreValidationError(f"{field_name}_invalid")
+        normalized = value.strip()
+        if not normalized:
+            return None
+        if len(normalized.encode("utf-8")) > _MAX_METADATA_TEXT_BYTES:
+            raise ImageStoreValidationError(f"{field_name}_too_long")
+        return normalized
+
+    def _normalize_oci_layer_digests(self, values: Any) -> list[str]:
+        if values is None:
+            return []
+        if not isinstance(values, list) or len(values) > _MAX_OCI_LAYER_DIGESTS:
+            raise ImageStoreValidationError("oci_layer_digests_invalid")
+        normalized: list[str] = []
+        for value in values:
+            item = self._normalize_optional_metadata_text(value, "oci_layer_digest")
+            if item is None:
+                raise ImageStoreValidationError("oci_layer_digests_invalid")
+            normalized.append(item)
         return normalized
 
     def _sha256_file(self, path: Path) -> str:

--- a/tldw_Server_API/app/core/Sandbox/image_store.py
+++ b/tldw_Server_API/app/core/Sandbox/image_store.py
@@ -12,7 +12,9 @@ from pathlib import Path
 from typing import Any
 
 MANIFEST_SCHEMA_VERSION = 1
-_ALLOWED_ARTIFACT_FORMATS = frozenset({"tldw_bundle", "raw_artifacts", "oci_image", "unknown"})
+_ALLOWED_ARTIFACT_FORMATS = frozenset(
+    {"tldw_bundle", "raw_artifacts", "oci_image", "unknown"}
+)
 _MAX_METADATA_TEXT_BYTES = 2048
 _MAX_OCI_LAYER_DIGESTS = 128
 
@@ -733,6 +735,8 @@ class SandboxImageStore:
             raise ImageStoreValidationError("oci_layer_digests_invalid")
         normalized: list[str] = []
         for value in values:
+            if not isinstance(value, str):
+                raise ImageStoreValidationError("oci_layer_digests_invalid")
             item = self._normalize_optional_metadata_text(value, "oci_layer_digest")
             if item is None:
                 raise ImageStoreValidationError("oci_layer_digests_invalid")

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -254,7 +254,9 @@ def _image_store_template_item(record: Any) -> dict[str, object]:
         "artifact_format": record.artifact_format,
         "source_path": record.source_path,
         "artifact_count": len(record.artifacts),
-        "artifact_size_bytes": sum(int(artifact.size_bytes) for artifact in record.artifacts),
+        "artifact_size_bytes": sum(
+            int(artifact.size_bytes) for artifact in record.artifacts
+        ),
         "oci_image_ref": record.oci_image_ref,
         "oci_platform": record.oci_platform,
         "oci_manifest_digest": record.oci_manifest_digest,

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -244,6 +244,28 @@ def probe_reconciliation(orchestrator: Any | None = None) -> dict[str, object]:
     return collect_vz_reconciliation(orchestrator)
 
 
+def _image_store_template_item(record: Any) -> dict[str, object]:
+    """Return read-only admin diagnostics for one registered image-store template."""
+
+    return {
+        "template_id": record.template_id,
+        "runtime": record.runtime,
+        "template_name": record.template_name,
+        "artifact_format": record.artifact_format,
+        "source_path": record.source_path,
+        "artifact_count": len(record.artifacts),
+        "artifact_size_bytes": sum(int(artifact.size_bytes) for artifact in record.artifacts),
+        "oci_image_ref": record.oci_image_ref,
+        "oci_platform": record.oci_platform,
+        "oci_manifest_digest": record.oci_manifest_digest,
+        "oci_config_digest": record.oci_config_digest,
+        "oci_layer_digests": list(record.oci_layer_digests),
+        "registry": record.registry,
+        "imported_at": record.imported_at,
+        "provenance": dict(record.provenance),
+    }
+
+
 def probe_image_store(reconciliation: dict[str, object] | None = None) -> dict[str, object]:
     """Report read-only image-store state plus correlation to reconciliation items."""
 
@@ -255,6 +277,7 @@ def probe_image_store(reconciliation: dict[str, object] | None = None) -> dict[s
             "registered_templates": 0,
             "run_manifests": 0,
             "gc_candidates": 0,
+            "templates": [],
             "items": [],
             "reasons": [],
         }
@@ -268,6 +291,7 @@ def probe_image_store(reconciliation: dict[str, object] | None = None) -> dict[s
                 "registered_templates": 0,
                 "run_manifests": 0,
                 "gc_candidates": 0,
+                "templates": [],
                 "items": [],
                 "reasons": ["image_store_root_missing"],
             }
@@ -278,6 +302,7 @@ def probe_image_store(reconciliation: dict[str, object] | None = None) -> dict[s
                 "registered_templates": 0,
                 "run_manifests": 0,
                 "gc_candidates": 0,
+                "templates": [],
                 "items": [],
                 "reasons": ["image_store_root_not_directory"],
             }
@@ -289,6 +314,7 @@ def probe_image_store(reconciliation: dict[str, object] | None = None) -> dict[s
             "registered_templates": 0,
             "run_manifests": 0,
             "gc_candidates": 0,
+            "templates": [],
             "items": [],
             "reasons": [f"image_store_unavailable: {exc}"],
         }
@@ -303,8 +329,10 @@ def probe_image_store(reconciliation: dict[str, object] | None = None) -> dict[s
     }
     active_run_ids.discard("")
 
+    template_records = store.list_templates()
     manifests = store.list_run_clone_manifests()
     gc_plan = store.plan_garbage_collection(active_run_ids=active_run_ids)
+    templates = [_image_store_template_item(record) for record in template_records]
     gc_by_run_id = {candidate.run_id: candidate for candidate in gc_plan.run_candidates}
     unmatched_gc_run_ids = set(gc_by_run_id)
 
@@ -376,9 +404,10 @@ def probe_image_store(reconciliation: dict[str, object] | None = None) -> dict[s
     return {
         "configured": True,
         "root_path": root_text,
-        "registered_templates": len(store.list_templates()),
+        "registered_templates": len(template_records),
         "run_manifests": len(manifests),
         "gc_candidates": len(gc_plan.run_candidates),
+        "templates": templates,
         "items": sorted(items, key=lambda item: str(item.get("run_id") or "")),
         "reasons": [],
     }

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -98,6 +98,25 @@ def _sample_diagnostics_payload() -> dict:
             "registered_templates": 0,
             "run_manifests": 0,
             "gc_candidates": 0,
+            "templates": [
+                {
+                    "template_id": "vz_linux:sample",
+                    "runtime": "vz_linux",
+                    "template_name": "sample",
+                    "artifact_format": "tldw_bundle",
+                    "source_path": "/tmp/vz-linux-bundle",
+                    "artifact_count": 2,
+                    "artifact_size_bytes": 1024,
+                    "oci_image_ref": None,
+                    "oci_platform": None,
+                    "oci_manifest_digest": None,
+                    "oci_config_digest": None,
+                    "oci_layer_digests": [],
+                    "registry": None,
+                    "imported_at": None,
+                    "provenance": {"suite": "bookworm"},
+                }
+            ],
             "items": [],
             "reasons": [],
         },
@@ -348,6 +367,9 @@ def test_admin_schema_accepts_macos_diagnostics_payload() -> None:
     assert model.reconciliation.healthy_session_ids == ["sess-live"]
     assert model.reconciliation.owned_orphaned_vm_ids == []
     assert model.reconciliation.items
+    assert model.image_store is not None
+    assert model.image_store.templates[0].artifact_format == "tldw_bundle"
+    assert model.image_store.templates[0].provenance == {"suite": "bookworm"}
 
 
 def test_admin_schema_accepts_startup_warning_summary() -> None:
@@ -641,6 +663,12 @@ def test_collect_macos_diagnostics_reports_image_store_correlation(monkeypatch, 
     assert image_store["registered_templates"] == 1
     assert image_store["run_manifests"] == 3
     assert image_store["gc_candidates"] == 3
+    templates = {template["template_id"]: template for template in image_store["templates"]}
+    assert templates[template_id]["artifact_format"] == "tldw_bundle"
+    assert templates[template_id]["runtime"] == "vz_linux"
+    assert templates[template_id]["template_name"] == "debian-bookworm-arm64"
+    assert templates[template_id]["artifact_count"] == 2
+    assert templates[template_id]["artifact_size_bytes"] == len(b"kernel") + len(b"rootfs")
     items_by_run = {item["run_id"]: item for item in image_store["items"]}
     assert items_by_run["run-live"]["matched_vm_id"] == "vm-live"
     assert items_by_run["run-live"]["matched_reconciliation_status"] == "healthy"
@@ -666,3 +694,38 @@ def test_probe_image_store_does_not_create_missing_root(monkeypatch, tmp_path) -
     assert data["items"] == []
     assert "image_store_root_missing" in data["reasons"]
     assert not store_root.exists()
+
+
+def test_probe_image_store_reports_oci_template_metadata(monkeypatch, tmp_path) -> None:
+    store_root = tmp_path / "image-store"
+    disk = tmp_path / "rootfs.img"
+    disk.write_bytes(b"rootfs")
+    store = SandboxImageStore(root_path=store_root)
+    template_id = store.register_template(
+        runtime="vz_linux",
+        template_name="oci-backed",
+        disk_paths=[str(disk)],
+        artifact_format="oci_image",
+        oci_image_ref="registry.example/tldw/sandbox:bookworm",
+        oci_platform="linux/arm64",
+        oci_manifest_digest="sha256:" + "a" * 64,
+        oci_config_digest="sha256:" + "b" * 64,
+        oci_layer_digests=["sha256:" + "c" * 64],
+        registry="registry.example",
+        imported_at="2026-05-02T00:00:00+00:00",
+        provenance={"suite": "bookworm"},
+    )
+    monkeypatch.setenv("TLDW_SANDBOX_IMAGE_STORE_ROOT", str(store_root))
+
+    data = diagnostics_module.probe_image_store()
+
+    templates = {template["template_id"]: template for template in data["templates"]}
+    assert templates[template_id]["artifact_format"] == "oci_image"
+    assert templates[template_id]["oci_image_ref"] == "registry.example/tldw/sandbox:bookworm"
+    assert templates[template_id]["oci_platform"] == "linux/arm64"
+    assert templates[template_id]["oci_manifest_digest"] == "sha256:" + "a" * 64
+    assert templates[template_id]["oci_config_digest"] == "sha256:" + "b" * 64
+    assert templates[template_id]["oci_layer_digests"] == ["sha256:" + "c" * 64]
+    assert templates[template_id]["registry"] == "registry.example"
+    assert templates[template_id]["imported_at"] == "2026-05-02T00:00:00+00:00"
+    assert templates[template_id]["provenance"] == {"suite": "bookworm"}

--- a/tldw_Server_API/tests/sandbox/test_macos_image_store.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_image_store.py
@@ -249,13 +249,15 @@ def test_image_store_rejects_invalid_oci_layer_digests(tmp_path: Path) -> None:
     disk.write_bytes(b"rootfs")
     store = SandboxImageStore(root_path=tmp_path / "store")
 
-    with pytest.raises(ImageStoreValidationError, match="oci_layer_digests_invalid"):
-        store.register_template(
-            runtime="vz_linux",
-            template_name="bad-oci",
-            disk_paths=[str(disk)],
-            oci_layer_digests=[""],
-        )
+    invalid_values = [[""], [123]]
+    for index, oci_layer_digests in enumerate(invalid_values):
+        with pytest.raises(ImageStoreValidationError, match="oci_layer_digests_invalid"):
+            store.register_template(
+                runtime="vz_linux",
+                template_name=f"bad-oci-{index}",
+                disk_paths=[str(disk)],
+                oci_layer_digests=oci_layer_digests,
+            )
 
 
 def test_image_store_lists_templates_and_plans_run_gc(tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_macos_image_store.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_image_store.py
@@ -55,6 +55,45 @@ def test_image_store_persists_template_manifest_and_reloads(tmp_path: Path) -> N
     assert record.artifacts[0].size_bytes == len(b"rootfs-image")
 
 
+def test_image_store_reloads_legacy_manifest_without_artifact_format(tmp_path: Path) -> None:
+    disk = tmp_path / "rootfs.img"
+    disk.write_bytes(b"rootfs")
+    store_root = tmp_path / "store"
+    manifest_path = store_root / "templates" / "vz_linux" / "legacy" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "template_id": "vz_linux:legacy",
+                "runtime": "vz_linux",
+                "template_name": "legacy",
+                "source_path": None,
+                "registered_at": "2026-04-01T00:00:00+00:00",
+                "disk_paths": [str(disk)],
+                "artifacts": [
+                    {
+                        "name": disk.name,
+                        "path": str(disk),
+                        "size_bytes": len(b"rootfs"),
+                        "sha256": "d5d75963e365d7b3e74c0e75bc7b5900921c97b6185cd139ab62fc29f6b81b71",
+                    }
+                ],
+                "labels": {},
+                "provenance": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    record = SandboxImageStore(root_path=store_root).get_template("vz_linux:legacy")
+
+    assert record is not None
+    assert record.artifact_format == "unknown"
+    assert record.oci_image_ref is None
+    assert record.oci_layer_digests == []
+
+
 def test_image_store_rejects_missing_template_artifacts(tmp_path: Path) -> None:
     store = SandboxImageStore(root_path=tmp_path / "store")
 
@@ -121,6 +160,102 @@ def test_image_store_registers_bundle_with_build_provenance(tmp_path: Path) -> N
     assert record.source_path == str(bundle)
     assert record.provenance == {"suite": "bookworm", "architecture": "arm64"}
     assert {artifact.name for artifact in record.artifacts} == {"kernel", "rootfs.img", "initrd"}
+
+
+def test_image_store_registers_bundle_with_tldw_bundle_artifact_format(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "kernel").write_bytes(b"kernel")
+    (bundle / "rootfs.img").write_bytes(b"rootfs")
+    (bundle / "manifest.json").write_text(
+        json.dumps({"schema_version": 1, "boot_mode": "linux_direct"}),
+        encoding="utf-8",
+    )
+    store_root = tmp_path / "store"
+    store = SandboxImageStore(root_path=store_root)
+
+    template_id = store.register_bundle(
+        runtime="vz_linux",
+        template_name="debian-bookworm-arm64",
+        bundle_path=bundle,
+    )
+
+    manifest_path = store_root / "templates" / "vz_linux" / "debian-bookworm-arm64" / "manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["artifact_format"] == "tldw_bundle"
+
+    reloaded = SandboxImageStore(root_path=store_root).get_template(template_id)
+    assert reloaded is not None
+    assert reloaded.artifact_format == "tldw_bundle"
+    assert reloaded.oci_image_ref is None
+    assert reloaded.oci_layer_digests == []
+
+
+def test_image_store_persists_optional_oci_metadata(tmp_path: Path) -> None:
+    disk = tmp_path / "rootfs.img"
+    disk.write_bytes(b"rootfs")
+    store_root = tmp_path / "store"
+    store = SandboxImageStore(root_path=store_root)
+
+    template_id = store.register_template(
+        runtime="vz_linux",
+        template_name="oci-backed",
+        disk_paths=[str(disk)],
+        artifact_format="oci_image",
+        oci_image_ref="registry.example/tldw/sandbox:bookworm",
+        oci_platform="linux/arm64",
+        oci_manifest_digest="sha256:" + "a" * 64,
+        oci_config_digest="sha256:" + "b" * 64,
+        oci_layer_digests=["sha256:" + "c" * 64],
+        registry="registry.example",
+        imported_at="2026-05-02T00:00:00+00:00",
+    )
+
+    manifest_path = store_root / "templates" / "vz_linux" / "oci-backed" / "manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["artifact_format"] == "oci_image"
+    assert payload["oci_image_ref"] == "registry.example/tldw/sandbox:bookworm"
+    assert payload["oci_platform"] == "linux/arm64"
+    assert payload["oci_layer_digests"] == ["sha256:" + "c" * 64]
+
+    reloaded = SandboxImageStore(root_path=store_root).get_template(template_id)
+    assert reloaded is not None
+    assert reloaded.artifact_format == "oci_image"
+    assert reloaded.oci_image_ref == "registry.example/tldw/sandbox:bookworm"
+    assert reloaded.oci_platform == "linux/arm64"
+    assert reloaded.oci_manifest_digest == "sha256:" + "a" * 64
+    assert reloaded.oci_config_digest == "sha256:" + "b" * 64
+    assert reloaded.oci_layer_digests == ["sha256:" + "c" * 64]
+    assert reloaded.registry == "registry.example"
+    assert reloaded.imported_at == "2026-05-02T00:00:00+00:00"
+
+
+def test_image_store_rejects_unknown_artifact_format(tmp_path: Path) -> None:
+    disk = tmp_path / "rootfs.img"
+    disk.write_bytes(b"rootfs")
+    store = SandboxImageStore(root_path=tmp_path / "store")
+
+    with pytest.raises(ImageStoreValidationError, match="artifact_format_invalid"):
+        store.register_template(
+            runtime="vz_linux",
+            template_name="bad-format",
+            disk_paths=[str(disk)],
+            artifact_format="tarball",
+        )
+
+
+def test_image_store_rejects_invalid_oci_layer_digests(tmp_path: Path) -> None:
+    disk = tmp_path / "rootfs.img"
+    disk.write_bytes(b"rootfs")
+    store = SandboxImageStore(root_path=tmp_path / "store")
+
+    with pytest.raises(ImageStoreValidationError, match="oci_layer_digests_invalid"):
+        store.register_template(
+            runtime="vz_linux",
+            template_name="bad-oci",
+            disk_paths=[str(disk)],
+            oci_layer_digests=[""],
+        )
 
 
 def test_image_store_lists_templates_and_plans_run_gc(tmp_path: Path) -> None:

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -258,4 +258,11 @@ The store writes:
 
 The manifest records `kernel`, `rootfs.img`, optional `initrd`, artifact sizes,
 SHA-256 hashes, labels, source path, registration time, and `build-info.json`
-provenance when present. The helper still owns bootability validation.
+provenance when present. Canonical bundle registration writes
+`artifact_format="tldw_bundle"`.
+
+The manifest also has optional OCI/source provenance fields such as
+`oci_image_ref`, `oci_platform`, manifest/config/layer digests, `registry`, and
+`imported_at`. These fields are metadata scaffolding only; the helper still
+boots the repo-owned bundle path and remains the source of truth for
+bootability.


### PR DESCRIPTION
## Summary
- Add sandbox module roadmap and OCI-aware image-store implementation plan.
- Persist artifact_format and optional OCI provenance fields in SandboxImageStore while preserving current bundle boot behavior.
- Surface template provenance in macOS image-store diagnostics and document metadata-only semantics.

## Test Plan
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_macos_image_store.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Sandbox/image_store.py tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_oci_image_store_metadata.json
- [x] git diff --check

## Change summary
Human-authored summary required before merge.