### PR TITLE
Phase 2.2: defer admin router imports

### DIFF
--- a/backlog/tasks/task-21 - Phase-2.2-admin-router-conditional-cleanup-C.md
+++ b/backlog/tasks/task-21 - Phase-2.2-admin-router-conditional-cleanup-C.md
@@ -4,6 +4,7 @@ title: Phase 2.2 admin router conditional cleanup C
 status: Done
 assignee: []
 created_date: '2026-05-03 23:07'
+updated_date: '2026-05-03 23:45'
 labels:
   - phase-2
   - router-groups
@@ -34,6 +35,18 @@ Move only covered single-router admin specs onto the shared lazy ImportedRouterS
 1. Add a focused regression test proving selected admin router attribute lookup is deferred until RouterSpec resolution. 2. Run the focused selection red on current code. 3. Replace only the covered single-router admin imports with ImportedRouterSpec plus append_imported_router_spec. 4. Run focused and full router contract tests plus adjacent main/OpenAPI contract tests. 5. Run Bandit on touched router source and git diff --check. 6. Commit the narrow tranche and update the task record.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-03 PR #1246 review follow-up: hardened test_iter_admin_router_specs_defers_selected_router_attr_lookup so sandbox must be stubbed in sys.modules before iter_admin_router_specs() runs. Added an importlib guard that fails if the test would import the real sandbox endpoint module during spec registration.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered single-router admin registrations to the shared lazy `ImportedRouterSpec` helper while preserving prefixes, tags, route keys, default stability, order, and per-router skip logging. Added regression coverage proving selected admin router attributes are not resolved until `RouterSpec.router` is used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 Acceptance criteria completed
@@ -54,9 +67,3 @@ Move only covered single-router admin specs onto the shared lazy ImportedRouterS
 - Documentation: no user-facing docs required for this internal router registration refactor.
 - Known skips or blockers: none.
 <!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Moved the covered single-router admin registrations to the shared lazy `ImportedRouterSpec` helper while preserving prefixes, tags, route keys, default stability, order, and per-router skip logging. Added regression coverage proving selected admin router attributes are not resolved until `RouterSpec.router` is used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-21 - Phase-2.2-admin-router-conditional-cleanup-C.md
+++ b/backlog/tasks/task-21 - Phase-2.2-admin-router-conditional-cleanup-C.md
@@ -1,0 +1,62 @@
+---
+id: TASK-21
+title: Phase 2.2 admin router conditional cleanup C
+status: Done
+assignee: []
+created_date: '2026-05-03 23:07'
+labels:
+  - phase-2
+  - router-groups
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move only covered single-router admin specs onto the shared lazy ImportedRouterSpec helper. Preserve public route prefixes, tags, route keys, default stability, skip behavior, and minimal app behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected admin RouterSpec metadata is preserved.
+- [x] #2 Router attribute lookup for moved admin specs is lazy through RouterSpec resolution.
+- [x] #3 Full router group contract and adjacent main/OpenAPI contract tests pass.
+- [x] #4 Bandit touched-source scope and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test proving selected admin router attribute lookup is deferred until RouterSpec resolution. 2. Run the focused selection red on current code. 3. Replace only the covered single-router admin imports with ImportedRouterSpec plus append_imported_router_spec. 4. Run focused and full router contract tests plus adjacent main/OpenAPI contract tests. 5. Run Bandit on touched router source and git diff --check. 6. Commit the narrow tranche and update the task record.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "admin_router_specs_defers_selected" -q` failed before implementation because selected admin router attributes were resolved during spec construction.
+- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "admin_router_specs_defers_selected or admin_router_specs_populates_expected" -q` passed with `2 passed`.
+- Green full/adjacent checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `42 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/admin.py -f json -o /tmp/bandit_phase2_2_admin_router_conditionals_c.json` reported `0 results` and `0 errors`; `git diff --check` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered single-router admin registrations to the shared lazy `ImportedRouterSpec` helper while preserving prefixes, tags, route keys, default stability, order, and per-router skip logging. Added regression coverage proving selected admin router attributes are not resolved until `RouterSpec.router` is used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/admin.py
+++ b/tldw_Server_API/app/api/v1/router_groups/admin.py
@@ -18,62 +18,41 @@ def iter_admin_router_specs() -> Iterable[RouterSpec]:
     """Yield admin/ops router specs."""
     specs: list[RouterSpec] = []
 
-    # Admin endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.admin import router as admin_router
-
-        specs.append(RouterSpec(
-            router=admin_router,
+    for admin_spec in (
+        # Admin endpoints
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.admin",
+            log_name="admin",
             prefix=f"{API_V1_PREFIX}",
             tags=("admin",),
             route_key="admin",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping admin router: {e}")
-
-    # Guardian and family safety endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.family_wizard import router as family_wizard_router
-
-        specs.append(RouterSpec(
-            router=family_wizard_router,
+        ),
+        # Guardian and family safety endpoints
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.family_wizard",
+            log_name="family_wizard",
             prefix=f"{API_V1_PREFIX}/guardian",
             tags=("guardian",),
             route_key="guardian",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping family_wizard router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.guardian_controls import router as guardian_controls_router
-
-        specs.append(RouterSpec(
-            router=guardian_controls_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.guardian_controls",
+            log_name="guardian_controls",
             prefix=f"{API_V1_PREFIX}/guardian",
             tags=("guardian",),
             route_key="guardian",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping guardian_controls router: {e}")
-
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.self_monitoring import router as self_monitoring_router
-
-        specs.append(RouterSpec(
-            router=self_monitoring_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.self_monitoring",
+            log_name="self_monitoring",
             prefix=f"{API_V1_PREFIX}/self-monitoring",
             tags=("self-monitoring",),
             route_key="self-monitoring",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping self_monitoring router: {e}")
-
-    # Sandbox admin/ops endpoints.
-    append_imported_router_spec(
-        specs,
+        ),
+        # Sandbox admin/ops endpoints.
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.sandbox",
             log_name="sandbox",
@@ -82,156 +61,99 @@ def iter_admin_router_specs() -> Iterable[RouterSpec]:
             route_key="sandbox",
             default_stable=False,
         ),
-    )
-
-    # Billing endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.billing import router as billing_router
-
-        specs.append(RouterSpec(
-            router=billing_router,
+        # Billing endpoints
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.billing",
+            log_name="billing",
             prefix=f"{API_V1_PREFIX}",
             tags=("billing",),
             route_key="billing",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping billing router: {e}")
-
-    # Benchmarks endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.benchmark_api import router as benchmark_router
-
-        specs.append(RouterSpec(
-            router=benchmark_router,
+        ),
+        # Benchmarks endpoints
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.benchmark_api",
+            log_name="benchmark",
             prefix=f"{API_V1_PREFIX}",
             tags=("benchmarks",),
             route_key="benchmarks",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping benchmark router: {e}")
-
-    # MCP catalogs management
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.mcp_catalogs_manage import (
-            router as mcp_catalogs_manage_router,
-        )
-
-        specs.append(RouterSpec(
-            router=mcp_catalogs_manage_router,
+        ),
+        # MCP catalogs management
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.mcp_catalogs_manage",
+            log_name="mcp_catalogs",
             prefix=f"{API_V1_PREFIX}",
             route_key="mcp-catalogs",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping mcp_catalogs router: {e}")
-
-    # MCP hub management
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.mcp_hub_management import (
-            router as mcp_hub_management_router,
-        )
-
-        specs.append(RouterSpec(
-            router=mcp_hub_management_router,
+        ),
+        # MCP hub management
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.mcp_hub_management",
+            log_name="mcp_hub",
             prefix=f"{API_V1_PREFIX}",
             tags=("mcp-hub",),
             route_key="mcp-hub",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping mcp_hub router: {e}")
-
-    # Organizations management
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.orgs import router as orgs_router
-
-        specs.append(RouterSpec(
-            router=orgs_router,
+        ),
+        # Organizations management
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.orgs",
+            log_name="orgs",
             prefix=f"{API_V1_PREFIX}",
             tags=("organizations",),
             route_key="orgs",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping orgs router: {e}")
-
-    # Scoped shared key management
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.shared_keys_scoped import (
-            router as shared_keys_scoped_router,
-        )
-
-        specs.append(RouterSpec(
-            router=shared_keys_scoped_router,
+        ),
+        # Scoped shared key management
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.shared_keys_scoped",
+            log_name="shared_keys_scoped",
             prefix=f"{API_V1_PREFIX}",
             tags=("organizations",),
             route_key="orgs",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping shared_keys_scoped router: {e}")
-
-    # Privileges management
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.privileges import router as privileges_router
-
-        specs.append(RouterSpec(
-            router=privileges_router,
+        ),
+        # Privileges management
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.privileges",
+            log_name="privileges",
             prefix=f"{API_V1_PREFIX}",
             tags=("privileges",),
             route_key="privileges",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping privileges router: {e}")
-
-    # Admin config diagnostics
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.config_admin import router as config_admin_router
-
-        specs.append(RouterSpec(
-            router=config_admin_router,
+        ),
+        # Admin config diagnostics
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.config_admin",
+            log_name="config_admin",
             prefix=f"{API_V1_PREFIX}",
             tags=("config", "admin"),
             route_key="config",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping config_admin router: {e}")
-
-    # Resource Governor diagnostics
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.resource_governor import router as resource_governor_router
-
-        specs.append(RouterSpec(
-            router=resource_governor_router,
+        ),
+        # Resource Governor diagnostics
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.resource_governor",
+            log_name="resource_governor",
             prefix=f"{API_V1_PREFIX}",
             tags=("resource-governor",),
             route_key="resource-governor",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping resource_governor router: {e}")
-
-    # Jobs admin diagnostics
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.jobs_admin import router as jobs_admin_router
-
-        specs.append(RouterSpec(
-            router=jobs_admin_router,
+        ),
+        # Jobs admin diagnostics
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.jobs_admin",
+            log_name="jobs_admin",
             prefix=f"{API_V1_PREFIX}",
             tags=("jobs",),
             route_key="jobs",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping jobs_admin router: {e}")
-
-    # Organization invites
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.org_invites import router as org_invites_router
-
-        specs.append(RouterSpec(
-            router=org_invites_router,
+        ),
+        # Organization invites
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.org_invites",
+            log_name="org_invites",
             prefix=f"{API_V1_PREFIX}",
             tags=("invites",),
             route_key="org-invites",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping org_invites router: {e}")
+        ),
+    ):
+        try:
+            append_imported_router_spec(specs, admin_spec)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Skipping {admin_spec.log_name} router: {e}")
 
     return specs

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -325,6 +325,60 @@ def test_iter_core_router_specs_defers_chat_router_attr_lookup(
     }
 
 
+def test_iter_admin_router_specs_defers_selected_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered admin specs keep router attr lookup lazy."""
+    router_definitions = {
+        "tldw_Server_API.app.api.v1.endpoints.admin": "/admin/status",
+        "tldw_Server_API.app.api.v1.endpoints.family_wizard": "/guardian/family-wizard",
+        "tldw_Server_API.app.api.v1.endpoints.guardian_controls": "/guardian/controls",
+        "tldw_Server_API.app.api.v1.endpoints.self_monitoring": "/self-monitoring/status",
+        "tldw_Server_API.app.api.v1.endpoints.billing": "/billing/status",
+        "tldw_Server_API.app.api.v1.endpoints.benchmark_api": "/benchmarks/status",
+        "tldw_Server_API.app.api.v1.endpoints.mcp_catalogs_manage": "/mcp/catalogs",
+        "tldw_Server_API.app.api.v1.endpoints.mcp_hub_management": "/mcp/hub",
+        "tldw_Server_API.app.api.v1.endpoints.orgs": "/orgs",
+        "tldw_Server_API.app.api.v1.endpoints.shared_keys_scoped": "/shared-keys/scoped",
+        "tldw_Server_API.app.api.v1.endpoints.privileges": "/privileges",
+        "tldw_Server_API.app.api.v1.endpoints.config_admin": "/admin/config/effective",
+        "tldw_Server_API.app.api.v1.endpoints.resource_governor": "/resource-governor/status",
+        "tldw_Server_API.app.api.v1.endpoints.jobs_admin": "/jobs/status",
+        "tldw_Server_API.app.api.v1.endpoints.org_invites": "/orgs/invites",
+    }
+    access_count = {module_name: 0 for module_name in router_definitions}
+
+    for module_name, path in router_definitions.items():
+        router = APIRouter()
+
+        @router.get(path)
+        def _endpoint() -> dict[str, str]:
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_admin_router_specs())
+    assert access_count == {module_name: 0 for module_name in router_definitions}
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
+    assert set(router_definitions.values()).issubset(by_first_path)
+    assert access_count == {module_name: 1 for module_name in router_definitions}
+
+
 def test_iter_core_router_specs_skips_crashing_chat_import(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -329,11 +329,15 @@ def test_iter_admin_router_specs_defers_selected_router_attr_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify covered admin specs keep router attr lookup lazy."""
+    import importlib
+
+    sandbox_module_name = "tldw_Server_API.app.api.v1.endpoints.sandbox"
     router_definitions = {
         "tldw_Server_API.app.api.v1.endpoints.admin": "/admin/status",
         "tldw_Server_API.app.api.v1.endpoints.family_wizard": "/guardian/family-wizard",
         "tldw_Server_API.app.api.v1.endpoints.guardian_controls": "/guardian/controls",
         "tldw_Server_API.app.api.v1.endpoints.self_monitoring": "/self-monitoring/status",
+        sandbox_module_name: "/sandbox/status",
         "tldw_Server_API.app.api.v1.endpoints.billing": "/billing/status",
         "tldw_Server_API.app.api.v1.endpoints.benchmark_api": "/benchmarks/status",
         "tldw_Server_API.app.api.v1.endpoints.mcp_catalogs_manage": "/mcp/catalogs",
@@ -347,6 +351,14 @@ def test_iter_admin_router_specs_defers_selected_router_attr_lookup(
         "tldw_Server_API.app.api.v1.endpoints.org_invites": "/orgs/invites",
     }
     access_count = {module_name: 0 for module_name in router_definitions}
+    real_import_module = importlib.import_module
+
+    def _guarded_import_module(module_name: str, package: str | None = None) -> ModuleType:
+        if module_name == sandbox_module_name and module_name not in sys.modules:
+            raise AssertionError("sandbox router was imported without a test stub")
+        return real_import_module(module_name, package)
+
+    monkeypatch.setattr(importlib, "import_module", _guarded_import_module)
 
     for module_name, path in router_definitions.items():
         router = APIRouter()


### PR DESCRIPTION
## Summary
- Moves covered single-router admin registrations onto the shared lazy ImportedRouterSpec helper.
- Preserves admin route prefixes, tags, route keys, default stability, order, and per-router skip logging.
- Adds regression coverage that selected admin router attributes are not resolved until RouterSpec.router is used.

## Change summary
TODO: human-authored summary required before merge under Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

## Test Plan
- [x] python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "admin_router_specs_defers_selected" -q
- [x] python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "admin_router_specs_defers_selected or admin_router_specs_populates_expected" -q
- [x] python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- [x] python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- [x] python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- [x] python -m bandit -r tldw_Server_API/app/api/v1/router_groups/admin.py -f json -o /tmp/bandit_phase2_2_admin_router_conditionals_c.json
- [x] git diff --check
