### PR TITLE
Document VZ Linux host-gated CI acceptance policy

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -464,6 +464,10 @@ does not accidentally execute arbitrary feature-branch code on the prepared
 host. External actions in this workflow are pinned to immutable SHAs because
 they execute on the self-hosted runner.
 
+The acceptance policy for when this workflow should run, what counts as an
+expected skip, and what counts as a blocking `vz_linux` regression lives in
+`Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`.
+
 The workflow calls the same operator smoke script documented above:
 
 ```bash

--- a/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
+++ b/Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md
@@ -1,0 +1,157 @@
+# VZ Linux Host-Gated CI Acceptance Policy
+
+**Status:** Active policy for real `vz_linux` Apple silicon CI.
+**Date:** 2026-05-03.
+**Workflow:** `.github/workflows/vz-linux-host-gated.yml`.
+
+## Purpose
+
+Real `vz_linux` execution depends on Apple silicon macOS,
+`Virtualization.framework`, a prepared helper build/signing environment, and a
+canonical Linux bundle on the runner. That cannot be part of normal hosted CI.
+
+This policy defines when the host-gated workflow should run, what it proves,
+which skips are expected, and what counts as a blocking regression.
+
+## Entry Points
+
+The workflow has only two triggers:
+
+| Trigger | Runs when | Intended use |
+| --- | --- | --- |
+| `workflow_dispatch` | A maintainer starts it manually on `main` or `dev`. | Validate a candidate `dev` state or investigate a real-host regression. |
+| `schedule` | The repository variable `TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY=1` is set and the ref is `main` or `dev`. | Nightly prepared-host acceptance coverage. |
+
+The workflow must not run on pull request events or normal pushes. Normal CI
+must remain portable and should continue to exercise fake/scaffolded paths,
+workflow contract tests, and host-independent unit tests.
+
+## Host And Repository Requirements
+
+The runner must be a prepared self-hosted Apple silicon macOS runner with these
+labels:
+
+- `self-hosted`
+- `macOS`
+- `ARM64`
+- `vz-linux`
+
+The runner must provide:
+
+- SwiftPM and Xcode command line tools
+- `codesign` through `xcrun`
+- a canonical `vz_linux` bundle containing `kernel` and `rootfs.img`
+- permission to create private runtime directories, Unix sockets, serial logs,
+  and Virtualization.framework VMs
+
+The workflow needs either the manual input `bundle_path` or repository variable
+`TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH`.
+
+Optional configuration:
+
+- `TLDW_SANDBOX_VZ_HELPER_ENTITLEMENTS_PATH` or manual `entitlements_path`
+- `TLDW_SANDBOX_VZ_HELPER_SKIP_SIGN`
+- `TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY=1` to enable scheduled runs
+
+Manual `skip_sign: false` must override a true repository variable. This keeps
+one-off signing validation possible without changing repository configuration.
+
+## Branch And Action Safety
+
+The job is branch-gated to `refs/heads/main` and `refs/heads/dev`. Manual
+dispatch must not execute arbitrary feature-branch code on the prepared host.
+
+External actions in this workflow must be pinned to immutable SHAs. The
+workflow permissions must remain minimal:
+
+```yaml
+permissions:
+  contents: read
+```
+
+The job should delegate VM work to:
+
+```bash
+tools/vz-linux-image/scripts/run-host-e2e-smoke.sh
+```
+
+That keeps CI aligned with the operator workflow instead of creating a separate
+helper lifecycle path.
+
+## What The Workflow Proves
+
+The host-gated smoke is an acceptance gate for the prepared-host path. It must
+cover:
+
+- prepared Apple silicon host validation
+- helper build and optional signing
+- helper daemon bundle smoke
+- helper startup on a private Unix socket
+- real `vz_linux` ephemeral execution
+- same-session VM reuse with a second command in the same VM
+- helper shutdown/cleanup on exit
+- helper stdout/stderr and serial-log artifact upload
+
+## Expected Skips And Non-Blocking Conditions
+
+These are expected and should not block ordinary PRs:
+
+- workflow absent from pull request checks
+- scheduled workflow skipped because
+  `TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY` is unset or not `1`
+- workflow skipped on refs other than `main` and `dev`
+- normal hosted CI lacking Apple silicon VZ support
+- local developer machines without a prepared bundle/helper environment
+
+A manual run that fails before VM execution because the runner is missing the
+configured bundle path is an operator setup failure, not a sandbox runtime
+regression. Fix the runner or repository variable before treating runtime code
+as suspect.
+
+## Blocking Regression Criteria
+
+A host-gated run is a blocking regression for `vz_linux` when it runs on a
+prepared host and fails one of the accepted runtime guarantees:
+
+- helper cannot build, sign, start, or answer daemon smoke with the documented
+  configuration
+- canonical bundle validation fails for a bundle that previously passed on the
+  same runner
+- real ephemeral command execution fails after helper/template readiness passes
+- same-session VM reuse fails after the first command succeeds
+- cleanup leaves the helper process or accepted socket path behind
+- helper protocol mismatch is introduced without a matching compatibility plan
+- artifacts/logs are not uploaded when the job fails
+
+Failures caused by missing runner labels, absent bundles, unavailable Xcode
+tools, or disabled nightly opt-in are host-preparation failures. They should be
+reported clearly but should not block unrelated code unless the change under
+review modified the host-gated workflow, smoke script, helper lifecycle, or
+bundle contract.
+
+## Artifact And Log Expectations
+
+The workflow must upload helper logs from:
+
+```text
+${{ runner.temp }}/tldw-vz-helper-ci/**
+```
+
+The upload step must run with `if: always()` and `if-no-files-found: ignore` so
+failed early setup still preserves available logs without creating noisy
+secondary failures.
+
+Uploaded logs are for operator debugging. They must not be treated as public API
+output and should not contain secrets or raw user data.
+
+## Maintenance Rules
+
+- Keep this policy aligned with `.github/workflows/vz-linux-host-gated.yml`.
+- Update `tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`
+  when changing workflow triggers, labels, action pins, permissions, artifact
+  paths, or nightly opt-in behavior.
+- Do not add PR or push triggers without a new security review.
+- Do not remove branch gating without replacing it with an equivalent trusted
+  ref policy.
+- Prefer improving `run-host-e2e-smoke.sh` over adding ad hoc workflow-only
+  helper lifecycle logic.

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -149,6 +149,11 @@ Current limitations:
   `TLDW_SANDBOX_MACOS_HELPER_SOCKET=<socket>`, `SANDBOX_ENABLE_EXECUTION=1`,
   and `SANDBOX_BACKGROUND_EXECUTION=0`.
 - Real helper-daemon smoke coverage is opt-in through `tldw_Server_API/tests/sandbox/test_macos_virtualization_helper_daemon_host_gated.py` and requires `TLDW_SANDBOX_MACOS_HELPER_DAEMON_SMOKE=1`.
+- The host-gated CI acceptance policy for real `vz_linux` smoke lives in
+  `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md`. It defines
+  manual/nightly gates, expected skips, artifact upload expectations, branch
+  allowlisting, and blocking regression criteria for prepared Apple silicon
+  runners.
 
 ## Operations And Development
 

--- a/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
+++ b/tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py
@@ -10,6 +10,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "vz-linux-host-gated.yml"
+POLICY_PATH = REPO_ROOT / "Docs" / "Sandbox" / "vz-linux-host-gated-ci-acceptance-policy.md"
 
 
 def _load_workflow() -> dict[str, Any]:
@@ -31,6 +32,7 @@ def test_vz_linux_host_gated_workflow_is_manual_and_nightly() -> None:
     workflow = _load_workflow()
     triggers = _workflow_triggers(workflow)
 
+    assert set(triggers) == {"workflow_dispatch", "schedule"}  # nosec B101
     assert "workflow_dispatch" in triggers  # nosec B101
     assert "schedule" in triggers  # nosec B101
     assert triggers["workflow_dispatch"]["inputs"]["bundle_path"]["required"] is False  # nosec B101
@@ -68,6 +70,15 @@ def test_vz_linux_host_gated_workflow_rejects_untrusted_refs() -> None:
     assert "github.ref" in job["if"]  # nosec B101
 
 
+def test_vz_linux_host_gated_workflow_schedule_requires_repo_opt_in() -> None:
+    """Nightly host-gated runs should require an explicit repository variable."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["vz-linux-host-gated-smoke"]
+
+    assert "github.event_name == 'workflow_dispatch'" in job["if"]  # nosec B101
+    assert "vars.TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY == '1'" in job["if"]  # nosec B101
+
+
 def test_vz_linux_host_gated_workflow_uses_operator_smoke_script() -> None:
     """The workflow should delegate real VM work to the repo's operator smoke script."""
     workflow = _load_workflow()
@@ -89,3 +100,29 @@ def test_vz_linux_host_gated_workflow_pins_external_actions() -> None:
 
     assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" in uses_entries  # nosec B101
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in uses_entries  # nosec B101
+
+
+def test_vz_linux_host_gated_workflow_uses_minimal_permissions_and_uploads_logs() -> None:
+    """Self-hosted VZ runs should use minimal repo permissions and preserve helper logs."""
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["vz-linux-host-gated-smoke"]["steps"]
+    upload_steps = [
+        step
+        for step in steps
+        if str(step.get("uses", "")).startswith("actions/upload-artifact@")
+    ]
+
+    assert workflow["permissions"] == {"contents": "read"}  # nosec B101
+    assert len(upload_steps) == 1  # nosec B101
+    assert upload_steps[0]["if"] == "always()"  # nosec B101
+    assert upload_steps[0]["with"]["if-no-files-found"] == "ignore"  # nosec B101
+    assert "${{ runner.temp }}/tldw-vz-helper-ci/**" in upload_steps[0]["with"]["path"]  # nosec B101
+
+
+def test_vz_linux_host_gated_acceptance_policy_doc_exists_and_references_workflow() -> None:
+    """The host-gated workflow should have an operator-facing acceptance policy."""
+    policy = POLICY_PATH.read_text(encoding="utf-8")
+
+    assert ".github/workflows/vz-linux-host-gated.yml" in policy  # nosec B101
+    assert "TLDW_SANDBOX_VZ_LINUX_HOST_GATED_NIGHTLY" in policy  # nosec B101
+    assert "blocking regression" in policy.lower()  # nosec B101

--- a/tools/vz-linux-image/README.md
+++ b/tools/vz-linux-image/README.md
@@ -231,6 +231,11 @@ repository variable
 set `TLDW_SANDBOX_VZ_LINUX_BUNDLE_PATH` or pass the manual `bundle_path` input
 to point at the canonical bundle on the runner.
 
+See `Docs/Sandbox/vz-linux-host-gated-ci-acceptance-policy.md` for the
+workflow acceptance policy, including manual/nightly gates, expected skips,
+artifact upload expectations, branch allowlisting, and blocking regression
+criteria.
+
 ## Image Store Registration
 
 Canonical bundles can be registered in the sandbox image store for durable local


### PR DESCRIPTION
## Summary
- Add a VZ Linux host-gated CI acceptance policy covering manual/nightly gates, prepared-host requirements, expected skips, artifact/log handling, branch allowlisting, and blocking regression criteria.
- Cross-link the policy from macOS operator notes, the sandbox README, and the VZ Linux image smoke docs.
- Extend workflow contract tests for trigger isolation, nightly opt-in gating, minimal permissions, pinned/log-upload expectations, and policy-doc coverage.

## Change summary
TODO: human-authored summary required before merge.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py -q` -> 9 passed, 5 warnings
- [x] `git diff --check`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tldw_Server_API/tests/Infrastructure/test_vz_linux_host_gated_workflow.py`