### PR TITLE
Phase 4.4: extract storage admin quota routes

### DIFF
--- a/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
+++ b/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
@@ -215,7 +215,7 @@ Notes:
 **Goal:** Avoid mixing special route behavior into the first decomposition PR.
 **Success Criteria:** Download and admin route movement have their own accepted plan before any move.
 **Tests:** Download path traversal tests and admin claim tests.
-**Status:** Not Started
+**Status:** In Progress
 
 Download route requirements:
 
@@ -230,6 +230,15 @@ Admin quota route requirements:
 - Preserve legacy `is_admin` compatibility.
 - Preserve 401 behavior when principal dependency is unavailable in tests.
 - Preserve 403 detail for non-admin principals.
+
+Notes:
+
+- Admin quota routes were split into `storage_admin_quotas.py` as a conservative JSON-only tranche.
+- Preserved the `storage._get_service` monkeypatch seam through dynamic sidecar service resolution.
+- Re-exported admin quota handlers and `require_storage_admin` from `storage.py` for direct import compatibility.
+- Added direct compatibility coverage for storage/admin sidecar re-exports.
+- Focused storage/admin suite passed after admin route movement: `57 passed, 6 warnings`.
+- Download route remains in `storage.py` and should move in a separate tranche focused on `FileResponse` and path traversal behavior.
 
 ## Verification
 
@@ -255,7 +264,7 @@ Touched-scope Bandit:
 
 ```bash
 source .venv/bin/activate
-python3 -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server_API/app/api/v1/endpoints/storage_helpers.py tldw_Server_API/app/api/v1/endpoints/storage_user_files.py tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py tldw_Server_API/app/api/v1/endpoints/storage_usage.py tldw_Server_API/app/api/v1/endpoints/storage_trash.py -f json -o /tmp/bandit_phase4_4_storage_endpoint.json
+python3 -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server_API/app/api/v1/endpoints/storage_admin_quotas.py tldw_Server_API/app/api/v1/endpoints/storage_helpers.py tldw_Server_API/app/api/v1/endpoints/storage_user_files.py tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py tldw_Server_API/app/api/v1/endpoints/storage_usage.py tldw_Server_API/app/api/v1/endpoints/storage_trash.py -f json -o /tmp/bandit_phase4_4_storage_endpoint.json
 ```
 
 ## Out Of Scope

--- a/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
+++ b/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
@@ -234,7 +234,7 @@ Admin quota route requirements:
 Notes:
 
 - Admin quota routes were split into `storage_admin_quotas.py` as a conservative JSON-only tranche.
-- Preserved the `storage._get_service` monkeypatch seam through dynamic sidecar service resolution.
+- Admin quota tests now patch the sidecar service dependency directly, avoiding a circular import back into `storage.py`.
 - Re-exported admin quota handlers and `require_storage_admin` from `storage.py` for direct import compatibility.
 - Added direct compatibility coverage for storage/admin sidecar re-exports.
 - Focused storage/admin suite passed after admin route movement: `57 passed, 6 warnings`.

--- a/tldw_Server_API/app/api/v1/endpoints/storage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage.py
@@ -12,17 +12,24 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_auth_principal, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.endpoints import (
+    storage_admin_quotas,
     storage_trash,
     storage_usage,
     storage_user_files,
     storage_user_folders,
 )
 from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
-    _principal_is_storage_admin,
     _resolve_storage_base_dir,
-    _to_quota_status,
+)
+from tldw_Server_API.app.api.v1.endpoints.storage_admin_quotas import (  # noqa: F401
+    get_org_quota,
+    get_team_quota,
+    require_storage_admin,
+    set_org_quota,
+    set_team_quota,
+    set_user_quota,
 )
 # Re-export moved handlers so direct imports/tests against storage.py keep working.
 from tldw_Server_API.app.api.v1.endpoints.storage_user_files import (  # noqa: F401
@@ -47,18 +54,6 @@ from tldw_Server_API.app.api.v1.endpoints.storage_usage import (  # noqa: F401
     get_storage_usage,
     get_usage_breakdown,
 )
-from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
-    OrgQuotaResponse,
-    QuotaStatus,
-    SetQuotaRequest,
-    SetQuotaResponse,
-    TeamQuotaResponse,
-)
-from tldw_Server_API.app.core.AuthNZ.exceptions import (
-    StorageError,
-    UserNotFoundError,
-)
-from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths as _DatabasePaths
 from tldw_Server_API.app.services.storage_quota_service import get_storage_service
 
@@ -78,24 +73,11 @@ async def _get_service():
     return await get_storage_service()
 
 
-async def require_storage_admin(principal: AuthPrincipal = Depends(get_auth_principal)) -> AuthPrincipal:
-    """Authorize storage admin endpoints with legacy `is_admin` compatibility."""
-    if _principal_is_storage_admin(principal):
-        return principal
-    raise HTTPException(
-        status_code=403,
-        detail="Access denied. Required role(s): admin",
-    )
-
-
-# =========================================================================
-# File Endpoints
-# =========================================================================
-
 router.include_router(storage_user_files.router)
 router.include_router(storage_user_folders.router)
 router.include_router(storage_usage.router)
 router.include_router(storage_trash.router)
+router.include_router(storage_admin_quotas.router)
 
 
 @router.get("/files/{file_id}/download")
@@ -146,114 +128,4 @@ async def download_file(
         path=str(full_path),
         filename=filename,
         media_type=mime_type,
-    )
-
-# =========================================================================
-# Admin Quota Endpoints
-# =========================================================================
-
-@router.put("/admin/quotas/user/{user_id}", response_model=SetQuotaResponse)
-async def set_user_quota(
-    user_id: int,
-    request: SetQuotaRequest,
-    _principal: AuthPrincipal = Depends(require_storage_admin),
-):
-    """Set storage quota for a user (admin only)."""
-    service = await _get_service()
-
-    try:
-        result = await service.set_user_quota(user_id, request.quota_mb)
-        return SetQuotaResponse(
-            success=True,
-            quota=QuotaStatus(
-                quota_mb=result.get("storage_quota_mb"),
-                used_mb=result.get("storage_used_mb", 0.0),
-                remaining_mb=result.get("available_mb", 0.0),
-                usage_pct=result.get("usage_percentage", 0.0),
-                at_soft_limit=result.get("usage_percentage", 0) >= request.soft_limit_pct,
-                at_hard_limit=result.get("usage_percentage", 0) >= request.hard_limit_pct,
-                has_quota=True,
-            ),
-        )
-    except UserNotFoundError:
-        raise HTTPException(status_code=404, detail="User not found") from None
-    except StorageError as e:
-        raise HTTPException(status_code=500, detail="Failed to set user storage quota") from e
-
-
-@router.put("/admin/quotas/team/{team_id}", response_model=SetQuotaResponse)
-async def set_team_quota(
-    team_id: int,
-    request: SetQuotaRequest,
-    _principal: AuthPrincipal = Depends(require_storage_admin),
-):
-    """Set storage quota for a team (admin only)."""
-    service = await _get_service()
-
-    await service.set_team_quota(
-        team_id,
-        request.quota_mb,
-        soft_limit_pct=request.soft_limit_pct,
-        hard_limit_pct=request.hard_limit_pct,
-    )
-
-    quota_status = await service.get_team_quota(team_id)
-
-    return SetQuotaResponse(
-        success=True,
-        quota=_to_quota_status(quota_status),
-    )
-
-
-@router.put("/admin/quotas/org/{org_id}", response_model=SetQuotaResponse)
-async def set_org_quota(
-    org_id: int,
-    request: SetQuotaRequest,
-    _principal: AuthPrincipal = Depends(require_storage_admin),
-):
-    """Set storage quota for an organization (admin only)."""
-    service = await _get_service()
-
-    await service.set_org_quota(
-        org_id,
-        request.quota_mb,
-        soft_limit_pct=request.soft_limit_pct,
-        hard_limit_pct=request.hard_limit_pct,
-    )
-
-    quota_status = await service.get_org_quota(org_id)
-
-    return SetQuotaResponse(
-        success=True,
-        quota=_to_quota_status(quota_status),
-    )
-
-
-@router.get("/admin/quotas/team/{team_id}", response_model=TeamQuotaResponse)
-async def get_team_quota(
-    team_id: int,
-    _principal: AuthPrincipal = Depends(require_storage_admin),
-):
-    """Get storage quota for a team (admin only)."""
-    service = await _get_service()
-    quota_status = await service.get_team_quota(team_id)
-
-    return TeamQuotaResponse(
-        team_id=team_id,
-        quota=_to_quota_status(quota_status),
-    )
-
-
-@router.get("/admin/quotas/org/{org_id}", response_model=OrgQuotaResponse)
-async def get_org_quota(
-    org_id: int,
-    _principal: AuthPrincipal = Depends(require_storage_admin),
-):
-    """Get storage quota for an organization (admin only)."""
-    service = await _get_service()
-    quota_status = await service.get_org_quota(org_id)
-
-    return OrgQuotaResponse(
-        org_id=org_id,
-        quota=_to_quota_status(quota_status),
     )

--- a/tldw_Server_API/app/api/v1/endpoints/storage_admin_quotas.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_admin_quotas.py
@@ -10,23 +10,20 @@ from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
 )
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
     OrgQuotaResponse,
-    QuotaStatus,
     SetQuotaRequest,
     SetQuotaResponse,
     TeamQuotaResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.exceptions import StorageError, UserNotFoundError
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService
+from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService, get_storage_service
 
 router = APIRouter()
 
 
 async def _get_storage_service() -> StorageQuotaService:
-    """Resolve the storage service through storage.py for legacy monkeypatch seams."""
-    from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
-
-    return await storage_endpoint._get_service()
+    """Get initialized storage quota service."""
+    return await get_storage_service()
 
 
 async def require_storage_admin(principal: AuthPrincipal = Depends(get_auth_principal)) -> AuthPrincipal:
@@ -50,17 +47,18 @@ async def set_user_quota(
 
     try:
         result = await service.set_user_quota(user_id, request.quota_mb)
+        status_data = {
+            "quota_mb": result.get("storage_quota_mb"),
+            "used_mb": result.get("storage_used_mb", 0.0),
+            "remaining_mb": result.get("available_mb", 0.0),
+            "usage_pct": result.get("usage_percentage", 0.0),
+            "at_soft_limit": result.get("usage_percentage", 0) >= request.soft_limit_pct,
+            "at_hard_limit": result.get("usage_percentage", 0) >= request.hard_limit_pct,
+            "has_quota": True,
+        }
         return SetQuotaResponse(
             success=True,
-            quota=QuotaStatus(
-                quota_mb=result.get("storage_quota_mb"),
-                used_mb=result.get("storage_used_mb", 0.0),
-                remaining_mb=result.get("available_mb", 0.0),
-                usage_pct=result.get("usage_percentage", 0.0),
-                at_soft_limit=result.get("usage_percentage", 0) >= request.soft_limit_pct,
-                at_hard_limit=result.get("usage_percentage", 0) >= request.hard_limit_pct,
-                has_quota=True,
-            ),
+            quota=_to_quota_status(status_data),
         )
     except UserNotFoundError:
         raise HTTPException(status_code=404, detail="User not found") from None

--- a/tldw_Server_API/app/api/v1/endpoints/storage_admin_quotas.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_admin_quotas.py
@@ -1,0 +1,146 @@
+"""Storage admin quota routes."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
+    _principal_is_storage_admin,
+    _to_quota_status,
+)
+from tldw_Server_API.app.api.v1.schemas.storage_schemas import (
+    OrgQuotaResponse,
+    QuotaStatus,
+    SetQuotaRequest,
+    SetQuotaResponse,
+    TeamQuotaResponse,
+)
+from tldw_Server_API.app.core.AuthNZ.exceptions import StorageError, UserNotFoundError
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService
+
+router = APIRouter()
+
+
+async def _get_storage_service() -> StorageQuotaService:
+    """Resolve the storage service through storage.py for legacy monkeypatch seams."""
+    from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
+
+    return await storage_endpoint._get_service()
+
+
+async def require_storage_admin(principal: AuthPrincipal = Depends(get_auth_principal)) -> AuthPrincipal:
+    """Authorize storage admin endpoints with legacy `is_admin` compatibility."""
+    if _principal_is_storage_admin(principal):
+        return principal
+    raise HTTPException(
+        status_code=403,
+        detail="Access denied. Required role(s): admin",
+    )
+
+
+@router.put("/admin/quotas/user/{user_id}", response_model=SetQuotaResponse)
+async def set_user_quota(
+    user_id: int,
+    request: SetQuotaRequest,
+    _principal: AuthPrincipal = Depends(require_storage_admin),
+) -> SetQuotaResponse:
+    """Set storage quota for a user (admin only)."""
+    service = await _get_storage_service()
+
+    try:
+        result = await service.set_user_quota(user_id, request.quota_mb)
+        return SetQuotaResponse(
+            success=True,
+            quota=QuotaStatus(
+                quota_mb=result.get("storage_quota_mb"),
+                used_mb=result.get("storage_used_mb", 0.0),
+                remaining_mb=result.get("available_mb", 0.0),
+                usage_pct=result.get("usage_percentage", 0.0),
+                at_soft_limit=result.get("usage_percentage", 0) >= request.soft_limit_pct,
+                at_hard_limit=result.get("usage_percentage", 0) >= request.hard_limit_pct,
+                has_quota=True,
+            ),
+        )
+    except UserNotFoundError:
+        raise HTTPException(status_code=404, detail="User not found") from None
+    except StorageError as e:
+        raise HTTPException(status_code=500, detail="Failed to set user storage quota") from e
+
+
+@router.put("/admin/quotas/team/{team_id}", response_model=SetQuotaResponse)
+async def set_team_quota(
+    team_id: int,
+    request: SetQuotaRequest,
+    _principal: AuthPrincipal = Depends(require_storage_admin),
+) -> SetQuotaResponse:
+    """Set storage quota for a team (admin only)."""
+    service = await _get_storage_service()
+
+    await service.set_team_quota(
+        team_id,
+        request.quota_mb,
+        soft_limit_pct=request.soft_limit_pct,
+        hard_limit_pct=request.hard_limit_pct,
+    )
+
+    quota_status = await service.get_team_quota(team_id)
+
+    return SetQuotaResponse(
+        success=True,
+        quota=_to_quota_status(quota_status),
+    )
+
+
+@router.put("/admin/quotas/org/{org_id}", response_model=SetQuotaResponse)
+async def set_org_quota(
+    org_id: int,
+    request: SetQuotaRequest,
+    _principal: AuthPrincipal = Depends(require_storage_admin),
+) -> SetQuotaResponse:
+    """Set storage quota for an organization (admin only)."""
+    service = await _get_storage_service()
+
+    await service.set_org_quota(
+        org_id,
+        request.quota_mb,
+        soft_limit_pct=request.soft_limit_pct,
+        hard_limit_pct=request.hard_limit_pct,
+    )
+
+    quota_status = await service.get_org_quota(org_id)
+
+    return SetQuotaResponse(
+        success=True,
+        quota=_to_quota_status(quota_status),
+    )
+
+
+@router.get("/admin/quotas/team/{team_id}", response_model=TeamQuotaResponse)
+async def get_team_quota(
+    team_id: int,
+    _principal: AuthPrincipal = Depends(require_storage_admin),
+) -> TeamQuotaResponse:
+    """Get storage quota for a team (admin only)."""
+    service = await _get_storage_service()
+    quota_status = await service.get_team_quota(team_id)
+
+    return TeamQuotaResponse(
+        team_id=team_id,
+        quota=_to_quota_status(quota_status),
+    )
+
+
+@router.get("/admin/quotas/org/{org_id}", response_model=OrgQuotaResponse)
+async def get_org_quota(
+    org_id: int,
+    _principal: AuthPrincipal = Depends(require_storage_admin),
+) -> OrgQuotaResponse:
+    """Get storage quota for an organization (admin only)."""
+    service = await _get_storage_service()
+    quota_status = await service.get_org_quota(org_id)
+
+    return OrgQuotaResponse(
+        org_id=org_id,
+        quota=_to_quota_status(quota_status),
+    )

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_storage_admin_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_storage_admin_claims.py
@@ -9,6 +9,7 @@ from starlette.requests import Request
 
 from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.endpoints import storage as storage_mod
+from tldw_Server_API.app.api.v1.endpoints import storage_admin_quotas
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 
 
@@ -130,7 +131,7 @@ async def test_storage_admin_quota_endpoints_403_for_non_admin_principal(
     async def _fake_get_service() -> _FakeStorageService:
         return _FakeStorageService()
 
-    monkeypatch.setattr(storage_mod, "_get_service", _fake_get_service)
+    monkeypatch.setattr(storage_admin_quotas, "_get_storage_service", _fake_get_service)
     with TestClient(app) as client:
         resp = client.request(method.upper(), path, json=payload)
     assert resp.status_code == 403
@@ -144,7 +145,7 @@ async def test_storage_admin_quota_endpoints_200_for_admin_role_claim(monkeypatc
     async def _fake_get_service() -> _FakeStorageService:
         return _FakeStorageService()
 
-    monkeypatch.setattr(storage_mod, "_get_service", _fake_get_service)
+    monkeypatch.setattr(storage_admin_quotas, "_get_storage_service", _fake_get_service)
 
     with TestClient(app) as client:
         user_put = client.put(
@@ -177,7 +178,7 @@ async def test_storage_admin_quota_endpoints_200_for_is_admin_claim(monkeypatch:
     async def _fake_get_service() -> _FakeStorageService:
         return _FakeStorageService()
 
-    monkeypatch.setattr(storage_mod, "_get_service", _fake_get_service)
+    monkeypatch.setattr(storage_admin_quotas, "_get_storage_service", _fake_get_service)
 
     with TestClient(app) as client:
         resp = client.get("/api/v1/storage/admin/quotas/team/3")

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -9,6 +9,8 @@ Tests cover:
 - Admin quota management
 - Soft/hard limit warnings in usage responses
 """
+from importlib import import_module
+
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -880,6 +882,20 @@ class TestSoftDeleteRestoreCycle:
 
 class TestAdminQuotaEndpoints:
     """Tests for admin quota management endpoints."""
+
+    @pytest.mark.unit
+    def test_admin_quota_handlers_reexport_from_storage_after_sidecar_split(self):
+        """Admin quota handlers remain import-compatible after sidecar extraction."""
+        storage_admin_quotas = import_module(
+            "tldw_Server_API.app.api.v1.endpoints.storage_admin_quotas"
+        )
+
+        assert storage_endpoints.require_storage_admin is storage_admin_quotas.require_storage_admin
+        assert storage_endpoints.set_user_quota is storage_admin_quotas.set_user_quota
+        assert storage_endpoints.set_team_quota is storage_admin_quotas.set_team_quota
+        assert storage_endpoints.set_org_quota is storage_admin_quotas.set_org_quota
+        assert storage_endpoints.get_team_quota is storage_admin_quotas.get_team_quota
+        assert storage_endpoints.get_org_quota is storage_admin_quotas.get_org_quota
 
     @pytest.mark.unit
     def test_set_quota_requires_admin(self, mock_user):

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock
 from datetime import datetime, timezone
 
 from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoints
+from tldw_Server_API.app.api.v1.endpoints import storage_admin_quotas
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import SetQuotaRequest
 from tldw_Server_API.app.core.AuthNZ.exceptions import StorageError
 
@@ -929,7 +930,7 @@ class TestAdminQuotaEndpoints:
         async def _get_broken_service():
             return _BrokenStorageService()
 
-        monkeypatch.setattr(storage_endpoints, "_get_service", _get_broken_service)
+        monkeypatch.setattr(storage_admin_quotas, "_get_storage_service", _get_broken_service)
 
         with pytest.raises(HTTPException) as exc_info:
             await storage_endpoints.set_user_quota(


### PR DESCRIPTION
## Change summary
TODO(user): Human-authored summary required before merge. Explain why the admin quota routes were split as a separate JSON-only Phase 4.4 tranche and why the download route remains separate.

## What changed
- Moved `/api/v1/storage/admin/quotas/*` handlers into `storage_admin_quotas.py`.
- Kept `storage.router` as the public router and included the new sidecar router there.
- Re-exported admin quota handlers and `require_storage_admin` from `storage.py` for direct import compatibility.
- Updated admin route tests to patch the admin sidecar service dependency directly, avoiding a circular import back into `storage.py`.
- Normalized `set_user_quota` service output through `_to_quota_status`, matching team/org quota handlers.
- Updated the Phase 4.4 storage endpoint decomposition plan to record the admin split and leave download route movement as a separate tranche.

## Verification
- RED: `python -m pytest tldw_Server_API/tests/Storage/test_storage_endpoints.py -k "admin_quota_handlers_reexport" -q` failed before the sidecar existed.
- Focused review tests: `python -m pytest tldw_Server_API/tests/Storage/test_storage_endpoints.py -k "admin_quota_handlers_reexport or set_user_quota_sanitizes" -q` -> 2 passed.
- Admin auth tests: `python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_storage_admin_claims.py -q` -> 8 passed.
- Focused suite: `python -m pytest tldw_Server_API/tests/Storage/test_storage_endpoints.py tldw_Server_API/tests/AuthNZ_Unit/test_storage_admin_claims.py tldw_Server_API/tests/Admin/test_admin_storage_quotas.py -q` -> 57 passed, 6 warnings.
- OpenAPI: `bun run verify:openapi` from `apps/extension` -> passed with 256 ClientPath entries and 46 media fallback fields verified.
- Bandit: touched storage endpoint scope -> 0 findings in `/tmp/bandit_phase4_4_storage_admin_routes_review.json`.
- `git diff --check` -> passed.

## Scope boundary
- Does not move the file download route.
- Does not change public route paths, payloads, auth semantics, or admin quota behavior.
- Does not introduce response-envelope changes.