### PR TITLE
docs: reconcile sandbox runtime support docs

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -8,6 +8,26 @@ Auth: Standard tldw AuthNZ
 - Single user: `X-API-KEY: <key>`
 - Multi user (JWT): `Authorization: Bearer <token>`
 
+## Runtime support contract
+
+Runtime discovery and runtime preflight are authoritative for the current host.
+Use GET `/api/v1/sandbox/runtimes` to discover what this deployment can admit
+before choosing a runtime. The current support inventory is maintained in
+`Docs/Sandbox/sandbox-runtime-capability-inventory.md`; the isolation and policy
+contract is maintained in `Docs/Sandbox/sandbox-security-policy-matrix.md`.
+
+Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
+`vz_macos`, `seatbelt`, and `worktree`. Availability does not imply a security
+guarantee:
+- `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
+- `worktree` is host-local. `worktree` is not `untrusted`-eligible.
+- `vz_macos` real execution is not implemented; it is a scaffold/preflight
+  identity until the real runner lands.
+- `firecracker`, `lima`, and `vz_linux` are host-gated VM-grade paths and must
+  pass their own prerequisites before use.
+- `untrusted` workloads require a VM-grade runtime that preflight admits. Do not
+  substitute `seatbelt` or `worktree` when a VM-grade runtime is requested.
+
 ## Firecracker host prep
 
 If you plan to use the Firecracker runtime, follow the host prerequisites and
@@ -15,7 +35,8 @@ smoke-test steps in `Docs/Deployment/Operations/Firecracker_Host_Checklist.md`.
 
 ## Lima runtime (macOS/Linux VMs)
 
-Lima provides full VM isolation via Virtualization.framework (macOS) or QEMU (Linux).
+Lima is a VM runtime identity backed by Virtualization.framework on macOS or
+QEMU on Linux when host prerequisites and enforcement preflight pass.
 
 ### Requirements
 - Install Lima: `brew install lima` (macOS) or via package manager
@@ -33,13 +54,16 @@ Lima provides full VM isolation via Virtualization.framework (macOS) or QEMU (Li
 ```
 
 ### Notes
-- VMs use Virtualization.framework on macOS (faster) or QEMU on Linux
-- Network isolation: deny_all by default (no internet access)
+- VMs use Virtualization.framework on macOS or QEMU on Linux
+- Network isolation: `deny_all` only when the Lima enforcer preflight proves
+  strict enforcement for this host
 - Workspace mounted at `/workspace` inside VM
 - Slower startup than containers (~10-30s vs ~1s for Docker)
-- Recommended for macOS development or when maximum isolation is required
-- Runtime parity: REST, MCP `sandbox.run`, and ACP all accept `docker|firecracker|lima`
-- Strict fail-closed mode: Lima accepts only `deny_all|allowlist` network policies; unsupported requirements are rejected
+- Recommended for macOS development when VM-grade Linux isolation is available
+- Runtime parity: REST, MCP `sandbox.run`, and ACP use the current runtime enum;
+  clients should confirm host support through runtime discovery before dispatch
+- Strict fail-closed mode: Lima accepts `deny_all` only when enforcement is
+  ready; `allowlist` execution is not supported today
 - Platform constraint: Windows/WSL strict Lima enforcement is not supported yet and fails closed
 
 ## Trust-Level Tiers
@@ -56,7 +80,7 @@ Risk-based isolation profiles auto-apply resource limits based on code trustwort
 ```json
 {
   "spec_version": "1.0",
-  "runtime": "docker",
+  "runtime": "firecracker",
   "base_image": "python:3.11-slim",
   "trust_level": "untrusted"
 }
@@ -66,20 +90,27 @@ Risk-based isolation profiles auto-apply resource limits based on code trustwort
 ```json
 {
   "spec_version": "1.0",
-  "runtime": "docker",
+  "runtime": "firecracker",
   "base_image": "python:3.11-slim",
   "command": ["python", "user_script.py"],
   "trust_level": "untrusted"
 }
 ```
 
-When `untrusted` is specified, the run is automatically constrained to:
+The examples use `firecracker` as a VM-grade runtime placeholder. Replace it
+with a VM-grade runtime available on your host, such as `lima` or `vz_linux`
+when their preflight checks pass.
+
+When `untrusted` is specified and admitted, the run is automatically constrained to:
 - Max 1 CPU
 - Max 1GB memory
 - Max 60s execution timeout
 - Network deny_all (no egress)
 - Max 64 PIDs
 - Restricted file descriptors (256)
+
+`seatbelt` and `worktree` are host-local runtimes and are rejected for
+`untrusted` workloads.
 
 ## Feature discovery
 GET `/api/v1/sandbox/runtimes`

--- a/Docs/Product/Sandbox/Code_Interpreter_Sandbox_PRD.md
+++ b/Docs/Product/Sandbox/Code_Interpreter_Sandbox_PRD.md
@@ -8,6 +8,7 @@ Last updated: 2025-11-03
 - [Revision History](#revision-history)
 - [1) Summary](#1-summary)
  - [Implementation Status (v0.3)](#implementation-status-v03)
+ - [Current Runtime Reconciliation](#current-runtime-reconciliation)
  - [1) Summary](#1-summary)
 - [2) Problem Statement](#2-problem-statement)
 - [3) Goals and Non-Goals](#3-goals-and-non-goals)
@@ -81,6 +82,26 @@ Clarifications
 - Artifact downloads: single‑range supported; multi‑range returns 416.
 - `supported_spec_versions`: servers may advertise `["1.0","1.1"]`; 1.1 is backward‑compatible and adds optional fields/capabilities.
 
+## Current Runtime Reconciliation
+
+This PRD started as the Docker/Firecracker code-interpreter plan. The current
+runtime contract is broader and should be read from the active sandbox docs:
+`Docs/Sandbox/sandbox-runtime-capability-inventory.md`,
+`Docs/Sandbox/sandbox-security-policy-matrix.md`,
+`Docs/API-related/Sandbox_API.md`, and
+`tldw_Server_API/app/core/Sandbox/README.md`.
+
+Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
+`vz_macos`, `seatbelt`, and `worktree`; runtime discovery and runtime preflight
+remain authoritative for the current host. `seatbelt` and `worktree` are
+host-local runtimes, not VM-grade isolation boundaries. `seatbelt` and
+`worktree` are not `untrusted`-eligible.
+`vz_macos` real execution is not implemented; it remains a scaffold/preflight
+identity until the real runner defines execution, workspace, and network
+behavior. Firecracker real execution also remains host-gated by Linux/KVM
+prerequisites and should not be described as broadly available without passing
+preflight.
+
 Primary use cases:
 - Validate LLM-generated code safely, before running it locally.
 - Run tests, scripts, and small apps against a provided workspace snapshot.
@@ -97,7 +118,8 @@ Developers increasingly rely on LLMs to generate code. Executing untrusted snipp
 
 ### Goals
 1. Provide a sandboxed code execution service with clear isolation guarantees.
-2. Offer two runtimes: Docker (broad support) and Firecracker (stronger isolation on Linux).
+2. Preserve the original Docker/Firecracker goal while deferring current
+   runtime status to the active capability inventory and security matrix.
 3. Expose a clean REST + WebSocket API for runs, logs, and artifacts.
 4. Provide an LSP bridge so IDEs can trigger runs and show diagnostics inline.
 5. Support agent/workflow invocation (incl. MCP tool) with policy and approvals.
@@ -145,7 +167,9 @@ vNext
 ## 6) Scope
 
 In Scope (MVP)
-- Docker and Firecracker runtimes (selectable via policy or request).
+- Docker and Firecracker runtimes were the original MVP scope. Current runtime
+  support is broader and host-dependent; see
+  [Current Runtime Reconciliation](#current-runtime-reconciliation).
 - Language base images: Python, Node.js, Go, Java, .NET, plus a generic image.
 - One-shot runs with tar/zip uploads or remote git clone + patch.
 - Resource controls: CPU, memory, disk, wall-clock timeout.
@@ -235,7 +259,9 @@ Auth: Reuse existing AuthNZ (JWT for multi-user or API key for single-user). App
 
 Endpoints
 - POST `/sessions`
-  - Create a session. Body: `spec_version`, runtime (`docker`|`firecracker`), base_image, cpu/mem limits, timeout, network_policy, env (non-secret), labels.
+  - Create a session. Body: `spec_version`, runtime (current enum from
+    runtime discovery), base_image, cpu/mem limits, timeout, network_policy,
+    env (non-secret), labels.
   - Returns: `session_id`, `expires_at`, runtime info, `policy_hash`.
 
 - POST `/sessions/{session_id}/files`
@@ -991,7 +1017,9 @@ Warm Pools & Caching
 
 ## 17) Admin & Policy
 
-- Runtime selection policy: Docker default on macOS/Windows; Firecracker allowed on supported Linux hosts (direct integration).
+- Runtime selection policy: choose defaults from the active capability
+  inventory and runtime discovery; do not assume a host can run VM-grade
+  backends without preflight.
 - Quotas: per-user daily CPU-seconds cap; concurrent run cap; total artifacts size/day.
 - Network policy: deny_all default; allowlist domains (vNext) per policy; domain wildcards controlled via config.
 - Approvals: optional manual approval gates for large runs or network-enabled runs.
@@ -1000,7 +1028,7 @@ Warm Pools & Caching
 See also: [Security Defaults](#security-defaults-quick-reference)
 
   Configuration Keys (examples)
-- `SANDBOX_DEFAULT_RUNTIME` (docker|firecracker)
+- `SANDBOX_DEFAULT_RUNTIME` (current runtime enum; validate with discovery)
 - `SANDBOX_NETWORK_DEFAULT` (deny_all|allowlist)
 - `SANDBOX_MAX_UPLOAD_MB`
 - `SANDBOX_ARTIFACT_TTL_HOURS`

--- a/Docs/Published/API-related/Sandbox_API.md
+++ b/Docs/Published/API-related/Sandbox_API.md
@@ -8,6 +8,26 @@ Auth: Standard tldw AuthNZ
 - Single user: `X-API-KEY: <key>`
 - Multi user (JWT): `Authorization: Bearer <token>`
 
+## Runtime support contract
+
+Runtime discovery and runtime preflight are authoritative for the current host.
+Use GET `/api/v1/sandbox/runtimes` to discover what this deployment can admit
+before choosing a runtime. The current support inventory is maintained in
+`Docs/Sandbox/sandbox-runtime-capability-inventory.md`; the isolation and policy
+contract is maintained in `Docs/Sandbox/sandbox-security-policy-matrix.md`.
+
+Current runtime identities are `docker`, `firecracker`, `lima`, `vz_linux`,
+`vz_macos`, `seatbelt`, and `worktree`. Availability does not imply a security
+guarantee:
+- `seatbelt` is host-local. `seatbelt` is not `untrusted`-eligible.
+- `worktree` is host-local. `worktree` is not `untrusted`-eligible.
+- `vz_macos` real execution is not implemented; it is a scaffold/preflight
+  identity until the real runner lands.
+- `firecracker`, `lima`, and `vz_linux` are host-gated VM-grade paths and must
+  pass their own prerequisites before use.
+- `untrusted` workloads require a VM-grade runtime that preflight admits. Do not
+  substitute `seatbelt` or `worktree` when a VM-grade runtime is requested.
+
 ## Firecracker host prep
 
 If you plan to use the Firecracker runtime, follow the host prerequisites and
@@ -15,7 +35,8 @@ smoke-test steps in `Docs/Deployment/Operations/Firecracker_Host_Checklist.md`.
 
 ## Lima runtime (macOS/Linux VMs)
 
-Lima provides full VM isolation via Virtualization.framework (macOS) or QEMU (Linux).
+Lima is a VM runtime identity backed by Virtualization.framework on macOS or
+QEMU on Linux when host prerequisites and enforcement preflight pass.
 
 ### Requirements
 - Install Lima: `brew install lima` (macOS) or via package manager
@@ -33,13 +54,16 @@ Lima provides full VM isolation via Virtualization.framework (macOS) or QEMU (Li
 ```
 
 ### Notes
-- VMs use Virtualization.framework on macOS (faster) or QEMU on Linux
-- Network isolation: deny_all by default (no internet access)
+- VMs use Virtualization.framework on macOS or QEMU on Linux
+- Network isolation: `deny_all` only when the Lima enforcer preflight proves
+  strict enforcement for this host
 - Workspace mounted at `/workspace` inside VM
 - Slower startup than containers (~10-30s vs ~1s for Docker)
-- Recommended for macOS development or when maximum isolation is required
-- Runtime parity: REST, MCP `sandbox.run`, and ACP all accept `docker|firecracker|lima`
-- Strict fail-closed mode: Lima accepts only `deny_all|allowlist` network policies; unsupported requirements are rejected
+- Recommended for macOS development when VM-grade Linux isolation is available
+- Runtime parity: REST, MCP `sandbox.run`, and ACP use the current runtime enum;
+  clients should confirm host support through runtime discovery before dispatch
+- Strict fail-closed mode: Lima accepts `deny_all` only when enforcement is
+  ready; `allowlist` execution is not supported today
 - Platform constraint: Windows/WSL strict Lima enforcement is not supported yet and fails closed
 
 ## Trust-Level Tiers
@@ -56,7 +80,7 @@ Risk-based isolation profiles auto-apply resource limits based on code trustwort
 ```json
 {
   "spec_version": "1.0",
-  "runtime": "docker",
+  "runtime": "firecracker",
   "base_image": "python:3.11-slim",
   "trust_level": "untrusted"
 }
@@ -66,20 +90,27 @@ Risk-based isolation profiles auto-apply resource limits based on code trustwort
 ```json
 {
   "spec_version": "1.0",
-  "runtime": "docker",
+  "runtime": "firecracker",
   "base_image": "python:3.11-slim",
   "command": ["python", "user_script.py"],
   "trust_level": "untrusted"
 }
 ```
 
-When `untrusted` is specified, the run is automatically constrained to:
+The examples use `firecracker` as a VM-grade runtime placeholder. Replace it
+with a VM-grade runtime available on your host, such as `lima` or `vz_linux`
+when their preflight checks pass.
+
+When `untrusted` is specified and admitted, the run is automatically constrained to:
 - Max 1 CPU
 - Max 1GB memory
 - Max 60s execution timeout
 - Network deny_all (no egress)
 - Max 64 PIDs
 - Restricted file descriptors (256)
+
+`seatbelt` and `worktree` are host-local runtimes and are rejected for
+`untrusted` workloads.
 
 ## Feature discovery
 GET `/api/v1/sandbox/runtimes`

--- a/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
+++ b/tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py
@@ -1,0 +1,90 @@
+"""Contracts for public sandbox runtime support documentation."""
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+PUBLIC_API_DOCS = (
+    REPO_ROOT / "Docs/API-related/Sandbox_API.md",
+    REPO_ROOT / "Docs/Published/API-related/Sandbox_API.md",
+)
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _normalized_text(path: Path) -> str:
+    return " ".join(_text(path).split())
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        pytest.fail(message)
+
+
+@pytest.mark.parametrize("doc_path", PUBLIC_API_DOCS)
+def test_public_sandbox_api_docs_reference_runtime_contract_docs(doc_path: Path) -> None:
+    """Public API guides should point callers at the current runtime contracts."""
+    text = _text(doc_path)
+
+    for contract_path in (
+        "Docs/Sandbox/sandbox-runtime-capability-inventory.md",
+        "Docs/Sandbox/sandbox-security-policy-matrix.md",
+    ):
+        _require(
+            contract_path in text,
+            f"{doc_path} should reference {contract_path}",
+        )
+
+
+@pytest.mark.parametrize("doc_path", PUBLIC_API_DOCS)
+def test_public_sandbox_api_docs_do_not_overclaim_runtime_support(doc_path: Path) -> None:
+    """Public API guides should name current runtimes without overstating guarantees."""
+    text = _text(doc_path)
+
+    for runtime in (
+        "docker",
+        "firecracker",
+        "lima",
+        "vz_linux",
+        "vz_macos",
+        "seatbelt",
+        "worktree",
+    ):
+        _require(runtime in text, f"{doc_path} should mention runtime {runtime}")
+
+    for host_local_runtime in ("seatbelt", "worktree"):
+        _require(
+            f"`{host_local_runtime}` is host-local" in text,
+            f"{doc_path} should describe {host_local_runtime} as host-local",
+        )
+        _require(
+            f"`{host_local_runtime}` is not `untrusted`-eligible" in text,
+            f"{doc_path} should not classify {host_local_runtime} as untrusted-eligible",
+        )
+
+    _require(
+        "`vz_macos` real execution is not implemented" in text,
+        f"{doc_path} should state vz_macos real execution is not implemented",
+    )
+
+
+def test_code_interpreter_prd_reconciles_current_runtime_status() -> None:
+    """Historical product PRD should defer current runtime status to contract docs."""
+    text = _normalized_text(
+        REPO_ROOT / "Docs/Product/Sandbox/Code_Interpreter_Sandbox_PRD.md"
+    )
+
+    for snippet in (
+        "Current Runtime Reconciliation",
+        "Docs/Sandbox/sandbox-runtime-capability-inventory.md",
+        "Docs/Sandbox/sandbox-security-policy-matrix.md",
+        "`seatbelt` and `worktree` are host-local",
+        "`seatbelt` and `worktree` are not `untrusted`-eligible",
+        "`vz_macos` real execution is not implemented",
+    ):
+        _require(snippet in text, f"Sandbox PRD should include: {snippet}")


### PR DESCRIPTION
## Change summary

TODO: human-authored change summary required before merge.

## Summary

- Aligns the public Sandbox API guide and published mirror with the runtime capability inventory and security policy matrix.
- Clarifies that `seatbelt` and `worktree` are host-local and not `untrusted`-eligible, and that `vz_macos` real execution is not implemented.
- Reconciles the historical Code Interpreter Sandbox PRD so current runtime support defers to discovery, preflight, and the active sandbox contract docs.

## Test plan

- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py -q`
- [x] `git diff --check`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q tldw_Server_API/tests/Docs/test_sandbox_public_docs_contract.py`
