### PR TITLE
refactor(workers): register remaining primary jobs pollers

### DIFF
--- a/tldw_Server_API/app/services/startup_primary_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_primary_jobs_pollers.py
@@ -61,18 +61,21 @@ async def start_primary_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     data_tables_jobs_stop_event, data_tables_jobs_task = await _start_data_tables_jobs_worker(
         app=app,
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     prompt_studio_jobs_stop_event, prompt_studio_jobs_task = await _start_prompt_studio_jobs_worker(
         app=app,
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     return PrimaryJobsPollerHandles(
         core_jobs_stop_event=core_jobs_stop_event,
@@ -146,12 +149,25 @@ async def _start_files_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[[str, str], bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         enabled = should_start_worker("FILES_JOBS_WORKER_ENABLED", "files")
         if not enabled:
             logger.info("File Artifacts Jobs worker disabled by flag (FILES_JOBS_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="files_jobs_task",
+                task_name="files_jobs_task",
+                coroutine_factory=_run_file_artifacts_jobs_worker_service,
+                timeout_sec=5.0,
+                category="jobs",
+                shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+            )
+            logger.info("File Artifacts Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_file_artifacts_jobs_worker_service(stop_event))
@@ -175,12 +191,25 @@ async def _start_data_tables_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[[str, str], bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         enabled = should_start_worker("DATA_TABLES_JOBS_WORKER_ENABLED", "data-tables")
         if not enabled:
             logger.info("Data Tables Jobs worker disabled by flag (DATA_TABLES_JOBS_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="data_tables_jobs_task",
+                task_name="data_tables_jobs_task",
+                coroutine_factory=_run_data_tables_jobs_worker_service,
+                timeout_sec=5.0,
+                category="jobs",
+                shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+            )
+            logger.info("Data Tables Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_data_tables_jobs_worker_service(stop_event))
@@ -204,12 +233,25 @@ async def _start_prompt_studio_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[[str, str], bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         enabled = should_start_worker("PROMPT_STUDIO_JOBS_WORKER_ENABLED", "prompt-studio")
         if not enabled:
             logger.info("Prompt Studio Jobs worker disabled by flag (PROMPT_STUDIO_JOBS_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="prompt_studio_jobs_task",
+                task_name="prompt_studio_jobs_task",
+                coroutine_factory=_run_prompt_studio_jobs_worker_service,
+                timeout_sec=5.0,
+                category="jobs",
+                shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+            )
+            logger.info("Prompt Studio Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_prompt_studio_jobs_worker_service(stop_event))

--- a/tldw_Server_API/app/services/startup_primary_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_primary_jobs_pollers.py
@@ -151,6 +151,8 @@ async def _start_files_jobs_worker(
     should_start_worker: Callable[[str, str], bool],
     worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the File Artifacts jobs poller and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("FILES_JOBS_WORKER_ENABLED", "files")
         if not enabled:
@@ -193,6 +195,8 @@ async def _start_data_tables_jobs_worker(
     should_start_worker: Callable[[str, str], bool],
     worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the Data Tables jobs poller and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("DATA_TABLES_JOBS_WORKER_ENABLED", "data-tables")
         if not enabled:
@@ -235,6 +239,8 @@ async def _start_prompt_studio_jobs_worker(
     should_start_worker: Callable[[str, str], bool],
     worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the Prompt Studio jobs poller and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("PROMPT_STUDIO_JOBS_WORKER_ENABLED", "prompt-studio")
         if not enabled:

--- a/tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
@@ -22,21 +22,29 @@ async def test_start_primary_jobs_pollers_combines_handles_in_order(
     calls: list[str] = []
 
     async def _record_core(**kwargs: object) -> tuple[str, str]:
+        """Record that the core worker starter ran."""
+
         del kwargs
         calls.append("core")
         return ("core-stop", "core-task")
 
     async def _record_files(**kwargs: object) -> tuple[str, str]:
+        """Record that the files worker starter ran."""
+
         del kwargs
         calls.append("files")
         return ("files-stop", "files-task")
 
     async def _record_data_tables(**kwargs: object) -> tuple[str, str]:
+        """Record that the data tables worker starter ran."""
+
         del kwargs
         calls.append("data-tables")
         return ("data-tables-stop", "data-tables-task")
 
     async def _record_prompt_studio(**kwargs: object) -> tuple[str, str]:
+        """Record that the Prompt Studio worker starter ran."""
+
         del kwargs
         calls.append("prompt-studio")
         return ("prompt-studio-stop", "prompt-studio-task")
@@ -74,7 +82,11 @@ async def test_start_primary_jobs_pollers_passes_inventory_to_workers(
     captured_kwargs_by_worker: dict[str, dict[str, object]] = {}
 
     def _record_worker(label: str) -> Callable[..., object]:
+        """Build a starter stub that captures kwargs for one worker label."""
+
         async def _record(**kwargs: object) -> tuple[str, str]:
+            """Capture worker startup kwargs and return deterministic handles."""
+
             captured_kwargs_by_worker[label] = kwargs
             return (f"{label}-stop", f"{label}-task")
 
@@ -220,7 +232,11 @@ async def test_primary_jobs_worker_registers_with_worker_inventory_when_enabled(
     registrations: list[dict[str, object]] = []
 
     class _FakeWorkerInventory:
+        """Test double that records custom worker registration calls."""
+
         async def register_custom(self, **kwargs: object) -> tuple[str, str]:
+            """Capture registration kwargs and return deterministic handles."""
+
             registrations.append(kwargs)
             return f"{registered_name}-task", f"{registered_name}-stop"
 

--- a/tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Callable
 
 import pytest
 
@@ -20,22 +21,22 @@ async def test_start_primary_jobs_pollers_combines_handles_in_order(
     startup_pollers = _import_startup_primary_jobs_pollers()
     calls: list[str] = []
 
-    async def _record_core(**kwargs):
+    async def _record_core(**kwargs: object) -> tuple[str, str]:
         del kwargs
         calls.append("core")
         return ("core-stop", "core-task")
 
-    async def _record_files(**kwargs):
+    async def _record_files(**kwargs: object) -> tuple[str, str]:
         del kwargs
         calls.append("files")
         return ("files-stop", "files-task")
 
-    async def _record_data_tables(**kwargs):
+    async def _record_data_tables(**kwargs: object) -> tuple[str, str]:
         del kwargs
         calls.append("data-tables")
         return ("data-tables-stop", "data-tables-task")
 
-    async def _record_prompt_studio(**kwargs):
+    async def _record_prompt_studio(**kwargs: object) -> tuple[str, str]:
         del kwargs
         calls.append("prompt-studio")
         return ("prompt-studio-stop", "prompt-studio-task")
@@ -65,25 +66,24 @@ async def test_start_primary_jobs_pollers_combines_handles_in_order(
 
 
 @pytest.mark.asyncio
-async def test_start_primary_jobs_pollers_passes_inventory_to_core_worker(
+async def test_start_primary_jobs_pollers_passes_inventory_to_workers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     startup_pollers = _import_startup_primary_jobs_pollers()
     worker_inventory = object()
-    captured_kwargs: dict[str, object] = {}
+    captured_kwargs_by_worker: dict[str, dict[str, object]] = {}
 
-    async def _record_core(**kwargs: object) -> tuple[str, str]:
-        captured_kwargs.update(kwargs)
-        return ("core-stop", "core-task")
+    def _record_worker(label: str) -> Callable[..., object]:
+        async def _record(**kwargs: object) -> tuple[str, str]:
+            captured_kwargs_by_worker[label] = kwargs
+            return (f"{label}-stop", f"{label}-task")
 
-    async def _record_worker(**kwargs: object) -> tuple[None, None]:
-        del kwargs
-        return (None, None)
+        return _record
 
-    monkeypatch.setattr(startup_pollers, "_start_core_jobs_worker", _record_core)
-    monkeypatch.setattr(startup_pollers, "_start_files_jobs_worker", _record_worker)
-    monkeypatch.setattr(startup_pollers, "_start_data_tables_jobs_worker", _record_worker)
-    monkeypatch.setattr(startup_pollers, "_start_prompt_studio_jobs_worker", _record_worker)
+    monkeypatch.setattr(startup_pollers, "_start_core_jobs_worker", _record_worker("core"))
+    monkeypatch.setattr(startup_pollers, "_start_files_jobs_worker", _record_worker("files"))
+    monkeypatch.setattr(startup_pollers, "_start_data_tables_jobs_worker", _record_worker("data-tables"))
+    monkeypatch.setattr(startup_pollers, "_start_prompt_studio_jobs_worker", _record_worker("prompt-studio"))
 
     await startup_pollers.start_primary_jobs_pollers(
         app="app",
@@ -94,7 +94,15 @@ async def test_start_primary_jobs_pollers_passes_inventory_to_core_worker(
         worker_inventory=worker_inventory,
     )
 
-    assert captured_kwargs["worker_inventory"] is worker_inventory
+    assert {
+        worker: kwargs["worker_inventory"]
+        for worker, kwargs in captured_kwargs_by_worker.items()
+    } == {
+        "core": worker_inventory,
+        "files": worker_inventory,
+        "data-tables": worker_inventory,
+        "prompt-studio": worker_inventory,
+    }
 
 
 @pytest.mark.asyncio
@@ -160,6 +168,91 @@ async def test_start_core_jobs_worker_registers_with_worker_inventory_when_enabl
             "name": "core_jobs_task",
             "task_name": "core_jobs_task",
             "coroutine_factory": startup_pollers._run_chatbooks_core_jobs_worker_service,
+            "timeout_sec": 5.0,
+            "category": "jobs",
+            "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    (
+        "starter_name",
+        "flag_name",
+        "route_name",
+        "registered_name",
+        "factory_name",
+    ),
+    [
+        (
+            "_start_files_jobs_worker",
+            "FILES_JOBS_WORKER_ENABLED",
+            "files",
+            "files_jobs_task",
+            "_run_file_artifacts_jobs_worker_service",
+        ),
+        (
+            "_start_data_tables_jobs_worker",
+            "DATA_TABLES_JOBS_WORKER_ENABLED",
+            "data-tables",
+            "data_tables_jobs_task",
+            "_run_data_tables_jobs_worker_service",
+        ),
+        (
+            "_start_prompt_studio_jobs_worker",
+            "PROMPT_STUDIO_JOBS_WORKER_ENABLED",
+            "prompt-studio",
+            "prompt_studio_jobs_task",
+            "_run_prompt_studio_jobs_worker_service",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_primary_jobs_worker_registers_with_worker_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    starter_name: str,
+    flag_name: str,
+    route_name: str,
+    registered_name: str,
+    factory_name: str,
+) -> None:
+    startup_pollers = _import_startup_primary_jobs_pollers()
+    registrations: list[dict[str, object]] = []
+
+    class _FakeWorkerInventory:
+        async def register_custom(self, **kwargs: object) -> tuple[str, str]:
+            registrations.append(kwargs)
+            return f"{registered_name}-task", f"{registered_name}-stop"
+
+    monkeypatch.setattr(
+        startup_pollers,
+        "_make_event",
+        lambda: (_ for _ in ()).throw(AssertionError("legacy event path should not run")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_create_task",
+        lambda coro: (_ for _ in ()).throw(AssertionError("legacy task path should not run")),
+    )
+
+    def _register_owned_job_poller(*args: object, **kwargs: object) -> None:
+        raise AssertionError("legacy poller registration should not run")
+
+    stop_event, task = await getattr(startup_pollers, starter_name)(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=_register_owned_job_poller,
+        should_start_worker=lambda flag, route: (flag, route) == (flag_name, route_name),
+        worker_inventory=_FakeWorkerInventory(),
+    )
+
+    assert stop_event == f"{registered_name}-stop"
+    assert task == f"{registered_name}-task"
+    assert registrations == [
+        {
+            "name": registered_name,
+            "task_name": registered_name,
+            "coroutine_factory": getattr(startup_pollers, factory_name),
             "timeout_sec": 5.0,
             "category": "jobs",
             "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,


### PR DESCRIPTION
## Change summary
TODO: human-authored summary required before merge.

## Implementation notes
- Registers the files, data tables, and Prompt Studio jobs pollers through WorkerRegistry when startup has a worker inventory.
- Preserves the legacy direct owned-job-poller registration fallback for no-inventory startup paths.
- Extends primary poller tests for inventory propagation and registry registration metadata.

Refs #1114.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py tldw_Server_API/tests/Services/test_shutdown_job_poller_handoff.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_startup_tail_finalization.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py tldw_Server_API/tests/Services/test_shutdown_job_poller_handoff.py tldw_Server_API/tests/Services/test_shutdown_core_jobs_worker.py tldw_Server_API/tests/Services/test_shutdown_primary_late_stop_workers.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_primary_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_primary_jobs_pollers.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_primary_jobs_pollers.py -f json -o /tmp/bandit_primary_jobs_poller_registry_1114.json
- git diff --check