### PR TITLE
Phase 4.5: codify API versioning policy

### DIFF
--- a/Docs/API/Pagination.md
+++ b/Docs/API/Pagination.md
@@ -13,6 +13,10 @@ Canonical backend schema names are `OffsetPaginationMeta`,
 matching `OffsetPaginationMeta`, `PagePaginationMeta`, `CursorPaginationMeta`,
 and `ApiPaginationMeta` TypeScript types from `response-envelope.ts`.
 
+When a route opts into the canonical response envelope, the nested envelope
+location is `metadata.pagination`. For default legacy-shaped `v1` route bodies,
+the additive nested field remains `pagination`.
+
 ## Offset Pagination
 
 Offset-based endpoints use `limit` and `offset` request parameters and return
@@ -116,10 +120,14 @@ Clients must treat `null` totals as "unknown", not zero.
 
 - Preserve legacy top-level pagination aliases on migrated endpoints.
 - Prefer `pagination` for new client code when it exists.
+- Prefer `metadata.pagination` when consuming canonical envelope responses.
 - Do not infer a missing `pagination` object means more data exists.
 - Do not alter provider-compatible payloads only to add canonical metadata.
 - Do not add response-body pagination to raw-list endpoints without a versioned
   object-envelope route.
+- Do not change the default body shape of a `v1` route merely to move
+  pagination into an envelope; use a sibling route or `/api/v2/` for
+  default-breaking migrations.
 - Keep streaming, file export, and binary download continuation in their stream,
   file, header, or query contract rather than inventing a JSON pagination body.
 
@@ -137,3 +145,7 @@ Current exemption categories:
 - Operation results and aggregate counts: not list pagination.
 - Detail and nested subresource routes: only paginate if they expose direct
   list/search/history/job/event semantics.
+
+See [API Versioning Strategy](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/Docs/API/api-versioning-strategy.md)
+for the rule that default-breaking shape changes should move to a sibling route
+or `/api/v2/`.

--- a/Docs/API/Pagination.md
+++ b/Docs/API/Pagination.md
@@ -146,6 +146,6 @@ Current exemption categories:
 - Detail and nested subresource routes: only paginate if they expose direct
   list/search/history/job/event semantics.
 
-See [API Versioning Strategy](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/Docs/API/api-versioning-strategy.md)
+See [API Versioning Strategy](api-versioning-strategy.md)
 for the rule that default-breaking shape changes should move to a sibling route
 or `/api/v2/`.

--- a/Docs/API/api-versioning-strategy.md
+++ b/Docs/API/api-versioning-strategy.md
@@ -31,7 +31,64 @@ The following changes require a major version bump (e.g., v1 to v2):
 - Adding new enum values to existing fields
 - Relaxing validation (e.g., increasing max length)
 
+## Phase 3 / Phase 4 Compatibility Policy
+
+During the Phase 3 and Phase 4 contract cleanup work, `/api/v1/` remains
+legacy-default.
+
+This means:
+
+- existing default response bodies remain unchanged unless an additive change is
+  non-breaking under the rules above;
+- existing default error shapes and status behavior remain unchanged;
+- existing accepted pagination aliases remain valid in `v1` unless a future
+  versioned migration explicitly changes them.
+
+Standard response-envelope behavior inside `v1` is transitional and additive.
+If a first-party JSON route supports envelope-style opt-in behavior, that opt-in
+does not create a new major-version mechanism. Major default-breaking contract
+changes should move to `/api/v2/`, not to a public header-only version.
+
+### Transitional Opt-In In `v1`
+
+For first-party JSON routes, additive opt-in behavior may be exposed with:
+
+```http
+X-TLDW-Response-Envelope: v1
+```
+
+This header is a compatibility tool for additive behavior inside `v1`. It does
+not replace path-based major versioning.
+
+### Exempt Route Families
+
+The following route families are exempt from standard envelopes by default
+unless they explicitly document otherwise:
+
+- streaming responses
+- file downloads and binary exports
+- webhooks
+- WebSockets
+- `204 No Content` routes
+- OpenAI-compatible and provider-compatible payloads
+
+### Default-Breaking Migration Triggers
+
+The following changes should move to a sibling route or `/api/v2/` instead of
+changing the default `v1` contract in place:
+
+- wrapping the default response body under `data`
+- changing the default error body shape
+- removing or renaming existing response fields
+- removing accepted pagination aliases
+- changing auth requirements or auth/status behavior
+- converting provider-compatible defaults into tldw-specific normalized shapes
+
 ## Deprecation Policy
+
+The deprecation policy below applies when maintainers approve an actual
+deprecation window. It should not be interpreted to mean that additive `v1`
+pilot behavior automatically deprecates the existing default `v1` shape.
 
 ### Timeline
 

--- a/Docs/superpowers/plans/2026-05-03-phase4-5-api-versioning-policy-plan.md
+++ b/Docs/superpowers/plans/2026-05-03-phase4-5-api-versioning-policy-plan.md
@@ -1,0 +1,284 @@
+# Phase 4.5 API Versioning Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a docs-only Phase 4.5 versioning policy that aligns the existing `v1` contract, shared envelope/pagination helpers, and frontend/client migration rules.
+
+**Architecture:** Keep this tranche policy-only. Update the canonical API docs and roadmap tracker so future route-family work has one explicit decision framework for additive `v1` changes versus sibling-route or `/api/v2/` migrations. Do not change runtime code or endpoint behavior in this plan.
+
+**Tech Stack:** Markdown docs, GitHub issue tracker, focused verification via grep and `git diff --check`
+
+---
+
+## File Map
+
+- Modify: `Docs/API/api-versioning-strategy.md`
+- Modify: `Docs/API/Pagination.md`
+- Modify: `Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md`
+- Optionally modify: `Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-phase3-alignment.md`
+- Reference only: `tldw_Server_API/app/api/v1/schemas/response_envelope.py`
+- Reference only: `tldw_Server_API/app/api/v1/utils/response_envelope.py`
+- Reference only: `apps/packages/ui/src/services/response-envelope.ts`
+- External update: GitHub issue `#1116`
+
+## Task 1: Update Canonical Versioning Strategy Doc
+
+**Files:**
+- Modify: `Docs/API/api-versioning-strategy.md`
+- Reference: `Docs/superpowers/specs/2026-05-03-api-versioning-policy-design.md`
+
+- [ ] **Step 1: Write the failing review expectation**
+
+Define the expected additions before editing:
+
+- `v1` remains legacy-default
+- additive header opt-in is transitional only
+- future default-breaking changes use `/api/v2/`
+- provider-compatible and transport exemptions are explicit
+- deprecation headers are not implied for additive `v1` pilots
+
+- [ ] **Step 2: Verify the current doc lacks those specifics**
+
+Run:
+
+```bash
+rg -n "legacy-default|X-TLDW-Response-Envelope|provider-compatible|metadata.pagination|transitional" Docs/API/api-versioning-strategy.md
+```
+
+Expected:
+
+- either no matches or incomplete coverage proving the policy update is needed
+
+- [ ] **Step 3: Write minimal doc updates**
+
+Edit `Docs/API/api-versioning-strategy.md` to add:
+
+- a Phase 3 / Phase 4 compatibility policy section;
+- the `v1` legacy-default rule;
+- the additive-header-versus-path-version distinction;
+- the route exemption classes;
+- the deprecation-header rule for approved deprecation windows only.
+
+- [ ] **Step 4: Verify the updated doc contains the new policy anchors**
+
+Run:
+
+```bash
+rg -n "legacy-default|X-TLDW-Response-Envelope|/api/v2/|provider-compatible|Deprecation" Docs/API/api-versioning-strategy.md
+```
+
+Expected:
+
+- all key policy anchors present
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docs/API/api-versioning-strategy.md
+git commit -m "docs: codify Phase 4.5 API versioning policy"
+```
+
+## Task 2: Reconcile Pagination Doc With Shipped Helper Contract
+
+**Files:**
+- Modify: `Docs/API/Pagination.md`
+- Reference: `tldw_Server_API/app/api/v1/schemas/response_envelope.py`
+- Reference: `tldw_Server_API/app/api/v1/utils/response_envelope.py`
+- Reference: `apps/packages/ui/src/services/response-envelope.ts`
+
+- [ ] **Step 1: Write the failing review expectation**
+
+Define the expected clarification:
+
+- `pagination` stays the additive nested body field for default `v1` route bodies
+- canonical envelope metadata uses `metadata.pagination`
+- raw-list and provider-compatible migrations still require sibling-route or
+  `/api/v2/` policy decisions
+
+- [ ] **Step 2: Verify the current doc is ambiguous or incomplete**
+
+Run:
+
+```bash
+rg -n "metadata.pagination|raw-list|provider-compatible|v2" Docs/API/Pagination.md
+```
+
+Expected:
+
+- missing or incomplete references that justify the doc update
+
+- [ ] **Step 3: Write minimal clarification**
+
+Edit `Docs/API/Pagination.md` to:
+
+- explicitly distinguish body-level `pagination` from envelope-level
+  `metadata.pagination`;
+- reaffirm compatibility rules for raw-list and provider-compatible routes;
+- point version-breaking pagination migrations back to the versioning policy.
+
+- [ ] **Step 4: Verify the clarification landed**
+
+Run:
+
+```bash
+rg -n "metadata.pagination|raw-list|provider-compatible|versioning" Docs/API/Pagination.md
+```
+
+Expected:
+
+- all clarifying anchors present
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docs/API/Pagination.md
+git commit -m "docs: align pagination guide with Phase 4.5 policy"
+```
+
+## Task 3: Refresh The Phase 4.5 Decision Packet
+
+**Files:**
+- Modify: `Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md`
+- Optionally modify: `Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-phase3-alignment.md`
+
+- [ ] **Step 1: Write the failing review expectation**
+
+Expected decision-packet fixes:
+
+- replace stale `meta.pagination` language with the shipped `metadata` contract
+- include frontend/client boundary rules
+- tighten the distinction between additive `v1` behavior and `/api/v2/`
+  default-breaking migrations
+
+- [ ] **Step 2: Verify stale wording exists**
+
+Run:
+
+```bash
+rg -n "meta.pagination|query opt-in|v2|frontend owner|client" \
+  Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md \
+  Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-phase3-alignment.md
+```
+
+Expected:
+
+- stale or incomplete wording visible
+
+- [ ] **Step 3: Update the review artifacts**
+
+Edit the decision packet, and the alignment doc only if needed, so they match
+the new policy spec and no longer conflict with shipped helper terminology.
+
+- [ ] **Step 4: Verify the packet matches the canonical policy**
+
+Run:
+
+```bash
+rg -n "metadata.pagination|legacy-default|provider-compatible|/api/v2/" \
+  Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md \
+  Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-phase3-alignment.md
+```
+
+Expected:
+
+- canonical wording present, stale wording removed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md \
+  Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-phase3-alignment.md
+git commit -m "docs: refresh Phase 4.5 versioning decision packet"
+```
+
+## Task 4: Update Roadmap Tracker
+
+**Files:**
+- External update: GitHub issue `#1116`
+
+- [ ] **Step 1: Draft the issue comment content**
+
+The comment should state:
+
+- Phase 4.4 is complete and merged
+- Phase 4.5 is now active as a policy/docs tranche
+- the spec and doc updates define the next decision gate for future response-shape
+  migration work
+
+- [ ] **Step 2: Post the tracker update**
+
+Run:
+
+```bash
+gh issue comment 1116 --repo rmusser01/tldw_server --body "<finalized update>"
+```
+
+Expected:
+
+- GitHub returns the new comment URL
+
+- [ ] **Step 3: Verify the roadmap issue reflects the new status**
+
+Run:
+
+```bash
+gh issue view 1116 --repo rmusser01/tldw_server --json comments
+```
+
+Expected:
+
+- latest comment reflects Phase 4.5 activation and policy-doc status
+
+## Task 5: Final Verification And Handoff
+
+**Files:**
+- Verify all touched docs and tracker references
+
+- [ ] **Step 1: Run focused grep checks**
+
+Run:
+
+```bash
+rg -n "legacy-default|metadata.pagination|provider-compatible|/api/v2/|Deprecation" \
+  Docs/API/api-versioning-strategy.md \
+  Docs/API/Pagination.md \
+  Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md
+```
+
+Expected:
+
+- all policy anchors present and internally consistent
+
+- [ ] **Step 2: Run whitespace / patch hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected:
+
+- no output
+
+- [ ] **Step 3: Review branch status**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected:
+
+- only intended docs changes, or a clean branch after commits
+
+- [ ] **Step 4: Prepare PR summary**
+
+Summarize:
+
+- canonical `v1` compatibility policy
+- `metadata.pagination` reconciliation
+- frontend/client boundary rules
+- roadmap activation of Phase 4.5

--- a/Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-phase3-alignment.md
+++ b/Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-phase3-alignment.md
@@ -63,7 +63,7 @@ Safe in `v1` when compatible:
 Recommendation:
 
 - Keep legacy pagination fields during `v1`.
-- Put canonical pagination metadata in `meta.pagination` only when Phase 3.1 envelope opt-in is active, or in an additive nested field after route-family approval.
+- Put canonical pagination metadata in `metadata.pagination` when Phase 3.1 envelope opt-in is active, or in an additive nested `pagination` field for legacy-shaped `v1` responses after route-family approval.
 - Reserve legacy alias removal for `v2`.
 
 ### Phase 3.4 Auth Dependencies
@@ -92,6 +92,7 @@ For Phase 3:
 
 - `v1` remains legacy-default.
 - Standard envelope and canonical pagination metadata are opt-in.
+- Header opt-in inside `v1` is transitional and does not replace path-based major versioning.
 - Exemptions remain explicit:
   - streaming
   - file downloads
@@ -100,6 +101,7 @@ For Phase 3:
   - WebSocket messages
 - OpenAI-compatible and provider-compatible payloads unless route-specific approval exists
 - Deprecation headers are not emitted for legacy response shapes during the first pilot.
+- Shared client/service layers may own opt-in and unwrap behavior, while UI/domain consumers remain legacy-shaped by default.
 
 Draft maintainer decision packet:
 

--- a/Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md
+++ b/Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md
@@ -28,6 +28,7 @@ Recommendation:
 
 - Public opt-in mechanism: `X-TLDW-Response-Envelope: v1`.
 - Query opt-in, if implemented, should be test-only or internal until maintainers approve it as public API.
+- This header is transitional inside `v1`; it does not replace path-based major versioning.
 - Provider-compatible, streaming, file, webhook, WebSocket, and `204 No Content` routes stay exempt unless explicitly approved route-by-route.
 
 Reason:
@@ -40,7 +41,7 @@ Reason:
 Recommendation:
 
 - Keep existing `page`, `per_page`, `results_per_page`, `count`, `total`, `limit`, `offset`, and cursor aliases where routes already expose them.
-- Add canonical pagination metadata only as an opt-in envelope `meta.pagination` field during the pilot.
+- Add canonical pagination metadata as `metadata.pagination` for canonical envelope responses during the pilot.
 - Add non-envelope nested pagination metadata only after route-family approval.
 
 Reason:
@@ -71,6 +72,23 @@ Reason:
 
 - Current project docs define path-based versioning.
 - Path-based versioning keeps Swagger/OpenAPI and client code generation simpler.
+
+### Decision 6: Frontend And Client Boundaries Stay Domain-Shaped By Default
+
+Recommendation:
+
+- Shared client/service layers may send opt-in headers and unwrap canonical
+  envelopes or transitional wrappers.
+- UI/domain consumers should continue receiving stable domain-shaped data by
+  default instead of raw transport envelopes.
+- Route-family migration work is not complete until backend docs, OpenAPI
+  treatment, and client unwrap/typing behavior are all defined together.
+
+Reason:
+
+- This preserves the Phase 3 boundary that transport concerns live in shared
+  client layers, not scattered UI components.
+- It avoids accidental frontend lock-in to temporary transport shapes.
 
 ## Proposed Policy Text
 
@@ -129,11 +147,13 @@ Open question:
 - Is `X-TLDW-Response-Envelope: v1` the public opt-in mechanism?
 - Is query opt-in test-only during the pilot?
 - Are provider-compatible routes permanently exempt?
-- Should a future `v2` be planned now, or deferred until after the `skills` pilot?
+- Should a future `v2` be planned now, or deferred until a route family has an approved default-breaking migration?
+- Do maintainers accept that client/service layers own opt-in and unwrap behavior while domain consumers remain legacy-shaped by default?
 
 ## Handoff Checklist
 
 - [ ] Maintainers accept or amend the five recommended decisions.
+- [ ] Maintainers accept or amend the frontend/client boundary decision.
 - [ ] `Docs/API/api-versioning-strategy.md` is updated only after acceptance.
 - [ ] OpenAPI owner decides how opt-in envelope variants should be documented.
 - [ ] Frontend owner confirms whether any client should send the opt-in header during the pilot.

--- a/Docs/superpowers/specs/2026-05-03-api-versioning-policy-design.md
+++ b/Docs/superpowers/specs/2026-05-03-api-versioning-policy-design.md
@@ -1,0 +1,229 @@
+# Phase 4.5 API Versioning Policy Design
+
+**Date:** 2026-05-03
+
+**Status:** Proposed design for maintainer review.
+
+## Purpose
+
+Define the policy that governs response-shape migrations after the completed
+Phase 3 helper work and Phase 4 guardrail/decomposition stack. The goal is to
+make future API contract changes predictable for both backend owners and
+frontend/client consumers before any route family attempts to change its
+default `v1` response shape.
+
+This design is policy-first. It does not approve immediate runtime migrations.
+
+## Current Constraints
+
+Current versioning documentation in [Docs/API/api-versioning-strategy.md](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/Docs/API/api-versioning-strategy.md)
+already defines path-based `/api/v1/` versioning and treats response-field
+removal, error-format changes, auth changes, and path changes as breaking.
+
+Current shared helper surfaces already exist:
+
+- Backend canonical envelope schema uses `metadata`, not `meta`:
+  [response_envelope.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/tldw_Server_API/app/api/v1/schemas/response_envelope.py)
+- Backend envelope builders and detection also use `metadata`:
+  [response_envelope.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/tldw_Server_API/app/api/v1/utils/response_envelope.py)
+- Frontend shared unwrap helpers use the same `metadata` contract:
+  [response-envelope.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/apps/packages/ui/src/services/response-envelope.ts)
+- Canonical pagination docs currently describe additive nested `pagination`
+  objects in `v1`:
+  [Pagination.md](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/Docs/API/Pagination.md)
+
+The older Phase 3 / Phase 4 planning notes are directionally useful but stale
+in one important way: they refer to `meta.pagination`, which no longer matches
+the helper contract that shipped. Phase 4.5 must resolve that drift and define
+the canonical long-term rule.
+
+## Design Goals
+
+- Keep `/api/v1/` stable for current callers by default.
+- Define when additive `v1` contract growth is allowed.
+- Define when a change requires a sibling route or `/api/v2/`.
+- Define the client-side migration contract so frontend/service code does not
+  drift from backend policy.
+- Make provider-compatible and special transport routes explicit exemptions
+  instead of ad hoc exceptions.
+- Keep the policy aligned with generated OpenAPI and shared helper code.
+
+## Non-Goals
+
+- No route implementation changes in this tranche.
+- No immediate introduction of `/api/v2/` endpoints.
+- No new public opt-in shipped by runtime code in this tranche.
+- No mass rewrite of old planning documents beyond the docs chosen for this
+  policy update.
+
+## Recommended Policy
+
+### 1. `v1` Remains Legacy-Default
+
+`/api/v1/` keeps current default response shapes, default error bodies, default
+pagination aliases, and current auth/status behavior unless a route family
+documents an additive change that is non-breaking under the existing versioning
+rules.
+
+Implication:
+
+- Default body-shape replacements in `v1` are not allowed.
+- Default error-shape replacements in `v1` are not allowed.
+- Default removal or rejection of accepted pagination aliases in `v1` is not
+  allowed.
+
+### 2. Header Opt-In Is Transitional, Not A New Major Version
+
+If first-party JSON routes continue to support envelope-style or other additive
+opt-in behavior within `v1`, that opt-in is transitional and subordinate to the
+path-based versioning model.
+
+Recommended rule:
+
+- Header opt-in may be used for additive behavior inside `v1`.
+- Header opt-in must not become the primary major-version mechanism.
+- Future default-breaking behavior should move to `/api/v2/`, not to a new
+  public header version.
+
+This keeps the public major-version story consistent with the existing
+path-based strategy.
+
+### 3. Canonical Nested Metadata Uses `metadata.pagination`
+
+The canonical nested location for additive pagination metadata inside canonical
+envelopes is `metadata.pagination`, not `meta.pagination`.
+
+Reason:
+
+- It matches the backend schema/helper code already in the repo.
+- It matches the frontend shared unwrap typing that already shipped.
+- It avoids introducing a second nested metadata convention that would need its
+  own migration later.
+
+For non-envelope additive `v1` responses that expose nested canonical
+pagination, the body-level field remains `pagination` as documented today in
+`Docs/API/Pagination.md`.
+
+### 4. Route Families Must Follow Explicit Migration Rules
+
+Phase 4.5 should classify routes into policy families:
+
+- **First-party JSON routes**
+  - Can add non-breaking fields in place.
+  - Can expose additive opt-in envelope behavior in `v1`.
+  - Can move default-breaking body changes to `/api/v2/`.
+- **Provider-compatible routes**
+  - Must preserve upstream/provider body shapes by default.
+  - Must not be silently normalized into tldw-specific default envelopes or
+    pagination shapes in `v1`.
+  - If tldw-specific normalization is desired, use a sibling route or `/api/v2/`.
+- **Raw-list and custom legacy-envelope routes**
+  - Must not be reshaped in place when the default body contract changes.
+  - Require a sibling object route or `/api/v2/` for default-breaking shape
+    upgrades.
+- **Transport/special routes**
+  - Streaming, file downloads, webhooks, WebSockets, and `204 No Content`
+    remain envelope-exempt unless explicitly documented otherwise.
+
+### 5. Frontend/Client Contract Must Stay Domain-Shaped By Default
+
+Client behavior needs to be part of the policy, not an afterthought.
+
+Recommended rule:
+
+- Shared client/service layers may detect, send opt-in headers for, and unwrap
+  canonical envelopes or transitional wrappers.
+- UI/domain consumers should continue to receive stable domain-shaped data
+  rather than raw transport envelopes unless they intentionally target a new
+  versioned contract.
+- Route-family migration is incomplete until backend docs, OpenAPI treatment,
+  and frontend/client unwrap/typing behavior are all defined together.
+
+This preserves the boundary established by the Phase 3 frontend unwrap helpers:
+transport concerns live in shared client layers, not scattered UI components.
+
+### 6. Deprecation Headers Are For Approved Deprecation Windows, Not Additive `v1` Pilots
+
+The repo-wide deprecation header guidance stays valid, but it should not be
+applied automatically to additive Phase 3/Phase 4 compatibility work.
+
+Recommended rule:
+
+- Do not emit deprecation headers merely because a legacy `v1` shape coexists
+  with additive opt-in behavior.
+- Emit `Deprecation` / `Sunset` headers only when maintainers approve a real
+  deprecation window for a route, field, or versioned surface.
+
+This avoids implying that every additive `v1` pilot is already on a removal
+timeline.
+
+## Decision Table
+
+| Change | Allowed in default `v1`? | Allowed as additive `v1` opt-in? | Requires sibling route or `/api/v2/`? |
+| --- | --- | --- | --- |
+| Add optional response fields to first-party JSON route | Yes | Yes | No |
+| Replace legacy default body with envelope | No | Yes, if additive only | Yes for default behavior |
+| Replace legacy default error body/status contract | No | Yes, if additive only | Yes for default behavior |
+| Add canonical nested `pagination` while preserving current fields | Yes | Yes | No |
+| Remove legacy pagination aliases/fields | No | No | Yes |
+| Normalize provider-compatible body into tldw envelope by default | No | No by default | Yes |
+| Convert raw list response into object body by default | No | No | Yes |
+| Change auth requirement or auth status behavior | No | No | Yes |
+
+## OpenAPI And Documentation Policy
+
+- `Docs/API/api-versioning-strategy.md` remains the canonical high-level
+  versioning policy document.
+- `Docs/API/Pagination.md` remains the canonical additive pagination contract
+  document for `v1`.
+- Phase 4.5 should decide how opt-in `v1` variants are documented:
+  - narrative docs only;
+  - alternate generated OpenAPI responses for selected routes; or
+  - deferred until a route family is explicitly versioned.
+- `/api/v2/` should remain path-based by default for major versioning.
+
+Recommended default:
+
+- Keep generated OpenAPI centered on default `v1` behavior.
+- Document additive opt-in semantics narratively unless a route family
+  explicitly needs generated alternate responses.
+
+## Migration Trigger Checklist
+
+Future route-family work should require `/api/v2/` or a sibling route if any of
+these are true:
+
+- default response fields are removed, renamed, or wrapped;
+- default error shape changes;
+- default auth/status behavior changes;
+- a raw list must become an object response;
+- a provider-compatible payload must become tldw-normalized by default;
+- clients would need to change default deserialization logic for the same `v1`
+  path.
+
+## Concrete Phase 4.5 Docs Tranche
+
+This policy tranche should produce:
+
+- an update to `Docs/API/api-versioning-strategy.md`;
+- a small update to `Docs/API/Pagination.md` clarifying how additive `v1`
+  pagination relates to `metadata.pagination` and default-breaking migrations;
+- a roadmap/tracker update in issue `#1116` summarizing that Phase 4.5 is now a
+  policy/spec item and that prior Phase 4 implementation work is complete;
+- no runtime behavior changes.
+
+## Risks
+
+- Leaving the `meta.pagination` wording uncorrected would bake a stale contract
+  back into policy and create unnecessary future migration work.
+- Over-specifying OpenAPI alternate responses too early could create a contract
+  maintenance burden before route families are actually versioned.
+- A backend-only policy would leave client migration ownership ambiguous and
+  encourage UI-level transport leakage.
+
+## Recommendation
+
+Adopt the policy above and keep the first implementation tranche strictly
+docs-only. After that lands, future route-family work can use this policy as
+the decision gate for whether a change belongs in additive `v1`, a sibling
+route, or `/api/v2/`.

--- a/Docs/superpowers/specs/2026-05-03-api-versioning-policy-design.md
+++ b/Docs/superpowers/specs/2026-05-03-api-versioning-policy-design.md
@@ -16,21 +16,21 @@ This design is policy-first. It does not approve immediate runtime migrations.
 
 ## Current Constraints
 
-Current versioning documentation in [Docs/API/api-versioning-strategy.md](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/Docs/API/api-versioning-strategy.md)
+Current versioning documentation in [Docs/API/api-versioning-strategy.md](../../API/api-versioning-strategy.md)
 already defines path-based `/api/v1/` versioning and treats response-field
 removal, error-format changes, auth changes, and path changes as breaking.
 
 Current shared helper surfaces already exist:
 
 - Backend canonical envelope schema uses `metadata`, not `meta`:
-  [response_envelope.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/tldw_Server_API/app/api/v1/schemas/response_envelope.py)
+  [response_envelope.py](../../../tldw_Server_API/app/api/v1/schemas/response_envelope.py)
 - Backend envelope builders and detection also use `metadata`:
-  [response_envelope.py](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/tldw_Server_API/app/api/v1/utils/response_envelope.py)
+  [response_envelope.py](../../../tldw_Server_API/app/api/v1/utils/response_envelope.py)
 - Frontend shared unwrap helpers use the same `metadata` contract:
-  [response-envelope.ts](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/apps/packages/ui/src/services/response-envelope.ts)
+  [response-envelope.ts](../../../apps/packages/ui/src/services/response-envelope.ts)
 - Canonical pagination docs currently describe additive nested `pagination`
   objects in `v1`:
-  [Pagination.md](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/phase4-5-api-versioning-policy/Docs/API/Pagination.md)
+  [Pagination.md](../../API/Pagination.md)
 
 The older Phase 3 / Phase 4 planning notes are directionally useful but stale
 in one important way: they refer to `meta.pagination`, which no longer matches

--- a/backlog/tasks/task-4 - Address-PR-1238-review-comments-on-absolute-documentation-links.md
+++ b/backlog/tasks/task-4 - Address-PR-1238-review-comments-on-absolute-documentation-links.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-4
 title: 'Address PR #1238 review comments on absolute documentation links'
-status: In Progress
+status: Done
 assignee:
   - codex
 created_date: '2026-05-03 18:23'
-updated_date: '2026-05-03 18:24'
+updated_date: '2026-05-03 18:29'
 labels:
   - docs
   - pr-review
@@ -29,10 +29,10 @@ Fix the actionable review feedback on PR #1238 by replacing local absolute Markd
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 Changed documentation no longer contains Markdown links to local /Users/.../.worktrees paths.
+- [x] #1 Changed documentation no longer contains Markdown links to local absolute workspace paths.
 - [x] #2 All referenced in-repository files use correct relative links from their Markdown file location.
-- [x] #3 Focused validation confirms no absolute local workspace paths remain in the PR documentation changes.
-- [ ] #4 PR branch is committed and pushed after verification.
+- [x] #3 Focused validation confirms no absolute local workspace path strings remain in the PR documentation changes.
+- [x] #4 PR branch is committed and pushed after verification.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,17 +48,27 @@ Fix the actionable review feedback on PR #1238 by replacing local absolute Markd
 
 <!-- SECTION:NOTES:BEGIN -->
 Validated link remediation before commit:
-- rg over the six PR documentation files found no /Users/, .worktrees, or Documents/GitHub references.
+- rg over the six PR documentation files found no local absolute workspace path references.
 - test -f checks confirmed each replacement relative target exists from its source document.
 - git diff --check passed for the current edits.
+
+Committed and pushed 4caf51e64c to origin/codex/phase4-5-api-versioning-policy. Bandit was not run because the touched repo files are Markdown documentation and a Backlog task record only. GitHub checks are still pending after the push.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed the reviewed Markdown links in Docs/API/Pagination.md and Docs/superpowers/specs/2026-05-03-api-versioning-policy-design.md from local absolute worktree targets to repository-relative links so the documentation renders correctly for GitHub and other contributors. Added the Backlog task record to the PR branch for traceability.
+
+Verification: rg scan over the six PR docs found no local absolute workspace path references; test -f confirmed the replacement link targets exist from their source documents; git diff --check and git diff --cached --check passed. Bandit skipped because this was documentation-only. Pushed commit 4caf51e64c to the PR branch; GitHub checks were still pending at final review.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 Acceptance criteria completed
-- [ ] #2 Tests or verification recorded
-- [ ] #3 Documentation updated when relevant
-- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
-- [ ] #5 Final summary added
-- [ ] #6 Known skips or blockers documented
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
 <!-- DOD:END -->

--- a/backlog/tasks/task-4 - Address-PR-1238-review-comments-on-absolute-documentation-links.md
+++ b/backlog/tasks/task-4 - Address-PR-1238-review-comments-on-absolute-documentation-links.md
@@ -1,0 +1,64 @@
+---
+id: TASK-4
+title: 'Address PR #1238 review comments on absolute documentation links'
+status: In Progress
+assignee:
+  - codex
+created_date: '2026-05-03 18:23'
+updated_date: '2026-05-03 18:24'
+labels:
+  - docs
+  - pr-review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1238'
+  - 'https://github.com/rmusser01/tldw_server/pull/1238#discussion_r3178557603'
+  - 'https://github.com/rmusser01/tldw_server/pull/1238#discussion_r3178557606'
+  - 'https://github.com/rmusser01/tldw_server/pull/1238#discussion_r3178557607'
+  - 'https://github.com/rmusser01/tldw_server/pull/1238#discussion_r3178557610'
+  - 'https://github.com/rmusser01/tldw_server/pull/1238#discussion_r3178557612'
+  - 'https://github.com/rmusser01/tldw_server/pull/1238#discussion_r3178557613'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the actionable review feedback on PR #1238 by replacing local absolute Markdown links in the Phase 4.5 API versioning policy documentation with repository-relative links that render correctly on GitHub and in hosted docs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Changed documentation no longer contains Markdown links to local /Users/.../.worktrees paths.
+- [x] #2 All referenced in-repository files use correct relative links from their Markdown file location.
+- [x] #3 Focused validation confirms no absolute local workspace paths remain in the PR documentation changes.
+- [ ] #4 PR branch is committed and pushed after verification.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect the PR documentation changes for local absolute Markdown links.
+2. Replace each in-repository absolute path with the correct relative Markdown target from that file's directory.
+3. Validate with rg scans and git diff --check.
+4. Commit and push the PR branch, then record verification in the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Validated link remediation before commit:
+- rg over the six PR documentation files found no /Users/, .worktrees, or Documents/GitHub references.
+- test -f checks confirmed each replacement relative target exists from its source document.
+- git diff --check passed for the current edits.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 Acceptance criteria completed
+- [ ] #2 Tests or verification recorded
+- [ ] #3 Documentation updated when relevant
+- [ ] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [ ] #5 Final summary added
+- [ ] #6 Known skips or blockers documented
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- adds a Phase 4.5 versioning policy spec and implementation plan on a clean post-Phase-4.4 base
- updates the canonical API versioning and pagination docs to define `v1` as legacy-default and reconcile canonical envelope pagination as `metadata.pagination`
- refreshes the older Phase 4.5 decision/alignment artifacts and updates roadmap tracker issue #1116

## Change summary
This tranche is docs-only because Phase 4.5 is a policy gate, not a safe runtime refactor target by itself. The main correction is aligning the repository on the shipped helper contract: additive envelope behavior inside `v1` is transitional only, default-breaking response-shape changes move to a sibling route or `/api/v2/`, and canonical envelope pagination uses `metadata.pagination` rather than the stale `meta.pagination` wording in older planning notes. The updated docs also make the frontend/client boundary explicit so transport opt-in and unwrap behavior stays in shared service layers instead of leaking into domain/UI consumers.

## Test Plan
- `rg -n "legacy-default|X-TLDW-Response-Envelope|provider-compatible|metadata.pagination|transitional|/api/v2/|Deprecation" Docs/API/api-versioning-strategy.md Docs/API/Pagination.md Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-policy-decision-packet.md Docs/superpowers/reviews/phase4-parking-lot/2026-04-25-api-versioning-phase3-alignment.md`
- `git diff --check`

Refs #1116
