### PR TITLE
Phase 4: add OpenAPI raw response contracts

### DIFF
--- a/apps/extension/tests/unit/verify-openapi-client-paths.test.ts
+++ b/apps/extension/tests/unit/verify-openapi-client-paths.test.ts
@@ -59,4 +59,21 @@ describe("extractFallbackFieldNamesFromSource", () => {
       "final-field",
     ])
   })
+
+  it("skips type annotation brackets before the fallback initializer", () => {
+    const src = `
+      export const MEDIA_ADD_SCHEMA_FALLBACK: Array<{
+        name: string
+        enum?: unknown[]
+      }> = [
+        { name: "api_name" },
+        { name: "chunk_method", enum: ["semantic", "tokens"] }
+      ]
+    `
+
+    expect(extractFallbackFieldNamesFromSource(src)).toEqual([
+      "api_name",
+      "chunk_method",
+    ])
+  })
 })

--- a/backlog/tasks/task-13 - Address-PR-1237-embeddings-SSE-producer-shutdown-review.md
+++ b/backlog/tasks/task-13 - Address-PR-1237-embeddings-SSE-producer-shutdown-review.md
@@ -1,0 +1,58 @@
+---
+id: TASK-13
+title: Address PR 1237 embeddings SSE producer shutdown review
+status: Done
+assignee: []
+created_date: '2026-05-03 20:16'
+updated_date: '2026-05-03 20:19'
+labels:
+  - pr-review
+  - openapi
+  - embeddings
+  - phase4
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1237'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the non-inline CodeRabbit PR #1237 review-body finding that the unified embeddings orchestrator SSE normal shutdown path can await an infinite producer without cancelling it. Keep the change narrow to producer cancellation/lifecycle semantics and focused tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Unified embeddings orchestrator SSE normal generator close cancels the producer before awaiting it.
+- [x] #2 A focused regression fails before the fix and passes after it.
+- [x] #3 Focused tests, Bandit touched-source scope, and git diff --check are run and recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression around STREAMS_UNIFIED orchestrator_events body iterator close that proves generator shutdown returns promptly and cancels the producer. 2. Patch only the normal shutdown path to cancel the producer before gather, matching the existing cancellation path. 3. Run focused embeddings SSE tests, Bandit on touched source/tests, and git diff --check. 4. Record verification and push the PR review-fix commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: test_embeddings_orchestrator_events_unified_normal_close_cancels_producer timed out before the fix while awaiting the still-running producer task. GREEN: focused normal_close regression passed after the production change. Adjacent verification: test_orchestrator_sse_unified_flag.py plus test_orchestrator_sse.py passed with existing Redis-fixture skips (1 passed, 5 skipped); OpenAPI embeddings orchestrator contract selection passed (1 passed). Bandit source scope reported 0 findings in /tmp/bandit_pr1237_embeddings_sse_producer.json. git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the PR #1237 non-inline embeddings SSE review finding by cancelling the long-running unified orchestrator producer before awaiting it on normal stream completion. Added a focused regression proving the body iterator completes promptly and the producer task is cancelled.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-14 - Fix-PR-1237-audio-transcription-SRT-OpenAPI-contract.md
+++ b/backlog/tasks/task-14 - Fix-PR-1237-audio-transcription-SRT-OpenAPI-contract.md
@@ -1,0 +1,62 @@
+---
+id: TASK-14
+title: Fix PR 1237 audio transcription SRT OpenAPI contract
+status: Done
+assignee: []
+created_date: '2026-05-03 20:36'
+updated_date: '2026-05-03 20:39'
+labels:
+  - openapi
+  - audio
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1237'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the PR #1237 review finding where the audio transcription 200-response description mentions SRT but the OpenAPI 200-response content map does not expose an SRT-specific media type. The endpoint already supports response_format=srt, so align the generated contract and focused tests with runtime behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Generated OpenAPI for /api/v1/audio/transcriptions and /api/v1/audio/translations documents an SRT media type when SRT is described as supported.
+- [x] #2 Focused contract tests/constants cover the SRT content type for both OpenAI-compatible audio routes.
+- [x] #3 Runtime SRT responses use the documented SRT media type or the description is adjusted to match actual runtime support.
+- [x] #4 Focused pytest verification and touched-scope Bandit checks are run and recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify runtime SRT support and current OpenAPI response content. 2. Add failing contract/runtime assertions for SRT media type. 3. Update endpoint OpenAPI content and SRT response media type. 4. Run focused pytest, OpenAPI verifier, diff check, and Bandit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red verification before implementation: focused pytest failed because generated OpenAPI lacked application/x-subrip and response_format=srt returned text/plain; charset=utf-8.
+
+Implementation: added application/x-subrip to the shared audio transcript response content map and changed response_format=srt responses to return application/x-subrip. Updated OpenAPI contract constants and SRT runtime test coverage.
+
+Verification: focused red run failed before implementation for missing application/x-subrip and text/plain SRT runtime response. Green checks: 73 related pytest tests passed, apps/packages/ui and apps/extension verify:openapi passed with existing reviewed exceptions, git diff --check passed, Bandit on audio_transcriptions.py reported zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed the OpenAI-compatible audio transcription/translation response contract to include the SRT-specific application/x-subrip media type, matching documented response_format=srt support. The SRT runtime response now returns application/x-subrip instead of generic text/plain, and focused tests cover both generated OpenAPI content and actual SRT response headers. Verification covered the focused red-green regression, the broader OpenAPI/audio timed-segment pytest files, both frontend OpenAPI drift verifiers, git diff whitespace checks, and Bandit on the touched backend file.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-5 - Address-PR-1237-OpenAPI-tag-declaration-review-comment.md
+++ b/backlog/tasks/task-5 - Address-PR-1237-OpenAPI-tag-declaration-review-comment.md
@@ -1,0 +1,62 @@
+---
+id: TASK-5
+title: Address PR 1237 OpenAPI tag declaration review comment
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-03 18:32'
+updated_date: '2026-05-03 18:32'
+labels:
+  - pr-review
+  - openapi
+  - phase4
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1237'
+  - 'https://github.com/rmusser01/tldw_server/pull/1237#discussion_r3178558700'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the live review thread on PR #1237 by verifying the OpenAPI tag declaration helper is not repeated after schema caching and making that behavior explicit without broadening the Phase 4 OpenAPI contract scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The unresolved review comment on tldw_Server_API/app/main.py is addressed with a narrowly scoped change or documented technical response.
+- [x] #2 Relevant OpenAPI contract tests verify that schema generation caching prevents repeated tag declaration work.
+- [x] #3 Focused backend tests and security checks for the touched scope are run and recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused OpenAPI contract test that resets the app OpenAPI cache, wraps _ensure_openapi_operation_tags_declared, calls app.openapi() twice, and verifies the helper only runs during the first schema build.
+2. Add a concise comment in custom_openapi() documenting that tag declaration work is covered by app.openapi_schema caching.
+3. Run the focused OpenAPI contract test, git diff --check, and Bandit on the touched backend files. Record verification in the task.
+4. If verification passes, commit the narrow PR follow-up and push to codex/phase4-openapi-contract-testing; then re-check the review thread/status.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a focused OpenAPI schema-cache regression test and added a cache-boundary comment in custom_openapi(). Verification: targeted pytest for the new regression plus existing tag-declaration contract passed (2 passed, 5 warnings); git diff --check passed; Bandit on main.py passed with zero findings; Bandit on touched app/test files passed with B101 skipped because pytest asserts are expected in tests. A full test_openapi_contracts.py run timed out in existing TestClient startup/teardown after one test, so the focused contract verification is the reliable signal for this review comment.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1237 review feedback by documenting that OpenAPI schema normalization is covered by app.openapi_schema caching and adding a regression test proving tag declaration normalization runs only during the first schema build. No production behavior change beyond the clarifying comment.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-6 - Address-remaining-PR-1237-OpenAPI-review-threads.md
+++ b/backlog/tasks/task-6 - Address-remaining-PR-1237-OpenAPI-review-threads.md
@@ -1,0 +1,70 @@
+---
+id: TASK-6
+title: Address remaining PR 1237 OpenAPI review threads
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-03 18:37'
+updated_date: '2026-05-03 18:43'
+labels:
+  - pr-review
+  - openapi
+  - phase4
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1237'
+  - 'https://github.com/rmusser01/tldw_server/pull/1237#discussion_r3178567209'
+  - 'https://github.com/rmusser01/tldw_server/pull/1237#discussion_r3178567210'
+  - 'https://github.com/rmusser01/tldw_server/pull/1237#discussion_r3178567211'
+  - 'https://github.com/rmusser01/tldw_server/pull/1237#discussion_r3178567212'
+  - 'https://github.com/rmusser01/tldw_server/pull/1237#discussion_r3178567216'
+  - 'https://github.com/rmusser01/tldw_server/pull/1237#discussion_r3178567219'
+  - 'https://github.com/rmusser01/tldw_server/pull/1237#discussion_r3178567220'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the additional CodeRabbit review threads on PR #1237 by verifying each OpenAPI contract/tagging finding against runtime code and applying narrow contract fixes where valid.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 OpenAPI contracts for audio speech, chat document generation, quickstart fallback, HAL raw formats, and VN asset content match reachable runtime response media types.
+- [x] #2 OpenAPI tag normalization ignores malformed non-sequence tag values instead of expanding strings into single-character tags.
+- [x] #3 Public control-plane routes retain the health tag in the generated OpenAPI schema.
+- [x] #4 Focused contract tests, diff check, and Bandit verification are run and recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect each reviewed endpoint/helper against current runtime code and existing contract tests.
+2. Add or update focused OpenAPI contract tests that encode the valid reviewer findings before changing production code.
+3. Apply minimal response-contract/tagging fixes in the reviewed files.
+4. Run focused pytest coverage for the changed contract tests plus git diff --check and Bandit on touched backend files.
+5. Commit, push to codex/phase4-openapi-contract-testing, and resolve the addressed review threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented validated CodeRabbit follow-ups: generic PCM OpenAPI media type for audio speech and reading TTS, explicit chat document JSON/SSE response content, explicit quickstart HTML fallback response, HAL Atom/RSS media types, VN asset image media types, hardened operation tag extraction for malformed scalar tags, and restored health tags on public control-plane routes. Red test run before production edits failed 7 expected assertions; final focused run passed 12 tests with 19 warnings. git diff --check passed. Bandit on touched backend/test files passed with B101 skipped for pytest asserts and zero findings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed the remaining PR #1237 OpenAPI review threads with narrow contract and tag fixes, plus focused regression coverage for the media-type and tagging gaps.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_bundle_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_bundle_ops.py
@@ -370,7 +370,16 @@ async def get_bundle_metadata(
 # ---------------------------------------------------------------------------
 # Route 5: GET /backups/bundles/{bundle_id}/download
 # ---------------------------------------------------------------------------
-@router.get("/backups/bundles/{bundle_id}/download")
+@router.get(
+    "/backups/bundles/{bundle_id}/download",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "description": "Backup bundle zip file",
+            "content": {"application/zip": {}},
+        },
+    },
+)
 async def download_bundle(
     bundle_id: str,
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_events_stream.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_events_stream.py
@@ -122,7 +122,16 @@ async def emit_admin_event(
 # SSE Endpoint
 # ---------------------------------------------------------------------------
 
-@router.get("/events/stream")
+@router.get(
+    "/events/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Server-sent events stream for admin dashboard events",
+            "content": {"text/event-stream": {}},
+        },
+    },
+)
 async def admin_events_stream(
     request: Request,
     categories: str | None = Query(

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_system.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_system.py
@@ -155,7 +155,18 @@ async def get_audit_log(
     )
 
 
-@router.get("/audit-log/export")
+@router.get(
+    "/audit-log/export",
+    responses={
+        200: {
+            "description": "Audit log export as JSON or CSV.",
+            "content": {
+                "application/json": {},
+                "text/csv": {},
+            },
+        },
+    },
+)
 async def export_audit_log(
     user_id: int | None = None,
     action: str | None = None,

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_usage.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_usage.py
@@ -82,7 +82,18 @@ async def run_usage_aggregate(day: str | None = Query(None, description="YYYY-MM
         ) from exc
 
 
-@router.get("/usage/daily/export.csv", response_class=PlainTextResponse)
+@router.get(
+    "/usage/daily/export.csv",
+    response_class=PlainTextResponse,
+    responses={
+        200: {
+            "description": "Daily usage export as CSV.",
+            "content": {
+                "text/csv": {},
+            },
+        },
+    },
+)
 async def export_usage_daily_csv(
     user_id: int | None = None,
     start: str | None = Query(None, description="YYYY-MM-DD inclusive"),
@@ -111,7 +122,18 @@ async def export_usage_daily_csv(
     return resp
 
 
-@router.get("/usage/top/export.csv", response_class=PlainTextResponse)
+@router.get(
+    "/usage/top/export.csv",
+    response_class=PlainTextResponse,
+    responses={
+        200: {
+            "description": "Top usage export as CSV.",
+            "content": {
+                "text/csv": {},
+            },
+        },
+    },
+)
 async def export_usage_top_csv(
     start: str | None = Query(None, description="YYYY-MM-DD inclusive"),
     end: str | None = Query(None, description="YYYY-MM-DD inclusive"),
@@ -245,7 +267,18 @@ async def get_llm_top_spenders(
     )
 
 
-@router.get("/llm-usage/export.csv", response_class=PlainTextResponse)
+@router.get(
+    "/llm-usage/export.csv",
+    response_class=PlainTextResponse,
+    responses={
+        200: {
+            "description": "LLM usage export as CSV.",
+            "content": {
+                "text/csv": {},
+            },
+        },
+    },
+)
 async def export_llm_usage_csv(
     user_id: int | None = None,
     provider: str | None = None,

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
@@ -186,7 +186,18 @@ async def list_users(
         ) from e
 
 
-@router.get("/users/export")
+@router.get(
+    "/users/export",
+    responses={
+        200: {
+            "description": "User export as JSON or CSV.",
+            "content": {
+                "application/json": {},
+                "text/csv": {},
+            },
+        },
+    },
+)
 async def export_users(
     role: str | None = None,
     is_active: bool | None = None,

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -2501,6 +2501,13 @@ async def acp_session_events(
 
 @router.get(
     "/sessions/{session_id}/events/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "ACP session event stream.",
+            "content": {"text/event-stream": {}},
+        },
+    },
     dependencies=[Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="acp.sessions.read"))],
 )
 async def acp_session_events_stream(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_history.py
@@ -393,6 +393,8 @@ async def update_tts_history_entry(
 @router.delete(
     "/history/{history_id}",
     summary="Delete a TTS history entry (soft delete).",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
     dependencies=[
         Depends(check_rate_limit),
         Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.history", count_as="call")),

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_jobs.py
@@ -366,7 +366,17 @@ async def get_audio_job(
         raise HTTPException(status_code=500, detail="Failed to fetch job") from None
 
 
-@router.get("/jobs/{job_id}/progress/stream", summary="Stream audio job progress (SSE)")
+@router.get(
+    "/jobs/{job_id}/progress/stream",
+    summary="Stream audio job progress (SSE)",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Server-sent events stream of audio job progress",
+            "content": {"text/event-stream": {}},
+        },
+    },
+)
 async def stream_audio_job_progress(
     job_id: int,
     current_user: Annotated[User, Depends(get_request_user)],

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_tokenizer.py
@@ -179,6 +179,16 @@ async def encode_audio_tokenizer(
 @router.post(
     "/tokenizer/decode",
     summary="Decode Qwen3-TTS tokens into audio",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Decoded audio bytes from tokenizer tokens.",
+            "content": {
+                "audio/wav": {},
+                "application/octet-stream": {},
+            },
+        },
+    },
     dependencies=[
         Depends(check_rate_limit),
         Depends(

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -96,6 +96,18 @@ _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS = (
     UnicodeDecodeError,
     ValueError,
 )
+_OPENAI_AUDIO_TRANSCRIPT_RESPONSE_CONTENT = {
+    "application/json": {},
+    "text/plain": {},
+    "text/vtt": {},
+}
+_OPENAI_AUDIO_TRANSCRIPT_RESPONSES = {
+    status.HTTP_200_OK: {
+        "description": "OpenAI-compatible transcript response in JSON, plain text, SRT, or VTT format.",
+        "content": _OPENAI_AUDIO_TRANSCRIPT_RESPONSE_CONTENT,
+    },
+    status.HTTP_402_PAYMENT_REQUIRED: {"description": "Billing limit exceeded. Upgrade plan to continue."},
+}
 
 _AUDIO_UPLOAD_SUFFIX_BY_CONTENT_TYPE: dict[str, str] = {
     "audio/wav": ".wav",
@@ -429,9 +441,7 @@ def _dictation_error_detail(
 @router.post(
     "/transcriptions",
     summary="Transcribes audio into text (OpenAI Compatible)",
-    responses={
-        status.HTTP_402_PAYMENT_REQUIRED: {"description": "Billing limit exceeded. Upgrade plan to continue."},
-    },
+    responses=_OPENAI_AUDIO_TRANSCRIPT_RESPONSES,
     dependencies=[
         Depends(check_rate_limit),
         Depends(
@@ -1333,9 +1343,7 @@ async def create_transcription(
 @router.post(
     "/translations",
     summary="Translates audio into English (OpenAI Compatible)",
-    responses={
-        status.HTTP_402_PAYMENT_REQUIRED: {"description": "Billing limit exceeded. Upgrade plan to continue."},
-    },
+    responses=_OPENAI_AUDIO_TRANSCRIPT_RESPONSES,
     dependencies=[
         Depends(check_rate_limit),
         Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.translations", count_as="call")),

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -98,6 +98,7 @@ _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS = (
 )
 _OPENAI_AUDIO_TRANSCRIPT_RESPONSE_CONTENT = {
     "application/json": {},
+    "application/x-subrip": {},
     "text/plain": {},
     "text/vtt": {},
 }
@@ -1169,7 +1170,7 @@ async def create_transcription(
             else:
                 srt_content = f"1\n00:00:00,000 --> 00:00:10,000\n{transcribed_text}\n"
             _emit_success_metrics(redaction_outcome=redaction_outcome)
-            return Response(content=srt_content, media_type="text/plain")
+            return Response(content=srt_content, media_type="application/x-subrip")
 
         if response_format == "vtt":
             _raise_on_transcription_error(transcribed_text)

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_tts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_tts.py
@@ -259,12 +259,22 @@ async def get_tts_service() -> TTSServiceV2:
 @router.post(
     "/speech",
     summary="Generates audio from text input.",
+    response_class=Response,
     dependencies=[
         Depends(check_rate_limit),
         Depends(TokenScopeGuard("any", require_if_present=True, endpoint_id="audio.speech", count_as="call")),
     ],
     responses={
         200: {
+            "description": "Generated speech audio bytes or stream",
+            "content": {
+                "audio/aac": {},
+                "audio/flac": {},
+                "audio/L16; rate=24000; channels=1": {},
+                "audio/mpeg": {},
+                "audio/opus": {},
+                "audio/wav": {},
+            },
             "headers": {
                 "X-Audio-Sample-Rate": {
                     "description": "Resolved PCM sample rate in Hz (present when response_format=pcm).",

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_tts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_tts.py
@@ -270,7 +270,7 @@ async def get_tts_service() -> TTSServiceV2:
             "content": {
                 "audio/aac": {},
                 "audio/flac": {},
-                "audio/L16; rate=24000; channels=1": {},
+                "audio/L16": {},
                 "audio/mpeg": {},
                 "audio/opus": {},
                 "audio/wav": {},

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_voices.py
@@ -281,6 +281,13 @@ async def delete_voice(
 @router.post(
     "/voices/{voice_id}/preview",
     summary="Generate voice preview",
+    response_class=StreamingResponse,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "MP3 audio stream for a custom voice preview",
+            "content": {"audio/mpeg": {}},
+        },
+    },
     dependencies=[
         Depends(check_rate_limit),
         Depends(

--- a/tldw_Server_API/app/api/v1/endpoints/audit.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audit.py
@@ -193,6 +193,16 @@ def _sanitize_filename(name: str, default_name: str) -> str:
 
 @router.get(
     "/audit/export",
+    responses={
+        200: {
+            "description": "Audit export as JSON, NDJSON, or CSV.",
+            "content": {
+                "application/json": {},
+                "application/x-ndjson": {},
+                "text/csv": {},
+            },
+        },
+    },
     summary="Export audit events (JSON/JSONL/CSV)",
     dependencies=[Depends(RequirePermission(SYSTEM_LOGS))],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -375,6 +375,17 @@ async def _issue_multi_user_tokens(
 @router.get(
     "/federation/{provider_slug}/login",
     dependencies=[Depends(check_auth_rate_limit)],
+    responses={
+        status.HTTP_307_TEMPORARY_REDIRECT: {
+            "description": "Redirect to the identity provider authorization URL.",
+            "headers": {
+                "Location": {
+                    "description": "Identity provider authorization URL.",
+                    "schema": {"type": "string"},
+                },
+            },
+        },
+    },
 )
 async def federation_login(
     provider_slug: str,

--- a/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py
@@ -4580,6 +4580,12 @@ async def prompt_assembly_preview(
         "Streaming: when stream=true, response is sent as SSE and assistant content is NOT persisted,"
         " even if save_to_db=true. Use non-streaming to persist, or persist manually after streaming."
     ),
+    responses={
+        200: {
+            "description": "Character chat completion response or SSE stream.",
+            "content": {"text/event-stream": {}},
+        },
+    },
     tags=["Chat Sessions"],
 )
 async def character_chat_completion(

--- a/tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/characters_endpoint.py
@@ -3007,8 +3007,21 @@ def _encode_png_with_chara_metadata(
     return png_header + ihdr + text_chunk + idat + iend
 
 
-@router.get("/{character_id:int}/export", response_model=None,
-            summary="Export character in various formats", tags=["characters"])
+@router.get(
+    "/{character_id:int}/export",
+    response_model=None,
+    responses={
+        200: {
+            "description": "Character export as JSON card data or PNG character card.",
+            "content": {
+                "application/json": {},
+                "image/png": {},
+            },
+        },
+    },
+    summary="Export character in various formats",
+    tags=["characters"],
+)
 async def export_character(
     character_id: int = FastAPIPath(..., description="Character ID to export", gt=0),
     format: str = Query("v3", description="Export format (v3, v2, json, png)"),

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -2238,6 +2238,13 @@ async def _persist_system_message_if_needed(
     ),
     tags=["chat"],
     responses={
+        status.HTTP_200_OK: {
+            "description": "OpenAI-compatible chat completion JSON response or SSE stream.",
+            "content": {
+                "application/json": {},
+                "text/event-stream": {},
+            },
+        },
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid request (e.g., empty messages, text too long, bad parameters)."},
         status.HTTP_401_UNAUTHORIZED: {"description": "Invalid authentication token."},
         status.HTTP_404_NOT_FOUND: {"description": "Resource not found (e.g., character)."},

--- a/tldw_Server_API/app/api/v1/endpoints/chat_documents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat_documents.py
@@ -80,7 +80,17 @@ _CHAT_DOCS_NONCRITICAL_EXCEPTIONS = (
     responses={
         200: {
             "description": "Generated document result, async job metadata, or SSE stream.",
-            "content": {"text/event-stream": {}},
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "oneOf": [
+                            {"$ref": "#/components/schemas/GenerateDocumentResponse"},
+                            {"$ref": "#/components/schemas/AsyncGenerationResponse"},
+                        ]
+                    }
+                },
+                "text/event-stream": {},
+            },
         },
     },
     summary="Generate a document from conversation",

--- a/tldw_Server_API/app/api/v1/endpoints/chat_documents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat_documents.py
@@ -77,6 +77,12 @@ _CHAT_DOCS_NONCRITICAL_EXCEPTIONS = (
 @router.post(
     "/documents/generate",
     response_model=Union[GenerateDocumentResponse, AsyncGenerationResponse],
+    responses={
+        200: {
+            "description": "Generated document result, async job metadata, or SSE stream.",
+            "content": {"text/event-stream": {}},
+        },
+    },
     summary="Generate a document from conversation",
     description="Generate a document using conversation content and a template. May return async job metadata.",
     tags=["chat-documents"],

--- a/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chatbooks.py
@@ -1133,7 +1133,16 @@ async def get_import_job(
         ) from None
 
 
-@router.get("/download/{job_id}")
+@router.get(
+    "/download/{job_id}",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "description": "Exported chatbook zip file",
+            "content": {"application/zip": {}},
+        },
+    },
+)
 async def download_chatbook(
     job_id: str,
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/claims.py
+++ b/tldw_Server_API/app/api/v1/endpoints/claims.py
@@ -598,7 +598,18 @@ def list_claims_analytics_exports(
     )
 
 
-@router.get("/analytics/export/{export_id}")
+@router.get(
+    "/analytics/export/{export_id}",
+    responses={
+        200: {
+            "description": "Prepared claims analytics export as JSON or CSV.",
+            "content": {
+                "application/json": {},
+                "text/csv": {},
+            },
+        },
+    },
+)
 def download_claims_analytics_export(
     export_id: str,
     principal: AuthPrincipal = Depends(get_auth_principal),

--- a/tldw_Server_API/app/api/v1/endpoints/collections_websub.py
+++ b/tldw_Server_API/app/api/v1/endpoints/collections_websub.py
@@ -222,7 +222,19 @@ async def websub_status(
 callback_router = APIRouter(prefix="/websub/callback", tags=["collections-websub"])
 
 
-@callback_router.get("/{user_id}/{callback_token}", summary="WebSub hub verification challenge")
+@callback_router.get(
+    "/{user_id}/{callback_token}",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Plaintext WebSub hub challenge response.",
+            "content": {
+                "text/plain": {},
+            },
+        },
+    },
+    summary="WebSub hub verification challenge",
+)
 async def websub_verify_callback(
     user_id: int = Path(..., ge=1),
     callback_token: str = Path(...),
@@ -263,7 +275,16 @@ async def websub_verify_callback(
     return Response(content=hub_challenge, media_type="text/plain", status_code=200)
 
 
-@callback_router.post("/{user_id}/{callback_token}", summary="WebSub push notification")
+@callback_router.post(
+    "/{user_id}/{callback_token}",
+    summary="WebSub push notification",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "WebSub hub acknowledgement; no response body.",
+        },
+    },
+)
 async def websub_push_callback(
     request: Request,
     background_tasks: BackgroundTasks,

--- a/tldw_Server_API/app/api/v1/endpoints/config_info.py
+++ b/tldw_Server_API/app/api/v1/endpoints/config_info.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -361,7 +361,21 @@ async def get_jobs_config_info():
     }
 
 
-@router.get("/config/quickstart")
+@router.get(
+    "/config/quickstart",
+    response_class=HTMLResponse,
+    responses={
+        status.HTTP_307_TEMPORARY_REDIRECT: {
+            "description": "Redirect to the configured quickstart destination.",
+            "headers": {
+                "location": {
+                    "description": "Quickstart destination URL.",
+                    "schema": {"type": "string"},
+                },
+            },
+        },
+    },
+)
 async def get_quickstart_redirect():
     """
     Redirect to a Quickstart URL defined in config.txt or environment.

--- a/tldw_Server_API/app/api/v1/endpoints/config_info.py
+++ b/tldw_Server_API/app/api/v1/endpoints/config_info.py
@@ -365,6 +365,12 @@ async def get_jobs_config_info():
     "/config/quickstart",
     response_class=HTMLResponse,
     responses={
+        status.HTTP_200_OK: {
+            "description": "Fallback quickstart HTML page when redirect resolution fails.",
+            "content": {
+                "text/html": {},
+            },
+        },
         status.HTTP_307_TEMPORARY_REDIRECT: {
             "description": "Redirect to the configured quickstart destination.",
             "headers": {

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -995,7 +995,17 @@ async def trigger_source_sync(
     )
 
 
-@router.api_route("/providers/{provider}/webhook", methods=["GET", "POST"], response_model=ConnectorWebhookCallbackResponse)
+@router.api_route(
+    "/providers/{provider}/webhook",
+    methods=["GET", "POST"],
+    response_model=ConnectorWebhookCallbackResponse,
+    responses={
+        200: {
+            "description": "Connector webhook callback result or plaintext validation challenge.",
+            "content": {"text/plain": {}},
+        },
+    },
+)
 async def provider_webhook_callback(
     provider: str,
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/data_tables.py
+++ b/tldw_Server_API/app/api/v1/endpoints/data_tables.py
@@ -728,6 +728,15 @@ async def get_data_table(
 @router.get(
     "/{table_uuid}/export",
     response_model=DataTableExportResponse,
+    responses={
+        200: {
+            "description": "Data table export metadata or direct download content.",
+            "content": {
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {},
+                "text/csv": {},
+            },
+        },
+    },
     summary="Export a data table",
     dependencies=[
         Depends(RequirePermission(MEDIA_READ)),

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -4703,8 +4703,10 @@ async def orchestrator_events(_current_user: User = Depends(get_request_user)):
                         await asyncio.gather(producer, return_exceptions=True)
                 raise
             else:
-                # Normal shutdown: ensure producer completes without forced cancel
+                # Normal shutdown: the producer loop is long-running, so cancel before awaiting it.
                 if not producer.done():
+                    with suppress(_EMBEDDINGS_NONCRITICAL_EXCEPTIONS):
+                        producer.cancel()
                     with suppress(_EMBEDDINGS_NONCRITICAL_EXCEPTIONS):
                         await asyncio.gather(producer, return_exceptions=True)
         finally:

--- a/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
+++ b/tldw_Server_API/app/api/v1/endpoints/embeddings_v5_production_enhanced.py
@@ -4628,6 +4628,13 @@ async def _sse_orchestrator_stream(client: aioredis.Redis):
 @router.get(
     "/embeddings/orchestrator/events",
     summary="SSE: embeddings orchestrator live summary (admin only)",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Embeddings orchestrator event stream.",
+            "content": {"text/event-stream": {}},
+        },
+    },
     dependencies=[Depends(RequirePermission(EMBEDDINGS_ADMIN))],
 )
 async def orchestrator_events(_current_user: User = Depends(get_request_user)):

--- a/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py
@@ -12,6 +12,7 @@ import time
 from typing import Annotated, Any, Optional, Union
 
 from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Query, Request, Response, UploadFile, status
+from fastapi.responses import StreamingResponse
 from fastapi.routing import APIRoute
 from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, rbac_rate_limit, RequireRole, User
@@ -411,7 +412,18 @@ from tldw_Server_API.app.core.Evaluations.run_state import (
 )
 
 
-@router.get("/embeddings/abtest/{test_id}/events")
+@router.get(
+    "/embeddings/abtest/{test_id}/events",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Server-sent events for A/B test progress.",
+            "content": {
+                "text/event-stream": {},
+            },
+        },
+    },
+)
 async def stream_embeddings_abtest_events(
     test_id: str,
     user_ctx: str = Depends(verify_api_key),
@@ -421,8 +433,6 @@ async def stream_embeddings_abtest_events(
     """SSE stream of progress and updates for an A/B test, using SSEStream for heartbeats and metrics."""
     import asyncio as _aio
     import json as _json
-
-    from fastapi.responses import StreamingResponse
 
     from tldw_Server_API.app.core.Streaming.streams import SSEStream
 
@@ -534,6 +544,15 @@ async def delete_embeddings_abtest(
 
 @router.get(
     "/embeddings/abtest/{test_id}/export",
+    responses={
+        200: {
+            "description": "A/B test export as JSON or CSV.",
+            "content": {
+                "application/json": {},
+                "text/csv": {},
+            },
+        },
+    },
     dependencies=[
         Depends(RequireRole("admin")),
         Depends(rbac_rate_limit("evals.abtest.export")),
@@ -723,7 +742,19 @@ async def health_check():
         )
 
 
-@router.get("/metrics", dependencies=[Depends(require_eval_permissions(EVALS_READ))])
+@router.get(
+    "/metrics",
+    responses={
+        200: {
+            "description": "Evaluation metrics as JSON or Prometheus text.",
+            "content": {
+                "application/json": {},
+                "text/plain; version=0.0.4; charset=utf-8": {},
+            },
+        },
+    },
+    dependencies=[Depends(require_eval_permissions(EVALS_READ))],
+)
 async def get_metrics(
     request: Request,
     user_id: str = Depends(verify_api_key),

--- a/tldw_Server_API/app/api/v1/endpoints/files.py
+++ b/tldw_Server_API/app/api/v1/endpoints/files.py
@@ -45,6 +45,7 @@ _EXPORT_MIME_TYPES = {
     "jpg": "image/jpeg",
     "webp": "image/webp",
 }
+_EXPORT_RESPONSE_CONTENT = {content_type: {} for content_type in sorted(set(_EXPORT_MIME_TYPES.values()))}
 
 def _file_artifacts_http_exception(exc: FileArtifactsError) -> HTTPException:
     detail = exc.detail if exc.detail is not None else exc.code
@@ -186,6 +187,13 @@ async def get_file_artifact(
 @router.get(
     "/{file_id}/export",
     summary="Download a file artifact export",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "description": "Raw file artifact export",
+            "content": _EXPORT_RESPONSE_CONTENT,
+        },
+    },
 )
 async def export_file_artifact(
     file_id: int,

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -930,7 +930,18 @@ async def upload_flashcard_asset(
     )
 
 
-@router.get("/assets/{asset_uuid}/content")
+@router.get(
+    "/assets/{asset_uuid}/content",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Flashcard asset content.",
+            "content": {
+                "application/octet-stream": {},
+            },
+        },
+    },
+)
 def get_flashcard_asset_content(
     asset_uuid: str,
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
@@ -2318,7 +2329,21 @@ async def generate_flashcards(payload: FlashcardGenerateRequest):
         raise HTTPException(status_code=500, detail="Failed to generate flashcards") from e
 
 
-@router.get("/export")
+@router.get(
+    "/export",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Flashcard export download.",
+            "content": {
+                "application/apkg": {},
+                "application/json; charset=utf-8": {},
+                "text/csv; charset=utf-8": {},
+                "text/tab-separated-values; charset=utf-8": {},
+            },
+        },
+    },
+)
 def export_flashcards(
     deck_id: Optional[int] = None,
     workspace_id: Optional[str] = None,

--- a/tldw_Server_API/app/api/v1/endpoints/jobs_admin.py
+++ b/tldw_Server_API/app/api/v1/endpoints/jobs_admin.py
@@ -978,7 +978,18 @@ async def list_job_events(
             conn.close()
 
 
-@router.get("/jobs/events/stream")
+@router.get(
+    "/jobs/events/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Server-sent events stream of job outbox events.",
+            "content": {
+                "text/event-stream": {},
+            },
+        },
+    },
+)
 async def stream_job_events(
     after_id: int = 0,
     domain: str | None = None,

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -2657,7 +2657,16 @@ async def list_governance_audit_findings(
     )
 
 
-@router.get("/events/stream")
+@router.get(
+    "/events/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "MCP Hub governance event stream.",
+            "content": {"text/event-stream": {}},
+        },
+    },
+)
 async def stream_mcp_hub_events(
     request: Request,
     after_event_id: str | None = Query(

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_unified_endpoint.py
@@ -734,7 +734,15 @@ async def websocket_endpoint(
 # HTTP endpoints
 
 
-@router.post("/request", response_model=MCPResponse)
+@router.post(
+    "/request",
+    response_model=MCPResponse,
+    responses={
+        status.HTTP_204_NO_CONTENT: {
+            "description": "MCP request acknowledged with no response body.",
+        },
+    },
+)
 async def mcp_request(
     request: MCPRequest,
     http_request: Request,
@@ -954,7 +962,16 @@ async def get_server_metrics(
     return ServerMetricsResponse(**metrics)
 
 
-@router.get("/metrics/prometheus")
+@router.get(
+    "/metrics/prometheus",
+    response_class=Response,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Prometheus text-format MCP metrics",
+            "content": {"text/plain; version=0.0.4; charset=utf-8": {}},
+        },
+    },
+)
 async def get_prometheus_metrics(
     _principal: AuthPrincipal = Depends(RequirePermission(SYSTEM_LOGS)),
     _guard: None = Depends(enforce_http_security),

--- a/tldw_Server_API/app/api/v1/endpoints/media/file.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/file.py
@@ -118,7 +118,13 @@ def _parse_range_header(range_header: str, file_size: int) -> tuple[int, int] | 
                 "application/octet-stream": {},
             },
         },
-        206: {"description": "Partial content (Range request)"},
+        206: {
+            "description": "Partial content (Range request)",
+            "content": {
+                "application/pdf": {},
+                "application/octet-stream": {},
+            },
+        },
         304: {"description": "Not modified (ETag match)"},
         404: {"description": "Media item or file not found"},
         416: {"description": "Range not satisfiable"},

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
@@ -642,6 +642,13 @@ async def list_media_ingest_jobs(
     summary="Stream media ingest job events (SSE)",
     tags=["Media Ingestion Jobs"],
     dependencies=[Depends(check_rate_limit)],
+    response_class=StreamingResponse,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Server-sent events stream of media ingest job updates",
+            "content": {"text/event-stream": {}},
+        },
+    },
 )
 async def stream_media_ingest_job_events(
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/media/item.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/item.py
@@ -54,6 +54,11 @@ def _is_test_mode() -> bool:
     "/{media_id:int}",
     status_code=status.HTTP_200_OK,
     summary="Get Media Item Details",
+    responses={
+        status.HTTP_304_NOT_MODIFIED: {
+            "description": "Media item not modified (ETag match).",
+        },
+    },
 )
 async def get_media_item(
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/media/listing.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/listing.py
@@ -48,6 +48,11 @@ from .....core.DB_Management.media_db.legacy_maintenance import (
 )
 
 router = APIRouter(tags=["Media Management"])
+_NOT_MODIFIED_OPENAPI_RESPONSE = {
+    status.HTTP_304_NOT_MODIFIED: {
+        "description": "Media listing not modified (ETag match).",
+    },
+}
 
 _MEDIA_LISTING_COERCE_EXCEPTIONS = (
     AttributeError,
@@ -166,6 +171,7 @@ def _should_delegate_media_search_to_email(
 @router.get(
     "/",
     summary="List Media (slash)",
+    responses=_NOT_MODIFIED_OPENAPI_RESPONSE,
 )
 async def list_media_endpoint(
     request: Request,
@@ -353,6 +359,7 @@ async def list_media_endpoint(
 @router.get(
     "/trash",
     summary="List trashed media items",
+    responses=_NOT_MODIFIED_OPENAPI_RESPONSE,
 )
 async def list_media_trash_endpoint(
     request: Request,
@@ -591,6 +598,7 @@ async def empty_media_trash_endpoint(
 @router.get(
     "/metadata-search",
     summary="Search media by safe metadata",
+    responses=_NOT_MODIFIED_OPENAPI_RESPONSE,
 )
 async def search_by_metadata(
     request: Request,
@@ -840,6 +848,7 @@ async def _validate_identifier_query(
     "/by-identifier",
     summary="Find media by standard identifier (DOI/PMID/PMCID/arXiv/S2)",
     dependencies=[Depends(_validate_identifier_query)],
+    responses=_NOT_MODIFIED_OPENAPI_RESPONSE,
 )
 async def get_by_identifier(
     request: Request,
@@ -941,6 +950,7 @@ async def get_by_identifier(
     status_code=status.HTTP_200_OK,
     summary="Search Media Items",
     response_model=MediaListResponse,
+    responses=_NOT_MODIFIED_OPENAPI_RESPONSE,
 )
 async def search_media_items(
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
@@ -240,6 +240,13 @@ async def _process_mediawiki_dump(
     summary="Ingest and process a MediaWiki XML dump, storing results to database and vector store.",
     tags=["MediaWiki Processing"],
     dependencies=[Depends(guard_backpressure_and_quota), Depends(guard_storage_quota)],
+    response_class=StreamingResponse,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "NDJSON stream of MediaWiki ingest events",
+            "content": {"application/x-ndjson": {}},
+        },
+    },
 )
 async def ingest_mediawiki_dump_endpoint(
     form_data: MediaWikiDumpOptionsForm = Depends(get_mediawiki_form_data),
@@ -268,6 +275,13 @@ async def ingest_mediawiki_dump_endpoint(
     summary="Process a MediaWiki XML dump and return structured content without database storage.",
     tags=["MediaWiki Processing"],
     dependencies=[Depends(guard_backpressure_and_quota), Depends(guard_storage_quota)],
+    response_class=StreamingResponse,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "NDJSON stream of processed MediaWiki pages",
+            "content": {"application/x-ndjson": {}},
+        },
+    },
 )
 async def process_mediawiki_dump_ephemeral_endpoint(
     form_data: MediaWikiDumpOptionsForm = Depends(get_mediawiki_form_data),

--- a/tldw_Server_API/app/api/v1/endpoints/meetings.py
+++ b/tldw_Server_API/app/api/v1/endpoints/meetings.py
@@ -414,7 +414,19 @@ def share_session_to_webhook(
     )
 
 
-@router.get("/sessions/{session_id}/events", dependencies=[Depends(check_rate_limit)])
+@router.get(
+    "/sessions/{session_id}/events",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Meeting session event stream.",
+            "content": {
+                "text/event-stream": {},
+            },
+        },
+    },
+    dependencies=[Depends(check_rate_limit)],
+)
 async def stream_session_events(
     session_id: str,
     meetings_db: MeetingsDatabase = Depends(get_meetings_db_for_user),

--- a/tldw_Server_API/app/api/v1/endpoints/messages.py
+++ b/tldw_Server_API/app/api/v1/endpoints/messages.py
@@ -612,6 +612,15 @@ async def _handle_count_tokens(
     "/messages",
     summary="Anthropic-compatible Messages API",
     dependencies=[Depends(check_rate_limit)],
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Anthropic-compatible messages JSON response or SSE stream.",
+            "content": {
+                "application/json": {},
+                "text/event-stream": {},
+            },
+        },
+    },
 )
 async def create_messages(
     request: Request,
@@ -634,6 +643,15 @@ async def create_messages(
     "/v1/messages",
     summary="Anthropic-compatible Messages API",
     dependencies=[Depends(check_rate_limit)],
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Anthropic-compatible messages JSON response or SSE stream.",
+            "content": {
+                "application/json": {},
+                "text/event-stream": {},
+            },
+        },
+    },
 )
 async def create_messages_public(
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/metrics.py
+++ b/tldw_Server_API/app/api/v1/endpoints/metrics.py
@@ -119,9 +119,17 @@ async def build_prometheus_metrics_response() -> Response:
 
 # Note: Avoid path conflict with the JSON metrics in main.py (`/api/v1/metrics`).
 # Expose text format under `/api/v1/metrics/text`.
-@router.get("/metrics/text",
-            summary="Get metrics in Prometheus text format",
-            response_class=Response)
+@router.get(
+    "/metrics/text",
+    summary="Get metrics in Prometheus text format",
+    response_class=Response,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Prometheus text-format metrics",
+            "content": {"text/plain; version=0.0.4": {}},
+        },
+    },
+)
 async def get_prometheus_metrics() -> Response:
     """
     Export all metrics in Prometheus text format.

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -1509,6 +1509,12 @@ async def export_notes(
 @router.get(
     "/export.csv",
     response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Notes CSV export download.",
+            "content": {"text/csv; charset=utf-8": {}},
+        },
+    },
     summary="Export notes as CSV",
     tags=["notes"]
 )
@@ -1610,6 +1616,12 @@ async def export_notes_post(
 @router.post(
     "/export.csv",
     response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Selected notes CSV export download.",
+            "content": {"text/csv; charset=utf-8": {}},
+        },
+    },
     summary="Export selected notes as CSV",
     tags=["notes"]
 )
@@ -3170,6 +3182,12 @@ async def list_note_attachments(
 @router.get(
     "/{note_id}/attachments/{file_name}",
     response_class=FileResponse,
+    responses={
+        200: {
+            "description": "Raw note attachment file.",
+            "content": {"application/octet-stream": {}},
+        },
+    },
     summary="Download an attachment for a note",
     tags=["notes"],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/notifications.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notifications.py
@@ -339,6 +339,15 @@ async def patch_preferences(
 
 @router.get(
     "/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Notification event stream.",
+            "content": {
+                "text/event-stream": {},
+            },
+        },
+    },
     dependencies=[Depends(rbac_rate_limit("notifications.read"))],
 )
 async def stream_notifications(

--- a/tldw_Server_API/app/api/v1/endpoints/outputs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/outputs.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime
 from pathlib import Path as PathlibPath
 
-from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException, Response
 from fastapi import Path as FastAPIPath
 from loguru import logger
 from pydantic import BaseModel
@@ -520,7 +520,22 @@ async def get_output(
     )
 
 
-@router.get("/{output_id}/download", summary="Download output artifact")
+@router.get(
+    "/{output_id}/download",
+    summary="Download output artifact",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "description": "Output artifact file",
+            "content": {
+                "application/octet-stream": {},
+                "audio/mpeg": {},
+                "text/html; charset=utf-8": {},
+                "text/markdown; charset=utf-8": {},
+            },
+        },
+    },
+)
 async def download_output(
     output_id: int = FastAPIPath(..., ge=1),
     current_user: User = Depends(get_request_user),
@@ -560,7 +575,22 @@ async def download_output(
     )
 
 
-@router.get("/download/by-name", summary="Download output artifact by title")
+@router.get(
+    "/download/by-name",
+    summary="Download output artifact by title",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "description": "Output artifact file",
+            "content": {
+                "application/octet-stream": {},
+                "audio/mpeg": {},
+                "text/html; charset=utf-8": {},
+                "text/markdown; charset=utf-8": {},
+            },
+        },
+    },
+)
 async def download_output_by_name(
     title: str,
     format: str | None = None,
@@ -599,7 +629,16 @@ async def download_output_by_name(
     )
 
 
-@router.head("/{output_id}/download", summary="Check output artifact availability")
+@router.head(
+    "/{output_id}/download",
+    summary="Check output artifact availability",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Output artifact headers only; no response body.",
+        },
+    },
+)
 async def head_download_output(
     output_id: int = FastAPIPath(..., ge=1),
     current_user: User = Depends(get_request_user),
@@ -631,7 +670,6 @@ async def head_download_output(
         "mp3": "audio/mpeg",
     }
     mt = media_types.get(row.format.lower(), "application/octet-stream")
-    from fastapi import Response
     headers = {"Content-Type": mt, "Content-Length": str(path.stat().st_size)}
     return Response(status_code=200, headers=headers)
 

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -116,6 +116,8 @@ _RAW_HAL_RESPONSES = _raw_passthrough_responses(
     "application/octet-stream",
     "text/csv",
     "text/plain",
+    "application/atom+xml",
+    "application/rss+xml",
 )
 
 _PROVIDER_TIMEOUT_DETAIL = "Upstream provider request timed out"

--- a/tldw_Server_API/app/api/v1/endpoints/paper_search.py
+++ b/tldw_Server_API/app/api/v1/endpoints/paper_search.py
@@ -94,6 +94,30 @@ from tldw_Server_API.app.core.Utils.pydantic_compat import model_dump_compat
 
 router = APIRouter()
 
+
+def _raw_passthrough_responses(*media_types: str) -> dict[int, dict[str, Any]]:
+    return {
+        200: {
+            "description": "Raw upstream provider response.",
+            "content": {media_type: {} for media_type in media_types},
+        },
+    }
+
+
+_RAW_JSON_XML_HTML_RESPONSES = _raw_passthrough_responses("application/json", "application/xml", "text/html")
+_RAW_JSON_CSV_RESPONSES = _raw_passthrough_responses("application/json", "text/csv")
+_RAW_JSON_XML_RESPONSES = _raw_passthrough_responses("application/json", "application/xml")
+_RAW_XML_RESPONSES = _raw_passthrough_responses("application/xml")
+_RAW_JSON_RESPONSES = _raw_passthrough_responses("application/json")
+_RAW_PDF_RESPONSES = _raw_passthrough_responses("application/pdf")
+_RAW_HAL_RESPONSES = _raw_passthrough_responses(
+    "application/json",
+    "application/xml",
+    "application/octet-stream",
+    "text/csv",
+    "text/plain",
+)
+
 _PROVIDER_TIMEOUT_DETAIL = "Upstream provider request timed out"
 _PROVIDER_ERROR_DETAIL = "Upstream provider request failed"
 _PROVIDER_UNEXPECTED_DETAIL = "Unexpected provider error"
@@ -415,6 +439,8 @@ async def paper_search_medrxiv_by_doi(
 @router.get(
     "/medrxiv/raw/details",
     summary="Raw passthrough for MedRxiv details endpoint (json|xml|html)",
+    response_class=Response,
+    responses=_RAW_JSON_XML_HTML_RESPONSES,
     tags=["paper-search"],
 )
 async def medrxiv_raw_details(
@@ -451,6 +477,8 @@ async def medrxiv_raw_details(
 @router.get(
     "/medrxiv/raw/pubs",
     summary="Raw passthrough for MedRxiv pubs endpoint (json|csv)",
+    response_class=Response,
+    responses=_RAW_JSON_CSV_RESPONSES,
     tags=["paper-search"],
 )
 async def medrxiv_raw_pubs(
@@ -485,6 +513,8 @@ async def medrxiv_raw_pubs(
 @router.get(
     "/medrxiv/raw/pub",
     summary="Raw passthrough for MedRxiv pub endpoint (json|csv)",
+    response_class=Response,
+    responses=_RAW_JSON_CSV_RESPONSES,
     tags=["paper-search"],
 )
 async def medrxiv_raw_pub(
@@ -753,6 +783,8 @@ from fastapi.responses import Response, StreamingResponse  # noqa: E402, F811
 @router.get(
     "/pmc-oa/fetch-pdf",
     summary="Fetch PMC PDF by PMCID and return as attachment",
+    response_class=StreamingResponse,
+    responses=_RAW_PDF_RESPONSES,
     tags=["paper-search"],
 )
 async def pmc_oa_fetch_pdf(pmcid: str = Query(..., description="PMCID numeric or with 'PMC' prefix")):
@@ -2128,6 +2160,8 @@ async def paper_search_biorxiv_usage(
 @router.get(
     "/biorxiv/raw/details",
     summary="Raw passthrough for BioRxiv details endpoint (supports json/xml/html)",
+    response_class=Response,
+    responses=_RAW_JSON_XML_HTML_RESPONSES,
     tags=["paper-search"],
 )
 async def biorxiv_raw_details(
@@ -2165,6 +2199,8 @@ async def biorxiv_raw_details(
 @router.get(
     "/biorxiv/raw/pubs",
     summary="Raw passthrough for BioRxiv pubs endpoint (supports json/csv)",
+    response_class=Response,
+    responses=_RAW_JSON_CSV_RESPONSES,
     tags=["paper-search"],
 )
 async def biorxiv_raw_pubs(
@@ -2200,6 +2236,8 @@ async def biorxiv_raw_pubs(
 @router.get(
     "/biorxiv/raw/pub",
     summary="Raw passthrough for BioRxiv pub endpoint (supports json/csv)",
+    response_class=Response,
+    responses=_RAW_JSON_CSV_RESPONSES,
     tags=["paper-search"],
 )
 async def biorxiv_raw_pub(
@@ -2231,6 +2269,8 @@ async def biorxiv_raw_pub(
 @router.get(
     "/biorxiv/raw/funder",
     summary="Raw passthrough for BioRxiv funder endpoint (supports json/xml)",
+    response_class=Response,
+    responses=_RAW_JSON_XML_RESPONSES,
     tags=["paper-search"],
 )
 async def biorxiv_raw_funder(
@@ -2268,6 +2308,8 @@ async def biorxiv_raw_funder(
 @router.get(
     "/biorxiv/raw/reports/summary",
     summary="Raw passthrough for BioRxiv summary (supports json/csv)",
+    response_class=Response,
+    responses=_RAW_JSON_CSV_RESPONSES,
     tags=["paper-search"],
 )
 async def biorxiv_raw_summary(
@@ -2286,6 +2328,8 @@ async def biorxiv_raw_summary(
 @router.get(
     "/biorxiv/raw/reports/usage",
     summary="Raw passthrough for BioRxiv usage (supports json/csv)",
+    response_class=Response,
+    responses=_RAW_JSON_CSV_RESPONSES,
     tags=["paper-search"],
 )
 async def biorxiv_raw_usage(
@@ -3609,6 +3653,8 @@ async def chemrxiv_version():
 @router.get(
     "/chemrxiv/oai",
     summary="ChemRxiv OAI-PMH passthrough (XML)",
+    response_class=Response,
+    responses=_RAW_XML_RESPONSES,
     tags=["paper-search"],
 )
 async def chemrxiv_oai(
@@ -3666,6 +3712,8 @@ async def iacr_conf(
 @router.get(
     "/iacr/conf/raw",
     summary="IACR conference metadata raw (download)",
+    response_class=Response,
+    responses=_RAW_JSON_RESPONSES,
     tags=["paper-search"],
 )
 async def iacr_conf_raw(
@@ -4015,6 +4063,8 @@ async def osf_ingest(
 @router.get(
     "/osf/raw",
     summary="Raw passthrough for OSF preprints list (JSON)",
+    response_class=Response,
+    responses=_RAW_JSON_RESPONSES,
     tags=["paper-search"],
 )
 async def osf_raw(
@@ -4047,6 +4097,8 @@ async def osf_raw(
 @router.get(
     "/osf/raw/by-id",
     summary="Raw passthrough for a single OSF preprint (JSON)",
+    response_class=Response,
+    responses=_RAW_JSON_RESPONSES,
     tags=["paper-search"],
 )
 async def osf_raw_by_id(osf_id: str = Query(..., min_length=3)):
@@ -4152,6 +4204,8 @@ async def zenodo_by_doi(doi: str = Query(..., min_length=3)):
 @router.get(
     "/zenodo/oai",
     summary="Zenodo OAI-PMH passthrough (XML)",
+    response_class=Response,
+    responses=_RAW_XML_RESPONSES,
     tags=["paper-search"],
 )
 async def zenodo_oai(
@@ -4439,6 +4493,8 @@ async def figshare_by_doi(doi: str = Query(..., min_length=3)):
 @router.get(
     "/figshare/oai",
     summary="Figshare OAI-PMH passthrough (XML)",
+    response_class=Response,
+    responses=_RAW_XML_RESPONSES,
     tags=["paper-search"],
 )
 async def figshare_oai(
@@ -4828,6 +4884,8 @@ async def hal_search(
 @router.get(
     "/hal/raw",
     summary="HAL raw passthrough (wt=json|xml|xml-tei|csv|bibtex|endnote|atom|rss)",
+    response_class=Response,
+    responses=_RAW_HAL_RESPONSES,
     tags=["paper-search"],
 )
 async def hal_raw(

--- a/tldw_Server_API/app/api/v1/endpoints/privileges.py
+++ b/tldw_Server_API/app/api/v1/endpoints/privileges.py
@@ -308,7 +308,18 @@ async def export_privilege_snapshot_json(
     return response
 
 
-@router.get("/snapshots/{snapshot_id}/export.csv")
+@router.get(
+    "/snapshots/{snapshot_id}/export.csv",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Privilege snapshot export as CSV.",
+            "content": {
+                "text/csv": {},
+            },
+        },
+    },
+)
 async def export_privilege_snapshot_csv(
     *,
     snapshot_id: str,

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -1728,7 +1728,14 @@ async def resume_batch_endpoint(
         Depends(check_rate_limit),
         Depends(RequirePermission(MEDIA_READ)),
         Depends(require_within_limit(LimitCategory.RAG_QUERIES_DAY, 1)),
-    ]
+    ],
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "NDJSON stream of unified RAG search events",
+            "content": {"application/x-ndjson": {}},
+        },
+    },
 )
 async def unified_search_stream_endpoint(
     request_raw: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/reading.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading.py
@@ -1044,7 +1044,7 @@ async def summarize_reading_item(
             "content": {
                 "audio/aac": {},
                 "audio/flac": {},
-                "audio/L16; rate=24000; channels=1": {},
+                "audio/L16": {},
                 "audio/mpeg": {},
                 "audio/opus": {},
                 "audio/wav": {},

--- a/tldw_Server_API/app/api/v1/endpoints/reading.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading.py
@@ -1038,6 +1038,19 @@ async def summarize_reading_item(
 @router.post(
     "/items/{item_id}/tts",
     response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Generated reading item audio.",
+            "content": {
+                "audio/aac": {},
+                "audio/flac": {},
+                "audio/L16; rate=24000; channels=1": {},
+                "audio/mpeg": {},
+                "audio/opus": {},
+                "audio/wav": {},
+            },
+        },
+    },
     summary="Generate TTS audio for a reading item",
     dependencies=[Depends(rbac_rate_limit("reading.tts"))],
 )
@@ -1348,6 +1361,15 @@ async def create_reading_archive(
 @router.get(
     "/export",
     response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Reading item export download.",
+            "content": {
+                "application/x-ndjson": {},
+                "application/zip": {},
+            },
+        },
+    },
     summary="Export reading list items",
     dependencies=[Depends(rbac_rate_limit("reading.export"))],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/research_runs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/research_runs.py
@@ -132,7 +132,17 @@ async def delete_research_run(
     return ResearchRunDeleteResponse(deleted=bool(deleted))
 
 
-@router.get("/runs/{session_id}/events/stream", summary="Stream live deep research run events")
+@router.get(
+    "/runs/{session_id}/events/stream",
+    summary="Stream live deep research run events",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Server-sent events stream of research run updates",
+            "content": {"text/event-stream": {}},
+        },
+    },
+)
 async def stream_research_run_events(
     session_id: str = Path(..., min_length=1),
     after_id: int = Query(0, ge=0),

--- a/tldw_Server_API/app/api/v1/endpoints/skills.py
+++ b/tldw_Server_API/app/api/v1/endpoints/skills.py
@@ -403,7 +403,20 @@ async def import_skill_from_file(
         ) from e
 
 
-@router.get("/{skill_name}/export")
+@router.get(
+    "/{skill_name}/export",
+    response_class=Response,
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Skill zip archive",
+            "content": {
+                "application/zip": {
+                    "schema": {"type": "string", "format": "binary"},
+                },
+            },
+        },
+    },
+)
 async def export_skill(
     skill_name: str,
     service: SkillsService = Depends(get_skills_service),

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -2251,6 +2251,18 @@ async def generate_from_rag(
 
 @router.get(
     "/presentations/{presentation_id}/export",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Presentation export download.",
+            "content": {
+                "application/json": {},
+                "application/pdf": {},
+                "application/zip": {},
+                "text/markdown": {},
+            },
+        },
+    },
     summary="Export presentation",
     dependencies=[Depends(RequirePermission(MEDIA_READ)), Depends(rbac_rate_limit("slides.export"))],
 )

--- a/tldw_Server_API/app/api/v1/endpoints/storage_download.py
+++ b/tldw_Server_API/app/api/v1/endpoints/storage_download.py
@@ -18,7 +18,18 @@ async def _get_storage_service() -> StorageQuotaService:
     return await get_storage_service()
 
 
-@router.get("/files/{file_id}/download")
+@router.get(
+    "/files/{file_id}/download",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "description": "Generated file download.",
+            "content": {
+                "application/octet-stream": {},
+            },
+        },
+    },
+)
 async def download_file(
     file_id: int,
     user: User = Depends(get_request_user),

--- a/tldw_Server_API/app/api/v1/endpoints/user_keys.py
+++ b/tldw_Server_API/app/api/v1/endpoints/user_keys.py
@@ -1152,6 +1152,17 @@ async def authorize_openai_oauth(
     "/keys/openai/oauth/callback",
     response_model=OpenAIOAuthCallbackResponse,
     status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_303_SEE_OTHER: {
+            "description": "Redirect to the stored OAuth return path when redirect=true.",
+            "headers": {
+                "Location": {
+                    "description": "Stored OAuth return path.",
+                    "schema": {"type": "string"},
+                },
+            },
+        },
+    },
 )
 async def callback_openai_oauth(
     request: Request,

--- a/tldw_Server_API/app/api/v1/endpoints/users.py
+++ b/tldw_Server_API/app/api/v1/endpoints/users.py
@@ -346,7 +346,15 @@ router = APIRouter(prefix="/users", tags=["users"], responses={404: {"descriptio
 # User Profile Endpoints
 
 
-@router.get("/profile/catalog", response_model=UserProfileCatalogResponse)
+@router.get(
+    "/profile/catalog",
+    response_model=UserProfileCatalogResponse,
+    responses={
+        status.HTTP_304_NOT_MODIFIED: {
+            "description": "User profile catalog not modified (ETag match).",
+        },
+    },
+)
 async def get_user_profile_catalog(
     principal: AuthPrincipal = Depends(get_auth_principal),
     if_none_match: Optional[str] = Header(None),

--- a/tldw_Server_API/app/api/v1/endpoints/vn_assets.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_assets.py
@@ -338,6 +338,9 @@ async def review_item(
         200: {
             "description": "VN asset item content.",
             "content": {
+                "image/jpeg": {},
+                "image/png": {},
+                "image/webp": {},
                 "application/octet-stream": {},
             },
         },

--- a/tldw_Server_API/app/api/v1/endpoints/vn_assets.py
+++ b/tldw_Server_API/app/api/v1/endpoints/vn_assets.py
@@ -331,7 +331,18 @@ async def review_item(
         raise _handle_value_error(exc) from exc
 
 
-@router.get("/packs/{pack_id}/items/{item_id}/content")
+@router.get(
+    "/packs/{pack_id}/items/{item_id}/content",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "description": "VN asset item content.",
+            "content": {
+                "application/octet-stream": {},
+            },
+        },
+    },
+)
 async def get_item_content(
     pack_id: int,
     item_id: int,

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -1564,7 +1564,19 @@ async def list_sources(
 
 
 # OPML import/export placed before /sources/{source_id} to avoid route conflicts
-@router.get("/sources/export", summary="Export sources to OPML")
+@router.get(
+    "/sources/export",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Watchlist sources exported as OPML XML.",
+            "content": {
+                "application/xml": {},
+            },
+        },
+    },
+    summary="Export sources to OPML",
+)
 async def export_sources_opml(
     tag: list[str] | None = Query(None, description="Filter by tag(s)"),
     group: list[int] | None = Query(None, description="Filter by group id(s) (OR semantics)"),
@@ -3704,7 +3716,19 @@ async def list_runs_global(
     )
 
 
-@router.get("/runs/export.csv", response_class=PlainTextResponse, summary="Export runs as CSV (global or by job)")
+@router.get(
+    "/runs/export.csv",
+    response_class=PlainTextResponse,
+    responses={
+        200: {
+            "description": "Watchlist runs exported as CSV.",
+            "content": {
+                "text/csv; charset=utf-8": {},
+            },
+        },
+    },
+    summary="Export runs as CSV (global or by job)",
+)
 async def export_runs_csv(
     scope: str = Query("global", pattern="^(global|job)$"),
     job_id: int | None = Query(None, ge=1),
@@ -4451,7 +4475,19 @@ async def get_run_audio(
 # --------------------
 
 
-@router.get("/runs/{run_id}/tallies.csv", response_class=PlainTextResponse, summary="Export filter tallies for a run as CSV")
+@router.get(
+    "/runs/{run_id}/tallies.csv",
+    response_class=PlainTextResponse,
+    responses={
+        200: {
+            "description": "Watchlist run filter tallies exported as CSV.",
+            "content": {
+                "text/csv; charset=utf-8": {},
+            },
+        },
+    },
+    summary="Export filter tallies for a run as CSV",
+)
 async def export_run_tallies_csv(
     run_id: int = Path(..., ge=1),
     target_user_id: int | None = Query(
@@ -5528,7 +5564,21 @@ async def get_output(
     return output
 
 
-@router.get("/outputs/{output_id}/download", summary="Download rendered output")
+@router.get(
+    "/outputs/{output_id}/download",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Rendered watchlist output download.",
+            "content": {
+                "audio/mpeg": {},
+                "text/html": {},
+                "text/markdown": {},
+            },
+        },
+    },
+    summary="Download rendered output",
+)
 async def download_output(
     output_id: int = Path(..., ge=1),
     current_user: User = Depends(get_request_user),

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -3174,6 +3174,17 @@ async def verify_artifacts_batch(
 
 @router.get(
     "/artifacts/{artifact_id}/download",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "description": "Workflow artifact file download.",
+            "content": {"application/octet-stream": {}},
+        },
+        206: {
+            "description": "Partial workflow artifact file download.",
+            "content": {"application/octet-stream": {}},
+        },
+    },
     dependencies=[
         Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],
@@ -3358,6 +3369,13 @@ async def download_artifact(
 
 @router.get(
     "/runs/{run_id}/artifacts/download",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Workflow run artifacts ZIP download.",
+            "content": {"application/zip": {}},
+        },
+    },
     dependencies=[
         Depends(RequirePermission(WORKFLOWS_RUNS_READ)),
     ],

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1996,6 +1996,7 @@ def _ensure_openapi_operation_tags_declared(openapi_schema: dict[str, Any]) -> N
 
 # Add global security schemes, servers, and branding to the generated OpenAPI schema
 def custom_openapi():
+    # All schema normalization below is covered by FastAPI's OpenAPI schema cache.
     if app.openapi_schema:
         return app.openapi_schema
 

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1988,7 +1988,9 @@ def _ensure_openapi_operation_tags_declared(openapi_schema: dict[str, Any]) -> N
         for method, operation in operations.items():
             if method.lower() not in _OPENAPI_HTTP_METHODS or not isinstance(operation, dict):
                 continue
-            operation_tags.update(tag for tag in operation.get("tags", []) if isinstance(tag, str))
+            op_tags = operation.get("tags", [])
+            if isinstance(op_tags, (list, tuple, set)):
+                operation_tags.update(tag for tag in op_tags if isinstance(tag, str))
 
     for missing_tag in sorted(operation_tags - declared_tags):
         tags.append({"name": missing_tag})
@@ -2746,8 +2748,9 @@ async def readiness_alias(request: Request) -> JSONResponse:
 
 
 def _add_public_control_plane_route(path: str, endpoint: Any) -> None:
-    app.add_api_route(path, endpoint, methods=["GET"], openapi_extra={"security": []})
-    app.add_api_route(path, endpoint, methods=["HEAD"], openapi_extra={"security": []})
+    route_kwargs = {"tags": ["health"], "openapi_extra": {"security": []}}
+    app.add_api_route(path, endpoint, methods=["GET"], **route_kwargs)
+    app.add_api_route(path, endpoint, methods=["HEAD"], **route_kwargs)
 
 
 # Register control-plane health endpoints (works in both minimal and full modes)

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1970,6 +1970,30 @@ async def _guard_sandbox_artifact_path(request: Request, call_next):
     return await call_next(request)
 
 
+_OPENAPI_HTTP_METHODS = {"get", "post", "put", "patch", "delete", "options", "head", "trace"}
+
+
+def _ensure_openapi_operation_tags_declared(openapi_schema: dict[str, Any]) -> None:
+    tags = openapi_schema.setdefault("tags", [])
+    declared_tags = {
+        tag["name"]
+        for tag in tags
+        if isinstance(tag, dict) and isinstance(tag.get("name"), str)
+    }
+    operation_tags: set[str] = set()
+
+    for operations in openapi_schema.get("paths", {}).values():
+        if not isinstance(operations, dict):
+            continue
+        for method, operation in operations.items():
+            if method.lower() not in _OPENAPI_HTTP_METHODS or not isinstance(operation, dict):
+                continue
+            operation_tags.update(tag for tag in operation.get("tags", []) if isinstance(tag, str))
+
+    for missing_tag in sorted(operation_tags - declared_tags):
+        tags.append({"name": missing_tag})
+
+
 # Add global security schemes, servers, and branding to the generated OpenAPI schema
 def custom_openapi():
     if app.openapi_schema:
@@ -1982,6 +2006,7 @@ def custom_openapi():
         routes=app.routes,
         tags=OPENAPI_TAGS,
     )
+    _ensure_openapi_operation_tags_declared(openapi_schema)
 
     # Servers for common deployments
     openapi_schema["servers"] = [
@@ -2458,7 +2483,21 @@ async def favicon():
     return FileResponse(FAVICON_PATH, media_type="image/x-icon")
 
 
-@app.get("/", openapi_extra={"security": []})
+@app.get(
+    "/",
+    openapi_extra={"security": []},
+    responses={
+        _starlette_status.HTTP_307_TEMPORARY_REDIRECT: {
+            "description": "Redirect to the first-time setup page when setup is required.",
+            "headers": {
+                "Location": {
+                    "description": "Setup page URL.",
+                    "schema": {"type": "string"},
+                },
+            },
+        },
+    },
+)
 async def root():
     try:
         if needs_setup():
@@ -2705,19 +2744,24 @@ async def readiness_alias(request: Request) -> JSONResponse:
     return await readiness_check(request)
 
 
+def _add_public_control_plane_route(path: str, endpoint: Any) -> None:
+    app.add_api_route(path, endpoint, methods=["GET"], openapi_extra={"security": []})
+    app.add_api_route(path, endpoint, methods=["HEAD"], openapi_extra={"security": []})
+
+
 # Register control-plane health endpoints (works in both minimal and full modes)
 try:
     if route_enabled("health"):
-        app.add_api_route("/health", health_check, methods=["GET", "HEAD"], openapi_extra={"security": []})
-        app.add_api_route("/ready", readiness_check, methods=["GET", "HEAD"], openapi_extra={"security": []})
-        app.add_api_route("/health/ready", readiness_alias, methods=["GET", "HEAD"], openapi_extra={"security": []})
+        _add_public_control_plane_route("/health", health_check)
+        _add_public_control_plane_route("/ready", readiness_check)
+        _add_public_control_plane_route("/health/ready", readiness_alias)
     else:
         logger.info("Route disabled by policy: health (/health, /ready, /health/ready)")
 except _STARTUP_GUARD_EXCEPTIONS as _health_rt_err:
     logger.warning(f"Route gating error for health; including by default. Error: {_health_rt_err}")
-    app.add_api_route("/health", health_check, methods=["GET", "HEAD"], openapi_extra={"security": []})
-    app.add_api_route("/ready", readiness_check, methods=["GET", "HEAD"], openapi_extra={"security": []})
-    app.add_api_route("/health/ready", readiness_alias, methods=["GET", "HEAD"], openapi_extra={"security": []})
+    _add_public_control_plane_route("/health", health_check)
+    _add_public_control_plane_route("/ready", readiness_check)
+    _add_public_control_plane_route("/health/ready", readiness_alias)
 
 # Import-time CI/startup guard: fail immediately if the route table contains duplicates.
 _fail_on_duplicate_route_method_pairs(app, context="module import")

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_timed_segments.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_timed_segments.py
@@ -298,6 +298,7 @@ def test_audio_transcriptions_uses_provider_timed_segments_for_srt(monkeypatch, 
         if resp.status_code == 404:
             pytest.skip("audio/transcriptions endpoint not mounted in this build")
         assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"].startswith("application/x-subrip")
         assert "00:00:01,000 --> 00:00:02,500" in resp.text
         assert "00:00:02,500 --> 00:00:04,000" in resp.text
         assert "00:00:00,000 --> 00:00:10,000" not in resp.text

--- a/tldw_Server_API/tests/Embeddings/test_orchestrator_sse_unified_flag.py
+++ b/tldw_Server_API/tests/Embeddings/test_orchestrator_sse_unified_flag.py
@@ -3,6 +3,7 @@ Integration test (function-level) for embeddings orchestrator SSE behind STREAMS
 direct endpoint invocation to avoid event-loop conflicts with the Redis harness.
 """
 
+import asyncio
 import os
 import json
 import pytest
@@ -70,3 +71,63 @@ def test_embeddings_orchestrator_events_unified_sse(redis_client, monkeypatch):
     finally:
         os.environ.pop("STREAMS_UNIFIED", None)
         os.environ.pop("STREAM_HEARTBEAT_MODE", None)
+
+
+@pytest.mark.asyncio
+async def test_embeddings_orchestrator_events_unified_normal_close_cancels_producer(monkeypatch) -> None:
+    os.environ["STREAMS_UNIFIED"] = "1"
+
+    try:
+        from tldw_Server_API.app.api.v1.endpoints import embeddings_v5_production_enhanced as endpoint
+        from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+
+        created_tasks: list[asyncio.Task] = []
+
+        class _FakeSSEStream:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def send_event(self, _event, _payload):
+                return None
+
+            async def error(self, *_args, **_kwargs):
+                return None
+
+            async def iter_sse(self):
+                if False:
+                    yield ""
+                return
+
+        async def _fake_get_redis_client():
+            return object()
+
+        async def _fake_build_snapshot(_client):
+            return {"queues": {}, "stages": {}, "flags": {}, "ts": "now"}
+
+        async def _fake_close(_client):
+            return None
+
+        real_create_task = asyncio.create_task
+
+        def _tracked_create_task(coro):
+            task = real_create_task(coro)
+            created_tasks.append(task)
+            return task
+
+        monkeypatch.setattr(endpoint, "SSEStream", _FakeSSEStream)
+        monkeypatch.setattr(endpoint, "_get_redis_client", _fake_get_redis_client)
+        monkeypatch.setattr(endpoint, "_build_orchestrator_snapshot", _fake_build_snapshot)
+        monkeypatch.setattr(endpoint, "ensure_async_client_closed", _fake_close)
+        monkeypatch.setattr(endpoint.asyncio, "create_task", _tracked_create_task)
+
+        admin = User(id=1, username="admin", email="a@x", is_active=True, is_admin=True)
+        response = await endpoint.orchestrator_events(_current_user=admin)
+        iterator = response.body_iterator
+
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+
+        assert len(created_tasks) == 1
+        assert created_tasks[0].cancelled()
+    finally:
+        os.environ.pop("STREAMS_UNIFIED", None)

--- a/tldw_Server_API/tests/Services/test_openapi_contracts.py
+++ b/tldw_Server_API/tests/Services/test_openapi_contracts.py
@@ -327,6 +327,32 @@ def test_openapi_declares_all_operation_tags(openapi_spec: dict[str, Any]) -> No
 
 
 @pytest.mark.integration
+def test_custom_openapi_reuses_cached_schema_for_tag_declarations(monkeypatch) -> None:
+    """Operation tag declaration normalization should run only on the first schema build."""
+    from tldw_Server_API.app import main as main_module
+
+    helper_calls = 0
+    original_schema = main_module.app.openapi_schema
+    original_helper = main_module._ensure_openapi_operation_tags_declared
+
+    def counting_helper(openapi_schema: dict[str, Any]) -> None:
+        nonlocal helper_calls
+        helper_calls += 1
+        original_helper(openapi_schema)
+
+    monkeypatch.setattr(main_module, "_ensure_openapi_operation_tags_declared", counting_helper)
+    main_module.app.openapi_schema = None
+    try:
+        first_schema = main_module.app.openapi()
+        second_schema = main_module.app.openapi()
+    finally:
+        main_module.app.openapi_schema = original_schema
+
+    assert second_schema is first_schema
+    assert helper_calls == 1
+
+
+@pytest.mark.integration
 def test_openapi_path_parameters_match_route_templates(openapi_spec: dict[str, Any]) -> None:
     """Path placeholders and OpenAPI path parameters must stay in sync for generated clients."""
     missing_parameters: list[str] = []

--- a/tldw_Server_API/tests/Services/test_openapi_contracts.py
+++ b/tldw_Server_API/tests/Services/test_openapi_contracts.py
@@ -35,6 +35,7 @@ AUDIO_SPEECH_CONTENT_TYPES = {
 }
 AUDIO_TRANSCRIPTION_CONTENT_TYPES = {
     "application/json",
+    "application/x-subrip",
     "text/plain",
     "text/vtt",
 }

--- a/tldw_Server_API/tests/Services/test_openapi_contracts.py
+++ b/tldw_Server_API/tests/Services/test_openapi_contracts.py
@@ -1,0 +1,1173 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+import re
+from typing import Any
+
+from fastapi import FastAPI
+import pytest
+
+
+HTTP_METHODS = {"get", "post", "put", "patch", "delete", "options", "head", "trace"}
+PATH_PARAMETER_PATTERN = re.compile(r"{([^}/]+)}")
+CANONICAL_PAGINATION_COMPONENT_FIELDS = {
+    "OffsetPaginationMeta": {"mode", "limit", "offset", "total", "has_more", "next_offset"},
+    "CursorPaginationMeta": {"mode", "limit", "cursor", "next_cursor", "has_more"},
+    "PagePaginationMeta": {"mode", "page", "per_page", "total", "total_pages", "has_more"},
+}
+SKILLS_EXPORT_PATH = "/api/v1/skills/{skill_name}/export"
+SKILLS_ITEM_PATH = "/api/v1/skills/{skill_name}"
+STREAMING_RESPONSE_EXEMPTIONS = {
+    ("get", "/api/v1/admin/events/stream"): "text/event-stream",
+    ("get", "/api/v1/media/ingest/jobs/events/stream"): "text/event-stream",
+    ("post", "/api/v1/media/mediawiki/ingest-dump"): "application/x-ndjson",
+    ("post", "/api/v1/media/mediawiki/process-dump"): "application/x-ndjson",
+    ("get", "/api/v1/research/runs/{session_id}/events/stream"): "text/event-stream",
+    ("post", "/api/v1/rag/search/stream"): "application/x-ndjson",
+}
+AUDIO_SPEECH_CONTENT_TYPES = {
+    "audio/aac",
+    "audio/flac",
+    "audio/L16; rate=24000; channels=1",
+    "audio/mpeg",
+    "audio/opus",
+    "audio/wav",
+}
+AUDIO_TRANSCRIPTION_CONTENT_TYPES = {
+    "application/json",
+    "text/plain",
+    "text/vtt",
+}
+AUDIO_TOKENIZER_DECODE_CONTENT_TYPES = {
+    "application/octet-stream",
+    "audio/wav",
+}
+AUDIO_TTS_HISTORY_PATH = "/api/v1/audio/history/{history_id}"
+CONFIG_QUICKSTART_PATH = "/api/v1/config/quickstart"
+ROOT_PATH = "/"
+FEDERATION_LOGIN_PATH = "/api/v1/auth/federation/{provider_slug}/login"
+OPENAI_OAUTH_CALLBACK_PATH = "/api/v1/users/keys/openai/oauth/callback"
+OUTPUT_DOWNLOAD_CONTENT_TYPES = {
+    "application/octet-stream",
+    "audio/mpeg",
+    "text/html; charset=utf-8",
+    "text/markdown; charset=utf-8",
+}
+OUTPUT_DOWNLOAD_PATH = "/api/v1/outputs/{output_id}/download"
+FILE_ARTIFACT_EXPORT_CONTENT_TYPES = {
+    "application/json",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "text/calendar",
+    "text/csv",
+    "text/html",
+    "text/markdown",
+}
+FILE_ARTIFACT_EXPORT_PATH = "/api/v1/files/{file_id}/export"
+CHAT_COMPLETIONS_PATH = "/api/v1/chat/completions"
+MESSAGES_COMPLETION_PATHS = ("/api/v1/messages", "/v1/messages")
+PROMETHEUS_TEXT_RESPONSE_PATHS = ("/api/v1/metrics/text", "/api/v1/mcp/metrics/prometheus")
+MCP_REQUEST_PATH = "/api/v1/mcp/request"
+CLAIMS_ANALYTICS_EXPORT_DOWNLOAD_PATH = "/api/v1/claims/analytics/export/{export_id}"
+PRIVILEGE_SNAPSHOT_CSV_EXPORT_PATH = "/api/v1/privileges/snapshots/{snapshot_id}/export.csv"
+EVALUATIONS_ABTEST_EVENTS_PATH = "/api/v1/evaluations/embeddings/abtest/{test_id}/events"
+EVALUATIONS_ABTEST_EXPORT_PATH = "/api/v1/evaluations/embeddings/abtest/{test_id}/export"
+EVALUATIONS_METRICS_PATH = "/api/v1/evaluations/metrics"
+STORAGE_FILE_DOWNLOAD_PATH = "/api/v1/storage/files/{file_id}/download"
+JOBS_EVENTS_STREAM_PATH = "/api/v1/jobs/events/stream"
+WATCHLIST_SOURCES_EXPORT_PATH = "/api/v1/watchlists/sources/export"
+WATCHLIST_RUNS_CSV_EXPORT_PATH = "/api/v1/watchlists/runs/export.csv"
+WATCHLIST_RUN_TALLIES_CSV_EXPORT_PATH = "/api/v1/watchlists/runs/{run_id}/tallies.csv"
+WATCHLIST_OUTPUT_DOWNLOAD_PATH = "/api/v1/watchlists/outputs/{output_id}/download"
+WATCHLIST_OUTPUT_DOWNLOAD_CONTENT_TYPES = {
+    "audio/mpeg",
+    "text/html",
+    "text/markdown",
+}
+CHARACTER_EXPORT_PATH = "/api/v1/characters/{character_id}/export"
+ADMIN_USAGE_CSV_EXPORT_PATHS = (
+    "/api/v1/admin/usage/daily/export.csv",
+    "/api/v1/admin/usage/top/export.csv",
+    "/api/v1/admin/llm-usage/export.csv",
+)
+ADMIN_JSON_CSV_EXPORT_PATHS = (
+    "/api/v1/admin/users/export",
+    "/api/v1/admin/audit-log/export",
+)
+FLASHCARD_ASSET_CONTENT_PATH = "/api/v1/flashcards/assets/{asset_uuid}/content"
+FLASHCARD_EXPORT_PATH = "/api/v1/flashcards/export"
+FLASHCARD_EXPORT_CONTENT_TYPES = {
+    "application/apkg",
+    "application/json; charset=utf-8",
+    "text/csv; charset=utf-8",
+    "text/tab-separated-values; charset=utf-8",
+}
+READING_TTS_PATH = "/api/v1/reading/items/{item_id}/tts"
+READING_EXPORT_PATH = "/api/v1/reading/export"
+READING_EXPORT_CONTENT_TYPES = {
+    "application/x-ndjson",
+    "application/zip",
+}
+AUDIT_EXPORT_PATH = "/api/v1/audit/export"
+AUDIT_EXPORT_CONTENT_TYPES = {
+    "application/json",
+    "application/x-ndjson",
+    "text/csv",
+}
+MEETING_EVENTS_PATH = "/api/v1/meetings/sessions/{session_id}/events"
+NOTIFICATIONS_STREAM_PATH = "/api/v1/notifications/stream"
+VN_ASSET_CONTENT_PATH = "/api/v1/vn-assets/packs/{pack_id}/items/{item_id}/content"
+SLIDES_EXPORT_PATH = "/api/v1/slides/presentations/{presentation_id}/export"
+SLIDES_EXPORT_CONTENT_TYPES = {
+    "application/json",
+    "application/pdf",
+    "application/zip",
+    "text/markdown",
+}
+WEBSUB_VERIFY_CALLBACK_PATH = "/api/v1/websub/callback/{user_id}/{callback_token}"
+WEBSUB_PUSH_CALLBACK_PATH = "/api/v1/websub/callback/{user_id}/{callback_token}"
+NOTES_CSV_EXPORT_PATHS = (
+    "/api/v1/notes/export.csv",
+)
+NOTES_ATTACHMENT_DOWNLOAD_PATH = "/api/v1/notes/{note_id}/attachments/{file_name}"
+CONNECTOR_PROVIDER_WEBHOOK_PATH = "/api/v1/connectors/providers/{provider}/webhook"
+WORKFLOW_ARTIFACT_DOWNLOAD_PATH = "/api/v1/workflows/artifacts/{artifact_id}/download"
+WORKFLOW_RUN_ARTIFACTS_DOWNLOAD_PATH = "/api/v1/workflows/runs/{run_id}/artifacts/download"
+DATA_TABLE_EXPORT_PATH = "/api/v1/data-tables/{table_uuid}/export"
+DATA_TABLE_EXPORT_CONTENT_TYPES = {
+    "application/json",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "text/csv",
+}
+CHAT_DOCUMENT_GENERATE_PATH = "/api/v1/chat/documents/generate"
+ACP_SESSION_EVENTS_STREAM_PATH = "/api/v1/acp/sessions/{session_id}/events/stream"
+MCP_HUB_EVENTS_STREAM_PATH = "/api/v1/mcp/hub/events/stream"
+EMBEDDINGS_ORCHESTRATOR_EVENTS_PATH = "/api/v1/embeddings/orchestrator/events"
+CHARACTER_CHAT_COMPLETION_V2_PATH = "/api/v1/chats/{chat_id}/complete-v2"
+PAPER_SEARCH_RAW_JSON_XML_HTML_PATHS = (
+    "/api/v1/paper-search/medrxiv/raw/details",
+    "/api/v1/paper-search/biorxiv/raw/details",
+)
+PAPER_SEARCH_RAW_JSON_CSV_PATHS = (
+    "/api/v1/paper-search/medrxiv/raw/pubs",
+    "/api/v1/paper-search/medrxiv/raw/pub",
+    "/api/v1/paper-search/biorxiv/raw/pubs",
+    "/api/v1/paper-search/biorxiv/raw/pub",
+    "/api/v1/paper-search/biorxiv/raw/reports/summary",
+    "/api/v1/paper-search/biorxiv/raw/reports/usage",
+)
+PAPER_SEARCH_RAW_JSON_XML_PATHS = (
+    "/api/v1/paper-search/biorxiv/raw/funder",
+)
+PAPER_SEARCH_RAW_XML_PATHS = (
+    "/api/v1/paper-search/chemrxiv/oai",
+    "/api/v1/paper-search/zenodo/oai",
+    "/api/v1/paper-search/figshare/oai",
+)
+PAPER_SEARCH_RAW_JSON_PATHS = (
+    "/api/v1/paper-search/iacr/conf/raw",
+    "/api/v1/paper-search/osf/raw",
+    "/api/v1/paper-search/osf/raw/by-id",
+)
+PAPER_SEARCH_PMC_OA_PDF_PATH = "/api/v1/paper-search/pmc-oa/fetch-pdf"
+PAPER_SEARCH_HAL_RAW_PATH = "/api/v1/paper-search/hal/raw"
+MEDIA_FILE_PATH = "/api/v1/media/{media_id}/file"
+NOT_MODIFIED_RESPONSE_OPERATIONS = (
+    ("get", "/api/v1/users/profile/catalog"),
+    ("get", "/api/v1/media/"),
+    ("get", "/api/v1/media/trash"),
+    ("get", "/api/v1/media/metadata-search"),
+    ("get", "/api/v1/media/by-identifier"),
+    ("post", "/api/v1/media/search"),
+    ("get", "/api/v1/media/{media_id}"),
+    ("get", MEDIA_FILE_PATH),
+)
+
+
+@pytest.fixture()
+def openapi_spec(client_user_only) -> dict[str, Any]:
+    response = client_user_only.get("/openapi.json")
+    assert response.status_code == 200
+    return response.json()
+
+
+def _iter_internal_refs(node: Any, path: tuple[str, ...] = ()) -> Iterator[tuple[str, str]]:
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/"):
+            yield ".".join(path + ("$ref",)), ref
+        for key, value in node.items():
+            yield from _iter_internal_refs(value, path + (str(key),))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from _iter_internal_refs(value, path + (str(index),))
+
+
+def _resolve_json_pointer(document: dict[str, Any], pointer: str) -> Any:
+    current: Any = document
+    for raw_part in pointer.removeprefix("#/").split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(part)
+        current = current[part]
+    return current
+
+
+def _iter_http_operations(openapi_spec: dict[str, Any]) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    for route, operations in openapi_spec.get("paths", {}).items():
+        if not isinstance(operations, dict):
+            continue
+        for method, operation in operations.items():
+            if method.lower() in HTTP_METHODS and isinstance(operation, dict):
+                yield route, method, operation
+
+
+def _contains_ref_fragment(node: Any, fragment: str) -> bool:
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and fragment in ref:
+            return True
+        return any(_contains_ref_fragment(value, fragment) for value in node.values())
+    if isinstance(node, list):
+        return any(_contains_ref_fragment(item, fragment) for item in node)
+    return False
+
+
+def _assert_streaming_response_content(operation: dict[str, Any], media_type: str) -> None:
+    content = operation["responses"]["200"].get("content", {})
+
+    assert media_type in content
+    assert "application/json" not in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+def _assert_file_response_content(operation: dict[str, Any], media_types: set[str]) -> None:
+    content = operation["responses"]["200"].get("content", {})
+
+    assert media_types.issubset(content)
+    assert "application/json" not in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+def _assert_no_body_response(operation: dict[str, Any], status_code: str = "200") -> None:
+    response = operation["responses"][status_code]
+
+    assert "content" not in response
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+def _assert_redirect_response(operation: dict[str, Any], status_code: str) -> None:
+    response = operation["responses"][status_code]
+    headers = {key.lower(): value for key, value in response.get("headers", {}).items()}
+
+    assert "content" not in response
+    assert "location" in headers
+    assert headers["location"]["schema"]["type"] == "string"
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+def _assert_raw_response_content(operation: dict[str, Any], media_types: set[str]) -> None:
+    content = operation["responses"]["200"].get("content", {})
+
+    assert media_types.issubset(content)
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_openapi_internal_refs_resolve(openapi_spec: dict[str, Any]) -> None:
+    """Every internal OpenAPI JSON pointer must resolve inside the generated spec."""
+    missing: list[str] = []
+    for path, ref in _iter_internal_refs(openapi_spec):
+        try:
+            _resolve_json_pointer(openapi_spec, ref)
+        except KeyError:
+            missing.append(f"{path}: {ref}")
+
+    assert not missing, "Unresolved OpenAPI refs:\n" + "\n".join(missing[:50])
+
+
+@pytest.mark.integration
+def test_openapi_operation_ids_are_present_and_unique(openapi_spec: dict[str, Any]) -> None:
+    """Each HTTP operation must expose one globally unique operationId for client generation."""
+    seen: dict[str, str] = {}
+    missing: list[str] = []
+    duplicates: list[str] = []
+
+    for route, method, operation in _iter_http_operations(openapi_spec):
+        location = f"{method.upper()} {route}"
+        operation_id = operation.get("operationId")
+        if not isinstance(operation_id, str) or not operation_id.strip():
+            missing.append(location)
+            continue
+
+        existing_location = seen.setdefault(operation_id, location)
+        if existing_location != location:
+            duplicates.append(f"{operation_id}: {existing_location} and {location}")
+
+    assert not missing, "OpenAPI operations missing operationId:\n" + "\n".join(missing[:50])
+    assert not duplicates, "Duplicate OpenAPI operationIds:\n" + "\n".join(duplicates[:50])
+
+
+@pytest.mark.integration
+def test_openapi_declares_all_operation_tags(openapi_spec: dict[str, Any]) -> None:
+    """Every operation tag must be declared at the top level so docs and generators can group them."""
+    declared_tags = {
+        tag["name"]
+        for tag in openapi_spec.get("tags", [])
+        if isinstance(tag, dict) and isinstance(tag.get("name"), str)
+    }
+    used_tags: set[str] = set()
+    for _, _, operation in _iter_http_operations(openapi_spec):
+        used_tags.update(tag for tag in operation.get("tags", []) if isinstance(tag, str))
+
+    missing_tags = sorted(used_tags - declared_tags)
+    assert not missing_tags, "OpenAPI operation tags missing top-level declarations:\n" + "\n".join(missing_tags[:80])
+
+
+@pytest.mark.integration
+def test_openapi_path_parameters_match_route_templates(openapi_spec: dict[str, Any]) -> None:
+    """Path placeholders and OpenAPI path parameters must stay in sync for generated clients."""
+    missing_parameters: list[str] = []
+    extra_parameters: list[str] = []
+    optional_parameters: list[str] = []
+
+    for route, method, operation in _iter_http_operations(openapi_spec):
+        route_parameters = set(PATH_PARAMETER_PATTERN.findall(route))
+        operation_parameters = [
+            parameter
+            for parameter in operation.get("parameters", [])
+            if isinstance(parameter, dict) and parameter.get("in") == "path"
+        ]
+        declared_parameters = {
+            parameter["name"]
+            for parameter in operation_parameters
+            if isinstance(parameter.get("name"), str)
+        }
+        location = f"{method.upper()} {route}"
+
+        for name in sorted(route_parameters - declared_parameters):
+            missing_parameters.append(f"{location}: missing {name}")
+        for name in sorted(declared_parameters - route_parameters):
+            extra_parameters.append(f"{location}: extra {name}")
+        for parameter in operation_parameters:
+            if parameter.get("required") is not True:
+                optional_parameters.append(f"{location}: {parameter.get('name')}")
+
+    assert not missing_parameters, "OpenAPI path parameters missing route placeholders:\n" + "\n".join(
+        missing_parameters[:50]
+    )
+    assert not extra_parameters, "OpenAPI path parameters not present in route template:\n" + "\n".join(
+        extra_parameters[:50]
+    )
+    assert not optional_parameters, "OpenAPI path parameters must be required:\n" + "\n".join(
+        optional_parameters[:50]
+    )
+
+
+@pytest.mark.integration
+def test_openapi_declares_canonical_pagination_components(openapi_spec: dict[str, Any]) -> None:
+    """Canonical pagination helper component names must stay stable for clients."""
+    schemas = openapi_spec["components"]["schemas"]
+    missing_components: list[str] = []
+    missing_fields: list[str] = []
+
+    for component_name, expected_fields in CANONICAL_PAGINATION_COMPONENT_FIELDS.items():
+        schema = schemas.get(component_name)
+        if not isinstance(schema, dict):
+            missing_components.append(component_name)
+            continue
+
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            missing_fields.append(f"{component_name}: missing properties")
+            continue
+
+        for field_name in sorted(expected_fields - set(properties)):
+            missing_fields.append(f"{component_name}: missing {field_name}")
+
+    assert not missing_components, "Missing canonical pagination schemas:\n" + "\n".join(missing_components)
+    assert not missing_fields, "Canonical pagination schema fields drifted:\n" + "\n".join(missing_fields)
+
+
+@pytest.mark.integration
+def test_openapi_preserves_skills_file_and_no_content_exemptions(openapi_spec: dict[str, Any]) -> None:
+    """Skills file downloads and 204 deletes must not be modeled as JSON envelopes."""
+    paths = openapi_spec["paths"]
+
+    export_operation = paths[SKILLS_EXPORT_PATH]["get"]
+    export_response = export_operation["responses"]["200"]
+    export_content = export_response.get("content", {})
+    assert "application/zip" in export_content
+    assert "application/json" not in export_content
+    assert not _contains_ref_fragment(export_operation, "ResponseEnvelope")
+
+    delete_response = paths[SKILLS_ITEM_PATH]["delete"]["responses"]["204"]
+    assert not delete_response.get("content")
+    assert not _contains_ref_fragment(delete_response, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_openapi_preserves_streaming_response_exemptions(openapi_spec: dict[str, Any]) -> None:
+    """Streaming SSE and NDJSON routes must not be modeled as JSON envelopes."""
+    paths = openapi_spec["paths"]
+
+    for (method, path), media_type in STREAMING_RESPONSE_EXEMPTIONS.items():
+        operation = paths[path][method]
+
+        _assert_streaming_response_content(operation, media_type)
+
+
+@pytest.mark.integration
+def test_audio_job_progress_stream_openapi_documents_sse_response() -> None:
+    """Audio job progress SSE docs must stay correct even when minimal app skips the router."""
+    from tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs import router as audio_jobs_router
+
+    app = FastAPI()
+    app.include_router(audio_jobs_router, prefix="/api/v1/audio")
+    operation = app.openapi()["paths"]["/api/v1/audio/jobs/{job_id}/progress/stream"]["get"]
+
+    _assert_streaming_response_content(operation, "text/event-stream")
+
+
+@pytest.mark.integration
+def test_audio_speech_openapi_documents_audio_response() -> None:
+    """OpenAI-compatible speech responses must be documented as audio, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.audio.audio_tts import router as audio_tts_router
+
+    app = FastAPI()
+    app.include_router(audio_tts_router, prefix="/api/v1/audio")
+    operation = app.openapi()["paths"]["/api/v1/audio/speech"]["post"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert AUDIO_SPEECH_CONTENT_TYPES.issubset(content)
+    assert "application/json" not in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_audio_transcription_openapi_documents_text_and_json_responses() -> None:
+    """OpenAI-compatible transcription and translation responses must document text and JSON formats."""
+    from tldw_Server_API.app.api.v1.endpoints.audio.audio_transcriptions import router as audio_transcriptions_router
+
+    app = FastAPI()
+    app.include_router(audio_transcriptions_router, prefix="/api/v1/audio")
+    paths = app.openapi()["paths"]
+
+    for path in ("/api/v1/audio/transcriptions", "/api/v1/audio/translations"):
+        operation = paths[path]["post"]
+        content = operation["responses"]["200"].get("content", {})
+
+        assert AUDIO_TRANSCRIPTION_CONTENT_TYPES.issubset(content)
+        assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_audio_voice_preview_openapi_documents_audio_response() -> None:
+    """Custom voice preview responses must be documented as audio, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.audio.audio_voices import router as audio_voices_router
+
+    app = FastAPI()
+    app.include_router(audio_voices_router, prefix="/api/v1/audio")
+    operation = app.openapi()["paths"]["/api/v1/audio/voices/{voice_id}/preview"]["post"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "audio/mpeg" in content
+    assert "application/json" not in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_audio_tokenizer_decode_openapi_documents_audio_response() -> None:
+    """Audio tokenizer decode responses must be documented as audio bytes, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.audio.audio_tokenizer import router as audio_tokenizer_router
+
+    app = FastAPI()
+    app.include_router(audio_tokenizer_router, prefix="/api/v1/audio")
+    operation = app.openapi()["paths"]["/api/v1/audio/tokenizer/decode"]["post"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert AUDIO_TOKENIZER_DECODE_CONTENT_TYPES.issubset(content)
+    assert "application/json" not in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_audio_tts_history_delete_openapi_documents_no_content_response() -> None:
+    """TTS history deletes must document the 204 no-content response they return."""
+    from tldw_Server_API.app.api.v1.endpoints.audio.audio_history import router as audio_history_router
+
+    app = FastAPI()
+    app.include_router(audio_history_router, prefix="/api/v1/audio")
+    operation = app.openapi()["paths"][AUDIO_TTS_HISTORY_PATH]["delete"]
+
+    _assert_no_body_response(operation, "204")
+
+
+@pytest.mark.integration
+def test_config_quickstart_openapi_documents_redirect_and_html_fallback(openapi_spec: dict[str, Any]) -> None:
+    """Quickstart must document its redirect response and built-in HTML fallback."""
+    operation = openapi_spec["paths"][CONFIG_QUICKSTART_PATH]["get"]
+    fallback_content = operation["responses"]["200"].get("content", {})
+
+    assert "307" in operation["responses"]
+    assert "text/html" in fallback_content
+    assert "application/json" not in fallback_content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_redirect_routes_openapi_document_location_responses(openapi_spec: dict[str, Any]) -> None:
+    """Routes that return redirects must document the redirect status and Location header."""
+    cases = (
+        (ROOT_PATH, "get", "307"),
+        (FEDERATION_LOGIN_PATH, "get", "307"),
+        (OPENAI_OAUTH_CALLBACK_PATH, "get", "303"),
+    )
+
+    for path, method, status_code in cases:
+        operation = openapi_spec["paths"][path][method]
+
+        _assert_redirect_response(operation, status_code)
+
+
+@pytest.mark.integration
+def test_zip_download_openapi_documents_file_responses() -> None:
+    """Zip download routes must be documented as files, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.admin.admin_bundle_ops import router as admin_bundle_router
+    from tldw_Server_API.app.api.v1.endpoints.chatbooks import router as chatbooks_router
+
+    app = FastAPI()
+    app.include_router(admin_bundle_router, prefix="/api/v1/admin")
+    app.include_router(chatbooks_router, prefix="/api/v1")
+    paths = app.openapi()["paths"]
+
+    _assert_file_response_content(
+        paths["/api/v1/admin/backups/bundles/{bundle_id}/download"]["get"],
+        {"application/zip"},
+    )
+    _assert_file_response_content(
+        paths["/api/v1/chatbooks/download/{job_id}"]["get"],
+        {"application/zip"},
+    )
+
+
+@pytest.mark.integration
+def test_output_download_openapi_documents_file_responses() -> None:
+    """Output artifact downloads must advertise file media types instead of JSON."""
+    from tldw_Server_API.app.api.v1.endpoints.outputs import router as outputs_router
+
+    app = FastAPI()
+    app.include_router(outputs_router, prefix="/api/v1")
+    paths = app.openapi()["paths"]
+
+    _assert_file_response_content(
+        paths["/api/v1/outputs/{output_id}/download"]["get"],
+        OUTPUT_DOWNLOAD_CONTENT_TYPES,
+    )
+    _assert_file_response_content(
+        paths["/api/v1/outputs/download/by-name"]["get"],
+        OUTPUT_DOWNLOAD_CONTENT_TYPES,
+    )
+
+
+@pytest.mark.integration
+def test_output_download_head_openapi_documents_no_body_response() -> None:
+    """Output download HEAD checks must be documented as header-only responses."""
+    from tldw_Server_API.app.api.v1.endpoints.outputs import router as outputs_router
+
+    app = FastAPI()
+    app.include_router(outputs_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][OUTPUT_DOWNLOAD_PATH]["head"]
+
+    _assert_no_body_response(operation)
+
+
+@pytest.mark.integration
+def test_file_artifact_export_openapi_documents_file_responses(openapi_spec: dict[str, Any]) -> None:
+    """File artifact exports must advertise raw file media types for generated clients."""
+    operation = openapi_spec["paths"][FILE_ARTIFACT_EXPORT_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert FILE_ARTIFACT_EXPORT_CONTENT_TYPES.issubset(content)
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_openai_chat_completion_openapi_documents_json_and_sse(openapi_spec: dict[str, Any]) -> None:
+    """OpenAI-compatible chat completions must document JSON and SSE provider-shaped responses."""
+    operation = openapi_spec["paths"][CHAT_COMPLETIONS_PATH]["post"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "application/json" in content
+    assert "text/event-stream" in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_anthropic_messages_openapi_documents_json_and_sse(openapi_spec: dict[str, Any]) -> None:
+    """Anthropic-compatible messages endpoints must document JSON and SSE provider-shaped responses."""
+    for path in MESSAGES_COMPLETION_PATHS:
+        operation = openapi_spec["paths"][path]["post"]
+        content = operation["responses"]["200"].get("content", {})
+
+        assert "application/json" in content
+        assert "text/event-stream" in content
+        assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_prometheus_text_openapi_documents_plaintext_response(openapi_spec: dict[str, Any]) -> None:
+    """Prometheus scrape endpoints must be documented as text, not JSON envelopes."""
+    for path in PROMETHEUS_TEXT_RESPONSE_PATHS:
+        operation = openapi_spec["paths"][path]["get"]
+        content = operation["responses"]["200"].get("content", {})
+
+        assert "text/plain; version=0.0.4" in content or "text/plain; version=0.0.4; charset=utf-8" in content
+        assert "application/json" not in content
+        assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_mcp_request_openapi_documents_json_and_no_content_response(openapi_spec: dict[str, Any]) -> None:
+    """MCP HTTP requests can return JSON-RPC results or a 204 no-content acknowledgement."""
+    operation = openapi_spec["paths"][MCP_REQUEST_PATH]["post"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "application/json" in content
+    _assert_no_body_response(operation, "204")
+
+
+@pytest.mark.integration
+def test_conditional_cache_routes_openapi_document_304_no_body_response(openapi_spec: dict[str, Any]) -> None:
+    """Conditional cache routes with ETags must document 304 no-body responses."""
+    for method, path in NOT_MODIFIED_RESPONSE_OPERATIONS:
+        operation = openapi_spec["paths"][path][method]
+        _assert_no_body_response(operation, "304")
+
+
+@pytest.mark.integration
+def test_claims_analytics_export_openapi_documents_csv_response(openapi_spec: dict[str, Any]) -> None:
+    """Claims analytics export downloads must document CSV as an alternate response format."""
+    operation = openapi_spec["paths"][CLAIMS_ANALYTICS_EXPORT_DOWNLOAD_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "application/json" in content
+    assert "text/csv" in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_privilege_snapshot_csv_export_openapi_documents_csv_response() -> None:
+    """Privilege snapshot CSV exports must be documented as CSV streams, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.privileges import router as privileges_router
+
+    app = FastAPI()
+    app.include_router(privileges_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][PRIVILEGE_SNAPSHOT_CSV_EXPORT_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "text/csv" in content
+    assert "application/json" not in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_evaluations_abtest_events_openapi_documents_sse_response() -> None:
+    """Evaluation A/B test event streams must be documented as SSE, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_unified import router as evaluations_router
+
+    app = FastAPI()
+    app.include_router(evaluations_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][EVALUATIONS_ABTEST_EVENTS_PATH]["get"]
+
+    _assert_streaming_response_content(operation, "text/event-stream")
+
+
+@pytest.mark.integration
+def test_evaluations_abtest_export_openapi_documents_json_and_csv_response() -> None:
+    """Evaluation A/B test exports must document both JSON and CSV formats."""
+    from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_unified import router as evaluations_router
+
+    app = FastAPI()
+    app.include_router(evaluations_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][EVALUATIONS_ABTEST_EXPORT_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "application/json" in content
+    assert "text/csv" in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_evaluations_metrics_openapi_documents_json_and_prometheus_response() -> None:
+    """Evaluation metrics must document both JSON and Prometheus text formats."""
+    from tldw_Server_API.app.api.v1.endpoints.evaluations.evaluations_unified import router as evaluations_router
+
+    app = FastAPI()
+    app.include_router(evaluations_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][EVALUATIONS_METRICS_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "application/json" in content
+    assert "text/plain; version=0.0.4; charset=utf-8" in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_storage_file_download_openapi_documents_file_response() -> None:
+    """Generated file downloads must be documented as files, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.storage import router as storage_router
+
+    app = FastAPI()
+    app.include_router(storage_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][STORAGE_FILE_DOWNLOAD_PATH]["get"]
+
+    _assert_file_response_content(operation, {"application/octet-stream"})
+
+
+@pytest.mark.integration
+def test_jobs_events_stream_openapi_documents_sse_response() -> None:
+    """Jobs event streams must be documented as SSE, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.jobs_admin import router as jobs_admin_router
+
+    app = FastAPI()
+    app.include_router(jobs_admin_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][JOBS_EVENTS_STREAM_PATH]["get"]
+
+    _assert_streaming_response_content(operation, "text/event-stream")
+
+
+@pytest.mark.integration
+def test_watchlist_sources_export_openapi_documents_xml_response() -> None:
+    """Watchlist source OPML exports must be documented as XML, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import router as watchlists_router
+
+    app = FastAPI()
+    app.include_router(watchlists_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][WATCHLIST_SOURCES_EXPORT_PATH]["get"]
+
+    _assert_file_response_content(operation, {"application/xml"})
+
+
+@pytest.mark.integration
+def test_watchlist_runs_csv_exports_openapi_document_csv_responses() -> None:
+    """Watchlist run CSV exports must document CSV media types for generated clients."""
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import router as watchlists_router
+
+    app = FastAPI()
+    app.include_router(watchlists_router, prefix="/api/v1")
+    paths = app.openapi()["paths"]
+
+    for path in (WATCHLIST_RUNS_CSV_EXPORT_PATH, WATCHLIST_RUN_TALLIES_CSV_EXPORT_PATH):
+        _assert_file_response_content(paths[path]["get"], {"text/csv; charset=utf-8"})
+
+
+@pytest.mark.integration
+def test_watchlist_output_download_openapi_documents_rendered_file_responses() -> None:
+    """Watchlist rendered output downloads must advertise their raw media types."""
+    from tldw_Server_API.app.api.v1.endpoints.watchlists import router as watchlists_router
+
+    app = FastAPI()
+    app.include_router(watchlists_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][WATCHLIST_OUTPUT_DOWNLOAD_PATH]["get"]
+
+    _assert_file_response_content(operation, WATCHLIST_OUTPUT_DOWNLOAD_CONTENT_TYPES)
+
+
+@pytest.mark.integration
+def test_character_export_openapi_documents_json_and_png_responses() -> None:
+    """Character exports must document JSON card data and PNG character-card downloads."""
+    from tldw_Server_API.app.api.v1.endpoints.characters_endpoint import router as characters_router
+
+    app = FastAPI()
+    app.include_router(characters_router, prefix="/api/v1/characters")
+    operation = app.openapi()["paths"][CHARACTER_EXPORT_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "application/json" in content
+    assert "image/png" in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_admin_usage_csv_exports_openapi_document_csv_responses() -> None:
+    """Admin usage CSV exports must document CSV media types for generated clients."""
+    from tldw_Server_API.app.api.v1.endpoints.admin.admin_usage import router as admin_usage_router
+
+    app = FastAPI()
+    app.include_router(admin_usage_router, prefix="/api/v1/admin")
+    paths = app.openapi()["paths"]
+
+    for path in ADMIN_USAGE_CSV_EXPORT_PATHS:
+        _assert_file_response_content(paths[path]["get"], {"text/csv"})
+
+
+@pytest.mark.integration
+def test_admin_json_csv_exports_openapi_document_raw_response_formats() -> None:
+    """Admin exports that can return JSON or CSV must document both raw formats."""
+    from tldw_Server_API.app.api.v1.endpoints.admin.admin_system import router as admin_system_router
+    from tldw_Server_API.app.api.v1.endpoints.admin.admin_user import router as admin_user_router
+
+    app = FastAPI()
+    app.include_router(admin_user_router, prefix="/api/v1/admin")
+    app.include_router(admin_system_router, prefix="/api/v1/admin")
+    paths = app.openapi()["paths"]
+
+    for path in ADMIN_JSON_CSV_EXPORT_PATHS:
+        content = paths[path]["get"]["responses"]["200"].get("content", {})
+
+        assert "application/json" in content
+        assert "text/csv" in content
+        assert not _contains_ref_fragment(paths[path]["get"], "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_flashcard_asset_content_openapi_documents_binary_response() -> None:
+    """Flashcard asset content must be documented as a raw binary response."""
+    from tldw_Server_API.app.api.v1.endpoints.flashcards import router as flashcards_router
+
+    app = FastAPI()
+    app.include_router(flashcards_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][FLASHCARD_ASSET_CONTENT_PATH]["get"]
+
+    _assert_file_response_content(operation, {"application/octet-stream"})
+
+
+@pytest.mark.integration
+def test_flashcard_export_openapi_documents_raw_response_formats() -> None:
+    """Flashcard export must document all supported raw download formats."""
+    from tldw_Server_API.app.api.v1.endpoints.flashcards import router as flashcards_router
+
+    app = FastAPI()
+    app.include_router(flashcards_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][FLASHCARD_EXPORT_PATH]["get"]
+
+    _assert_file_response_content(operation, FLASHCARD_EXPORT_CONTENT_TYPES)
+
+
+@pytest.mark.integration
+def test_reading_tts_openapi_documents_audio_responses() -> None:
+    """Reading item TTS must document supported audio response formats."""
+    from tldw_Server_API.app.api.v1.endpoints.reading import router as reading_router
+
+    app = FastAPI()
+    app.include_router(reading_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][READING_TTS_PATH]["post"]
+
+    _assert_file_response_content(operation, AUDIO_SPEECH_CONTENT_TYPES)
+
+
+@pytest.mark.integration
+def test_reading_export_openapi_documents_raw_response_formats() -> None:
+    """Reading exports must document NDJSON and ZIP download formats."""
+    from tldw_Server_API.app.api.v1.endpoints.reading import router as reading_router
+
+    app = FastAPI()
+    app.include_router(reading_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][READING_EXPORT_PATH]["get"]
+
+    _assert_file_response_content(operation, READING_EXPORT_CONTENT_TYPES)
+
+
+@pytest.mark.integration
+def test_audit_export_openapi_documents_raw_response_formats() -> None:
+    """Audit export must document raw JSON, NDJSON, and CSV response formats."""
+    from tldw_Server_API.app.api.v1.endpoints.audit import router as audit_router
+
+    app = FastAPI()
+    app.include_router(audit_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][AUDIT_EXPORT_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert AUDIT_EXPORT_CONTENT_TYPES.issubset(content)
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_meeting_events_openapi_documents_sse_response() -> None:
+    """Meeting session events must document SSE stream responses."""
+    from tldw_Server_API.app.api.v1.endpoints.meetings import router as meetings_router
+
+    app = FastAPI()
+    app.include_router(meetings_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][MEETING_EVENTS_PATH]["get"]
+
+    _assert_streaming_response_content(operation, "text/event-stream")
+
+
+@pytest.mark.integration
+def test_notifications_stream_openapi_documents_sse_response() -> None:
+    """Notifications stream must document SSE responses."""
+    from tldw_Server_API.app.api.v1.endpoints.notifications import router as notifications_router
+
+    app = FastAPI()
+    app.include_router(notifications_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][NOTIFICATIONS_STREAM_PATH]["get"]
+
+    _assert_streaming_response_content(operation, "text/event-stream")
+
+
+@pytest.mark.integration
+def test_vn_asset_content_openapi_documents_file_response() -> None:
+    """VN asset item content must document a raw file response."""
+    from tldw_Server_API.app.api.v1.endpoints.vn_assets import router as vn_assets_router
+
+    app = FastAPI()
+    app.include_router(vn_assets_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][VN_ASSET_CONTENT_PATH]["get"]
+
+    _assert_file_response_content(operation, {"application/octet-stream"})
+
+
+@pytest.mark.integration
+def test_slides_export_openapi_documents_raw_response_formats() -> None:
+    """Slides exports must document supported raw download formats."""
+    from tldw_Server_API.app.api.v1.endpoints.slides import router as slides_router
+
+    app = FastAPI()
+    app.include_router(slides_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][SLIDES_EXPORT_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert SLIDES_EXPORT_CONTENT_TYPES.issubset(content)
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_websub_verify_callback_openapi_documents_plaintext_response() -> None:
+    """WebSub verification callbacks must document their plaintext challenge response."""
+    from tldw_Server_API.app.api.v1.endpoints.collections_websub import callback_router
+
+    app = FastAPI()
+    app.include_router(callback_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][WEBSUB_VERIFY_CALLBACK_PATH]["get"]
+
+    _assert_file_response_content(operation, {"text/plain"})
+
+
+@pytest.mark.integration
+def test_websub_push_callback_openapi_documents_no_body_response() -> None:
+    """WebSub push callbacks acknowledge hubs with an empty response body."""
+    from tldw_Server_API.app.api.v1.endpoints.collections_websub import callback_router
+
+    app = FastAPI()
+    app.include_router(callback_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][WEBSUB_PUSH_CALLBACK_PATH]["post"]
+
+    _assert_no_body_response(operation)
+
+
+@pytest.mark.integration
+def test_notes_csv_exports_openapi_document_csv_response() -> None:
+    """Notes CSV exports must document CSV streams instead of JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.notes import router as notes_router
+
+    app = FastAPI()
+    app.include_router(notes_router, prefix="/api/v1/notes")
+    paths = app.openapi()["paths"]
+
+    for method in ("get", "post"):
+        operation = paths[NOTES_CSV_EXPORT_PATHS[0]][method]
+        _assert_file_response_content(operation, {"text/csv; charset=utf-8"})
+
+
+@pytest.mark.integration
+def test_notes_attachment_download_openapi_documents_file_response() -> None:
+    """Note attachment downloads must document raw file content for generated clients."""
+    from tldw_Server_API.app.api.v1.endpoints.notes import router as notes_router
+
+    app = FastAPI()
+    app.include_router(notes_router, prefix="/api/v1/notes")
+    operation = app.openapi()["paths"][NOTES_ATTACHMENT_DOWNLOAD_PATH]["get"]
+
+    _assert_file_response_content(operation, {"application/octet-stream"})
+
+
+@pytest.mark.integration
+def test_connector_provider_webhook_openapi_documents_validation_token_response() -> None:
+    """Connector provider webhooks must document JSON callbacks and plaintext validation tokens."""
+    from tldw_Server_API.app.api.v1.endpoints.connectors import router as connectors_router
+
+    app = FastAPI()
+    app.include_router(connectors_router, prefix="/api/v1")
+    paths = app.openapi()["paths"]
+
+    for method in ("get", "post"):
+        operation = paths[CONNECTOR_PROVIDER_WEBHOOK_PATH][method]
+        content = operation["responses"]["200"].get("content", {})
+
+        assert "application/json" in content
+        assert "text/plain" in content
+        assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_workflow_artifact_downloads_openapi_document_file_responses() -> None:
+    """Workflow artifact downloads must document raw file and ZIP response formats."""
+    from tldw_Server_API.app.api.v1.endpoints.workflows import router as workflows_router
+
+    app = FastAPI()
+    app.include_router(workflows_router)
+    paths = app.openapi()["paths"]
+
+    _assert_file_response_content(
+        paths[WORKFLOW_ARTIFACT_DOWNLOAD_PATH]["get"],
+        {"application/octet-stream"},
+    )
+    _assert_file_response_content(
+        paths[WORKFLOW_RUN_ARTIFACTS_DOWNLOAD_PATH]["get"],
+        {"application/zip"},
+    )
+
+
+@pytest.mark.integration
+def test_data_table_export_openapi_documents_json_and_download_responses() -> None:
+    """Data table exports must document JSON metadata and direct download media types."""
+    from tldw_Server_API.app.api.v1.endpoints.data_tables import router as data_tables_router
+
+    app = FastAPI()
+    app.include_router(data_tables_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][DATA_TABLE_EXPORT_PATH]["get"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert DATA_TABLE_EXPORT_CONTENT_TYPES.issubset(content)
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_chat_document_generate_openapi_documents_json_and_sse_response() -> None:
+    """Chat document generation must document JSON results and optional SSE streams."""
+    from tldw_Server_API.app.api.v1.endpoints.chat_documents import router as chat_documents_router
+
+    app = FastAPI()
+    app.include_router(chat_documents_router, prefix="/api/v1/chat")
+    operation = app.openapi()["paths"][CHAT_DOCUMENT_GENERATE_PATH]["post"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "application/json" in content
+    assert "text/event-stream" in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_acp_session_events_stream_openapi_documents_sse_response() -> None:
+    """ACP session event streams must be documented as SSE, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.agent_client_protocol import router as acp_router
+
+    app = FastAPI()
+    app.include_router(acp_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][ACP_SESSION_EVENTS_STREAM_PATH]["get"]
+
+    _assert_streaming_response_content(operation, "text/event-stream")
+
+
+@pytest.mark.integration
+def test_mcp_hub_events_stream_openapi_documents_sse_response() -> None:
+    """MCP Hub governance event streams must be documented as SSE, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.mcp_hub_management import router as mcp_hub_router
+
+    app = FastAPI()
+    app.include_router(mcp_hub_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][MCP_HUB_EVENTS_STREAM_PATH]["get"]
+
+    _assert_streaming_response_content(operation, "text/event-stream")
+
+
+@pytest.mark.integration
+def test_embeddings_orchestrator_events_openapi_documents_sse_response() -> None:
+    """Embeddings orchestrator event streams must be documented as SSE, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced import router as embeddings_router
+
+    app = FastAPI()
+    app.include_router(embeddings_router, prefix="/api/v1")
+    operation = app.openapi()["paths"][EMBEDDINGS_ORCHESTRATOR_EVENTS_PATH]["get"]
+
+    _assert_streaming_response_content(operation, "text/event-stream")
+
+
+@pytest.mark.integration
+def test_character_chat_completion_v2_openapi_documents_json_and_sse_response() -> None:
+    """Character chat completion v2 must document JSON results and optional SSE streams."""
+    from tldw_Server_API.app.api.v1.endpoints.character_chat_sessions import router as character_chats_router
+
+    app = FastAPI()
+    app.include_router(character_chats_router, prefix="/api/v1/chats")
+    operation = app.openapi()["paths"][CHARACTER_CHAT_COMPLETION_V2_PATH]["post"]
+    content = operation["responses"]["200"].get("content", {})
+
+    assert "application/json" in content
+    assert "text/event-stream" in content
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_paper_search_raw_passthrough_openapi_documents_raw_content_types() -> None:
+    """Paper-search raw passthrough routes must document upstream content types, not JSON envelopes."""
+    from tldw_Server_API.app.api.v1.endpoints.paper_search import router as paper_search_router
+
+    app = FastAPI()
+    app.include_router(paper_search_router, prefix="/api/v1/paper-search")
+    paths = app.openapi()["paths"]
+
+    for path in PAPER_SEARCH_RAW_JSON_XML_HTML_PATHS:
+        _assert_raw_response_content(paths[path]["get"], {"application/json", "application/xml", "text/html"})
+
+    for path in PAPER_SEARCH_RAW_JSON_CSV_PATHS:
+        _assert_raw_response_content(paths[path]["get"], {"application/json", "text/csv"})
+
+    for path in PAPER_SEARCH_RAW_JSON_XML_PATHS:
+        _assert_raw_response_content(paths[path]["get"], {"application/json", "application/xml"})
+
+    for path in PAPER_SEARCH_RAW_XML_PATHS:
+        _assert_raw_response_content(paths[path]["get"], {"application/xml"})
+
+    for path in PAPER_SEARCH_RAW_JSON_PATHS:
+        _assert_raw_response_content(paths[path]["get"], {"application/json"})
+
+    _assert_raw_response_content(paths[PAPER_SEARCH_PMC_OA_PDF_PATH]["get"], {"application/pdf"})
+    _assert_raw_response_content(
+        paths[PAPER_SEARCH_HAL_RAW_PATH]["get"],
+        {"application/json", "application/xml", "application/octet-stream", "text/csv", "text/plain"},
+    )
+
+
+@pytest.mark.integration
+def test_media_file_openapi_documents_full_and_partial_file_responses() -> None:
+    """Media file downloads must document both full and range-streamed file response content."""
+    from tldw_Server_API.app.api.v1.endpoints.media.file import router as media_file_router
+
+    app = FastAPI()
+    app.include_router(media_file_router, prefix="/api/v1/media")
+    operation = app.openapi()["paths"][MEDIA_FILE_PATH]["get"]
+    full_content = operation["responses"]["200"].get("content", {})
+    partial_content = operation["responses"]["206"].get("content", {})
+
+    assert {"application/pdf", "application/octet-stream"}.issubset(full_content)
+    assert {"application/pdf", "application/octet-stream"}.issubset(partial_content)
+    assert not _contains_ref_fragment(operation, "ResponseEnvelope")
+
+
+@pytest.mark.integration
+def test_openapi_documents_supported_auth_schemes(openapi_spec: dict[str, Any]) -> None:
+    """The generated OpenAPI document must advertise both supported authentication schemes."""
+    security_schemes = openapi_spec["components"]["securitySchemes"]
+
+    assert security_schemes["ApiKeyAuth"]["type"] == "apiKey"
+    assert security_schemes["ApiKeyAuth"]["in"] == "header"
+    assert security_schemes["ApiKeyAuth"]["name"] == "X-API-KEY"
+    assert security_schemes["BearerAuth"]["type"] == "http"
+    assert security_schemes["BearerAuth"]["scheme"] == "bearer"
+    assert {"ApiKeyAuth": []} in openapi_spec["security"]
+    assert {"BearerAuth": []} in openapi_spec["security"]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("path", ["/health", "/ready", "/health/ready"])
+def test_control_plane_head_routes_are_registered(client_user_only, path: str) -> None:
+    """The HEAD health probes must remain routable after splitting OpenAPI operations."""
+    response = client_user_only.head(path)
+
+    assert response.status_code in {200, 503}
+    assert response.text == ""

--- a/tldw_Server_API/tests/Services/test_openapi_contracts.py
+++ b/tldw_Server_API/tests/Services/test_openapi_contracts.py
@@ -28,7 +28,7 @@ STREAMING_RESPONSE_EXEMPTIONS = {
 AUDIO_SPEECH_CONTENT_TYPES = {
     "audio/aac",
     "audio/flac",
-    "audio/L16; rate=24000; channels=1",
+    "audio/L16",
     "audio/mpeg",
     "audio/opus",
     "audio/wav",
@@ -350,6 +350,31 @@ def test_custom_openapi_reuses_cached_schema_for_tag_declarations(monkeypatch) -
 
     assert second_schema is first_schema
     assert helper_calls == 1
+
+
+@pytest.mark.integration
+def test_openapi_operation_tag_declaration_ignores_malformed_tag_values() -> None:
+    """Malformed scalar tag values must not be expanded into one-character top-level tags."""
+    from tldw_Server_API.app import main as main_module
+
+    openapi_schema: dict[str, Any] = {
+        "tags": [],
+        "paths": {
+            "/valid": {"get": {"tags": ["media"]}},
+            "/malformed": {"get": {"tags": "health"}},
+        },
+    }
+
+    main_module._ensure_openapi_operation_tags_declared(openapi_schema)
+
+    declared_tags = {
+        tag["name"]
+        for tag in openapi_schema["tags"]
+        if isinstance(tag, dict) and isinstance(tag.get("name"), str)
+    }
+    assert "media" in declared_tags
+    assert "health" not in declared_tags
+    assert not set("health") & declared_tags
 
 
 @pytest.mark.integration
@@ -944,7 +969,7 @@ def test_vn_asset_content_openapi_documents_file_response() -> None:
     app.include_router(vn_assets_router, prefix="/api/v1")
     operation = app.openapi()["paths"][VN_ASSET_CONTENT_PATH]["get"]
 
-    _assert_file_response_content(operation, {"application/octet-stream"})
+    _assert_file_response_content(operation, {"application/octet-stream", "image/jpeg", "image/png", "image/webp"})
 
 
 @pytest.mark.integration
@@ -1155,7 +1180,15 @@ def test_paper_search_raw_passthrough_openapi_documents_raw_content_types() -> N
     _assert_raw_response_content(paths[PAPER_SEARCH_PMC_OA_PDF_PATH]["get"], {"application/pdf"})
     _assert_raw_response_content(
         paths[PAPER_SEARCH_HAL_RAW_PATH]["get"],
-        {"application/json", "application/xml", "application/octet-stream", "text/csv", "text/plain"},
+        {
+            "application/atom+xml",
+            "application/json",
+            "application/octet-stream",
+            "application/rss+xml",
+            "application/xml",
+            "text/csv",
+            "text/plain",
+        },
     )
 
 
@@ -1197,3 +1230,12 @@ def test_control_plane_head_routes_are_registered(client_user_only, path: str) -
 
     assert response.status_code in {200, 503}
     assert response.text == ""
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("path", ["/health", "/ready", "/health/ready"])
+def test_control_plane_routes_keep_health_openapi_tag(openapi_spec: dict[str, Any], path: str) -> None:
+    """Control-plane probe routes should remain grouped under the health tag."""
+    for method in ("get", "head"):
+        operation = openapi_spec["paths"][path][method]
+        assert "health" in operation.get("tags", [])


### PR DESCRIPTION
## Change summary\nTODO: human-authored summary required before merge.\n\n## What changed\n- Adds OpenAPI contract guardrails for raw responses, streaming responses, file downloads, redirects, 204/304 no-body responses, and path-parameter normalization.\n- Documents raw/non-envelope response metadata across existing endpoints without changing runtime payloads.\n- Extends frontend OpenAPI verification for client paths and media fallback schema fields.\n\n## Test plan\n- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py tldw_Server_API/tests/Config/test_openapi_config_jobs.py tldw_Server_API/tests/Services/test_openapi_contracts.py -q\n- bun run verify:openapi in apps/packages/ui\n- bun run verify:openapi in apps/extension\n- bunx vitest run tests/unit/verify-openapi-client-paths.test.ts in apps/extension\n- Generated OpenAPI gap scanner: GAPS 0\n- git diff --check origin/dev..HEAD\n- Bandit touched source scope: existing B106 baseline only, CHANGED_LINE_OVERLAPS 0