### PR TITLE
Phase 4.1: establish coverage ratchet baseline

### DIFF
--- a/.github/workflows/coverage-required.yml
+++ b/.github/workflows/coverage-required.yml
@@ -75,4 +75,4 @@ jobs:
           pytest -q --maxfail=1 --disable-warnings -p pytest_cov -p pytest_asyncio.plugin \
             -m "not jobs and not e2e" \
             tldw_Server_API/tests/unit tldw_Server_API/tests/sanity_tests \
-            --cov=tldw_Server_API --cov-report=xml --cov-report=term-missing --cov-fail-under=4
+            --cov=tldw_Server_API --cov-report=xml --cov-report=term-missing --cov-fail-under=5

--- a/Docs/superpowers/plans/2026-04-25-phase4-1-coverage-ratchet-baseline-plan.md
+++ b/Docs/superpowers/plans/2026-04-25-phase4-1-coverage-ratchet-baseline-plan.md
@@ -34,11 +34,11 @@ Measurement handoff packet:
 
 **Tests:** Existing coverage-required command only.
 
-**Status:** Not Started
+**Status:** Complete - measured 2026-05-03
 
-- [ ] Create a clean worktree from the accepted base.
-- [ ] Activate the virtual environment.
-- [ ] Run the current CI-equivalent command:
+- [x] Create a clean worktree from the accepted base.
+- [x] Activate the virtual environment.
+- [x] Run the current CI-equivalent command:
 
 ```bash
 source .venv/bin/activate
@@ -49,9 +49,9 @@ python3 -m pytest -q --maxfail=1 --disable-warnings -p pytest_cov -p pytest_asyn
   --cov=tldw_Server_API --cov-report=xml --cov-report=term-missing --cov-fail-under=0
 ```
 
-- [ ] Record the coverage percentage.
-- [ ] Record failed or skipped behavior if the command does not complete.
-- [ ] Do not change the CI floor in this stage.
+- [x] Record the coverage percentage.
+- [x] Record failed or skipped behavior if the command does not complete.
+- [x] Do not change the CI floor in this stage.
 
 ## Stage 2: Measure Frontend Baseline
 
@@ -61,17 +61,19 @@ python3 -m pytest -q --maxfail=1 --disable-warnings -p pytest_cov -p pytest_asyn
 
 **Tests:** Existing frontend coverage script.
 
-**Status:** Not Started
+**Status:** Complete with blockers - measured 2026-05-03
 
-- [ ] Run WebUI coverage:
+- [x] Run WebUI coverage:
 
 ```bash
 cd apps/tldw-frontend
 bun run test:coverage
 ```
 
-- [ ] Decide whether `apps/packages/ui` needs a separate coverage script.
-- [ ] Do not merge frontend and backend percentages into a single threshold.
+- [x] Decide whether `apps/packages/ui` needs a separate coverage script.
+- [x] Do not merge frontend and backend percentages into a single threshold.
+
+Result: WebUI coverage required adding `@vitest/coverage-v8@4.0.18`; after that, the full suite exposed broad unrelated frontend failures and eventually hit a Node heap OOM before producing a reliable coverage percentage. Frontend ratcheting remains blocked on separate test-suite stabilization or sharding.
 
 ## Stage 3: Define Ratchet Policy
 
@@ -81,7 +83,7 @@ bun run test:coverage
 
 **Tests:** None.
 
-**Status:** Not Started
+**Status:** Complete - first ratchet recorded 2026-05-03
 
 Recommended policy:
 
@@ -112,12 +114,12 @@ source .venv/bin/activate
 python3 -m pytest tldw_Server_API/tests/CI/test_required_workflow_contracts.py -v
 ```
 
-**Status:** Not Started
+**Status:** Complete - first backend floor update
 
-- [ ] Update `.github/workflows/coverage-required.yml`.
-- [ ] Update `test_coverage_required_uses_documented_global_floor`.
-- [ ] Add a dated note explaining why the new floor is reachable.
-- [ ] Keep threshold-only PRs separate from runtime refactors.
+- [x] Update `.github/workflows/coverage-required.yml`.
+- [x] Update `test_coverage_required_uses_documented_global_floor`.
+- [x] Add a dated note explaining why the new floor is reachable.
+- [x] Keep threshold-only PRs separate from runtime refactors.
 
 ## Stage 5: Prepare 25% Follow-Up
 

--- a/Docs/superpowers/reviews/phase4-parking-lot/2026-05-03-phase4-1-coverage-baseline.md
+++ b/Docs/superpowers/reviews/phase4-parking-lot/2026-05-03-phase4-1-coverage-baseline.md
@@ -1,0 +1,56 @@
+# Phase 4.1 Coverage Baseline - 2026-05-03
+
+## Backend Baseline
+
+- Base at measurement time: `4f2dda1ab2 docs: add sandbox security policy matrix (#1218)`.
+- Python: `Python 3.11.13` from the repo-root virtual environment.
+- Command:
+
+```bash
+PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 TEST_MODE=true DISABLE_HEAVY_STARTUP=1 \
+/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q \
+  --maxfail=1 --disable-warnings -p pytest_cov -p pytest_asyncio.plugin \
+  -m "not jobs and not e2e" \
+  tldw_Server_API/tests/unit tldw_Server_API/tests/sanity_tests \
+  --cov=tldw_Server_API --cov-report=xml --cov-report=term-missing --cov-fail-under=0
+```
+
+- Result: `215 passed, 8 warnings in 66.42s`.
+- Coverage XML summary: `lines-valid=592952`, `lines-covered=37753`, `line-rate=0.06367`.
+- Terminal total: `6%`.
+- Generated artifacts: `.coverage` and `coverage.xml` are produced locally and ignored by git.
+
+## First Ratchet
+
+The measured backend total supports raising the required backend global floor from `4` to `5`.
+This keeps a one-point buffer below the observed `6%` total and avoids any jump toward the Phase 4 target before additional decomposition coverage exists.
+
+The workflow and contract test should move together:
+
+- `.github/workflows/coverage-required.yml`: `--cov-fail-under=5`
+- `tldw_Server_API/tests/CI/test_required_workflow_contracts.py`: expected floor `5`
+
+## Frontend Baseline
+
+- Initial command: `cd apps/tldw-frontend && bun run test:coverage`.
+- Initial blocker: `MISSING DEPENDENCY Cannot find dependency '@vitest/coverage-v8'`.
+- Dependency fix: add `@vitest/coverage-v8@4.0.18` to the WebUI dev dependencies.
+- After dependency install, `bun run test:coverage` started successfully but did not produce a reliable coverage percentage.
+- The full frontend run surfaced broad unrelated failures across existing UI tests, then hit Node heap OOM during the large `CharactersManager` test file and hung during Vitest worker termination.
+- The run was terminated after the OOM with `error: script "test:coverage" exited with code 143`.
+
+Representative frontend blockers observed before termination:
+
+- stale mocks missing exports such as `createWorkspaceStorage`, `useUpdateDeckMutation`, `useAttemptRemediationConversionsQuery`, `useCreateFlashcardTemplateMutation`, and `Trans`
+- router-context failures in tests rendering components that now call `useNavigate` or `Link`
+- snapshot and route-registry drift in media, moderation, repo2txt, watchlists, companion, and family-wizard tests
+- full-suite memory pressure culminating in `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`
+
+No frontend coverage floor should be set from this run. Frontend coverage needs a separate stabilization pass that either fixes the stale test harnesses or introduces a smaller, shardable coverage command before any ratchet.
+
+## Follow-Up
+
+- Re-run the backend coverage-required command after this branch is rebased onto the latest `dev`.
+- Keep frontend coverage separate from backend coverage.
+- Do not use the failed frontend full-suite coverage attempt as a numeric baseline.
+- Consider adding a package-level UI coverage script only after the high-churn shared UI test failures are addressed or sharded.

--- a/Docs/superpowers/reviews/phase4-parking-lot/2026-05-03-phase4-1-coverage-baseline.md
+++ b/Docs/superpowers/reviews/phase4-parking-lot/2026-05-03-phase4-1-coverage-baseline.md
@@ -2,7 +2,8 @@
 
 ## Backend Baseline
 
-- Base at measurement time: `4f2dda1ab2 docs: add sandbox security policy matrix (#1218)`.
+- Base at initial measurement time: `4f2dda1ab2 docs: add sandbox security policy matrix (#1218)`.
+- Post-rebase verification base: `1016a3b056 refactor(flashcards): split import/export tab panels (#1217)`.
 - Python: `Python 3.11.13` from the repo-root virtual environment.
 - Command:
 
@@ -18,6 +19,7 @@ PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 TEST_MODE=true DISABLE_HEAVY_START
 - Result: `215 passed, 8 warnings in 66.42s`.
 - Coverage XML summary: `lines-valid=592952`, `lines-covered=37753`, `line-rate=0.06367`.
 - Terminal total: `6%`.
+- Post-rebase ratchet check with `--cov-fail-under=5`: `215 passed, 8 warnings in 64.91s`; `Required test coverage of 5% reached. Total coverage: 6.37%`.
 - Generated artifacts: `.coverage` and `coverage.xml` are produced locally and ignored by git.
 
 ## First Ratchet
@@ -50,7 +52,6 @@ No frontend coverage floor should be set from this run. Frontend coverage needs 
 
 ## Follow-Up
 
-- Re-run the backend coverage-required command after this branch is rebased onto the latest `dev`.
 - Keep frontend coverage separate from backend coverage.
 - Do not use the failed frontend full-suite coverage attempt as a numeric baseline.
 - Consider adding a package-level UI coverage script only after the high-churn shared UI test failures are addressed or sharded.

--- a/apps/bun.lock
+++ b/apps/bun.lock
@@ -316,6 +316,7 @@
         "@typescript-eslint/eslint-plugin": "^8.50.0",
         "@typescript-eslint/parser": "^8.50.0",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "4.0.18",
         "autoprefixer": "^10.4.23",
         "cross-env": "^7.0.3",
         "eslint": "^9.39.2",
@@ -441,6 +442,8 @@
     "@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
 
     "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.1", "", {}, "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw=="],
 
@@ -1464,6 +1467,8 @@
 
     "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.0.18", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.0.18", "ast-v8-to-istanbul": "^0.3.10", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.1", "obug": "^2.1.1", "std-env": "^3.10.0", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "@vitest/browser": "4.0.18", "vitest": "4.0.18" }, "optionalPeers": ["@vitest/browser"] }, "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg=="],
+
     "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
@@ -1639,6 +1644,8 @@
     "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -2530,6 +2537,12 @@
 
     "isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
     "javascript-natural-sort": ["javascript-natural-sort@0.7.1", "", {}, "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="],
@@ -2693,6 +2706,8 @@
     "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
 
     "make-cancellable-promise": ["make-cancellable-promise@1.3.2", "", {}, "sha512-GCXh3bq/WuMbS+Ky4JBPW1hYTOU+znU+Q5m9Pu+pI8EoUqIHk9+tviOKC6/qhHh8C4/As3tzJ69IF32kdz85ww=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
@@ -3856,6 +3871,8 @@
 
     "@vitejs/plugin-vue/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
+    "@vitest/coverage-v8/magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
     "@vitest/mocker/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
@@ -3879,6 +3896,8 @@
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "archiver-utils/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
@@ -3996,6 +4015,8 @@
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
+    "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
@@ -4011,6 +4032,8 @@
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "lowlight/highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
+    "make-dir/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
@@ -4265,6 +4288,10 @@
     "@vitejs/plugin-vue/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@vitejs/plugin-vue/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "@vitest/coverage-v8/magicast/@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@vitest/coverage-v8/magicast/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@vitest/mocker/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/apps/tldw-frontend/package.json
+++ b/apps/tldw-frontend/package.json
@@ -168,6 +168,7 @@
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "4.0.18",
     "autoprefixer": "^10.4.23",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.0",

--- a/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
@@ -68,7 +68,7 @@ def test_coverage_required_uses_documented_global_floor() -> None:
     workflow = _load(".github/workflows/coverage-required.yml")
     steps = workflow["jobs"]["coverage-required"]["steps"]
     coverage_step = _get_step(steps, "Run global coverage floor")
-    assert "--cov-fail-under=4" in coverage_step["run"]
+    assert "--cov-fail-under=5" in coverage_step["run"]
 
 
 def test_frontend_required_lane_exists() -> None:


### PR DESCRIPTION
## Summary
- records the Phase 4.1 backend coverage baseline and first ratchet rationale
- raises the required backend coverage floor from 4% to 5% with matching workflow-contract coverage
- adds the missing WebUI Vitest v8 coverage provider and documents why frontend coverage cannot yet be ratcheted

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/CI/test_required_workflow_contracts.py -v`
- `bunx vitest run __tests__/frontend-dev-config.test.ts --coverage`
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 TEST_MODE=true DISABLE_HEAVY_STARTUP=1 /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q --maxfail=1 --disable-warnings -p pytest_cov -p pytest_asyncio.plugin -m "not jobs and not e2e" tldw_Server_API/tests/unit tldw_Server_API/tests/sanity_tests --cov=tldw_Server_API --cov-report=xml --cov-report=term-missing --cov-fail-under=5`
- `git diff --check`

## Change summary
TODO(user): Human-authored rationale required before merge.