### PR TITLE
Phase 2.2: extract covered router conditionals

### DIFF
--- a/backlog/tasks/task-10 - Phase-2.2-router-conditional-cleanup-A.md
+++ b/backlog/tasks/task-10 - Phase-2.2-router-conditional-cleanup-A.md
@@ -48,6 +48,11 @@ Verification completed:
 - Full/adjacent: router_groups_contract 33 passed; main_router_contract 6 passed; openapi_phase4_contract 5 passed.
 - Bandit router group scope: 0 findings in /tmp/bandit_phase2_2_router_conditionals_a.json.
 - git diff --check passed.
+- Review follow-up:
+  - RED: `test_append_imported_router_spec_defers_router_attr_lookup_until_resolution` failed with eager router attribute access.
+  - GREEN/focused: `test_router_groups_contract.py -k "append_imported_router_spec or populates_llm_specs"` passed 3 selected tests.
+  - Full/adjacent: `test_router_groups_contract.py -q` passed 34 tests.
+  - Bandit review-follow-up scope: 0 findings in `/tmp/bandit_pr1242_router_groups.json`.
 
 PR opened: https://github.com/rmusser01/tldw_server/pull/1242
 <!-- SECTION:NOTES:END -->
@@ -56,6 +61,8 @@ PR opened: https://github.com/rmusser01/tldw_server/pull/1242
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Added a shared conditional router import helper and used it for the covered ACP and sandbox RouterSpec families in core, admin, and minimal router groups. The change preserves existing prefixes, tags, route keys, default stability, and skip logging while removing repeated optional import-to-RouterSpec blocks.
+
+Review follow-up: `append_imported_router_spec()` now preserves that metadata while deferring router attribute lookup until `RouterSpec.resolve_router()`, and `minimal.py` now reuses the shared helper for the covered `llm_providers` and `mlx` optional imports instead of keeping a duplicate local helper.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-10 - Phase-2.2-router-conditional-cleanup-A.md
+++ b/backlog/tasks/task-10 - Phase-2.2-router-conditional-cleanup-A.md
@@ -1,0 +1,67 @@
+---
+id: TASK-10
+title: Phase 2.2 router conditional cleanup A
+status: Done
+assignee: []
+created_date: '2026-05-03 19:00'
+updated_date: '2026-05-03 19:03'
+labels:
+  - phase-2
+  - issue-1116
+  - router-groups
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Conservative Phase 2.2 follow-up tranche for #1116. Characterize sandbox/ACP router conditional specs first, then extract or narrow repeated conditional router construction only where tests cover the result. Preserve route paths, prefixes, tags, route keys, lazy import behavior, and minimal test app behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sandbox and/or ACP router conditional specs preserve prefix, tags, route keys, default stability, and lazy import behavior.
+- [x] #2 Repeated conditional import logic is extracted only where characterization tests cover the result.
+- [x] #3 Minimal test app behavior remains unchanged.
+- [x] #4 Focused router contract tests, OpenAPI route contract tests if applicable, Bandit, and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect existing router group conditional specs and tests for sandbox and ACP route families.
+2. Add characterization tests for the selected smallest router family before refactoring.
+3. Run focused router contract tests to prove baseline behavior.
+4. Extract the smallest helper only if it removes repeated conditional RouterSpec construction without changing route metadata or eager imports; otherwise make the smallest local cleanup and stop.
+5. Rerun focused router/main/OpenAPI tests as applicable, Bandit on touched router source, and git diff --check before commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification completed:
+- RED: test_append_imported_router_spec_preserves_metadata failed before implementation with missing router_groups.conditional module.
+- GREEN/focused: router_groups_contract -k "append_imported_router_spec or acp or ACP or sandbox" passed 3 selected tests.
+- Full/adjacent: router_groups_contract 33 passed; main_router_contract 6 passed; openapi_phase4_contract 5 passed.
+- Bandit router group scope: 0 findings in /tmp/bandit_phase2_2_router_conditionals_a.json.
+- git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a shared conditional router import helper and used it for the covered ACP and sandbox RouterSpec families in core, admin, and minimal router groups. The change preserves existing prefixes, tags, route keys, default stability, and skip logging while removing repeated optional import-to-RouterSpec blocks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-10 - Phase-2.2-router-conditional-cleanup-A.md
+++ b/backlog/tasks/task-10 - Phase-2.2-router-conditional-cleanup-A.md
@@ -4,7 +4,7 @@ title: Phase 2.2 router conditional cleanup A
 status: Done
 assignee: []
 created_date: '2026-05-03 19:00'
-updated_date: '2026-05-03 19:03'
+updated_date: '2026-05-03 20:09'
 labels:
   - phase-2
   - issue-1116
@@ -48,6 +48,8 @@ Verification completed:
 - Full/adjacent: router_groups_contract 33 passed; main_router_contract 6 passed; openapi_phase4_contract 5 passed.
 - Bandit router group scope: 0 findings in /tmp/bandit_phase2_2_router_conditionals_a.json.
 - git diff --check passed.
+
+PR opened: https://github.com/rmusser01/tldw_server/pull/1242
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-17 - Address-PR-1242-review-comments.md
+++ b/backlog/tasks/task-17 - Address-PR-1242-review-comments.md
@@ -1,0 +1,68 @@
+---
+id: TASK-17
+title: 'Address PR #1242 review comments'
+status: Done
+assignee:
+  - codex
+created_date: '2026-05-03 21:35'
+updated_date: '2026-05-03 21:39'
+labels:
+  - phase-2
+  - router-groups
+  - pr-review
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1242'
+  - TASK-10
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up for PR #1242 on the Phase 2.2 router conditional cleanup branch. Address review feedback by narrowing optional router import exception handling and documenting the new helper tests while preserving optional router behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 append_imported_router_spec skips only intended optional missing module or missing router attribute cases and does not suppress unrelated import-time/runtime exceptions.
+- [x] #2 New or modified helper tests document the behavior they assert.
+- [x] #3 Focused router contract tests pass for the changed helper behavior.
+- [x] #4 Bandit on touched router source and git diff --check are run and results recorded.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused regression coverage proving append_imported_router_spec still skips missing optional modules and missing router attributes but propagates unrelated import-time exceptions. 2. Add concise docstrings to the new helper tests. 3. Narrow the helper exception handling to ModuleNotFoundError/ImportError and AttributeError only. 4. Run focused router contract tests, Bandit on the touched helper source, and git diff --check; record results before pushing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RED: test_append_imported_router_spec_propagates_unexpected_import_error failed before the helper change because RuntimeError from importlib.import_module was swallowed as a skipped optional router.
+
+GREEN/focused: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "append_imported_router_spec" -q passed 5 selected tests.
+
+Full focused suite: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q passed 37 tests.
+
+Bandit: python -m bandit -r tldw_Server_API/app/api/v1/router_groups/conditional.py -f json -o /tmp/bandit_pr1242_review_comments.json reported 0 results and 0 errors.
+
+git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1242 review feedback by replacing the broad helper-level exception catch with explicit optional import handling. ImportError and ModuleNotFoundError still skip unavailable optional routers, AttributeError from lazy router lookup is logged and re-raised into the existing registration skip path, and unrelated import-time runtime failures now propagate. Added docstrings and regression coverage for optional import misses, unexpected import failures, and lazy missing-attribute registration behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-17 - Address-PR-1242-review-comments.md
+++ b/backlog/tasks/task-17 - Address-PR-1242-review-comments.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - codex
 created_date: '2026-05-03 21:35'
-updated_date: '2026-05-03 21:39'
+updated_date: '2026-05-03 21:43'
 labels:
   - phase-2
   - router-groups
@@ -49,12 +49,24 @@ Full focused suite: python -m pytest tldw_Server_API/tests/Services/test_router_
 Bandit: python -m bandit -r tldw_Server_API/app/api/v1/router_groups/conditional.py -f json -o /tmp/bandit_pr1242_review_comments.json reported 0 results and 0 errors.
 
 git diff --check passed.
+
+Additional CodeRabbit follow-up: unresolved but outdated inline thread still applies to static modules missing the router attr. Plan is to change the helper to skip static missing attrs at append time while preserving lazy lookup for modules that define module-level __getattr__.
+
+CodeRabbit static attr RED: test_append_imported_router_spec_skips_static_missing_attr failed because a static module without the requested router attr still appended a RouterSpec.
+
+CodeRabbit static attr GREEN/focused: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "append_imported_router_spec" -q passed 5 selected tests after the helper checks static module attrs before appending.
+
+Final full focused suite rerun: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q passed 37 tests.
+
+Final Bandit rerun: python -m bandit -r tldw_Server_API/app/api/v1/router_groups/conditional.py -f json -o /tmp/bandit_pr1242_review_comments.json reported 0 results and 0 errors.
+
+Final git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Addressed PR #1242 review feedback by replacing the broad helper-level exception catch with explicit optional import handling. ImportError and ModuleNotFoundError still skip unavailable optional routers, AttributeError from lazy router lookup is logged and re-raised into the existing registration skip path, and unrelated import-time runtime failures now propagate. Added docstrings and regression coverage for optional import misses, unexpected import failures, and lazy missing-attribute registration behavior.
+Addressed PR #1242 review feedback by replacing the broad helper-level exception catch with explicit optional import handling. ImportError and ModuleNotFoundError skip unavailable optional modules; static modules missing the requested router attr are skipped before appending; modules with module-level __getattr__ keep lazy attr lookup; and unrelated import-time runtime failures now propagate. Added docstrings and regression coverage for optional import misses, unexpected import failures, static missing attrs, and dynamic lazy attr lookup.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_Server_API/app/api/v1/router_groups/admin.py
+++ b/tldw_Server_API/app/api/v1/router_groups/admin.py
@@ -5,6 +5,10 @@ from typing import Iterable
 
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.router_groups.conditional import (
+    ImportedRouterSpec,
+    append_imported_router_spec,
+)
 from tldw_Server_API.app.api.v1.router_groups.spec import RouterSpec
 
 API_V1_PREFIX = "/api/v1"
@@ -68,18 +72,17 @@ def iter_admin_router_specs() -> Iterable[RouterSpec]:
         logger.debug(f"Skipping self_monitoring router: {e}")
 
     # Sandbox admin/ops endpoints.
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.sandbox import router as sandbox_router
-
-        specs.append(RouterSpec(
-            router=sandbox_router,
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.sandbox",
+            log_name="sandbox",
             prefix=f"{API_V1_PREFIX}",
             tags=("sandbox",),
             route_key="sandbox",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping sandbox router: {e}")
+        ),
+    )
 
     # Billing endpoints
     try:

--- a/tldw_Server_API/app/api/v1/router_groups/conditional.py
+++ b/tldw_Server_API/app/api/v1/router_groups/conditional.py
@@ -30,9 +30,13 @@ def append_imported_router_spec(
     """Append an optional imported router spec, preserving existing skip logging."""
     try:
         module = importlib.import_module(definition.import_path)
+
+        def _router_factory():
+            return getattr(module, definition.attr_name)
+
         specs.append(
             RouterSpec(
-                router=getattr(module, definition.attr_name),
+                router=_router_factory,
                 prefix=definition.prefix,
                 tags=definition.tags,
                 route_key=definition.route_key,

--- a/tldw_Server_API/app/api/v1/router_groups/conditional.py
+++ b/tldw_Server_API/app/api/v1/router_groups/conditional.py
@@ -30,18 +30,26 @@ def append_imported_router_spec(
     """Append an optional imported router spec, preserving existing skip logging."""
     try:
         module = importlib.import_module(definition.import_path)
-    except ImportError as e:
+        module_attrs = vars(module)
+        if definition.attr_name in module_attrs:
+            router = module_attrs[definition.attr_name]
+
+            def _router_factory():
+                return router
+        elif "__getattr__" in module_attrs:
+            def _router_factory():
+                try:
+                    return getattr(module, definition.attr_name)
+                except AttributeError as e:
+                    context = f" {definition.skip_context}" if definition.skip_context else ""
+                    logger.debug(f"Skipping {definition.log_name} router{context}: {e}")
+                    raise
+        else:
+            raise AttributeError(definition.attr_name)
+    except (ImportError, AttributeError) as e:
         context = f" {definition.skip_context}" if definition.skip_context else ""
         logger.debug(f"Skipping {definition.log_name} router{context}: {e}")
         return
-
-    def _router_factory():
-        try:
-            return getattr(module, definition.attr_name)
-        except AttributeError as e:
-            context = f" {definition.skip_context}" if definition.skip_context else ""
-            logger.debug(f"Skipping {definition.log_name} router{context}: {e}")
-            raise
 
     specs.append(
         RouterSpec(

--- a/tldw_Server_API/app/api/v1/router_groups/conditional.py
+++ b/tldw_Server_API/app/api/v1/router_groups/conditional.py
@@ -1,0 +1,44 @@
+"""Helpers for optional router imports used by router groups."""
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.router_groups.spec import RouterSpec
+
+
+@dataclass(frozen=True)
+class ImportedRouterSpec:
+    """RouterSpec metadata for a router imported inside a router group."""
+
+    import_path: str
+    log_name: str
+    prefix: str = ""
+    tags: tuple[str, ...] = ()
+    route_key: str = ""
+    default_stable: bool = True
+    attr_name: str = "router"
+    skip_context: str = ""
+
+
+def append_imported_router_spec(
+    specs: list[RouterSpec],
+    definition: ImportedRouterSpec,
+) -> None:
+    """Append an optional imported router spec, preserving existing skip logging."""
+    try:
+        module = importlib.import_module(definition.import_path)
+        specs.append(
+            RouterSpec(
+                router=getattr(module, definition.attr_name),
+                prefix=definition.prefix,
+                tags=definition.tags,
+                route_key=definition.route_key,
+                default_stable=definition.default_stable,
+            )
+        )
+    except Exception as e:  # noqa: BLE001
+        context = f" {definition.skip_context}" if definition.skip_context else ""
+        logger.debug(f"Skipping {definition.log_name} router{context}: {e}")

--- a/tldw_Server_API/app/api/v1/router_groups/conditional.py
+++ b/tldw_Server_API/app/api/v1/router_groups/conditional.py
@@ -30,19 +30,25 @@ def append_imported_router_spec(
     """Append an optional imported router spec, preserving existing skip logging."""
     try:
         module = importlib.import_module(definition.import_path)
-
-        def _router_factory():
-            return getattr(module, definition.attr_name)
-
-        specs.append(
-            RouterSpec(
-                router=_router_factory,
-                prefix=definition.prefix,
-                tags=definition.tags,
-                route_key=definition.route_key,
-                default_stable=definition.default_stable,
-            )
-        )
-    except Exception as e:  # noqa: BLE001
+    except ImportError as e:
         context = f" {definition.skip_context}" if definition.skip_context else ""
         logger.debug(f"Skipping {definition.log_name} router{context}: {e}")
+        return
+
+    def _router_factory():
+        try:
+            return getattr(module, definition.attr_name)
+        except AttributeError as e:
+            context = f" {definition.skip_context}" if definition.skip_context else ""
+            logger.debug(f"Skipping {definition.log_name} router{context}: {e}")
+            raise
+
+    specs.append(
+        RouterSpec(
+            router=_router_factory,
+            prefix=definition.prefix,
+            tags=definition.tags,
+            route_key=definition.route_key,
+            default_stable=definition.default_stable,
+        )
+    )

--- a/tldw_Server_API/app/api/v1/router_groups/core.py
+++ b/tldw_Server_API/app/api/v1/router_groups/core.py
@@ -9,6 +9,10 @@ from typing import Iterable
 
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.router_groups.conditional import (
+    ImportedRouterSpec,
+    append_imported_router_spec,
+)
 from tldw_Server_API.app.api.v1.router_groups.spec import RouterSpec
 from tldw_Server_API.app.core.testing import is_explicit_pytest_runtime as _is_explicit_pytest_runtime
 
@@ -256,70 +260,49 @@ def iter_core_router_specs() -> Iterable[RouterSpec]:
         logger.debug(f"Skipping tools router: {e}")
 
     # Agent Client Protocol (ACP) endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.agent_client_protocol import router as acp_router
-
-        specs.append(RouterSpec(
-            router=acp_router,
+    for acp_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.agent_client_protocol",
+            log_name="acp",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp",),
             route_key="acp",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping acp router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.acp_schedules import router as acp_schedules_router
-
-        specs.append(RouterSpec(
-            router=acp_schedules_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_schedules",
+            log_name="acp_schedules",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp-schedules",),
             route_key="acp",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping acp_schedules router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.acp_triggers import router as acp_triggers_router
-
-        specs.append(RouterSpec(
-            router=acp_triggers_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_triggers",
+            log_name="acp_triggers",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp-triggers",),
             route_key="acp",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping acp_triggers router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.acp_permissions import router as acp_permissions_router
-
-        specs.append(RouterSpec(
-            router=acp_permissions_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_permissions",
+            log_name="acp_permissions",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp-permissions",),
             route_key="acp",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping acp_permissions router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.acp_multiplex import router as acp_multiplex_router
-
-        specs.append(RouterSpec(
-            router=acp_multiplex_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_multiplex",
+            log_name="acp_multiplex",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp-multiplex",),
             route_key="acp",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping acp_multiplex router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, acp_spec)
 
     # LLM Providers listing
     try:

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -10,6 +10,10 @@ from typing import Any, Iterable
 
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.router_groups.conditional import (
+    ImportedRouterSpec,
+    append_imported_router_spec,
+)
 from tldw_Server_API.app.api.v1.router_groups.factories import evaluations_router_factory
 from tldw_Server_API.app.api.v1.router_groups.spec import RouterSpec
 from tldw_Server_API.app.core.testing import (
@@ -985,60 +989,44 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     except Exception as e:  # noqa: BLE001
         logger.debug(f"Skipping tools router in minimal test app: {e}")
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.agent_client_protocol import router as acp_router
-
-        specs.append(RouterSpec(
-            router=acp_router,
+    for acp_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.agent_client_protocol",
+            log_name="ACP",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping ACP router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.acp_schedules import router as acp_schedules_router
-
-        specs.append(RouterSpec(
-            router=acp_schedules_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_schedules",
+            log_name="ACP schedules",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp-schedules",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping ACP schedules router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.acp_triggers import router as acp_triggers_router
-
-        specs.append(RouterSpec(
-            router=acp_triggers_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_triggers",
+            log_name="ACP triggers",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp-triggers",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping ACP triggers router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.acp_permissions import router as acp_permissions_router
-
-        specs.append(RouterSpec(
-            router=acp_permissions_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_permissions",
+            log_name="ACP permissions",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp-permissions",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping ACP permissions router in minimal test app: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.acp_multiplex import router as acp_multiplex_router
-
-        specs.append(RouterSpec(
-            router=acp_multiplex_router,
+            skip_context="in minimal test app",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_multiplex",
+            log_name="ACP multiplex",
             prefix=f"{API_V1_PREFIX}",
             tags=("acp-multiplex",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping ACP multiplex router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    ):
+        append_imported_router_spec(specs, acp_spec)
 
     try:
         from tldw_Server_API.app.api.v1.endpoints.agent_orchestration import router as orch_router
@@ -1084,15 +1072,15 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     except Exception as e:  # noqa: BLE001
         logger.debug(f"Skipping authnz_debug router in tests: {e}")
 
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.sandbox import router as sandbox_router
-
-        specs.append(RouterSpec(
-            router=sandbox_router,
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.sandbox",
+            log_name="sandbox",
             prefix=f"{API_V1_PREFIX}",
             tags=("sandbox",),
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping sandbox router in minimal test app: {e}")
+            skip_context="in minimal test app",
+        ),
+    )
 
     return specs

--- a/tldw_Server_API/app/api/v1/router_groups/minimal.py
+++ b/tldw_Server_API/app/api/v1/router_groups/minimal.py
@@ -5,8 +5,7 @@ integration tests working without importing the broader endpoint surface.
 """
 from __future__ import annotations
 
-import importlib
-from typing import Any, Iterable
+from typing import Iterable
 
 from loguru import logger
 
@@ -23,23 +22,6 @@ from tldw_Server_API.app.core.testing import (
 )
 
 API_V1_PREFIX = "/api/v1"
-
-
-def _try_add_spec(
-    specs: list[RouterSpec],
-    import_path: str,
-    *,
-    log_name: str,
-    attr_name: str = "router",
-    **spec_kwargs: Any,
-) -> None:
-    try:
-        module = importlib.import_module(import_path)
-        specs.append(RouterSpec(router=getattr(module, attr_name), **spec_kwargs))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping {log_name} router in minimal test app: {e}")
-
-
 def iter_minimal_test_router_specs() -> Iterable[RouterSpec]:
     """Yield the always-included minimal-test router specs."""
     from tldw_Server_API.app.api.v1.endpoints.auth import router as auth_router
@@ -91,19 +73,25 @@ def iter_minimal_optional_router_specs() -> Iterable[RouterSpec]:
     """Yield optional minimal-test router specs, skipping unavailable imports."""
     specs: list[RouterSpec] = []
 
-    _try_add_spec(
+    append_imported_router_spec(
         specs,
-        "tldw_Server_API.app.api.v1.endpoints.llm_providers",
-        log_name="llm providers",
-        prefix=f"{API_V1_PREFIX}",
-        tags=("llm",),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.llm_providers",
+            log_name="llm providers",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("llm",),
+            skip_context="in minimal test app",
+        ),
     )
-    _try_add_spec(
+    append_imported_router_spec(
         specs,
-        "tldw_Server_API.app.api.v1.endpoints.mlx",
-        log_name="mlx",
-        prefix=f"{API_V1_PREFIX}",
-        tags=("llm",),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.mlx",
+            log_name="mlx",
+            prefix=f"{API_V1_PREFIX}",
+            tags=("llm",),
+            skip_context="in minimal test app",
+        ),
     )
 
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -192,10 +192,10 @@ def test_append_imported_router_spec_propagates_unexpected_import_error(
     assert specs == []
 
 
-def test_append_imported_router_spec_missing_attr_skips_at_registration(
+def test_append_imported_router_spec_skips_static_missing_attr(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify missing router attributes are skipped through lazy registration."""
+    """Verify static modules missing router attrs are skipped before registration."""
     from tldw_Server_API.app.api.v1.router_groups.conditional import (
         ImportedRouterSpec,
         append_imported_router_spec,
@@ -215,11 +215,7 @@ def test_append_imported_router_spec_missing_attr_skips_at_registration(
         ),
     )
 
-    app = FastAPI()
-
-    assert len(specs) == 1
-    assert register_router_specs(app, specs) == 0
-    assert "/api/v1/missing-router-attr" not in {route.path for route in app.routes}
+    assert specs == []
 
 
 def test_register_router_specs_respects_route_policy(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -88,6 +88,49 @@ def test_append_imported_router_spec_preserves_metadata(
     assert specs[0].default_stable is False
 
 
+def test_append_imported_router_spec_defers_router_attr_lookup_until_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.api.v1.router_groups.conditional import (
+        ImportedRouterSpec,
+        append_imported_router_spec,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.lazy_router"
+    access_count = {"router": 0}
+    fake_module = ModuleType(module_name)
+    router = APIRouter()
+
+    @router.get("/lazy/router")
+    def _lazy_router() -> dict[str, str]:
+        return {"status": "ok"}
+
+    def _module_getattr(name: str) -> APIRouter:
+        if name != "router":
+            raise AttributeError(name)
+        access_count["router"] += 1
+        return router
+
+    fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs: list[RouterSpec] = []
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path=module_name,
+            log_name="lazy-router",
+            prefix="/api/v1",
+            tags=("lazy-router",),
+        ),
+    )
+
+    assert len(specs) == 1
+    assert access_count["router"] == 0
+    assert _first_router_path(specs[0].router) == "/lazy/router"
+    assert access_count["router"] == 1
+
+
 def test_register_router_specs_respects_route_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     app = FastAPI()
     router = APIRouter()

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -53,6 +53,41 @@ def _first_router_path(router: APIRouter | Callable[[], APIRouter]) -> str:
     raise AssertionError("router had no path-bearing routes")
 
 
+def test_append_imported_router_spec_preserves_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.api.v1.router_groups.conditional import (
+        ImportedRouterSpec,
+        append_imported_router_spec,
+    )
+
+    specs: list[RouterSpec] = []
+    _install_fake_router_module(
+        monkeypatch,
+        "tldw_Server_API.app.api.v1.endpoints.acp_schedules",
+        path="/acp/schedules",
+    )
+
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.acp_schedules",
+            log_name="acp_schedules",
+            prefix="/api/v1",
+            tags=("acp-schedules",),
+            route_key="acp",
+            default_stable=False,
+        ),
+    )
+
+    assert len(specs) == 1
+    assert _first_router_path(specs[0].router) == "/acp/schedules"
+    assert specs[0].prefix == "/api/v1"
+    assert specs[0].tags == ("acp-schedules",)
+    assert specs[0].route_key == "acp"
+    assert specs[0].default_stable is False
+
+
 def test_register_router_specs_respects_route_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     app = FastAPI()
     router = APIRouter()

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -56,6 +56,7 @@ def _first_router_path(router: APIRouter | Callable[[], APIRouter]) -> str:
 def test_append_imported_router_spec_preserves_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify imported router specs retain the metadata used for registration."""
     from tldw_Server_API.app.api.v1.router_groups.conditional import (
         ImportedRouterSpec,
         append_imported_router_spec,
@@ -91,6 +92,7 @@ def test_append_imported_router_spec_preserves_metadata(
 def test_append_imported_router_spec_defers_router_attr_lookup_until_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify router attribute lookup stays lazy until RouterSpec resolution."""
     from tldw_Server_API.app.api.v1.router_groups.conditional import (
         ImportedRouterSpec,
         append_imported_router_spec,
@@ -129,6 +131,95 @@ def test_append_imported_router_spec_defers_router_attr_lookup_until_resolution(
     assert access_count["router"] == 0
     assert _first_router_path(specs[0].router) == "/lazy/router"
     assert access_count["router"] == 1
+
+
+def test_append_imported_router_spec_skips_optional_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify unavailable optional router modules are skipped during import."""
+    from tldw_Server_API.app.api.v1.router_groups.conditional import (
+        ImportedRouterSpec,
+        append_imported_router_spec,
+    )
+
+    def _raise_import_error(_import_path: str) -> ModuleType:
+        raise ModuleNotFoundError("optional router is unavailable")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _raise_import_error,
+    )
+    specs: list[RouterSpec] = []
+
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.optional_missing",
+            log_name="optional-missing",
+        ),
+    )
+
+    assert specs == []
+
+
+def test_append_imported_router_spec_propagates_unexpected_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify unexpected import-time failures are not hidden as optional routers."""
+    from tldw_Server_API.app.api.v1.router_groups.conditional import (
+        ImportedRouterSpec,
+        append_imported_router_spec,
+    )
+
+    def _raise_runtime_error(_import_path: str) -> ModuleType:
+        raise RuntimeError("router module crashed during import")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _raise_runtime_error,
+    )
+    specs: list[RouterSpec] = []
+
+    with pytest.raises(RuntimeError, match="router module crashed"):
+        append_imported_router_spec(
+            specs,
+            ImportedRouterSpec(
+                import_path="tldw_Server_API.app.api.v1.endpoints.crashing_router",
+                log_name="crashing-router",
+            ),
+        )
+
+    assert specs == []
+
+
+def test_append_imported_router_spec_missing_attr_skips_at_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify missing router attributes are skipped through lazy registration."""
+    from tldw_Server_API.app.api.v1.router_groups.conditional import (
+        ImportedRouterSpec,
+        append_imported_router_spec,
+    )
+
+    module_name = "tldw_Server_API.app.api.v1.endpoints.missing_router_attr"
+    monkeypatch.setitem(sys.modules, module_name, ModuleType(module_name))
+    specs: list[RouterSpec] = []
+
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path=module_name,
+            log_name="missing-router-attr",
+            prefix="/api/v1",
+            tags=("missing-router-attr",),
+        ),
+    )
+
+    app = FastAPI()
+
+    assert len(specs) == 1
+    assert register_router_specs(app, specs) == 0
+    assert "/api/v1/missing-router-attr" not in {route.path for route in app.routes}
 
 
 def test_register_router_specs_respects_route_policy(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Extracts covered router conditional assembly into smaller router group helpers without changing route registration behavior.
- Keeps the tranche constrained to already-covered ACP, sandbox, admin, core, and minimal router paths.

## Change summary

TODO: human-authored summary required before merge.

## Test Plan

- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py tldw_Server_API/tests/Services/test_main_router_contract.py tldw_Server_API/tests/Utils/test_openapi_phase4_contract.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/admin.py tldw_Server_API/app/api/v1/router_groups/conditional.py tldw_Server_API/app/api/v1/router_groups/core.py tldw_Server_API/app/api/v1/router_groups/minimal.py -f json -o /tmp/bandit_phase2_2_router_conditionals_a_pr.json`
- [x] `git diff --check origin/dev..HEAD`
