### PR TITLE
fix: clean up worktree runtime on startup failures

### DIFF
--- a/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
@@ -253,7 +253,7 @@ class WorktreeRunner:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-        except subprocess.CalledProcessError:
+        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
             logger.warning(
                 "git worktree remove failed for {}, cleaning up manually",
                 worktree_path,
@@ -481,6 +481,8 @@ class WorktreeRunner:
         phase = RunPhase.failed
         proc: subprocess.Popen[bytes] | None = None
         run_dir: str | None = None
+        repo_path_for_cleanup: str | None = None
+        worktree_path: str | None = None
 
         with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
             hub.publish_event(
@@ -536,6 +538,7 @@ class WorktreeRunner:
             # Validate repo_path is under an allowed directory
             self._validate_repo_path(repo_path)
 
+            repo_path_for_cleanup = repo_path
             worktree_path = self.create_worktree(repo_path, branch="HEAD")
 
             # Copy session_workspace files into the worktree if they came from
@@ -619,10 +622,6 @@ class WorktreeRunner:
                 artifacts_map = {}
                 message = "canceled_by_user"
 
-            # Tear down the worktree
-            with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
-                self.destroy_worktree(worktree_path, repo_path)
-
         except _WORKTREE_NONCRITICAL_EXCEPTIONS as exc:
             logger.error("Worktree execution error for run {}: {}", run_id, exc)
             message = f"worktree execution error: {exc}"
@@ -631,6 +630,9 @@ class WorktreeRunner:
                 message = "canceled_by_user"
         finally:
             finished = datetime.now(timezone.utc)
+            if worktree_path and repo_path_for_cleanup:
+                with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+                    self.destroy_worktree(worktree_path, repo_path_for_cleanup)
             run_dir_to_remove = self._clear_active_run(run_id)
             if run_dir_to_remove:
                 run_dir = run_dir_to_remove

--- a/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py
@@ -66,6 +66,13 @@ _WORKTREE_NONCRITICAL_EXCEPTIONS = (
     subprocess.SubprocessError,
 )
 
+_WORKTREE_CLEANUP_EXCEPTIONS = (
+    FileNotFoundError,
+    PermissionError,
+    OSError,
+    subprocess.SubprocessError,
+)
+
 
 # ---------------------------------------------------------------------------
 # Availability helpers (module-level, mirrors docker_available pattern)
@@ -253,14 +260,14 @@ class WorktreeRunner:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-        except _WORKTREE_NONCRITICAL_EXCEPTIONS:
+        except _WORKTREE_CLEANUP_EXCEPTIONS:
             logger.warning(
                 "git worktree remove failed for {}, cleaning up manually",
                 worktree_path,
             )
             shutil.rmtree(worktree_path, ignore_errors=True)
             # Prune stale worktree references
-            with contextlib.suppress(_WORKTREE_NONCRITICAL_EXCEPTIONS):
+            with contextlib.suppress(_WORKTREE_CLEANUP_EXCEPTIONS):
                 subprocess.check_call(
                     ["git", "worktree", "prune"],
                     cwd=repo_path,

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -94,6 +95,17 @@ def test_destroy_session_removes_worktree(test_repo: str) -> None:
     assert os.path.isdir(wt)
     WorktreeRunner.destroy_worktree(wt, test_repo)
     assert not os.path.isdir(wt)
+
+
+def test_destroy_worktree_falls_back_when_repo_path_is_missing(tmp_path: Path) -> None:
+    """Manual cleanup should still run if git cannot use the original repo path."""
+    wt = tmp_path / "detached-worktree"
+    wt.mkdir()
+
+    WorktreeRunner.destroy_worktree(str(wt), str(tmp_path / "missing-repo"))
+
+    if wt.exists():
+        pytest.fail("destroy_worktree should remove the worktree directory")
 
 
 def test_create_session_invalid_repo(tmp_path: Path) -> None:
@@ -254,6 +266,55 @@ def test_run_without_session_workspace() -> None:
     result = r.start_run("test-run-003", spec, session_workspace=None)
     assert result.phase == RunPhase.completed
     assert result.exit_code == 0
+
+
+def test_start_run_failure_after_worktree_create_destroys_worktree(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Failures after worktree creation must not leak detached worktrees."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    created_worktree = tmp_path / "created-worktree"
+    destroy_calls: list[tuple[str, str]] = []
+
+    def _create_worktree(repo_path: str, branch: str = "HEAD") -> str:
+        if repo_path != str(repo):
+            pytest.fail(f"unexpected repo path: {repo_path}")
+        if branch != "HEAD":
+            pytest.fail(f"unexpected branch: {branch}")
+        created_worktree.mkdir()
+        return str(created_worktree)
+
+    def _destroy_worktree(worktree_path: str, repo_path: str) -> None:
+        destroy_calls.append((worktree_path, repo_path))
+        shutil.rmtree(worktree_path)
+
+    monkeypatch.setattr(WorktreeRunner, "_is_git_repo", staticmethod(lambda path: path == str(repo)))
+    monkeypatch.setattr(WorktreeRunner, "create_worktree", staticmethod(_create_worktree))
+    monkeypatch.setattr(WorktreeRunner, "destroy_worktree", staticmethod(_destroy_worktree))
+
+    result = WorktreeRunner(allowed_repo_dirs=[str(tmp_path)]).start_run(
+        "run-worktree-invalid-inline",
+        RunSpec(
+            session_id=None,
+            runtime=RuntimeType.worktree,
+            base_image=None,
+            command=["/bin/echo", "unused"],
+            timeout_sec=10,
+            files_inline=[("../escape.txt", b"not allowed")],
+        ),
+        session_workspace=str(repo),
+    )
+
+    if result.phase != RunPhase.failed:
+        pytest.fail(f"expected failed run, got {result.phase}")
+    if "invalid inline file path" not in (result.message or ""):
+        pytest.fail(f"unexpected failure message: {result.message}")
+    if destroy_calls != [(str(created_worktree), str(repo))]:
+        pytest.fail(f"unexpected destroy calls: {destroy_calls}")
+    if created_worktree.exists():
+        pytest.fail("created worktree should have been removed")
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/sandbox/test_worktree_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_worktree_runner.py
@@ -108,6 +108,26 @@ def test_destroy_worktree_falls_back_when_repo_path_is_missing(tmp_path: Path) -
         pytest.fail("destroy_worktree should remove the worktree directory")
 
 
+def test_destroy_worktree_reraises_unexpected_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Programming defects during cleanup should not be hidden."""
+    wt = tmp_path / "detached-worktree"
+    repo = tmp_path / "repo"
+    wt.mkdir()
+    repo.mkdir()
+
+    def _raise_type_error(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise TypeError("programming defect")
+
+    monkeypatch.setattr(subprocess, "check_call", _raise_type_error)
+
+    with pytest.raises(TypeError, match="programming defect"):
+        WorktreeRunner.destroy_worktree(str(wt), str(repo))
+
+
 def test_create_session_invalid_repo(tmp_path: Path) -> None:
     """Non-git directory raises RuntimeError."""
     non_git = tmp_path / "not_a_repo"


### PR DESCRIPTION
## Change summary

TODO: human-authored change summary required before merge.

## Summary

- Ensures `WorktreeRunner` destroys the detached worktree from `finally` even when startup/input validation fails after worktree creation.
- Makes `destroy_worktree()` fall back to manual directory cleanup when the original repo path is unavailable, while still re-raising unexpected programming exceptions.
- Adds focused regression coverage for missing-repo fallback cleanup, post-create startup failure cleanup, and unexpected cleanup exception propagation.

## Test plan

- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_worktree_runner.py tldw_Server_API/tests/sandbox/test_runner_cancel_and_timeouts.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/runners/worktree_runner.py tldw_Server_API/tests/sandbox/test_worktree_runner.py`
- [x] `git diff --check`
- [x] Bandit baseline comparison on touched files: no new findings versus `origin/dev` baseline
