### PR TITLE
refactor(workers): register sidecar jobs pollers

### DIFF
--- a/tldw_Server_API/app/services/startup_sidecar_owned_jobs_pollers.py
+++ b/tldw_Server_API/app/services/startup_sidecar_owned_jobs_pollers.py
@@ -11,6 +11,12 @@ from typing import Any, Callable
 
 from loguru import logger
 
+from tldw_Server_API.app.services.lifecycle_workers import (
+    ManagedWorker,
+    ShutdownPhase,
+    WorkerRegistry,
+)
+
 _STARTUP_GUARD_EXCEPTIONS = (
     AttributeError,
     ImportError,
@@ -43,6 +49,7 @@ async def start_sidecar_owned_jobs_pollers(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     sidecar_mode: bool,
+    worker_inventory: WorkerRegistry | None = None,
 ) -> SidecarOwnedJobsPollerHandles:
     """Start sidecar-gated owned jobs pollers and return their handles."""
 
@@ -51,12 +58,14 @@ async def start_sidecar_owned_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         sidecar_mode=sidecar_mode,
+        worker_inventory=worker_inventory,
     )
     admin_backup_jobs_stop_event, admin_backup_jobs_task = await _start_admin_backup_jobs_worker(
         app=app,
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         sidecar_mode=sidecar_mode,
+        worker_inventory=worker_inventory,
     )
     (
         admin_byok_validation_jobs_stop_event,
@@ -66,6 +75,7 @@ async def start_sidecar_owned_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         sidecar_mode=sidecar_mode,
+        worker_inventory=worker_inventory,
     )
     (
         admin_maintenance_rotation_jobs_stop_event,
@@ -75,12 +85,14 @@ async def start_sidecar_owned_jobs_pollers(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         sidecar_mode=sidecar_mode,
+        worker_inventory=worker_inventory,
     )
     recipe_run_jobs_stop_event, recipe_run_jobs_task = await _start_recipe_run_jobs_worker(
         app=app,
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         sidecar_mode=sidecar_mode,
+        worker_inventory=worker_inventory,
     )
     return SidecarOwnedJobsPollerHandles(
         reminder_jobs_stop_event=reminder_jobs_stop_event,
@@ -106,12 +118,63 @@ async def _resolve_result(result: Any) -> Any:
     return result
 
 
+def _safe_cancel_task(task: Any) -> None:
+    """Best-effort cancel a started worker after startup registration rollback."""
+
+    cancel = getattr(task, "cancel", None)
+    if cancel is None:
+        return
+    try:
+        cancel()
+    except _STARTUP_GUARD_EXCEPTIONS as exc:
+        logger.debug(f"Failed to cancel sidecar-owned Jobs worker during startup rollback: {exc}")
+
+
+def _register_started_jobs_worker(
+    *,
+    app: Any,
+    owned_job_pollers: list[Any],
+    register_owned_job_poller: Callable[..., None],
+    worker_inventory: WorkerRegistry | None,
+    name: str,
+    task: Any,
+    stop_event: Any,
+) -> None:
+    """Register an already-started sidecar-owned jobs poller."""
+
+    if worker_inventory is not None:
+        try:
+            worker_inventory.register(
+                ManagedWorker(
+                    name=name,
+                    task=task,
+                    stop_event=stop_event,
+                    timeout_sec=5.0,
+                    category="jobs",
+                    shutdown_phase=ShutdownPhase.JOB_POLLER_QUIESCE,
+                )
+            )
+        except _STARTUP_GUARD_EXCEPTIONS:
+            _safe_cancel_task(task)
+            raise
+        return
+
+    register_owned_job_poller(
+        app,
+        owned_job_pollers,
+        name=name,
+        task=task,
+        stop_event=stop_event,
+    )
+
+
 async def _start_reminder_jobs_worker(
     *,
     app: Any,
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     sidecar_mode: bool,
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         if sidecar_mode:
@@ -122,9 +185,11 @@ async def _start_reminder_jobs_worker(
         task = await _resolve_result(_start_reminder_jobs_worker_service(stop_event=stop_event))
         if task:
             logger.info("Reminder Jobs worker started")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
+            _register_started_jobs_worker(
+                app=app,
+                owned_job_pollers=owned_job_pollers,
+                register_owned_job_poller=register_owned_job_poller,
+                worker_inventory=worker_inventory,
                 name="reminder_jobs_task",
                 task=task,
                 stop_event=stop_event,
@@ -143,6 +208,7 @@ async def _start_admin_backup_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     sidecar_mode: bool,
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         if sidecar_mode:
@@ -153,9 +219,11 @@ async def _start_admin_backup_jobs_worker(
         task = await _resolve_result(_start_admin_backup_jobs_worker_service(stop_event=stop_event))
         if task:
             logger.info("Admin backup Jobs worker started")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
+            _register_started_jobs_worker(
+                app=app,
+                owned_job_pollers=owned_job_pollers,
+                register_owned_job_poller=register_owned_job_poller,
+                worker_inventory=worker_inventory,
                 name="admin_backup_jobs_task",
                 task=task,
                 stop_event=stop_event,
@@ -174,6 +242,7 @@ async def _start_admin_byok_validation_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     sidecar_mode: bool,
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         if sidecar_mode:
@@ -184,9 +253,11 @@ async def _start_admin_byok_validation_jobs_worker(
         task = await _resolve_result(_start_admin_byok_validation_jobs_worker_service(stop_event=stop_event))
         if task:
             logger.info("Admin BYOK validation Jobs worker started")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
+            _register_started_jobs_worker(
+                app=app,
+                owned_job_pollers=owned_job_pollers,
+                register_owned_job_poller=register_owned_job_poller,
+                worker_inventory=worker_inventory,
                 name="admin_byok_validation_jobs_task",
                 task=task,
                 stop_event=stop_event,
@@ -208,6 +279,7 @@ async def _start_admin_maintenance_rotation_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     sidecar_mode: bool,
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         if sidecar_mode:
@@ -218,9 +290,11 @@ async def _start_admin_maintenance_rotation_jobs_worker(
         task = await _resolve_result(_start_admin_maintenance_rotation_jobs_worker_service(stop_event=stop_event))
         if task:
             logger.info("Admin maintenance rotation Jobs worker started")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
+            _register_started_jobs_worker(
+                app=app,
+                owned_job_pollers=owned_job_pollers,
+                register_owned_job_poller=register_owned_job_poller,
+                worker_inventory=worker_inventory,
                 name="admin_maintenance_rotation_jobs_task",
                 task=task,
                 stop_event=stop_event,
@@ -242,6 +316,7 @@ async def _start_recipe_run_jobs_worker(
     owned_job_pollers: list[Any],
     register_owned_job_poller: Callable[..., None],
     sidecar_mode: bool,
+    worker_inventory: WorkerRegistry | None = None,
 ) -> tuple[Any | None, Any | None]:
     try:
         if sidecar_mode:
@@ -252,9 +327,11 @@ async def _start_recipe_run_jobs_worker(
         task = await _resolve_result(_start_recipe_run_jobs_worker_service(stop_event=stop_event))
         if task:
             logger.info("Evaluation recipe-run Jobs worker started")
-            register_owned_job_poller(
-                app,
-                owned_job_pollers,
+            _register_started_jobs_worker(
+                app=app,
+                owned_job_pollers=owned_job_pollers,
+                register_owned_job_poller=register_owned_job_poller,
+                worker_inventory=worker_inventory,
                 name="recipe_run_jobs_task",
                 task=task,
                 stop_event=stop_event,

--- a/tldw_Server_API/app/services/startup_worker_groups.py
+++ b/tldw_Server_API/app/services/startup_worker_groups.py
@@ -145,6 +145,7 @@ async def start_worker_groups(
         owned_job_pollers=owned_job_pollers,
         register_owned_job_poller=register_owned_job_poller,
         sidecar_mode=sidecar_mode,
+        worker_inventory=worker_inventory,
     )
     notifications_abtest_startup_handles = await _start_notifications_abtest_workers(
         app=app,

--- a/tldw_Server_API/tests/Services/test_startup_sidecar_owned_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_sidecar_owned_jobs_pollers.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Callable
 
 import pytest
-
 
 pytestmark = pytest.mark.unit
 
@@ -21,27 +21,37 @@ async def test_start_sidecar_owned_jobs_pollers_combines_handles_in_order(
     startup_pollers = _import_startup_sidecar_owned_jobs_pollers()
     calls: list[str] = []
 
-    async def _record_reminder(**kwargs):
+    async def _record_reminder(**kwargs: object) -> tuple[str, str]:
+        """Record that the reminder worker starter ran."""
+
         del kwargs
         calls.append("reminder")
         return ("reminder-stop", "reminder-task")
 
-    async def _record_admin_backup(**kwargs):
+    async def _record_admin_backup(**kwargs: object) -> tuple[str, str]:
+        """Record that the admin backup worker starter ran."""
+
         del kwargs
         calls.append("admin-backup")
         return ("admin-backup-stop", "admin-backup-task")
 
-    async def _record_admin_byok(**kwargs):
+    async def _record_admin_byok(**kwargs: object) -> tuple[str, str]:
+        """Record that the admin BYOK worker starter ran."""
+
         del kwargs
         calls.append("admin-byok")
         return ("admin-byok-stop", "admin-byok-task")
 
-    async def _record_admin_maintenance(**kwargs):
+    async def _record_admin_maintenance(**kwargs: object) -> tuple[str, str]:
+        """Record that the admin maintenance worker starter ran."""
+
         del kwargs
         calls.append("admin-maintenance")
         return ("admin-maintenance-stop", "admin-maintenance-task")
 
-    async def _record_recipe(**kwargs):
+    async def _record_recipe(**kwargs: object) -> tuple[str, str]:
+        """Record that the recipe-run worker starter ran."""
+
         del kwargs
         calls.append("recipe")
         return ("recipe-stop", "recipe-task")
@@ -74,6 +84,138 @@ async def test_start_sidecar_owned_jobs_pollers_combines_handles_in_order(
     assert handles.admin_maintenance_rotation_jobs_task == "admin-maintenance-task"
     assert handles.recipe_run_jobs_stop_event == "recipe-stop"
     assert handles.recipe_run_jobs_task == "recipe-task"
+
+
+@pytest.mark.asyncio
+async def test_start_sidecar_owned_jobs_pollers_passes_inventory_to_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_pollers = _import_startup_sidecar_owned_jobs_pollers()
+    worker_inventory = object()
+    captured_kwargs_by_worker: dict[str, dict[str, object]] = {}
+
+    def _record_worker(label: str) -> Callable[..., object]:
+        """Build a starter stub that captures kwargs for one worker label."""
+
+        async def _record(**kwargs: object) -> tuple[str, str]:
+            """Capture worker startup kwargs and return deterministic handles."""
+
+            captured_kwargs_by_worker[label] = kwargs
+            return (f"{label}-stop", f"{label}-task")
+
+        return _record
+
+    monkeypatch.setattr(startup_pollers, "_start_reminder_jobs_worker", _record_worker("reminder"))
+    monkeypatch.setattr(startup_pollers, "_start_admin_backup_jobs_worker", _record_worker("admin-backup"))
+    monkeypatch.setattr(startup_pollers, "_start_admin_byok_validation_jobs_worker", _record_worker("admin-byok"))
+    monkeypatch.setattr(
+        startup_pollers,
+        "_start_admin_maintenance_rotation_jobs_worker",
+        _record_worker("admin-maintenance"),
+    )
+    monkeypatch.setattr(startup_pollers, "_start_recipe_run_jobs_worker", _record_worker("recipe"))
+
+    await startup_pollers.start_sidecar_owned_jobs_pollers(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=lambda *args, **kwargs: None,
+        sidecar_mode=False,
+        worker_inventory=worker_inventory,
+    )
+
+    assert {
+        worker: kwargs["worker_inventory"]
+        for worker, kwargs in captured_kwargs_by_worker.items()
+    } == {
+        "reminder": worker_inventory,
+        "admin-backup": worker_inventory,
+        "admin-byok": worker_inventory,
+        "admin-maintenance": worker_inventory,
+        "recipe": worker_inventory,
+    }
+
+
+@pytest.mark.parametrize(
+    (
+        "starter_name",
+        "registered_name",
+        "service_name",
+    ),
+    [
+        (
+            "_start_reminder_jobs_worker",
+            "reminder_jobs_task",
+            "_start_reminder_jobs_worker_service",
+        ),
+        (
+            "_start_admin_backup_jobs_worker",
+            "admin_backup_jobs_task",
+            "_start_admin_backup_jobs_worker_service",
+        ),
+        (
+            "_start_admin_byok_validation_jobs_worker",
+            "admin_byok_validation_jobs_task",
+            "_start_admin_byok_validation_jobs_worker_service",
+        ),
+        (
+            "_start_admin_maintenance_rotation_jobs_worker",
+            "admin_maintenance_rotation_jobs_task",
+            "_start_admin_maintenance_rotation_jobs_worker_service",
+        ),
+        (
+            "_start_recipe_run_jobs_worker",
+            "recipe_run_jobs_task",
+            "_start_recipe_run_jobs_worker_service",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_sidecar_owned_jobs_worker_registers_with_worker_inventory_when_task_created(
+    monkeypatch: pytest.MonkeyPatch,
+    starter_name: str,
+    registered_name: str,
+    service_name: str,
+) -> None:
+    startup_pollers = _import_startup_sidecar_owned_jobs_pollers()
+    registrations: list[object] = []
+
+    class _FakeWorkerInventory:
+        """Test double that records lifecycle inventory registrations."""
+
+        def register(self, worker: object) -> object:
+            """Capture the registered worker and return it."""
+
+            registrations.append(worker)
+            return worker
+
+    monkeypatch.setattr(startup_pollers, "_make_event", lambda: f"{registered_name}-stop")
+    monkeypatch.setattr(
+        startup_pollers,
+        service_name,
+        lambda *, stop_event: f"{registered_name}-task",
+    )
+
+    def _register_owned_job_poller(*args: object, **kwargs: object) -> None:
+        raise AssertionError("legacy poller registration should not run")
+
+    stop_event, task = await getattr(startup_pollers, starter_name)(
+        app="app",
+        owned_job_pollers=[],
+        register_owned_job_poller=_register_owned_job_poller,
+        sidecar_mode=False,
+        worker_inventory=_FakeWorkerInventory(),
+    )
+
+    assert stop_event == f"{registered_name}-stop"
+    assert task == f"{registered_name}-task"
+    assert len(registrations) == 1
+    worker = registrations[0]
+    assert worker.name == registered_name
+    assert worker.task == f"{registered_name}-task"
+    assert worker.stop_event == f"{registered_name}-stop"
+    assert worker.timeout_sec == 5.0
+    assert worker.category == "jobs"
+    assert worker.shutdown_phase == startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Services/test_startup_sidecar_owned_jobs_pollers.py
+++ b/tldw_Server_API/tests/Services/test_startup_sidecar_owned_jobs_pollers.py
@@ -135,88 +135,39 @@ async def test_start_sidecar_owned_jobs_pollers_passes_inventory_to_workers(
     }
 
 
-@pytest.mark.parametrize(
-    (
-        "starter_name",
-        "registered_name",
-        "service_name",
-    ),
-    [
-        (
-            "_start_reminder_jobs_worker",
-            "reminder_jobs_task",
-            "_start_reminder_jobs_worker_service",
-        ),
-        (
-            "_start_admin_backup_jobs_worker",
-            "admin_backup_jobs_task",
-            "_start_admin_backup_jobs_worker_service",
-        ),
-        (
-            "_start_admin_byok_validation_jobs_worker",
-            "admin_byok_validation_jobs_task",
-            "_start_admin_byok_validation_jobs_worker_service",
-        ),
-        (
-            "_start_admin_maintenance_rotation_jobs_worker",
-            "admin_maintenance_rotation_jobs_task",
-            "_start_admin_maintenance_rotation_jobs_worker_service",
-        ),
-        (
-            "_start_recipe_run_jobs_worker",
-            "recipe_run_jobs_task",
-            "_start_recipe_run_jobs_worker_service",
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_sidecar_owned_jobs_worker_registers_with_worker_inventory_when_task_created(
+`@pytest.mark.asyncio`
+async def test_sidecar_owned_jobs_worker_cancels_task_when_inventory_registration_fails(
     monkeypatch: pytest.MonkeyPatch,
-    starter_name: str,
-    registered_name: str,
-    service_name: str,
 ) -> None:
     startup_pollers = _import_startup_sidecar_owned_jobs_pollers()
-    registrations: list[object] = []
+    cancelled: list[bool] = []
 
-    class _FakeWorkerInventory:
-        """Test double that records lifecycle inventory registrations."""
+    class _FakeTask:
+        def cancel(self) -> None:
+            cancelled.append(True)
 
-        def register(self, worker: object) -> object:
-            """Capture the registered worker and return it."""
+    class _FailingWorkerInventory:
+        def register(self, worker: object) -> None:
+            raise RuntimeError("boom")
 
-            registrations.append(worker)
-            return worker
-
-    monkeypatch.setattr(startup_pollers, "_make_event", lambda: f"{registered_name}-stop")
+    monkeypatch.setattr(startup_pollers, "_make_event", lambda: "reminder-stop")
     monkeypatch.setattr(
         startup_pollers,
-        service_name,
-        lambda *, stop_event: f"{registered_name}-task",
+        "_start_reminder_jobs_worker_service",
+        lambda *, stop_event: _FakeTask(),
     )
 
-    def _register_owned_job_poller(*args: object, **kwargs: object) -> None:
-        raise AssertionError("legacy poller registration should not run")
-
-    stop_event, task = await getattr(startup_pollers, starter_name)(
+    stop_event, task = await startup_pollers._start_reminder_jobs_worker(
         app="app",
         owned_job_pollers=[],
-        register_owned_job_poller=_register_owned_job_poller,
+        register_owned_job_poller=lambda *args, **kwargs: None,
         sidecar_mode=False,
-        worker_inventory=_FakeWorkerInventory(),
+        worker_inventory=_FailingWorkerInventory(),
     )
 
-    assert stop_event == f"{registered_name}-stop"
-    assert task == f"{registered_name}-task"
-    assert len(registrations) == 1
-    worker = registrations[0]
-    assert worker.name == registered_name
-    assert worker.task == f"{registered_name}-task"
-    assert worker.stop_event == f"{registered_name}-stop"
-    assert worker.timeout_sec == 5.0
-    assert worker.category == "jobs"
-    assert worker.shutdown_phase == startup_pollers.ShutdownPhase.JOB_POLLER_QUIESCE
-
+    assert cancelled == [True]
+    assert stop_event is None
+    assert task is None
 
 @pytest.mark.asyncio
 async def test_start_reminder_jobs_worker_skips_in_sidecar_mode(

--- a/tldw_Server_API/tests/Services/test_startup_worker_groups.py
+++ b/tldw_Server_API/tests/Services/test_startup_worker_groups.py
@@ -139,12 +139,17 @@ async def test_start_worker_groups_runs_helpers_in_order_and_returns_handles(
 
     async def _record_sidecar_owned_jobs_pollers(
         *,
-        app,
-        owned_job_pollers,
-        register_owned_job_poller,
-        sidecar_mode,
-    ):
+        app: object,
+        owned_job_pollers: list[object],
+        register_owned_job_poller: object,
+        sidecar_mode: bool,
+        worker_inventory: object | None,
+    ) -> SimpleNamespace:
+        """Record the sidecar-owned jobs startup group call."""
+
+        del app, owned_job_pollers, register_owned_job_poller
         assert sidecar_mode is False
+        assert worker_inventory is worker_inventory_ref
         calls.append("sidecar")
         return SimpleNamespace(
             reminder_jobs_stop_event="reminder-stop",


### PR DESCRIPTION
## Change summary
TODO: human-authored summary required before merge.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_sidecar_owned_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_sidecar_owned_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_worker_bootstrap.py tldw_Server_API/tests/Services/test_startup_tail_finalization.py tldw_Server_API/tests/Services/test_lifespan_startup_sequence.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_shutdown_owned_job_pollers.py tldw_Server_API/tests/Services/test_shutdown_job_poller_handoff.py tldw_Server_API/tests/Services/test_shutdown_reading_study_companion_jobs_workers.py tldw_Server_API/tests/Services/test_shutdown_privilege_snapshot_worker.py tldw_Server_API/tests/Services/test_shutdown_primary_late_stop_workers.py tldw_Server_API/tests/Services/test_shutdown_grouped_late_stop_workers.py tldw_Server_API/tests/Services/test_lifecycle_workers.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m ruff check tldw_Server_API/app/services/startup_sidecar_owned_jobs_pollers.py tldw_Server_API/app/services/startup_worker_groups.py tldw_Server_API/tests/Services/test_startup_sidecar_owned_jobs_pollers.py tldw_Server_API/tests/Services/test_startup_worker_groups.py
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/startup_sidecar_owned_jobs_pollers.py tldw_Server_API/app/services/startup_worker_groups.py -f json -o /tmp/bandit_sidecar_owned_jobs_worker_registry_1114.json
- git diff --check