### PR TITLE
refactor(workers): register study privilege pollers

### DIFF
--- a/tldw_Server_API/app/services/startup_study_privilege_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_study_privilege_jobs_pollers.py
@@ -10,6 +10,8 @@ from typing import Any, Callable
 
 from loguru import logger
 
+from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase, WorkerRegistry
+
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
     OSError,
@@ -37,6 +39,7 @@ async def start_study_privilege_jobs_pollers(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> StudyPrivilegeJobsPollerHandles:
     """Start study and privilege jobs pollers and return their handles."""
 
@@ -45,6 +48,7 @@ async def start_study_privilege_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     (
         study_suggestions_jobs_stop_event,
@@ -54,12 +58,14 @@ async def start_study_privilege_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     privilege_snapshot_stop_event, privilege_snapshot_task = await _start_privilege_snapshot_worker(
         app=app,
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     return StudyPrivilegeJobsPollerHandles(
         study_pack_jobs_stop_event=study_pack_jobs_stop_event,
@@ -85,12 +91,27 @@ async def _start_study_pack_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the Study Pack jobs worker and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("STUDY_PACK_JOBS_WORKER_ENABLED", "flashcards")
         if not enabled:
             logger.info("Study-pack Jobs worker disabled by flag (STUDY_PACK_JOBS_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="study_pack_jobs_task",
+                task_name="study_pack_jobs_task",
+                coroutine_factory=_run_study_pack_jobs_worker_service,
+                timeout_sec=5.0,
+                category="jobs",
+                shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+            )
+            logger.info("Study-pack Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_study_pack_jobs_worker_service(stop_event))
@@ -114,12 +135,27 @@ async def _start_study_suggestions_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the Study Suggestions jobs worker and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("STUDY_SUGGESTIONS_JOBS_WORKER_ENABLED", "study-suggestions")
         if not enabled:
             logger.info("Study-suggestions Jobs worker disabled by flag (STUDY_SUGGESTIONS_JOBS_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="study_suggestions_jobs_task",
+                task_name="study_suggestions_jobs_task",
+                coroutine_factory=_run_study_suggestions_jobs_worker_service,
+                timeout_sec=5.0,
+                category="jobs",
+                shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+            )
+            logger.info("Study-suggestions Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_study_suggestions_jobs_worker_service(stop_event))
@@ -143,12 +179,27 @@ async def _start_privilege_snapshot_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the privilege snapshot worker and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("PRIVILEGE_SNAPSHOT_WORKER_ENABLED", "privileges")
         if not enabled:
             logger.info("Privilege snapshot worker disabled by flag (PRIVILEGE_SNAPSHOT_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            task, stop_event = await worker_inventory.register_custom(
+                name="privilege_snapshot_task",
+                task_name="privilege_snapshot_task",
+                coroutine_factory=_run_privilege_snapshot_worker_service,
+                timeout_sec=5.0,
+                category="jobs",
+                shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+            )
+            logger.info("Privilege snapshot worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_privilege_snapshot_worker_service(stop_event))

--- a/tldw_Server_API/app/services/startup_worker_groups.py
+++ b/tldw_Server_API/app/services/startup_worker_groups.py
@@ -127,6 +127,7 @@ async def start_worker_groups(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=_should_start_worker,
+        worker_inventory=worker_inventory,
     )
     compactor_websub_startup_handles = await _start_compactor_websub_workers(
         should_start_worker=_should_start_worker,

--- a/tldw_Server_API/tests/Services/test_startup_study_privilege_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_study_privilege_jobs_pollers.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Callable
 
 import pytest
-
 
 pytestmark = pytest.mark.unit
 
@@ -21,17 +21,23 @@ async def test_start_study_privilege_jobs_pollers_combines_handles_in_order(
     startup_pollers = _import_startup_study_privilege_jobs_pollers()
     calls: list[str] = []
 
-    async def _record_study_pack(**kwargs):
+    async def _record_study_pack(**kwargs: object) -> tuple[str, str]:
+        """Record that the Study Pack worker starter ran."""
+
         del kwargs
         calls.append("study-pack")
         return ("study-pack-stop", "study-pack-task")
 
-    async def _record_study_suggestions(**kwargs):
+    async def _record_study_suggestions(**kwargs: object) -> tuple[str, str]:
+        """Record that the Study Suggestions worker starter ran."""
+
         del kwargs
         calls.append("study-suggestions")
         return ("study-suggestions-stop", "study-suggestions-task")
 
-    async def _record_privilege_snapshot(**kwargs):
+    async def _record_privilege_snapshot(**kwargs: object) -> tuple[str, str]:
+        """Record that the privilege snapshot worker starter ran."""
+
         del kwargs
         calls.append("privilege-snapshot")
         return ("privilege-stop", "privilege-task")
@@ -54,6 +60,146 @@ async def test_start_study_privilege_jobs_pollers_combines_handles_in_order(
     assert handles.study_suggestions_jobs_task == "study-suggestions-task"
     assert handles.privilege_snapshot_stop_event == "privilege-stop"
     assert handles.privilege_snapshot_task == "privilege-task"
+
+
+@pytest.mark.asyncio
+async def test_start_study_privilege_jobs_pollers_passes_inventory_to_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_study_privilege_jobs_pollers()
+    worker_inventory = object()
+    captured_kwargs_by_worker: dict[str, dict[str, object]] = {}
+
+    def _record_worker(label: str) -> Callable[..., object]:
+        """Build a starter stub that captures kwargs for one worker label."""
+
+        async def _record(**kwargs: object) -> tuple[str, str]:
+            """Capture worker startup kwargs and return deterministic handles."""
+
+            captured_kwargs_by_worker[label] = kwargs
+            return (f"{label}-stop", f"{label}-task")
+
+        return _record
+
+    monkeypatch.setattr(startup_pollers, "_start_study_pack_jobs_worker", _record_worker("study-pack"))
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_study_suggestions_jobs_worker",
+        _record_worker("study-suggestions"),
+    )
+    monkeypatch.setattr(startup_pollers, "_start_privilege_snapshot_worker", _record_worker("privilege"))
+
+    await startup_pollers.start_study_privilege_jobs_pollers(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=lambda *args, **kwargs: None,
+        should_start_worker=lambda *args, **kwargs: False,
+        worker_inventory=worker_inventory,
+    )
+
+    assert {
+        worker: kwargs["worker_inventory"]
+        for worker, kwargs in captured_kwargs_by_worker.items()
+    } == {
+        "study-pack": worker_inventory,
+        "study-suggestions": worker_inventory,
+        "privilege": worker_inventory,
+    }
+
+
+@pytest.mark.parametrize(
+    (
+        "starter_name",
+        "flag_name",
+        "route_name",
+        "registered_name",
+        "factory_name",
+    ),
+    [
+        (
+            "_start_study_pack_jobs_worker",
+            "STUDY_PACK_JOBS_WORKER_ENABLED",
+            "flashcards",
+            "study_pack_jobs_task",
+            "_run_study_pack_jobs_worker_service",
+        ),
+        (
+            "_start_study_suggestions_jobs_worker",
+            "STUDY_SUGGESTIONS_JOBS_WORKER_ENABLED",
+            "study-suggestions",
+            "study_suggestions_jobs_task",
+            "_run_study_suggestions_jobs_worker_service",
+        ),
+        (
+            "_start_privilege_snapshot_worker",
+            "PRIVILEGE_SNAPSHOT_WORKER_ENABLED",
+            "privileges",
+            "privilege_snapshot_task",
+            "_run_privilege_snapshot_worker_service",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_study_privilege_jobs_worker_registers_with_worker_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    starter_name: str,
+    flag_name: str,
+    route_name: str,
+    registered_name: str,
+    factory_name: str,
+) -> None:
+    startup_pollers = _import_startup_study_privilege_jobs_pollers()
+    registrations: list[dict[str, object]] = []
+
+    class _FakeWorkerInventory:
+        """Test double that records custom worker registration calls."""
+
+        async def register_custom(self, **kwargs: object) -> tuple[str, str]:
+            """Capture registration kwargs and return deterministic handles."""
+
+            registrations.append(kwargs)
+            return f"{registered_name}-task", f"{registered_name}-stop"
+
+    monkeypatch.setattr(
+        startup_pollers,
+        "_make_event",
+        lambda: (_ for _ in ()).throw(AssertionError("legacy event path should not run")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_create_task",
+        lambda coro: (_ for _ in ()).throw(AssertionError("legacy task path should not run")),
+    )
+
+    def _register_owned_job_poller(*args: object, **kwargs: object) -> None:
+        """Fail when the registry path falls back to legacy registration."""
+
+        raise AssertionError("legacy poller registration should not run")
+
+    stop_event, task = await getattr(startup_pollers, starter_name)(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=_register_owned_job_poller,
+        should_start_worker=lambda flag, route, **kwargs: (flag, route, kwargs) == (
+            flag_name,
+            route_name,
+            {},
+        ),
+        worker_inventory=_FakeWorkerInventory(),
+    )
+
+    assert stop_event == f"{registered_name}-stop"
+    assert task == f"{registered_name}-task"
+    assert registrations == [
+        {
+            "name": registered_name,
+            "task_name": registered_name,
+            "coroutine_factory": getattr(startup_pollers, factory_name),
+            "timeout_sec": 5.0,
+            "category": "jobs",
+            "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_worker_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_groups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
@@ -70,11 +71,16 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
 
     async def _record_study_privilege_jobs_pollers(
         *,
-        app,
-        owned_job_pollers,
-        register_owned_job_poller,
-        should_start_worker,
-    ):
+        app: object,
+        owned_job_pollers: list[object],
+        register_owned_job_poller: object,
+        should_start_worker: Callable[..., bool],
+        worker_inventory: object | None,
+    ) -> SimpleNamespace:
+        """Record the study/privilege startup group call."""
+
+        del app, owned_job_pollers, register_owned_job_poller
+        assert worker_inventory is worker_inventory_ref
         assert should_start_worker("STUDY_PACK_JOBS_WORKER_ENABLED", "flashcards") is False
         calls.append("study")
         return SimpleNamespace(


### PR DESCRIPTION
## Change summary
TODO: human-authored summary required before merge.

## Implementation notes
- Registers Study Pack, Study Suggestions, and privilege snapshot workers through WorkerRegistry when startup has a worker inventory.
- Preserves the legacy direct owned-job-poller registration fallback for no-inventory startup paths.
- Threads worker_inventory through startup_worker_groups into the study/privilege poller group.
- Extends tests for inventory propagation and registry registration metadata.

Refs #1114.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_study_privilege_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_startup_tail_finalization.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py tldw_Server_API/tests/Services/test_shutdown_job_poller_handoff.py tldw_Server_API/tests/Services/test_shutdown_reading_study_companion_jobs_workers.py tldw_Server_API/tests/Services/test_shutdown_privilege_snapshot_worker.py tldw_Server_API/tests/Services/test_shutdown_primary_late_stop_workers.py tldw_Server_API/tests/Services/test_shutdown_grouped_late_stop_workers.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_study_privilege_jobs_pollers.py tldw_Server_API/app/services/startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_study_privilege_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_study_privilege_jobs_pollers.py tldw_Server_API/app/services/startup_worker_groups.py -f json -o /tmp/bandit_study_privilege_worker_registry_1114.json
- git diff --check