### PR TITLE
Phase 2.2: defer core chat router imports

### DIFF
--- a/backlog/tasks/task-19 - Phase-2.2-chat-router-conditional-cleanup-B.md
+++ b/backlog/tasks/task-19 - Phase-2.2-chat-router-conditional-cleanup-B.md
@@ -1,0 +1,65 @@
+---
+id: TASK-19
+title: Phase 2.2 chat router conditional cleanup B
+status: Done
+assignee: []
+created_date: '2026-05-03 22:03'
+labels:
+  - phase-2
+  - router-groups
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+documentation:
+  - Docs/superpowers/specs/2026-05-03-phase2-followup-stack-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-03-phase2-followup-stack-implementation-plan.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move only the covered core chat router specs onto the shared conditional router helper introduced by the Phase 2.2 A tranche. Preserve public route paths, tags, route keys, route enablement behavior, and minimal-app behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Core chat, chat_loop, and conversations_alias RouterSpec metadata is preserved.
+- [x] #2 Router attribute lookup for the moved chat specs is lazy through RouterSpec resolution.
+- [x] #3 Minimal test app chat behavior remains unchanged.
+- [x] #4 Focused router contract tests, Bandit touched-source scope, and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test proving core chat router attribute lookup is deferred until RouterSpec resolution. 2. Run the focused selection red on current code. 3. Replace the three covered open-coded core chat imports with ImportedRouterSpec plus append_imported_router_spec. 4. Run focused and full router contract tests. 5. Run Bandit on touched router source and git diff --check. 6. Commit the narrow tranche and update the task record.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "core_router_specs_defers_chat" -q` failed before the implementation because core chat router attributes were resolved while building specs.
+- Green checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `38 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/core.py -f json -o /tmp/bandit_phase2_2_chat_router_conditionals_b.json` reported `0 results` and `0 errors`; `git diff --check` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered core chat, chat loop, and conversations alias router registrations from eager local imports to the shared lazy `ImportedRouterSpec` helper while preserving prefixes, tags, and route keys. Added a regression test that proves these chat router attributes are not resolved until the `RouterSpec.router` accessor is used, and verified the focused router contracts, minimal main-router contract, OpenAPI contracts, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-19.1 - Address-PR-1245-review-comments.md
+++ b/backlog/tasks/task-19.1 - Address-PR-1245-review-comments.md
@@ -1,0 +1,53 @@
+---
+id: TASK-19.1
+title: 'Address PR #1245 review comments'
+status: Done
+assignee: []
+created_date: '2026-05-03 22:45'
+updated_date: '2026-05-03 22:50'
+labels:
+  - phase-2
+  - router-groups
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1245'
+parent_task_id: TASK-19
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow up on PR #1245 review feedback for the Phase 2.2 chat router conditional cleanup. Verify and fix the chat router import crash regression, ambiguous skip logging for lazy router resolution failures, test helper fake-module leakage risk, and overlong test asserts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Unexpected import-time exceptions from covered core chat router modules are caught and skip only the affected chat router spec with a router-specific log name.
+- [x] #2 RouterSpec resolution failure logs use a router-specific name when available and preserve the existing route_key fallback.
+- [x] #3 Router contract test helpers do not mutate pre-imported real endpoint modules when installing fake routers.
+- [x] #4 Focused router contract tests, Bandit touched-source scope, and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Red check: python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k 'fake_router_module_does_not_mutate or crashing_chat_import or logs_spec_name' -q failed on the expected fake-module mutation, unhandled chat_loop RuntimeError, and missing RouterSpec name support. Green checks: focused review selection passed with 3 passed; full router contract passed with 41 passed; main router plus OpenAPI contracts passed with 75 passed. Security and hygiene: Bandit touched source scope reported 0 results and 0 errors in /tmp/bandit_pr1245_review_fixes.json; git diff --check passed; newly-added line-length scan found no added lines over 100 characters.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1245 review feedback by preserving catch-and-skip behavior for covered core chat router import crashes, carrying ImportedRouterSpec.log_name into RouterSpec diagnostics, using that name for lazy router resolution skip logs, preventing fake-router test helpers from mutating real pre-imported modules, and wrapping the reviewed overlong assertions.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/conditional.py
+++ b/tldw_Server_API/app/api/v1/router_groups/conditional.py
@@ -58,5 +58,6 @@ def append_imported_router_spec(
             tags=definition.tags,
             route_key=definition.route_key,
             default_stable=definition.default_stable,
+            name=definition.log_name,
         )
     )

--- a/tldw_Server_API/app/api/v1/router_groups/core.py
+++ b/tldw_Server_API/app/api/v1/router_groups/core.py
@@ -211,39 +211,29 @@ def iter_core_router_specs() -> Iterable[RouterSpec]:
         logger.debug(f"Skipping sync router: {e}")
 
     # Chat endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chat import router as chat_router
-
-        specs.append(RouterSpec(
-            router=chat_router,
+    for chat_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chat",
+            log_name="chat",
             prefix=f"{API_V1_PREFIX}/chat",
             route_key="chat",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping chat router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chat_loop import router as chat_loop_router
-
-        specs.append(RouterSpec(
-            router=chat_loop_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chat_loop",
+            log_name="chat_loop",
             prefix=f"{API_V1_PREFIX}",
             route_key="chat",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping chat_loop router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chat import conversations_alias_router
-
-        specs.append(RouterSpec(
-            router=conversations_alias_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chat",
+            log_name="conversations_alias",
             prefix=f"{API_V1_PREFIX}/chats",
             tags=("chat",),
             route_key="chat",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping conversations_alias router: {e}")
+            attr_name="conversations_alias_router",
+        ),
+    ):
+        append_imported_router_spec(specs, chat_spec)
 
     # Tools endpoint
     try:

--- a/tldw_Server_API/app/api/v1/router_groups/core.py
+++ b/tldw_Server_API/app/api/v1/router_groups/core.py
@@ -233,7 +233,10 @@ def iter_core_router_specs() -> Iterable[RouterSpec]:
             attr_name="conversations_alias_router",
         ),
     ):
-        append_imported_router_spec(specs, chat_spec)
+        try:
+            append_imported_router_spec(specs, chat_spec)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Skipping {chat_spec.log_name} router: {e}")
 
     # Tools endpoint
     try:

--- a/tldw_Server_API/app/api/v1/router_groups/spec.py
+++ b/tldw_Server_API/app/api/v1/router_groups/spec.py
@@ -18,12 +18,14 @@ class RouterSpec:
         tags: OpenAPI tags for grouping.
         route_key: Config key for route_enabled() gating. Empty string means always enabled.
         default_stable: Passed to route_enabled() as default_stable kwarg.
+        name: Optional display name for diagnostics; falls back to route_key.
     """
     router: APIRouter | RouterFactory
     prefix: str = ""
     tags: tuple[str, ...] = ()
     route_key: str = ""
     default_stable: bool = True
+    name: str = ""
     _resolved_router: APIRouter | None = field(default=None, init=False, repr=False, compare=False)
 
     def resolve_router(self) -> APIRouter:

--- a/tldw_Server_API/app/api/v1/router_registry.py
+++ b/tldw_Server_API/app/api/v1/router_registry.py
@@ -54,7 +54,8 @@ def register_router_specs(app: FastAPI, specs: Iterable[RouterSpec]) -> int:
         try:
             router = spec.resolve_router()
         except Exception as e:  # noqa: BLE001
-            logger.debug(f"Skipping {spec.route_key or 'unnamed'} router: {e}")
+            spec_name = spec.name or spec.route_key or "unnamed"
+            logger.debug(f"Skipping {spec_name} router: {e}")
             continue
 
         if include_router_idempotent(app, router, prefix=spec.prefix, tags=spec.tags):

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -218,6 +218,82 @@ def test_append_imported_router_spec_skips_static_missing_attr(
     assert specs == []
 
 
+def test_iter_core_router_specs_defers_chat_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered core chat specs keep router attr lookup lazy."""
+    chat_module_name = "tldw_Server_API.app.api.v1.endpoints.chat"
+    chat_loop_module_name = "tldw_Server_API.app.api.v1.endpoints.chat_loop"
+    access_count = {
+        "chat.router": 0,
+        "chat.conversations_alias_router": 0,
+        "chat_loop.router": 0,
+    }
+
+    chat_router = APIRouter()
+    conversations_router = APIRouter()
+    chat_loop_router = APIRouter()
+
+    @chat_router.get("/chat/completions")
+    def _chat_completions() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @conversations_router.get("/conversations")
+    def _conversations() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @chat_loop_router.get("/chat/loop/start")
+    def _chat_loop_start() -> dict[str, str]:
+        return {"status": "ok"}
+
+    chat_module = ModuleType(chat_module_name)
+
+    def _chat_getattr(name: str) -> APIRouter:
+        if name == "router":
+            access_count["chat.router"] += 1
+            return chat_router
+        if name == "conversations_alias_router":
+            access_count["chat.conversations_alias_router"] += 1
+            return conversations_router
+        raise AttributeError(name)
+
+    chat_module.__getattr__ = _chat_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, chat_module_name, chat_module)
+
+    chat_loop_module = ModuleType(chat_loop_module_name)
+
+    def _chat_loop_getattr(name: str) -> APIRouter:
+        if name == "router":
+            access_count["chat_loop.router"] += 1
+            return chat_loop_router
+        raise AttributeError(name)
+
+    chat_loop_module.__getattr__ = _chat_loop_getattr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, chat_loop_module_name, chat_loop_module)
+
+    specs = list(iter_core_router_specs())
+    assert access_count == {
+        "chat.router": 0,
+        "chat.conversations_alias_router": 0,
+        "chat_loop.router": 0,
+    }
+
+    by_meta = {
+        (spec.prefix, spec.tags): spec
+        for spec in specs
+        if spec.route_key == "chat"
+    }
+
+    assert _first_router_path(by_meta[("/api/v1/chat", ())].router) == "/chat/completions"
+    assert _first_router_path(by_meta[("/api/v1", ())].router) == "/chat/loop/start"
+    assert _first_router_path(by_meta[("/api/v1/chats", ("chat",))].router) == "/conversations"
+    assert access_count == {
+        "chat.router": 1,
+        "chat.conversations_alias_router": 1,
+        "chat_loop.router": 1,
+    }
+
+
 def test_register_router_specs_respects_route_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     app = FastAPI()
     router = APIRouter()

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -36,8 +36,13 @@ def _install_fake_router_module(
     def _endpoint() -> dict[str, str]:
         return {"path": path}
 
-    existing_module = sys.modules.get(module_name)
-    fake_module = existing_module if isinstance(existing_module, ModuleType) else ModuleType(module_name)
+    fake_module = sys.modules.get(module_name)
+    if (
+        not isinstance(fake_module, ModuleType)
+        or not getattr(fake_module, "_router_test_fake", False)
+    ):
+        fake_module = ModuleType(module_name)
+        setattr(fake_module, "_router_test_fake", True)
     setattr(fake_module, attr_name, router)
     monkeypatch.setitem(sys.modules, module_name, fake_module)
     return router
@@ -51,6 +56,25 @@ def _first_router_path(router: APIRouter | Callable[[], APIRouter]) -> str:
         if route_path is not None:
             return str(route_path)
     raise AssertionError("router had no path-bearing routes")
+
+
+def test_install_fake_router_module_does_not_mutate_existing_real_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify test fakes replace real modules instead of mutating them in place."""
+    module_name = "tldw_Server_API.app.api.v1.endpoints.fake_existing_real"
+    real_module = ModuleType(module_name)
+    monkeypatch.setitem(sys.modules, module_name, real_module)
+
+    router = _install_fake_router_module(
+        monkeypatch,
+        module_name,
+        path="/fake-existing-real",
+    )
+
+    assert not hasattr(real_module, "router")
+    assert sys.modules[module_name] is not real_module
+    assert getattr(sys.modules[module_name], "router") is router
 
 
 def test_append_imported_router_spec_preserves_metadata(
@@ -284,14 +308,77 @@ def test_iter_core_router_specs_defers_chat_router_attr_lookup(
         if spec.route_key == "chat"
     }
 
-    assert _first_router_path(by_meta[("/api/v1/chat", ())].router) == "/chat/completions"
-    assert _first_router_path(by_meta[("/api/v1", ())].router) == "/chat/loop/start"
-    assert _first_router_path(by_meta[("/api/v1/chats", ("chat",))].router) == "/conversations"
+    expected_paths_by_meta = {
+        ("/api/v1/chat", ()): "/chat/completions",
+        ("/api/v1", ()): "/chat/loop/start",
+        ("/api/v1/chats", ("chat",)): "/conversations",
+    }
+    assert {
+        meta: _first_router_path(spec.router)
+        for meta, spec in by_meta.items()
+        if meta in expected_paths_by_meta
+    } == expected_paths_by_meta
     assert access_count == {
         "chat.router": 1,
         "chat.conversations_alias_router": 1,
         "chat_loop.router": 1,
     }
+
+
+def test_iter_core_router_specs_skips_crashing_chat_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify chat import crashes skip only the affected chat router spec."""
+    import importlib
+
+    chat_module_name = "tldw_Server_API.app.api.v1.endpoints.chat"
+    chat_loop_module_name = "tldw_Server_API.app.api.v1.endpoints.chat_loop"
+    chat_module = ModuleType(chat_module_name)
+    chat_router = APIRouter()
+    conversations_router = APIRouter()
+    debug_messages: list[str] = []
+
+    @chat_router.get("/chat/completions")
+    def _chat_completions() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @conversations_router.get("/conversations")
+    def _conversations() -> dict[str, str]:
+        return {"status": "ok"}
+
+    chat_module.router = chat_router  # type: ignore[attr-defined]
+    chat_module.conversations_alias_router = conversations_router  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, chat_module_name, chat_module)
+
+    real_import_module = importlib.import_module
+
+    def _import_module(module_name: str) -> ModuleType:
+        if module_name == chat_loop_module_name:
+            raise RuntimeError("chat loop crashed during import")
+        return real_import_module(module_name)
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.conditional.importlib.import_module",
+        _import_module,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.api.v1.router_groups.core.logger.debug",
+        debug_messages.append,
+    )
+
+    specs = list(iter_core_router_specs())
+    chat_specs = [
+        spec
+        for spec in specs
+        if spec.route_key == "chat"
+    ]
+    chat_paths = {
+        _first_router_path(spec.router)
+        for spec in chat_specs
+    }
+
+    assert chat_paths == {"/chat/completions", "/conversations"}
+    assert "Skipping chat_loop router: chat loop crashed during import" in debug_messages
 
 
 def test_register_router_specs_respects_route_policy(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -356,6 +443,38 @@ def test_register_router_specs_resolves_lazy_router_after_route_policy(
     assert enabled_count == 1
     assert calls == 1
     assert "/api/v1/lazy" in {route.path for route in app.routes}
+
+
+def test_register_router_specs_logs_spec_name_for_resolution_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    debug_messages: list[str] = []
+
+    def router_factory() -> APIRouter:
+        raise RuntimeError("lazy router failed")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.config.route_enabled",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr("loguru.logger.debug", debug_messages.append)
+
+    count = register_router_specs(
+        app,
+        [
+            RouterSpec(
+                router=router_factory,
+                prefix="/api/v1",
+                tags=("lazy",),
+                route_key="chat",
+                name="chat_loop",
+            ),
+        ],
+    )
+
+    assert count == 0
+    assert debug_messages == ["Skipping chat_loop router: lazy router failed"]
 
 
 def test_register_router_specs_fails_closed_when_route_policy_errors(


### PR DESCRIPTION
## Summary
- Moves the covered core chat, chat_loop, and conversations_alias router registrations onto the shared lazy ImportedRouterSpec helper.
- Preserves route prefixes, tags, and route keys while avoiding eager router attr lookup during core spec construction.
- Adds regression coverage for deferred chat router attr resolution.

## Change summary
TODO: human-authored summary required before merge under Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

## Test Plan
- [x] python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- [x] python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- [x] python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- [x] python -m bandit -r tldw_Server_API/app/api/v1/router_groups/core.py -f json -o /tmp/bandit_phase2_2_chat_router_conditionals_b.json
- [x] git diff --check