### PR TITLE
Label sandbox runtime implementation states

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -29,16 +29,21 @@ avoid overclaiming isolation, networking, recovery, or CI coverage.
 ## Discovery Contract
 
 `/api/v1/sandbox/runtimes` is the summarized client-facing discovery surface.
-It should include every value from `RuntimeType`:
+It should include every value from `RuntimeType` and expose two separate
+concepts:
 
-| Runtime | Discovery entry | Source |
+- `available`: current host/preflight truth.
+- `implementation_state`: roadmap maturity label independent of whether this
+  specific host has the required binaries, helper, VM support, or feature flags.
+
+| Runtime | `implementation_state` | Discovery source |
 | --- | --- | --- |
 | `docker` | `supported` | `SandboxService.feature_discovery()` plus `docker_available()` |
-| `firecracker` | `supported` | `SandboxService.feature_discovery()` plus `firecracker_available()` |
-| `lima` | `supported` | `LimaRunner.preflight()` |
-| `vz_linux` | `supported` | `VZLinuxRunner.preflight()` |
-| `vz_macos` | `supported` | `VZMacOSRunner.preflight()` |
-| `seatbelt` | `supported` | `SeatbeltRunner.preflight()` |
+| `firecracker` | `host_gated` | `SandboxService.feature_discovery()` plus `firecracker_available()` |
+| `lima` | `host_gated` | `LimaRunner.preflight()` |
+| `vz_linux` | `host_gated` | `VZLinuxRunner.preflight()` |
+| `vz_macos` | `scaffold` | `VZMacOSRunner.preflight()` |
+| `seatbelt` | `host_gated` | `SeatbeltRunner.preflight()` |
 | `worktree` | `supported` | `WorktreeRunner.preflight()` |
 
 Discovery is intentionally summarized. Admin/operator diagnostics can expose

--- a/backlog/tasks/task-2 - Normalize-sandbox-runtime-implementation-state-in-discovery.md
+++ b/backlog/tasks/task-2 - Normalize-sandbox-runtime-implementation-state-in-discovery.md
@@ -1,0 +1,57 @@
+---
+id: TASK-2
+title: Normalize sandbox runtime implementation state in discovery
+status: Done
+assignee: []
+created_date: '2026-05-03 17:16'
+updated_date: '2026-05-03 17:24'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a runtime discovery implementation_state field using the sandbox roadmap state vocabulary so clients can distinguish host availability from runtime maturity.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sandbox runtime discovery includes implementation_state for every runtime
+- [x] #2 Schema documents the supported state vocabulary
+- [x] #3 Focused tests cover docker, vz_linux, vz_macos, seatbelt, and worktree state labels
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented runtime implementation_state labels for /api/v1/sandbox/runtimes using the roadmap state vocabulary. Added centralized state mapping in runtime_capabilities.py, surfaced it through SandboxService.feature_discovery(), extended the response schema, and documented the available vs implementation_state split in sandbox docs.
+
+Verification:
+- focused red test first failed with KeyError: implementation_state
+- python -m pytest tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py -k implementation_state_labels -q: passed
+- python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q --timeout=60: passed
+- python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capabilities_policy.py -q --timeout=60: passed
+- python -m py_compile touched Python modules: passed
+- python -m bandit -r touched Python files -f json -o /tmp/bandit_runtime_state.json: passed, 0 findings
+- git diff --check: passed
+
+Known skip/blocker:
+- Full test_feature_discovery_flags.py timed out in existing TestClient teardown/job-worker startup path at test_egress_allowlist_supported_when_enforced, not in the new implementation_state test.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added normalized runtime implementation_state labels to sandbox runtime discovery so clients can distinguish current host availability from runtime maturity. Updated schema and docs, added focused coverage, and recorded the existing full-file TestClient timeout separately.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma: no cover - pydantic v1 fallback
     from pydantic import root_validator as model_validator  # type: ignore
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimeImplementationState
 
 RuntimeType = Literal[
     "docker",
@@ -33,6 +34,13 @@ def _default_offset_pagination_aliases(response):
 class SandboxRuntimeInfo(BaseModel):
     name: RuntimeType
     available: bool = Field(description="Whether this runtime is detected/usable on host")
+    implementation_state: RuntimeImplementationState | None = Field(
+        default=None,
+        description=(
+            "Roadmap maturity label for this runtime independent of current host availability: "
+            "supported, unsupported, scaffold, host_gated, or not_applicable"
+        ),
+    )
     reasons: list[str] | None = Field(default=None, description="Preflight reasons when the runtime is unavailable or constrained")
     supported_trust_levels: list[TrustLevelType] | None = Field(default=None, description="Trust levels supported by this runtime under current host policy")
     default_images: list[str] = Field(default_factory=list)

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -171,6 +171,10 @@ Current limitations:
   - `/api/v1/sandbox/runs`
 
 `/api/v1/sandbox/runtimes` is the summarized discovery surface used by clients and ACP.
+Each runtime entry includes `available` for current host truth and
+`implementation_state` for roadmap maturity (`supported`, `unsupported`,
+`scaffold`, `host_gated`, or `not_applicable`), so clients do not infer security
+or maturity guarantees from availability alone.
 `/api/v1/sandbox/admin/macos-diagnostics` is an admin-only diagnostics surface for
 operator troubleshooting and exposes helper/template readiness details that are not
 included in the public discovery payload, plus reconciliation data for persisted

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -1,9 +1,32 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, Mapping
 
 from .models import RuntimeType
+
+RuntimeImplementationState = Literal[
+    "supported",
+    "unsupported",
+    "scaffold",
+    "host_gated",
+    "not_applicable",
+]
+
+RUNTIME_IMPLEMENTATION_STATES: Mapping[RuntimeType, RuntimeImplementationState] = {
+    RuntimeType.docker: "supported",
+    RuntimeType.firecracker: "host_gated",
+    RuntimeType.lima: "host_gated",
+    RuntimeType.vz_linux: "host_gated",
+    RuntimeType.vz_macos: "scaffold",
+    RuntimeType.seatbelt: "host_gated",
+    RuntimeType.worktree: "supported",
+}
+
+
+def runtime_implementation_state(runtime: RuntimeType) -> RuntimeImplementationState:
+    """Return the roadmap maturity label for a runtime, independent of host availability."""
+    return RUNTIME_IMPLEMENTATION_STATES.get(runtime, "unsupported")
 
 
 @dataclass

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -55,7 +55,11 @@ from .runners.seatbelt_runner import SeatbeltRunner
 from .runners.vz_linux_runner import VZLinuxRunner
 from .runners.vz_macos_runner import VZMacOSRunner
 from .runners.worktree_runner import WorktreeRunner, worktree_available
-from .runtime_capabilities import RuntimePreflightResult, collect_runtime_preflights
+from .runtime_capabilities import (
+    RuntimePreflightResult,
+    collect_runtime_preflights,
+    runtime_implementation_state,
+)
 from .snapshots import SnapshotManager
 from .store import get_store_mode
 from .streams import get_hub
@@ -878,6 +882,7 @@ class SandboxService:
         return [
             {
                 "name": "docker",
+                "implementation_state": runtime_implementation_state(RuntimeType.docker),
                 "available": bool(docker_preflight.available) if docker_preflight is not None else bool(docker_available()),
                 "default_images": images,
                 "max_cpu": max_cpu,
@@ -910,6 +915,7 @@ class SandboxService:
             },
             {
                 "name": "firecracker",
+                "implementation_state": runtime_implementation_state(RuntimeType.firecracker),
                 "available": bool(firecracker_preflight.available) if firecracker_preflight is not None else bool(firecracker_available()),
                 "default_images": images,  # firecracker images will differ; placeholder for UX
                 "max_cpu": max_cpu,
@@ -949,6 +955,7 @@ class SandboxService:
             },
             {
                 "name": "lima",
+                "implementation_state": runtime_implementation_state(RuntimeType.lima),
                 "available": bool(lima_preflight.available) if lima_preflight is not None else bool(lima_available()),
                 "default_images": ["ubuntu:24.04"],  # Lima uses distro images
                 "max_cpu": max_cpu,
@@ -973,6 +980,7 @@ class SandboxService:
             },
             {
                 "name": "vz_linux",
+                "implementation_state": runtime_implementation_state(RuntimeType.vz_linux),
                 "default_images": ["ubuntu-24.04"],
                 "max_cpu": max_cpu,
                 "max_mem_mb": max_mem_mb,
@@ -993,6 +1001,7 @@ class SandboxService:
             },
             {
                 "name": "vz_macos",
+                "implementation_state": runtime_implementation_state(RuntimeType.vz_macos),
                 "default_images": ["macos-15"],
                 "max_cpu": max_cpu,
                 "max_mem_mb": max_mem_mb,
@@ -1013,6 +1022,7 @@ class SandboxService:
             },
             {
                 "name": "seatbelt",
+                "implementation_state": runtime_implementation_state(RuntimeType.seatbelt),
                 "default_images": ["host-local"],
                 "max_cpu": max_cpu,
                 "max_mem_mb": max_mem_mb,
@@ -1033,6 +1043,7 @@ class SandboxService:
             },
             {
                 "name": "worktree",
+                "implementation_state": runtime_implementation_state(RuntimeType.worktree),
                 "default_images": ["host-local"],
                 "max_cpu": max_cpu,
                 "max_mem_mb": max_mem_mb,

--- a/tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
+++ b/tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
@@ -144,6 +144,26 @@ def test_runtimes_discovery_includes_macos_runtime_capabilities(monkeypatch) -> 
         assert isinstance(runtimes["vz_macos"].get("host"), dict)
 
 
+def test_runtimes_discovery_includes_implementation_state_labels(monkeypatch) -> None:
+    """Verify discovery exposes roadmap maturity labels for every sandbox runtime."""
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    clear_config_cache()
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/sandbox/runtimes")
+
+    assert response.status_code == 200
+    runtimes = {item["name"]: item for item in response.json()["runtimes"]}
+    assert runtimes["docker"]["implementation_state"] == "supported"
+    assert runtimes["firecracker"]["implementation_state"] == "host_gated"
+    assert runtimes["lima"]["implementation_state"] == "host_gated"
+    assert runtimes["vz_linux"]["implementation_state"] == "host_gated"
+    assert runtimes["vz_macos"]["implementation_state"] == "scaffold"
+    assert runtimes["seatbelt"]["implementation_state"] == "host_gated"
+    assert runtimes["worktree"]["implementation_state"] == "supported"
+
+
 def test_runtimes_discovery_keeps_macos_diagnostics_summarized(monkeypatch) -> None:
     monkeypatch.setenv("TEST_MODE", "1")
     monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")


### PR DESCRIPTION
## Summary
- Add a normalized `implementation_state` label to sandbox runtime discovery while preserving existing `available` behavior.
- Document the distinction between host readiness and runtime implementation maturity in sandbox docs.
- Add focused coverage for runtime labels across docker, firecracker, lima, vz_linux, vz_macos, seatbelt, and worktree.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py -k implementation_state_labels -q`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
- [x] `git diff --check HEAD~1..HEAD`

## Human Change summary
TODO: human maintainer must add the merge-gate change summary explaining what changed and why these implementation choices were made.