### PR TITLE
Phase 2.2: defer media/audio router imports

### DIFF
--- a/backlog/tasks/task-23 - Phase-2.2-media-audio-router-conditional-cleanup-E.md
+++ b/backlog/tasks/task-23 - Phase-2.2-media-audio-router-conditional-cleanup-E.md
@@ -1,0 +1,62 @@
+---
+id: TASK-23
+title: Phase 2.2 media/audio router conditional cleanup E
+status: Done
+assignee: []
+created_date: '2026-05-04 00:54'
+labels:
+  - phase-2
+  - router-groups
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move only the covered media and audio router specs onto the shared lazy ImportedRouterSpec helper. Preserve public route prefixes, tags, route keys, pytest audio opt-in behavior, and registration ordering.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Media, audio, audio websocket, and audio jobs RouterSpec metadata is preserved.
+- [x] #2 Router attribute lookup for moved media/audio specs is lazy through RouterSpec resolution.
+- [x] #3 Full router group contract and adjacent main/OpenAPI contract tests pass.
+- [x] #4 Bandit touched-source scope and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test proving selected media/audio router attribute lookup is deferred until RouterSpec resolution. 2. Run the focused selection red on current code. 3. Replace only the selected covered imports with ImportedRouterSpec plus append_imported_router_spec while keeping the audio pytest opt-in guard. 4. Run focused and full router contract tests plus adjacent main/OpenAPI contract tests. 5. Run Bandit on touched router source and git diff --check. 6. Commit the narrow tranche and update the issue.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "media_audio_router_attr_lookup" -q` failed before implementation because selected media/audio router attributes were resolved during spec construction.
+- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "media_audio_router_attr_lookup" -q` passed with `1 passed`.
+- Green full/adjacent checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `46 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_media_audio_router_conditionals_e.json` reported `0 results` and `0 errors`; `git diff --check` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: audio router specs still respect `audio_imports_enabled_for_runtime()`, so explicit pytest runs keep the existing no-audio-by-default behavior unless `MINIMAL_TEST_INCLUDE_AUDIO=1` is set.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered `media`, `audio`, `audio-websocket`, and `audio-jobs` registrations to the shared lazy `ImportedRouterSpec` helper while preserving route prefixes, tags, route keys, ordering, and pytest audio opt-in behavior. Added regression coverage proving selected media/audio router attributes are not resolved until the selected `RouterSpec` objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -123,50 +123,50 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ))
 
     # Media endpoints
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.media import router as media_router
-
-        specs.append(RouterSpec(
-            router=media_router,
+    append_imported_router_spec(
+        specs,
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.media",
+            log_name="media",
             prefix=f"{API_V1_PREFIX}/media",
             tags=("media",),
             route_key="media",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping media router: {e}")
+        ),
+    )
 
     # Audio endpoints can import heavyweight optional transcriber dependencies.
     if audio_imports_enabled_for_runtime():
-        try:
-            from tldw_Server_API.app.api.v1.endpoints.audio.audio import router as audio_router
-            from tldw_Server_API.app.api.v1.endpoints.audio.audio import ws_router as audio_ws_router
-
-            specs.append(RouterSpec(
-                router=audio_router,
+        append_imported_router_spec(
+            specs,
+            ImportedRouterSpec(
+                import_path="tldw_Server_API.app.api.v1.endpoints.audio.audio",
+                log_name="audio",
                 prefix=f"{API_V1_PREFIX}/audio",
                 tags=("audio",),
                 route_key="audio",
-            ))
-            specs.append(RouterSpec(
-                router=audio_ws_router,
+            ),
+        )
+        append_imported_router_spec(
+            specs,
+            ImportedRouterSpec(
+                import_path="tldw_Server_API.app.api.v1.endpoints.audio.audio",
+                log_name="audio_websocket",
                 prefix=f"{API_V1_PREFIX}/audio",
                 tags=("audio-websocket",),
                 route_key="audio-websocket",
-            ))
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"Skipping audio routers: {e}")
-
-        try:
-            from tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs import router as audio_jobs_router
-
-            specs.append(RouterSpec(
-                router=audio_jobs_router,
+                attr_name="ws_router",
+            ),
+        )
+        append_imported_router_spec(
+            specs,
+            ImportedRouterSpec(
+                import_path="tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs",
+                log_name="audio_jobs",
                 prefix=f"{API_V1_PREFIX}/audio",
                 tags=("audio-jobs",),
                 route_key="audio-jobs",
-            ))
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"Skipping audio_jobs router: {e}")
+            ),
+        )
     else:
         logger.info("Skipping audio router imports in pytest (set MINIMAL_TEST_INCLUDE_AUDIO=1 to enable)")
 

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1043,6 +1043,81 @@ def test_iter_content_router_specs_defers_discovery_router_attr_lookup(
     assert access_count == {module_name: 1 for module_name in router_definitions}
 
 
+def test_iter_content_router_specs_defers_media_audio_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered media/audio specs keep router attr lookup lazy."""
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_media_audio")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_AUDIO", "1")
+    module_paths = {
+        "tldw_Server_API.app.api.v1.endpoints.media": {"router": "/media/list"},
+        "tldw_Server_API.app.api.v1.endpoints.audio.audio": {
+            "router": "/transcriptions",
+            "ws_router": "/stream/transcribe",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.audio.audio_jobs": {"router": "/audio/jobs"},
+    }
+    access_count = {
+        f"{module_name}.{attr_name}": 0
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+    for module_name, attr_paths in module_paths.items():
+        fake_module = ModuleType(module_name)
+        routers: dict[str, APIRouter] = {}
+        for attr_name, path in attr_paths.items():
+            router = APIRouter()
+
+            @router.get(path)
+            def _endpoint() -> dict[str, str]:
+                return {"status": "ok"}
+
+            routers[attr_name] = router
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            routers: dict[str, APIRouter] = routers,
+        ) -> APIRouter:
+            if name not in routers:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers[name]
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        f"{module_name}.{attr_name}": 0
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+    selected_specs = [
+        spec
+        for spec in specs
+        if spec.route_key in {"media", "audio", "audio-websocket", "audio-jobs"}
+    ]
+    by_first_path = {_first_router_path(spec.router): spec for spec in selected_specs}
+
+    assert by_first_path["/media/list"].prefix == "/api/v1/media"
+    assert by_first_path["/media/list"].tags == ("media",)
+    assert by_first_path["/transcriptions"].prefix == "/api/v1/audio"
+    assert by_first_path["/transcriptions"].tags == ("audio",)
+    assert by_first_path["/stream/transcribe"].prefix == "/api/v1/audio"
+    assert by_first_path["/stream/transcribe"].tags == ("audio-websocket",)
+    assert by_first_path["/audio/jobs"].prefix == "/api/v1/audio"
+    assert by_first_path["/audio/jobs"].tags == ("audio-jobs",)
+    assert access_count == {
+        f"{module_name}.{attr_name}": 1
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Moves media, audio, audio websocket, and audio jobs router registrations onto the shared lazy ImportedRouterSpec helper.
- Preserves prefixes, tags, route keys, ordering, and pytest audio opt-in behavior.
- Adds regression coverage proving selected media/audio attrs are not resolved during spec construction.

## Change summary
TODO: human-authored summary required before merge under Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_media_audio_router_conditionals_e.json
- [x] git diff --check HEAD~1..HEAD