### PR TITLE
Phase 4.2: add deployment mode chooser

### DIFF
--- a/Docs/Getting_Started/README.md
+++ b/Docs/Getting_Started/README.md
@@ -7,6 +7,19 @@ Recommended default:
 - Use `Docker multi-user + Postgres` when you need JWT auth, a first admin account, and bundled Postgres.
 - Use `Local single-user` for development, debugging, or contributor workflows.
 
+Deployment mode chooser:
+
+| Goal | Start here | Use when | Follow-up docs |
+| --- | --- | --- | --- |
+| Local single-user | [Local single-user](./Profile_Local_Single_User.md) | You are developing, debugging, or running a local contributor setup. | Add audio only after the base profile verifies. |
+| Docker single-user + WebUI | [Docker single-user + WebUI](./Profile_Docker_Single_User.md) | You want the shortest self-hosted path with the bundled WebUI and API key auth. | [Minimal deployment](../Deployment/minimal-deploy.md), [reverse proxy examples](../Deployment/Reverse_Proxy_Examples.md), and [CDN/static assets](../Deployment/cdn-static-assets.md). |
+| Docker multi-user + Postgres | [Docker multi-user + Postgres](./Profile_Docker_Multi_User_Postgres.md) | You need JWT auth, a first admin account, and bundled Postgres. | [Postgres migration guide](../Deployment/Postgres_Migration_Guide.md) and [long-term admin guide](../Deployment/Long_Term_Admin_Guide.md). |
+| Production or horizontal scaling | [Docker multi-user + Postgres](./Profile_Docker_Multi_User_Postgres.md) first, then [horizontal scaling](../Deployment/horizontal-scaling.md) | You are preparing a shared or multi-node deployment. | [Resource requirements](../Deployment/resource-requirements.md), [sidecar workers](../Deployment/Sidecar_Workers.md), and monitoring/operations docs. |
+| Offline or air-gapped | [Offline and air-gapped deployment](../Deployment/offline-air-gapped.md) | You need controlled egress, preloaded models, or disconnected operation. | Validate provider, model, and package assumptions before first production use. |
+| Sidecar workers | [Sidecar workers](../Deployment/Sidecar_Workers.md) | You want background workers split from the API/WebUI process. | Use the profile guide first, then add worker compose or service units after the base stack verifies. |
+| Audio or GPU setup | [CPU audio setup](./First_Time_Audio_Setup_CPU.md) or [GPU/accelerated audio setup](./First_Time_Audio_Setup_GPU_Accelerated.md) | Speech, transcription, TTS, or diarization is part of day-one setup. | Start from a healthy base profile, then add CPU or GPU audio prerequisites. |
+| Monitoring and operations | `make monitoring-up` plus `Docs/Deployment/Monitoring/README.md` | You need Prometheus, Grafana, Alertmanager, or operator runbooks. | Monitoring published output is generated as top-level `Docs/Published/Monitoring`; do not move it by hand. |
+
 Canonical base profiles:
 
 1. [Docker single-user + WebUI](./Profile_Docker_Single_User.md)

--- a/Docs/Published/Getting_Started/README.md
+++ b/Docs/Published/Getting_Started/README.md
@@ -7,6 +7,19 @@ Recommended default:
 - Use `Docker multi-user + Postgres` when you need JWT auth, a first admin account, and bundled Postgres.
 - Use `Local single-user` for development, debugging, or contributor workflows.
 
+Deployment mode chooser:
+
+| Goal | Start here | Use when | Follow-up docs |
+| --- | --- | --- | --- |
+| Local single-user | [Local single-user](./Profile_Local_Single_User.md) | You are developing, debugging, or running a local contributor setup. | Add audio only after the base profile verifies. |
+| Docker single-user + WebUI | [Docker single-user + WebUI](./Profile_Docker_Single_User.md) | You want the shortest self-hosted path with the bundled WebUI and API key auth. | [Minimal deployment](../Deployment/minimal-deploy.md), [reverse proxy examples](../Deployment/Reverse_Proxy_Examples.md), and [CDN/static assets](../Deployment/cdn-static-assets.md). |
+| Docker multi-user + Postgres | [Docker multi-user + Postgres](./Profile_Docker_Multi_User_Postgres.md) | You need JWT auth, a first admin account, and bundled Postgres. | [Postgres migration guide](../Deployment/Postgres_Migration_Guide.md) and [long-term admin guide](../Deployment/Long_Term_Admin_Guide.md). |
+| Production or horizontal scaling | [Docker multi-user + Postgres](./Profile_Docker_Multi_User_Postgres.md) first, then [horizontal scaling](../Deployment/horizontal-scaling.md) | You are preparing a shared or multi-node deployment. | [Resource requirements](../Deployment/resource-requirements.md), [sidecar workers](../Deployment/Sidecar_Workers.md), and monitoring/operations docs. |
+| Offline or air-gapped | [Offline and air-gapped deployment](../Deployment/offline-air-gapped.md) | You need controlled egress, preloaded models, or disconnected operation. | Validate provider, model, and package assumptions before first production use. |
+| Sidecar workers | [Sidecar workers](../Deployment/Sidecar_Workers.md) | You want background workers split from the API/WebUI process. | Use the profile guide first, then add worker compose or service units after the base stack verifies. |
+| Audio or GPU setup | [CPU audio setup](./First_Time_Audio_Setup_CPU.md) or [GPU/accelerated audio setup](./First_Time_Audio_Setup_GPU_Accelerated.md) | Speech, transcription, TTS, or diarization is part of day-one setup. | Start from a healthy base profile, then add CPU or GPU audio prerequisites. |
+| Monitoring and operations | `make monitoring-up` plus `Docs/Deployment/Monitoring/README.md` | You need Prometheus, Grafana, Alertmanager, or operator runbooks. | Monitoring published output is generated as top-level `Docs/Published/Monitoring`; do not move it by hand. |
+
 Canonical base profiles:
 
 1. [Docker single-user + WebUI](./Profile_Docker_Single_User.md)

--- a/Docs/superpowers/plans/2026-04-25-phase4-2-deployment-docs-refresh-plan.md
+++ b/Docs/superpowers/plans/2026-04-25-phase4-2-deployment-docs-refresh-plan.md
@@ -23,7 +23,7 @@
 **Goal:** Confirm what is allowed to change before prose edits.
 **Success Criteria:** Maintainers accept the source/published flow and the first deployment-mode slice.
 **Tests:** None.
-**Status:** Not Started
+**Status:** Complete
 
 - [ ] Confirm `Docs/Getting_Started/` and `Docs/Deployment/` are canonical source docs.
 - [ ] Confirm `Docs/Published/` should be regenerated with `Helper_Scripts/refresh_docs_published.sh`, not edited by hand except for preserved `index.md` files.
@@ -34,12 +34,14 @@
   - alternate: `Docs/Deployment/First_Time_Production_Setup.md` production checklist
   - alternate: `Docs/Deployment/horizontal-scaling.md` plus HA guide alignment
 
+Status note: maintainer continuation accepted the docs-only Phase 4.2 slice. This tranche uses `Docs/Getting_Started/README.md` as the source edit and preserves the existing HA and Monitoring publishing decisions without changing them.
+
 ## Stage 2: Source-Only Refresh
 
 **Goal:** Make one small source-doc improvement without touching runtime behavior.
 **Success Criteria:** One deployment-mode slice is clearer and still matches current commands.
 **Tests:** Static command/path checks from Stage 4.
-**Status:** Not Started
+**Status:** Complete
 
 Recommended first edit:
 
@@ -68,7 +70,7 @@ Implementation constraints:
 **Goal:** Refresh generated/curated published docs from source after source edits.
 **Success Criteria:** Generated published changes are intentional and limited to the selected docs slice.
 **Tests:** Refresh script exits 0.
-**Status:** Not Started
+**Status:** Complete
 
 Run:
 
@@ -83,12 +85,14 @@ Review:
 - confirm Monitoring is under `Docs/Published/Monitoring`
 - confirm no private or draft-only docs were promoted accidentally
 
+Status note: `Helper_Scripts/refresh_docs_published.sh` exits 0, but the full refresh currently surfaces unrelated source/published drift. This PR keeps only the matching `Docs/Published/Getting_Started/README.md` mirror for the selected source slice; the broader refresh drift remains out of scope.
+
 ## Stage 4: Local Docs Gate
 
 **Goal:** Reproduce the required onboarding docs gate locally.
 **Success Criteria:** Docs refresh, boundary checks, docs tests, and MkDocs build pass.
 **Tests:** Commands below.
-**Status:** Not Started
+**Status:** Complete
 
 Run:
 
@@ -111,12 +115,14 @@ python Helper_Scripts/docs/check_readme_docs_path_hygiene.py
 python Helper_Scripts/docs/check_docs_index_path_hygiene.py
 ```
 
+Status note: required docs checks pass when the repo-root virtual environment is on `PATH`; direct venv Python without `PATH` fails two docs tests that spawn `python`. `mkdocs build -f Docs/mkdocs.yml` exits 0 with existing nav/link warnings. Optional public/private and path-hygiene checks pass.
+
 ## Stage 5: Owner Review Packet
 
 **Goal:** Make docs review easy for the owner.
 **Success Criteria:** PR description explains source edits, generated published changes, validation, and open owner decisions.
 **Tests:** None.
-**Status:** Not Started
+**Status:** In Progress
 
 Include in handoff:
 


### PR DESCRIPTION
## Summary
- adds a deployment-mode chooser matrix to the Getting Started source index
- mirrors the same scoped update into the published Getting Started index
- records Phase 4.2 validation status and the current broader `Docs/Published` refresh drift in the plan

## Verification
- `bash Helper_Scripts/refresh_docs_published.sh` exits 0, but currently surfaces unrelated source/published drift; this PR intentionally keeps only the selected Getting Started mirror
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python Helper_Scripts/docs/check_onboarding_command_boundaries.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python Helper_Scripts/docs/check_onboarding_endpoint_drift.py`
- `PATH=/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin:$PATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest -q -p pytest_asyncio.plugin tldw_Server_API/tests/Docs`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/mkdocs build -f Docs/mkdocs.yml` exits 0 with existing nav/link warnings
- optional docs path/public-private hygiene scripts pass
- `git diff --check`

## Change summary
TODO(user): Human-authored rationale required before merge.