### PR TITLE
Phase 4.4: extract storage user route groups

### DIFF
--- a/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
+++ b/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
@@ -70,7 +70,7 @@ Special behavior:
 **Goal:** Record current behavior before moving routes.
 **Success Criteria:** Focused storage tests pass on the accepted base, and OpenAPI path set is captured.
 **Tests:** Focused storage endpoint/admin tests and OpenAPI path guard.
-**Status:** Complete With Caveat
+**Status:** Complete
 
 - [x] Create a clean worktree from the accepted base.
 - [x] Confirm no active dirty work exists in `storage.py`.
@@ -88,7 +88,7 @@ python3 -m pytest \
 - [x] Run OpenAPI guard from the UI package if dependencies are installed:
 
 ```bash
-cd apps/packages/ui
+cd apps/extension
 bun run verify:openapi
 ```
 
@@ -97,9 +97,8 @@ bun run verify:openapi
 
 Notes:
 
-- Focused storage/admin baseline passed: `43 passed, 6 warnings`.
-- `bun run verify:openapi` currently fails on `origin/dev` before storage route movement with `No MEDIA_ADD_SCHEMA_FALLBACK entries were parsed from fallback-schemas.ts`. Root cause is the guard's fallback parser matching `MEDIA_ADD_SCHEMA_FALLBACK_VERSION` before the actual fallback array. Route movement is deferred until the Phase 4.6 guardrail fix is merged or rebased into this branch.
-- The failing guard had already checked 256 client paths and did not identify storage-route drift before the fallback parser failure.
+- Focused storage/admin baseline passed after #1220 was merged into `dev`: `43 passed, 6 warnings`.
+- `bun run verify:openapi` passed from `apps/extension`, verifying 256 client paths and 46 media fallback fields with the reviewed OSS exceptions unchanged.
 
 ## Stage 2: Extract Storage Endpoint Helpers
 
@@ -139,7 +138,7 @@ Notes:
 **Goal:** Move only user-owned JSON routes into sidecar route modules while keeping public paths unchanged.
 **Success Criteria:** `storage.router` still registers the same paths, methods, response models, and dependency behavior.
 **Tests:** Focused storage endpoint tests and OpenAPI path guard.
-**Status:** Not Started
+**Status:** Complete
 
 Candidate modules:
 
@@ -166,12 +165,22 @@ Implementation constraints:
 - Preserve ownership checks and status codes.
 - Do not change response shapes or introduce Phase 3 envelopes.
 
+Notes:
+
+- Moved user-owned file routes to `storage_user_files.py` and folder routes to `storage_user_folders.py`.
+- Preserved the existing `storage._get_service` monkeypatch seam through a dynamic sidecar resolver and re-exported moved handler functions from `storage.py` for direct-test compatibility.
+- Added route-level regression coverage proving `GET /api/v1/storage/files/least-accessed` is no longer captured by `GET /files/{file_id}`.
+- Added canonical pagination metadata to the least-accessed response to satisfy the existing generated list response schema.
+- Focused storage/admin suite passed after route movement: `44 passed, 6 warnings`.
+- OpenAPI verifier passed from `apps/extension`.
+- Touched-scope Bandit passed with zero findings.
+
 ## Stage 4: Extract Usage And Trash JSON Routes
 
 **Goal:** Move usage and trash route groups after file/folder route extraction is stable.
 **Success Criteria:** Usage counters, restore behavior, and trash response models remain unchanged.
 **Tests:** Focused storage endpoint tests.
-**Status:** Not Started
+**Status:** Complete
 
 Candidate modules:
 
@@ -191,6 +200,15 @@ Implementation constraints:
 - Preserve quota warning calculation.
 - Preserve restore quota counter updates for user, org, and team usage.
 - Preserve trash permanent-delete status behavior.
+
+Notes:
+
+- Moved usage routes to `storage_usage.py` and trash routes to `storage_trash.py`.
+- Added route-level characterization coverage for `/usage`, `/usage/breakdown`, `/trash`, `/trash/restore/{file_id}`, and `/trash/{file_id}` before extraction.
+- Preserved the existing `storage._get_service` monkeypatch seam through dynamic sidecar resolvers and re-exported moved handler functions from `storage.py`.
+- Focused storage/admin suite passed after route movement: `49 passed, 6 warnings`.
+- OpenAPI verifier passed from `apps/extension`.
+- Touched-scope Bandit passed with zero findings.
 
 ## Stage 5: Plan Download And Admin Splits Separately
 
@@ -229,7 +247,7 @@ python3 -m pytest \
 OpenAPI guard:
 
 ```bash
-cd apps/packages/ui
+cd apps/extension
 bun run verify:openapi
 ```
 
@@ -255,6 +273,6 @@ python3 -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server
 - [x] Maintainers accept `storage.py` user-owned JSON routes as the first Phase 4.4 endpoint target.
 - [x] Clean worktree from accepted base exists.
 - [x] Stage 1 focused tests pass before route movement.
-- [ ] OpenAPI path set is captured before route movement.
+- [x] OpenAPI path set is captured before route movement.
 - [x] File download and admin quota routes remain excluded from the first route split.
 - [x] Bandit is run on touched source before PR handoff.

--- a/tldw_Server_API/app/api/v1/endpoints/storage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage.py
@@ -9,42 +9,50 @@ Provides endpoints for:
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_auth_principal, get_request_user
-from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.endpoints import (
+    storage_trash,
+    storage_usage,
+    storage_user_files,
+    storage_user_folders,
+)
 from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
     _principal_is_storage_admin,
     _resolve_storage_base_dir,
-    _to_generated_file,
     _to_quota_status,
 )
+# Re-export moved handlers so direct imports/tests against storage.py keep working.
+from tldw_Server_API.app.api.v1.endpoints.storage_user_files import (  # noqa: F401
+    bulk_delete_files,
+    bulk_move_files,
+    delete_file,
+    get_file,
+    list_files,
+    list_least_accessed_files,
+    update_file,
+)
+from tldw_Server_API.app.api.v1.endpoints.storage_user_folders import (  # noqa: F401
+    create_folder,
+    list_folders,
+)
+from tldw_Server_API.app.api.v1.endpoints.storage_trash import (  # noqa: F401
+    list_trashed_files,
+    permanently_delete_file,
+    restore_file,
+)
+from tldw_Server_API.app.api.v1.endpoints.storage_usage import (  # noqa: F401
+    get_storage_usage,
+    get_usage_breakdown,
+)
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
-    BulkDeleteRequest,
-    BulkDeleteResponse,
-    BulkMoveRequest,
-    BulkMoveResponse,
-    CategoryUsage,
-    FileCategory,
-    FolderCreateRequest,
-    FolderInfo,
-    FolderListResponse,
-    GeneratedFileResponse,
-    GeneratedFilesListResponse,
-    GeneratedFileUpdate,
     OrgQuotaResponse,
-    PermanentDeleteResponse,
     QuotaStatus,
-    RestoreResponse,
     SetQuotaRequest,
     SetQuotaResponse,
-    SourceFeature,
-    StorageUsage,
-    StorageUsageResponse,
     TeamQuotaResponse,
-    TrashListResponse,
-    UsageBreakdownResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.exceptions import (
     StorageError,
@@ -84,71 +92,10 @@ async def require_storage_admin(principal: AuthPrincipal = Depends(get_auth_prin
 # File Endpoints
 # =========================================================================
 
-@router.get("/files", response_model=GeneratedFilesListResponse)
-async def list_files(
-    user: User = Depends(get_request_user),
-    offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=50, ge=1, le=200),
-    file_category: FileCategory | None = Query(default=None),
-    source_feature: SourceFeature | None = Query(default=None),
-    folder_tag: str | None = Query(default=None),
-    search: str | None = Query(default=None, max_length=100),
-    include_deleted: bool = Query(default=False),
-):
-    """
-    List generated files for the current user.
-
-    Supports filtering by category, source feature, folder, and search term.
-    """
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    files, total = await files_repo.list_files(
-        user_id=user.id,
-        offset=offset,
-        limit=limit,
-        file_category=file_category,
-        source_feature=source_feature,
-        folder_tag=folder_tag,
-        search=search,
-        include_deleted=include_deleted,
-    )
-
-    return GeneratedFilesListResponse(
-        files=[_to_generated_file(f) for f in files],
-        total=total,
-        offset=offset,
-        limit=limit,
-        pagination=build_offset_pagination_meta(
-            total=total,
-            offset=offset,
-            limit=limit,
-            count=len(files),
-        ),
-    )
-
-
-@router.get("/files/{file_id}", response_model=GeneratedFileResponse)
-async def get_file(
-    file_id: int,
-    user: User = Depends(get_request_user),
-):
-    """Get metadata for a specific file."""
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    file_record = await files_repo.get_file_by_id(file_id)
-    if not file_record:
-        raise HTTPException(status_code=404, detail="File not found")
-
-    # Verify ownership
-    if file_record.get("user_id") != user.id:
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    # Update accessed_at
-    await files_repo.update_accessed_at(file_id)
-
-    return GeneratedFileResponse(file=_to_generated_file(file_record))
+router.include_router(storage_user_files.router)
+router.include_router(storage_user_folders.router)
+router.include_router(storage_usage.router)
+router.include_router(storage_trash.router)
 
 
 @router.get("/files/{file_id}/download")
@@ -200,392 +147,6 @@ async def download_file(
         filename=filename,
         media_type=mime_type,
     )
-
-
-@router.delete("/files/{file_id}")
-async def delete_file(
-    file_id: int,
-    user: User = Depends(get_request_user),
-    hard_delete: bool = Query(default=False),
-):
-    """
-    Delete a generated file.
-
-    By default, performs a soft delete (moves to trash).
-    Use hard_delete=true for permanent deletion.
-    """
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    file_record = await files_repo.get_file_by_id(file_id)
-    if not file_record:
-        raise HTTPException(status_code=404, detail="File not found")
-
-    # Verify ownership
-    if file_record.get("user_id") != user.id:
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    success = await service.unregister_generated_file(file_id, hard_delete=hard_delete)
-
-    if not success:
-        raise HTTPException(status_code=500, detail="Failed to delete file")
-
-    return {"success": True, "file_id": file_id, "hard_delete": hard_delete}
-
-
-@router.patch("/files/{file_id}", response_model=GeneratedFileResponse)
-async def update_file(
-    file_id: int,
-    update: GeneratedFileUpdate,
-    user: User = Depends(get_request_user),
-):
-    """Update file metadata (folder, tags, retention)."""
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    file_record = await files_repo.get_file_by_id(file_id)
-    if not file_record:
-        raise HTTPException(status_code=404, detail="File not found")
-
-    # Verify ownership
-    if file_record.get("user_id") != user.id:
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    updated = await files_repo.update_file(
-        file_id,
-        folder_tag=update.folder_tag,
-        tags=update.tags,
-        retention_policy=update.retention_policy,
-        expires_at=update.expires_at,
-    )
-
-    return GeneratedFileResponse(file=_to_generated_file(updated or file_record))
-
-
-# =========================================================================
-# Bulk Operations
-# =========================================================================
-
-@router.post("/files/bulk-delete", response_model=BulkDeleteResponse)
-async def bulk_delete_files(
-    request: BulkDeleteRequest,
-    user: User = Depends(get_request_user),
-):
-    """Bulk delete multiple files."""
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    # Verify ownership for all files
-    for file_id in request.file_ids:
-        file_record = await files_repo.get_file_by_id(file_id)
-        if file_record and file_record.get("user_id") != user.id:
-            raise HTTPException(status_code=403, detail=f"Access denied for file {file_id}")
-
-    if request.hard_delete:
-        # Hard delete each file with usage tracking
-        deleted_count = 0
-        for file_id in request.file_ids:
-            if await service.unregister_generated_file(file_id, hard_delete=True):
-                deleted_count += 1
-    else:
-        # Soft delete each file with usage tracking (not bulk, to update quotas properly)
-        deleted_count = 0
-        for file_id in request.file_ids:
-            if await service.unregister_generated_file(file_id, hard_delete=False):
-                deleted_count += 1
-
-    return BulkDeleteResponse(
-        deleted_count=deleted_count,
-        file_ids=request.file_ids,
-    )
-
-
-@router.post("/files/bulk-move", response_model=BulkMoveResponse)
-async def bulk_move_files(
-    request: BulkMoveRequest,
-    user: User = Depends(get_request_user),
-):
-    """Move multiple files to a folder."""
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    # Verify ownership for all files
-    for file_id in request.file_ids:
-        file_record = await files_repo.get_file_by_id(file_id)
-        if file_record and file_record.get("user_id") != user.id:
-            raise HTTPException(status_code=403, detail=f"Access denied for file {file_id}")
-
-    moved_count = await files_repo.bulk_move_to_folder(request.file_ids, request.folder_tag)
-
-    return BulkMoveResponse(
-        moved_count=moved_count,
-        file_ids=request.file_ids,
-        folder_tag=request.folder_tag,
-    )
-
-
-# =========================================================================
-# Folder Endpoints
-# =========================================================================
-
-@router.get("/folders", response_model=FolderListResponse)
-async def list_folders(
-    user: User = Depends(get_request_user),
-):
-    """List virtual folders for the current user."""
-    service = await _get_service()
-    folders = await service.get_user_folders(user.id)
-
-    return FolderListResponse(
-        folders=[
-            FolderInfo(
-                folder_tag=f["folder_tag"],
-                file_count=f["file_count"],
-                total_bytes=f["total_bytes"],
-                total_mb=round(f["total_bytes"] / (1024 * 1024), 2),
-            )
-            for f in folders
-        ]
-    )
-
-
-@router.post("/folders")
-async def create_folder(
-    request: FolderCreateRequest,
-    user: User = Depends(get_request_user),
-):
-    """
-    Create a virtual folder.
-
-    Note: Folders are virtual (tag-based). This endpoint validates the name
-    but the folder only exists when files are assigned to it.
-    """
-    # Validate folder name
-    name = request.name.strip()
-    if not name or "/" in name or "\\" in name:
-        raise HTTPException(status_code=400, detail="Invalid folder name")
-
-    return {"success": True, "folder_tag": name, "message": "Folder created (virtual)"}
-
-
-@router.get("/files/least-accessed", response_model=GeneratedFilesListResponse)
-async def list_least_accessed_files(
-    user: User = Depends(get_request_user),
-    limit: int = Query(default=20, ge=1, le=100),
-):
-    """
-    List least recently accessed files (candidates for cleanup).
-
-    Useful for users approaching quota limits who need to free up space.
-    Returns files sorted by access time (oldest first), with never-accessed
-    files sorted by creation time.
-    """
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    files = await files_repo.list_least_accessed(user.id, limit=limit)
-
-    return GeneratedFilesListResponse(
-        files=[_to_generated_file(f) for f in files],
-        total=len(files),
-        offset=0,
-        limit=limit,
-    )
-
-
-# =========================================================================
-# Usage Endpoints
-# =========================================================================
-
-@router.get("/usage", response_model=StorageUsageResponse)
-async def get_storage_usage(
-    user: User = Depends(get_request_user),
-):
-    """Get storage usage summary for the current user."""
-    service = await _get_service()
-    usage_data = await service.get_user_generated_files_usage(user.id)
-
-    # Build category usage
-    by_category = {}
-    for cat, data in usage_data.get("by_category", {}).items():
-        by_category[cat] = CategoryUsage(
-            file_count=data.get("file_count", 0),
-            total_bytes=data.get("total_bytes", 0),
-            total_mb=round(data.get("total_bytes", 0) / (1024 * 1024), 2),
-        )
-
-    usage = StorageUsage(
-        total_bytes=usage_data.get("total_bytes", 0),
-        total_mb=usage_data.get("total_mb", 0.0),
-        by_category=by_category,
-        trash_bytes=usage_data.get("trash_bytes", 0),
-        trash_mb=usage_data.get("trash_mb", 0.0),
-    )
-
-    quota_mb = usage_data.get("quota_mb", 0)
-    quota_used_mb = usage_data.get("quota_used_mb", 0.0)
-    available_mb = max(0, quota_mb - quota_used_mb) if quota_mb else None
-
-    # Calculate limit status
-    usage_pct = (quota_used_mb / quota_mb * 100) if quota_mb else 0
-    at_soft_limit = usage_pct >= 80
-    at_hard_limit = usage_pct >= 100
-    warning_message = None
-    if at_hard_limit:
-        warning_message = "Storage quota exceeded - delete files to continue"
-    elif at_soft_limit:
-        warning_message = "Approaching storage limit (80%+)"
-
-    return StorageUsageResponse(
-        usage=usage,
-        quota_mb=quota_mb if quota_mb else None,
-        quota_used_mb=quota_used_mb if quota_used_mb else None,
-        available_mb=available_mb,
-        usage_percentage=round(usage_pct, 1),
-        at_soft_limit=at_soft_limit,
-        at_hard_limit=at_hard_limit,
-        warning=warning_message,
-    )
-
-
-@router.get("/usage/breakdown", response_model=UsageBreakdownResponse)
-async def get_usage_breakdown(
-    user: User = Depends(get_request_user),
-):
-    """Get detailed storage usage breakdown."""
-    service = await _get_service()
-
-    usage_data = await service.get_user_generated_files_usage(user.id)
-    folders = await service.get_user_folders(user.id)
-
-    # Build category usage
-    by_category = {}
-    for cat, data in usage_data.get("by_category", {}).items():
-        by_category[cat] = CategoryUsage(
-            file_count=data.get("file_count", 0),
-            total_bytes=data.get("total_bytes", 0),
-            total_mb=round(data.get("total_bytes", 0) / (1024 * 1024), 2),
-        )
-
-    quota_mb = usage_data.get("quota_mb", 0) or 0
-    total_mb = usage_data.get("total_mb", 0.0)
-
-    return UsageBreakdownResponse(
-        user_id=user.id,
-        by_category=by_category,
-        by_folder=[
-            FolderInfo(
-                folder_tag=f["folder_tag"],
-                file_count=f["file_count"],
-                total_bytes=f["total_bytes"],
-                total_mb=round(f["total_bytes"] / (1024 * 1024), 2),
-            )
-            for f in folders
-        ],
-        total_bytes=usage_data.get("total_bytes", 0),
-        total_mb=total_mb,
-        quota_mb=quota_mb,
-        available_mb=max(0, quota_mb - total_mb),
-        usage_percentage=round((total_mb / quota_mb * 100) if quota_mb else 0, 1),
-    )
-
-
-# =========================================================================
-# Trash Endpoints
-# =========================================================================
-
-@router.get("/trash", response_model=TrashListResponse)
-async def list_trashed_files(
-    user: User = Depends(get_request_user),
-    offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=50, ge=1, le=200),
-):
-    """List files in trash."""
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    files, total = await files_repo.list_trashed_files(
-        user.id,
-        offset=offset,
-        limit=limit,
-    )
-
-    return TrashListResponse(
-        files=[_to_generated_file(f) for f in files],
-        total=total,
-        offset=offset,
-        limit=limit,
-        pagination=build_offset_pagination_meta(
-            total=total,
-            offset=offset,
-            limit=limit,
-            count=len(files),
-        ),
-    )
-
-
-@router.post("/trash/restore/{file_id}", response_model=RestoreResponse)
-async def restore_file(
-    file_id: int,
-    user: User = Depends(get_request_user),
-):
-    """Restore a file from trash."""
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    file_record = await files_repo.get_file_by_id(file_id)
-    if not file_record:
-        raise HTTPException(status_code=404, detail="File not found")
-
-    # Verify ownership
-    if file_record.get("user_id") != user.id:
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    if not file_record.get("is_deleted"):
-        raise HTTPException(status_code=400, detail="File is not in trash")
-
-    success = await files_repo.restore_file(file_id)
-
-    if success:
-        # Re-add to usage counters
-        file_size = file_record.get("file_size_bytes", 0)
-        await service.update_usage(user.id, file_size, operation="add")
-
-        if file_record.get("org_id"):
-            await service.update_org_usage(file_record["org_id"], file_size)
-        if file_record.get("team_id"):
-            await service.update_team_usage(file_record["team_id"], file_size)
-
-        updated = await files_repo.get_file_by_id(file_id)
-        return RestoreResponse(success=True, file=_to_generated_file(updated or file_record))
-
-    return RestoreResponse(success=False, file=None)
-
-
-@router.delete("/trash/{file_id}", response_model=PermanentDeleteResponse)
-async def permanently_delete_file(
-    file_id: int,
-    user: User = Depends(get_request_user),
-):
-    """Permanently delete a file from trash."""
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    file_record = await files_repo.get_file_by_id(file_id)
-    if not file_record:
-        raise HTTPException(status_code=404, detail="File not found")
-
-    # Verify ownership
-    if file_record.get("user_id") != user.id:
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    if not file_record.get("is_deleted"):
-        raise HTTPException(status_code=400, detail="File is not in trash")
-
-    success = await files_repo.hard_delete_file(file_id)
-
-    return PermanentDeleteResponse(success=success, file_id=file_id)
-
 
 # =========================================================================
 # Admin Quota Endpoints

--- a/tldw_Server_API/app/api/v1/endpoints/storage_helpers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_helpers.py
@@ -80,6 +80,16 @@ def _resolve_storage_base_dir(user_id: int, record: dict) -> PathlibPath:
     return DatabasePaths.get_user_outputs_dir(user_id)
 
 
+def _normalize_folder_tag(folder_tag: str | None) -> str | None:
+    """Normalize optional virtual folder tags using the storage folder rules."""
+    if folder_tag is None:
+        return None
+    name = folder_tag.strip()
+    if not name or "/" in name or "\\" in name:
+        raise ValueError("Invalid folder name")
+    return name
+
+
 def _to_quota_status(data: dict) -> QuotaStatus:
     """Convert quota service data to an API schema."""
     return QuotaStatus(

--- a/tldw_Server_API/app/api/v1/endpoints/storage_trash.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_trash.py
@@ -11,11 +11,12 @@ from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     RestoreResponse,
     TrashListResponse,
 )
+from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService
 
 router = APIRouter()
 
 
-async def _get_storage_service():
+async def _get_storage_service() -> StorageQuotaService:
     """Resolve the storage service through storage.py for legacy monkeypatch seams."""
     from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
 
@@ -27,9 +28,9 @@ async def list_trashed_files(
     user: User = Depends(get_request_user),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=50, ge=1, le=200),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> TrashListResponse:
     """List files in trash."""
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
 
     files, total = await files_repo.list_trashed_files(
@@ -56,9 +57,9 @@ async def list_trashed_files(
 async def restore_file(
     file_id: int,
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> RestoreResponse:
     """Restore a file from trash."""
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
 
     file_record = await files_repo.get_file_by_id(file_id)
@@ -72,20 +73,9 @@ async def restore_file(
     if not file_record.get("is_deleted"):
         raise HTTPException(status_code=400, detail="File is not in trash")
 
-    success = await files_repo.restore_file(file_id)
-
-    if success:
-        # Re-add to usage counters
-        file_size = file_record.get("file_size_bytes", 0)
-        await service.update_usage(user.id, file_size, operation="add")
-
-        if file_record.get("org_id"):
-            await service.update_org_usage(file_record["org_id"], file_size)
-        if file_record.get("team_id"):
-            await service.update_team_usage(file_record["team_id"], file_size)
-
-        updated = await files_repo.get_file_by_id(file_id)
-        return RestoreResponse(success=True, file=_to_generated_file(updated or file_record))
+    restored = await service.restore_generated_file(file_id, file_record=file_record)
+    if restored:
+        return RestoreResponse(success=True, file=_to_generated_file(restored))
 
     return RestoreResponse(success=False, file=None)
 
@@ -94,9 +84,9 @@ async def restore_file(
 async def permanently_delete_file(
     file_id: int,
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> PermanentDeleteResponse:
     """Permanently delete a file from trash."""
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
 
     file_record = await files_repo.get_file_by_id(file_id)

--- a/tldw_Server_API/app/api/v1/endpoints/storage_trash.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_trash.py
@@ -1,0 +1,115 @@
+"""User-owned storage trash routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.endpoints.storage_helpers import _to_generated_file
+from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
+    PermanentDeleteResponse,
+    RestoreResponse,
+    TrashListResponse,
+)
+
+router = APIRouter()
+
+
+async def _get_storage_service():
+    """Resolve the storage service through storage.py for legacy monkeypatch seams."""
+    from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
+
+    return await storage_endpoint._get_service()
+
+
+@router.get("/trash", response_model=TrashListResponse)
+async def list_trashed_files(
+    user: User = Depends(get_request_user),
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=200),
+):
+    """List files in trash."""
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    files, total = await files_repo.list_trashed_files(
+        user.id,
+        offset=offset,
+        limit=limit,
+    )
+
+    return TrashListResponse(
+        files=[_to_generated_file(f) for f in files],
+        total=total,
+        offset=offset,
+        limit=limit,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(files),
+        ),
+    )
+
+
+@router.post("/trash/restore/{file_id}", response_model=RestoreResponse)
+async def restore_file(
+    file_id: int,
+    user: User = Depends(get_request_user),
+):
+    """Restore a file from trash."""
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    file_record = await files_repo.get_file_by_id(file_id)
+    if not file_record:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # Verify ownership
+    if file_record.get("user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not file_record.get("is_deleted"):
+        raise HTTPException(status_code=400, detail="File is not in trash")
+
+    success = await files_repo.restore_file(file_id)
+
+    if success:
+        # Re-add to usage counters
+        file_size = file_record.get("file_size_bytes", 0)
+        await service.update_usage(user.id, file_size, operation="add")
+
+        if file_record.get("org_id"):
+            await service.update_org_usage(file_record["org_id"], file_size)
+        if file_record.get("team_id"):
+            await service.update_team_usage(file_record["team_id"], file_size)
+
+        updated = await files_repo.get_file_by_id(file_id)
+        return RestoreResponse(success=True, file=_to_generated_file(updated or file_record))
+
+    return RestoreResponse(success=False, file=None)
+
+
+@router.delete("/trash/{file_id}", response_model=PermanentDeleteResponse)
+async def permanently_delete_file(
+    file_id: int,
+    user: User = Depends(get_request_user),
+):
+    """Permanently delete a file from trash."""
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    file_record = await files_repo.get_file_by_id(file_id)
+    if not file_record:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # Verify ownership
+    if file_record.get("user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not file_record.get("is_deleted"):
+        raise HTTPException(status_code=400, detail="File is not in trash")
+
+    success = await files_repo.hard_delete_file(file_id)
+
+    return PermanentDeleteResponse(success=success, file_id=file_id)

--- a/tldw_Server_API/app/api/v1/endpoints/storage_usage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_usage.py
@@ -11,11 +11,12 @@ from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     StorageUsageResponse,
     UsageBreakdownResponse,
 )
+from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService
 
 router = APIRouter()
 
 
-async def _get_storage_service():
+async def _get_storage_service() -> StorageQuotaService:
     """Resolve the storage service through storage.py for legacy monkeypatch seams."""
     from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
 
@@ -25,9 +26,9 @@ async def _get_storage_service():
 @router.get("/usage", response_model=StorageUsageResponse)
 async def get_storage_usage(
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> StorageUsageResponse:
     """Get storage usage summary for the current user."""
-    service = await _get_storage_service()
     usage_data = await service.get_user_generated_files_usage(user.id)
 
     # Build category usage
@@ -48,7 +49,9 @@ async def get_storage_usage(
     )
 
     quota_mb = usage_data.get("quota_mb", 0)
-    quota_used_mb = usage_data.get("quota_used_mb", 0.0)
+    quota_used_mb = usage_data.get("quota_used_mb")
+    if quota_used_mb is None:
+        quota_used_mb = usage_data.get("total_mb", 0.0)
     available_mb = max(0, quota_mb - quota_used_mb) if quota_mb else None
 
     # Calculate limit status
@@ -64,7 +67,7 @@ async def get_storage_usage(
     return StorageUsageResponse(
         usage=usage,
         quota_mb=quota_mb if quota_mb else None,
-        quota_used_mb=quota_used_mb if quota_used_mb else None,
+        quota_used_mb=quota_used_mb,
         available_mb=available_mb,
         usage_percentage=round(usage_pct, 1),
         at_soft_limit=at_soft_limit,
@@ -76,10 +79,9 @@ async def get_storage_usage(
 @router.get("/usage/breakdown", response_model=UsageBreakdownResponse)
 async def get_usage_breakdown(
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> UsageBreakdownResponse:
     """Get detailed storage usage breakdown."""
-    service = await _get_storage_service()
-
     usage_data = await service.get_user_generated_files_usage(user.id)
     folders = await service.get_user_folders(user.id)
 
@@ -94,6 +96,9 @@ async def get_usage_breakdown(
 
     quota_mb = usage_data.get("quota_mb", 0) or 0
     total_mb = usage_data.get("total_mb", 0.0)
+    quota_used_mb = usage_data.get("quota_used_mb")
+    if quota_used_mb is None:
+        quota_used_mb = total_mb
 
     return UsageBreakdownResponse(
         user_id=user.id,
@@ -110,6 +115,6 @@ async def get_usage_breakdown(
         total_bytes=usage_data.get("total_bytes", 0),
         total_mb=total_mb,
         quota_mb=quota_mb,
-        available_mb=max(0, quota_mb - total_mb),
-        usage_percentage=round((total_mb / quota_mb * 100) if quota_mb else 0, 1),
+        available_mb=max(0, quota_mb - quota_used_mb),
+        usage_percentage=round((quota_used_mb / quota_mb * 100) if quota_mb else 0, 1),
     )

--- a/tldw_Server_API/app/api/v1/endpoints/storage_usage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_usage.py
@@ -1,0 +1,115 @@
+"""User-owned storage usage routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
+    CategoryUsage,
+    FolderInfo,
+    StorageUsage,
+    StorageUsageResponse,
+    UsageBreakdownResponse,
+)
+
+router = APIRouter()
+
+
+async def _get_storage_service():
+    """Resolve the storage service through storage.py for legacy monkeypatch seams."""
+    from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
+
+    return await storage_endpoint._get_service()
+
+
+@router.get("/usage", response_model=StorageUsageResponse)
+async def get_storage_usage(
+    user: User = Depends(get_request_user),
+):
+    """Get storage usage summary for the current user."""
+    service = await _get_storage_service()
+    usage_data = await service.get_user_generated_files_usage(user.id)
+
+    # Build category usage
+    by_category = {}
+    for cat, data in usage_data.get("by_category", {}).items():
+        by_category[cat] = CategoryUsage(
+            file_count=data.get("file_count", 0),
+            total_bytes=data.get("total_bytes", 0),
+            total_mb=round(data.get("total_bytes", 0) / (1024 * 1024), 2),
+        )
+
+    usage = StorageUsage(
+        total_bytes=usage_data.get("total_bytes", 0),
+        total_mb=usage_data.get("total_mb", 0.0),
+        by_category=by_category,
+        trash_bytes=usage_data.get("trash_bytes", 0),
+        trash_mb=usage_data.get("trash_mb", 0.0),
+    )
+
+    quota_mb = usage_data.get("quota_mb", 0)
+    quota_used_mb = usage_data.get("quota_used_mb", 0.0)
+    available_mb = max(0, quota_mb - quota_used_mb) if quota_mb else None
+
+    # Calculate limit status
+    usage_pct = (quota_used_mb / quota_mb * 100) if quota_mb else 0
+    at_soft_limit = usage_pct >= 80
+    at_hard_limit = usage_pct >= 100
+    warning_message = None
+    if at_hard_limit:
+        warning_message = "Storage quota exceeded - delete files to continue"
+    elif at_soft_limit:
+        warning_message = "Approaching storage limit (80%+)"
+
+    return StorageUsageResponse(
+        usage=usage,
+        quota_mb=quota_mb if quota_mb else None,
+        quota_used_mb=quota_used_mb if quota_used_mb else None,
+        available_mb=available_mb,
+        usage_percentage=round(usage_pct, 1),
+        at_soft_limit=at_soft_limit,
+        at_hard_limit=at_hard_limit,
+        warning=warning_message,
+    )
+
+
+@router.get("/usage/breakdown", response_model=UsageBreakdownResponse)
+async def get_usage_breakdown(
+    user: User = Depends(get_request_user),
+):
+    """Get detailed storage usage breakdown."""
+    service = await _get_storage_service()
+
+    usage_data = await service.get_user_generated_files_usage(user.id)
+    folders = await service.get_user_folders(user.id)
+
+    # Build category usage
+    by_category = {}
+    for cat, data in usage_data.get("by_category", {}).items():
+        by_category[cat] = CategoryUsage(
+            file_count=data.get("file_count", 0),
+            total_bytes=data.get("total_bytes", 0),
+            total_mb=round(data.get("total_bytes", 0) / (1024 * 1024), 2),
+        )
+
+    quota_mb = usage_data.get("quota_mb", 0) or 0
+    total_mb = usage_data.get("total_mb", 0.0)
+
+    return UsageBreakdownResponse(
+        user_id=user.id,
+        by_category=by_category,
+        by_folder=[
+            FolderInfo(
+                folder_tag=f["folder_tag"],
+                file_count=f["file_count"],
+                total_bytes=f["total_bytes"],
+                total_mb=round(f["total_bytes"] / (1024 * 1024), 2),
+            )
+            for f in folders
+        ],
+        total_bytes=usage_data.get("total_bytes", 0),
+        total_mb=total_mb,
+        quota_mb=quota_mb,
+        available_mb=max(0, quota_mb - total_mb),
+        usage_percentage=round((total_mb / quota_mb * 100) if quota_mb else 0, 1),
+    )

--- a/tldw_Server_API/app/api/v1/endpoints/storage_user_files.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_user_files.py
@@ -1,11 +1,13 @@
 """User-owned storage file routes."""
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
-from tldw_Server_API.app.api.v1.endpoints.storage_helpers import _to_generated_file
+from tldw_Server_API.app.api.v1.endpoints.storage_helpers import _normalize_folder_tag, _to_generated_file
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     BulkDeleteRequest,
     BulkDeleteResponse,
@@ -16,16 +18,45 @@ from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     GeneratedFilesListResponse,
     GeneratedFileUpdate,
     SourceFeature,
+    StorageDeleteResponse,
 )
+from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService
 
 router = APIRouter()
 
 
-async def _get_storage_service():
+async def _get_storage_service() -> StorageQuotaService:
     """Resolve the storage service through storage.py for legacy monkeypatch seams."""
     from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
 
     return await storage_endpoint._get_service()
+
+
+async def _get_files_by_ids(files_repo: Any, file_ids: list[int]) -> list[dict[str, Any]]:
+    """Load file records with a single repo call when the backend supports it."""
+    get_files_by_ids = getattr(files_repo, "get_files_by_ids", None)
+    if callable(get_files_by_ids):
+        return await get_files_by_ids(file_ids)
+
+    records: list[dict[str, Any]] = []
+    for file_id in file_ids:
+        file_record = await files_repo.get_file_by_id(file_id)
+        if file_record:
+            records.append(file_record)
+    return records
+
+
+async def _load_owned_file_records(
+    files_repo: Any,
+    file_ids: list[int],
+    user_id: int,
+) -> list[dict[str, Any]]:
+    """Load bulk file records and reject records owned by another user."""
+    file_records = await _get_files_by_ids(files_repo, file_ids)
+    for file_record in file_records:
+        if file_record.get("user_id") != user_id:
+            raise HTTPException(status_code=403, detail=f"Access denied for file {file_record.get('id')}")
+    return file_records
 
 
 @router.get("/files", response_model=GeneratedFilesListResponse)
@@ -38,13 +69,13 @@ async def list_files(
     folder_tag: str | None = Query(default=None),
     search: str | None = Query(default=None, max_length=100),
     include_deleted: bool = Query(default=False),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> GeneratedFilesListResponse:
     """
     List generated files for the current user.
 
     Supports filtering by category, source feature, folder, and search term.
     """
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
 
     files, total = await files_repo.list_files(
@@ -76,7 +107,8 @@ async def list_files(
 async def list_least_accessed_files(
     user: User = Depends(get_request_user),
     limit: int = Query(default=20, ge=1, le=100),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> GeneratedFilesListResponse:
     """
     List least recently accessed files (candidates for cleanup).
 
@@ -84,18 +116,19 @@ async def list_least_accessed_files(
     Returns files sorted by access time (oldest first), with never-accessed
     files sorted by creation time.
     """
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
 
     files = await files_repo.list_least_accessed(user.id, limit=limit)
+    count_least_accessed = getattr(files_repo, "count_least_accessed", None)
+    total = await count_least_accessed(user.id) if callable(count_least_accessed) else len(files)
 
     return GeneratedFilesListResponse(
         files=[_to_generated_file(f) for f in files],
-        total=len(files),
+        total=total,
         offset=0,
         limit=limit,
         pagination=build_offset_pagination_meta(
-            total=len(files),
+            total=total,
             offset=0,
             limit=limit,
             count=len(files),
@@ -107,29 +140,16 @@ async def list_least_accessed_files(
 async def bulk_delete_files(
     request: BulkDeleteRequest,
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> BulkDeleteResponse:
     """Bulk delete multiple files."""
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
+    file_records = await _load_owned_file_records(files_repo, request.file_ids, user.id)
 
-    # Verify ownership for all files
-    for file_id in request.file_ids:
-        file_record = await files_repo.get_file_by_id(file_id)
-        if file_record and file_record.get("user_id") != user.id:
-            raise HTTPException(status_code=403, detail=f"Access denied for file {file_id}")
-
-    if request.hard_delete:
-        # Hard delete each file with usage tracking
-        deleted_count = 0
-        for file_id in request.file_ids:
-            if await service.unregister_generated_file(file_id, hard_delete=True):
-                deleted_count += 1
-    else:
-        # Soft delete each file with usage tracking (not bulk, to update quotas properly)
-        deleted_count = 0
-        for file_id in request.file_ids:
-            if await service.unregister_generated_file(file_id, hard_delete=False):
-                deleted_count += 1
+    deleted_count = await service.unregister_generated_files(
+        file_records,
+        hard_delete=request.hard_delete,
+    )
 
     return BulkDeleteResponse(
         deleted_count=deleted_count,
@@ -141,23 +161,23 @@ async def bulk_delete_files(
 async def bulk_move_files(
     request: BulkMoveRequest,
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> BulkMoveResponse:
     """Move multiple files to a folder."""
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
+    try:
+        folder_tag = _normalize_folder_tag(request.folder_tag)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid folder name") from None
 
-    # Verify ownership for all files
-    for file_id in request.file_ids:
-        file_record = await files_repo.get_file_by_id(file_id)
-        if file_record and file_record.get("user_id") != user.id:
-            raise HTTPException(status_code=403, detail=f"Access denied for file {file_id}")
+    await _load_owned_file_records(files_repo, request.file_ids, user.id)
 
-    moved_count = await files_repo.bulk_move_to_folder(request.file_ids, request.folder_tag)
+    moved_count = await files_repo.bulk_move_to_folder(request.file_ids, folder_tag)
 
     return BulkMoveResponse(
         moved_count=moved_count,
         file_ids=request.file_ids,
-        folder_tag=request.folder_tag,
+        folder_tag=folder_tag,
     )
 
 
@@ -165,9 +185,9 @@ async def bulk_move_files(
 async def get_file(
     file_id: int,
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> GeneratedFileResponse:
     """Get metadata for a specific file."""
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
 
     file_record = await files_repo.get_file_by_id(file_id)
@@ -184,19 +204,19 @@ async def get_file(
     return GeneratedFileResponse(file=_to_generated_file(file_record))
 
 
-@router.delete("/files/{file_id}")
+@router.delete("/files/{file_id}", response_model=StorageDeleteResponse)
 async def delete_file(
     file_id: int,
     user: User = Depends(get_request_user),
     hard_delete: bool = Query(default=False),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> StorageDeleteResponse:
     """
     Delete a generated file.
 
     By default, performs a soft delete (moves to trash).
     Use hard_delete=true for permanent deletion.
     """
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
 
     file_record = await files_repo.get_file_by_id(file_id)
@@ -212,7 +232,7 @@ async def delete_file(
     if not success:
         raise HTTPException(status_code=500, detail="Failed to delete file")
 
-    return {"success": True, "file_id": file_id, "hard_delete": hard_delete}
+    return StorageDeleteResponse(success=True, file_id=file_id, hard_delete=hard_delete)
 
 
 @router.patch("/files/{file_id}", response_model=GeneratedFileResponse)
@@ -220,9 +240,9 @@ async def update_file(
     file_id: int,
     update: GeneratedFileUpdate,
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> GeneratedFileResponse:
     """Update file metadata (folder, tags, retention)."""
-    service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()
 
     file_record = await files_repo.get_file_by_id(file_id)

--- a/tldw_Server_API/app/api/v1/endpoints/storage_user_files.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_user_files.py
@@ -1,0 +1,244 @@
+"""User-owned storage file routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
+from tldw_Server_API.app.api.v1.endpoints.storage_helpers import _to_generated_file
+from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
+    BulkDeleteRequest,
+    BulkDeleteResponse,
+    BulkMoveRequest,
+    BulkMoveResponse,
+    FileCategory,
+    GeneratedFileResponse,
+    GeneratedFilesListResponse,
+    GeneratedFileUpdate,
+    SourceFeature,
+)
+
+router = APIRouter()
+
+
+async def _get_storage_service():
+    """Resolve the storage service through storage.py for legacy monkeypatch seams."""
+    from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
+
+    return await storage_endpoint._get_service()
+
+
+@router.get("/files", response_model=GeneratedFilesListResponse)
+async def list_files(
+    user: User = Depends(get_request_user),
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=200),
+    file_category: FileCategory | None = Query(default=None),
+    source_feature: SourceFeature | None = Query(default=None),
+    folder_tag: str | None = Query(default=None),
+    search: str | None = Query(default=None, max_length=100),
+    include_deleted: bool = Query(default=False),
+):
+    """
+    List generated files for the current user.
+
+    Supports filtering by category, source feature, folder, and search term.
+    """
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    files, total = await files_repo.list_files(
+        user_id=user.id,
+        offset=offset,
+        limit=limit,
+        file_category=file_category,
+        source_feature=source_feature,
+        folder_tag=folder_tag,
+        search=search,
+        include_deleted=include_deleted,
+    )
+
+    return GeneratedFilesListResponse(
+        files=[_to_generated_file(f) for f in files],
+        total=total,
+        offset=offset,
+        limit=limit,
+        pagination=build_offset_pagination_meta(
+            total=total,
+            offset=offset,
+            limit=limit,
+            count=len(files),
+        ),
+    )
+
+
+@router.get("/files/least-accessed", response_model=GeneratedFilesListResponse)
+async def list_least_accessed_files(
+    user: User = Depends(get_request_user),
+    limit: int = Query(default=20, ge=1, le=100),
+):
+    """
+    List least recently accessed files (candidates for cleanup).
+
+    Useful for users approaching quota limits who need to free up space.
+    Returns files sorted by access time (oldest first), with never-accessed
+    files sorted by creation time.
+    """
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    files = await files_repo.list_least_accessed(user.id, limit=limit)
+
+    return GeneratedFilesListResponse(
+        files=[_to_generated_file(f) for f in files],
+        total=len(files),
+        offset=0,
+        limit=limit,
+        pagination=build_offset_pagination_meta(
+            total=len(files),
+            offset=0,
+            limit=limit,
+            count=len(files),
+        ),
+    )
+
+
+@router.post("/files/bulk-delete", response_model=BulkDeleteResponse)
+async def bulk_delete_files(
+    request: BulkDeleteRequest,
+    user: User = Depends(get_request_user),
+):
+    """Bulk delete multiple files."""
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    # Verify ownership for all files
+    for file_id in request.file_ids:
+        file_record = await files_repo.get_file_by_id(file_id)
+        if file_record and file_record.get("user_id") != user.id:
+            raise HTTPException(status_code=403, detail=f"Access denied for file {file_id}")
+
+    if request.hard_delete:
+        # Hard delete each file with usage tracking
+        deleted_count = 0
+        for file_id in request.file_ids:
+            if await service.unregister_generated_file(file_id, hard_delete=True):
+                deleted_count += 1
+    else:
+        # Soft delete each file with usage tracking (not bulk, to update quotas properly)
+        deleted_count = 0
+        for file_id in request.file_ids:
+            if await service.unregister_generated_file(file_id, hard_delete=False):
+                deleted_count += 1
+
+    return BulkDeleteResponse(
+        deleted_count=deleted_count,
+        file_ids=request.file_ids,
+    )
+
+
+@router.post("/files/bulk-move", response_model=BulkMoveResponse)
+async def bulk_move_files(
+    request: BulkMoveRequest,
+    user: User = Depends(get_request_user),
+):
+    """Move multiple files to a folder."""
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    # Verify ownership for all files
+    for file_id in request.file_ids:
+        file_record = await files_repo.get_file_by_id(file_id)
+        if file_record and file_record.get("user_id") != user.id:
+            raise HTTPException(status_code=403, detail=f"Access denied for file {file_id}")
+
+    moved_count = await files_repo.bulk_move_to_folder(request.file_ids, request.folder_tag)
+
+    return BulkMoveResponse(
+        moved_count=moved_count,
+        file_ids=request.file_ids,
+        folder_tag=request.folder_tag,
+    )
+
+
+@router.get("/files/{file_id}", response_model=GeneratedFileResponse)
+async def get_file(
+    file_id: int,
+    user: User = Depends(get_request_user),
+):
+    """Get metadata for a specific file."""
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    file_record = await files_repo.get_file_by_id(file_id)
+    if not file_record:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # Verify ownership
+    if file_record.get("user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    # Update accessed_at
+    await files_repo.update_accessed_at(file_id)
+
+    return GeneratedFileResponse(file=_to_generated_file(file_record))
+
+
+@router.delete("/files/{file_id}")
+async def delete_file(
+    file_id: int,
+    user: User = Depends(get_request_user),
+    hard_delete: bool = Query(default=False),
+):
+    """
+    Delete a generated file.
+
+    By default, performs a soft delete (moves to trash).
+    Use hard_delete=true for permanent deletion.
+    """
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    file_record = await files_repo.get_file_by_id(file_id)
+    if not file_record:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # Verify ownership
+    if file_record.get("user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    success = await service.unregister_generated_file(file_id, hard_delete=hard_delete)
+
+    if not success:
+        raise HTTPException(status_code=500, detail="Failed to delete file")
+
+    return {"success": True, "file_id": file_id, "hard_delete": hard_delete}
+
+
+@router.patch("/files/{file_id}", response_model=GeneratedFileResponse)
+async def update_file(
+    file_id: int,
+    update: GeneratedFileUpdate,
+    user: User = Depends(get_request_user),
+):
+    """Update file metadata (folder, tags, retention)."""
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    file_record = await files_repo.get_file_by_id(file_id)
+    if not file_record:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # Verify ownership
+    if file_record.get("user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    updated = await files_repo.update_file(
+        file_id,
+        folder_tag=update.folder_tag,
+        tags=update.tags,
+        retention_policy=update.retention_policy,
+        expires_at=update.expires_at,
+    )
+
+    return GeneratedFileResponse(file=_to_generated_file(updated or file_record))

--- a/tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.endpoints.storage_helpers import _normalize_folder_tag
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     FolderCreateRequest,
     FolderInfo,
     FolderListResponse,
 )
+from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService
 
 router = APIRouter()
 
 
-async def _get_storage_service():
+async def _get_storage_service() -> StorageQuotaService:
     """Resolve the storage service through storage.py for legacy monkeypatch seams."""
     from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
 
@@ -23,9 +25,9 @@ async def _get_storage_service():
 @router.get("/folders", response_model=FolderListResponse)
 async def list_folders(
     user: User = Depends(get_request_user),
-):
+    service: StorageQuotaService = Depends(_get_storage_service),
+) -> FolderListResponse:
     """List virtual folders for the current user."""
-    service = await _get_storage_service()
     folders = await service.get_user_folders(user.id)
 
     return FolderListResponse(
@@ -45,16 +47,16 @@ async def list_folders(
 async def create_folder(
     request: FolderCreateRequest,
     user: User = Depends(get_request_user),
-):
+) -> dict[str, bool | str]:
     """
     Create a virtual folder.
 
     Note: Folders are virtual (tag-based). This endpoint validates the name
     but the folder only exists when files are assigned to it.
     """
-    # Validate folder name
-    name = request.name.strip()
-    if not name or "/" in name or "\\" in name:
+    try:
+        name = _normalize_folder_tag(request.name)
+    except ValueError:
         raise HTTPException(status_code=400, detail="Invalid folder name")
 
     return {"success": True, "folder_tag": name, "message": "Folder created (virtual)"}

--- a/tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py
@@ -1,0 +1,60 @@
+"""User-owned storage folder routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
+    FolderCreateRequest,
+    FolderInfo,
+    FolderListResponse,
+)
+
+router = APIRouter()
+
+
+async def _get_storage_service():
+    """Resolve the storage service through storage.py for legacy monkeypatch seams."""
+    from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
+
+    return await storage_endpoint._get_service()
+
+
+@router.get("/folders", response_model=FolderListResponse)
+async def list_folders(
+    user: User = Depends(get_request_user),
+):
+    """List virtual folders for the current user."""
+    service = await _get_storage_service()
+    folders = await service.get_user_folders(user.id)
+
+    return FolderListResponse(
+        folders=[
+            FolderInfo(
+                folder_tag=f["folder_tag"],
+                file_count=f["file_count"],
+                total_bytes=f["total_bytes"],
+                total_mb=round(f["total_bytes"] / (1024 * 1024), 2),
+            )
+            for f in folders
+        ]
+    )
+
+
+@router.post("/folders")
+async def create_folder(
+    request: FolderCreateRequest,
+    user: User = Depends(get_request_user),
+):
+    """
+    Create a virtual folder.
+
+    Note: Folders are virtual (tag-based). This endpoint validates the name
+    but the folder only exists when files are assigned to it.
+    """
+    # Validate folder name
+    name = request.name.strip()
+    if not name or "/" in name or "\\" in name:
+        raise HTTPException(status_code=400, detail="Invalid folder name")
+
+    return {"success": True, "folder_tag": name, "message": "Folder created (virtual)"}

--- a/tldw_Server_API/app/api/v1/schemas/storage_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/storage_schemas.py
@@ -137,6 +137,13 @@ class BulkDeleteResponse(BaseModel):
     file_ids: list[int]
 
 
+class StorageDeleteResponse(BaseModel):
+    """Response for deleting a generated storage file."""
+    success: bool
+    file_id: int
+    hard_delete: bool
+
+
 class BulkMoveRequest(BaseModel):
     """Request for bulk move to folder."""
     file_ids: list[int] = Field(min_length=1, max_length=100, description="File IDs to move")

--- a/tldw_Server_API/app/core/AuthNZ/repos/generated_files_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/generated_files_repo.py
@@ -257,6 +257,32 @@ class AuthnzGeneratedFilesRepo:
             logger.error(f"AuthnzGeneratedFilesRepo.get_file_by_id failed: {exc}")
             raise
 
+    async def get_files_by_ids(self, file_ids: list[int]) -> list[dict[str, Any]]:
+        """Fetch generated file records for a bounded list of IDs."""
+        if not file_ids:
+            return []
+
+        try:
+            async with self.db_pool.acquire() as conn:
+                if self._is_postgres():
+                    rows = await conn.fetch(
+                        "SELECT * FROM generated_files WHERE id = ANY($1)",
+                        file_ids,
+                    )
+                    return [self._normalize_record(row) for row in rows]
+
+                placeholders = ",".join("?" for _ in file_ids)
+                id_list_clause = f"({placeholders})"
+                select_sql_template = "SELECT * FROM generated_files WHERE id IN {id_list_clause}"
+                select_sql = select_sql_template.format_map(locals())  # nosec B608
+                cursor = await conn.execute(select_sql, tuple(file_ids))
+                rows = await cursor.fetchall()
+                cols = [desc[0] for desc in cursor.description] if cursor.description else []
+                return [self._normalize_record(dict(zip(cols, row))) for row in rows]
+        except Exception as exc:
+            logger.error(f"AuthnzGeneratedFilesRepo.get_files_by_ids failed: {exc}")
+            raise
+
     async def get_file_by_uuid(self, file_uuid: str) -> dict[str, Any] | None:
         """Fetch a file record by UUID."""
         try:
@@ -947,4 +973,33 @@ class AuthnzGeneratedFilesRepo:
                     return [self._normalize_record(dict(zip(cols, row))) for row in rows]
         except Exception as exc:
             logger.error(f"AuthnzGeneratedFilesRepo.list_least_accessed failed: {exc}")
+            raise
+
+    async def count_least_accessed(self, user_id: int) -> int:
+        """Count current cleanup candidates for least-accessed pagination metadata."""
+        try:
+            async with self.db_pool.acquire() as conn:
+                if self._is_postgres():
+                    return int(
+                        await conn.fetchval(
+                            """
+                            SELECT COUNT(*) FROM generated_files
+                            WHERE user_id = $1 AND is_deleted = FALSE
+                            """,
+                            user_id,
+                        )
+                        or 0
+                    )
+
+                cursor = await conn.execute(
+                    """
+                    SELECT COUNT(*) FROM generated_files
+                    WHERE user_id = ? AND is_deleted = 0
+                    """,
+                    (user_id,),
+                )
+                row = await cursor.fetchone()
+                return int(row[0] if row else 0)
+        except Exception as exc:
+            logger.error(f"AuthnzGeneratedFilesRepo.count_least_accessed failed: {exc}")
             raise

--- a/tldw_Server_API/app/services/storage_quota_service.py
+++ b/tldw_Server_API/app/services/storage_quota_service.py
@@ -878,6 +878,57 @@ class StorageQuotaService:
 
         return file_record
 
+    def _unlink_voice_clone_file(self, file_record: dict[str, Any]) -> None:
+        """Best-effort cleanup for generated voice clone files removed from the DB."""
+        user_id = file_record.get("user_id")
+        file_category = file_record.get("file_category")
+        storage_path = str(file_record.get("storage_path") or "")
+        if file_category != FILE_CATEGORY_VOICE_CLONE or not user_id or not storage_path:
+            return
+
+        try:
+            base_dir = DatabasePaths.get_user_voices_dir(user_id)
+            resolved_path = (base_dir / storage_path).resolve()
+            if resolved_path.is_relative_to(base_dir.resolve()) and resolved_path.exists():
+                resolved_path.unlink()
+        except Exception as exc:
+            logger.debug(f"Failed to remove voice clone file {file_record.get('id')} from disk: {exc}")
+
+    async def _apply_generated_file_usage_delta(
+        self,
+        file_records: list[dict[str, Any]],
+        *,
+        operation: str,
+    ) -> None:
+        """Apply aggregated user/org/team usage changes for generated files."""
+        if not file_records:
+            return
+
+        user_deltas: dict[int, int] = {}
+        org_deltas: dict[int, int] = {}
+        team_deltas: dict[int, int] = {}
+        for file_record in file_records:
+            size = int(file_record.get("file_size_bytes", 0) or 0)
+            if size <= 0:
+                continue
+            user_id = file_record.get("user_id")
+            org_id = file_record.get("org_id")
+            team_id = file_record.get("team_id")
+            if user_id:
+                user_deltas[int(user_id)] = user_deltas.get(int(user_id), 0) + size
+            if org_id:
+                org_deltas[int(org_id)] = org_deltas.get(int(org_id), 0) + size
+            if team_id:
+                team_deltas[int(team_id)] = team_deltas.get(int(team_id), 0) + size
+
+        org_multiplier = -1 if operation == "remove" else 1
+        for user_id, bytes_delta in user_deltas.items():
+            await self.update_usage(user_id, bytes_delta, operation=operation)
+        for org_id, bytes_delta in org_deltas.items():
+            await self.update_org_usage(org_id, org_multiplier * bytes_delta)
+        for team_id, bytes_delta in team_deltas.items():
+            await self.update_team_usage(team_id, org_multiplier * bytes_delta)
+
     async def unregister_generated_file(
         self,
         file_id: int,
@@ -908,8 +959,6 @@ class StorageQuotaService:
         org_id = file_record.get("org_id")
         team_id = file_record.get("team_id")
         file_size_bytes = file_record.get("file_size_bytes", 0)
-        file_category = file_record.get("file_category")
-        storage_path = str(file_record.get("storage_path") or "")
 
         if hard_delete:
             success = await files_repo.hard_delete_file(file_id)
@@ -926,17 +975,65 @@ class StorageQuotaService:
             if team_id:
                 await self.update_team_usage(team_id, -file_size_bytes)
 
-        # On hard delete, attempt to remove the voice clone from disk.
-        if success and hard_delete and file_category == FILE_CATEGORY_VOICE_CLONE and user_id and storage_path:
-            try:
-                base_dir = DatabasePaths.get_user_voices_dir(user_id)
-                resolved_path = (base_dir / storage_path).resolve()
-                if resolved_path.is_relative_to(base_dir.resolve()) and resolved_path.exists():
-                    resolved_path.unlink()
-            except Exception as exc:
-                logger.debug(f"Failed to remove voice clone file {file_id} from disk: {exc}")
+        if success and hard_delete:
+            self._unlink_voice_clone_file(file_record)
 
         return success
+
+    async def unregister_generated_files(
+        self,
+        file_records: list[dict[str, Any]],
+        hard_delete: bool = False,
+    ) -> int:
+        """Unregister generated files from already-loaded records and update usage in aggregate."""
+        if not self._initialized:
+            await self.initialize()
+
+        if not file_records:
+            return 0
+
+        files_repo = await self.get_generated_files_repo()
+
+        if hard_delete:
+            deleted_records: list[dict[str, Any]] = []
+            for file_record in file_records:
+                file_id = file_record.get("id")
+                if file_id and await files_repo.hard_delete_file(file_id):
+                    deleted_records.append(file_record)
+                    self._unlink_voice_clone_file(file_record)
+        else:
+            active_records = [record for record in file_records if not bool(record.get("is_deleted"))]
+            deleted_count = await files_repo.bulk_soft_delete(
+                [int(record["id"]) for record in active_records if record.get("id")]
+            )
+            deleted_records = active_records[:deleted_count]
+
+        usage_records = [record for record in deleted_records if not bool(record.get("is_deleted"))]
+        await self._apply_generated_file_usage_delta(usage_records, operation="remove")
+        return len(deleted_records)
+
+    async def restore_generated_file(
+        self,
+        file_id: int,
+        *,
+        file_record: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Restore a generated file and update usage counters in the service layer."""
+        if not self._initialized:
+            await self.initialize()
+
+        files_repo = await self.get_generated_files_repo()
+        file_record = file_record or await files_repo.get_file_by_id(file_id)
+        if not file_record or not file_record.get("is_deleted"):
+            return None
+
+        success = await files_repo.restore_file(file_id)
+        if not success:
+            return None
+
+        await self._apply_generated_file_usage_delta([file_record], operation="add")
+        updated = await files_repo.get_file_by_id(file_id)
+        return updated or file_record
 
     async def get_user_generated_files_usage(self, user_id: int) -> dict[str, Any]:
         """Get detailed usage breakdown for user's generated files."""

--- a/tldw_Server_API/tests/Storage/conftest.py
+++ b/tldw_Server_API/tests/Storage/conftest.py
@@ -57,6 +57,7 @@ def mock_files_repo():
     repo = AsyncMock()
     repo.list_files = AsyncMock(return_value=([], 0))
     repo.get_file_by_id = AsyncMock(return_value=None)
+    repo.get_files_by_ids = AsyncMock(return_value=[])
     repo.create_file = AsyncMock()
     repo.update_file = AsyncMock()
     repo.soft_delete_file = AsyncMock(return_value=True)
@@ -77,6 +78,7 @@ def mock_files_repo():
     repo.get_old_trashed_files = AsyncMock(return_value=[])
     repo.update_accessed_at = AsyncMock()
     repo.list_least_accessed = AsyncMock(return_value=[])
+    repo.count_least_accessed = AsyncMock(return_value=0)
     return repo
 
 
@@ -136,6 +138,8 @@ def mock_storage_service(mock_files_repo, mock_quotas_repo):
     # File management
     service.register_generated_file = AsyncMock(return_value={"id": 1})
     service.unregister_generated_file = AsyncMock(return_value=True)
+    service.unregister_generated_files = AsyncMock(return_value=0)
+    service.restore_generated_file = AsyncMock(return_value=None)
     service.get_user_generated_files_usage = AsyncMock(return_value={
         "total_bytes": 100 * 1024 * 1024,
         "total_mb": 100.0,

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -134,6 +134,101 @@ class TestListFilesEndpoint:
         assert response.next_offset == 5
 
 
+class TestUsageEndpoint:
+    """Tests for storage usage route behavior."""
+
+    @pytest.mark.unit
+    def test_usage_route_returns_quota_warning_state(
+        self,
+        mock_storage_service,
+        mock_user,
+        monkeypatch,
+    ):
+        """Usage route returns quota status and category usage."""
+        mock_storage_service.get_user_generated_files_usage = AsyncMock(
+            return_value={
+                "total_bytes": 850 * 1024 * 1024,
+                "total_mb": 850.0,
+                "by_category": {
+                    "tts_audio": {
+                        "file_count": 2,
+                        "total_bytes": 850 * 1024 * 1024,
+                    }
+                },
+                "trash_bytes": 0,
+                "trash_mb": 0.0,
+                "quota_mb": 1000,
+                "quota_used_mb": 850.0,
+            }
+        )
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.get("/api/v1/storage/usage")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["quota_mb"] == 1000
+        assert payload["usage_percentage"] == 85.0
+        assert payload["at_soft_limit"] is True
+        assert payload["at_hard_limit"] is False
+        assert payload["warning"] == "Approaching storage limit (80%+)"
+        assert payload["usage"]["by_category"]["tts_audio"]["file_count"] == 2
+
+    @pytest.mark.unit
+    def test_usage_breakdown_route_returns_folder_totals(
+        self,
+        mock_storage_service,
+        mock_user,
+        monkeypatch,
+    ):
+        """Usage breakdown route returns category and folder totals."""
+        mock_storage_service.get_user_generated_files_usage = AsyncMock(
+            return_value={
+                "total_bytes": 200 * 1024 * 1024,
+                "total_mb": 200.0,
+                "by_category": {
+                    "tts_audio": {
+                        "file_count": 1,
+                        "total_bytes": 200 * 1024 * 1024,
+                    }
+                },
+                "quota_mb": 1000,
+            }
+        )
+        mock_storage_service.get_user_folders = AsyncMock(
+            return_value=[
+                {
+                    "folder_tag": "archive",
+                    "file_count": 1,
+                    "total_bytes": 200 * 1024 * 1024,
+                }
+            ]
+        )
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.get("/api/v1/storage/usage/breakdown")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["user_id"] == mock_user.id
+        assert payload["total_mb"] == 200.0
+        assert payload["available_mb"] == 800.0
+        assert payload["by_category"]["tts_audio"]["file_count"] == 1
+        assert payload["by_folder"][0]["folder_tag"] == "archive"
+
+
 class TestTrashEndpoint:
     """Tests for GET /storage/trash endpoint."""
 
@@ -189,6 +284,55 @@ class TestTrashEndpoint:
         assert response.pagination.next_offset == 3
         assert response.has_more is True
         assert response.next_offset == 3
+
+    @pytest.mark.unit
+    def test_trash_route_returns_canonical_pagination(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """Trash route returns paginated deleted files."""
+        mock_files_repo.list_trashed_files = AsyncMock(
+            return_value=(
+                [
+                    {
+                        "id": 9,
+                        "uuid": "uuid-9",
+                        "user_id": mock_user.id,
+                        "filename": "deleted.wav",
+                        "storage_path": "tts_audio/deleted.wav",
+                        "file_category": "tts_audio",
+                        "source_feature": "tts",
+                        "file_size_bytes": 2048,
+                        "is_deleted": True,
+                        "is_transient": False,
+                        "tags": [],
+                        "created_at": datetime.now(timezone.utc),
+                        "updated_at": datetime.now(timezone.utc),
+                        "deleted_at": datetime.now(timezone.utc),
+                    }
+                ],
+                4,
+            )
+        )
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.get("/api/v1/storage/trash?offset=1&limit=2")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total"] == 4
+        assert payload["pagination"]["has_more"] is True
+        assert payload["pagination"]["next_offset"] == 3
 
 
 class TestDownloadFileEndpoint:
@@ -481,6 +625,71 @@ class TestSoftDeleteRestoreCycle:
         assert len(update_calls) == 1
         assert update_calls[0][2] == "add"
 
+    @pytest.mark.unit
+    def test_restore_route_readds_to_usage(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        sample_deleted_file_record,
+        monkeypatch,
+    ):
+        """Restore route restores deleted files and re-adds usage."""
+        restored_record = sample_deleted_file_record.copy()
+        restored_record["is_deleted"] = False
+        restored_record["deleted_at"] = None
+        mock_files_repo.get_file_by_id = AsyncMock(
+            side_effect=[sample_deleted_file_record, restored_record]
+        )
+        mock_files_repo.restore_file = AsyncMock(return_value=True)
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.post("/api/v1/storage/trash/restore/1")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["file"]["is_deleted"] is False
+        mock_storage_service.update_usage.assert_awaited_once_with(
+            mock_user.id,
+            sample_deleted_file_record["file_size_bytes"],
+            operation="add",
+        )
+
+    @pytest.mark.unit
+    def test_permanent_delete_route_removes_deleted_file(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        sample_deleted_file_record,
+        monkeypatch,
+    ):
+        """Permanent delete route hard-deletes files already in trash."""
+        mock_files_repo.get_file_by_id = AsyncMock(return_value=sample_deleted_file_record)
+        mock_files_repo.hard_delete_file = AsyncMock(return_value=True)
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.delete("/api/v1/storage/trash/1")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "file_id": 1}
+        mock_files_repo.hard_delete_file.assert_awaited_once_with(1)
+
 
 class TestAdminQuotaEndpoints:
     """Tests for admin quota management endpoints."""
@@ -622,3 +831,48 @@ class TestLeastAccessedEndpoint:
 
         assert len(result) == 2
         assert result[0]["id"] == 1  # Oldest first
+
+    @pytest.mark.unit
+    def test_least_accessed_route_is_not_captured_by_file_id_route(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """The static least-accessed route returns cleanup candidates."""
+        file_record = {
+            "id": 1,
+            "uuid": "uuid-1",
+            "user_id": mock_user.id,
+            "filename": "old.wav",
+            "original_filename": "old.wav",
+            "mime_type": "audio/wav",
+            "storage_path": "tts_audio/old.wav",
+            "file_category": "tts_audio",
+            "source_feature": "tts",
+            "file_size_bytes": 1024,
+            "is_deleted": False,
+            "is_transient": False,
+            "tags": [],
+            "created_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
+            "updated_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
+            "accessed_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
+        }
+        mock_files_repo.list_least_accessed = AsyncMock(return_value=[file_record])
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.get("/api/v1/storage/files/least-accessed")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total"] == 1
+        assert payload["files"][0]["id"] == 1
+        assert payload["pagination"]["total"] == 1

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -120,7 +120,12 @@ class TestListFilesEndpoint:
             AsyncMock(return_value=mock_storage_service),
         )
 
-        response = await storage_endpoints.list_files(user=mock_user, offset=2, limit=3)
+        response = await storage_endpoints.list_files(
+            user=mock_user,
+            offset=2,
+            limit=3,
+            service=mock_storage_service,
+        )
 
         assert response.total == 7
         assert response.offset == 2
@@ -181,6 +186,38 @@ class TestUsageEndpoint:
         assert payload["usage"]["by_category"]["tts_audio"]["file_count"] == 2
 
     @pytest.mark.unit
+    def test_usage_route_preserves_zero_quota_used(
+        self,
+        mock_storage_service,
+        mock_user,
+        monkeypatch,
+    ):
+        """Usage route preserves authoritative zero quota usage."""
+        mock_storage_service.get_user_generated_files_usage = AsyncMock(
+            return_value={
+                "total_bytes": 0,
+                "total_mb": 0.0,
+                "by_category": {},
+                "trash_bytes": 0,
+                "trash_mb": 0.0,
+                "quota_mb": 1000,
+                "quota_used_mb": 0.0,
+            }
+        )
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.get("/api/v1/storage/usage")
+
+        assert response.status_code == 200
+        assert response.json()["quota_used_mb"] == 0.0
+
+    @pytest.mark.unit
     def test_usage_breakdown_route_returns_folder_totals(
         self,
         mock_storage_service,
@@ -228,6 +265,40 @@ class TestUsageEndpoint:
         assert payload["by_category"]["tts_audio"]["file_count"] == 1
         assert payload["by_folder"][0]["folder_tag"] == "archive"
 
+    @pytest.mark.unit
+    def test_usage_breakdown_route_uses_authoritative_quota_counter(
+        self,
+        mock_storage_service,
+        mock_user,
+        monkeypatch,
+    ):
+        """Usage breakdown availability is based on quota_used_mb, not file totals."""
+        mock_storage_service.get_user_generated_files_usage = AsyncMock(
+            return_value={
+                "total_bytes": 200 * 1024 * 1024,
+                "total_mb": 200.0,
+                "by_category": {},
+                "quota_mb": 1000,
+                "quota_used_mb": 350.0,
+            }
+        )
+        mock_storage_service.get_user_folders = AsyncMock(return_value=[])
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.get("/api/v1/storage/usage/breakdown")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total_mb"] == 200.0
+        assert payload["available_mb"] == 650.0
+        assert payload["usage_percentage"] == 35.0
+
 
 class TestTrashEndpoint:
     """Tests for GET /storage/trash endpoint."""
@@ -272,7 +343,12 @@ class TestTrashEndpoint:
             AsyncMock(return_value=mock_storage_service),
         )
 
-        response = await storage_endpoints.list_trashed_files(user=mock_user, offset=1, limit=2)
+        response = await storage_endpoints.list_trashed_files(
+            user=mock_user,
+            offset=1,
+            limit=2,
+            service=mock_storage_service,
+        )
 
         assert response.total == 4
         assert response.offset == 1
@@ -582,6 +658,119 @@ class TestBulkDeleteEndpoint:
         assert deleted_count == 3
         assert call_count == 3, "unregister_generated_file should be called for each file"
 
+    @pytest.mark.unit
+    def test_bulk_delete_route_loads_files_once_and_delegates_to_service(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """Bulk delete verifies ownership in one repo call and delegates deletion."""
+        file_records = [
+            {"id": 1, "user_id": mock_user.id, "is_deleted": False, "file_size_bytes": 1024},
+            {"id": 2, "user_id": mock_user.id, "is_deleted": False, "file_size_bytes": 2048},
+        ]
+        mock_files_repo.get_files_by_ids = AsyncMock(return_value=file_records)
+        mock_storage_service.unregister_generated_files = AsyncMock(return_value=2)
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/v1/storage/files/bulk-delete",
+                json={"file_ids": [1, 2], "hard_delete": False},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["deleted_count"] == 2
+        mock_files_repo.get_files_by_ids.assert_awaited_once_with([1, 2])
+        mock_files_repo.get_file_by_id.assert_not_awaited()
+        mock_storage_service.unregister_generated_files.assert_awaited_once_with(
+            file_records,
+            hard_delete=False,
+        )
+
+    @pytest.mark.unit
+    def test_bulk_move_route_rejects_invalid_folder_tag(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """Bulk move validates folder tags consistently with folder creation."""
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/v1/storage/files/bulk-move",
+                json={"file_ids": [1], "folder_tag": "bad/name"},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid folder name"
+        mock_files_repo.bulk_move_to_folder.assert_not_awaited()
+
+    @pytest.mark.unit
+    def test_bulk_move_route_loads_files_once_and_uses_trimmed_folder_tag(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """Bulk move verifies ownership in one repo call and normalizes folder tags."""
+        file_records = [
+            {"id": 1, "user_id": mock_user.id, "is_deleted": False},
+            {"id": 2, "user_id": mock_user.id, "is_deleted": False},
+        ]
+        mock_files_repo.get_files_by_ids = AsyncMock(return_value=file_records)
+        mock_files_repo.bulk_move_to_folder = AsyncMock(return_value=2)
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/v1/storage/files/bulk-move",
+                json={"file_ids": [1, 2], "folder_tag": " archive "},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["folder_tag"] == "archive"
+        mock_files_repo.get_files_by_ids.assert_awaited_once_with([1, 2])
+        mock_files_repo.get_file_by_id.assert_not_awaited()
+        mock_files_repo.bulk_move_to_folder.assert_awaited_once_with([1, 2], "archive")
+
+    @pytest.mark.unit
+    def test_delete_file_route_has_response_model(
+        self,
+        mock_user,
+    ):
+        """Delete file route publishes a modeled OpenAPI response."""
+        app = _storage_download_test_app(mock_user)
+
+        operation = app.openapi()["paths"]["/api/v1/storage/files/{file_id}"]["delete"]
+        schema_ref = operation["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+
+        assert schema_ref.endswith("/StorageDeleteResponse")
+
 
 class TestSoftDeleteRestoreCycle:
     """Tests for soft delete and restore lifecycle."""
@@ -638,11 +827,9 @@ class TestSoftDeleteRestoreCycle:
         restored_record = sample_deleted_file_record.copy()
         restored_record["is_deleted"] = False
         restored_record["deleted_at"] = None
-        mock_files_repo.get_file_by_id = AsyncMock(
-            side_effect=[sample_deleted_file_record, restored_record]
-        )
-        mock_files_repo.restore_file = AsyncMock(return_value=True)
+        mock_files_repo.get_file_by_id = AsyncMock(return_value=sample_deleted_file_record)
         mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        mock_storage_service.restore_generated_file = AsyncMock(return_value=restored_record)
         monkeypatch.setattr(
             storage_endpoints,
             "_get_service",
@@ -657,11 +844,11 @@ class TestSoftDeleteRestoreCycle:
         payload = response.json()
         assert payload["success"] is True
         assert payload["file"]["is_deleted"] is False
-        mock_storage_service.update_usage.assert_awaited_once_with(
-            mock_user.id,
-            sample_deleted_file_record["file_size_bytes"],
-            operation="add",
+        mock_storage_service.restore_generated_file.assert_awaited_once_with(
+            1,
+            file_record=sample_deleted_file_record,
         )
+        mock_storage_service.update_usage.assert_not_awaited()
 
     @pytest.mark.unit
     def test_permanent_delete_route_removes_deleted_file(
@@ -860,6 +1047,7 @@ class TestLeastAccessedEndpoint:
             "accessed_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
         }
         mock_files_repo.list_least_accessed = AsyncMock(return_value=[file_record])
+        mock_files_repo.count_least_accessed = AsyncMock(return_value=1)
         mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
         monkeypatch.setattr(
             storage_endpoints,
@@ -876,3 +1064,46 @@ class TestLeastAccessedEndpoint:
         assert payload["total"] == 1
         assert payload["files"][0]["id"] == 1
         assert payload["pagination"]["total"] == 1
+
+    @pytest.mark.unit
+    def test_least_accessed_route_uses_total_candidate_count(
+        self,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """Least-accessed pagination reports total cleanup candidates."""
+        file_record = {
+            "id": 1,
+            "uuid": "uuid-1",
+            "user_id": mock_user.id,
+            "filename": "old.wav",
+            "storage_path": "tts_audio/old.wav",
+            "file_category": "tts_audio",
+            "source_feature": "tts",
+            "file_size_bytes": 1024,
+            "is_deleted": False,
+            "is_transient": False,
+            "tags": [],
+            "created_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
+            "updated_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
+        }
+        mock_files_repo.list_least_accessed = AsyncMock(return_value=[file_record])
+        mock_files_repo.count_least_accessed = AsyncMock(return_value=25)
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+        monkeypatch.setattr(
+            storage_endpoints,
+            "_get_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app) as client:
+            response = client.get("/api/v1/storage/files/least-accessed?limit=1")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total"] == 25
+        assert payload["pagination"]["has_more"] is True
+        assert payload["pagination"]["next_offset"] == 1

--- a/tldw_Server_API/tests/Storage/test_storage_quota_service.py
+++ b/tldw_Server_API/tests/Storage/test_storage_quota_service.py
@@ -294,6 +294,78 @@ class TestUnregisterGeneratedFile:
         assert result is True
         assert not file_path.exists()
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_bulk_unregister_uses_repo_bulk_soft_delete_and_aggregates_usage(self):
+        """Bulk unregister soft-deletes through the repo and aggregates usage updates."""
+        service = StorageQuotaService(db_pool=MagicMock())
+        service._initialized = True
+
+        file_records = [
+            {
+                "id": 1,
+                "user_id": 1,
+                "org_id": 7,
+                "team_id": 9,
+                "is_deleted": False,
+                "file_size_bytes": 1024,
+            },
+            {
+                "id": 2,
+                "user_id": 1,
+                "org_id": 7,
+                "team_id": 9,
+                "is_deleted": False,
+                "file_size_bytes": 2048,
+            },
+        ]
+        mock_repo = AsyncMock()
+        mock_repo.bulk_soft_delete = AsyncMock(return_value=2)
+        service.get_generated_files_repo = AsyncMock(return_value=mock_repo)
+        service.update_usage = AsyncMock()
+        service.update_org_usage = AsyncMock()
+        service.update_team_usage = AsyncMock()
+
+        result = await service.unregister_generated_files(file_records, hard_delete=False)
+
+        assert result == 2
+        mock_repo.bulk_soft_delete.assert_awaited_once_with([1, 2])
+        service.update_usage.assert_awaited_once_with(1, 3072, operation="remove")
+        service.update_org_usage.assert_awaited_once_with(7, -3072)
+        service.update_team_usage.assert_awaited_once_with(9, -3072)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_restore_generated_file_updates_usage_in_service_layer(self):
+        """Restore orchestration updates file state and usage counters in the service."""
+        service = StorageQuotaService(db_pool=MagicMock())
+        service._initialized = True
+
+        deleted_record = {
+            "id": 3,
+            "user_id": 1,
+            "org_id": 7,
+            "team_id": 9,
+            "is_deleted": True,
+            "file_size_bytes": 4096,
+        }
+        restored_record = deleted_record | {"is_deleted": False}
+        mock_repo = AsyncMock()
+        mock_repo.restore_file = AsyncMock(return_value=True)
+        mock_repo.get_file_by_id = AsyncMock(return_value=restored_record)
+        service.get_generated_files_repo = AsyncMock(return_value=mock_repo)
+        service.update_usage = AsyncMock()
+        service.update_org_usage = AsyncMock()
+        service.update_team_usage = AsyncMock()
+
+        result = await service.restore_generated_file(3, file_record=deleted_record)
+
+        assert result == restored_record
+        mock_repo.restore_file.assert_awaited_once_with(3)
+        service.update_usage.assert_awaited_once_with(1, 4096, operation="add")
+        service.update_org_usage.assert_awaited_once_with(7, 4096)
+        service.update_team_usage.assert_awaited_once_with(9, 4096)
+
 
 class TestGetAllUsersStorage:
     """Tests for get_all_users_storage method."""


### PR DESCRIPTION
## Summary
- Extract storage user file and folder JSON handlers into sidecar routers while preserving the existing /api/v1/storage public paths.
- Extract storage usage and trash JSON handlers into sidecar routers, leaving download and admin quota routes in storage.py.
- Add route-level coverage for least-accessed route ordering and usage/trash behavior, and update the Phase 4.4 plan state.

## Verification
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Storage/test_storage_endpoints.py tldw_Server_API/tests/AuthNZ_Unit/test_storage_admin_claims.py tldw_Server_API/tests/Admin/test_admin_storage_quotas.py -q
- cd apps/extension && bun run verify:openapi
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server_API/app/api/v1/endpoints/storage_helpers.py tldw_Server_API/app/api/v1/endpoints/storage_user_files.py tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py tldw_Server_API/app/api/v1/endpoints/storage_usage.py tldw_Server_API/app/api/v1/endpoints/storage_trash.py -f json -o /tmp/bandit_phase4_4_storage_endpoint.json
- git diff --check

## Maintainer note
Per the repo AI-generated PR policy, this PR needs a human-written Change summary before merge.