### PR TITLE
Add flashcard deck hierarchy foundation

### DIFF
--- a/apps/packages/ui/src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx
@@ -92,6 +92,7 @@ describe("useCreateDeckMutation", () => {
       id: 9,
       name: "Biology Basics",
       description: null,
+      parent_deck_id: 4,
       review_prompt_side: "back",
       deleted: false,
       client_id: "test-client",
@@ -111,6 +112,7 @@ describe("useCreateDeckMutation", () => {
       await result.current.mutateAsync({
         name: "  Biology Basics  ",
         description: "  Intro deck  ",
+        parent_deck_id: 4,
         review_prompt_side: "back",
         scheduler_settings: schedulerEnvelope
       })
@@ -119,6 +121,7 @@ describe("useCreateDeckMutation", () => {
     expect(createDeck).toHaveBeenCalledWith({
       name: "Biology Basics",
       description: "Intro deck",
+      parent_deck_id: 4,
       review_prompt_side: "back",
       scheduler_settings: schedulerEnvelope
     })

--- a/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
@@ -33,6 +33,7 @@ import {
   exportFlashcardsFile,
   getFlashcardsImportLimits,
   type Deck,
+  type DeckCreateInput,
   type DeckUpdate,
   type Flashcard,
   type FlashcardTemplateCreate,
@@ -687,17 +688,32 @@ export function useCreateDeckMutation() {
     mutationFn: (params: {
       name: string
       description?: string
+      parent_deck_id?: number | null
       review_prompt_side?: Deck["review_prompt_side"]
       scheduler_type?: Deck["scheduler_type"]
       scheduler_settings?: Deck["scheduler_settings"]
-    }) =>
-      createDeck({
-        name: params.name.trim(),
-        description: params.description?.trim() || undefined,
-        review_prompt_side: params.review_prompt_side,
-        scheduler_type: params.scheduler_type,
-        scheduler_settings: params.scheduler_settings
-      }),
+    }) => {
+      const input: DeckCreateInput = {
+        name: params.name.trim()
+      }
+      const description = params.description?.trim()
+      if (description) {
+        input.description = description
+      }
+      if (params.parent_deck_id !== undefined) {
+        input.parent_deck_id = params.parent_deck_id
+      }
+      if (params.review_prompt_side !== undefined) {
+        input.review_prompt_side = params.review_prompt_side
+      }
+      if (params.scheduler_type !== undefined) {
+        input.scheduler_type = params.scheduler_type
+      }
+      if (params.scheduler_settings !== undefined) {
+        input.scheduler_settings = params.scheduler_settings
+      }
+      return createDeck(input)
+    },
     onSuccess: () => {
       invalidateFlashcardsQueries(qc)
     },

--- a/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ManageTab.tsx
@@ -61,7 +61,10 @@ import { FLASHCARDS_DRAWER_WIDTH_PX } from "../constants"
 import { formatCardType } from "../utils/model-type-labels"
 import { FlashcardQueueStateBadge } from "../utils/queue-state-badges"
 import { getFlashcardSourceMeta } from "../utils/source-reference"
-import { formatDeckDisplayName } from "../utils/deck-display"
+import {
+  formatDeckHierarchyLabel,
+  getDeckDescendantIds
+} from "../utils/deck-display"
 import {
   formatFlashcardsUiErrorMessage,
   mapFlashcardsUiError
@@ -331,10 +334,24 @@ export const ManageTab: React.FC<ManageTabProps> = ({
       if (deckId == null) {
         return t("option:flashcards.noDeck", { defaultValue: "No deck" })
       }
-      return formatDeckDisplayName(deckMap.get(deckId), `Deck ${deckId}`)
+      return formatDeckHierarchyLabel(deckMap.get(deckId), deckMap, `Deck ${deckId}`)
     },
     [deckMap, t]
   )
+  const deckParentOptions = React.useMemo(() => {
+    if (!selectedDeck) {
+      return []
+    }
+    const decks = decksQuery.data || []
+    const blockedDeckIds = getDeckDescendantIds(decks, selectedDeck.id)
+    blockedDeckIds.add(selectedDeck.id)
+    return decks
+      .filter((deck) => !blockedDeckIds.has(deck.id))
+      .map((deck) => ({
+        label: formatDeckHierarchyLabel(deck, deckMap, `Deck ${deck.id}`),
+        value: deck.id
+      }))
+  }, [deckMap, decksQuery.data, selectedDeck])
   const workspaceFilterOptions = React.useMemo(() => {
     const workspaceIds = new Set<string>()
     ;(decksQuery.data || []).forEach((deck) => {
@@ -676,7 +693,8 @@ export const ManageTab: React.FC<ManageTabProps> = ({
   const openDeckScopeEditor = () => {
     if (!selectedDeck) return
     deckScopeForm.setFieldsValue({
-      workspaceId: selectedDeck.workspace_id ?? ""
+      workspaceId: selectedDeck.workspace_id ?? "",
+      parentDeckId: selectedDeck.parent_deck_id ?? undefined
     })
     setDeckScopeOpen(true)
   }
@@ -698,10 +716,12 @@ export const ManageTab: React.FC<ManageTabProps> = ({
     try {
       const values = await deckScopeForm.validateFields()
       const workspaceId = typeof values.workspaceId === "string" ? values.workspaceId.trim() : ""
+      const parentDeckId = typeof values.parentDeckId === "number" ? values.parentDeckId : null
       await updateDeckMutation.mutateAsync({
         deckId: selectedDeck.id,
         update: {
           workspace_id: workspaceId.length > 0 ? workspaceId : null,
+          parent_deck_id: parentDeckId,
           expected_version: selectedDeck.version
         }
       })
@@ -1638,7 +1658,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
               className="min-w-44"
               data-testid="flashcards-manage-deck-select"
               options={(decksQuery.data || []).map((d) => ({
-                label: formatDeckDisplayName(d, `Deck ${d.id}`),
+                label: formatDeckHierarchyLabel(d, deckMap, `Deck ${d.id}`),
                 value: d.id
               }))}
             />
@@ -2460,6 +2480,18 @@ export const ManageTab: React.FC<ManageTabProps> = ({
               })}
             />
           </Form.Item>
+          <Form.Item
+            name="parentDeckId"
+            label={t("option:flashcards.parentDeck", { defaultValue: "Parent deck" })}
+          >
+            <Select<number>
+              allowClear
+              placeholder={t("option:flashcards.topLevelDeck", {
+                defaultValue: "Top-level deck"
+              })}
+              options={deckParentOptions}
+            />
+          </Form.Item>
         </Form>
       </Modal>
 
@@ -2508,7 +2540,7 @@ export const ManageTab: React.FC<ManageTabProps> = ({
           value={moveDeckId ?? undefined}
           onChange={(v) => setMoveDeckId(v ?? null)}
           options={(decksQuery.data || []).map((d) => ({
-            label: d.name,
+            label: formatDeckHierarchyLabel(d, deckMap, `Deck ${d.id}`),
             value: d.id
           }))}
         />

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx
@@ -591,6 +591,7 @@ describe("ManageTab scheduling metadata visibility", () => {
         deckId: 1,
         update: {
           workspace_id: "workspace-77",
+          parent_deck_id: null,
           expected_version: 1
         }
       })

--- a/apps/packages/ui/src/components/Flashcards/utils/__tests__/deck-display.test.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/__tests__/deck-display.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import type { Deck } from "@/services/flashcards"
+import {
+  formatDeckHierarchyLabel,
+  getDeckDescendantIds
+} from "../deck-display"
+import { DEFAULT_SCHEDULER_SETTINGS_ENVELOPE } from "../scheduler-settings"
+
+const makeDeck = (overrides: Partial<Deck> & Pick<Deck, "id" | "name">): Deck => ({
+  description: null,
+  workspace_id: null,
+  parent_deck_id: null,
+  review_prompt_side: "front",
+  deleted: false,
+  client_id: "test",
+  version: 1,
+  created_at: null,
+  last_modified: null,
+  scheduler_type: "sm2_plus",
+  scheduler_settings_json: null,
+  scheduler_settings: DEFAULT_SCHEDULER_SETTINGS_ENVELOPE,
+  ...overrides
+})
+
+describe("deck-display hierarchy helpers", () => {
+  it("formats deck labels with ancestor names and workspace scope", () => {
+    const parent = makeDeck({ id: 1, name: "Languages" })
+    const child = makeDeck({
+      id: 2,
+      name: "Spanish",
+      parent_deck_id: 1,
+      workspace_id: "ws-study"
+    })
+    const deckMap = new Map([
+      [parent.id, parent],
+      [child.id, child]
+    ])
+
+    expect(formatDeckHierarchyLabel(child, deckMap)).toBe("Languages / Spanish · ws-study")
+  })
+
+  it("falls back safely when deck hierarchy data contains a cycle", () => {
+    const first = makeDeck({ id: 1, name: "First", parent_deck_id: 2 })
+    const second = makeDeck({ id: 2, name: "Second", parent_deck_id: 1 })
+    const deckMap = new Map([
+      [first.id, first],
+      [second.id, second]
+    ])
+
+    expect(formatDeckHierarchyLabel(first, deckMap)).toBe("Second / First")
+  })
+
+  it("returns all descendant ids for filtering parent deck options", () => {
+    const decks = [
+      makeDeck({ id: 1, name: "Root" }),
+      makeDeck({ id: 2, name: "Child", parent_deck_id: 1 }),
+      makeDeck({ id: 3, name: "Grandchild", parent_deck_id: 2 }),
+      makeDeck({ id: 4, name: "Sibling", parent_deck_id: 1 }),
+      makeDeck({ id: 5, name: "Other root" })
+    ]
+
+    expect(getDeckDescendantIds(decks, 1)).toEqual(new Set([2, 3, 4]))
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/utils/deck-display.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/deck-display.ts
@@ -1,6 +1,7 @@
 import type { Deck } from "@/services/flashcards"
 
 type DeckLabelInput = Pick<Deck, "name" | "workspace_id"> | null | undefined
+type DeckHierarchyInput = Pick<Deck, "id" | "name" | "workspace_id" | "parent_deck_id"> | null | undefined
 
 export const getDeckWorkspaceId = (deck: DeckLabelInput): string | null => {
   const workspaceId = deck?.workspace_id?.trim()
@@ -14,4 +15,57 @@ export const formatDeckDisplayName = (
   const baseName = deck?.name?.trim() || fallbackName
   const workspaceId = getDeckWorkspaceId(deck)
   return workspaceId ? `${baseName} · ${workspaceId}` : baseName
+}
+
+export const formatDeckHierarchyLabel = (
+  deck: DeckHierarchyInput,
+  deckMap: Map<number, DeckHierarchyInput>,
+  fallbackName = "Untitled deck"
+): string => {
+  if (!deck) {
+    return fallbackName
+  }
+
+  const names: string[] = []
+  const seenDeckIds = new Set<number>()
+  let current: DeckHierarchyInput = deck
+
+  while (current && !seenDeckIds.has(current.id)) {
+    seenDeckIds.add(current.id)
+    names.unshift(current.name?.trim() || `Deck ${current.id}`)
+    const parentDeckId = current.parent_deck_id
+    current = parentDeckId == null ? null : deckMap.get(parentDeckId)
+  }
+
+  const workspaceId = getDeckWorkspaceId(deck)
+  const baseName = names.length > 0 ? names.join(" / ") : fallbackName
+  return workspaceId ? `${baseName} · ${workspaceId}` : baseName
+}
+
+export const getDeckDescendantIds = (
+  decks: DeckHierarchyInput[],
+  rootDeckId: number
+): Set<number> => {
+  const childrenByParentId = new Map<number, number[]>()
+  decks.forEach((deck) => {
+    if (!deck || deck.parent_deck_id == null) {
+      return
+    }
+    const children = childrenByParentId.get(deck.parent_deck_id) ?? []
+    children.push(deck.id)
+    childrenByParentId.set(deck.parent_deck_id, children)
+  })
+
+  const descendants = new Set<number>()
+  const queue = [...(childrenByParentId.get(rootDeckId) ?? [])]
+  while (queue.length > 0) {
+    const deckId = queue.shift()
+    if (deckId == null || descendants.has(deckId) || deckId === rootDeckId) {
+      continue
+    }
+    descendants.add(deckId)
+    queue.push(...(childrenByParentId.get(deckId) ?? []))
+  }
+
+  return descendants
 }

--- a/apps/packages/ui/src/services/flashcards.ts
+++ b/apps/packages/ui/src/services/flashcards.ts
@@ -198,6 +198,7 @@ export type Deck = {
   name: string
   description?: string | null
   workspace_id?: string | null
+  parent_deck_id?: number | null
   review_prompt_side: DeckReviewPromptSide
   deleted: boolean
   client_id: string
@@ -306,6 +307,7 @@ export type DeckUpdate = {
   name?: string | null
   description?: string | null
   workspace_id?: string | null
+  parent_deck_id?: number | null
   review_prompt_side?: DeckReviewPromptSide
   scheduler_type?: DeckSchedulerType | null
   scheduler_settings?: DeckSchedulerSettingsEnvelopeUpdate | null
@@ -316,6 +318,7 @@ export type DeckCreateInput = {
   name: string
   description?: string | null
   workspace_id?: string | null
+  parent_deck_id?: number | null
   review_prompt_side?: DeckReviewPromptSide
   scheduler_type?: DeckSchedulerType | null
   scheduler_settings?: DeckSchedulerSettingsEnvelope | null

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -685,12 +685,14 @@ def create_deck(payload: DeckCreate, db: CharactersRAGDB = Depends(get_chacha_db
         _ensure_workspace_exists(db, payload.workspace_id)
         visibility = payload.visibility if "visibility" in payload.model_fields_set else None
         review_prompt_side = payload.review_prompt_side if "review_prompt_side" in payload.model_fields_set else None
+        parent_deck_id = payload.parent_deck_id if "parent_deck_id" in payload.model_fields_set else ...
         deck_id = db.add_deck(
             payload.name,
             payload.description,
             payload.scheduler_settings.model_dump() if payload.scheduler_settings else None,
             scheduler_type=payload.scheduler_type,
             workspace_id=payload.workspace_id,
+            parent_deck_id=parent_deck_id,
             visibility=visibility,
             review_prompt_side=review_prompt_side,
         )
@@ -704,6 +706,7 @@ def create_deck(payload: DeckCreate, db: CharactersRAGDB = Depends(get_chacha_db
             "name": payload.name,
             "description": payload.description,
             "workspace_id": payload.workspace_id,
+            "parent_deck_id": None if parent_deck_id is ... else parent_deck_id,
             "visibility": visibility or "private",
             "review_prompt_side": payload.review_prompt_side,
             "created_at": None,
@@ -761,6 +764,7 @@ def update_deck(
     review_prompt_side = data.pop("review_prompt_side", None)
     visibility = data.pop("visibility", None)
     workspace_id = data.pop("workspace_id", ...)
+    parent_deck_id = data.pop("parent_deck_id", ...)
     try:
         if workspace_id is not ...:
             _ensure_workspace_exists(db, workspace_id)
@@ -773,6 +777,7 @@ def update_deck(
             scheduler_settings=scheduler_settings,
             scheduler_type=scheduler_type,
             workspace_id=workspace_id,
+            parent_deck_id=parent_deck_id,
             expected_version=expected_version,
         )
         if not ok:

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -110,6 +110,7 @@ class DeckCreate(BaseModel):
     name: str = Field(..., description="Deck name (unique)")
     description: Optional[str] = Field(None, description="Deck description")
     workspace_id: Optional[str] = Field(None, description="Canonical owning workspace ID; null means general scope")
+    parent_deck_id: Optional[int] = Field(None, ge=1, description="Parent deck ID for nested deck hierarchies")
     visibility: DeckVisibility = "private"
     review_prompt_side: DeckReviewPromptSide = "front"
     scheduler_type: DeckSchedulerType = "sm2_plus"
@@ -128,6 +129,7 @@ class DeckUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     workspace_id: Optional[str] = None
+    parent_deck_id: Optional[int] = Field(None, ge=1)
     visibility: Optional[DeckVisibility] = None
     review_prompt_side: Optional[DeckReviewPromptSide] = None
     scheduler_type: Optional[DeckSchedulerType] = None
@@ -156,6 +158,7 @@ class Deck(BaseModel):
     name: str
     description: Optional[str] = None
     workspace_id: Optional[str] = None
+    parent_deck_id: Optional[int] = None
     visibility: DeckVisibility = "private"
     review_prompt_side: DeckReviewPromptSide = "front"
     created_at: Optional[str] = None

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -1469,6 +1469,7 @@ CREATE TABLE IF NOT EXISTS decks(
   id            INTEGER PRIMARY KEY AUTOINCREMENT,
   name          TEXT UNIQUE NOT NULL,
   description   TEXT,
+  parent_deck_id INTEGER REFERENCES decks(id) ON DELETE SET NULL,
   workspace_id  TEXT REFERENCES workspaces(id) ON DELETE SET NULL,
   review_prompt_side TEXT NOT NULL DEFAULT 'front',
   created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1480,6 +1481,7 @@ CREATE TABLE IF NOT EXISTS decks(
 CREATE INDEX IF NOT EXISTS idx_decks_deleted ON decks(deleted);
 CREATE INDEX IF NOT EXISTS idx_decks_last_modified ON decks(last_modified);
 CREATE INDEX IF NOT EXISTS idx_decks_workspace_id ON decks(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_decks_parent_deck_id ON decks(parent_deck_id);
 
 /* Flashcards table - with integer id for FTS external-content */
 CREATE TABLE IF NOT EXISTS flashcards(
@@ -9493,6 +9495,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'create',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'parent_deck_id',NEW.parent_deck_id,
                                      'visibility',NEW.visibility,
                                      'review_prompt_side',NEW.review_prompt_side,
                                      'scheduler_type',NEW.scheduler_type,
@@ -9506,6 +9509,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 WHEN OLD.deleted = NEW.deleted AND (
                      OLD.name IS NOT NEW.name OR
                      OLD.description IS NOT NEW.description OR
+                     OLD.parent_deck_id IS NOT NEW.parent_deck_id OR
                      OLD.visibility IS NOT NEW.visibility OR
                      OLD.review_prompt_side IS NOT NEW.review_prompt_side OR
                      OLD.scheduler_type IS NOT NEW.scheduler_type OR
@@ -9516,6 +9520,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'update',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'parent_deck_id',NEW.parent_deck_id,
                                      'visibility',NEW.visibility,
                                      'review_prompt_side',NEW.review_prompt_side,
                                      'scheduler_type',NEW.scheduler_type,
@@ -9541,6 +9546,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'update',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'parent_deck_id',NEW.parent_deck_id,
                                      'visibility',NEW.visibility,
                                      'review_prompt_side',NEW.review_prompt_side,
                                      'scheduler_type',NEW.scheduler_type,
@@ -9755,6 +9761,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         try:
             if decks_exists:
                 deck_cols = {str(row[1]): row for row in conn.execute("PRAGMA table_info('decks')").fetchall()}
+                if "parent_deck_id" not in deck_cols:
+                    conn.execute(
+                        "ALTER TABLE decks ADD COLUMN parent_deck_id INTEGER REFERENCES decks(id) ON DELETE SET NULL"
+                    )
                 if "scheduler_settings_json" not in deck_cols:
                     conn.execute(
                         f"ALTER TABLE decks ADD COLUMN scheduler_settings_json TEXT NOT NULL DEFAULT '{default_settings_json}'"
@@ -9795,6 +9805,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     """
                 )
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_decks_visibility ON decks(visibility)")
+                conn.execute("CREATE INDEX IF NOT EXISTS idx_decks_parent_deck_id ON decks(parent_deck_id)")
         except sqlite3.Error as exc:
             raise SchemaError(f"Failed ensuring decks review-orientation schema: {exc}") from exc  # noqa: TRY003
 
@@ -10135,6 +10146,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         default_settings_json = scheduler_settings_to_json(None)
         try:
             self.backend.execute(
+                "ALTER TABLE decks ADD COLUMN IF NOT EXISTS parent_deck_id BIGINT REFERENCES decks(id) ON DELETE SET NULL",
+                connection=conn,
+            )
+            self.backend.execute(
                 "ALTER TABLE decks ADD COLUMN IF NOT EXISTS scheduler_settings_json TEXT NOT NULL DEFAULT '{}'",
                 connection=conn,
             )
@@ -10169,6 +10184,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
             self.backend.execute(
                 "CREATE INDEX IF NOT EXISTS idx_decks_visibility ON decks(visibility)",
+                connection=conn,
+            )
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_decks_parent_deck_id ON decks(parent_deck_id)",
                 connection=conn,
             )
             self.backend.execute(
@@ -16804,6 +16823,66 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     # ==========================
     # Flashcards & Decks (V5)
     # ==========================
+    @staticmethod
+    def _normalize_deck_parent_id(parent_deck_id: Any) -> int | None:
+        if parent_deck_id is None:
+            return None
+        if isinstance(parent_deck_id, bool):
+            raise InputError("parent_deck_id must be a positive integer")  # noqa: TRY003
+        try:
+            normalized = int(parent_deck_id)
+        except (TypeError, ValueError) as exc:
+            raise InputError("parent_deck_id must be a positive integer") from exc  # noqa: TRY003
+        if normalized <= 0:
+            raise InputError("parent_deck_id must be a positive integer")  # noqa: TRY003
+        return normalized
+
+    def _validate_deck_parent_locked(
+        self,
+        conn: Any,
+        *,
+        deck_id: int | None,
+        parent_deck_id: Any,
+    ) -> int | None:
+        parent_id = self._normalize_deck_parent_id(parent_deck_id)
+        if parent_id is None:
+            return None
+
+        target_deck_id = int(deck_id) if deck_id is not None else None
+        if target_deck_id is not None and parent_id == target_deck_id:
+            raise InputError("Deck cannot be its own parent")  # noqa: TRY003
+
+        parent_row = self._coerce_mapping_row(
+            conn.execute(
+                "SELECT id, parent_deck_id FROM decks WHERE id = ? AND deleted = 0",
+                (parent_id,),
+            ).fetchone()
+        )
+        if not parent_row:
+            raise InputError("Parent deck not found")  # noqa: TRY003
+
+        if target_deck_id is None:
+            return parent_id
+
+        seen: set[int] = set()
+        current_parent_id: int | None = parent_id
+        while current_parent_id is not None:
+            if current_parent_id == target_deck_id or current_parent_id in seen:
+                raise InputError("Deck parent would create a cycle")  # noqa: TRY003
+            seen.add(current_parent_id)
+            row = self._coerce_mapping_row(
+                conn.execute(
+                    "SELECT parent_deck_id FROM decks WHERE id = ?",
+                    (current_parent_id,),
+                ).fetchone()
+            )
+            if not row:
+                return parent_id
+            raw_parent_id = row.get("parent_deck_id")
+            current_parent_id = None if raw_parent_id is None else self._normalize_deck_parent_id(raw_parent_id)
+
+        return parent_id
+
     def add_deck(
         self,
         name: str,
@@ -16812,6 +16891,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         *,
         scheduler_type: str = "sm2_plus",
         workspace_id: str | None = None,
+        parent_deck_id: Any = ...,
         visibility: str | None = None,
         review_prompt_side: str | None = None,
     ) -> int:
@@ -16829,6 +16909,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         scheduler_settings_json = scheduler_settings_to_json(scheduler_settings)
         try:
             with self.transaction() as conn:
+                parent_for_insert = (
+                    None
+                    if parent_deck_id is ...
+                    else self._validate_deck_parent_locked(
+                        conn,
+                        deck_id=None,
+                        parent_deck_id=parent_deck_id,
+                    )
+                )
                 # Undelete if a deck with the same name exists but is deleted
                 deleted_row = conn.execute(
                     "SELECT id, version FROM decks WHERE name = ? AND deleted = 1",
@@ -16836,33 +16925,45 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 ).fetchone()
                 if deleted_row:
                     deck_id, current_version = int(deleted_row[0]), int(deleted_row[1])
+                    if parent_deck_id is not ...:
+                        self._validate_deck_parent_locked(
+                            conn,
+                            deck_id=deck_id,
+                            parent_deck_id=parent_for_insert,
+                        )
                     next_version = current_version + 1
                     deleted_value = False if self.backend_type == BackendType.POSTGRESQL else 0
+                    set_parts = [
+                        "deleted = ?",
+                        "last_modified = ?",
+                        "version = ?",
+                        "client_id = ?",
+                        "description = COALESCE(?, description)",
+                        "workspace_id = ?",
+                        "visibility = COALESCE(?, visibility)",
+                        "review_prompt_side = COALESCE(?, review_prompt_side)",
+                        "scheduler_type = COALESCE(?, scheduler_type)",
+                        "scheduler_settings_json = COALESCE(?, scheduler_settings_json)",
+                    ]
+                    params: list[Any] = [
+                        deleted_value,
+                        now,
+                        next_version,
+                        self.client_id,
+                        description,
+                        workspace_id,
+                        normalized_visibility,
+                        normalized_prompt_side,
+                        scheduler_type,
+                        scheduler_settings_json,
+                    ]
+                    if parent_deck_id is not ...:
+                        set_parts.append("parent_deck_id = ?")
+                        params.append(parent_for_insert)
+                    params.extend([deck_id, current_version])
                     rc = conn.execute(
-                        (
-                            "UPDATE decks SET deleted = ?, last_modified = ?, version = ?, client_id = ?, "
-                            "description = COALESCE(?, description), "
-                            "workspace_id = ?, "
-                            "visibility = COALESCE(?, visibility), "
-                            "review_prompt_side = COALESCE(?, review_prompt_side), "
-                            "scheduler_type = COALESCE(?, scheduler_type), "
-                            "scheduler_settings_json = COALESCE(?, scheduler_settings_json) "
-                            "WHERE id = ? AND version = ?"
-                        ),
-                        (
-                            deleted_value,
-                            now,
-                            next_version,
-                            self.client_id,
-                            description,
-                            workspace_id,
-                            normalized_visibility,
-                            normalized_prompt_side,
-                            scheduler_type,
-                            scheduler_settings_json,
-                            deck_id,
-                            current_version,
-                        ),
+                        f"UPDATE decks SET {', '.join(set_parts)} WHERE id = ? AND version = ?",  # nosec B608
+                        tuple(params),
                     ).rowcount
                     if rc == 0:
                         raise ConflictError(  # noqa: TRY003
@@ -16873,12 +16974,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     return deck_id
                 insert_sql = (
                     "INSERT INTO decks("
-                    "name, description, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, client_id, version, deleted"
-                    ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                    "name, description, parent_deck_id, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, client_id, version, deleted"
+                    ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
                 )
                 params = (
                     name,
                     description,
+                    parent_for_insert,
                     workspace_id,
                     visibility_for_insert,
                     prompt_side_for_insert,
@@ -16924,7 +17026,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     ) -> list[dict[str, Any]]:
         if shared_with_user_id is not None:
             query = (
-                "SELECT d.id, d.name, d.description, d.workspace_id, d.visibility, d.review_prompt_side, "
+                "SELECT d.id, d.name, d.description, d.parent_deck_id, d.workspace_id, d.visibility, d.review_prompt_side, "
                 "d.scheduler_settings_json, d.scheduler_type, d.created_at, d.last_modified, "
                 "d.deleted, d.client_id, d.version FROM decks d "
                 "JOIN deck_shares ds ON ds.deck_id = d.id "
@@ -16948,7 +17050,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 raise
 
         select_sql = (
-            "SELECT id, name, description, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, "
+            "SELECT id, name, description, parent_deck_id, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, "
             "deleted, client_id, version FROM decks "
         )
         if include_deleted:
@@ -16980,7 +17082,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def get_deck(self, deck_id: int) -> dict[str, Any] | None:
         """Fetch a single deck row by id."""
         query = (
-            "SELECT id, name, description, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, deleted, client_id, version "
+            "SELECT id, name, description, parent_deck_id, workspace_id, visibility, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, last_modified, deleted, client_id, version "
             "FROM decks WHERE id = ?"
         )
         try:
@@ -16994,13 +17096,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         """Fetch one deck row by name using the repository-wide unique-name invariant."""
         if include_deleted:
             query = (
-                "SELECT id, name, description, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, "
+                "SELECT id, name, description, parent_deck_id, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, "
                 "last_modified, deleted, client_id, version, visibility FROM decks WHERE name = ? "
                 "ORDER BY id LIMIT 1"
             )
         else:
             query = (
-                "SELECT id, name, description, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, "
+                "SELECT id, name, description, parent_deck_id, workspace_id, review_prompt_side, scheduler_settings_json, scheduler_type, created_at, "
                 "last_modified, deleted, client_id, version, visibility FROM decks WHERE name = ? AND deleted = 0 "
                 "ORDER BY id LIMIT 1"
             )
@@ -17142,6 +17244,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         scheduler_settings: Mapping[str, Any] | str | None = None,
         scheduler_type: str | None = None,
         workspace_id: Any = ...,
+        parent_deck_id: Any = ...,
         expected_version: int | None = None,
     ) -> bool:
         """Update mutable deck fields with optimistic locking."""
@@ -17168,6 +17271,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if workspace_id is not ...:
             set_parts.append("workspace_id = ?")
             params.append(workspace_id)
+        if parent_deck_id is not ...:
+            set_parts.append("parent_deck_id = ?")
+            params.append(self._normalize_deck_parent_id(parent_deck_id))
         if not set_parts:
             if expected_version is None:
                 return True
@@ -17193,6 +17299,12 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 current_version = int(row[0])
                 if expected_version is not None and current_version != expected_version:
                     raise ConflictError("Version mismatch updating deck", entity="decks", identifier=deck_id)  # noqa: TRY003
+                if parent_deck_id is not ...:
+                    params[set_parts.index("parent_deck_id = ?")] = self._validate_deck_parent_locked(
+                        conn,
+                        deck_id=int(deck_id),
+                        parent_deck_id=parent_deck_id,
+                    )
 
                 params_final = params + [deck_id]
                 query = f"UPDATE decks SET {', '.join(set_parts)} WHERE id = ? AND deleted = 0"  # nosec B608
@@ -17203,6 +17315,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 raise ConflictError("Deck name already exists", entity="decks", identifier=name or deck_id) from exc  # noqa: TRY003
             raise CharactersRAGDBError(f"Failed to update deck: {exc}") from exc  # noqa: TRY003
         except sqlite3.Error as exc:
+            raise CharactersRAGDBError(f"Failed to update deck: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError("Deck name already exists", entity="decks", identifier=name or deck_id) from exc  # noqa: TRY003
             raise CharactersRAGDBError(f"Failed to update deck: {exc}") from exc  # noqa: TRY003
 
     def _flashcard_template_default_placeholders(self, raw_definitions: Any) -> list[dict[str, Any]]:

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -16852,9 +16852,17 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if target_deck_id is not None and parent_id == target_deck_id:
             raise InputError("Deck cannot be its own parent")  # noqa: TRY003
 
+        if self.backend_type == BackendType.POSTGRESQL:
+            parent_lookup_query = (
+                "SELECT id, parent_deck_id FROM decks WHERE id = ? AND deleted = 0 FOR UPDATE"
+            )
+            ancestor_lookup_query = "SELECT parent_deck_id FROM decks WHERE id = ? FOR UPDATE"
+        else:
+            parent_lookup_query = "SELECT id, parent_deck_id FROM decks WHERE id = ? AND deleted = 0"
+            ancestor_lookup_query = "SELECT parent_deck_id FROM decks WHERE id = ?"
         parent_row = self._coerce_mapping_row(
             conn.execute(
-                "SELECT id, parent_deck_id FROM decks WHERE id = ? AND deleted = 0",
+                parent_lookup_query,
                 (parent_id,),
             ).fetchone()
         )
@@ -16872,7 +16880,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             seen.add(current_parent_id)
             row = self._coerce_mapping_row(
                 conn.execute(
-                    "SELECT parent_deck_id FROM decks WHERE id = ?",
+                    ancestor_lookup_query,
                     (current_parent_id,),
                 ).fetchone()
             )

--- a/tldw_Server_API/tests/Flashcards/test_flashcard_deck_hierarchy_locking.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcard_deck_hierarchy_locking.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.backends.base import BackendType
+
+
+class _FakeCursor:
+    def __init__(self, row: dict[str, Any] | None):
+        self._row = row
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self._row
+
+
+class _RecordingConnection:
+    def __init__(self, rows: list[dict[str, Any] | None]):
+        self._rows = rows
+        self.queries: list[str] = []
+
+    def execute(self, query: str, params: tuple[Any, ...]) -> _FakeCursor:
+        self.queries.append(query)
+        if not self._rows:
+            raise AssertionError(f"Unexpected query: {query}")
+        return _FakeCursor(self._rows.pop(0))
+
+
+@pytest.mark.parametrize(
+    ("backend_type", "expects_lock"),
+    [
+        (BackendType.POSTGRESQL, True),
+        (BackendType.SQLITE, False),
+    ],
+)
+def test_deck_parent_cycle_check_locks_parent_chain_for_postgres(
+    monkeypatch: pytest.MonkeyPatch,
+    backend_type: BackendType,
+    expects_lock: bool,
+) -> None:
+    monkeypatch.setattr(
+        CharactersRAGDB,
+        "backend_type",
+        property(lambda _self: backend_type),
+    )
+    db = object.__new__(CharactersRAGDB)
+    conn = _RecordingConnection(
+        [
+            {"id": 2, "parent_deck_id": 3},
+            {"parent_deck_id": 3},
+            {"parent_deck_id": None},
+        ]
+    )
+
+    assert db._validate_deck_parent_locked(conn, deck_id=1, parent_deck_id=2) == 2
+
+    assert len(conn.queries) == 3
+    if expects_lock:
+        assert all(query.endswith(" FOR UPDATE") for query in conn.queries)
+    else:
+        assert all("FOR UPDATE" not in query for query in conn.queries)

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -300,6 +300,105 @@ def test_deck_workspace_id_contract_and_scope_filters(
     assert any(item["id"] == deck_id for item in general_list.json())
 
 
+def test_deck_parent_id_contract_create_list_and_patch(
+    client_with_flashcards_db: TestClient,
+):
+    parent_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Parent Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert parent_response.status_code == 200
+    parent = parent_response.json()
+
+    child_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Child Deck", "parent_deck_id": parent["id"]},
+        headers=AUTH_HEADERS,
+    )
+    assert child_response.status_code == 200
+    child = child_response.json()
+    assert child["parent_deck_id"] == parent["id"]
+
+    listed_response = client_with_flashcards_db.get("/api/v1/flashcards/decks", headers=AUTH_HEADERS)
+    assert listed_response.status_code == 200
+    listed_child = next(deck for deck in listed_response.json() if deck["id"] == child["id"])
+    assert listed_child["parent_deck_id"] == parent["id"]
+
+    clear_response = client_with_flashcards_db.patch(
+        f"/api/v1/flashcards/decks/{child['id']}",
+        json={"parent_deck_id": None, "expected_version": child["version"]},
+        headers=AUTH_HEADERS,
+    )
+    assert clear_response.status_code == 200
+    assert clear_response.json()["parent_deck_id"] is None
+
+
+def test_deck_parent_id_rejects_missing_parent(client_with_flashcards_db: TestClient):
+    response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Orphan Deck", "parent_deck_id": 999999},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Parent deck not found"
+
+
+def test_deck_parent_id_rejects_self_parent(client_with_flashcards_db: TestClient):
+    create_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Self Parent Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert create_response.status_code == 200
+    deck = create_response.json()
+
+    response = client_with_flashcards_db.patch(
+        f"/api/v1/flashcards/decks/{deck['id']}",
+        json={"parent_deck_id": deck["id"], "expected_version": deck["version"]},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Deck cannot be its own parent"
+
+
+def test_deck_parent_id_rejects_cycles(client_with_flashcards_db: TestClient):
+    grandparent_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Grandparent Deck"},
+        headers=AUTH_HEADERS,
+    )
+    assert grandparent_response.status_code == 200
+    grandparent = grandparent_response.json()
+
+    parent_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Parent Cycle Deck", "parent_deck_id": grandparent["id"]},
+        headers=AUTH_HEADERS,
+    )
+    assert parent_response.status_code == 200
+    parent = parent_response.json()
+
+    child_response = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={"name": "Child Cycle Deck", "parent_deck_id": parent["id"]},
+        headers=AUTH_HEADERS,
+    )
+    assert child_response.status_code == 200
+    child = child_response.json()
+
+    response = client_with_flashcards_db.patch(
+        f"/api/v1/flashcards/decks/{grandparent['id']}",
+        json={"parent_deck_id": child["id"], "expected_version": grandparent["version"]},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Deck parent would create a cycle"
+
+
 def test_deck_share_endpoints_manage_user_roles(
     client_with_flashcards_db: TestClient,
 ):

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py
@@ -31,6 +31,7 @@ def test_scheduler_schema_columns_exist_on_fresh_db(chacha_db: CharactersRAGDB):
 
     assert "scheduler_settings_json" in deck_columns
     assert "scheduler_type" in deck_columns
+    assert "parent_deck_id" in deck_columns
     assert "queue_state" in flashcard_columns
     assert "step_index" in flashcard_columns
     assert "suspended_reason" in flashcard_columns


### PR DESCRIPTION
## Summary
- Add `parent_deck_id` to the flashcard deck API and persistence contract, including SQLite/PostgreSQL schema ensure paths, sync payloads, and cycle/missing-parent validation.
- Extend the frontend flashcards client and ManageTab so deck selectors can show parent-qualified labels and the scope modal can set or clear a parent deck.
- Cover the hierarchy foundation with backend endpoint/schema tests and frontend helper/hook/ManageTab tests.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py -q` - 154 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py -q` - 3 passed
- `./node_modules/.bin/vitest run src/components/Flashcards/utils/__tests__/deck-display.test.ts src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx src/components/Flashcards/tabs/__tests__/ManageTab.scheduling-metadata.test.tsx --reporter=verbose` - 14 passed
- `git diff --check` - clean
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/schemas/flashcards.py tldw_Server_API/app/api/v1/endpoints/flashcards.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_issue_988.json` - 0 findings

Refs #988

## Change summary
Human-authored summary required before merge per repo policy.
