### PR TITLE
Phase 2.1: suppress stopped chatbooks cleanup handles

### DIFF
--- a/backlog/tasks/task-9 - Phase-2.1-worker-lifecycle-cleanup-A.md
+++ b/backlog/tasks/task-9 - Phase-2.1-worker-lifecycle-cleanup-A.md
@@ -1,0 +1,68 @@
+---
+id: TASK-9
+title: Phase 2.1 worker lifecycle cleanup A
+status: Done
+assignee: []
+created_date: '2026-05-03 18:51'
+updated_date: '2026-05-03 18:58'
+labels:
+  - phase-2
+  - issue-1116
+  - lifecycle
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+documentation:
+  - Docs/superpowers/specs/2026-05-03-phase2-followup-stack-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+First conservative Phase 2.1 follow-up tranche for #1116. Prove the selected lifecycle worker has a single registry shutdown owner, then remove one duplicate legacy direct-stop path only if covered by focused tests. Keep startup order, enablement flags, app-state inventory semantics, and shutdown behavior stable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A focused lifecycle ownership test proves the targeted worker is registry-owned in the expected shutdown phase.
+- [x] #2 The targeted worker no longer has an unguarded duplicate legacy direct-stop path.
+- [x] #3 Startup/shutdown behavior and app-state inventory semantics are preserved.
+- [x] #4 Focused lifecycle/startup/shutdown tests, Bandit touched-source scope, and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused coverage proving chatbooks_cleanup is registry-owned in BACKGROUND_WORKER_SHUTDOWN and appears exactly once in app-state worker inventory.
+2. Add focused red coverage proving shutdown_pre_worker_cleanup drops legacy chatbooks_cleanup task/stop-event handles after WorkerRegistry has already stopped chatbooks_cleanup.
+3. Patch only the shutdown pre-worker handoff to suppress those legacy chatbooks_cleanup handles when stopped_background_worker_names contains chatbooks_cleanup, preserving existing behavior for unstopped handles and other workers.
+4. Rerun focused startup/shutdown tests, related lifecycle shutdown tests, Bandit on touched source, and git diff --check before commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification completed:
+- RED: test_shutdown_pre_worker_cleanup_drops_registry_stopped_chatbooks_handles failed before implementation because chatbooks_cleanup handles still passed through.
+- GREEN: startup chatbooks focused 4 passed; shutdown pre-worker chatbooks focused 4 passed.
+- Full/adjacent: startup_cleanup_workers 15 passed; shutdown_pre_worker_cleanup 12 passed; lifecycle_workers 14 passed; lifespan_shutdown_sequence 1 passed; shutdown_coordinated_legacy_components 6 passed; shutdown_transition_handoff 4 passed; main_lifecycle_contract 55 passed.
+- Bandit touched source: 0 findings in /tmp/bandit_phase2_1_lifecycle_cleanup_a.json.
+- git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added focused worker ownership coverage for chatbooks_cleanup and a red/green shutdown pre-worker regression proving registry-stopped chatbooks handles are removed from the legacy direct-stop handoff. The production change is limited to reusing the existing background-stopped suppression helper for chatbooks task and stop-event handles before invoking and returning pre-worker cleanup state.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-9 - Phase-2.1-worker-lifecycle-cleanup-A.md
+++ b/backlog/tasks/task-9 - Phase-2.1-worker-lifecycle-cleanup-A.md
@@ -4,7 +4,7 @@ title: Phase 2.1 worker lifecycle cleanup A
 status: Done
 assignee: []
 created_date: '2026-05-03 18:51'
-updated_date: '2026-05-03 20:09'
+updated_date: '2026-05-03 21:35'
 labels:
   - phase-2
   - issue-1116
@@ -29,6 +29,7 @@ First conservative Phase 2.1 follow-up tranche for #1116. Prove the selected lif
 - [x] #2 The targeted worker no longer has an unguarded duplicate legacy direct-stop path.
 - [x] #3 Startup/shutdown behavior and app-state inventory semantics are preserved.
 - [x] #4 Focused lifecycle/startup/shutdown tests, Bandit touched-source scope, and git diff --check pass.
+- [x] #5 PR #1241 review comments are resolved: stopped-handle filtering has a single helper path and the new async regression test has an intent docstring.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -51,12 +52,18 @@ Verification completed:
 - git diff --check passed.
 
 PR opened: https://github.com/rmusser01/tldw_server/pull/1241
+
+Review follow-up started for PR #1241: Qodo requested an intent docstring on the new async regression test and centralization of duplicated chatbooks stopped-handle suppression between normal and fallback paths.
+
+Review follow-up verification completed: RED helper test failed with AttributeError before implementation; GREEN helper test passed after adding _filtered_pre_worker_handles; focused Services tests passed with 28 passed; Bandit touched source reported 0 findings in /tmp/bandit_pr1241_review_fixes.json; git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added focused worker ownership coverage for chatbooks_cleanup and a red/green shutdown pre-worker regression proving registry-stopped chatbooks handles are removed from the legacy direct-stop handoff. The production change is limited to reusing the existing background-stopped suppression helper for chatbooks task and stop-event handles before invoking and returning pre-worker cleanup state.
+
+Review follow-up centralized pre-worker stopped-handle filtering in _filtered_pre_worker_handles and added the requested intent docstring to the chatbooks regression test.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-9 - Phase-2.1-worker-lifecycle-cleanup-A.md
+++ b/backlog/tasks/task-9 - Phase-2.1-worker-lifecycle-cleanup-A.md
@@ -4,7 +4,7 @@ title: Phase 2.1 worker lifecycle cleanup A
 status: Done
 assignee: []
 created_date: '2026-05-03 18:51'
-updated_date: '2026-05-03 18:58'
+updated_date: '2026-05-03 20:09'
 labels:
   - phase-2
   - issue-1116
@@ -49,6 +49,8 @@ Verification completed:
 - Full/adjacent: startup_cleanup_workers 15 passed; shutdown_pre_worker_cleanup 12 passed; lifecycle_workers 14 passed; lifespan_shutdown_sequence 1 passed; shutdown_coordinated_legacy_components 6 passed; shutdown_transition_handoff 4 passed; main_lifecycle_contract 55 passed.
 - Bandit touched source: 0 findings in /tmp/bandit_phase2_1_lifecycle_cleanup_a.json.
 - git diff --check passed.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1241
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
@@ -34,37 +34,24 @@ async def shutdown_pre_worker_cleanup(
 ) -> PreWorkerCleanupHandles:
     """Run the cleanup/reset shutdown slice that precedes the worker helpers."""
     stopped_background_worker_names = stopped_background_worker_names or set()
-    cleanup_task_for_shutdown = _unless_background_stopped(
-        "ephemeral_cleanup_task",
-        cleanup_task,
-        stopped_background_worker_names,
-    )
-    chatbooks_cleanup_task_for_shutdown = _unless_background_stopped(
-        "chatbooks_cleanup",
-        chatbooks_cleanup_task,
-        stopped_background_worker_names,
-    )
-    chatbooks_cleanup_stop_event_for_shutdown = _unless_background_stopped(
-        "chatbooks_cleanup",
-        chatbooks_cleanup_stop_event,
-        stopped_background_worker_names,
+    handles = _filtered_pre_worker_handles(
+        cleanup_task=cleanup_task,
+        chatbooks_cleanup_task=chatbooks_cleanup_task,
+        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
+        storage_cleanup_service=storage_cleanup_service,
+        stopped_background_worker_names=stopped_background_worker_names,
     )
     await _shutdown_pre_worker_cleanup(
         app=app,
-        cleanup_task=cleanup_task_for_shutdown,
-        chatbooks_cleanup_task=chatbooks_cleanup_task_for_shutdown,
-        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event_for_shutdown,
-        storage_cleanup_service=storage_cleanup_service,
+        cleanup_task=handles.cleanup_task,
+        chatbooks_cleanup_task=handles.chatbooks_cleanup_task,
+        chatbooks_cleanup_stop_event=handles.chatbooks_cleanup_stop_event,
+        storage_cleanup_service=handles.storage_cleanup_service,
         coordinated_legacy_component_names=coordinated_legacy_component_names,
         guard_exceptions=guard_exceptions,
         stopped_background_worker_names=stopped_background_worker_names,
     )
-    return PreWorkerCleanupHandles(
-        cleanup_task=cleanup_task_for_shutdown,
-        chatbooks_cleanup_task=chatbooks_cleanup_task_for_shutdown,
-        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event_for_shutdown,
-        storage_cleanup_service=storage_cleanup_service,
-    )
+    return handles
 
 
 async def run_shutdown_pre_worker_cleanup(
@@ -93,23 +80,12 @@ async def run_shutdown_pre_worker_cleanup(
         )
     except guard_exceptions as exc:
         logger.debug(f"Pre-worker cleanup skipped: {exc}")
-        return PreWorkerCleanupHandles(
-            cleanup_task=_unless_background_stopped(
-                "ephemeral_cleanup_task",
-                cleanup_task,
-                stopped_background_worker_names,
-            ),
-            chatbooks_cleanup_task=_unless_background_stopped(
-                "chatbooks_cleanup",
-                chatbooks_cleanup_task,
-                stopped_background_worker_names,
-            ),
-            chatbooks_cleanup_stop_event=_unless_background_stopped(
-                "chatbooks_cleanup",
-                chatbooks_cleanup_stop_event,
-                stopped_background_worker_names,
-            ),
+        return _filtered_pre_worker_handles(
+            cleanup_task=cleanup_task,
+            chatbooks_cleanup_task=chatbooks_cleanup_task,
+            chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
             storage_cleanup_service=storage_cleanup_service,
+            stopped_background_worker_names=stopped_background_worker_names,
         )
 
 
@@ -168,6 +144,35 @@ def _unless_background_stopped(
     if name in stopped_background_worker_names:
         return None
     return value
+
+
+def _filtered_pre_worker_handles(
+    *,
+    cleanup_task: Any | None,
+    chatbooks_cleanup_task: Any | None,
+    chatbooks_cleanup_stop_event: Any | None,
+    storage_cleanup_service: Any | None,
+    stopped_background_worker_names: set[str],
+) -> PreWorkerCleanupHandles:
+    """Return legacy handles still owned by pre-worker cleanup."""
+    return PreWorkerCleanupHandles(
+        cleanup_task=_unless_background_stopped(
+            "ephemeral_cleanup_task",
+            cleanup_task,
+            stopped_background_worker_names,
+        ),
+        chatbooks_cleanup_task=_unless_background_stopped(
+            "chatbooks_cleanup",
+            chatbooks_cleanup_task,
+            stopped_background_worker_names,
+        ),
+        chatbooks_cleanup_stop_event=_unless_background_stopped(
+            "chatbooks_cleanup",
+            chatbooks_cleanup_stop_event,
+            stopped_background_worker_names,
+        ),
+        storage_cleanup_service=storage_cleanup_service,
+    )
 
 
 async def _cancel_deferred_startup_task(

--- a/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py
@@ -39,11 +39,21 @@ async def shutdown_pre_worker_cleanup(
         cleanup_task,
         stopped_background_worker_names,
     )
+    chatbooks_cleanup_task_for_shutdown = _unless_background_stopped(
+        "chatbooks_cleanup",
+        chatbooks_cleanup_task,
+        stopped_background_worker_names,
+    )
+    chatbooks_cleanup_stop_event_for_shutdown = _unless_background_stopped(
+        "chatbooks_cleanup",
+        chatbooks_cleanup_stop_event,
+        stopped_background_worker_names,
+    )
     await _shutdown_pre_worker_cleanup(
         app=app,
         cleanup_task=cleanup_task_for_shutdown,
-        chatbooks_cleanup_task=chatbooks_cleanup_task,
-        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
+        chatbooks_cleanup_task=chatbooks_cleanup_task_for_shutdown,
+        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event_for_shutdown,
         storage_cleanup_service=storage_cleanup_service,
         coordinated_legacy_component_names=coordinated_legacy_component_names,
         guard_exceptions=guard_exceptions,
@@ -51,8 +61,8 @@ async def shutdown_pre_worker_cleanup(
     )
     return PreWorkerCleanupHandles(
         cleanup_task=cleanup_task_for_shutdown,
-        chatbooks_cleanup_task=chatbooks_cleanup_task,
-        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
+        chatbooks_cleanup_task=chatbooks_cleanup_task_for_shutdown,
+        chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event_for_shutdown,
         storage_cleanup_service=storage_cleanup_service,
     )
 
@@ -89,8 +99,16 @@ async def run_shutdown_pre_worker_cleanup(
                 cleanup_task,
                 stopped_background_worker_names,
             ),
-            chatbooks_cleanup_task=chatbooks_cleanup_task,
-            chatbooks_cleanup_stop_event=chatbooks_cleanup_stop_event,
+            chatbooks_cleanup_task=_unless_background_stopped(
+                "chatbooks_cleanup",
+                chatbooks_cleanup_task,
+                stopped_background_worker_names,
+            ),
+            chatbooks_cleanup_stop_event=_unless_background_stopped(
+                "chatbooks_cleanup",
+                chatbooks_cleanup_stop_event,
+                stopped_background_worker_names,
+            ),
             storage_cleanup_service=storage_cleanup_service,
         )
 

--- a/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
@@ -88,6 +88,7 @@ async def test_shutdown_pre_worker_cleanup_returns_handles(
 async def test_shutdown_pre_worker_cleanup_drops_registry_stopped_chatbooks_handles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Suppress legacy chatbooks handles after the registry owns shutdown."""
     shutdown_cleanup = _import_shutdown_pre_worker_cleanup()
     calls: list[dict[str, object]] = []
 
@@ -113,6 +114,23 @@ async def test_shutdown_pre_worker_cleanup_drops_registry_stopped_chatbooks_hand
     assert handles.chatbooks_cleanup_task is None
     assert handles.chatbooks_cleanup_stop_event is None
     assert handles.cleanup_task == "cleanup-task"
+    assert handles.storage_cleanup_service == "storage-service"
+
+
+def test_filtered_pre_worker_handles_suppresses_registry_stopped_handles() -> None:
+    """Centralize background-stopped handle filtering for every caller."""
+    shutdown_cleanup = _import_shutdown_pre_worker_cleanup()
+    handles = shutdown_cleanup._filtered_pre_worker_handles(
+        cleanup_task="cleanup-task",
+        chatbooks_cleanup_task="chatbooks-task",
+        chatbooks_cleanup_stop_event="chatbooks-stop",
+        storage_cleanup_service="storage-service",
+        stopped_background_worker_names={"ephemeral_cleanup_task", "chatbooks_cleanup"},
+    )
+
+    assert handles.cleanup_task is None
+    assert handles.chatbooks_cleanup_task is None
+    assert handles.chatbooks_cleanup_stop_event is None
     assert handles.storage_cleanup_service == "storage-service"
 
 

--- a/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
+++ b/tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py
@@ -85,6 +85,38 @@ async def test_shutdown_pre_worker_cleanup_returns_handles(
 
 
 @pytest.mark.asyncio
+async def test_shutdown_pre_worker_cleanup_drops_registry_stopped_chatbooks_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shutdown_cleanup = _import_shutdown_pre_worker_cleanup()
+    calls: list[dict[str, object]] = []
+
+    async def _record_shutdown(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(shutdown_cleanup, "_shutdown_pre_worker_cleanup", _record_shutdown)
+
+    handles = await shutdown_cleanup.shutdown_pre_worker_cleanup(
+        app="app",
+        cleanup_task="cleanup-task",
+        chatbooks_cleanup_task="chatbooks-task",
+        chatbooks_cleanup_stop_event="chatbooks-stop",
+        storage_cleanup_service="storage-service",
+        coordinated_legacy_component_names=set(),
+        stopped_background_worker_names={"chatbooks_cleanup"},
+        guard_exceptions=(RuntimeError,),
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["chatbooks_cleanup_task"] is None
+    assert calls[0]["chatbooks_cleanup_stop_event"] is None
+    assert handles.chatbooks_cleanup_task is None
+    assert handles.chatbooks_cleanup_stop_event is None
+    assert handles.cleanup_task == "cleanup-task"
+    assert handles.storage_cleanup_service == "storage-service"
+
+
+@pytest.mark.asyncio
 async def test_shutdown_pre_worker_cleanup_cancels_deferred_and_cleanup_tasks_and_resets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_startup_cleanup_workers.py
+++ b/tldw_Server_API/tests/Services/test_startup_cleanup_workers.py
@@ -183,6 +183,56 @@ async def test_start_chatbooks_cleanup_worker_registers_background_inventory(
 
 
 @pytest.mark.asyncio
+async def test_start_chatbooks_cleanup_worker_has_single_background_registry_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    startup_cleanup = _import_startup_cleanup_workers()
+    from tldw_Server_API.app.services.worker_registry import WorkerRegistry
+
+    monkeypatch.setenv("CHATBOOKS_CLEANUP_INTERVAL_SEC", "30")
+    runner_started = asyncio.Event()
+
+    async def _fake_runner(stop_event: asyncio.Event) -> None:
+        runner_started.set()
+        await stop_event.wait()
+
+    app = FastAPI()
+    worker_inventory = WorkerRegistry(app)
+    monkeypatch.setattr(startup_cleanup, "_run_chatbooks_cleanup_loop", _fake_runner)
+
+    task, stop_event = await startup_cleanup._start_chatbooks_cleanup_worker(
+        worker_inventory=worker_inventory,
+    )
+    try:
+        await asyncio.wait_for(runner_started.wait(), timeout=1.0)
+
+        handles = worker_inventory.handles_for_phase(
+            startup_cleanup.ShutdownPhase.BACKGROUND_WORKER_SHUTDOWN
+        )
+        assert [handle.name for handle in handles].count("chatbooks_cleanup") == 1
+        assert app.state._tldw_shutdown_job_poller_inventory == []
+        assert [
+            item
+            for item in app.state._tldw_shutdown_worker_inventory
+            if item["name"] == "chatbooks_cleanup"
+        ] == [
+            {
+                "name": "chatbooks_cleanup",
+                "task_name": "chatbooks_cleanup_task",
+                "has_stop_event": True,
+                "timeout_sec": 5.0,
+                "category": "cleanup",
+                "shutdown_phase": "background_worker_shutdown",
+            }
+        ]
+    finally:
+        if stop_event is not None:
+            stop_event.set()
+        if task is not None:
+            await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_start_chatbooks_cleanup_worker_skips_when_interval_zero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Stops chatbooks startup-cleanup handles from being re-registered after they have already been stopped during shutdown pre-worker cleanup.
- Keeps the lifecycle cleanup change narrow by preserving the existing shutdown sequence and adding coverage around the covered cleanup paths.

## Change summary

TODO: human-authored summary required before merge.

## Test Plan

- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_startup_cleanup_workers.py tldw_Server_API/tests/Services/test_shutdown_pre_worker_cleanup.py tldw_Server_API/tests/Services/test_lifecycle_workers.py tldw_Server_API/tests/Services/test_lifespan_shutdown_sequence.py tldw_Server_API/tests/Services/test_shutdown_coordinated_legacy_components.py tldw_Server_API/tests/Services/test_shutdown_transition_handoff.py tldw_Server_API/tests/Services/test_main_lifecycle_contract.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/services/shutdown_pre_worker_cleanup.py -f json -o /tmp/bandit_phase2_1_lifecycle_cleanup_a_pr.json`
- [x] `git diff --check origin/dev..HEAD`
