### PR TITLE
Phase 4.4: extract storage download route

### DIFF
--- a/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
+++ b/Docs/superpowers/plans/2026-04-25-phase4-4-storage-endpoint-decomposition-plan.md
@@ -215,7 +215,7 @@ Notes:
 **Goal:** Avoid mixing special route behavior into the first decomposition PR.
 **Success Criteria:** Download and admin route movement have their own accepted plan before any move.
 **Tests:** Download path traversal tests and admin claim tests.
-**Status:** In Progress
+**Status:** Complete
 
 Download route requirements:
 
@@ -238,7 +238,13 @@ Notes:
 - Re-exported admin quota handlers and `require_storage_admin` from `storage.py` for direct import compatibility.
 - Added direct compatibility coverage for storage/admin sidecar re-exports.
 - Focused storage/admin suite passed after admin route movement: `57 passed, 6 warnings`.
-- Download route remains in `storage.py` and should move in a separate tranche focused on `FileResponse` and path traversal behavior.
+- Download route was split into `storage_download.py` as a separate `FileResponse` tranche.
+- Download tests now patch the sidecar service dependency directly, avoiding a circular import back into `storage.py`.
+- Re-exported `download_file` from `storage.py` for direct import compatibility.
+- Added direct compatibility coverage for the storage/download sidecar re-export.
+- Focused storage/admin suite passed after download route movement: `58 passed, 6 warnings`.
+- OpenAPI verifier passed from `apps/extension`.
+- Touched-scope Bandit passed with zero findings.
 
 ## Verification
 
@@ -264,7 +270,7 @@ Touched-scope Bandit:
 
 ```bash
 source .venv/bin/activate
-python3 -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server_API/app/api/v1/endpoints/storage_admin_quotas.py tldw_Server_API/app/api/v1/endpoints/storage_helpers.py tldw_Server_API/app/api/v1/endpoints/storage_user_files.py tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py tldw_Server_API/app/api/v1/endpoints/storage_usage.py tldw_Server_API/app/api/v1/endpoints/storage_trash.py -f json -o /tmp/bandit_phase4_4_storage_endpoint.json
+python3 -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server_API/app/api/v1/endpoints/storage_admin_quotas.py tldw_Server_API/app/api/v1/endpoints/storage_download.py tldw_Server_API/app/api/v1/endpoints/storage_helpers.py tldw_Server_API/app/api/v1/endpoints/storage_user_files.py tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py tldw_Server_API/app/api/v1/endpoints/storage_usage.py tldw_Server_API/app/api/v1/endpoints/storage_trash.py -f json -o /tmp/bandit_phase4_4_storage_endpoint.json
 ```
 
 ## Out Of Scope
@@ -284,4 +290,6 @@ python3 -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server
 - [x] Stage 1 focused tests pass before route movement.
 - [x] OpenAPI path set is captured before route movement.
 - [x] File download and admin quota routes remain excluded from the first route split.
+- [x] Admin quota routes are extracted in their own conservative tranche.
+- [x] File download route is extracted in its own conservative tranche.
 - [x] Bandit is run on touched source before PR handoff.

--- a/tldw_Server_API/app/api/v1/endpoints/storage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage.py
@@ -9,19 +9,16 @@ Provides endpoints for:
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi.responses import FileResponse
+from fastapi import APIRouter
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user  # noqa: F401
 from tldw_Server_API.app.api.v1.endpoints import (
     storage_admin_quotas,
+    storage_download,
     storage_trash,
     storage_usage,
     storage_user_files,
     storage_user_folders,
-)
-from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
-    _resolve_storage_base_dir,
 )
 from tldw_Server_API.app.api.v1.endpoints.storage_admin_quotas import (  # noqa: F401
     get_org_quota,
@@ -30,6 +27,9 @@ from tldw_Server_API.app.api.v1.endpoints.storage_admin_quotas import (  # noqa:
     set_org_quota,
     set_team_quota,
     set_user_quota,
+)
+from tldw_Server_API.app.api.v1.endpoints.storage_download import (  # noqa: F401
+    download_file,
 )
 # Re-export moved handlers so direct imports/tests against storage.py keep working.
 from tldw_Server_API.app.api.v1.endpoints.storage_user_files import (  # noqa: F401
@@ -78,54 +78,4 @@ router.include_router(storage_user_folders.router)
 router.include_router(storage_usage.router)
 router.include_router(storage_trash.router)
 router.include_router(storage_admin_quotas.router)
-
-
-@router.get("/files/{file_id}/download")
-async def download_file(
-    file_id: int,
-    user: User = Depends(get_request_user),
-):
-    """Download a generated file."""
-    service = await _get_service()
-    files_repo = await service.get_generated_files_repo()
-
-    file_record = await files_repo.get_file_by_id(file_id)
-    if not file_record:
-        raise HTTPException(status_code=404, detail="File not found")
-
-    # Verify ownership
-    if file_record.get("user_id") != user.id:
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    if file_record.get("is_deleted"):
-        raise HTTPException(status_code=410, detail="File has been deleted")
-
-    # Resolve file path
-    storage_path = file_record.get("storage_path", "")
-    base_dir = _resolve_storage_base_dir(user.id, file_record)
-    full_path = base_dir / storage_path
-
-    # Path traversal protection: ensure resolved path is within user's directory
-    try:
-        resolved_path = full_path.resolve()
-        if not resolved_path.is_relative_to(base_dir.resolve()):
-            raise HTTPException(status_code=403, detail="Invalid file path")
-        full_path = resolved_path
-    except ValueError:
-        raise HTTPException(status_code=403, detail="Invalid file path") from None
-
-    if not full_path.exists():
-        raise HTTPException(status_code=404, detail="File not found on disk")
-
-    # Update accessed_at
-    await files_repo.update_accessed_at(file_id)
-
-    # Return file
-    filename = file_record.get("original_filename") or file_record.get("filename", "download")
-    mime_type = file_record.get("mime_type") or "application/octet-stream"
-
-    return FileResponse(
-        path=str(full_path),
-        filename=filename,
-        media_type=mime_type,
-    )
+router.include_router(storage_download.router)

--- a/tldw_Server_API/app/api/v1/endpoints/storage_download.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_download.py
@@ -1,0 +1,64 @@
+"""Storage file download route."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import FileResponse
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
+from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
+    _resolve_storage_base_dir,
+)
+from tldw_Server_API.app.services.storage_quota_service import get_storage_service
+
+router = APIRouter()
+
+
+async def _get_storage_service():
+    """Get initialized storage quota service."""
+    return await get_storage_service()
+
+
+@router.get("/files/{file_id}/download")
+async def download_file(
+    file_id: int,
+    user: User = Depends(get_request_user),
+):
+    """Download a generated file."""
+    service = await _get_storage_service()
+    files_repo = await service.get_generated_files_repo()
+
+    file_record = await files_repo.get_file_by_id(file_id)
+    if not file_record:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    if file_record.get("user_id") != user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if file_record.get("is_deleted"):
+        raise HTTPException(status_code=410, detail="File has been deleted")
+
+    storage_path = file_record.get("storage_path", "")
+    base_dir = _resolve_storage_base_dir(user.id, file_record)
+    full_path = base_dir / storage_path
+
+    try:
+        resolved_path = full_path.resolve()
+        if not resolved_path.is_relative_to(base_dir.resolve()):
+            raise HTTPException(status_code=403, detail="Invalid file path")
+        full_path = resolved_path
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Invalid file path") from None
+
+    if not full_path.exists():
+        raise HTTPException(status_code=404, detail="File not found on disk")
+
+    await files_repo.update_accessed_at(file_id)
+
+    filename = file_record.get("original_filename") or file_record.get("filename", "download")
+    mime_type = file_record.get("mime_type") or "application/octet-stream"
+
+    return FileResponse(
+        path=str(full_path),
+        filename=filename,
+        media_type=mime_type,
+    )

--- a/tldw_Server_API/app/api/v1/endpoints/storage_download.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_download.py
@@ -8,12 +8,12 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import User, get_request_user
 from tldw_Server_API.app.api.v1.endpoints.storage_helpers import (
     _resolve_storage_base_dir,
 )
-from tldw_Server_API.app.services.storage_quota_service import get_storage_service
+from tldw_Server_API.app.services.storage_quota_service import StorageQuotaService, get_storage_service
 
 router = APIRouter()
 
 
-async def _get_storage_service():
+async def _get_storage_service() -> StorageQuotaService:
     """Get initialized storage quota service."""
     return await get_storage_service()
 
@@ -22,7 +22,7 @@ async def _get_storage_service():
 async def download_file(
     file_id: int,
     user: User = Depends(get_request_user),
-):
+) -> FileResponse:
     """Download a generated file."""
     service = await _get_storage_service()
     files_repo = await service.get_generated_files_repo()

--- a/tldw_Server_API/app/api/v1/endpoints/storage_download.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_download.py
@@ -37,7 +37,10 @@ async def download_file(
     if file_record.get("is_deleted"):
         raise HTTPException(status_code=410, detail="File has been deleted")
 
-    storage_path = file_record.get("storage_path", "")
+    storage_path = file_record.get("storage_path")
+    if not isinstance(storage_path, str) or not storage_path.strip():
+        raise HTTPException(status_code=404, detail="File not found")
+
     base_dir = _resolve_storage_base_dir(user.id, file_record)
     full_path = base_dir / storage_path
 
@@ -49,7 +52,7 @@ async def download_file(
     except ValueError:
         raise HTTPException(status_code=403, detail="Invalid file path") from None
 
-    if not full_path.exists():
+    if not full_path.is_file():
         raise HTTPException(status_code=404, detail="File not found on disk")
 
     await files_repo.update_accessed_at(file_id)

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 
 from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoints
 from tldw_Server_API.app.api.v1.endpoints import storage_admin_quotas
+from tldw_Server_API.app.api.v1.endpoints import storage_download
 from tldw_Server_API.app.api.v1.schemas.storage_schemas import SetQuotaRequest
 from tldw_Server_API.app.core.AuthNZ.exceptions import StorageError
 
@@ -418,6 +419,15 @@ class TestDownloadFileEndpoint:
     """Tests for GET /storage/files/{file_id}/download endpoint."""
 
     @pytest.mark.unit
+    def test_download_file_handler_reexport_from_storage_after_sidecar_split(self):
+        """Download handler remains import-compatible after sidecar extraction."""
+        storage_download = import_module(
+            "tldw_Server_API.app.api.v1.endpoints.storage_download"
+        )
+
+        assert storage_endpoints.download_file is storage_download.download_file
+
+    @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_path_traversal_blocked_double_dots(
         self,
@@ -442,8 +452,8 @@ class TestDownloadFileEndpoint:
         mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
 
         monkeypatch.setattr(
-            storage_endpoint,
-            "_get_service",
+            storage_download,
+            "_get_storage_service",
             AsyncMock(return_value=mock_storage_service),
         )
         monkeypatch.setattr(
@@ -490,8 +500,8 @@ class TestDownloadFileEndpointIntegration:
         mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
 
         monkeypatch.setattr(
-            storage_endpoint,
-            "_get_service",
+            storage_download,
+            "_get_storage_service",
             AsyncMock(return_value=mock_storage_service),
         )
         monkeypatch.setattr(
@@ -530,8 +540,8 @@ class TestDownloadFileEndpointIntegration:
         mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
 
         monkeypatch.setattr(
-            storage_endpoint,
-            "_get_service",
+            storage_download,
+            "_get_storage_service",
             AsyncMock(return_value=mock_storage_service),
         )
         monkeypatch.setattr(
@@ -575,8 +585,8 @@ class TestDownloadFileEndpointIntegration:
         mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
 
         monkeypatch.setattr(
-            storage_endpoint,
-            "_get_service",
+            storage_download,
+            "_get_storage_service",
             AsyncMock(return_value=mock_storage_service),
         )
         monkeypatch.setattr(
@@ -622,8 +632,8 @@ class TestDownloadFileEndpointIntegration:
         mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
 
         monkeypatch.setattr(
-            storage_endpoint,
-            "_get_service",
+            storage_download,
+            "_get_storage_service",
             AsyncMock(return_value=mock_storage_service),
         )
 

--- a/tldw_Server_API/tests/Storage/test_storage_endpoints.py
+++ b/tldw_Server_API/tests/Storage/test_storage_endpoints.py
@@ -556,6 +556,82 @@ class TestDownloadFileEndpointIntegration:
             assert resp.status_code == 403
 
     @pytest.mark.unit
+    def test_download_file_rejects_directory_storage_path(
+        self,
+        temp_user_outputs_dir,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """Directory storage paths are rejected before FileResponse handling."""
+        from tldw_Server_API.app.api.v1.endpoints import storage as storage_endpoint
+
+        rel_path = "tts_audio/not-a-file"
+        (temp_user_outputs_dir / rel_path).mkdir(parents=True)
+
+        file_record = {
+            "id": 4,
+            "user_id": mock_user.id,
+            "storage_path": rel_path,
+            "file_category": "tts_audio",
+            "is_deleted": False,
+        }
+
+        mock_files_repo.get_file_by_id = AsyncMock(return_value=file_record)
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+
+        monkeypatch.setattr(
+            storage_download,
+            "_get_storage_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+        monkeypatch.setattr(
+            storage_endpoint.DatabasePaths,
+            "get_user_outputs_dir",
+            lambda user_id: temp_user_outputs_dir,
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v1/storage/files/4/download")
+            assert resp.status_code == 404
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("storage_path", [None, ""])
+    def test_download_file_rejects_invalid_storage_path_shape(
+        self,
+        storage_path,
+        temp_user_outputs_dir,
+        mock_storage_service,
+        mock_user,
+        mock_files_repo,
+        monkeypatch,
+    ):
+        """Invalid stored path values are rejected before path resolution."""
+        file_record = {
+            "id": 5,
+            "user_id": mock_user.id,
+            "storage_path": storage_path,
+            "file_category": "tts_audio",
+            "is_deleted": False,
+        }
+
+        mock_files_repo.get_file_by_id = AsyncMock(return_value=file_record)
+        mock_storage_service.get_generated_files_repo = AsyncMock(return_value=mock_files_repo)
+
+        monkeypatch.setattr(
+            storage_download,
+            "_get_storage_service",
+            AsyncMock(return_value=mock_storage_service),
+        )
+
+        app = _storage_download_test_app(mock_user)
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v1/storage/files/5/download")
+            assert resp.status_code == 404
+
+    @pytest.mark.unit
     def test_download_file_uses_voices_dir_for_voice_clones(
         self,
         temp_storage_dir,


### PR DESCRIPTION
## Summary

- What changed: Moved `GET /api/v1/storage/files/{file_id}/download` into `storage_download.py`, while preserving the public storage router path, `FileResponse` behavior, and `download_file` re-export from `storage.py`; review follow-up also rejects invalid or non-file stored download targets before `FileResponse`.
- Why: This completes the conservative Phase 4.4 storage endpoint decomposition tranche while keeping the non-JSON download path isolated from the JSON/admin route movement.

## Change summary

This is the final conservative storage endpoint decomposition tranche from #1116. The download route was kept separate from JSON/admin route movement because it returns `FileResponse` and has path traversal/base-directory behavior that needed focused coverage. The sidecar uses a direct storage service dependency seam instead of importing `storage.py` back into the sidecar.

Review follow-up added explicit return annotations to the new download helpers and tightened download path validation so blank, non-string, directory, or otherwise non-file targets return controlled 404 responses instead of reaching `FileResponse`.

## Validation

- [x] Tests added/updated for behavior changes
- [x] Relevant unit/integration tests pass locally
- [x] Docs updated (if behavior, routes, or config changed)

Focused local checks:

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Storage/test_storage_endpoints.py -k "download_file_handler_reexport or download_file_success_returns_bytes or download_file_blocks_path_traversal or download_file_uses_voices_dir_for_voice_clones or path_traversal_blocked_double_dots or download_file_not_owned_returns_403" -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Storage/test_storage_endpoints.py tldw_Server_API/tests/AuthNZ_Unit/test_storage_admin_claims.py tldw_Server_API/tests/Admin/test_admin_storage_quotas.py -q`
- `bun run verify:openapi` (from `apps/extension`)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage.py tldw_Server_API/app/api/v1/endpoints/storage_admin_quotas.py tldw_Server_API/app/api/v1/endpoints/storage_download.py tldw_Server_API/app/api/v1/endpoints/storage_helpers.py tldw_Server_API/app/api/v1/endpoints/storage_user_files.py tldw_Server_API/app/api/v1/endpoints/storage_user_folders.py tldw_Server_API/app/api/v1/endpoints/storage_usage.py tldw_Server_API/app/api/v1/endpoints/storage_trash.py -f json -o /tmp/bandit_phase4_4_storage_download_route.json`
- `git diff --check`

Review follow-up checks after comment fixes:

- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Storage/test_storage_endpoints.py -q` (`40 passed, 5 warnings`)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage_download.py -f json -o /tmp/bandit_phase4_4_storage_download_review.json` (`0 findings`)
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/endpoints/storage_download.py -f json -o /tmp/bandit_phase4_4_storage_download_review2.json` (`0 findings`)
- `git diff --check`

## UX Audit Checklist (v2 Stage 5)

- [x] Not applicable: this PR only changes backend storage endpoint decomposition, storage tests, and the Phase 4.4 plan.

## Watchlists Accessibility Checklist (Group 09 Stage 5)

- [x] Not applicable: this PR does not touch Watchlists UI behavior.

## Watchlists Scale Checklist (Group 10 Stage 5)

- [x] Not applicable: this PR does not touch Watchlists polling, notifications, Activity, or batch triage behavior.

## Risk & Rollback

- Risk level: Low
- Rollback plan: Revert this PR or revert commits `5baafdcdd9`, `30d741aaf7`, and `a251d78c15` to restore the prior `storage.py` download handler layout and matching tests/docs.

Refs #1116
