### PR TITLE
feat(sandbox): add runtime capability inventory

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -220,6 +220,7 @@ item and reports `live_vm_matches_blocked_cleanup` instead of deleting files.
   - `vz_linux`
   - `vz_macos`
   - `seatbelt`
+  - `worktree`
 - `vz_linux` session-mode reuse exists now and reuses a persisted VM for later commands in the same sandbox session.
 - `vz_macos` still has no warm-session optimization.
 

--- a/Docs/Sandbox/sandbox-architecture-doctrine.md
+++ b/Docs/Sandbox/sandbox-architecture-doctrine.md
@@ -82,6 +82,10 @@ The current evaluation record is:
 
 - `Docs/Design/2026-05-02-apple-containerization-evaluation.md`
 
+The current cross-runtime support inventory is:
+
+- `Docs/Sandbox/sandbox-runtime-capability-inventory.md`
+
 ## Non-Negotiable Boundaries
 
 ### Trusted Control Plane vs Untrusted Compute

--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -1,0 +1,126 @@
+# Sandbox Runtime Capability Inventory
+
+**Status:** Phase 0 inventory baseline.
+**Date:** 2026-05-02.
+**Scope:** `docker`, `firecracker`, `lima`, `vz_linux`, `vz_macos`,
+`seatbelt`, and `worktree`.
+
+## Purpose
+
+This document records the current support state for every sandbox runtime using
+the roadmap vocabulary from
+`Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md`.
+
+It is an inventory, not a promise that every runtime should reach feature
+parity. Runtime discovery and preflight remain the source of truth for the
+current host. This document classifies subsystem guarantees so future plans can
+avoid overclaiming isolation, networking, recovery, or CI coverage.
+
+## State Vocabulary
+
+| State | Meaning |
+| --- | --- |
+| `supported` | Implemented in normal code paths and not host-gated beyond ordinary runtime dependencies. |
+| `unsupported` | Not implemented or intentionally rejected. |
+| `scaffold` | Shape exists, but real execution or enforcement is incomplete. |
+| `host_gated` | Implemented only on prepared hosts or with explicit opt-in prerequisites. |
+| `not_applicable` | The capability does not apply to this runtime model. |
+
+## Discovery Contract
+
+`/api/v1/sandbox/runtimes` is the summarized client-facing discovery surface.
+It should include every value from `RuntimeType`:
+
+| Runtime | Discovery entry | Source |
+| --- | --- | --- |
+| `docker` | `supported` | `SandboxService.feature_discovery()` plus `docker_available()` |
+| `firecracker` | `supported` | `SandboxService.feature_discovery()` plus `firecracker_available()` |
+| `lima` | `supported` | `LimaRunner.preflight()` |
+| `vz_linux` | `supported` | `VZLinuxRunner.preflight()` |
+| `vz_macos` | `supported` | `VZMacOSRunner.preflight()` |
+| `seatbelt` | `supported` | `SeatbeltRunner.preflight()` |
+| `worktree` | `supported` | `WorktreeRunner.preflight()` |
+
+Discovery is intentionally summarized. Admin/operator diagnostics can expose
+helper, template, reconciliation, and image-store details that should not be
+duplicated into the public discovery payload.
+
+## Trust-Level Support
+
+| Runtime | `trusted` | `standard` | `untrusted` | Notes |
+| --- | --- | --- | --- | --- |
+| `docker` | `supported` | `supported` | `supported` | Broad default runtime, but policy must not claim VM-grade isolation where that is required. |
+| `firecracker` | `supported` | `supported` | `supported` | VM-grade path when host prerequisites and real execution are available. |
+| `lima` | `supported` | `supported` | `supported` | VM isolation path with strict host preflight requirements. |
+| `vz_linux` | `supported` | `supported` | `supported` | Primary Apple silicon Linux VM path. |
+| `vz_macos` | `scaffold` | `scaffold` | `scaffold` | Trust levels are advertised through preflight, but real execution is not implemented. |
+| `seatbelt` | `supported` | `host_gated` | `unsupported` | `standard` requires `TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED=1`; never VM-grade. |
+| `worktree` | `supported` | `supported` | `unsupported` | Host-local VCS isolation only; never VM-grade. |
+
+## Network Policy Support
+
+| Runtime | `deny_all` | `allowlist` | Notes |
+| --- | --- | --- | --- |
+| `docker` | `supported` | `host_gated` | Deny-all can use container network isolation. Allowlist depends on configured egress enforcement. |
+| `firecracker` | `host_gated` | `scaffold` | Real mode requires a prepared Linux/KVM host. Allowlist is advertised only behind explicit enforcement flags and remains planned. |
+| `lima` | `host_gated` | `unsupported` | Deny-all depends on the Lima enforcer preflight. Service discovery intentionally forces allowlist false for execution. |
+| `vz_linux` | `host_gated` | `unsupported` | Real helper path accepts `deny_all` only and attaches no guest network device. |
+| `vz_macos` | `scaffold` | `unsupported` | No real execution yet. |
+| `seatbelt` | `unsupported` | `unsupported` | Deny-all is best effort and must not be reported as strict enforcement. |
+| `worktree` | `unsupported` | `unsupported` | Host-local process execution does not provide strict network isolation. |
+
+## Execution And Lifecycle Support
+
+| Runtime | Real execution | Interactivity | Sessions | Cancellation/timeouts | Artifacts |
+| --- | --- | --- | --- | --- | --- |
+| `docker` | `supported` | `supported` | `supported` | `supported` | `supported` |
+| `firecracker` | `host_gated` | `unsupported` | `scaffold` | `supported` | `supported` |
+| `lima` | `host_gated` | `unsupported` | `scaffold` | `supported` | `supported` |
+| `vz_linux` | `host_gated` | `unsupported` | `supported` | `supported` | `supported` |
+| `vz_macos` | `scaffold` | `unsupported` | `scaffold` | `scaffold` | `scaffold` |
+| `seatbelt` | `host_gated` | `unsupported` | `scaffold` | `supported` | `supported` |
+| `worktree` | `supported` | `unsupported` | `scaffold` | `supported` | `supported` |
+
+Session support means a runtime can participate in the sandbox session API.
+It does not imply a warm VM, warm container, or long-lived executor unless the
+runtime notes say so. Today `vz_linux` is the only VM path with real same-session
+VM reuse.
+
+## Recovery And Diagnostics Support
+
+| Runtime | Public discovery | Admin diagnostics | Reconciliation/repair | Resource usage | CI coverage |
+| --- | --- | --- | --- | --- | --- |
+| `docker` | `supported` | `scaffold` | `unsupported` | `supported` | `supported` |
+| `firecracker` | `supported` | `scaffold` | `unsupported` | `scaffold` | `supported` |
+| `lima` | `supported` | `scaffold` | `unsupported` | `scaffold` | `supported` |
+| `vz_linux` | `supported` | `supported` | `supported` | `host_gated` | `host_gated` |
+| `vz_macos` | `supported` | `supported` | `scaffold` | `scaffold` | `scaffold` |
+| `seatbelt` | `supported` | `supported` | `unsupported` | `scaffold` | `supported` |
+| `worktree` | `supported` | `scaffold` | `unsupported` | `supported` | `supported` |
+
+`vz_linux` currently has the deepest operator path: helper diagnostics,
+image-store correlation, reconciliation, dry-run repair, and host-gated real VM
+smoke. Those details are intentionally not generalized until other runtimes have
+an equally clear ownership model.
+
+## Current Gaps
+
+| Gap | Runtime(s) | Follow-up phase |
+| --- | --- | --- |
+| Public discovery lacks normalized state labels and reason taxonomy. | all | Phase 3 |
+| Host-local runtimes need clearer docs/API warnings that they are not VM-grade. | `seatbelt`, `worktree` | Phase 2 |
+| Allowlist support is inconsistent and often scaffold-only. | all except host-local unsupported paths | Phase 2 |
+| Session semantics are not normalized across warm VM, container, and host-local reuse. | all | Phase 4 |
+| Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
+| CI has no single cross-runtime capability gate. | all | Phase 5 |
+
+## Maintenance Rules
+
+- Add a runtime to this inventory when it is added to `RuntimeType`.
+- Keep `/api/v1/sandbox/runtimes` aligned with `RuntimeType`.
+- Do not use `available=true` as proof of a security guarantee.
+- Do not classify `seatbelt` or `worktree` as `untrusted`-eligible.
+- Prefer `unsupported` over ambiguous wording when a guarantee cannot be
+  proven.
+- Update this document before expanding `vz_macos`, Apple `containerization`,
+  vmnet networking, or new VM runtime support.

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -12,7 +12,15 @@ except ImportError:  # pragma: no cover - pydantic v1 fallback
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
 
-RuntimeType = Literal["docker", "firecracker", "lima", "vz_linux", "vz_macos", "seatbelt"]
+RuntimeType = Literal[
+    "docker",
+    "firecracker",
+    "lima",
+    "vz_linux",
+    "vz_macos",
+    "seatbelt",
+    "worktree",
+]
 TrustLevelType = Literal["trusted", "standard", "untrusted"]
 
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -26,6 +26,10 @@ from ....Sandbox.service import SandboxService
 from ..base import BaseModule
 
 
+def _runtime_values() -> list[str]:
+    return [runtime.value for runtime in SbxRuntimeType]
+
+
 class SandboxModule(BaseModule):
     async def on_initialize(self) -> None:
         logger.info(f"Initializing Sandbox module: {self.name}")
@@ -50,15 +54,7 @@ class SandboxModule(BaseModule):
                     "properties": {
                         "runtime": {
                             "type": "string",
-                            "enum": [
-                                "docker",
-                                "firecracker",
-                                "lima",
-                                "vz_linux",
-                                "vz_macos",
-                                "seatbelt",
-                                "worktree",
-                            ],
+                            "enum": _runtime_values(),
                         },
                         "session_id": {"type": "string"},
                         "base_image": {"type": "string"},
@@ -294,7 +290,7 @@ class SandboxModule(BaseModule):
         if (isinstance(sess, str) and sess) and (isinstance(img, str) and img):
             raise ValueError("Provide only one of session_id or base_image, not both")
         rt = arguments.get("runtime")
-        runtime_values = tuple(runtime.value for runtime in SbxRuntimeType)
+        runtime_values = tuple(_runtime_values())
         if rt is not None and str(rt).strip().lower() not in runtime_values:
             raise ValueError(
                 f"runtime must be {'|'.join(runtime_values)} when provided"

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -234,8 +234,12 @@ class SandboxModule(BaseModule):
 
     def _coerce_runtime(self, value: Any) -> SbxRuntimeType | None:
         runtime_raw = (str(value).strip().lower() if value is not None else "")
-        if runtime_raw in ("docker", "firecracker", "lima", "vz_linux", "vz_macos", "seatbelt"):
+        if not runtime_raw:
+            return None
+        try:
             return SbxRuntimeType(runtime_raw)
+        except ValueError:
+            pass
         return None
 
     def _coerce_trust_level(self, value: Any) -> TrustLevel | None:
@@ -290,15 +294,11 @@ class SandboxModule(BaseModule):
         if (isinstance(sess, str) and sess) and (isinstance(img, str) and img):
             raise ValueError("Provide only one of session_id or base_image, not both")
         rt = arguments.get("runtime")
-        if rt is not None and str(rt).lower() not in {
-            "docker",
-            "firecracker",
-            "lima",
-            "vz_linux",
-            "vz_macos",
-            "seatbelt",
-        }:
-            raise ValueError("runtime must be docker|firecracker|lima|vz_linux|vz_macos|seatbelt when provided")
+        runtime_values = tuple(runtime.value for runtime in SbxRuntimeType)
+        if rt is not None and str(rt).strip().lower() not in runtime_values:
+            raise ValueError(
+                f"runtime must be {'|'.join(runtime_values)} when provided"
+            )
         if arguments.get("timeout_sec") is not None:
             try:
                 ts = int(arguments.get("timeout_sec"))

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -44,13 +44,21 @@ class SandboxModule(BaseModule):
         return [
             {
                 "name": "sandbox.run",
-                "description": "Execute a run in the code sandbox (Docker/Firecracker/Lima).",
+                "description": "Execute a run in the code sandbox.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "runtime": {
                             "type": "string",
-                            "enum": ["docker", "firecracker", "lima", "vz_linux", "vz_macos", "seatbelt"],
+                            "enum": [
+                                "docker",
+                                "firecracker",
+                                "lima",
+                                "vz_linux",
+                                "vz_macos",
+                                "seatbelt",
+                                "worktree",
+                            ],
                         },
                         "session_id": {"type": "string"},
                         "base_image": {"type": "string"},

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -51,6 +51,10 @@ Trust-level rules:
   `Docs/superpowers/specs/2026-05-02-sandbox-module-roadmap-design.md`.
   It sequences remaining work across API, orchestrator, runtimes, security,
   admin, and CI without treating every runtime as equally mature.
+- The runtime capability inventory lives in
+  `Docs/Sandbox/sandbox-runtime-capability-inventory.md`. It classifies each
+  runtime's current trust, network, lifecycle, recovery, diagnostics, and CI
+  support states without treating host availability as a security guarantee.
 - macOS scaffolding currently includes:
   - a Unix-socket helper client plus protocol models in `macos_virtualization/`
   - frozen helper contract docs in `tools/macos-vz-helper/`

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -857,6 +857,7 @@ class SandboxService:
         vz_linux_preflight = runtime_preflights.get(RuntimeType.vz_linux)
         vz_macos_preflight = runtime_preflights.get(RuntimeType.vz_macos)
         seatbelt_preflight = runtime_preflights.get(RuntimeType.seatbelt)
+        worktree_preflight = runtime_preflights.get(RuntimeType.worktree)
         lima_enforcement_ready = dict((lima_preflight.enforcement_ready if lima_preflight else {}) or {})
         # Allowlist enforcement is not implemented for Lima runtime execution.
         lima_enforcement_ready["allowlist"] = False
@@ -1029,6 +1030,30 @@ class SandboxService:
                 "store_mode": store_mode,
                 "notes": "Host-local seatbelt process isolation for trusted macOS workflows with best-effort deny-all networking; not VM-grade isolation",
                 **_preflight_fields(seatbelt_preflight),
+            },
+            {
+                "name": "worktree",
+                "default_images": ["host-local"],
+                "max_cpu": max_cpu,
+                "max_mem_mb": max_mem_mb,
+                "max_upload_mb": max_upload_mb,
+                "max_log_bytes": max_log_bytes,
+                "max_artifact_file_bytes": max_artifact_file_bytes,
+                "max_artifact_total_bytes": max_artifact_total_bytes,
+                "queue_max_length": queue_max_length,
+                "queue_ttl_sec": queue_ttl_sec,
+                "workspace_cap_mb": workspace_cap_mb,
+                "artifact_ttl_hours": artifact_ttl_hours,
+                "supported_spec_versions": supported_spec_versions,
+                "interactive_supported": False,
+                "egress_allowlist_supported": False,
+                "store_mode": store_mode,
+                "notes": (
+                    "Host-local git worktree isolation for trusted and standard "
+                    "workflows; not VM-grade isolation and not suitable for "
+                    "untrusted workloads"
+                ),
+                **_preflight_fields(worktree_preflight),
             },
         ]
 

--- a/tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py
@@ -5,6 +5,7 @@ import pytest
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import SandboxRunCreateRequest
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.sandbox_module import SandboxModule
+from tldw_Server_API.app.core.Sandbox.models import RuntimeType
 
 
 def test_run_schema_accepts_vz_linux_runtime() -> None:
@@ -49,3 +50,18 @@ async def test_mcp_tool_schema_lists_new_macos_runtimes() -> None:
         "seatbelt",
         "worktree",
     ]
+
+
+def test_mcp_tool_validation_accepts_worktree_runtime() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+
+    module.validate_tool_arguments(
+        "sandbox.run",
+        {
+            "runtime": "worktree",
+            "base_image": "host-local",
+            "command": ["echo", "ok"],
+        },
+    )
+
+    assert module._coerce_runtime("worktree") == RuntimeType.worktree

--- a/tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py
@@ -42,13 +42,7 @@ async def test_mcp_tool_schema_lists_new_macos_runtimes() -> None:
     tool = next(item for item in tools if item["name"] == "sandbox.run")
 
     assert tool["inputSchema"]["properties"]["runtime"]["enum"] == [
-        "docker",
-        "firecracker",
-        "lima",
-        "vz_linux",
-        "vz_macos",
-        "seatbelt",
-        "worktree",
+        runtime.value for runtime in RuntimeType
     ]
 
 

--- a/tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py
@@ -20,6 +20,19 @@ def test_run_schema_accepts_vz_linux_runtime() -> None:
     assert model.runtime == "vz_linux"
 
 
+def test_run_schema_accepts_worktree_runtime() -> None:
+    body = {
+        "spec_version": "1.0",
+        "runtime": "worktree",
+        "base_image": "host-local",
+        "command": ["echo", "ok"],
+    }
+
+    model = SandboxRunCreateRequest.model_validate(body)
+
+    assert model.runtime == "worktree"
+
+
 @pytest.mark.asyncio
 async def test_mcp_tool_schema_lists_new_macos_runtimes() -> None:
     module = SandboxModule(ModuleConfig(name="sandbox"))
@@ -34,4 +47,5 @@ async def test_mcp_tool_schema_lists_new_macos_runtimes() -> None:
         "vz_linux",
         "vz_macos",
         "seatbelt",
+        "worktree",
     ]

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.models import RuntimeType
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def test_feature_discovery_covers_all_core_runtime_types(monkeypatch) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    discovery = SandboxService().feature_discovery()
+
+    discovered = {str(item.get("name")) for item in discovery}
+    assert discovered == {runtime.value for runtime in RuntimeType}
+
+
+def test_worktree_discovery_reports_host_local_limits(monkeypatch) -> None:
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setenv("TLDW_SANDBOX_WORKTREE_AVAILABLE", "1")
+
+    discovery = SandboxService().feature_discovery()
+    worktree = next(item for item in discovery if item["name"] == "worktree")
+
+    assert worktree["supported_trust_levels"] == ["trusted", "standard"]
+    assert worktree["strict_deny_all_supported"] is False
+    assert worktree["strict_allowlist_supported"] is False
+    assert worktree["egress_allowlist_supported"] is False
+    assert worktree["interactive_supported"] is False
+    assert "not VM-grade" in str(worktree["notes"])

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 
 
-def test_feature_discovery_covers_all_core_runtime_types(monkeypatch) -> None:
+def test_feature_discovery_covers_all_core_runtime_types(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
 
     discovery = SandboxService().feature_discovery()
@@ -13,7 +17,9 @@ def test_feature_discovery_covers_all_core_runtime_types(monkeypatch) -> None:
     assert discovered == {runtime.value for runtime in RuntimeType}
 
 
-def test_worktree_discovery_reports_host_local_limits(monkeypatch) -> None:
+def test_worktree_discovery_reports_host_local_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
     monkeypatch.setenv("TLDW_SANDBOX_WORKTREE_AVAILABLE", "1")
 


### PR DESCRIPTION
## Change summary
Human-authored change summary pending.

## What changed
- Added a repo-level sandbox runtime capability inventory covering trust, network, lifecycle, recovery, diagnostics, and CI states.
- Exposed the existing worktree runtime in public runtime discovery, API schema validation, and the MCP sandbox runtime enum.
- Added focused tests that keep runtime discovery aligned with core RuntimeType values and preserve worktree's host-local guarantee boundaries.

## Test Plan
- [x] python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py -q
- [x] python -m py_compile touched Python files
- [x] python -m bandit -r touched Python files -f json -o /tmp/bandit_runtime_capability_inventory.json
- [x] git diff --check