### PR TITLE
Fix VM runner cleanup on setup failures

### DIFF
--- a/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
@@ -271,175 +271,182 @@ class FirecrackerRunner:
             image_digest = None
 
         run_dir = tempfile.mkdtemp(prefix="tldw_fc_")
-        workspace = os.path.join(run_dir, "workspace")
-        os.makedirs(workspace, exist_ok=True)
-        if session_workspace and os.path.isdir(session_workspace):
-            _copy_tree(session_workspace, workspace)
-        # Inline files
-        for (path, data) in (spec.files_inline or []):
-            safe_path = path.lstrip("/\\").replace("..", "_")
-            full = os.path.join(workspace, safe_path)
-            os.makedirs(os.path.dirname(full), exist_ok=True)
-            with open(full, "wb") as f:
-                f.write(data)
-
-        _write_env_file(workspace, spec.env or {})
-        _write_entry_script(workspace, list(spec.command or []))
-
-        api_sock = os.path.join(run_dir, "fc.sock")
-        fc_proc = subprocess.Popen([
-            _fc_bin(),
-            "--api-sock",
-            api_sock,
-        ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=run_dir)
-
-        # Wait for socket
-        deadline = time.time() + 3.0
-        while not os.path.exists(api_sock) and time.time() < deadline:
-            time.sleep(0.05)
-        if not os.path.exists(api_sock):
-            fc_proc.terminate()
-            raise RuntimeError("Firecracker API socket not available")
-
-        # Configure VM
-        vcpu = int(max(1, int(spec.cpu) if spec.cpu else 1))
-        mem_mb = int(spec.memory_mb or int(os.getenv("SANDBOX_MAX_MEM_MB", "512")))
-        _fc_api_request(api_sock, "PUT", "/machine-config", {
-            "vcpu_count": vcpu,
-            "mem_size_mib": mem_mb,
-            "ht_enabled": False,
-        })
-        boot_args = os.getenv("SANDBOX_FC_BOOT_ARGS") or "console=ttyS0 reboot=k panic=1 pci=off"
-        boot_args = f"{boot_args} init=/workspace/entry.sh"
-        _fc_api_request(api_sock, "PUT", "/boot-source", {
-            "kernel_image_path": kernel_path,
-            "boot_args": boot_args,
-        })
-        _fc_api_request(api_sock, "PUT", "/drives/rootfs", {
-            "drive_id": "rootfs",
-            "path_on_host": rootfs_path,
-            "is_root_device": True,
-            "is_read_only": True,
-        })
-
+        fc_proc = None
         virtiofs_proc = None
-        if _virtiofs_enabled():
-            vfs_sock = os.path.join(run_dir, "virtiofs.sock")
-            virtiofs_proc = subprocess.Popen([
-                _virtiofsd_bin(),
-                "--socket-path", vfs_sock,
-                "-o", f"source={workspace}",
-            ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            _fc_api_request(api_sock, "PUT", "/fs", {
-                "mount_tag": "workspace",
-                "socket": vfs_sock,
-            })
-        else:
-            raise RuntimeError("Firecracker virtiofs disabled; no workspace mount available")
-
-        _fc_api_request(api_sock, "PUT", "/actions", {"action_type": "InstanceStart"})
-
-        # Tail logs (best-effort) until status appears
-        stop_flag = {"stop": False}
-        log_path = os.path.join(workspace, "run.log")
         tail_thread = None
+        stop_flag = {"stop": False}
         try:
-            import threading
-            tail_thread = threading.Thread(target=_tail_log, args=(run_id, log_path, stop_flag), daemon=True)
-            tail_thread.start()
-        except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-            tail_thread = None
+            workspace = os.path.join(run_dir, "workspace")
+            os.makedirs(workspace, exist_ok=True)
+            if session_workspace and os.path.isdir(session_workspace):
+                _copy_tree(session_workspace, workspace)
+            # Inline files
+            for (path, data) in (spec.files_inline or []):
+                safe_path = path.lstrip("/\\").replace("..", "_")
+                full = os.path.join(workspace, safe_path)
+                os.makedirs(os.path.dirname(full), exist_ok=True)
+                with open(full, "wb") as f:
+                    f.write(data)
 
-        timeout_sec = int(spec.timeout_sec or 300)
-        status_path = os.path.join(workspace, ".sandbox_status.json")
-        deadline = time.time() + timeout_sec
-        exit_code = None
-        reason = None
-        while time.time() < deadline:
-            if os.path.exists(status_path):
-                try:
-                    with open(status_path, encoding="utf-8") as rf:
-                        payload = json.load(rf)
-                    exit_code = payload.get("exit_code")
-                    reason = payload.get("reason")
-                    payload.get("duration_ms")
-                except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-                    pass
-                break
-            time.sleep(0.1)
+            _write_env_file(workspace, spec.env or {})
+            _write_entry_script(workspace, list(spec.command or []))
 
-        if exit_code is None:
-            # Timeout: kill VM
-            reason = "execution_timeout"
+            api_sock = os.path.join(run_dir, "fc.sock")
+            fc_proc = subprocess.Popen([
+                _fc_bin(),
+                "--api-sock",
+                api_sock,
+            ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=run_dir)
+
+            # Wait for socket
+            deadline = time.time() + 3.0
+            while not os.path.exists(api_sock) and time.time() < deadline:
+                time.sleep(0.05)
+            if not os.path.exists(api_sock):
+                raise RuntimeError("Firecracker API socket not available")
+
+            # Configure VM
+            vcpu = int(max(1, int(spec.cpu) if spec.cpu else 1))
+            mem_mb = int(spec.memory_mb or int(os.getenv("SANDBOX_MAX_MEM_MB", "512")))
+            _fc_api_request(api_sock, "PUT", "/machine-config", {
+                "vcpu_count": vcpu,
+                "mem_size_mib": mem_mb,
+                "ht_enabled": False,
+            })
+            boot_args = os.getenv("SANDBOX_FC_BOOT_ARGS") or "console=ttyS0 reboot=k panic=1 pci=off"
+            boot_args = f"{boot_args} init=/workspace/entry.sh"
+            _fc_api_request(api_sock, "PUT", "/boot-source", {
+                "kernel_image_path": kernel_path,
+                "boot_args": boot_args,
+            })
+            _fc_api_request(api_sock, "PUT", "/drives/rootfs", {
+                "drive_id": "rootfs",
+                "path_on_host": rootfs_path,
+                "is_root_device": True,
+                "is_read_only": True,
+            })
+
+            if _virtiofs_enabled():
+                vfs_sock = os.path.join(run_dir, "virtiofs.sock")
+                virtiofs_proc = subprocess.Popen([
+                    _virtiofsd_bin(),
+                    "--socket-path", vfs_sock,
+                    "-o", f"source={workspace}",
+                ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                _fc_api_request(api_sock, "PUT", "/fs", {
+                    "mount_tag": "workspace",
+                    "socket": vfs_sock,
+                })
+            else:
+                raise RuntimeError("Firecracker virtiofs disabled; no workspace mount available")
+
+            _fc_api_request(api_sock, "PUT", "/actions", {"action_type": "InstanceStart"})
+
+            # Tail logs (best-effort) until status appears
+            log_path = os.path.join(workspace, "run.log")
+            try:
+                import threading
+                tail_thread = threading.Thread(
+                    target=_tail_log,
+                    args=(run_id, log_path, stop_flag),
+                    daemon=True,
+                )
+                tail_thread.start()
+            except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
+                tail_thread = None
+
+            timeout_sec = int(spec.timeout_sec or 300)
+            status_path = os.path.join(workspace, ".sandbox_status.json")
+            deadline = time.time() + timeout_sec
+            exit_code = None
+            reason = None
+            while time.time() < deadline:
+                if os.path.exists(status_path):
+                    try:
+                        with open(status_path, encoding="utf-8") as rf:
+                            payload = json.load(rf)
+                        exit_code = payload.get("exit_code")
+                        reason = payload.get("reason")
+                        payload.get("duration_ms")
+                    except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
+                        pass
+                    break
+                time.sleep(0.1)
+
+            if exit_code is None:
+                # Timeout: kill VM
+                reason = "execution_timeout"
+                with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
+                    fc_proc.terminate()
+                phase = RunPhase.timed_out
+            else:
+                phase = RunPhase.completed if int(exit_code or 0) == 0 else RunPhase.failed
+
+            stop_flag["stop"] = True
+            if tail_thread is not None:
+                with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
+                    tail_thread.join(timeout=1)
+
             with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-                fc_proc.terminate()
-            phase = RunPhase.timed_out
-        else:
-            phase = RunPhase.completed if int(exit_code or 0) == 0 else RunPhase.failed
+                hub.publish_event(run_id, "end", {"exit_code": exit_code})
 
-        stop_flag["stop"] = True
-        if tail_thread is not None:
-            with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-                tail_thread.join(timeout=1)
+            finished = datetime.utcnow()
+            # Collect artifacts
+            artifacts_map: dict[str, bytes] = {}
+            try:
+                if spec.capture_patterns:
+                    for root, _dirs, files in os.walk(workspace):
+                        for fn in files:
+                            rel = os.path.relpath(os.path.join(root, fn), workspace)
+                            rel_posix = rel.replace(os.sep, "/")
+                            if any(fnmatch.fnmatchcase(rel_posix, pat) for pat in (spec.capture_patterns or [])):
+                                try:
+                                    with open(os.path.join(root, fn), "rb") as rf:
+                                        artifacts_map[rel_posix] = rf.read()
+                                except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
+                                    pass
+            except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
+                artifacts_map = {}
 
-        with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-            hub.publish_event(run_id, "end", {"exit_code": exit_code})
+            # Usage
+            try:
+                log_bytes_total = int(hub.get_log_bytes(run_id))
+            except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
+                log_bytes_total = 0
+            art_bytes = sum(len(v) for v in artifacts_map.values()) if artifacts_map else 0
+            usage: dict[str, int] = {
+                "cpu_time_sec": 0,
+                "wall_time_sec": int(max(0.0, (finished - started).total_seconds())),
+                "peak_rss_mb": 0,
+                "log_bytes": int(log_bytes_total),
+                "artifact_bytes": int(art_bytes),
+            }
 
-        finished = datetime.utcnow()
-        # Collect artifacts
-        artifacts_map: dict[str, bytes] = {}
-        try:
-            if spec.capture_patterns:
-                for root, _dirs, files in os.walk(workspace):
-                    for fn in files:
-                        rel = os.path.relpath(os.path.join(root, fn), workspace)
-                        rel_posix = rel.replace(os.sep, "/")
-                        if any(fnmatch.fnmatchcase(rel_posix, pat) for pat in (spec.capture_patterns or [])):
-                            try:
-                                with open(os.path.join(root, fn), "rb") as rf:
-                                    artifacts_map[rel_posix] = rf.read()
-                            except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-                                pass
-        except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-            artifacts_map = {}
-
-        # Usage
-        try:
-            log_bytes_total = int(hub.get_log_bytes(run_id))
-        except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-            log_bytes_total = 0
-        art_bytes = sum(len(v) for v in artifacts_map.values()) if artifacts_map else 0
-        usage: dict[str, int] = {
-            "cpu_time_sec": 0,
-            "wall_time_sec": int(max(0.0, (finished - started).total_seconds())),
-            "peak_rss_mb": 0,
-            "log_bytes": int(log_bytes_total),
-            "artifact_bytes": int(art_bytes),
-        }
-
-        # Cleanup
-        try:
+            return RunStatus(
+                id="",
+                phase=phase,
+                started_at=started,
+                finished_at=finished,
+                exit_code=exit_code,
+                message=(reason or "Firecracker execution"),
+                image_digest=image_digest,
+                runtime_version=firecracker_version(),
+                resource_usage=usage,
+                artifacts=(artifacts_map or None),
+            )
+        finally:
+            stop_flag["stop"] = True
+            if tail_thread is not None:
+                with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
+                    tail_thread.join(timeout=1)
             if virtiofs_proc is not None:
-                virtiofs_proc.terminate()
-        except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-            pass
-        with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-            fc_proc.terminate()
-        with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-            shutil.rmtree(run_dir, ignore_errors=True)
-
-        return RunStatus(
-            id="",
-            phase=phase,
-            started_at=started,
-            finished_at=finished,
-            exit_code=exit_code,
-            message=(reason or "Firecracker execution"),
-            image_digest=image_digest,
-            runtime_version=firecracker_version(),
-            resource_usage=usage,
-            artifacts=(artifacts_map or None),
-        )
+                with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
+                    virtiofs_proc.terminate()
+            if fc_proc is not None:
+                with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
+                    fc_proc.terminate()
+            with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
+                shutil.rmtree(run_dir, ignore_errors=True)
 
     def _run_fake(self, run_id: str, spec: RunSpec) -> RunStatus:
         """Execute a run in a Firecracker microVM (scaffolded)."""

--- a/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py
@@ -15,6 +15,8 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+from loguru import logger
+
 from tldw_Server_API.app.core.testing import is_truthy
 from ..models import RunPhase, RunSpec, RunStatus
 from ..streams import get_hub
@@ -208,6 +210,21 @@ def _copy_tree(src: str, dst: str) -> None:
                 shutil.copy2(s, t)
 
 
+def _terminate_process(proc: subprocess.Popen | None, name: str) -> None:
+    if proc is None:
+        return
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.warning(f"Firecracker cleanup timed out waiting for {name}; killing process")
+            proc.kill()
+            proc.wait(timeout=5)
+    except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS as e:
+        logger.warning(f"Firecracker cleanup failed for {name}: {e}")
+
+
 def _tail_log(run_id: str, log_path: str, stop_flag: dict[str, bool]) -> None:
     hub = get_hub()
     max_log = None
@@ -368,8 +385,11 @@ class FirecrackerRunner:
                         exit_code = payload.get("exit_code")
                         reason = payload.get("reason")
                         payload.get("duration_ms")
-                    except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS:
-                        pass
+                    except _FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS as e:
+                        logger.warning(
+                            f"Firecracker status parse failed for run_id={run_id} "
+                            f"status_path={status_path}: {e}"
+                        )
                     break
                 time.sleep(0.1)
 
@@ -439,12 +459,8 @@ class FirecrackerRunner:
             if tail_thread is not None:
                 with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                     tail_thread.join(timeout=1)
-            if virtiofs_proc is not None:
-                with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-                    virtiofs_proc.terminate()
-            if fc_proc is not None:
-                with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
-                    fc_proc.terminate()
+            _terminate_process(virtiofs_proc, "virtiofsd")
+            _terminate_process(fc_proc, "firecracker")
             with contextlib.suppress(_FIRECRACKER_RUNNER_NONCRITICAL_EXCEPTIONS):
                 shutil.rmtree(run_dir, ignore_errors=True)
 

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
@@ -403,7 +403,8 @@ class LimaRunner:
             with LimaRunner._active_lock:
                 LimaRunner._active_vm[run_id] = vm_name
                 LimaRunner._active_run_dir[run_id] = run_dir
-        except Exception:
+        except BaseException:
+            # Re-raise after cleanup so interrupts do not leak setup directories.
             with contextlib.suppress(_LIMA_RUNNER_NONCRITICAL_EXCEPTIONS):
                 shutil.rmtree(run_dir, ignore_errors=True)
             with LimaRunner._active_lock:

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
@@ -348,60 +348,68 @@ class LimaRunner:
 
         # Create temp directory for this run
         run_dir = tempfile.mkdtemp(prefix="tldw_lima_")
-        workspace = os.path.join(run_dir, "workspace")
-        os.makedirs(workspace, exist_ok=True)
-
-        # Copy session workspace files
-        if session_workspace and os.path.isdir(session_workspace):
-            self._copy_tree(session_workspace, workspace)
-
-        # Write inline files
-        for (path, data) in (spec.files_inline or []):
-            safe_path = path.lstrip("/\\").replace("..", "_")
-            full = os.path.join(workspace, safe_path)
-            os.makedirs(os.path.dirname(full), exist_ok=True)
-            with open(full, "wb") as f:
-                f.write(data)
-
-        # Write entry script
-        self._write_entry_script(workspace, list(spec.command or []))
-
-        # Write environment file
-        self._write_env_file(workspace, spec.env or {})
-
-        # Generate Lima config
-        cpu = int(spec.cpu) if spec.cpu else 2
-        memory_mb = int(spec.memory_mb) if spec.memory_mb else 2048
-        net_policy = (spec.network_policy or "deny_all").lower()
-        if net_policy == "allowlist":
-            raise RuntimeError("strict_allowlist_not_supported")
-
-        lima_config = _generate_lima_config(
-            workspace_host_path=workspace,
-            cpu=cpu,
-            memory_mb=memory_mb,
-            env=spec.env or {},
-            network_policy=net_policy,
-        )
-
-        # Write Lima config to YAML file
-        config_path = os.path.join(run_dir, "lima.yaml")
         try:
-            import yaml
-            with open(config_path, "w") as f:
-                yaml.safe_dump(lima_config, f)
-        except ImportError:
-            # Fallback to JSON-like YAML if pyyaml not available
-            with open(config_path, "w") as f:
-                json.dump(lima_config, f, indent=2)
+            workspace = os.path.join(run_dir, "workspace")
+            os.makedirs(workspace, exist_ok=True)
 
-        # Generate unique VM name
-        vm_name = f"tldw-sbx-{run_id[:12]}"
+            # Copy session workspace files
+            if session_workspace and os.path.isdir(session_workspace):
+                self._copy_tree(session_workspace, workspace)
 
-        # Register VM for cancellation
-        with LimaRunner._active_lock:
-            LimaRunner._active_vm[run_id] = vm_name
-            LimaRunner._active_run_dir[run_id] = run_dir
+            # Write inline files
+            for (path, data) in (spec.files_inline or []):
+                safe_path = path.lstrip("/\\").replace("..", "_")
+                full = os.path.join(workspace, safe_path)
+                os.makedirs(os.path.dirname(full), exist_ok=True)
+                with open(full, "wb") as f:
+                    f.write(data)
+
+            # Write entry script
+            self._write_entry_script(workspace, list(spec.command or []))
+
+            # Write environment file
+            self._write_env_file(workspace, spec.env or {})
+
+            # Generate Lima config
+            cpu = int(spec.cpu) if spec.cpu else 2
+            memory_mb = int(spec.memory_mb) if spec.memory_mb else 2048
+            net_policy = (spec.network_policy or "deny_all").lower()
+            if net_policy == "allowlist":
+                raise RuntimeError("strict_allowlist_not_supported")
+
+            lima_config = _generate_lima_config(
+                workspace_host_path=workspace,
+                cpu=cpu,
+                memory_mb=memory_mb,
+                env=spec.env or {},
+                network_policy=net_policy,
+            )
+
+            # Write Lima config to YAML file
+            config_path = os.path.join(run_dir, "lima.yaml")
+            try:
+                import yaml
+                with open(config_path, "w") as f:
+                    yaml.safe_dump(lima_config, f)
+            except ImportError:
+                # Fallback to JSON-like YAML if pyyaml not available
+                with open(config_path, "w") as f:
+                    json.dump(lima_config, f, indent=2)
+
+            # Generate unique VM name
+            vm_name = f"tldw-sbx-{run_id[:12]}"
+
+            # Register VM for cancellation
+            with LimaRunner._active_lock:
+                LimaRunner._active_vm[run_id] = vm_name
+                LimaRunner._active_run_dir[run_id] = run_dir
+        except Exception:
+            with contextlib.suppress(_LIMA_RUNNER_NONCRITICAL_EXCEPTIONS):
+                shutil.rmtree(run_dir, ignore_errors=True)
+            with LimaRunner._active_lock:
+                LimaRunner._active_vm.pop(run_id, None)
+                LimaRunner._active_run_dir.pop(run_id, None)
+            raise
 
         exit_code: int | None = None
         image_digest: str | None = None

--- a/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
+++ b/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import tldw_Server_API.app.core.Sandbox.runners.firecracker_runner as firecracker_module
+import tldw_Server_API.app.core.Sandbox.runners.lima_runner as lima_module
+from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType
+from tldw_Server_API.app.core.Sandbox.runners.firecracker_runner import FirecrackerRunner
+from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
+
+
+def _spec(runtime: RuntimeType, *, network_policy: str | None = "deny_all") -> RunSpec:
+    return RunSpec(
+        session_id=None,
+        runtime=runtime,
+        base_image=None,
+        command=["/bin/echo", "unused"],
+        network_policy=network_policy,
+        timeout_sec=5,
+    )
+
+
+def test_lima_real_run_cleans_run_dir_when_setup_fails_after_workspace_create(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "lima-run"
+
+    def _mkdtemp(prefix: str) -> str:
+        if prefix != "tldw_lima_":
+            pytest.fail(f"unexpected Lima temp prefix: {prefix}")
+        run_dir.mkdir()
+        return str(run_dir)
+
+    monkeypatch.setattr(lima_module.tempfile, "mkdtemp", _mkdtemp)
+
+    with pytest.raises(RuntimeError, match="strict_allowlist_not_supported"):
+        LimaRunner()._run_real(
+            "run-lima-cleanup",
+            _spec(RuntimeType.lima, network_policy="allowlist"),
+        )
+
+    if run_dir.exists():
+        pytest.fail("LimaRunner should remove the run directory on setup failure")
+
+
+def test_firecracker_real_run_cleans_run_dir_when_setup_fails_after_workspace_create(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "firecracker-run"
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.write_bytes(b"kernel")
+    rootfs.write_bytes(b"rootfs")
+
+    def _mkdtemp(prefix: str) -> str:
+        if prefix != "tldw_fc_":
+            pytest.fail(f"unexpected Firecracker temp prefix: {prefix}")
+        run_dir.mkdir()
+        return str(run_dir)
+
+    def _fail_write_env_file(workspace: str, env: dict[str, str]) -> None:
+        del workspace, env
+        raise RuntimeError("env write failed")
+
+    monkeypatch.setenv("SANDBOX_FC_KERNEL_PATH", str(kernel))
+    monkeypatch.setenv("SANDBOX_FC_ROOTFS_PATH", str(rootfs))
+    monkeypatch.setattr(firecracker_module.tempfile, "mkdtemp", _mkdtemp)
+    monkeypatch.setattr(firecracker_module, "_write_env_file", _fail_write_env_file)
+
+    with pytest.raises(RuntimeError, match="env write failed"):
+        FirecrackerRunner()._run_real(
+            "run-firecracker-cleanup",
+            _spec(RuntimeType.firecracker),
+        )
+
+    if run_dir.exists():
+        pytest.fail("FirecrackerRunner should remove the run directory on setup failure")

--- a/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
+++ b/tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
@@ -46,6 +46,32 @@ def test_lima_real_run_cleans_run_dir_when_setup_fails_after_workspace_create(
         pytest.fail("LimaRunner should remove the run directory on setup failure")
 
 
+def test_lima_real_run_cleans_run_dir_when_setup_is_interrupted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "lima-interrupted-run"
+
+    def _mkdtemp(prefix: str) -> str:
+        if prefix != "tldw_lima_":
+            pytest.fail(f"unexpected Lima temp prefix: {prefix}")
+        run_dir.mkdir()
+        return str(run_dir)
+
+    def _interrupt_entry_script(workspace: str, command: list[str]) -> None:
+        del workspace, command
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(lima_module.tempfile, "mkdtemp", _mkdtemp)
+    monkeypatch.setattr(LimaRunner, "_write_entry_script", staticmethod(_interrupt_entry_script))
+
+    with pytest.raises(KeyboardInterrupt):
+        LimaRunner()._run_real("run-lima-interrupted", _spec(RuntimeType.lima))
+
+    if run_dir.exists():
+        pytest.fail("LimaRunner should remove the run directory on setup interruption")
+
+
 def test_firecracker_real_run_cleans_run_dir_when_setup_fails_after_workspace_create(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -79,3 +105,106 @@ def test_firecracker_real_run_cleans_run_dir_when_setup_fails_after_workspace_cr
 
     if run_dir.exists():
         pytest.fail("FirecrackerRunner should remove the run directory on setup failure")
+
+
+def test_firecracker_real_run_waits_for_spawned_processes_on_setup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.write_bytes(b"kernel")
+    rootfs.write_bytes(b"rootfs")
+    processes: list[_FakeProcess] = []
+
+    def _fake_popen(args: list[str], **kwargs: object) -> _FakeProcess:
+        proc = _FakeProcess()
+        processes.append(proc)
+        if "--api-sock" in args:
+            cwd = kwargs.get("cwd")
+            if not isinstance(cwd, str):
+                pytest.fail("Firecracker Popen should receive a string cwd")
+            (Path(cwd) / "fc.sock").touch()
+        return proc
+
+    def _fail_api_request(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise RuntimeError("api configure failed")
+
+    monkeypatch.setenv("SANDBOX_FC_KERNEL_PATH", str(kernel))
+    monkeypatch.setenv("SANDBOX_FC_ROOTFS_PATH", str(rootfs))
+    monkeypatch.setattr(firecracker_module.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(firecracker_module, "_fc_api_request", _fail_api_request)
+
+    with pytest.raises(RuntimeError, match="api configure failed"):
+        FirecrackerRunner()._run_real("run-firecracker-proc-cleanup", _spec(RuntimeType.firecracker))
+
+    if len(processes) != 1:
+        pytest.fail(f"expected one Firecracker process, got {len(processes)}")
+    if processes[0].terminate_calls != 1:
+        pytest.fail("Firecracker process should be terminated on setup failure")
+    if processes[0].wait_calls == 0:
+        pytest.fail("Firecracker process should be waited after terminate")
+
+
+def test_firecracker_real_run_logs_status_parse_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    kernel = tmp_path / "vmlinux"
+    rootfs = tmp_path / "rootfs.ext4"
+    kernel.write_bytes(b"kernel")
+    rootfs.write_bytes(b"rootfs")
+    warnings: list[str] = []
+
+    class _Logger:
+        def warning(self, message: str, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+            warnings.append(message)
+
+    def _fake_popen(args: list[str], **kwargs: object) -> _FakeProcess:
+        proc = _FakeProcess()
+        if "--api-sock" in args:
+            cwd = kwargs.get("cwd")
+            if not isinstance(cwd, str):
+                pytest.fail("Firecracker Popen should receive a string cwd")
+            (Path(cwd) / "fc.sock").touch()
+        if "--socket-path" in args:
+            source_arg = next((arg for arg in args if arg.startswith("source=")), None)
+            if source_arg is None:
+                pytest.fail("virtiofsd Popen should receive a source mount option")
+            workspace = Path(source_arg.removeprefix("source="))
+            (workspace / ".sandbox_status.json").write_text("{not-json", encoding="utf-8")
+        return proc
+
+    monkeypatch.setenv("SANDBOX_FC_KERNEL_PATH", str(kernel))
+    monkeypatch.setenv("SANDBOX_FC_ROOTFS_PATH", str(rootfs))
+    monkeypatch.setenv("TLDW_SANDBOX_FIRECRACKER_VERSION", "test-version")
+    monkeypatch.setattr(firecracker_module.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(firecracker_module, "_fc_api_request", lambda *args, **kwargs: None)
+    monkeypatch.setattr(firecracker_module, "logger", _Logger(), raising=False)
+
+    FirecrackerRunner()._run_real("run-firecracker-status-parse", _spec(RuntimeType.firecracker))
+
+    if not warnings:
+        pytest.fail("Firecracker status parse failures should be logged")
+    if "status" not in warnings[0]:
+        pytest.fail(f"expected status parse context in warning, got: {warnings[0]}")
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_calls = 0
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        self.wait_calls += 1
+        return 0


### PR DESCRIPTION
## Summary
- Add portable cleanup contract tests for Lima and Firecracker setup failures after run directory creation.
- Remove Lima temp run directories when setup fails before VM registration.
- Ensure Firecracker real-run setup exits clean up temp directories and child processes via a single finally path.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m py_compile tldw_Server_API/app/core/Sandbox/runners/lima_runner.py tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py
- [x] git diff --check HEAD
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/core/Sandbox/runners/lima_runner.py tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py tldw_Server_API/tests/sandbox/test_cross_runtime_cleanup_contracts.py -f json -o /private/tmp/bandit_cross_runtime_cleanup_pr.json

## Change summary
TODO: human-authored rationale before merge.