### PR TITLE
Add VZ Linux observability diagnostics

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -244,6 +244,9 @@ It is admin-only and returns:
 - reconciliation data comparing persisted VZ session rows with live helper VM state
 - image-store correlation showing persisted run manifests, dry-run GC candidate
   classification, and any matching reconciliation/helper VM records
+- read-only observability for `vz_linux` helper stdout/stderr log pointers,
+  per-VM serial log pointers, guest readiness metadata, and helper-provided
+  resource counters when available
 - an additive image-store cleanup plan endpoint and a default-dry-run cleanup
   mutation endpoint for explicit operator action
 - additive `startup_warning_summary` showing whether current-process startup
@@ -259,6 +262,8 @@ is not cluster-wide or persisted across restarts.
 Use the admin endpoint when you are validating host setup or trying to explain why a
 runtime is unavailable. Use `/api/v1/sandbox/runtimes` for client-facing discovery;
 that payload stays summarized and does not expose helper/template internals.
+The diagnostics observability block reports log paths, existence, and byte
+sizes only; it does not read or return log contents.
 
 ACP sandbox session creation now performs runtime preflight validation before calling the sandbox service, and converts failures into `ACPResponseError` instead of leaking raw sandbox exceptions.
 

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -429,17 +429,23 @@ class SandboxAdminMacOSImageStoreDiagnostics(BaseModel):
 
 
 class SandboxAdminMacOSLogPointer(BaseModel):
+    """Read-only pointer to a host log file without exposing file contents."""
+
     path: str | None = None
     exists: bool = False
     size_bytes: int | None = None
 
 
 class SandboxAdminMacOSHelperLogPointers(BaseModel):
+    """Pointers to the managed VZ helper stdout and stderr logs."""
+
     stdout: SandboxAdminMacOSLogPointer
     stderr: SandboxAdminMacOSLogPointer
 
 
 class SandboxAdminMacOSGuestObservability(BaseModel):
+    """Guest-agent readiness metadata reported by the helper for a live VM."""
+
     version: str | None = None
     workspace_root: str | None = None
     capabilities_known: bool | None = None
@@ -447,6 +453,8 @@ class SandboxAdminMacOSGuestObservability(BaseModel):
 
 
 class SandboxAdminMacOSVMObservability(BaseModel):
+    """Per-VM boot-log, guest, and resource diagnostics for VZ Linux."""
+
     vm_id: str
     state: str | None = None
     healthy: bool
@@ -459,6 +467,8 @@ class SandboxAdminMacOSVMObservability(BaseModel):
 
 
 class SandboxAdminMacOSObservabilityDiagnostics(BaseModel):
+    """Aggregated read-only VZ Linux observability block for admin diagnostics."""
+
     configured: bool
     serial_log_dir: str | None = None
     helper_log_dir: str | None = None

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -428,6 +428,47 @@ class SandboxAdminMacOSImageStoreDiagnostics(BaseModel):
     reasons: list[str] = Field(default_factory=list)
 
 
+class SandboxAdminMacOSLogPointer(BaseModel):
+    path: str | None = None
+    exists: bool = False
+    size_bytes: int | None = None
+
+
+class SandboxAdminMacOSHelperLogPointers(BaseModel):
+    stdout: SandboxAdminMacOSLogPointer
+    stderr: SandboxAdminMacOSLogPointer
+
+
+class SandboxAdminMacOSGuestObservability(BaseModel):
+    version: str | None = None
+    workspace_root: str | None = None
+    capabilities_known: bool | None = None
+    capabilities: list[str] = Field(default_factory=list)
+
+
+class SandboxAdminMacOSVMObservability(BaseModel):
+    vm_id: str
+    state: str | None = None
+    healthy: bool
+    run_id: str | None = None
+    session_id: str | None = None
+    session_mode: bool = False
+    serial_log: SandboxAdminMacOSLogPointer
+    guest: SandboxAdminMacOSGuestObservability
+    resource_snapshot: dict[str, int] = Field(default_factory=dict)
+
+
+class SandboxAdminMacOSObservabilityDiagnostics(BaseModel):
+    configured: bool
+    serial_log_dir: str | None = None
+    helper_log_dir: str | None = None
+    helper_log_dir_source: str | None = None
+    helper_logs: SandboxAdminMacOSHelperLogPointers
+    live_vms: int = 0
+    vms: list[SandboxAdminMacOSVMObservability] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+
+
 class SandboxAdminStartupWarningSummary(BaseModel):
     """Compact startup warning summary projected into sandbox diagnostics."""
 
@@ -445,6 +486,7 @@ class SandboxAdminMacOSDiagnosticsResponse(BaseModel):
     runtimes: dict[str, SandboxAdminMacOSRuntimeDiagnostics] = Field(default_factory=dict)
     reconciliation: SandboxAdminMacOSReconciliationDiagnostics | None = None
     image_store: SandboxAdminMacOSImageStoreDiagnostics | None = None
+    observability: SandboxAdminMacOSObservabilityDiagnostics | None = None
     startup_warning_summary: SandboxAdminStartupWarningSummary | None = None
 
 

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -102,6 +102,10 @@ Current limitations:
 - `vz_linux` admin diagnostics now also project an additive
   `startup_warning_summary` field from the app-owned startup warning registry;
   low-level diagnostics collection remains app-agnostic.
+- `vz_linux` admin diagnostics include a read-only `observability` block with
+  helper stdout/stderr log pointers, per-VM serial log pointers, guest readiness
+  details, and helper-provided resource counters when available. Diagnostics
+  report file existence and byte sizes only; they do not read log contents.
 - `vz_linux` repair is explicit and admin-only through `POST /api/v1/sandbox/admin/macos-reconciliation/repair`; diagnostics do not mutate state.
 - `vz_linux` repair defaults to dry-run, skips active sessions, can delete stale or unhealthy inactive persisted session-control rows when requested, and can terminate orphan helper VMs only when `terminate_orphaned_vms=true` is explicitly requested, helper metadata proves `owner=tldw` and `runtime=vz_linux`, and the ownership record remains eligibility-complete. Eligibility-complete means `run_id` and `created_at` are present, and `session_id` is also present when `session_mode=true`.
 - `vz_linux` orphan VM diagnostics split live unreferenced helper VMs into `owned_orphaned_vm`, `unknown_orphaned_vm`, and `foreign_orphaned_vm`. Only ownership-eligible `owned_orphaned_vm` records can be terminated automatically; unknown, foreign, and legacy generic orphan records are reported but skipped by automated repair.
@@ -163,8 +167,9 @@ operator troubleshooting and exposes helper/template readiness details that are 
 included in the public discovery payload, plus reconciliation data for persisted
 `vz_linux` session-control rows versus live helper VM state, and image-store
 correlation for persisted run manifests and dry-run GC candidates. It is
-read-only and now includes a compact `startup_warning_summary` field projected from the
-current-process startup warning registry.
+read-only and now includes helper/serial log observability plus a compact
+`startup_warning_summary` field projected from the current-process startup
+warning registry.
 `/api/v1/admin/startup-warnings` is the generic admin-only companion surface for
 the same startup records and returns full current-process warning items plus
 grouped counts.
@@ -189,6 +194,7 @@ Selected configuration knobs:
   - `SANDBOX_MAX_ARTIFACT_TOTAL_BYTES`
 - macOS scaffolding:
   - `TLDW_SANDBOX_MACOS_HELPER_SOCKET`
+  - `TLDW_SANDBOX_MACOS_HELPER_LOG_DIR`
   - `TLDW_SANDBOX_MACOS_HELPER_READY`
   - `TLDW_SANDBOX_MACOS_HELPER_PATH`
   - `TLDW_SANDBOX_IMAGE_STORE_ROOT`

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -22,6 +22,18 @@ from .vz_reconciliation import collect_vz_reconciliation
 
 _VZ_LINUX_TEMPLATE_MISSING_REASON = "vz_linux_template_missing"
 _VZ_MACOS_TEMPLATE_MISSING_REASON = "macos_template_missing"
+_HELPER_LOG_DIR_ENV = "TLDW_SANDBOX_MACOS_HELPER_LOG_DIR"
+_VZ_LINUX_SERIAL_LOG_DIR_ENV = "TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR"
+_VZ_LINUX_RESOURCE_DETAIL_KEYS = (
+    "cpu_time_sec",
+    "wall_time_sec",
+    "peak_rss_mb",
+    "memory_rss_mb",
+    "disk_read_bytes",
+    "disk_write_bytes",
+    "network_rx_bytes",
+    "network_tx_bytes",
+)
 
 
 def _truthy(value: str | None) -> bool:
@@ -60,6 +72,100 @@ def _remediation_for_reasons(reasons: list[str]) -> str | None:
     if "seatbelt_unavailable" in reasons:
         return "Enable the seatbelt runtime on supported macOS hosts."
     return "Review runtime preflight reasons and host readiness."
+
+
+def _path_from_text(value: str | None) -> Path | None:
+    raw = str(value or "").strip()
+    if not raw or "\x00" in raw:
+        return None
+    try:
+        return Path(raw).expanduser()
+    except (OSError, ValueError):
+        return None
+
+
+def _file_pointer(path: Path | None) -> dict[str, object]:
+    if path is None:
+        return {"path": None, "exists": False, "size_bytes": None}
+    path_text = str(path)
+    try:
+        if not path.is_file():
+            return {"path": path_text, "exists": False, "size_bytes": None}
+        return {"path": path_text, "exists": True, "size_bytes": int(path.stat().st_size)}
+    except (OSError, ValueError):
+        return {"path": path_text, "exists": False, "size_bytes": None}
+
+
+def _sanitize_serial_log_component(value: str) -> str:
+    sanitized = "".join(
+        char if (char.isalnum() or char in "._-") else "_"
+        for char in str(value or "")
+    )
+    return sanitized or "vm"
+
+
+def _serial_log_pointer(vm_id: str, serial_log_dir: Path | None) -> dict[str, object]:
+    if serial_log_dir is None:
+        return _file_pointer(None)
+    return _file_pointer(serial_log_dir / f"{_sanitize_serial_log_component(vm_id)}.serial.log")
+
+
+def _detail_text(details: dict[str, object], key: str) -> str | None:
+    value = details.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _detail_bool(details: dict[str, object], key: str) -> bool | None:
+    value = details.get(key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return None
+
+
+def _detail_csv(details: dict[str, object], key: str) -> list[str]:
+    value = details.get(key)
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return []
+
+
+def _detail_int(details: dict[str, object], key: str) -> int | None:
+    value = details.get(key)
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _guest_observability(details: dict[str, object]) -> dict[str, object]:
+    return {
+        "version": _detail_text(details, "guest_version"),
+        "workspace_root": _detail_text(details, "guest_workspace_root"),
+        "capabilities_known": _detail_bool(details, "guest_capabilities_known"),
+        "capabilities": _detail_csv(details, "guest_capabilities"),
+    }
+
+
+def _resource_snapshot(details: dict[str, object]) -> dict[str, int]:
+    snapshot: dict[str, int] = {}
+    for key in _VZ_LINUX_RESOURCE_DETAIL_KEYS:
+        value = _detail_int(details, key)
+        if value is not None:
+            snapshot[key] = value
+    return snapshot
 
 
 def probe_host() -> dict[str, object]:
@@ -244,6 +350,73 @@ def probe_reconciliation(orchestrator: Any | None = None) -> dict[str, object]:
     return collect_vz_reconciliation(orchestrator)
 
 
+def probe_vz_linux_observability() -> dict[str, object]:
+    """Report read-only helper log pointers and live VM diagnostics."""
+
+    serial_log_dir = _path_from_text(os.getenv(_VZ_LINUX_SERIAL_LOG_DIR_ENV))
+    helper_log_source = "env"
+    helper_log_dir = _path_from_text(os.getenv(_HELPER_LOG_DIR_ENV))
+    if helper_log_dir is None and serial_log_dir is not None and serial_log_dir.name == "serial":
+        helper_log_dir = serial_log_dir.parent
+        helper_log_source = "inferred_from_serial_log_dir"
+    elif helper_log_dir is None:
+        helper_log_dir = Path.home() / "Library" / "Logs" / "tldw" / "macos-vz-helper"
+        helper_log_source = "default"
+
+    helper_logs = {
+        "stdout": _file_pointer(helper_log_dir / "helper.stdout.log"),
+        "stderr": _file_pointer(helper_log_dir / "helper.stderr.log"),
+    }
+    report: dict[str, object] = {
+        "configured": bool(serial_log_dir is not None or helper_log_dir is not None),
+        "serial_log_dir": str(serial_log_dir) if serial_log_dir is not None else None,
+        "helper_log_dir": str(helper_log_dir) if helper_log_dir is not None else None,
+        "helper_log_dir_source": helper_log_source,
+        "helper_logs": helper_logs,
+        "live_vms": 0,
+        "vms": [],
+        "reasons": [],
+    }
+
+    try:
+        live = MacOSVirtualizationHelperClient().list_vms()
+    except MacOSVirtualizationHelperUnavailable:
+        report["reasons"] = ["macos_virtualization_helper_unavailable"]
+        return report
+    except MacOSVirtualizationHelperProtocolError:
+        report["reasons"] = ["macos_virtualization_helper_protocol_mismatch"]
+        return report
+    except Exception:
+        report["reasons"] = ["vz_linux_observability_unavailable"]
+        return report
+
+    vm_items: list[dict[str, object]] = []
+    for vm in list(getattr(live, "vms", None) or []):
+        vm_id = str(getattr(vm, "vm_id", "") or "").strip()
+        if not vm_id:
+            continue
+        metadata = getattr(vm, "metadata", None)
+        details_raw = getattr(vm, "details", None)
+        details = dict(details_raw) if isinstance(details_raw, dict) else {}
+        vm_items.append(
+            {
+                "vm_id": vm_id,
+                "state": str(getattr(vm, "state", "") or "").strip() or None,
+                "healthy": bool(getattr(vm, "healthy", False)),
+                "run_id": str(getattr(metadata, "run_id", "") or "").strip() or None,
+                "session_id": str(getattr(metadata, "session_id", "") or "").strip() or None,
+                "session_mode": bool(getattr(metadata, "session_mode", False)),
+                "serial_log": _serial_log_pointer(vm_id, serial_log_dir),
+                "guest": _guest_observability(details),
+                "resource_snapshot": _resource_snapshot(details),
+            }
+        )
+
+    report["vms"] = sorted(vm_items, key=lambda item: str(item.get("vm_id") or ""))
+    report["live_vms"] = len(vm_items)
+    return report
+
+
 def _image_store_template_item(record: Any) -> dict[str, object]:
     """Return read-only admin diagnostics for one registered image-store template."""
 
@@ -425,6 +598,7 @@ def collect_macos_diagnostics(orchestrator: Any | None = None) -> dict[str, Any]
     runtimes = probe_runtime_statuses(runtime_preflights=runtime_preflights)
     reconciliation = probe_reconciliation(orchestrator)
     image_store = probe_image_store(reconciliation)
+    observability = probe_vz_linux_observability()
     return {
         "host": host,
         "helper": helper,
@@ -432,4 +606,5 @@ def collect_macos_diagnostics(orchestrator: Any | None = None) -> dict[str, Any]
         "runtimes": runtimes,
         "reconciliation": reconciliation,
         "image_store": image_store,
+        "observability": observability,
     }

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -7,21 +7,31 @@ import platform
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
 from tldw_Server_API.app.core.testing import is_truthy
 
 from .image_store import ImageStoreValidationError, SandboxImageStore
 from .macos_virtualization.helper_client import (
     MacOSVirtualizationHelperClient,
+    MacOSVirtualizationHelperFailure,
     MacOSVirtualizationHelperProtocolError,
     MacOSVirtualizationHelperUnavailable,
 )
 from .models import RuntimeType
 from .runners.vz_common import vz_host_facts
 from .runtime_capabilities import RuntimePreflightResult, collect_runtime_preflights
-from .vz_reconciliation import collect_vz_reconciliation
+from .vz_reconciliation import (
+    REASON_HELPER_FAILURE,
+    REASON_HELPER_UNAVAILABLE,
+    REASON_PROTOCOL_MISMATCH,
+    REASON_RECONCILIATION_UNAVAILABLE,
+    collect_vz_reconciliation,
+)
 
 _VZ_LINUX_TEMPLATE_MISSING_REASON = "vz_linux_template_missing"
 _VZ_MACOS_TEMPLATE_MISSING_REASON = "macos_template_missing"
+_VZ_LINUX_OBSERVABILITY_UNAVAILABLE_REASON = "vz_linux_observability_unavailable"
 _HELPER_LOG_DIR_ENV = "TLDW_SANDBOX_MACOS_HELPER_LOG_DIR"
 _VZ_LINUX_SERIAL_LOG_DIR_ENV = "TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR"
 _VZ_LINUX_RESOURCE_DETAIL_KEYS = (
@@ -75,6 +85,8 @@ def _remediation_for_reasons(reasons: list[str]) -> str | None:
 
 
 def _path_from_text(value: str | None) -> Path | None:
+    """Parse operator-provided path text without allowing invalid path payloads to escape."""
+
     raw = str(value or "").strip()
     if not raw or "\x00" in raw:
         return None
@@ -85,6 +97,8 @@ def _path_from_text(value: str | None) -> Path | None:
 
 
 def _file_pointer(path: Path | None) -> dict[str, object]:
+    """Return existence and size metadata for a file without reading file contents."""
+
     if path is None:
         return {"path": None, "exists": False, "size_bytes": None}
     path_text = str(path)
@@ -97,6 +111,8 @@ def _file_pointer(path: Path | None) -> dict[str, object]:
 
 
 def _sanitize_serial_log_component(value: str) -> str:
+    """Convert a helper VM id into the serial-log filename component used by helperctl."""
+
     sanitized = "".join(
         char if (char.isalnum() or char in "._-") else "_"
         for char in str(value or "")
@@ -105,12 +121,16 @@ def _sanitize_serial_log_component(value: str) -> str:
 
 
 def _serial_log_pointer(vm_id: str, serial_log_dir: Path | None) -> dict[str, object]:
+    """Build a read-only serial log pointer for one VM id."""
+
     if serial_log_dir is None:
         return _file_pointer(None)
     return _file_pointer(serial_log_dir / f"{_sanitize_serial_log_component(vm_id)}.serial.log")
 
 
 def _detail_text(details: dict[str, object], key: str) -> str | None:
+    """Extract a non-empty string detail from helper metadata."""
+
     value = details.get(key)
     if value is None:
         return None
@@ -119,6 +139,8 @@ def _detail_text(details: dict[str, object], key: str) -> str | None:
 
 
 def _detail_bool(details: dict[str, object], key: str) -> bool | None:
+    """Coerce helper detail booleans without trusting arbitrary truthy strings."""
+
     value = details.get(key)
     if isinstance(value, bool):
         return value
@@ -132,6 +154,8 @@ def _detail_bool(details: dict[str, object], key: str) -> bool | None:
 
 
 def _detail_csv(details: dict[str, object], key: str) -> list[str]:
+    """Extract a list-like helper detail from either a list or comma-separated string."""
+
     value = details.get(key)
     if isinstance(value, list):
         return [str(item).strip() for item in value if str(item).strip()]
@@ -141,6 +165,8 @@ def _detail_csv(details: dict[str, object], key: str) -> list[str]:
 
 
 def _detail_int(details: dict[str, object], key: str) -> int | None:
+    """Extract an integer helper detail while rejecting booleans."""
+
     value = details.get(key)
     if isinstance(value, bool):
         return None
@@ -151,6 +177,8 @@ def _detail_int(details: dict[str, object], key: str) -> int | None:
 
 
 def _guest_observability(details: dict[str, object]) -> dict[str, object]:
+    """Project helper guest-agent details into the admin observability schema."""
+
     return {
         "version": _detail_text(details, "guest_version"),
         "workspace_root": _detail_text(details, "guest_workspace_root"),
@@ -160,6 +188,8 @@ def _guest_observability(details: dict[str, object]) -> dict[str, object]:
 
 
 def _resource_snapshot(details: dict[str, object]) -> dict[str, int]:
+    """Project allowlisted helper resource counters into diagnostics."""
+
     snapshot: dict[str, int] = {}
     for key in _VZ_LINUX_RESOURCE_DETAIL_KEYS:
         value = _detail_int(details, key)
@@ -344,18 +374,51 @@ def probe_runtime_statuses(
     return statuses
 
 
-def probe_reconciliation(orchestrator: Any | None = None) -> dict[str, object]:
+def _fetch_live_vms_for_diagnostics() -> tuple[Any | None, str | None, str | None]:
+    """Fetch helper VM state once and return reconciliation/observability failure reasons."""
+
+    try:
+        return MacOSVirtualizationHelperClient().list_vms(), None, None
+    except MacOSVirtualizationHelperUnavailable:
+        return None, REASON_HELPER_UNAVAILABLE, REASON_HELPER_UNAVAILABLE
+    except MacOSVirtualizationHelperProtocolError:
+        return None, REASON_PROTOCOL_MISMATCH, REASON_PROTOCOL_MISMATCH
+    except MacOSVirtualizationHelperFailure as exc:
+        logger.debug("VZ helper returned failure while listing VMs for diagnostics: {}", exc.error_code)
+        return None, REASON_HELPER_FAILURE, REASON_HELPER_FAILURE
+    except Exception as exc:
+        logger.debug("Unable to collect VZ helper VM list for diagnostics: {}", exc)
+        return None, REASON_RECONCILIATION_UNAVAILABLE, _VZ_LINUX_OBSERVABILITY_UNAVAILABLE_REASON
+
+
+def probe_reconciliation(
+    orchestrator: Any | None = None,
+    *,
+    live: Any | None = None,
+    live_failure_reason: str | None = None,
+) -> dict[str, object]:
     """Compare persisted VZ session rows with live helper VM state when available."""
 
-    return collect_vz_reconciliation(orchestrator)
+    return collect_vz_reconciliation(
+        orchestrator,
+        live=live,
+        live_failure_reason=live_failure_reason,
+    )
 
 
-def probe_vz_linux_observability() -> dict[str, object]:
+def probe_vz_linux_observability(
+    *,
+    live: Any | None = None,
+    live_failure_reason: str | None = None,
+) -> dict[str, object]:
     """Report read-only helper log pointers and live VM diagnostics."""
 
-    serial_log_dir = _path_from_text(os.getenv(_VZ_LINUX_SERIAL_LOG_DIR_ENV))
+    raw_serial_log_dir = os.getenv(_VZ_LINUX_SERIAL_LOG_DIR_ENV)
+    raw_helper_log_dir = os.getenv(_HELPER_LOG_DIR_ENV)
+    serial_log_dir = _path_from_text(raw_serial_log_dir)
     helper_log_source = "env"
-    helper_log_dir = _path_from_text(os.getenv(_HELPER_LOG_DIR_ENV))
+    helper_log_dir = _path_from_text(raw_helper_log_dir)
+    configured = serial_log_dir is not None or helper_log_dir is not None
     if helper_log_dir is None and serial_log_dir is not None and serial_log_dir.name == "serial":
         helper_log_dir = serial_log_dir.parent
         helper_log_source = "inferred_from_serial_log_dir"
@@ -368,7 +431,7 @@ def probe_vz_linux_observability() -> dict[str, object]:
         "stderr": _file_pointer(helper_log_dir / "helper.stderr.log"),
     }
     report: dict[str, object] = {
-        "configured": bool(serial_log_dir is not None or helper_log_dir is not None),
+        "configured": configured,
         "serial_log_dir": str(serial_log_dir) if serial_log_dir is not None else None,
         "helper_log_dir": str(helper_log_dir) if helper_log_dir is not None else None,
         "helper_log_dir_source": helper_log_source,
@@ -378,17 +441,14 @@ def probe_vz_linux_observability() -> dict[str, object]:
         "reasons": [],
     }
 
-    try:
-        live = MacOSVirtualizationHelperClient().list_vms()
-    except MacOSVirtualizationHelperUnavailable:
-        report["reasons"] = ["macos_virtualization_helper_unavailable"]
+    if live_failure_reason:
+        report["reasons"] = [live_failure_reason]
         return report
-    except MacOSVirtualizationHelperProtocolError:
-        report["reasons"] = ["macos_virtualization_helper_protocol_mismatch"]
-        return report
-    except Exception:
-        report["reasons"] = ["vz_linux_observability_unavailable"]
-        return report
+    if live is None:
+        live, _, observability_failure_reason = _fetch_live_vms_for_diagnostics()
+        if observability_failure_reason:
+            report["reasons"] = [observability_failure_reason]
+            return report
 
     vm_items: list[dict[str, object]] = []
     for vm in list(getattr(live, "vms", None) or []):
@@ -596,9 +656,17 @@ def collect_macos_diagnostics(orchestrator: Any | None = None) -> dict[str, Any]
     templates = probe_templates()
     runtime_preflights = collect_runtime_preflights(network_policy="deny_all")
     runtimes = probe_runtime_statuses(runtime_preflights=runtime_preflights)
-    reconciliation = probe_reconciliation(orchestrator)
+    live, reconciliation_live_failure, observability_live_failure = _fetch_live_vms_for_diagnostics()
+    reconciliation = probe_reconciliation(
+        orchestrator,
+        live=live,
+        live_failure_reason=reconciliation_live_failure,
+    )
     image_store = probe_image_store(reconciliation)
-    observability = probe_vz_linux_observability()
+    observability = probe_vz_linux_observability(
+        live=live,
+        live_failure_reason=observability_live_failure,
+    )
     return {
         "host": host,
         "helper": helper,

--- a/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
+++ b/tldw_Server_API/app/core/Sandbox/vz_reconciliation.py
@@ -151,11 +151,15 @@ def collect_vz_reconciliation(
     *,
     helper_client: Any | None = None,
     active_session_checker: Callable[[str], bool] | None = None,
+    live: Any | None = None,
+    live_failure_reason: str | None = None,
 ) -> dict[str, object]:
     """Compare persisted VZ session-control rows with live helper VM state.
 
     This collector is intentionally read-only: it only lists persisted rows and
     live VMs, then reports mismatches for later explicit repair paths.
+    Callers that already fetched helper VM state can pass ``live`` or
+    ``live_failure_reason`` to avoid duplicate helper RPCs.
     """
 
     report = _empty_report()
@@ -177,23 +181,27 @@ def collect_vz_reconciliation(
 
     report["persisted_sessions"] = len(persisted_rows)
 
-    client = helper_client if helper_client is not None else MacOSVirtualizationHelperClient()
-    try:
-        live = client.list_vms()
-    except MacOSVirtualizationHelperUnavailable:
-        report["reasons"] = [REASON_HELPER_UNAVAILABLE]
+    if live_failure_reason:
+        report["reasons"] = [live_failure_reason]
         return report
-    except MacOSVirtualizationHelperProtocolError:
-        report["reasons"] = [REASON_PROTOCOL_MISMATCH]
-        return report
-    except MacOSVirtualizationHelperFailure as exc:
-        logger.debug("VZ helper returned failure for reconciliation: {}", exc.error_code)
-        report["reasons"] = [REASON_HELPER_FAILURE]
-        return report
-    except Exception as exc:
-        logger.debug("Unable to collect VZ helper VM list for reconciliation: {}", exc)
-        report["reasons"] = [REASON_RECONCILIATION_UNAVAILABLE]
-        return report
+    if live is None:
+        client = helper_client if helper_client is not None else MacOSVirtualizationHelperClient()
+        try:
+            live = client.list_vms()
+        except MacOSVirtualizationHelperUnavailable:
+            report["reasons"] = [REASON_HELPER_UNAVAILABLE]
+            return report
+        except MacOSVirtualizationHelperProtocolError:
+            report["reasons"] = [REASON_PROTOCOL_MISMATCH]
+            return report
+        except MacOSVirtualizationHelperFailure as exc:
+            logger.debug("VZ helper returned failure for reconciliation: {}", exc.error_code)
+            report["reasons"] = [REASON_HELPER_FAILURE]
+            return report
+        except Exception as exc:
+            logger.debug("Unable to collect VZ helper VM list for reconciliation: {}", exc)
+            report["reasons"] = [REASON_RECONCILIATION_UNAVAILABLE]
+            return report
 
     live_vm_by_id = {
         vm_id: vm

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -174,6 +174,7 @@ def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None
         "runtimes",
         "reconciliation",
         "image_store",
+        "observability",
         "startup_warning_summary",
     }
     assert body["host"]["supported"] is True
@@ -186,6 +187,7 @@ def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None
     assert body["reconciliation"]["items"] == []
     assert body["image_store"]["configured"] is False
     assert body["image_store"]["items"] == []
+    assert body["observability"] is None
     assert body["startup_warning_summary"] == {
         "present": True,
         "blocking": False,

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+import pytest
 import tldw_Server_API.app.core.Sandbox.macos_diagnostics as diagnostics_module
 import tldw_Server_API.app.core.Sandbox.vz_reconciliation as reconciliation_module
 from tldw_Server_API.app.core.Sandbox.image_store import SandboxImageStore
 from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
     MacOSVirtualizationHelperProtocolError,
+    MacOSVirtualizationHelperUnavailable,
 )
 from tldw_Server_API.app.core.Sandbox.macos_virtualization.models import (
     HelperPingReply,
@@ -118,6 +121,48 @@ def _sample_diagnostics_payload() -> dict:
                 }
             ],
             "items": [],
+            "reasons": [],
+        },
+        "observability": {
+            "configured": True,
+            "serial_log_dir": "/tmp/vz-serial",
+            "helper_log_dir": "/tmp/helper-logs",
+            "helper_log_dir_source": "env",
+            "helper_logs": {
+                "stdout": {
+                    "path": "/tmp/helper-logs/helper.stdout.log",
+                    "exists": False,
+                    "size_bytes": None,
+                },
+                "stderr": {
+                    "path": "/tmp/helper-logs/helper.stderr.log",
+                    "exists": False,
+                    "size_bytes": None,
+                },
+            },
+            "live_vms": 1,
+            "vms": [
+                {
+                    "vm_id": "vm-live",
+                    "state": "running",
+                    "healthy": True,
+                    "run_id": "run-live",
+                    "session_id": "sess-live",
+                    "session_mode": True,
+                    "serial_log": {
+                        "path": "/tmp/vz-serial/vm-live.serial.log",
+                        "exists": False,
+                        "size_bytes": None,
+                    },
+                    "guest": {
+                        "version": "1.0.0",
+                        "workspace_root": "/workspace",
+                        "capabilities_known": True,
+                        "capabilities": ["exec", "output_cap_v1"],
+                    },
+                    "resource_snapshot": {"cpu_time_sec": 1},
+                }
+            ],
             "reasons": [],
         },
     }
@@ -370,6 +415,11 @@ def test_admin_schema_accepts_macos_diagnostics_payload() -> None:
     assert model.image_store is not None
     assert model.image_store.templates[0].artifact_format == "tldw_bundle"
     assert model.image_store.templates[0].provenance == {"suite": "bookworm"}
+    assert model.observability is not None
+    assert model.observability.live_vms == 1
+    assert model.observability.vms[0].serial_log.path == "/tmp/vz-serial/vm-live.serial.log"
+    assert model.observability.vms[0].guest.capabilities == ["exec", "output_cap_v1"]
+    assert model.observability.vms[0].resource_snapshot == {"cpu_time_sec": 1}
 
 
 def test_admin_schema_accepts_startup_warning_summary() -> None:
@@ -729,3 +779,105 @@ def test_probe_image_store_reports_oci_template_metadata(monkeypatch, tmp_path) 
     assert templates[template_id]["registry"] == "registry.example"
     assert templates[template_id]["imported_at"] == "2026-05-02T00:00:00+00:00"
     assert templates[template_id]["provenance"] == {"suite": "bookworm"}
+
+
+def test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    helper_log_dir = tmp_path / "helper-logs"
+    serial_log_dir = helper_log_dir / "serial"
+    helper_log_dir.mkdir()
+    serial_log_dir.mkdir()
+    (helper_log_dir / "helper.stdout.log").write_bytes(b"helper stdout")
+    (helper_log_dir / "helper.stderr.log").write_bytes(b"helper stderr")
+    (serial_log_dir / "vm_serial_log.serial.log").write_bytes(b"boot log")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_LOG_DIR", str(helper_log_dir))
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR", str(serial_log_dir))
+
+    class _FakeHelper:
+        def list_vms(self):
+            return HelperVMListReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                vms=[
+                    HelperVMStatusReply(
+                        protocol_version="1",
+                        helper_version="0.1.0",
+                        vm_id="vm/serial log",
+                        state="running",
+                        healthy=True,
+                        metadata=HelperVMMetadata(
+                            owner="tldw",
+                            runtime="vz_linux",
+                            run_id="run-live",
+                            session_id="sess-live",
+                            session_mode=True,
+                        ),
+                        details={
+                            "guest_version": "1.0.0",
+                            "guest_workspace_root": "/workspace",
+                            "guest_capabilities_known": "true",
+                            "guest_capabilities": "exec,output_cap_v1",
+                            "cpu_time_sec": "7",
+                            "peak_rss_mb": 128,
+                            "disk_read_bytes": "2048",
+                            "unexpected_detail": "not surfaced",
+                        },
+                    )
+                ],
+            )
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _FakeHelper)
+
+    data = diagnostics_module.probe_vz_linux_observability()
+
+    assert data["configured"] is True
+    assert data["serial_log_dir"] == str(serial_log_dir)
+    assert data["helper_log_dir"] == str(helper_log_dir)
+    assert data["helper_logs"]["stdout"]["path"] == str(helper_log_dir / "helper.stdout.log")
+    assert data["helper_logs"]["stdout"]["exists"] is True
+    assert data["helper_logs"]["stdout"]["size_bytes"] == len(b"helper stdout")
+    assert data["helper_logs"]["stderr"]["path"] == str(helper_log_dir / "helper.stderr.log")
+    assert data["helper_logs"]["stderr"]["exists"] is True
+    assert data["live_vms"] == 1
+    assert data["reasons"] == []
+
+    vm = data["vms"][0]
+    assert vm["vm_id"] == "vm/serial log"
+    assert vm["run_id"] == "run-live"
+    assert vm["session_id"] == "sess-live"
+    assert vm["serial_log"]["path"] == str(serial_log_dir / "vm_serial_log.serial.log")
+    assert vm["serial_log"]["exists"] is True
+    assert vm["serial_log"]["size_bytes"] == len(b"boot log")
+    assert vm["guest"] == {
+        "version": "1.0.0",
+        "workspace_root": "/workspace",
+        "capabilities_known": True,
+        "capabilities": ["exec", "output_cap_v1"],
+    }
+    assert vm["resource_snapshot"] == {
+        "cpu_time_sec": 7,
+        "peak_rss_mb": 128,
+        "disk_read_bytes": 2048,
+    }
+
+
+def test_probe_vz_linux_observability_handles_helper_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _UnavailableHelper:
+        def list_vms(self):
+            raise MacOSVirtualizationHelperUnavailable("helper down")
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _UnavailableHelper)
+
+    data = diagnostics_module.probe_vz_linux_observability()
+
+    assert data["live_vms"] == 0
+    assert data["vms"] == []
+    assert data["reasons"] == ["macos_virtualization_helper_unavailable"]
+
+
+def test_observability_path_parser_rejects_embedded_nul() -> None:
+    assert diagnostics_module._path_from_text("bad\x00path") is None

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -796,7 +796,7 @@ def test_probe_vz_linux_observability_reports_log_pointers_and_vm_resources(
     monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR", str(serial_log_dir))
 
     class _FakeHelper:
-        def list_vms(self):
+        def list_vms(self) -> HelperVMListReply:
             return HelperVMListReply(
                 protocol_version="1",
                 helper_version="0.1.0",
@@ -867,7 +867,7 @@ def test_probe_vz_linux_observability_handles_helper_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _UnavailableHelper:
-        def list_vms(self):
+        def list_vms(self) -> HelperVMListReply:
             raise MacOSVirtualizationHelperUnavailable("helper down")
 
     monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _UnavailableHelper)
@@ -877,6 +877,104 @@ def test_probe_vz_linux_observability_handles_helper_unavailable(
     assert data["live_vms"] == 0
     assert data["vms"] == []
     assert data["reasons"] == ["macos_virtualization_helper_unavailable"]
+
+
+def test_probe_vz_linux_observability_default_log_dir_is_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_LOG_DIR", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_SERIAL_LOG_DIR", raising=False)
+
+    class _FakeHelper:
+        def list_vms(self) -> HelperVMListReply:
+            return HelperVMListReply(protocol_version="1", helper_version="0.1.0", vms=[])
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _FakeHelper)
+
+    data = diagnostics_module.probe_vz_linux_observability()
+
+    assert data["configured"] is False
+    assert data["helper_log_dir_source"] == "default"
+    assert data["live_vms"] == 0
+    assert data["reasons"] == []
+
+
+def test_collect_macos_diagnostics_fetches_live_vms_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_macos_host(monkeypatch)
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE", "/tmp/vz-linux.img")
+
+    class _FakeHelper:
+        list_calls = 0
+
+        def ping(self) -> HelperPingReply:
+            return HelperPingReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                status="ok",
+                details={"transport": "unix"},
+            )
+
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            return {
+                "template_id": "vz_linux:ubuntu-24.04",
+                "source": request["template"],
+                "ready": True,
+                "reasons": [],
+            }
+
+        def list_vms(self) -> HelperVMListReply:
+            _FakeHelper.list_calls += 1
+            return HelperVMListReply(
+                protocol_version="1",
+                helper_version="0.1.0",
+                vms=[
+                    HelperVMStatusReply(
+                        protocol_version="1",
+                        helper_version="0.1.0",
+                        vm_id="vm-live",
+                        state="running",
+                        healthy=True,
+                    )
+                ],
+            )
+
+    class _FakeOrchestrator:
+        def list_vz_session_controls(self) -> list[dict[str, str]]:
+            return [{"id": "sess-live", "vm_id": "vm-live"}]
+
+    monkeypatch.setattr(diagnostics_module, "MacOSVirtualizationHelperClient", _FakeHelper)
+    monkeypatch.setattr(
+        diagnostics_module,
+        "collect_runtime_preflights",
+        lambda network_policy="deny_all": {
+            RuntimeType.vz_linux: RuntimePreflightResult(
+                runtime=RuntimeType.vz_linux,
+                available=True,
+                reasons=[],
+                execution_mode="real",
+            ),
+            RuntimeType.vz_macos: RuntimePreflightResult(
+                runtime=RuntimeType.vz_macos,
+                available=False,
+                reasons=["macos_virtualization_helper_unavailable"],
+                execution_mode="none",
+            ),
+            RuntimeType.seatbelt: RuntimePreflightResult(
+                runtime=RuntimeType.seatbelt,
+                available=False,
+                reasons=["seatbelt_unavailable"],
+                execution_mode="none",
+                supported_trust_levels=["trusted"],
+            ),
+        },
+    )
+
+    data = diagnostics_module.collect_macos_diagnostics(_FakeOrchestrator())
+
+    assert _FakeHelper.list_calls == 1
+    assert data["reconciliation"]["live_vms"] == 1
+    assert data["observability"]["live_vms"] == 1
 
 
 def test_observability_path_parser_rejects_embedded_nul() -> None:


### PR DESCRIPTION
## Summary

- What changed: Adds read-only macOS sandbox diagnostics observability for VZ Linux helper logs, serial logs, live VM guest metadata, helper-provided resource counters, schemas, tests, and operator docs.
- Why: Operators need boot-log/resource pointers in admin diagnostics without reading log contents or mutating host state.

## Change summary

Human-authored change summary required before merge per the AI-generated PR policy.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py`
- [x] `git diff --check HEAD~1..HEAD`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_vz_boot_resource_diagnostics_pr.json`

## UX Audit Checklist (v2 Stage 5)

- [x] Not applicable: no WebUI changes

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable: no Watchlists UI changes

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable: no Watchlists behavior changes

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR to remove the additive diagnostics fields and docs/tests.