### PR TITLE
refactor(workers): register content jobs pollers

### DIFF
--- a/tldw_Server_API/app/services/shutdown_job_poller_handoff.py
+++ b/tldw_Server_API/app/services/shutdown_job_poller_handoff.py
@@ -5,10 +5,13 @@ Job-poller shutdown handoff helper extracted from the application lifespan.
 from __future__ import annotations
 
 import os as _env_os
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable
+from typing import Any, Callable
 
 from loguru import logger
+
+from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase
 
 
 @dataclass
@@ -30,10 +33,11 @@ async def shutdown_job_poller_handoff(
     """Quiesce owned job pollers and return the late-stop gating predicate."""
     wait_for_leases_sec = _resolve_wait_for_leases_sec(startup_guard_exceptions)
     count_active_processing = _build_count_active_processing(import_exceptions)
+    job_poller_handles = _filter_job_poller_quiesce_handles(owned_job_pollers)
 
     await quiesce_owned_job_pollers_for_shutdown(
         app,
-        owned_job_pollers,
+        job_poller_handles,
         wait_for_leases_sec=wait_for_leases_sec,
         count_active_processing=count_active_processing,
     )
@@ -45,6 +49,18 @@ async def shutdown_job_poller_handoff(
         early_quiesced_job_poller_names=early_quiesced_job_poller_names,
         should_run_late_stop=_build_should_run_late_stop(early_quiesced_job_poller_names),
     )
+
+
+def _filter_job_poller_quiesce_handles(handles: list[Any]) -> list[Any]:
+    """Return task-backed workers owned by the job-poller quiesce phase."""
+
+    return [
+        handle
+        for handle in handles
+        if getattr(handle, "task", None) is not None
+        and getattr(handle, "shutdown_phase", ShutdownPhase.JOB_POLLER_QUIESCE)
+        == ShutdownPhase.JOB_POLLER_QUIESCE
+    ]
 
 
 async def run_shutdown_job_poller_handoff(

--- a/tldw_Server_API/app/services/shutdown_owned_job_pollers.py
+++ b/tldw_Server_API/app/services/shutdown_owned_job_pollers.py
@@ -19,7 +19,6 @@ from tldw_Server_API.app.services.lifecycle_workers import (
     publish_worker_inventory,
 )
 
-
 DEFAULT_GUARD_EXCEPTIONS = (
     AttributeError,
     OSError,
@@ -201,19 +200,22 @@ async def stop_registered_job_pollers(
     """Stop registered job pollers, preferring explicit stop events."""
 
     async def _await_job_poller_shutdown(handle: ManagedJobPoller) -> bool:
+        task = handle.task
+        if task is None:
+            return True
         try:
-            await asyncio_module.wait_for(asyncio_module.shield(handle.task), timeout=handle.timeout_sec)
+            await asyncio_module.wait_for(asyncio_module.shield(task), timeout=handle.timeout_sec)
         except asyncio.CancelledError:
-            return bool(handle.task.done())
+            return bool(task.done())
         except asyncio.TimeoutError:
             logger_obj.warning(
                 "App Shutdown: Timed out waiting for job poller {} after {}s; cancelling",
                 handle.name,
                 handle.timeout_sec,
             )
-            handle.task.cancel()
+            task.cancel()
             try:
-                await asyncio_module.wait_for(handle.task, timeout=1.0)
+                await asyncio_module.wait_for(task, timeout=1.0)
             except asyncio.CancelledError:
                 pass
             except asyncio.TimeoutError:
@@ -221,7 +223,7 @@ async def stop_registered_job_pollers(
                     "App Shutdown: Job poller {} did not cancel within 1.0s after timeout",
                     handle.name,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - worker failures must not block shutdown.
                 logger_obj.warning(
                     "App Shutdown: Job poller {} raised after cancellation: {}",
                     handle.name,
@@ -233,18 +235,18 @@ async def stop_registered_job_pollers(
                 handle.name,
                 exc,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - worker failures must not block shutdown.
             logger_obj.warning(
                 "App Shutdown: Job poller {} exited during shutdown: {}",
                 handle.name,
                 exc,
             )
-        return bool(handle.task.done())
+        return bool(task.done())
 
     for handle in handles:
         if handle.stop_event is not None:
             handle.stop_event.set()
-        else:
+        elif handle.task is not None:
             with suppress(*guard_exceptions):
                 handle.task.cancel()
 

--- a/tldw_Server_API/app/services/startup_content_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_content_jobs_pollers.py
@@ -10,6 +10,8 @@ from typing import Any, Callable
 
 from loguru import logger
 
+from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase, WorkerRegistry
+
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
     OSError,
@@ -49,6 +51,7 @@ async def start_content_jobs_pollers(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> ContentJobsPollerHandles:
     """Start content jobs pollers and return their handles."""
 
@@ -57,12 +60,14 @@ async def start_content_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     audiobook_jobs_stop_event, audiobook_jobs_task = await _start_audiobook_jobs_worker(
         app=app,
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     presentation_render_jobs_stop_event, presentation_render_jobs_task = (
         await _start_presentation_render_jobs_worker(
@@ -70,6 +75,7 @@ async def start_content_jobs_pollers(
             owned_job_pollers=owned_job_pollers,
             register_owned_job_poller=register_owned_job_poller,
             should_start_worker=should_start_worker,
+            worker_inventory=worker_inventory,
         )
     )
     (
@@ -82,12 +88,14 @@ async def start_content_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     reading_digest_jobs_stop_event, reading_digest_jobs_task = await _start_reading_digest_jobs_worker(
         app=app,
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     (
         vn_asset_jobs_stop_event,
@@ -99,6 +107,7 @@ async def start_content_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=should_start_worker,
+        worker_inventory=worker_inventory,
     )
     companion_reflection_jobs_stop_event, companion_reflection_jobs_task = (
         await _start_companion_reflection_jobs_worker(
@@ -106,6 +115,7 @@ async def start_content_jobs_pollers(
             owned_job_pollers=owned_job_pollers,
             register_owned_job_poller=register_owned_job_poller,
             should_start_worker=should_start_worker,
+            worker_inventory=worker_inventory,
         )
     )
     return ContentJobsPollerHandles(
@@ -138,18 +148,49 @@ def _create_task(awaitable: Any) -> Any:
     return asyncio.create_task(awaitable)
 
 
+async def _register_jobs_worker_with_inventory(
+    worker_inventory: WorkerRegistry,
+    *,
+    name: str,
+    coroutine_factory: Callable[[Any], Any],
+) -> tuple[Any, Any]:
+    """Register a content jobs poller with the shared lifecycle inventory."""
+
+    task, stop_event = await worker_inventory.register_custom(
+        name=name,
+        task_name=name,
+        coroutine_factory=coroutine_factory,
+        timeout_sec=5.0,
+        category="jobs",
+        shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+    )
+    return stop_event, task
+
+
 async def _start_audio_jobs_worker(
     *,
     app: Any,
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the Audio jobs poller and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("AUDIO_JOBS_WORKER_ENABLED", "audio-jobs")
         if not enabled:
             logger.info("Audio Jobs worker disabled by flag (AUDIO_JOBS_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            stop_event, task = await _register_jobs_worker_with_inventory(
+                worker_inventory,
+                name="audio_jobs_task",
+                coroutine_factory=_run_audio_jobs_worker_service,
+            )
+            logger.info("Audio Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_audio_jobs_worker_service(stop_event))
@@ -173,12 +214,24 @@ async def _start_audiobook_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the Audiobook jobs poller and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("AUDIOBOOK_JOBS_WORKER_ENABLED", "audiobooks")
         if not enabled:
             logger.info("Audiobook Jobs worker disabled by flag (AUDIOBOOK_JOBS_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            stop_event, task = await _register_jobs_worker_with_inventory(
+                worker_inventory,
+                name="audiobook_jobs_task",
+                coroutine_factory=_run_audiobook_jobs_worker_service,
+            )
+            logger.info("Audiobook Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_audiobook_jobs_worker_service(stop_event))
@@ -202,7 +255,10 @@ async def _start_presentation_render_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the presentation-render jobs poller and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("PRESENTATION_RENDER_JOBS_WORKER_ENABLED", "slides")
         if not enabled:
@@ -210,6 +266,15 @@ async def _start_presentation_render_jobs_worker(
                 "Presentation Render Jobs worker disabled by flag (PRESENTATION_RENDER_JOBS_WORKER_ENABLED)"
             )
             return None, None
+
+        if worker_inventory is not None:
+            stop_event, task = await _register_jobs_worker_with_inventory(
+                worker_inventory,
+                name="presentation_render_jobs_task",
+                coroutine_factory=_run_presentation_render_jobs_worker_service,
+            )
+            logger.info("Presentation Render Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_presentation_render_jobs_worker_service(stop_event))
@@ -233,7 +298,10 @@ async def _start_media_ingest_jobs_workers(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None, Any | None, Any | None]:
+    """Start media ingest jobs pollers and return their shutdown handles."""
+
     media_ingest_jobs_stop_event = None
     media_ingest_jobs_task = None
     media_ingest_heavy_jobs_stop_event = None
@@ -242,18 +310,26 @@ async def _start_media_ingest_jobs_workers(
     try:
         enabled = should_start_worker("MEDIA_INGEST_JOBS_WORKER_ENABLED", "media")
         if enabled:
-            media_ingest_jobs_stop_event = _make_event()
-            media_ingest_jobs_task = _create_task(
-                _run_media_ingest_jobs_worker_service(media_ingest_jobs_stop_event)
-            )
+            if worker_inventory is not None:
+                media_ingest_jobs_stop_event, media_ingest_jobs_task = await _register_jobs_worker_with_inventory(
+                    worker_inventory,
+                    name="media_ingest_jobs_task",
+                    coroutine_factory=_run_media_ingest_jobs_worker_service,
+                )
+            else:
+                media_ingest_jobs_stop_event = _make_event()
+                media_ingest_jobs_task = _create_task(
+                    _run_media_ingest_jobs_worker_service(media_ingest_jobs_stop_event)
+                )
             logger.info("Media Ingest Jobs worker started with explicit stop_event signal")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
-                name="media_ingest_jobs_task",
-                task=media_ingest_jobs_task,
-                stop_event=media_ingest_jobs_stop_event,
-            )
+            if worker_inventory is None:
+                register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="media_ingest_jobs_task",
+                    task=media_ingest_jobs_task,
+                    stop_event=media_ingest_jobs_stop_event,
+                )
         else:
             logger.info("Media Ingest Jobs worker disabled by flag (MEDIA_INGEST_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as exc:
@@ -268,18 +344,28 @@ async def _start_media_ingest_jobs_workers(
             default_stable=False,
         )
         if heavy_enabled:
-            media_ingest_heavy_jobs_stop_event = _make_event()
-            media_ingest_heavy_jobs_task = _create_task(
-                _run_media_ingest_heavy_jobs_worker_service(media_ingest_heavy_jobs_stop_event)
-            )
+            if worker_inventory is not None:
+                media_ingest_heavy_jobs_stop_event, media_ingest_heavy_jobs_task = (
+                    await _register_jobs_worker_with_inventory(
+                        worker_inventory,
+                        name="media_ingest_heavy_jobs_task",
+                        coroutine_factory=_run_media_ingest_heavy_jobs_worker_service,
+                    )
+                )
+            else:
+                media_ingest_heavy_jobs_stop_event = _make_event()
+                media_ingest_heavy_jobs_task = _create_task(
+                    _run_media_ingest_heavy_jobs_worker_service(media_ingest_heavy_jobs_stop_event)
+                )
             logger.info("Media Ingest Heavy Jobs worker started with explicit stop_event signal")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
-                name="media_ingest_heavy_jobs_task",
-                task=media_ingest_heavy_jobs_task,
-                stop_event=media_ingest_heavy_jobs_stop_event,
-            )
+            if worker_inventory is None:
+                register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="media_ingest_heavy_jobs_task",
+                    task=media_ingest_heavy_jobs_task,
+                    stop_event=media_ingest_heavy_jobs_stop_event,
+                )
         else:
             logger.info(
                 "Media Ingest Heavy Jobs worker disabled by flag (MEDIA_INGEST_HEAVY_JOBS_WORKER_ENABLED)"
@@ -313,12 +399,24 @@ async def _start_reading_digest_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the reading digest jobs poller and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("READING_DIGEST_JOBS_WORKER_ENABLED", "reading")
         if not enabled:
             logger.info("Reading digest Jobs worker disabled by flag (READING_DIGEST_JOBS_WORKER_ENABLED)")
             return None, None
+
+        if worker_inventory is not None:
+            stop_event, task = await _register_jobs_worker_with_inventory(
+                worker_inventory,
+                name="reading_digest_jobs_task",
+                coroutine_factory=_run_reading_digest_jobs_worker_service,
+            )
+            logger.info("Reading digest Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_reading_digest_jobs_worker_service(stop_event))
@@ -342,7 +440,10 @@ async def _start_vn_asset_jobs_workers(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None, Any | None, Any | None]:
+    """Start VN asset jobs pollers and return their shutdown handles."""
+
     vn_asset_jobs_stop_event = None
     vn_asset_jobs_task = None
     vn_asset_generation_jobs_stop_event = None
@@ -355,18 +456,26 @@ async def _start_vn_asset_jobs_workers(
             default_stable=True,
         )
         if enabled:
-            vn_asset_jobs_stop_event = _make_event()
-            vn_asset_jobs_task = _create_task(
-                _run_vn_asset_jobs_worker_service(vn_asset_jobs_stop_event)
-            )
+            if worker_inventory is not None:
+                vn_asset_jobs_stop_event, vn_asset_jobs_task = await _register_jobs_worker_with_inventory(
+                    worker_inventory,
+                    name="vn_asset_jobs_task",
+                    coroutine_factory=_run_vn_asset_jobs_worker_service,
+                )
+            else:
+                vn_asset_jobs_stop_event = _make_event()
+                vn_asset_jobs_task = _create_task(
+                    _run_vn_asset_jobs_worker_service(vn_asset_jobs_stop_event)
+                )
             logger.info("VN asset Jobs worker started with explicit stop_event signal")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
-                name="vn_asset_jobs_task",
-                task=vn_asset_jobs_task,
-                stop_event=vn_asset_jobs_stop_event,
-            )
+            if worker_inventory is None:
+                register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="vn_asset_jobs_task",
+                    task=vn_asset_jobs_task,
+                    stop_event=vn_asset_jobs_stop_event,
+                )
         else:
             logger.info("VN asset Jobs worker disabled by flag (VN_ASSET_JOBS_WORKER_ENABLED)")
     except _STARTUP_GUARD_EXCEPTIONS as exc:
@@ -381,20 +490,30 @@ async def _start_vn_asset_jobs_workers(
             default_stable=True,
         )
         if generation_enabled:
-            vn_asset_generation_jobs_stop_event = _make_event()
-            vn_asset_generation_jobs_task = _create_task(
-                _run_vn_asset_generation_jobs_worker_service(
-                    vn_asset_generation_jobs_stop_event
+            if worker_inventory is not None:
+                vn_asset_generation_jobs_stop_event, vn_asset_generation_jobs_task = (
+                    await _register_jobs_worker_with_inventory(
+                        worker_inventory,
+                        name="vn_asset_generation_jobs_task",
+                        coroutine_factory=_run_vn_asset_generation_jobs_worker_service,
+                    )
                 )
-            )
+            else:
+                vn_asset_generation_jobs_stop_event = _make_event()
+                vn_asset_generation_jobs_task = _create_task(
+                    _run_vn_asset_generation_jobs_worker_service(
+                        vn_asset_generation_jobs_stop_event
+                    )
+                )
             logger.info("VN asset generation Jobs worker started with explicit stop_event signal")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
-                name="vn_asset_generation_jobs_task",
-                task=vn_asset_generation_jobs_task,
-                stop_event=vn_asset_generation_jobs_stop_event,
-            )
+            if worker_inventory is None:
+                register_owned_job_poller(
+                    app,
+                    owned_job_pollers,
+                    name="vn_asset_generation_jobs_task",
+                    task=vn_asset_generation_jobs_task,
+                    stop_event=vn_asset_generation_jobs_stop_event,
+                )
         else:
             logger.info(
                 "VN asset generation Jobs worker disabled by flag "
@@ -420,7 +539,10 @@ async def _start_companion_reflection_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     should_start_worker: Callable[..., bool],
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
+    """Start the companion reflection jobs poller and return its shutdown handles."""
+
     try:
         enabled = should_start_worker("COMPANION_REFLECTION_JOBS_WORKER_ENABLED", "companion")
         if not enabled:
@@ -428,6 +550,15 @@ async def _start_companion_reflection_jobs_worker(
                 "Companion reflection Jobs worker disabled by flag (COMPANION_REFLECTION_JOBS_WORKER_ENABLED)"
             )
             return None, None
+
+        if worker_inventory is not None:
+            stop_event, task = await _register_jobs_worker_with_inventory(
+                worker_inventory,
+                name="companion_reflection_jobs_task",
+                coroutine_factory=_run_companion_reflection_jobs_worker_service,
+            )
+            logger.info("Companion reflection Jobs worker started with explicit stop_event signal")
+            return stop_event, task
 
         stop_event = _make_event()
         task = _create_task(_run_companion_reflection_jobs_worker_service(stop_event))

--- a/tldw_Server_API/app/services/startup_worker_groups.py
+++ b/tldw_Server_API/app/services/startup_worker_groups.py
@@ -138,6 +138,7 @@ async def start_worker_groups(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         should_start_worker=_should_start_worker,
+        worker_inventory=worker_inventory,
     )
     sidecar_owned_jobs_poller_handles = await _start_sidecar_owned_jobs_pollers(
         app=app,

--- a/tldw_Server_API/tests/Services/test_shutdown_job_poller_handoff.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_job_poller_handoff.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from fastapi import FastAPI
+
+
+def _make_job_poller(name: str) -> SimpleNamespace:
+    from tldw_Server_API.app.services.lifecycle_workers import ShutdownPhase
+
+    return SimpleNamespace(
+        name=name,
+        task=object(),
+        shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+    )
 
 
 @pytest.mark.unit
@@ -15,7 +28,7 @@ async def test_shutdown_job_poller_handoff_uses_env_and_job_manager_when_availab
 
     app = FastAPI()
     recorded: dict[str, Any] = {}
-    owned_job_pollers = [object()]
+    owned_job_pollers = [_make_job_poller("poller")]
 
     class _FakeJobManager:
         def count_active_processing(self) -> int:
@@ -45,12 +58,78 @@ async def test_shutdown_job_poller_handoff_uses_env_and_job_manager_when_availab
     )
 
     assert recorded["app"] is app
-    assert recorded["poller_handles"] is owned_job_pollers
+    assert recorded["poller_handles"] == owned_job_pollers
     assert recorded["wait_for_leases_sec"] == 12
     assert recorded["active_processing"] == 7
     assert handles.early_quiesced_job_poller_names == set()
     assert handles.should_run_late_stop("media_ingest_jobs_task", object()) is True
     assert handles.should_run_late_stop("media_ingest_jobs_task", None) is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_shutdown_job_poller_handoff_filters_to_tasked_job_poller_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.services import shutdown_job_poller_handoff as handoff_module
+    from tldw_Server_API.app.services.lifecycle_workers import (
+        ManagedWorker,
+        ShutdownPhase,
+    )
+
+    app = FastAPI()
+    recorded: dict[str, Any] = {}
+    poller_stop_event = asyncio.Event()
+    poller_task = asyncio.create_task(poller_stop_event.wait(), name="content-poller")
+    owned_job_pollers = [
+        ManagedWorker(
+            name="authnz_scheduler",
+            task=None,
+            stop_event=None,
+            shutdown_callback=lambda: asyncio.sleep(0),
+            shutdown_phase=ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN,
+        ),
+        ManagedWorker(
+            name="content_jobs_task",
+            task=poller_task,
+            stop_event=poller_stop_event,
+            shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+        ),
+    ]
+
+    async def _fake_quiesce(
+        current_app: FastAPI,
+        poller_handles: list[ManagedWorker],
+        *,
+        wait_for_leases_sec: int,
+        count_active_processing,
+    ) -> None:
+        del wait_for_leases_sec, count_active_processing
+        recorded["app"] = current_app
+        recorded["poller_handles"] = poller_handles
+        current_app.state._tldw_shutdown_quiesced_job_poller_names = [
+            handle.name for handle in poller_handles
+        ]
+
+    monkeypatch.setattr(handoff_module._env_os, "getenv", lambda *_args, **_kwargs: "0")
+
+    try:
+        handles = await handoff_module.shutdown_job_poller_handoff(
+            app=app,
+            owned_job_pollers=owned_job_pollers,
+            quiesce_owned_job_pollers_for_shutdown=_fake_quiesce,
+            startup_guard_exceptions=(ValueError,),
+            import_exceptions=(ImportError,),
+        )
+    finally:
+        poller_stop_event.set()
+        poller_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await poller_task
+
+    assert recorded["app"] is app
+    assert recorded["poller_handles"] == [owned_job_pollers[1]]
+    assert handles.early_quiesced_job_poller_names == {"content_jobs_task"}
 
 
 @pytest.mark.unit
@@ -62,7 +141,10 @@ async def test_shutdown_job_poller_handoff_falls_back_on_invalid_env_and_import_
 
     app = FastAPI()
     recorded: dict[str, Any] = {}
-    owned_job_pollers = [object(), object()]
+    owned_job_pollers = [
+        _make_job_poller("files_jobs_task"),
+        _make_job_poller("audio_jobs_task"),
+    ]
 
     async def _fake_quiesce(
         current_app: FastAPI,
@@ -95,7 +177,7 @@ async def test_shutdown_job_poller_handoff_falls_back_on_invalid_env_and_import_
     )
 
     assert recorded["app"] is app
-    assert recorded["poller_handles"] is owned_job_pollers
+    assert recorded["poller_handles"] == owned_job_pollers
     assert recorded["wait_for_leases_sec"] == 0
     assert recorded["active_processing"] == 0
     assert handles.early_quiesced_job_poller_names == {

--- a/tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 import pytest
 from fastapi import FastAPI
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -44,7 +43,7 @@ async def test_register_owned_job_poller_publishes_lifecycle_worker_inventory() 
         handle = handles[0]
         assert isinstance(handle, ManagedWorker)
         assert handle.shutdown_phase is ShutdownPhase.JOB_POLLER_QUIESCE
-        assert getattr(app.state, "_tldw_shutdown_worker_inventory") == [
+        assert app.state._tldw_shutdown_worker_inventory == [
             {
                 "name": "core_jobs_task",
                 "task_name": "core-jobs-task",
@@ -54,7 +53,7 @@ async def test_register_owned_job_poller_publishes_lifecycle_worker_inventory() 
                 "shutdown_phase": "job_poller_quiesce",
             }
         ]
-        assert getattr(app.state, "_tldw_shutdown_job_poller_inventory") == [
+        assert app.state._tldw_shutdown_job_poller_inventory == [
             {
                 "name": "core_jobs_task",
                 "task_name": "core-jobs-task",
@@ -160,7 +159,7 @@ def test_register_and_replace_owned_job_poller_inventory_refreshes_app_state() -
         )
 
         assert [handle.name for handle in handles] == ["second"]
-        assert getattr(app.state, "_tldw_shutdown_job_poller_inventory") == [
+        assert app.state._tldw_shutdown_job_poller_inventory == [
             {
                 "name": "second",
                 "task_name": "second-task",
@@ -212,7 +211,7 @@ async def test_quiesce_owned_job_pollers_waits_then_calls_stop_callback() -> Non
 
     assert observed_sleeps == [0.5, 0.5]
     assert stop_calls == ["stop"]
-    segments = getattr(app.state, "_tldw_shutdown_timing_segments")
+    segments = app.state._tldw_shutdown_timing_segments
     assert segments[0]["segment"] == "optional_lease_wait"
     assert segments[0]["skipped"] is False
     assert segments[0]["initial_active"] == 2
@@ -287,3 +286,25 @@ async def test_stop_registered_job_pollers_logs_task_cancel_failure_at_warning()
     assert task.cancelled is True
     assert not any("Job poller cancel guard triggered" in message for message in debug_messages)
     assert any("raised after cancellation" in message for message in warning_messages)
+
+
+@pytest.mark.asyncio
+async def test_stop_registered_job_pollers_handles_taskless_worker_without_crashing() -> None:
+    shutdown_pollers = _import_shutdown_owned_job_pollers()
+    app = FastAPI()
+
+    await shutdown_pollers.stop_registered_job_pollers(
+        app,
+        [
+            shutdown_pollers.ManagedJobPoller(
+                name="callback_only_worker",
+                task=None,
+                stop_event=None,
+                timeout_sec=0.01,
+            )
+        ],
+    )
+
+    assert app.state._tldw_shutdown_quiesced_job_poller_names == [
+        "callback_only_worker"
+    ]

--- a/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
@@ -46,7 +46,9 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
         calls.append("reading-digest")
         return ("reading-stop", "reading-task")
 
-    async def _record_vn_asset(**kwargs):
+    async def _record_vn_asset(**kwargs: object) -> tuple[str, str, str, str]:
+        """Record that the VN asset worker starter ran."""
+
         del kwargs
         calls.append("vn-asset")
         return ("vn-asset-stop", "vn-asset-task", "vn-generation-stop", "vn-generation-task")

--- a/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Callable
 
 import pytest
-
 
 pytestmark = pytest.mark.unit
 
@@ -46,6 +46,11 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
         calls.append("reading-digest")
         return ("reading-stop", "reading-task")
 
+    async def _record_vn_asset(**kwargs):
+        del kwargs
+        calls.append("vn-asset")
+        return ("vn-asset-stop", "vn-asset-task", "vn-generation-stop", "vn-generation-task")
+
     async def _record_companion(**kwargs):
         del kwargs
         calls.append("companion")
@@ -56,6 +61,7 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
     monkeypatch.setattr(startup_pollers, "_start_presentation_render_jobs_worker", _record_presentation)
     monkeypatch.setattr(startup_pollers, "_start_media_ingest_jobs_workers", _record_media_ingest)
     monkeypatch.setattr(startup_pollers, "_start_reading_digest_jobs_worker", _record_reading_digest)
+    monkeypatch.setattr(startup_pollers, "_start_vn_asset_jobs_workers", _record_vn_asset)
     monkeypatch.setattr(startup_pollers, "_start_companion_reflection_jobs_worker", _record_companion)
 
     handles = await startup_pollers.start_content_jobs_pollers(
@@ -65,7 +71,15 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
         should_start_worker=lambda *args, **kwargs: False,
     )
 
-    assert calls == ["audio", "audiobook", "presentation", "media-ingest", "reading-digest", "companion"]
+    assert calls == [
+        "audio",
+        "audiobook",
+        "presentation",
+        "media-ingest",
+        "reading-digest",
+        "vn-asset",
+        "companion",
+    ]
     assert handles.audio_jobs_stop_event == "audio-stop"
     assert handles.audio_jobs_task == "audio-task"
     assert handles.audiobook_jobs_stop_event == "audiobook-stop"
@@ -78,8 +92,322 @@ async def test_start_content_jobs_pollers_combines_handles_in_order(
     assert handles.media_ingest_heavy_jobs_task == "media-heavy-task"
     assert handles.reading_digest_jobs_stop_event == "reading-stop"
     assert handles.reading_digest_jobs_task == "reading-task"
+    assert handles.vn_asset_jobs_stop_event == "vn-asset-stop"
+    assert handles.vn_asset_jobs_task == "vn-asset-task"
+    assert handles.vn_asset_generation_jobs_stop_event == "vn-generation-stop"
+    assert handles.vn_asset_generation_jobs_task == "vn-generation-task"
     assert handles.companion_reflection_jobs_stop_event == "companion-stop"
     assert handles.companion_reflection_jobs_task == "companion-task"
+
+
+@pytest.mark.asyncio
+async def test_start_content_jobs_pollers_passes_inventory_to_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_content_jobs_pollers()
+    worker_inventory = object()
+    captured_kwargs_by_worker: dict[str, dict[str, object]] = {}
+
+    def _record_worker(label: str, handles: tuple[object, ...]) -> Callable[..., object]:
+        """Build a starter stub that captures kwargs for one content worker group."""
+
+        async def _record(**kwargs: object) -> tuple[object, ...]:
+            """Capture worker startup kwargs and return deterministic handles."""
+
+            captured_kwargs_by_worker[label] = kwargs
+            return handles
+
+        return _record
+
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_audio_jobs_worker",
+        _record_worker("audio", ("audio-stop", "audio-task")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_audiobook_jobs_worker",
+        _record_worker("audiobook", ("audiobook-stop", "audiobook-task")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_presentation_render_jobs_worker",
+        _record_worker("presentation", ("presentation-stop", "presentation-task")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_media_ingest_jobs_workers",
+        _record_worker("media-ingest", ("media-stop", "media-task", "media-heavy-stop", "media-heavy-task")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_reading_digest_jobs_worker",
+        _record_worker("reading-digest", ("reading-stop", "reading-task")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_vn_asset_jobs_workers",
+        _record_worker("vn-asset", ("vn-asset-stop", "vn-asset-task", "vn-generation-stop", "vn-generation-task")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_companion_reflection_jobs_worker",
+        _record_worker("companion", ("companion-stop", "companion-task")),
+    )
+
+    await startup_pollers.start_content_jobs_pollers(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=lambda *args, **kwargs: None,
+        should_start_worker=lambda *args, **kwargs: False,
+        worker_inventory=worker_inventory,
+    )
+
+    assert {
+        worker: kwargs["worker_inventory"]
+        for worker, kwargs in captured_kwargs_by_worker.items()
+    } == {
+        "audio": worker_inventory,
+        "audiobook": worker_inventory,
+        "presentation": worker_inventory,
+        "media-ingest": worker_inventory,
+        "reading-digest": worker_inventory,
+        "vn-asset": worker_inventory,
+        "companion": worker_inventory,
+    }
+
+
+@pytest.mark.parametrize(
+    (
+        "starter_name",
+        "flag_name",
+        "route_name",
+        "registered_name",
+        "factory_name",
+    ),
+    [
+        (
+            "_start_audio_jobs_worker",
+            "AUDIO_JOBS_WORKER_ENABLED",
+            "audio-jobs",
+            "audio_jobs_task",
+            "_run_audio_jobs_worker_service",
+        ),
+        (
+            "_start_audiobook_jobs_worker",
+            "AUDIOBOOK_JOBS_WORKER_ENABLED",
+            "audiobooks",
+            "audiobook_jobs_task",
+            "_run_audiobook_jobs_worker_service",
+        ),
+        (
+            "_start_presentation_render_jobs_worker",
+            "PRESENTATION_RENDER_JOBS_WORKER_ENABLED",
+            "slides",
+            "presentation_render_jobs_task",
+            "_run_presentation_render_jobs_worker_service",
+        ),
+        (
+            "_start_reading_digest_jobs_worker",
+            "READING_DIGEST_JOBS_WORKER_ENABLED",
+            "reading",
+            "reading_digest_jobs_task",
+            "_run_reading_digest_jobs_worker_service",
+        ),
+        (
+            "_start_companion_reflection_jobs_worker",
+            "COMPANION_REFLECTION_JOBS_WORKER_ENABLED",
+            "companion",
+            "companion_reflection_jobs_task",
+            "_run_companion_reflection_jobs_worker_service",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_content_jobs_worker_registers_with_worker_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    starter_name: str,
+    flag_name: str,
+    route_name: str,
+    registered_name: str,
+    factory_name: str,
+) -> None:
+    startup_pollers = _import_startup_content_jobs_pollers()
+    registrations: list[dict[str, object]] = []
+
+    class _FakeWorkerInventory:
+        """Test double that records custom worker registration calls."""
+
+        async def register_custom(self, **kwargs: object) -> tuple[str, str]:
+            """Capture registration kwargs and return deterministic handles."""
+
+            registrations.append(kwargs)
+            return f"{registered_name}-task", f"{registered_name}-stop"
+
+    monkeypatch.setattr(
+        startup_pollers,
+        "_make_event",
+        lambda: (_ for _ in ()).throw(AssertionError("legacy event path should not run")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_create_task",
+        lambda coro: (_ for _ in ()).throw(AssertionError("legacy task path should not run")),
+    )
+
+    def _register_owned_job_poller(*args: object, **kwargs: object) -> None:
+        raise AssertionError("legacy poller registration should not run")
+
+    stop_event, task = await getattr(startup_pollers, starter_name)(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=_register_owned_job_poller,
+        should_start_worker=lambda flag, route, **kwargs: (flag, route, kwargs) == (flag_name, route_name, {}),
+        worker_inventory=_FakeWorkerInventory(),
+    )
+
+    assert stop_event == f"{registered_name}-stop"
+    assert task == f"{registered_name}-task"
+    assert registrations == [
+        {
+            "name": registered_name,
+            "task_name": registered_name,
+            "coroutine_factory": getattr(startup_pollers, factory_name),
+            "timeout_sec": 5.0,
+            "category": "jobs",
+            "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_media_ingest_jobs_workers_register_with_worker_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_content_jobs_pollers()
+    registrations: list[dict[str, object]] = []
+
+    class _FakeWorkerInventory:
+        """Test double that records custom worker registration calls."""
+
+        async def register_custom(self, **kwargs: object) -> tuple[str, str]:
+            """Capture registration kwargs and return deterministic handles."""
+
+            registrations.append(kwargs)
+            name = str(kwargs["name"])
+            return f"{name}-task", f"{name}-stop"
+
+    monkeypatch.setattr(
+        startup_pollers,
+        "_make_event",
+        lambda: (_ for _ in ()).throw(AssertionError("legacy event path should not run")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_create_task",
+        lambda coro: (_ for _ in ()).throw(AssertionError("legacy task path should not run")),
+    )
+
+    def _register_owned_job_poller(*args: object, **kwargs: object) -> None:
+        raise AssertionError("legacy poller registration should not run")
+
+    handles = await startup_pollers._start_media_ingest_jobs_workers(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=_register_owned_job_poller,
+        should_start_worker=lambda *args, **kwargs: True,
+        worker_inventory=_FakeWorkerInventory(),
+    )
+
+    assert handles == (
+        "media_ingest_jobs_task-stop",
+        "media_ingest_jobs_task-task",
+        "media_ingest_heavy_jobs_task-stop",
+        "media_ingest_heavy_jobs_task-task",
+    )
+    assert registrations == [
+        {
+            "name": "media_ingest_jobs_task",
+            "task_name": "media_ingest_jobs_task",
+            "coroutine_factory": startup_pollers._run_media_ingest_jobs_worker_service,
+            "timeout_sec": 5.0,
+            "category": "jobs",
+            "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,
+        },
+        {
+            "name": "media_ingest_heavy_jobs_task",
+            "task_name": "media_ingest_heavy_jobs_task",
+            "coroutine_factory": startup_pollers._run_media_ingest_heavy_jobs_worker_service,
+            "timeout_sec": 5.0,
+            "category": "jobs",
+            "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vn_asset_jobs_workers_register_with_worker_inventory_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_content_jobs_pollers()
+    registrations: list[dict[str, object]] = []
+
+    class _FakeWorkerInventory:
+        """Test double that records custom worker registration calls."""
+
+        async def register_custom(self, **kwargs: object) -> tuple[str, str]:
+            """Capture registration kwargs and return deterministic handles."""
+
+            registrations.append(kwargs)
+            name = str(kwargs["name"])
+            return f"{name}-task", f"{name}-stop"
+
+    monkeypatch.setattr(
+        startup_pollers,
+        "_make_event",
+        lambda: (_ for _ in ()).throw(AssertionError("legacy event path should not run")),
+    )
+    monkeypatch.setattr(
+        startup_pollers,
+        "_create_task",
+        lambda coro: (_ for _ in ()).throw(AssertionError("legacy task path should not run")),
+    )
+
+    def _register_owned_job_poller(*args: object, **kwargs: object) -> None:
+        raise AssertionError("legacy poller registration should not run")
+
+    handles = await startup_pollers._start_vn_asset_jobs_workers(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=_register_owned_job_poller,
+        should_start_worker=lambda *args, **kwargs: True,
+        worker_inventory=_FakeWorkerInventory(),
+    )
+
+    assert handles == (
+        "vn_asset_jobs_task-stop",
+        "vn_asset_jobs_task-task",
+        "vn_asset_generation_jobs_task-stop",
+        "vn_asset_generation_jobs_task-task",
+    )
+    assert registrations == [
+        {
+            "name": "vn_asset_jobs_task",
+            "task_name": "vn_asset_jobs_task",
+            "coroutine_factory": startup_pollers._run_vn_asset_jobs_worker_service,
+            "timeout_sec": 5.0,
+            "category": "jobs",
+            "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,
+        },
+        {
+            "name": "vn_asset_generation_jobs_task",
+            "task_name": "vn_asset_generation_jobs_task",
+            "coroutine_factory": startup_pollers._run_vn_asset_generation_jobs_worker_service,
+            "timeout_sec": 5.0,
+            "category": "jobs",
+            "shutdown_phase": startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE,
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_worker_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_groups.py
@@ -104,13 +104,16 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
 
     async def _record_content_jobs_pollers(
         *,
-        app,
-        owned_job_pollers,
-        register_owned_job_poller,
-        should_start_worker,
-        worker_inventory,
-    ):
+        app: object,
+        owned_job_pollers: list[object],
+        register_owned_job_poller: object,
+        should_start_worker: Callable[..., bool],
+        worker_inventory: object | None,
+    ) -> SimpleNamespace:
+        """Record the content jobs startup group call."""
+
         assert worker_inventory is worker_inventory_ref
+        del app, owned_job_pollers, register_owned_job_poller
         assert should_start_worker("READING_DIGEST_JOBS_WORKER_ENABLED", "collections-websub") is False
         calls.append("content")
         return SimpleNamespace(

--- a/tldw_Server_API/tests/Services/test_startup_worker_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_groups.py
@@ -108,7 +108,9 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
         owned_job_pollers,
         register_owned_job_poller,
         should_start_worker,
+        worker_inventory,
     ):
+        assert worker_inventory is worker_inventory_ref
         assert should_start_worker("READING_DIGEST_JOBS_WORKER_ENABLED", "collections-websub") is False
         calls.append("content")
         return SimpleNamespace(


### PR DESCRIPTION
## Change summary
TODO: human-authored summary required before merge.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_startup_tail_finalization.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py tldw_Server_API/tests/Services/test_shutdown_job_poller_handoff.py tldw_Server_API/tests/Services/test_shutdown_reading_study_companion_jobs_workers.py tldw_Server_API/tests/Services/test_shutdown_privilege_snapshot_worker.py tldw_Server_API/tests/Services/test_shutdown_primary_late_stop_workers.py tldw_Server_API/tests/Services/test_shutdown_grouped_late_stop_workers.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_content_jobs_pollers.py tldw_Server_API/app/services/startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_content_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_content_jobs_pollers.py tldw_Server_API/app/services/startup_worker_groups.py -f json -o /tmp/bandit_content_jobs_worker_registry_1114.json
- git diff --check