### PR TITLE
Add sandbox cleanup contract tests

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -337,6 +337,28 @@ Current diagnostics are mixed-mode:
 - `vz_linux` reports `execution_mode=real` only when the helper-backed path is reachable and the template validates
 - `vz_macos` reports `execution_mode=fake` only when `TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC=1`
 
+## Cleanup Contract Coverage
+
+Portable unit coverage asserts cleanup bookkeeping and temporary-directory
+removal without requiring Docker, `sandbox-exec`, or a real VM host. The
+hostless cleanup contract currently covers:
+
+- Docker container lifecycle paths that create a container and then complete,
+  hit startup timeout, or hit execution timeout; these must remove the container
+  and clear active cancellation/egress bookkeeping.
+- `seatbelt` and `worktree` cancellation paths; these must terminate the active
+  process group, clear active process/run-directory bookkeeping, and remove the
+  per-run directory.
+- `vz_linux` helper-execution failure after VM creation; this must terminate
+  the helper VM, clear active VM/run-directory bookkeeping, and remove the
+  auto-created workspace.
+
+Real Virtualization.framework cleanup remains host-gated. The portable tests do
+not prove that a prepared Apple silicon host releases every VM process,
+virtiofs resource, serial log handle, or helper-side run clone. Operators should
+use the real host smoke below for VM process lifecycle coverage, including
+ephemeral VM teardown and same-session VM reuse.
+
 ## Real Host E2E Smoke
 
 The preferred operator entrypoint for proving real `vz_linux` execution on a

--- a/tldw_Server_API/app/core/Sandbox/network_policy.py
+++ b/tldw_Server_API/app/core/Sandbox/network_policy.py
@@ -20,6 +20,7 @@ _SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS = (
     ValueError,
     subprocess.SubprocessError,
 )
+_IPTABLES_CLEANUP_TIMEOUT_SEC = 5
 
 
 def _truthy(v: str | None) -> bool:
@@ -281,7 +282,11 @@ def delete_rules_by_label(label: str) -> None:
     """
     # Try deletion by line numbers (descending)
     try:
-        out = subprocess.check_output(["iptables", "-L", "DOCKER-USER", "--line-numbers", "-n", "-v"], text=True)
+        out = subprocess.check_output(
+            ["iptables", "-L", "DOCKER-USER", "--line-numbers", "-n", "-v"],
+            text=True,
+            timeout=_IPTABLES_CLEANUP_TIMEOUT_SEC,
+        )
         lines = out.splitlines()
         # Skip header lines, find those with the comment
         numbered: list[int] = []
@@ -294,19 +299,31 @@ def delete_rules_by_label(label: str) -> None:
                     continue
         for num in sorted(numbered, reverse=True):
             with contextlib.suppress(_SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS):
-                subprocess.run(["iptables", "-D", "DOCKER-USER", str(num)], check=False)
+                subprocess.run(
+                    ["iptables", "-D", "DOCKER-USER", str(num)],
+                    check=False,
+                    timeout=_IPTABLES_CLEANUP_TIMEOUT_SEC,
+                )
         return
     except _SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS as e:
         logger.debug("network policy: delete_rules_by_label line-number path failed for {}: {}", label, e)
     # Fallback: translate `iptables -S` specs into deletions
     try:
-        out2 = subprocess.check_output(["iptables", "-S", "DOCKER-USER"], text=True)
+        out2 = subprocess.check_output(
+            ["iptables", "-S", "DOCKER-USER"],
+            text=True,
+            timeout=_IPTABLES_CLEANUP_TIMEOUT_SEC,
+        )
         for line in out2.splitlines():
             if label in line:
                 parts = line.strip().split()
                 if parts and parts[0] in {"-A", "-I"}:
                     parts[0] = "-D"
                     with contextlib.suppress(_SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS):
-                        subprocess.run(["iptables"] + parts, check=False)
+                        subprocess.run(
+                            ["iptables"] + parts,
+                            check=False,
+                            timeout=_IPTABLES_CLEANUP_TIMEOUT_SEC,
+                        )
     except _SANDBOX_NET_POLICY_NONCRITICAL_EXCEPTIONS as e:
         logger.debug("network policy: delete_rules_by_label -S fallback failed for {}: {}", label, e)

--- a/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
@@ -93,27 +93,55 @@ class DockerRunner:
     _egress_label: dict[str, str] = {}
 
     @staticmethod
-    def _cleanup_egress_resources(net: str | None, label: str) -> None:
-        try:
+    def _cleanup_egress_resources(
+        net: str | None,
+        label: str,
+        *,
+        cleanup_rules: bool = True,
+    ) -> None:
+        """Best-effort cleanup for Docker egress state owned by one run.
+
+        `net` is the optional per-run Docker network. `label` identifies
+        iptables rules that may have been installed after container start.
+        Early startup failures pass `cleanup_rules=False` because no iptables
+        rules have been applied yet and cleanup must return promptly.
+        """
+        if cleanup_rules:
             try:
                 delete_rules_by_label(label)
-            except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-                pass
-            if net:
-                with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-                    subprocess.run(["docker", "network", "rm", net], check=False)
-        except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-            pass
+            except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug(
+                    "docker egress rule cleanup failed label={} error={}",
+                    label,
+                    exc,
+                )
+        if net:
+            try:
+                subprocess.run(["docker", "network", "rm", net], check=False, timeout=5)
+            except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug(
+                    "docker egress network cleanup failed net={} label={} error={}",
+                    net,
+                    label,
+                    exc,
+                )
 
     @classmethod
-    def _cleanup_tracked_egress_resources(cls, run_id: str) -> None:
+    def _cleanup_tracked_egress_resources(
+        cls,
+        run_id: str,
+        *,
+        cleanup_rules: bool = True,
+    ) -> None:
+        """Read tracked egress metadata for a run and clean owned resources."""
         with cls._egress_lock:
             net = cls._egress_net.get(run_id)
             label = cls._egress_label.get(run_id, f"tldw-run-{run_id[:12]}")
-        cls._cleanup_egress_resources(net, label)
+        cls._cleanup_egress_resources(net, label, cleanup_rules=cleanup_rules)
 
     @classmethod
     def _clear_run_tracking(cls, run_id: str) -> None:
+        """Remove active container and egress bookkeeping for a finished run."""
         with cls._active_lock:
             cls._active_cid.pop(run_id, None)
         with cls._egress_lock:
@@ -439,8 +467,12 @@ class DockerRunner:
             remaining = max(1, int((deadline - datetime.utcnow()).total_seconds()))
             cid = subprocess.check_output(cmd, text=True, timeout=remaining).strip()
         except FileNotFoundError:
+            self._cleanup_egress_resources(egress_net_name, egress_label, cleanup_rules=False)
+            self._clear_run_tracking(run_id)
             raise RuntimeError("docker binary not found in PATH") from None
         except subprocess.TimeoutExpired:
+            self._cleanup_egress_resources(egress_net_name, egress_label, cleanup_rules=False)
+            self._clear_run_tracking(run_id)
             finished = datetime.utcnow()
             hub.publish_event(run_id, "end", {"exit_code": None, "reason": "startup_timeout"})
             # Usage (no logs/artifacts expected yet)
@@ -468,9 +500,13 @@ class DockerRunner:
                     logger.warning(f"docker create failed with security options; retrying without them: {e}")
                     cmd_wo_sec = [c for c in cmd if c not in security_opts]
                     cid = subprocess.check_output(cmd_wo_sec, text=True).strip()
-                except subprocess.CalledProcessError as e2:
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e2:
+                    self._cleanup_egress_resources(egress_net_name, egress_label, cleanup_rules=False)
+                    self._clear_run_tracking(run_id)
                     raise RuntimeError(f"docker create failed (without security opts): {e2}") from e2
             else:
+                self._cleanup_egress_resources(egress_net_name, egress_label, cleanup_rules=False)
+                self._clear_run_tracking(run_id)
                 raise RuntimeError(f"docker create failed: {e}") from e
 
         # Register container for cancellation
@@ -508,7 +544,7 @@ class DockerRunner:
             # Cleanup container
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
-            self._cleanup_tracked_egress_resources(run_id)
+            self._cleanup_tracked_egress_resources(run_id, cleanup_rules=False)
             self._clear_run_tracking(run_id)
             finished = datetime.utcnow()
             hub.publish_event(run_id, "end", {"exit_code": None, "reason": "startup_timeout"})
@@ -537,7 +573,7 @@ class DockerRunner:
             # Cleanup container
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
-            self._cleanup_tracked_egress_resources(run_id)
+            self._cleanup_tracked_egress_resources(run_id, cleanup_rules=False)
             self._clear_run_tracking(run_id)
             raise RuntimeError(f"docker cp failed: {e}") from e
 
@@ -563,7 +599,7 @@ class DockerRunner:
             # Remove after collecting stats
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
-            self._cleanup_tracked_egress_resources(run_id)
+            self._cleanup_tracked_egress_resources(run_id, cleanup_rules=False)
             self._clear_run_tracking(run_id)
             return RunStatus(
                 id="",
@@ -577,7 +613,7 @@ class DockerRunner:
         except subprocess.CalledProcessError as e:
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
-            self._cleanup_tracked_egress_resources(run_id)
+            self._cleanup_tracked_egress_resources(run_id, cleanup_rules=False)
             self._clear_run_tracking(run_id)
             raise RuntimeError(f"docker start failed: {e}") from e
 

--- a/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/docker_runner.py
@@ -92,6 +92,34 @@ class DockerRunner:
     _egress_net: dict[str, str | None] = {}
     _egress_label: dict[str, str] = {}
 
+    @staticmethod
+    def _cleanup_egress_resources(net: str | None, label: str) -> None:
+        try:
+            try:
+                delete_rules_by_label(label)
+            except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS:
+                pass
+            if net:
+                with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
+                    subprocess.run(["docker", "network", "rm", net], check=False)
+        except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS:
+            pass
+
+    @classmethod
+    def _cleanup_tracked_egress_resources(cls, run_id: str) -> None:
+        with cls._egress_lock:
+            net = cls._egress_net.get(run_id)
+            label = cls._egress_label.get(run_id, f"tldw-run-{run_id[:12]}")
+        cls._cleanup_egress_resources(net, label)
+
+    @classmethod
+    def _clear_run_tracking(cls, run_id: str) -> None:
+        with cls._active_lock:
+            cls._active_cid.pop(run_id, None)
+        with cls._egress_lock:
+            cls._egress_net.pop(run_id, None)
+            cls._egress_label.pop(run_id, None)
+
     @classmethod
     def cancel_run(cls, run_id: str) -> bool:
         with cls._active_lock:
@@ -128,23 +156,9 @@ class DockerRunner:
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.run(["docker", "rm", "-f", cid], check=False)
         finally:
-            with cls._active_lock:
-                cls._active_cid.pop(run_id, None)
-            with cls._egress_lock:
-                cls._egress_net.pop(run_id, None)
-                cls._egress_label.pop(run_id, None)
+            cls._clear_run_tracking(run_id)
         # Cleanup egress rules and network if present
-        try:
-            try:
-                # Use centralized helper to remove iptables rules by label
-                delete_rules_by_label(label)
-            except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-                pass
-            if net:
-                with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-                    subprocess.run(["docker", "network", "rm", net], check=False)
-        except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-            pass
+        cls._cleanup_egress_resources(net, label)
         # Do not publish WS end here; service layer will publish to avoid duplicates
         return True
 
@@ -494,6 +508,8 @@ class DockerRunner:
             # Cleanup container
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
+            self._cleanup_tracked_egress_resources(run_id)
+            self._clear_run_tracking(run_id)
             finished = datetime.utcnow()
             hub.publish_event(run_id, "end", {"exit_code": None, "reason": "startup_timeout"})
             # Attempt a best-effort CPU usage readback from cgroup before removal
@@ -521,6 +537,8 @@ class DockerRunner:
             # Cleanup container
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
+            self._cleanup_tracked_egress_resources(run_id)
+            self._clear_run_tracking(run_id)
             raise RuntimeError(f"docker cp failed: {e}") from e
 
         # Step 3: start container and stream logs
@@ -545,6 +563,8 @@ class DockerRunner:
             # Remove after collecting stats
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
+            self._cleanup_tracked_egress_resources(run_id)
+            self._clear_run_tracking(run_id)
             return RunStatus(
                 id="",
                 phase=RunPhase.timed_out,
@@ -557,6 +577,8 @@ class DockerRunner:
         except subprocess.CalledProcessError as e:
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
+            self._cleanup_tracked_egress_resources(run_id)
+            self._clear_run_tracking(run_id)
             raise RuntimeError(f"docker start failed: {e}") from e
 
         # If granular egress allowlist is enabled, inspect container IP and apply host iptables rules
@@ -747,6 +769,8 @@ class DockerRunner:
             }
             with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 subprocess.check_call(["docker", "rm", "-f", cid])
+            self._cleanup_tracked_egress_resources(run_id)
+            self._clear_run_tracking(run_id)
             return RunStatus(
                 id="",
                 phase=RunPhase.timed_out,
@@ -842,18 +866,9 @@ class DockerRunner:
         with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
             subprocess.check_call(["docker", "rm", "-f", cid])
         # Cleanup per-run network and iptables rules
-        try:
-            if net_policy == "allowlist" and enforced and granular:
-                # Delete iptables rules matching our label
-                with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-                    delete_rules_by_label(egress_label)
-                # Remove dedicated network if we created one
-                if egress_net_name:
-                    with contextlib.suppress(_DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-                        subprocess.run(["docker", "network", "rm", egress_net_name], check=False)
-        except _DOCKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-            # Best-effort cleanup; ignore failures
-            pass
+        if net_policy == "allowlist" and enforced and granular:
+            self._cleanup_tracked_egress_resources(run_id)
+        self._clear_run_tracking(run_id)
         return RunStatus(
             id="",
             phase=phase,

--- a/tldw_Server_API/tests/sandbox/test_network_policy_allowlist.py
+++ b/tldw_Server_API/tests/sandbox/test_network_policy_allowlist.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import subprocess
 from typing import List
 
 import pytest
 
-from tldw_Server_API.app.core.Sandbox.network_policy import expand_allowlist_to_targets, _build_restore_blob
+from tldw_Server_API.app.core.Sandbox.network_policy import (
+    _build_restore_blob,
+    delete_rules_by_label,
+    expand_allowlist_to_targets,
+)
 
 
 def test_expand_allowlist_hostname_and_wildcard_with_fake_resolver():
@@ -40,3 +45,21 @@ def test_build_restore_blob_shapes_rules_with_label():
     assert "-A DOCKER-USER -s 172.18.0.2 -d 1.2.3.0/24 -j ACCEPT" in blob
     assert "-A DOCKER-USER -s 172.18.0.2 -d 9.9.9.9/32 -j ACCEPT" in blob
     assert "-A DOCKER-USER -s 172.18.0.2 -j DROP" in blob
+
+
+def test_delete_rules_by_label_uses_bounded_iptables_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], int | None]] = []
+
+    def fake_check_output(args: list[str], text: bool = False, timeout: int | None = None):
+        del text
+        calls.append((list(args), timeout))
+        raise subprocess.TimeoutExpired(cmd=args, timeout=timeout or 0)
+
+    monkeypatch.setattr("subprocess.check_output", fake_check_output)
+
+    delete_rules_by_label("tldw-run-timeout-test")
+
+    assert calls == [
+        (["iptables", "-L", "DOCKER-USER", "--line-numbers", "-n", "-v"], 5),
+        (["iptables", "-S", "DOCKER-USER"], 5),
+    ]

--- a/tldw_Server_API/tests/sandbox/test_runner_cancel_and_timeouts.py
+++ b/tldw_Server_API/tests/sandbox/test_runner_cancel_and_timeouts.py
@@ -75,6 +75,10 @@ def _stub_docker_resource_probes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(DockerRunner, "_read_cgroup_mem_peak_mb_by_cid", staticmethod(lambda cid: None))
     monkeypatch.setattr(DockerRunner, "_get_mem_usage_mb", staticmethod(lambda cid: 0))
     monkeypatch.setattr(DockerRunner, "_get_cpu_time_sec", staticmethod(lambda cid, started, finished: 0))
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Sandbox.runners.docker_runner.delete_rules_by_label",
+        lambda label: None,
+    )
 
 
 @pytest.mark.unit
@@ -188,6 +192,42 @@ def test_runner_startup_timeout_on_create(monkeypatch: pytest.MonkeyPatch) -> No
     # Ensure WS end has reason=startup_timeout
     frames = list(hub._buffers.get(rid, []))  # type: ignore[attr-defined]
     assert any(f.get("type") == "event" and f.get("event") == "end" and f.get("data", {}).get("reason") == "startup_timeout" for f in frames)
+
+
+@pytest.mark.unit
+def test_runner_startup_timeout_on_create_removes_precreated_egress_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "0")
+    monkeypatch.setenv("SANDBOX_EGRESS_ENFORCEMENT", "true")
+    monkeypatch.setenv("SANDBOX_EGRESS_GRANULAR_ENFORCEMENT", "true")
+    monkeypatch.setattr("tldw_Server_API.app.core.Sandbox.runners.docker_runner.docker_available", lambda: True)
+    _stub_docker_resource_probes(monkeypatch)
+
+    import subprocess
+
+    rid = "run_create_timeout_cleanup"
+    run_calls: list[list[str]] = []
+
+    def _run(args: List[str], check: bool = False, **kwargs: Any):
+        run_calls.append(list(args))
+        return types.SimpleNamespace(returncode=0, stdout="")
+
+    def _raise_timeout(*args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
+        raise subprocess.TimeoutExpired(cmd=args[0] if args else "docker create", timeout=1)
+
+    monkeypatch.setattr("subprocess.run", _run)
+    monkeypatch.setattr("subprocess.check_output", _raise_timeout)
+
+    rs = DockerRunner().start_run(
+        rid,
+        _spec(["python", "-c", "print('x')"], network_policy="allowlist"),
+    )
+
+    assert rs.phase.value == "timed_out"
+    assert rs.message == "startup_timeout"
+    assert ["docker", "network", "rm", f"tldw_sbx_{rid[:12]}"] in run_calls
+    _assert_docker_tracking_cleared(rid)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/sandbox/test_runner_cancel_and_timeouts.py
+++ b/tldw_Server_API/tests/sandbox/test_runner_cancel_and_timeouts.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import os
 import signal
 import types
-from typing import Any, Dict, List, Tuple
+from typing import Any, List
 
 import pytest
 
@@ -13,7 +12,7 @@ from tldw_Server_API.app.core.Sandbox.runners.seatbelt_runner import SeatbeltRun
 from tldw_Server_API.app.core.Sandbox.streams import get_hub
 
 
-def _spec(cmd: List[str]) -> RunSpec:
+def _spec(cmd: List[str], *, network_policy: str = "deny_all") -> RunSpec:
     return RunSpec(
         session_id=None,
         runtime=RuntimeType.docker,
@@ -22,8 +21,60 @@ def _spec(cmd: List[str]) -> RunSpec:
         env={},
         timeout_sec=5,
         startup_timeout_sec=1,
-        network_policy="deny_all",
+        network_policy=network_policy,
     )
+
+
+class _EmptyPipe:
+    def readline(self) -> bytes:
+        return b""
+
+    def peek(self) -> bytes:
+        return b""
+
+
+class _DockerLogsPopen:
+    stdout = _EmptyPipe()
+    stderr = _EmptyPipe()
+
+    def poll(self) -> int:
+        return 0
+
+
+def _clear_docker_tracking(run_id: str) -> None:
+    with DockerRunner._active_lock:  # type: ignore[attr-defined]
+        DockerRunner._active_cid.pop(run_id, None)  # type: ignore[attr-defined]
+    with DockerRunner._egress_lock:  # type: ignore[attr-defined]
+        DockerRunner._egress_net.pop(run_id, None)  # type: ignore[attr-defined]
+        DockerRunner._egress_label.pop(run_id, None)  # type: ignore[attr-defined]
+
+
+def _assert_docker_tracking_cleared(run_id: str) -> None:
+    with DockerRunner._active_lock:  # type: ignore[attr-defined]
+        assert run_id not in DockerRunner._active_cid  # type: ignore[attr-defined]
+    with DockerRunner._egress_lock:  # type: ignore[attr-defined]
+        assert run_id not in DockerRunner._egress_net  # type: ignore[attr-defined]
+        assert run_id not in DockerRunner._egress_label  # type: ignore[attr-defined]
+
+
+def _docker_tracking_present(run_id: str) -> bool:
+    with DockerRunner._active_lock:  # type: ignore[attr-defined]
+        active_present = run_id in DockerRunner._active_cid  # type: ignore[attr-defined]
+    with DockerRunner._egress_lock:  # type: ignore[attr-defined]
+        egress_present = (
+            run_id in DockerRunner._egress_net  # type: ignore[attr-defined]
+            or run_id in DockerRunner._egress_label  # type: ignore[attr-defined]
+        )
+    return active_present or egress_present
+
+
+def _stub_docker_resource_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(DockerRunner, "_docker_version", staticmethod(lambda: "test-docker"))
+    monkeypatch.setattr(DockerRunner, "_resolve_cgroup_cpu_file_by_cid", staticmethod(lambda cid: None))
+    monkeypatch.setattr(DockerRunner, "_read_cgroup_cpu_time_sec_by_cid", staticmethod(lambda cid: None))
+    monkeypatch.setattr(DockerRunner, "_read_cgroup_mem_peak_mb_by_cid", staticmethod(lambda cid: None))
+    monkeypatch.setattr(DockerRunner, "_get_mem_usage_mb", staticmethod(lambda cid: 0))
+    monkeypatch.setattr(DockerRunner, "_get_cpu_time_sec", staticmethod(lambda cid, started, finished: 0))
 
 
 @pytest.mark.unit
@@ -68,6 +119,53 @@ def test_runner_cancel_term_grace_no_duplicate_end(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.unit
+def test_runner_completed_run_clears_active_container_and_egress_maps(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "0")
+    monkeypatch.setattr("tldw_Server_API.app.core.Sandbox.runners.docker_runner.docker_available", lambda: True)
+    _stub_docker_resource_probes(monkeypatch)
+
+    rid = "run_docker_complete_cleanup"
+    cid = "cid-complete"
+    _clear_docker_tracking(rid)
+
+    def _check_output(args: List[str], text: bool = False, timeout: int | None = None, **kwargs: Any):
+        if args[:2] == ["docker", "create"]:
+            return cid
+        if args[:3] == ["docker", "image", "inspect"]:
+            return "sha256:test-image"
+        return ""
+
+    check_calls: list[list[str]] = []
+
+    def _check_call(args: List[str], timeout: int | None = None, **kwargs: Any):
+        check_calls.append(list(args))
+        return 0
+
+    def _run(args: List[str], capture_output: bool = False, text: bool = False, timeout: int | None = None, **kwargs: Any):
+        if args[:2] == ["docker", "wait"]:
+            return types.SimpleNamespace(returncode=0, stdout="0")
+        return types.SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr("subprocess.check_output", _check_output)
+    monkeypatch.setattr("subprocess.check_call", _check_call)
+    monkeypatch.setattr("subprocess.run", _run)
+    monkeypatch.setattr("subprocess.Popen", lambda *args, **kwargs: _DockerLogsPopen())
+
+    try:
+        rs = DockerRunner().start_run(rid, _spec(["python", "-c", "print('x')"]))
+    finally:
+        # Keep this test isolated even while RED exposes a cleanup leak.
+        leaked_before_cleanup = _docker_tracking_present(rid)
+        _clear_docker_tracking(rid)
+
+    assert rs.phase.value == "completed"
+    assert rs.exit_code == 0
+    assert ["docker", "rm", "-f", cid] in check_calls
+    assert not leaked_before_cleanup
+    _assert_docker_tracking_cleared(rid)
+
+
+@pytest.mark.unit
 def test_runner_startup_timeout_on_create(monkeypatch: pytest.MonkeyPatch) -> None:
     # Make docker available and non-fake
     monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "0")
@@ -99,6 +197,8 @@ def test_runner_execution_timeout_on_wait(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr("tldw_Server_API.app.core.Sandbox.runners.docker_runner.docker_available", lambda: True)
 
     # Simulate docker create returns a CID, cp/start succeed, wait times out
+    _stub_docker_resource_probes(monkeypatch)
+
     def _check_output(args: List[str], text: bool = False, timeout: int | None = None):
         if args and args[0] == "docker" and args[1] not in ("image",):
             # docker create returns a CID once
@@ -130,6 +230,61 @@ def test_runner_execution_timeout_on_wait(monkeypatch: pytest.MonkeyPatch) -> No
     assert (rs.message or "") == "execution_timeout"
     frames = list(hub._buffers.get(rid, []))  # type: ignore[attr-defined]
     assert any(f.get("type") == "event" and f.get("event") == "end" and f.get("data", {}).get("reason") == "execution_timeout" for f in frames)
+    leaked_before_cleanup = _docker_tracking_present(rid)
+    _clear_docker_tracking(rid)
+    assert not leaked_before_cleanup
+    _assert_docker_tracking_cleared(rid)
+
+
+@pytest.mark.unit
+def test_runner_startup_timeout_after_container_create_clears_tracking(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "0")
+    monkeypatch.setenv("SANDBOX_EGRESS_ENFORCEMENT", "true")
+    monkeypatch.setenv("SANDBOX_EGRESS_GRANULAR_ENFORCEMENT", "true")
+    monkeypatch.setattr("tldw_Server_API.app.core.Sandbox.runners.docker_runner.docker_available", lambda: True)
+    _stub_docker_resource_probes(monkeypatch)
+
+    import subprocess
+
+    rid = "run_docker_start_timeout_cleanup"
+    cid = "cid-start-timeout"
+    _clear_docker_tracking(rid)
+
+    def _check_output(args: List[str], text: bool = False, timeout: int | None = None):
+        if args[:2] == ["docker", "create"]:
+            return cid
+        return ""
+
+    check_calls: list[list[str]] = []
+
+    def _check_call(args: List[str], timeout: int | None = None):
+        check_calls.append(list(args))
+        if args[:2] == ["docker", "start"]:
+            raise subprocess.TimeoutExpired(cmd=args, timeout=timeout or 1)
+        return 0
+
+    run_calls: list[list[str]] = []
+
+    def _run(args: List[str], check: bool = False, **kwargs: Any):
+        run_calls.append(list(args))
+        return types.SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr("subprocess.check_output", _check_output)
+    monkeypatch.setattr("subprocess.check_call", _check_call)
+    monkeypatch.setattr("subprocess.run", _run)
+
+    rs = DockerRunner().start_run(
+        rid,
+        _spec(["python", "-c", "print('x')"], network_policy="allowlist"),
+    )
+    assert rs.phase.value == "timed_out"
+    assert rs.message == "startup_timeout"
+    assert ["docker", "rm", "-f", cid] in check_calls
+    assert ["docker", "network", "rm", f"tldw_sbx_{rid[:12]}"] in run_calls
+    leaked_before_cleanup = _docker_tracking_present(rid)
+    _clear_docker_tracking(rid)
+    assert not leaked_before_cleanup
+    _assert_docker_tracking_cleared(rid)
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import tldw_Server_API.app.core.Sandbox.runners.vz_common as vz_common
 import tldw_Server_API.app.core.Sandbox.runners.vz_linux_runner as vz_linux_module
@@ -390,6 +391,61 @@ def test_vz_linux_raw_template_path_ignores_unavailable_image_store(monkeypatch,
 
     assert status.phase == RunPhase.completed
     assert calls[0] == ("validate_template", {"runtime": "vz_linux", "template": "/tmp/raw-vz-bundle"})
+
+
+def test_vz_linux_exec_failure_terminates_vm_and_removes_created_workspace(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    calls: list[tuple[str, object]] = []
+    workspaces: list[Path] = []
+
+    class _FakeHelper:
+        def validate_template(self, request: dict[str, object]) -> dict[str, object]:
+            calls.append(("validate_template", dict(request)))
+            return {
+                "template_id": "vz_linux:test-template",
+                "source": "/tmp/raw-vz-bundle",
+                "ready": True,
+                "reasons": [],
+            }
+
+        def create_vm(self, request: dict[str, object]) -> HelperVMReply:
+            calls.append(("create_vm", dict(request)))
+            workspaces.append(Path(str(request["workspace_path"])))
+            return HelperVMReply(vm_id="vm-exec-fails", state="created", details={})
+
+        def exec_guest(self, *, vm_id: str, request: dict[str, object]) -> HelperExecReply:
+            calls.append(("exec_guest", {"vm_id": vm_id, **request}))
+            raise RuntimeError("guest_exec_failed")
+
+        def terminate_vm(self, vm_id: str) -> bool:
+            calls.append(("terminate_vm", vm_id))
+            return True
+
+    monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
+
+    rid = "vz-run-exec-fails-cleanup"
+    status = VZLinuxRunner().start_run(
+        run_id=rid,
+        spec=RunSpec(
+            session_id=None,
+            runtime=RuntimeType.vz_linux,
+            base_image="/tmp/raw-vz-bundle",
+            command=["/bin/echo", "ok"],
+            network_policy="deny_all",
+        ),
+        session_workspace=None,
+    )
+
+    assert status.phase == RunPhase.failed
+    assert "guest_exec_failed" in status.message
+    assert ("terminate_vm", "vm-exec-fails") in calls
+    assert workspaces
+    assert not workspaces[0].exists()
+    with VZLinuxRunner._active_lock:  # type: ignore[attr-defined]
+        assert rid not in VZLinuxRunner._active_vm  # type: ignore[attr-defined]
+        assert rid not in VZLinuxRunner._active_run_dir  # type: ignore[attr-defined]
 
 
 def test_vz_linux_start_run_fails_when_image_store_template_id_has_no_source_path(

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import tldw_Server_API.app.core.Sandbox.runners.vz_common as vz_common
@@ -426,26 +427,33 @@ def test_vz_linux_exec_failure_terminates_vm_and_removes_created_workspace(
     monkeypatch.setattr(vz_linux_module.VZLinuxRunner, "helper_client_cls", _FakeHelper)
 
     rid = "vz-run-exec-fails-cleanup"
-    status = VZLinuxRunner().start_run(
-        run_id=rid,
-        spec=RunSpec(
-            session_id=None,
-            runtime=RuntimeType.vz_linux,
-            base_image="/tmp/raw-vz-bundle",
-            command=["/bin/echo", "ok"],
-            network_policy="deny_all",
-        ),
-        session_workspace=None,
-    )
+    try:
+        status = VZLinuxRunner().start_run(
+            run_id=rid,
+            spec=RunSpec(
+                session_id=None,
+                runtime=RuntimeType.vz_linux,
+                base_image="/tmp/raw-vz-bundle",
+                command=["/bin/echo", "ok"],
+                network_policy="deny_all",
+            ),
+            session_workspace=None,
+        )
 
-    assert status.phase == RunPhase.failed
-    assert "guest_exec_failed" in status.message
-    assert ("terminate_vm", "vm-exec-fails") in calls
-    assert workspaces
-    assert not workspaces[0].exists()
-    with VZLinuxRunner._active_lock:  # type: ignore[attr-defined]
-        assert rid not in VZLinuxRunner._active_vm  # type: ignore[attr-defined]
-        assert rid not in VZLinuxRunner._active_run_dir  # type: ignore[attr-defined]
+        assert status.phase == RunPhase.failed
+        assert "guest_exec_failed" in status.message
+        assert ("terminate_vm", "vm-exec-fails") in calls
+        assert workspaces
+        assert not workspaces[0].exists()
+        with VZLinuxRunner._active_lock:  # type: ignore[attr-defined]
+            assert rid not in VZLinuxRunner._active_vm  # type: ignore[attr-defined]
+            assert rid not in VZLinuxRunner._active_run_dir  # type: ignore[attr-defined]
+    finally:
+        with VZLinuxRunner._active_lock:  # type: ignore[attr-defined]
+            VZLinuxRunner._active_vm.pop(rid, None)  # type: ignore[attr-defined]
+            VZLinuxRunner._active_run_dir.pop(rid, None)  # type: ignore[attr-defined]
+        if workspaces and workspaces[0].exists():
+            shutil.rmtree(workspaces[0], ignore_errors=True)
 
 
 def test_vz_linux_start_run_fails_when_image_store_template_id_has_no_source_path(

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -326,6 +326,8 @@ def test_cancel_run_kills_active_process_group_and_removes_run_dir(
         ok = WorktreeRunner.cancel_run(rid)
     finally:
         with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
+            WorktreeRunner._active_proc.pop(rid, None)  # type: ignore[attr-defined]
+            WorktreeRunner._active_run_dir.pop(rid, None)  # type: ignore[attr-defined]
             WorktreeRunner._cancelled_runs.discard(rid)  # type: ignore[attr-defined]
 
     assert ok is True

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -295,6 +296,44 @@ def test_build_command_wraps_with_unshare_on_linux() -> None:
 def test_cancel_run_returns_false_when_no_proc() -> None:
     """cancel_run returns False when no process is tracked."""
     assert WorktreeRunner.cancel_run("nonexistent-run") is False
+
+
+def test_cancel_run_kills_active_process_group_and_removes_run_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """cancel_run cleans both process tracking and the per-run directory."""
+    rid = "run-worktree-cancel-cleanup"
+    run_dir = tmp_path / "worktree-run-dir"
+    run_dir.mkdir()
+
+    class _FakeProc:
+        pid = 4321
+
+        def wait(self, timeout: int | None = None) -> int:
+            del timeout
+            return 0
+
+    with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
+        WorktreeRunner._active_proc[rid] = _FakeProc()  # type: ignore[attr-defined]
+        WorktreeRunner._active_run_dir[rid] = str(run_dir)  # type: ignore[attr-defined]
+
+    killpg_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr("os.killpg", lambda pid, sig: killpg_calls.append((pid, sig)))
+    monkeypatch.setattr(WorktreeRunner, "_cancel_grace_seconds", classmethod(lambda cls: 0))
+
+    try:
+        ok = WorktreeRunner.cancel_run(rid)
+    finally:
+        with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
+            WorktreeRunner._cancelled_runs.discard(rid)  # type: ignore[attr-defined]
+
+    assert ok is True
+    assert killpg_calls == [(4321, signal.SIGTERM)]
+    assert not run_dir.exists()
+    with WorktreeRunner._active_lock:  # type: ignore[attr-defined]
+        assert rid not in WorktreeRunner._active_proc  # type: ignore[attr-defined]
+        assert rid not in WorktreeRunner._active_run_dir  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add hostless cleanup contract coverage for Docker completion/timeout paths, Worktree cancellation, and VZ Linux helper execution failure cleanup.
- Clear Docker active container and egress bookkeeping after post-create completion and timeout/error paths.
- Document which cleanup guarantees are covered by portable tests versus real Apple silicon host-gated VZ smoke tests.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_runner_cancel_and_timeouts.py tldw_Server_API/tests/sandbox/test_worktree_runner.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runners/docker_runner.py --severity-level medium`
- [x] `git diff --check`

## Change Summary
Human-authored change summary to be added before merge.
