### PR TITLE
Phase 2.2: defer workflow router imports

### DIFF
--- a/backlog/tasks/task-24 - Phase-2.2-workflow-router-conditional-cleanup-F.md
+++ b/backlog/tasks/task-24 - Phase-2.2-workflow-router-conditional-cleanup-F.md
@@ -1,0 +1,67 @@
+---
+id: TASK-24
+title: Phase 2.2 workflow router conditional cleanup F
+status: Done
+assignee: []
+created_date: '2026-05-04 01:52'
+labels:
+  - phase-2
+  - router-groups
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move only the covered workflow router specs onto the shared lazy ImportedRouterSpec helper. Preserve public route metadata, route ordering, and the explicit pytest runtime force-include behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workflows, chat workflows, and scheduler workflows RouterSpec metadata is preserved.
+- [x] #2 Router attribute lookup for moved workflow specs is lazy through RouterSpec resolution.
+- [x] #3 Full router group contract and adjacent main/OpenAPI contract tests pass.
+- [x] #4 Bandit touched-source scope and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test proving workflow router attribute lookup is deferred until RouterSpec resolution.
+2. Run the focused selection red on current code.
+3. Replace only the workflow import block with ImportedRouterSpec plus append_imported_router_spec while preserving explicit pytest route-key behavior.
+4. Run focused and full router contract tests plus adjacent main/OpenAPI contract tests.
+5. Run Bandit on touched router source and git diff --check.
+6. Commit the narrow tranche and update the issue.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "workflow_router_attr_lookup" -q` failed before implementation because workflow router attributes were resolved during spec construction.
+- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "workflow_router_attr_lookup" -q` passed with `1 passed`.
+- Green full/adjacent checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `47 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_workflow_router_conditionals_f.json` reported `0 results` and `0 errors`; `git diff --check` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: workflow route keys still intentionally become empty in explicit pytest runtime to preserve force-inclusion behavior for unit coverage.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered `workflows`, `chat-workflows`, and `scheduler` registrations to the shared lazy `ImportedRouterSpec` helper while preserving route metadata, default-stable flags, ordering, and explicit pytest force-include behavior. Added regression coverage proving workflow router attributes are not resolved until the selected `RouterSpec` objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -223,30 +223,29 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
         logger.debug(f"Skipping prompts router: {e}")
 
     # Workflow routers are force-included in explicit pytest runtime for unit coverage.
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chat_workflows import router as chat_workflows_router
-        from tldw_Server_API.app.api.v1.endpoints.scheduler_workflows import router as scheduler_workflows_router
-        from tldw_Server_API.app.api.v1.endpoints.workflows import router as workflows_router
-
-        specs.append(RouterSpec(
-            router=workflows_router,
+    for workflow_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.workflows",
+            log_name="workflows",
             tags=("workflows",),
             route_key="" if _is_explicit_pytest_runtime() else "workflows",
             default_stable=False,
-        ))
-        specs.append(RouterSpec(
-            router=chat_workflows_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chat_workflows",
+            log_name="chat_workflows",
             tags=("chat-workflows",),
             route_key="" if _is_explicit_pytest_runtime() else "chat-workflows",
-        ))
-        specs.append(RouterSpec(
-            router=scheduler_workflows_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.scheduler_workflows",
+            log_name="scheduler_workflows",
             tags=("scheduler",),
             route_key="" if _is_explicit_pytest_runtime() else "scheduler",
             default_stable=False,
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping workflow routers: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, workflow_spec)
 
     # Claims
     try:

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1118,6 +1118,59 @@ def test_iter_content_router_specs_defers_media_audio_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_workflow_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered workflow specs keep router attr lookup lazy."""
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_workflow_routers")
+    module_paths = {
+        "tldw_Server_API.app.api.v1.endpoints.workflows": "/workflows",
+        "tldw_Server_API.app.api.v1.endpoints.chat_workflows": "/chat/workflows",
+        "tldw_Server_API.app.api.v1.endpoints.scheduler_workflows": "/scheduler/workflows",
+    }
+    access_count = {module_name: 0 for module_name in module_paths}
+
+    for module_name, path in module_paths.items():
+        router = APIRouter()
+
+        @router.get(path)
+        def _endpoint() -> dict[str, str]:
+            return {"status": "ok"}
+
+        fake_module = ModuleType(module_name)
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            router: APIRouter = router,
+        ) -> APIRouter:
+            if name != "router":
+                raise AttributeError(name)
+            access_count[module_name] += 1
+            return router
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {module_name: 0 for module_name in module_paths}
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
+    assert by_first_path["/workflows"].prefix == ""
+    assert by_first_path["/workflows"].tags == ("workflows",)
+    assert by_first_path["/workflows"].route_key == ""
+    assert by_first_path["/workflows"].default_stable is False
+    assert by_first_path["/chat/workflows"].prefix == ""
+    assert by_first_path["/chat/workflows"].tags == ("chat-workflows",)
+    assert by_first_path["/chat/workflows"].route_key == ""
+    assert by_first_path["/scheduler/workflows"].prefix == ""
+    assert by_first_path["/scheduler/workflows"].tags == ("scheduler",)
+    assert by_first_path["/scheduler/workflows"].route_key == ""
+    assert by_first_path["/scheduler/workflows"].default_stable is False
+    assert access_count == {module_name: 1 for module_name in module_paths}
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Moves workflows, chat workflows, and scheduler workflows router registrations onto the shared lazy ImportedRouterSpec helper.
- Preserves tags, route keys, default-stable flags, ordering, and explicit pytest force-include behavior.
- Adds regression coverage proving selected workflow router attrs are not resolved during spec construction.

## Change summary
TODO: human-authored summary required before merge under Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "workflow_router_attr_lookup" -q (red before implementation, green after)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_workflow_router_conditionals_f.json
- [x] git diff --check HEAD~1..HEAD