### PR TITLE
Phase 4.4: extract storage endpoint helpers

### DIFF
--- a/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
+++ b/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
@@ -70,11 +70,11 @@ Special behavior:
 **Goal:** Record current behavior before moving routes.
 **Success Criteria:** Focused storage tests pass on the accepted base, and OpenAPI path set is captured.
 **Tests:** Focused storage endpoint/admin tests and OpenAPI path guard.
-**Status:** Not Started
+**Status:** Complete With Caveat
 
-- [ ] Create a clean worktree from the accepted base.
-- [ ] Confirm no active dirty work exists in `storage.py`.
-- [ ] Run focused backend tests:
+- [x] Create a clean worktree from the accepted base.
+- [x] Confirm no active dirty work exists in `storage.py`.
+- [x] Run focused backend tests:
 
 ```bash
 source .venv/bin/activate
@@ -85,22 +85,28 @@ python3 -m pytest \
   -v
 ```
 
-- [ ] Run OpenAPI guard from the UI package if dependencies are installed:
+- [x] Run OpenAPI guard from the UI package if dependencies are installed:
 
 ```bash
 cd apps/packages/ui
 bun run verify:openapi
 ```
 
-- [ ] Record whether `/api/v1/storage/*` paths are currently part of any client guard.
-- [ ] Do not edit runtime code in this stage.
+- [x] Record whether `/api/v1/storage/*` paths are currently part of any client guard.
+- [x] Do not edit runtime code in this stage.
+
+Notes:
+
+- Focused storage/admin baseline passed: `43 passed, 6 warnings`.
+- `bun run verify:openapi` currently fails on `origin/dev` before storage route movement with `No MEDIA_ADD_SCHEMA_FALLBACK entries were parsed from fallback-schemas.ts`. Root cause is the guard's fallback parser matching `MEDIA_ADD_SCHEMA_FALLBACK_VERSION` before the actual fallback array. Route movement is deferred until the Phase 4.6 guardrail fix is merged or rebased into this branch.
+- The failing guard had already checked 256 client paths and did not identify storage-route drift before the fallback parser failure.
 
 ## Stage 2: Extract Storage Endpoint Helpers
 
 **Goal:** Move pure helpers out of `storage.py` before moving any routes.
 **Success Criteria:** `storage.py` still exposes the same router and helper behavior; focused tests pass.
 **Tests:** Focused storage endpoint/admin tests.
-**Status:** Not Started
+**Status:** Complete
 
 Candidate helper module:
 
@@ -120,6 +126,13 @@ Implementation constraints:
 - Keep compatibility imports in `storage.py` if tests patch helper names directly.
 - Do not move routes in this stage.
 - Do not alter datetime parsing fallback behavior.
+
+Notes:
+
+- Extracted `_principal_is_storage_admin`, `_to_generated_file`, `_resolve_storage_base_dir`, `_parse_datetime`, and `_to_quota_status` to `storage_helpers.py`.
+- Added direct helper coverage in `test_storage_helpers.py` for admin claim compatibility, datetime parsing, generated-file conversion, base directory selection, and quota conversion.
+- Preserved the `storage.DatabasePaths` monkeypatch seam for existing download tests while keeping route behavior unchanged.
+- Focused helper/storage/admin suite passed: `53 passed, 6 warnings`.
 
 ## Stage 3: Extract User-Owned JSON File And Folder Routes
 
@@ -239,9 +252,9 @@ python3 -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server
 
 ## Handoff Checklist
 
-- [ ] Maintainers accept `storage.py` user-owned JSON routes as the first Phase 4.4 endpoint target.
-- [ ] Clean worktree from accepted base exists.
-- [ ] Stage 1 focused tests pass before route movement.
+- [x] Maintainers accept `storage.py` user-owned JSON routes as the first Phase 4.4 endpoint target.
+- [x] Clean worktree from accepted base exists.
+- [x] Stage 1 focused tests pass before route movement.
 - [ ] OpenAPI path set is captured before route movement.
-- [ ] File download and admin quota routes remain excluded from the first route split.
-- [ ] Bandit is run on touched source before PR handoff.
+- [x] File download and admin quota routes remain excluded from the first route split.
+- [x] Bandit is run on touched source before PR handoff.

--- a/tldw_Server_API/app/api/v1/endpoints/storage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage.py
@@ -11,11 +11,10 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, User
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_auth_principal, get_request_user
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
-    _parse_datetime,
     _principal_is_storage_admin,
     _resolve_storage_base_dir,
     _to_generated_file,
@@ -31,7 +30,6 @@ from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     FolderCreateRequest,
     FolderInfo,
     FolderListResponse,
-    GeneratedFile,
     GeneratedFileResponse,
     GeneratedFilesListResponse,
     GeneratedFileUpdate,

--- a/tldw_Server_API/app/api/v1/endpoints/storage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage.py
@@ -9,14 +9,18 @@ Provides endpoints for:
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from pathlib import Path as PathlibPath
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, get_request_user, User
 
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
+    _parse_datetime,
+    _principal_is_storage_admin,
+    _resolve_storage_base_dir,
+    _to_generated_file,
+    _to_quota_status,
+)
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     BulkDeleteRequest,
     BulkDeleteResponse,
@@ -48,12 +52,15 @@ from tldw_Server_API.app.core.AuthNZ.exceptions import (
     StorageError,
     UserNotFoundError,
 )
-from tldw_Server_API.app.core.AuthNZ.repos.generated_files_repo import FILE_CATEGORY_VOICE_CLONE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths as _DatabasePaths
 from tldw_Server_API.app.services.storage_quota_service import get_storage_service
 
 router = APIRouter(prefix="/storage", tags=["storage"])
+
+# Compatibility seam for existing download tests that monkeypatch
+# storage.DatabasePaths; storage_helpers imports the same class object.
+DatabasePaths = _DatabasePaths
 
 
 # =========================================================================
@@ -65,25 +72,6 @@ async def _get_service():
     return await get_storage_service()
 
 
-def _principal_is_storage_admin(principal: AuthPrincipal) -> bool:
-    """Storage admin compatibility check.
-
-    Storage admin endpoints intentionally preserve legacy `is_admin` support in
-    addition to claim-first admin role/permission checks.
-    """
-    roles = {str(role).strip().lower() for role in (principal.roles or []) if str(role).strip()}
-    permissions = {
-        str(permission).strip().lower()
-        for permission in (principal.permissions or [])
-        if str(permission).strip()
-    }
-    if bool(getattr(principal, "is_admin", False)):
-        return True
-    if "admin" in roles:
-        return True
-    return bool(permissions & {"*", "system.configure"})
-
-
 async def require_storage_admin(principal: AuthPrincipal = Depends(get_auth_principal)) -> AuthPrincipal:
     """Authorize storage admin endpoints with legacy `is_admin` compatibility."""
     if _principal_is_storage_admin(principal):
@@ -91,73 +79,6 @@ async def require_storage_admin(principal: AuthPrincipal = Depends(get_auth_prin
     raise HTTPException(
         status_code=403,
         detail="Access denied. Required role(s): admin",
-    )
-
-
-def _to_generated_file(record: dict) -> GeneratedFile:
-    """Convert database record to GeneratedFile schema."""
-    return GeneratedFile(
-        id=record.get("id", 0),
-        uuid=record.get("uuid", ""),
-        user_id=record.get("user_id", 0),
-        org_id=record.get("org_id"),
-        team_id=record.get("team_id"),
-        filename=record.get("filename", ""),
-        original_filename=record.get("original_filename"),
-        storage_path=record.get("storage_path", ""),
-        mime_type=record.get("mime_type"),
-        file_size_bytes=record.get("file_size_bytes", 0),
-        checksum=record.get("checksum"),
-        file_category=record.get("file_category", "image"),
-        source_feature=record.get("source_feature", "export"),
-        source_ref=record.get("source_ref"),
-        folder_tag=record.get("folder_tag"),
-        tags=record.get("tags", []),
-        is_transient=record.get("is_transient", False),
-        expires_at=_parse_datetime(record.get("expires_at")),
-        retention_policy=record.get("retention_policy", "user_default"),
-        is_deleted=record.get("is_deleted", False),
-        deleted_at=_parse_datetime(record.get("deleted_at")),
-        created_at=_parse_datetime(record.get("created_at")) or datetime.now(timezone.utc),
-        updated_at=_parse_datetime(record.get("updated_at")) or datetime.now(timezone.utc),
-        accessed_at=_parse_datetime(record.get("accessed_at")),
-    )
-
-
-def _resolve_storage_base_dir(user_id: int, record: dict) -> PathlibPath:
-    """Resolve the base directory for a stored file based on category."""
-    if record.get("file_category") == FILE_CATEGORY_VOICE_CLONE:
-        return DatabasePaths.get_user_voices_dir(user_id)
-    return DatabasePaths.get_user_outputs_dir(user_id)
-
-
-def _parse_datetime(value) -> datetime | None:
-    """Parse datetime from various formats."""
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        try:
-            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt
-        except Exception:
-            return None
-    return None
-
-
-def _to_quota_status(data: dict) -> QuotaStatus:
-    """Convert quota data to QuotaStatus schema."""
-    return QuotaStatus(
-        quota_mb=data.get("quota_mb"),
-        used_mb=data.get("used_mb", 0.0),
-        remaining_mb=data.get("remaining_mb"),
-        usage_pct=data.get("usage_pct", 0.0),
-        at_soft_limit=data.get("at_soft_limit", False),
-        at_hard_limit=data.get("at_hard_limit", False),
-        has_quota=data.get("has_quota", False),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/storage_helpers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_helpers.py
@@ -1,0 +1,93 @@
+"""Helper functions for storage endpoint record conversion and authorization."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path as PathlibPath
+
+from tldw_Server_API.app.api.v1.schemas.storage_schemas import GeneratedFile, QuotaStatus
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.generated_files_repo import FILE_CATEGORY_VOICE_CLONE
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+
+
+def _principal_is_storage_admin(principal: AuthPrincipal) -> bool:
+    """Check storage-admin compatibility claims."""
+    roles = {str(role).strip().lower() for role in (principal.roles or []) if str(role).strip()}
+    permissions = {
+        str(permission).strip().lower()
+        for permission in (principal.permissions or [])
+        if str(permission).strip()
+    }
+    if bool(getattr(principal, "is_admin", False)):
+        return True
+    if "admin" in roles:
+        return True
+    return bool(permissions & {"*", "system.configure"})
+
+
+def _parse_datetime(value) -> datetime | None:
+    """Parse datetime from API/database values."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except Exception:
+            return None
+    return None
+
+
+def _to_generated_file(record: dict) -> GeneratedFile:
+    """Convert a generated-files database record to an API schema."""
+    return GeneratedFile(
+        id=record.get("id", 0),
+        uuid=record.get("uuid", ""),
+        user_id=record.get("user_id", 0),
+        org_id=record.get("org_id"),
+        team_id=record.get("team_id"),
+        filename=record.get("filename", ""),
+        original_filename=record.get("original_filename"),
+        storage_path=record.get("storage_path", ""),
+        mime_type=record.get("mime_type"),
+        file_size_bytes=record.get("file_size_bytes", 0),
+        checksum=record.get("checksum"),
+        file_category=record.get("file_category", "image"),
+        source_feature=record.get("source_feature", "export"),
+        source_ref=record.get("source_ref"),
+        folder_tag=record.get("folder_tag"),
+        tags=record.get("tags", []),
+        is_transient=record.get("is_transient", False),
+        expires_at=_parse_datetime(record.get("expires_at")),
+        retention_policy=record.get("retention_policy", "user_default"),
+        is_deleted=record.get("is_deleted", False),
+        deleted_at=_parse_datetime(record.get("deleted_at")),
+        created_at=_parse_datetime(record.get("created_at")) or datetime.now(timezone.utc),
+        updated_at=_parse_datetime(record.get("updated_at")) or datetime.now(timezone.utc),
+        accessed_at=_parse_datetime(record.get("accessed_at")),
+    )
+
+
+def _resolve_storage_base_dir(user_id: int, record: dict) -> PathlibPath:
+    """Resolve the base directory for a stored file based on category."""
+    if record.get("file_category") == FILE_CATEGORY_VOICE_CLONE:
+        return DatabasePaths.get_user_voices_dir(user_id)
+    return DatabasePaths.get_user_outputs_dir(user_id)
+
+
+def _to_quota_status(data: dict) -> QuotaStatus:
+    """Convert quota service data to an API schema."""
+    return QuotaStatus(
+        quota_mb=data.get("quota_mb"),
+        used_mb=data.get("used_mb", 0.0),
+        remaining_mb=data.get("remaining_mb"),
+        usage_pct=data.get("usage_pct", 0.0),
+        at_soft_limit=data.get("at_soft_limit", False),
+        at_hard_limit=data.get("at_hard_limit", False),
+        has_quota=data.get("has_quota", False),
+    )

--- a/tldw_Server_API/app/api/v1/endpoints/storage_helpers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_helpers.py
@@ -26,7 +26,7 @@ def _principal_is_storage_admin(principal: AuthPrincipal) -> bool:
     return bool(permissions & {"*", "system.configure"})
 
 
-def _parse_datetime(value) -> datetime | None:
+def _parse_datetime(value: object) -> datetime | None:
     """Parse datetime from API/database values."""
     if value is None:
         return None
@@ -38,7 +38,7 @@ def _parse_datetime(value) -> datetime | None:
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
             return dt
-        except Exception:
+        except ValueError:
             return None
     return None
 

--- a/tldw_Server_API/tests/Storage/test_storage_helpers.py
+++ b/tldw_Server_API/tests/Storage/test_storage_helpers.py
@@ -1,3 +1,5 @@
+"""Tests for storage endpoint helper conversions and compatibility seams."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone

--- a/tldw_Server_API/tests/Storage/test_storage_helpers.py
+++ b/tldw_Server_API/tests/Storage/test_storage_helpers.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints import storage_helpers
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.generated_files_repo import FILE_CATEGORY_VOICE_CLONE
+
+
+def _principal(
+    *,
+    roles: list[str] | None = None,
+    permissions: list[str] | None = None,
+    is_admin: bool = False,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        roles=roles or [],
+        permissions=permissions or [],
+        is_admin=is_admin,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "principal",
+    [
+        _principal(roles=["admin"]),
+        _principal(permissions=["*"]),
+        _principal(permissions=["system.configure"]),
+        _principal(is_admin=True),
+    ],
+)
+def test_principal_is_storage_admin_preserves_accepted_admin_claims(principal: AuthPrincipal) -> None:
+    """Storage admin helper accepts the legacy and claim-first admin forms."""
+    assert storage_helpers._principal_is_storage_admin(principal) is True
+
+
+@pytest.mark.unit
+def test_principal_is_storage_admin_rejects_non_admin_claims() -> None:
+    """Storage admin helper rejects principals without accepted admin claims."""
+    principal = _principal(roles=["user"], permissions=["storage.read"])
+
+    assert storage_helpers._principal_is_storage_admin(principal) is False
+
+
+@pytest.mark.unit
+def test_parse_datetime_handles_z_suffix_and_naive_strings() -> None:
+    """Datetime helper preserves parsed values and defaults naive values to UTC."""
+    z_value = storage_helpers._parse_datetime("2026-01-02T03:04:05Z")
+    naive_value = storage_helpers._parse_datetime("2026-01-02T03:04:05")
+
+    assert z_value == datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    assert naive_value == datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+@pytest.mark.unit
+def test_parse_datetime_returns_none_for_invalid_values() -> None:
+    """Datetime helper preserves the endpoint fallback for invalid values."""
+    assert storage_helpers._parse_datetime(None) is None
+    assert storage_helpers._parse_datetime("not-a-date") is None
+    assert storage_helpers._parse_datetime(object()) is None
+
+
+@pytest.mark.unit
+def test_to_generated_file_applies_defaults_and_parses_timestamps() -> None:
+    """Generated-file helper converts sparse records with endpoint-compatible defaults."""
+    generated_file = storage_helpers._to_generated_file(
+        {
+            "id": 42,
+            "uuid": "file-uuid",
+            "user_id": 7,
+            "filename": "result.png",
+            "storage_path": "images/result.png",
+            "file_category": "image",
+            "source_feature": "image_gen",
+            "created_at": "2026-01-02T03:04:05Z",
+            "updated_at": "2026-01-02T04:05:06Z",
+            "accessed_at": "invalid",
+        }
+    )
+
+    assert generated_file.id == 42
+    assert generated_file.uuid == "file-uuid"
+    assert generated_file.user_id == 7
+    assert generated_file.filename == "result.png"
+    assert generated_file.storage_path == "images/result.png"
+    assert generated_file.file_size_bytes == 0
+    assert generated_file.tags == []
+    assert generated_file.is_deleted is False
+    assert generated_file.created_at == datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    assert generated_file.updated_at == datetime(2026, 1, 2, 4, 5, 6, tzinfo=timezone.utc)
+    assert generated_file.accessed_at is None
+
+
+@pytest.mark.unit
+def test_resolve_storage_base_dir_selects_voice_or_output_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Storage-base helper preserves voice clone routing and default output routing."""
+    voices_dir = Path("/tmp/test-voices")
+    outputs_dir = Path("/tmp/test-outputs")
+    monkeypatch.setattr(storage_helpers.DatabasePaths, "get_user_voices_dir", lambda user_id: voices_dir)
+    monkeypatch.setattr(storage_helpers.DatabasePaths, "get_user_outputs_dir", lambda user_id: outputs_dir)
+
+    assert (
+        storage_helpers._resolve_storage_base_dir(7, {"file_category": FILE_CATEGORY_VOICE_CLONE})
+        == voices_dir
+    )
+    assert storage_helpers._resolve_storage_base_dir(7, {"file_category": "image"}) == outputs_dir
+
+
+@pytest.mark.unit
+def test_to_quota_status_applies_endpoint_defaults() -> None:
+    """Quota helper converts sparse quota data with endpoint-compatible defaults."""
+    quota = storage_helpers._to_quota_status({"quota_mb": 1000, "used_mb": 125.5})
+
+    assert quota.quota_mb == 1000
+    assert quota.used_mb == 125.5
+    assert quota.remaining_mb is None
+    assert quota.usage_pct == 0.0
+    assert quota.at_soft_limit is False
+    assert quota.at_hard_limit is False
+    assert quota.has_quota is False


### PR DESCRIPTION
## Summary
- Extracts pure storage endpoint conversion/auth/path helpers from `storage.py` into `storage_helpers.py` without moving routes or changing payloads.
- Adds direct helper coverage for storage-admin claim compatibility, datetime parsing, generated-file conversion, base-directory resolution, and quota conversion.
- Records the Phase 4.4 OpenAPI guard caveat: route movement remains deferred until the Phase 4.6 guard parser fix is available on the branch.

## Change summary TODO(user)
Human maintainer must replace this section before merge with the rationale for accepting this Phase 4.4 helper-only tranche and deferring route movement until the OpenAPI guard baseline is healthy.

## Test Plan
- [x] `python -m pytest tldw_Server_API/tests/Storage/test_storage_helpers.py tldw_Server_API/tests/Storage/test_storage_endpoints.py tldw_Server_API/tests/AuthNZ_Unit/test_storage_admin_claims.py tldw_Server_API/tests/Admin/test_admin_storage_quotas.py -v`
- [x] `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server_API/app/api/v1/endpoints/storage_helpers.py -f json -o /tmp/bandit_phase4_4_storage_helpers_rebased.json`
- [x] `git diff --check HEAD~1..HEAD`

## Notes
- `bun run verify:openapi` currently fails on `origin/dev` before storage route movement with `No MEDIA_ADD_SCHEMA_FALLBACK entries were parsed from fallback-schemas.ts`; this branch intentionally avoids route movement until that guardrail fix is merged/rebased in.
