### PR TITLE
Normalize sandbox runtime discovery reason codes

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -35,6 +35,10 @@ concepts:
 - `available`: current host/preflight truth.
 - `implementation_state`: roadmap maturity label independent of whether this
   specific host has the required binaries, helper, VM support, or feature flags.
+- `reasons`: raw runtime/operator reason strings preserved for diagnostics.
+- `normalized_reasons`: stable client-facing reason codes derived from raw
+  reasons so clients can group failures without runtime-specific string
+  matching.
 
 | Runtime | `implementation_state` | Discovery source |
 | --- | --- | --- |
@@ -49,6 +53,30 @@ concepts:
 Discovery is intentionally summarized. Admin/operator diagnostics can expose
 helper, template, reconciliation, and image-store details that should not be
 duplicated into the public discovery payload.
+
+## Normalized Reason Codes
+
+Runtime discovery preserves raw `reasons` for operator diagnostics and exposes
+additive `normalized_reasons` for client logic. The normalized vocabulary is
+centralized in `runtime_capabilities.py`.
+
+| Normalized reason | Meaning |
+| --- | --- |
+| `runtime_unavailable` | The runtime itself is not available on the current host. |
+| `unsupported_os` | The runtime requires a different host operating system. |
+| `unsupported_arch` | The runtime requires a different host CPU architecture. |
+| `helper_unavailable` | A required helper daemon or helper connection is unavailable. |
+| `helper_protocol_mismatch` | A helper protocol or version check failed. |
+| `helper_missing` | A configured helper binary/path is missing or unusable. |
+| `template_missing` | A required VM image/template artifact is missing. |
+| `template_unconfigured` | No template or image source has been configured. |
+| `network_policy_unsupported` | The requested network policy is not supported by the runtime. |
+| `trust_policy_denied` | Trust-level policy denies this runtime or request shape. |
+| `host_prerequisite_missing` | A required host binary, device, or capability is missing. |
+| `host_permission_denied` | Host permissions block a required enforcement check. |
+| `feature_not_implemented` | Runtime shape exists, but the requested feature is not implemented. |
+| `image_store_unavailable` | Image-store configuration or probing failed. |
+| `unknown` | A raw reason has no stable normalized mapping yet. |
 
 ## Trust-Level Support
 
@@ -112,9 +140,9 @@ an equally clear ownership model.
 
 | Gap | Runtime(s) | Follow-up phase |
 | --- | --- | --- |
-| Public discovery lacks normalized state labels and reason taxonomy. | all | Phase 3 |
 | Host-local runtimes need clearer docs/API warnings that they are not VM-grade. | `seatbelt`, `worktree` | Phase 2 |
 | Allowlist support is inconsistent and often scaffold-only. | all except host-local unsupported paths | Phase 2 |
+| Common run status/error taxonomy is not normalized across runtimes. | all | Phase 3 |
 | Session semantics are not normalized across warm VM, container, and host-local reuse. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | CI has no single cross-runtime capability gate. | all | Phase 5 |

--- a/backlog/tasks/task-3 - Normalize-sandbox-runtime-reason-codes-in-discovery.md
+++ b/backlog/tasks/task-3 - Normalize-sandbox-runtime-reason-codes-in-discovery.md
@@ -1,0 +1,46 @@
+---
+id: TASK-3
+title: Normalize sandbox runtime reason codes in discovery
+status: Done
+assignee: []
+created_date: '2026-05-03 17:58'
+updated_date: '2026-05-03 18:03'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add an additive normalized reason-code layer to sandbox runtime discovery while preserving raw preflight reasons.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Discovery includes normalized_reasons for runtimes with raw reasons.
+- [x] #2 Raw reasons remain unchanged for operator diagnostics and compatibility.
+- [x] #3 Reason-code vocabulary is centralized in runtime_capabilities.py and exposed through the API schema.
+- [x] #4 Sandbox runtime inventory documents the additive normalized reason-code contract.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented additive normalized_reasons on runtime discovery while preserving raw reasons. Verification: runtime inventory contract tests passed; runtime capabilities policy tests passed; py_compile passed; Bandit touched Python scan had 0 findings; git diff --check passed. Known skip/caveat: selected TestClient-based feature_discovery_flags group timed out in existing app shutdown/background Jobs teardown after first selected test passed; stack was TestClient/Jobs teardown, not normalized reason code logic.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added centralized sandbox runtime reason-code normalization and exposed normalized_reasons in discovery/schema/docs.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-3 - Normalize-sandbox-runtime-reason-codes-in-discovery.md
+++ b/backlog/tasks/task-3 - Normalize-sandbox-runtime-reason-codes-in-discovery.md
@@ -2,9 +2,10 @@
 id: TASK-3
 title: Normalize sandbox runtime reason codes in discovery
 status: Done
-assignee: []
+assignee:
+  - codex
 created_date: '2026-05-03 17:58'
-updated_date: '2026-05-03 18:03'
+updated_date: '2026-05-03 18:26'
 labels: []
 dependencies: []
 ---
@@ -21,18 +22,33 @@ Add an additive normalized reason-code layer to sandbox runtime discovery while 
 - [x] #2 Raw reasons remain unchanged for operator diagnostics and compatibility.
 - [x] #3 Reason-code vocabulary is centralized in runtime_capabilities.py and exposed through the API schema.
 - [x] #4 Sandbox runtime inventory documents the additive normalized reason-code contract.
+- [x] #5 Helper protocol error variants normalize to helper_protocol_mismatch and keep raw reasons intact.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a regression assertion for macOS helper protocol error variants in tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py and verify it fails on the current implementation.
+2. Update runtime_capabilities.normalize_runtime_reason to classify macos_virtualization_helper_protocol* raw reason codes as helper_protocol_mismatch while preserving the existing explicit map and image store prefix behavior.
+3. Re-run the focused sandbox runtime inventory test, then run py_compile for touched Python, Bandit on touched Python paths, and git diff --check.
+4. Update TASK-3 notes/final summary with verification results, then commit and push the PR branch.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented additive normalized_reasons on runtime discovery while preserving raw reasons. Verification: runtime inventory contract tests passed; runtime capabilities policy tests passed; py_compile passed; Bandit touched Python scan had 0 findings; git diff --check passed. Known skip/caveat: selected TestClient-based feature_discovery_flags group timed out in existing app shutdown/background Jobs teardown after first selected test passed; stack was TestClient/Jobs teardown, not normalized reason code logic.
+
+Reopened for PR #1236 review follow-up: Qodo identified macOS helper protocol error variants that still normalize to unknown.
+
+Review follow-up implemented: helper protocol-prefixed raw reasons plus helper empty-response and invalid-json protocol failures now normalize to helper_protocol_mismatch.
+Verification: regression test failed before implementation with an extra unknown normalized reason; after the fix, python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q passed with 6 passed, 2 warnings. python -m py_compile passed for runtime_capabilities.py and test_runtime_inventory_contract.py. git diff --check passed. Bandit on runtime_capabilities.py had 0 findings; combined touched-path Bandit scan still reports the existing low-severity B101 pytest assertion baseline in the test file, with the new assertion explicitly skipped via nosec B101 so it does not add a new finding.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added centralized sandbox runtime reason-code normalization and exposed normalized_reasons in discovery/schema/docs.
+Added PR #1236 review follow-up so macOS helper protocol error variants normalize to helper_protocol_mismatch, with regression coverage and focused verification.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -11,7 +11,10 @@ except ImportError:  # pragma: no cover - pydantic v1 fallback
     from pydantic import root_validator as model_validator  # type: ignore
 
 from tldw_Server_API.app.api.v1.schemas.pagination import OffsetPaginationMeta
-from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimeImplementationState
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
+    RuntimeImplementationState,
+    RuntimeReasonCode,
+)
 
 RuntimeType = Literal[
     "docker",
@@ -42,6 +45,13 @@ class SandboxRuntimeInfo(BaseModel):
         ),
     )
     reasons: list[str] | None = Field(default=None, description="Preflight reasons when the runtime is unavailable or constrained")
+    normalized_reasons: list[RuntimeReasonCode] | None = Field(
+        default=None,
+        description=(
+            "Stable, client-facing reason codes derived from raw runtime preflight reasons; "
+            "raw reasons are preserved for operator diagnostics"
+        ),
+    )
     supported_trust_levels: list[TrustLevelType] | None = Field(default=None, description="Trust levels supported by this runtime under current host policy")
     default_images: list[str] = Field(default_factory=list)
     max_cpu: float | None = Field(default=None, description="Max CPU (cores) per run")

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -175,6 +175,9 @@ Each runtime entry includes `available` for current host truth and
 `implementation_state` for roadmap maturity (`supported`, `unsupported`,
 `scaffold`, `host_gated`, or `not_applicable`), so clients do not infer security
 or maturity guarantees from availability alone.
+Runtime entries also preserve raw preflight `reasons` for operator diagnostics
+and expose additive `normalized_reasons` for stable client grouping across
+runtime-specific failures.
 `/api/v1/sandbox/admin/macos-diagnostics` is an admin-only diagnostics surface for
 operator troubleshooting and exposes helper/template readiness details that are not
 included in the public discovery payload, plus reconciliation data for persisted

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -12,6 +12,23 @@ RuntimeImplementationState = Literal[
     "host_gated",
     "not_applicable",
 ]
+RuntimeReasonCode = Literal[
+    "runtime_unavailable",
+    "unsupported_os",
+    "unsupported_arch",
+    "helper_unavailable",
+    "helper_protocol_mismatch",
+    "helper_missing",
+    "template_missing",
+    "template_unconfigured",
+    "network_policy_unsupported",
+    "trust_policy_denied",
+    "host_prerequisite_missing",
+    "host_permission_denied",
+    "feature_not_implemented",
+    "image_store_unavailable",
+    "unknown",
+]
 
 RUNTIME_IMPLEMENTATION_STATES: Mapping[RuntimeType, RuntimeImplementationState] = {
     RuntimeType.docker: "supported",
@@ -23,10 +40,74 @@ RUNTIME_IMPLEMENTATION_STATES: Mapping[RuntimeType, RuntimeImplementationState] 
     RuntimeType.worktree: "supported",
 }
 
+_RUNTIME_REASON_CODE_MAP: Mapping[str, RuntimeReasonCode] = {
+    "/dev/kvm_missing": "host_prerequisite_missing",
+    "apple_silicon_required": "unsupported_arch",
+    "docker_unavailable": "runtime_unavailable",
+    "firecracker_binary_missing": "host_prerequisite_missing",
+    "firecracker_unavailable": "runtime_unavailable",
+    "git_too_old_or_missing": "host_prerequisite_missing",
+    "image_store_root_missing": "image_store_unavailable",
+    "image_store_root_not_directory": "image_store_unavailable",
+    "limactl_missing": "host_prerequisite_missing",
+    "macos_helper_missing": "helper_missing",
+    "macos_helper_not_executable": "helper_missing",
+    "macos_helper_path_missing": "helper_missing",
+    "macos_helper_path_unconfigured": "helper_missing",
+    "macos_required": "unsupported_os",
+    "macos_template_missing": "template_missing",
+    "macos_virtualization_helper_protocol_mismatch": "helper_protocol_mismatch",
+    "macos_virtualization_helper_unavailable": "helper_unavailable",
+    "permission_denied_host_enforcement": "host_permission_denied",
+    "real_execution_not_implemented": "feature_not_implemented",
+    "sandbox_exec_missing": "host_prerequisite_missing",
+    "seatbelt_standard_disabled": "trust_policy_denied",
+    "seatbelt_unavailable": "runtime_unavailable",
+    "strict_allowlist_not_supported": "network_policy_unsupported",
+    "strict_deny_all_not_supported": "network_policy_unsupported",
+    "template_missing": "template_missing",
+    "template_unconfigured": "template_unconfigured",
+    "trust_level_not_supported": "trust_policy_denied",
+    "trust_level_requires_vm_runtime": "trust_policy_denied",
+    "unshare_required_on_linux": "host_prerequisite_missing",
+    "unsupported_network_policy": "network_policy_unsupported",
+    "unsupported_platform": "unsupported_os",
+    "virtiofsd_missing": "host_prerequisite_missing",
+    "vz_linux_template_missing": "template_missing",
+    "vz_linux_unavailable": "runtime_unavailable",
+    "vz_macos_unavailable": "runtime_unavailable",
+    "worktree_unavailable": "runtime_unavailable",
+}
+
 
 def runtime_implementation_state(runtime: RuntimeType) -> RuntimeImplementationState:
     """Return the roadmap maturity label for a runtime, independent of host availability."""
     return RUNTIME_IMPLEMENTATION_STATES.get(runtime, "unsupported")
+
+
+def normalize_runtime_reason(reason: str) -> RuntimeReasonCode:
+    """Return a stable client-facing code for a raw runtime preflight reason."""
+
+    normalized = str(reason or "").strip()
+    if not normalized:
+        return "unknown"
+    if normalized.startswith("image_store_unavailable"):
+        return "image_store_unavailable"
+    return _RUNTIME_REASON_CODE_MAP.get(normalized, "unknown")
+
+
+def normalize_runtime_reasons(reasons: list[str] | tuple[str, ...]) -> list[RuntimeReasonCode]:
+    """Normalize raw runtime reasons while preserving first-seen order."""
+
+    normalized: list[RuntimeReasonCode] = []
+    seen: set[RuntimeReasonCode] = set()
+    for reason in reasons:
+        code = normalize_runtime_reason(reason)
+        if code in seen:
+            continue
+        seen.add(code)
+        normalized.append(code)
+    return normalized
 
 
 @dataclass

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -91,6 +91,13 @@ def normalize_runtime_reason(reason: str) -> RuntimeReasonCode:
     normalized = str(reason or "").strip()
     if not normalized:
         return "unknown"
+    if normalized.startswith("macos_virtualization_helper_protocol_"):
+        return "helper_protocol_mismatch"
+    if normalized in {
+        "macos_virtualization_helper_empty_response",
+        "macos_virtualization_helper_invalid_json",
+    }:
+        return "helper_protocol_mismatch"
     if normalized.startswith("image_store_unavailable"):
         return "image_store_unavailable"
     return _RUNTIME_REASON_CODE_MAP.get(normalized, "unknown")

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -96,8 +96,13 @@ def normalize_runtime_reason(reason: str) -> RuntimeReasonCode:
     return _RUNTIME_REASON_CODE_MAP.get(normalized, "unknown")
 
 
-def normalize_runtime_reasons(reasons: list[str] | tuple[str, ...]) -> list[RuntimeReasonCode]:
+def normalize_runtime_reasons(
+    reasons: list[str] | tuple[str, ...] | None,
+) -> list[RuntimeReasonCode]:
     """Normalize raw runtime reasons while preserving first-seen order."""
+
+    if reasons is None:
+        return []
 
     normalized: list[RuntimeReasonCode] = []
     seen: set[RuntimeReasonCode] = set()

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -58,6 +58,7 @@ from .runners.worktree_runner import WorktreeRunner, worktree_available
 from .runtime_capabilities import (
     RuntimePreflightResult,
     collect_runtime_preflights,
+    normalize_runtime_reasons,
     runtime_implementation_state,
 )
 from .snapshots import SnapshotManager
@@ -869,9 +870,11 @@ class SandboxService:
 
         def _preflight_fields(preflight: RuntimePreflightResult | None) -> dict[str, object]:
             enforcement_ready = dict((preflight.enforcement_ready if preflight else {}) or {})
+            reasons = list((preflight.reasons if preflight else []) or [])
             return {
                 "available": bool(preflight.available) if preflight is not None else False,
-                "reasons": list((preflight.reasons if preflight else []) or []),
+                "reasons": reasons,
+                "normalized_reasons": normalize_runtime_reasons(reasons),
                 "supported_trust_levels": list((preflight.supported_trust_levels if preflight else []) or []),
                 "strict_deny_all_supported": bool(enforcement_ready.get("deny_all")),
                 "strict_allowlist_supported": bool(enforcement_ready.get("allowlist")),
@@ -883,6 +886,7 @@ class SandboxService:
             {
                 "name": "docker",
                 "implementation_state": runtime_implementation_state(RuntimeType.docker),
+                **_preflight_fields(docker_preflight),
                 "available": bool(docker_preflight.available) if docker_preflight is not None else bool(docker_available()),
                 "default_images": images,
                 "max_cpu": max_cpu,
@@ -916,6 +920,7 @@ class SandboxService:
             {
                 "name": "firecracker",
                 "implementation_state": runtime_implementation_state(RuntimeType.firecracker),
+                **_preflight_fields(firecracker_preflight),
                 "available": bool(firecracker_preflight.available) if firecracker_preflight is not None else bool(firecracker_available()),
                 "default_images": images,  # firecracker images will differ; placeholder for UX
                 "max_cpu": max_cpu,
@@ -956,6 +961,7 @@ class SandboxService:
             {
                 "name": "lima",
                 "implementation_state": runtime_implementation_state(RuntimeType.lima),
+                **_preflight_fields(lima_preflight),
                 "available": bool(lima_preflight.available) if lima_preflight is not None else bool(lima_available()),
                 "default_images": ["ubuntu:24.04"],  # Lima uses distro images
                 "max_cpu": max_cpu,

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -84,6 +84,19 @@ def test_runtime_reason_normalization_treats_none_as_empty() -> None:
     assert normalize_runtime_reasons(None) == []  # type: ignore[arg-type]
 
 
+def test_runtime_reason_normalization_groups_helper_protocol_variants() -> None:
+    """Helper protocol failures should share one stable client-facing code."""
+
+    assert normalize_runtime_reasons(  # nosec B101
+        [
+            "macos_virtualization_helper_protocol_mismatch",
+            "macos_virtualization_helper_protocol_error",
+            "macos_virtualization_helper_empty_response",
+            "macos_virtualization_helper_invalid_json",
+        ]
+    ) == ["helper_protocol_mismatch"]
+
+
 def test_feature_discovery_preserves_raw_reasons_and_adds_normalized_codes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -78,6 +78,12 @@ def test_runtime_reason_normalization_maps_raw_runtime_reasons() -> None:
     ]
 
 
+def test_runtime_reason_normalization_treats_none_as_empty() -> None:
+    """Defensively handle absent reason lists from discovery callers."""
+
+    assert normalize_runtime_reasons(None) == []  # type: ignore[arg-type]
+
+
 def test_feature_discovery_preserves_raw_reasons_and_adds_normalized_codes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import pytest
 
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
+    RuntimePreflightResult,
+    normalize_runtime_reasons,
+)
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 
 
@@ -32,3 +36,128 @@ def test_worktree_discovery_reports_host_local_limits(
     assert worktree["egress_allowlist_supported"] is False
     assert worktree["interactive_supported"] is False
     assert "not VM-grade" in str(worktree["notes"])
+
+
+def test_runtime_reason_normalization_maps_raw_runtime_reasons() -> None:
+    """Verify raw runtime-specific reasons collapse into stable discovery codes."""
+
+    assert normalize_runtime_reasons(
+        [
+            "docker_unavailable",
+            "macos_required",
+            "apple_silicon_required",
+            "macos_virtualization_helper_unavailable",
+            "macos_virtualization_helper_protocol_mismatch",
+            "macos_helper_missing",
+            "vz_linux_template_missing",
+            "template_unconfigured",
+            "strict_allowlist_not_supported",
+            "seatbelt_standard_disabled",
+            "limactl_missing",
+            "permission_denied_host_enforcement",
+            "real_execution_not_implemented",
+            "image_store_unavailable: bad root",
+            "unexpected_future_reason",
+        ]
+    ) == [
+        "runtime_unavailable",
+        "unsupported_os",
+        "unsupported_arch",
+        "helper_unavailable",
+        "helper_protocol_mismatch",
+        "helper_missing",
+        "template_missing",
+        "template_unconfigured",
+        "network_policy_unsupported",
+        "trust_policy_denied",
+        "host_prerequisite_missing",
+        "host_permission_denied",
+        "feature_not_implemented",
+        "image_store_unavailable",
+        "unknown",
+    ]
+
+
+def test_feature_discovery_preserves_raw_reasons_and_adds_normalized_codes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery should expose stable reason codes without replacing raw reasons."""
+
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+
+    def _preflights(
+        self: SandboxService,
+        *,
+        network_policy: str | None,
+    ) -> dict[RuntimeType, RuntimePreflightResult]:
+        del self, network_policy
+        return {
+            RuntimeType.docker: RuntimePreflightResult(
+                runtime=RuntimeType.docker,
+                available=False,
+                reasons=["docker_unavailable"],
+            ),
+            RuntimeType.firecracker: RuntimePreflightResult(
+                runtime=RuntimeType.firecracker,
+                available=False,
+                reasons=["firecracker_unavailable", "/dev/kvm_missing"],
+            ),
+            RuntimeType.lima: RuntimePreflightResult(
+                runtime=RuntimeType.lima,
+                available=False,
+                reasons=["limactl_missing", "strict_deny_all_not_supported"],
+            ),
+            RuntimeType.vz_linux: RuntimePreflightResult(
+                runtime=RuntimeType.vz_linux,
+                available=False,
+                reasons=[
+                    "macos_virtualization_helper_unavailable",
+                    "vz_linux_template_missing",
+                ],
+            ),
+            RuntimeType.vz_macos: RuntimePreflightResult(
+                runtime=RuntimeType.vz_macos,
+                available=False,
+                reasons=["real_execution_not_implemented"],
+            ),
+            RuntimeType.seatbelt: RuntimePreflightResult(
+                runtime=RuntimeType.seatbelt,
+                available=False,
+                reasons=["macos_required", "sandbox_exec_missing"],
+                supported_trust_levels=["trusted"],
+            ),
+            RuntimeType.worktree: RuntimePreflightResult(
+                runtime=RuntimeType.worktree,
+                available=False,
+                reasons=["unsupported_platform"],
+                supported_trust_levels=["trusted", "standard"],
+            ),
+        }
+
+    monkeypatch.setattr(SandboxService, "_collect_runtime_preflights", _preflights)
+
+    discovery = {item["name"]: item for item in SandboxService().feature_discovery()}
+
+    assert discovery["docker"]["reasons"] == ["docker_unavailable"]
+    assert discovery["docker"]["normalized_reasons"] == ["runtime_unavailable"]
+    assert discovery["firecracker"]["normalized_reasons"] == [
+        "runtime_unavailable",
+        "host_prerequisite_missing",
+    ]
+    assert discovery["lima"]["normalized_reasons"] == [
+        "host_prerequisite_missing",
+        "network_policy_unsupported",
+    ]
+    assert discovery["vz_linux"]["reasons"] == [
+        "macos_virtualization_helper_unavailable",
+        "vz_linux_template_missing",
+    ]
+    assert discovery["vz_linux"]["normalized_reasons"] == [
+        "helper_unavailable",
+        "template_missing",
+    ]
+    assert discovery["seatbelt"]["normalized_reasons"] == [
+        "unsupported_os",
+        "host_prerequisite_missing",
+    ]
+    assert discovery["worktree"]["normalized_reasons"] == ["unsupported_os"]


### PR DESCRIPTION
## Summary
- Add additive `normalized_reasons` to sandbox runtime discovery while preserving raw preflight `reasons`.
- Centralize runtime reason-code normalization in `runtime_capabilities.py` and expose the shared type through the API schema.
- Document the normalized reason-code vocabulary and close the discovery reason-taxonomy gap in the sandbox inventory.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_runtime_inventory_contract.py -q --timeout=60`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_runtime_capabilities_policy.py -q --timeout=60`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_runtime_reason_codes_rebased.json`
- [x] `git diff --check origin/dev..HEAD`

## Known Verification Caveat
- `test_feature_discovery_flags.py` selected TestClient group timed out in existing app shutdown/background Jobs teardown after the first selected test passed; direct service-level coverage for this change passes.

## Human Change summary
TODO: human maintainer must add the merge-gate change summary explaining what changed and why these implementation choices were made.