### PR TITLE
Phase 2.2: defer content embedding router imports

### DIFF
--- a/backlog/tasks/task-26 - Address-PR-1250-missing-router-attribute-log-review.md
+++ b/backlog/tasks/task-26 - Address-PR-1250-missing-router-attribute-log-review.md
@@ -1,0 +1,51 @@
+---
+id: TASK-26
+title: Address PR 1250 missing router attribute log review
+status: Done
+assignee: []
+created_date: '2026-05-04 02:32'
+updated_date: '2026-05-04 02:35'
+labels:
+  - phase-2.2
+  - review
+  - router-groups
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1250'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the PR #1250 review finding that ImportedRouterSpec missing-attribute failures only log the attribute name. Preserve lazy router behavior while improving the exception/log message to include the import path and expected attribute.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Missing ImportedRouterSpec router attribute failures include both module import path and attribute name in registration debug logs.
+- [x] #2 Existing optional import and lazy lookup behavior is preserved.
+- [x] #3 Focused router-group tests pass after the change.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review thread verified via gh: Qodo reported missing module path in ImportedRouterSpec missing-attribute logs. Added a red regression by changing missing-attr expectations from bare attr name to module.attr, then updated append_imported_router_spec to raise AttributeError with import_path.attr_name while preserving the original AttributeError as cause.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Addressed PR #1250 review finding by making lazy ImportedRouterSpec missing-attribute failures log the full module attribute path. Verification: red focused missing_attr test, green append_imported_router_spec/missing_attr selection, full router_groups contract, main_router contract, OpenAPI contracts, Bandit on conditional.py/content.py, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-28 - Phase-2.2-content-embedding-router-conditional-cleanup-H.md
+++ b/backlog/tasks/task-28 - Phase-2.2-content-embedding-router-conditional-cleanup-H.md
@@ -1,0 +1,52 @@
+---
+id: TASK-28
+title: Phase 2.2 content embedding router conditional cleanup H
+status: Done
+assignee: []
+created_date: '2026-05-04 02:52'
+updated_date: '2026-05-04 02:54'
+labels:
+  - phase-2.2
+  - router-groups
+  - tests
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1250'
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+After #1251 merged the chunking/vector/prompts processing tranche, keep PR #1250 focused on the remaining content embedding routers. Defer router attribute lookup for embeddings_v5_production_enhanced and media_embeddings while preserving route metadata and ordering.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Content embeddings and media embeddings router specs defer router attribute lookup until resolution.
+- [x] #2 Existing prefixes, tags, route keys, and router ordering are preserved.
+- [x] #3 Focused and full router-group verification pass after rebase.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+After #1251 merged the processing router tranche, rebased PR #1250 and narrowed this slice to embeddings_v5_production_enhanced and media_embeddings. Preserved #1251 chunking/vector/prompts tests and added separate embedding router attr laziness coverage.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Deferred the remaining content embedding router imports behind ImportedRouterSpec factories while preserving prefix/tag/route_key metadata. Verification after rebase: focused router-group selection, full router_groups contract, main_router contract, OpenAPI contracts, Bandit on conditional.py/content.py, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/conditional.py
+++ b/tldw_Server_API/app/api/v1/router_groups/conditional.py
@@ -31,7 +31,7 @@ def append_imported_router_spec(
         try:
             return getattr(module, definition.attr_name)
         except AttributeError as e:
-            raise AttributeError(definition.attr_name) from e
+            raise AttributeError(f"{definition.import_path}.{definition.attr_name}") from e
 
     specs.append(
         RouterSpec(

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -71,7 +71,7 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, discovery_spec)
 
-    # Embeddings and content processing routers
+    # Embedding routers
     for processing_spec in (
         ImportedRouterSpec(
             import_path="tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced",

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -71,35 +71,24 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     ):
         append_imported_router_spec(specs, discovery_spec)
 
-    # Embeddings (OpenAI-compatible)
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced import (
-            router as embeddings_router,
-        )
-
-        specs.append(RouterSpec(
-            router=embeddings_router,
+    # Embeddings and content processing routers
+    for processing_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced",
+            log_name="embeddings",
             prefix=f"{API_V1_PREFIX}",
             tags=("embeddings",),
             route_key="embeddings",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping embeddings router: {e}")
-
-    # Media embeddings
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.media_embeddings import (
-            router as media_embeddings_router,
-        )
-
-        specs.append(RouterSpec(
-            router=media_embeddings_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.media_embeddings",
+            log_name="media_embeddings",
             prefix=f"{API_V1_PREFIX}",
             tags=("media-embeddings",),
             route_key="media-embeddings",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping media_embeddings router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, processing_spec)
 
     # Evaluations and OCR are lazy so route policy can disable them before
     # importing modules with heavier optional dependencies.

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1248,6 +1248,71 @@ def test_iter_content_router_specs_defers_processing_router_attr_lookup(
     }
 
 
+def test_iter_content_router_specs_defers_embedding_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered embedding specs keep router attr lookup lazy."""
+    module_paths = {
+        "tldw_Server_API.app.api.v1.endpoints.embeddings_v5_production_enhanced": {
+            "router": "/embeddings",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.media_embeddings": {
+            "router": "/media_embeddings",
+        },
+    }
+    access_count = {
+        f"{module_name}.{attr_name}": 0
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+    for module_name, attr_paths in module_paths.items():
+        fake_module = ModuleType(module_name)
+        routers: dict[str, APIRouter] = {}
+        for attr_name, path in attr_paths.items():
+            router = APIRouter()
+
+            @router.get(path)
+            def _endpoint() -> dict[str, str]:
+                return {"status": "ok"}
+
+            routers[attr_name] = router
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            routers: dict[str, APIRouter] = routers,
+        ) -> APIRouter:
+            if name not in routers:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers[name]
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        f"{module_name}.{attr_name}": 0
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
+    assert by_first_path["/embeddings"].prefix == "/api/v1"
+    assert by_first_path["/embeddings"].tags == ("embeddings",)
+    assert by_first_path["/embeddings"].route_key == "embeddings"
+    assert by_first_path["/media_embeddings"].prefix == "/api/v1"
+    assert by_first_path["/media_embeddings"].tags == ("media-embeddings",)
+    assert by_first_path["/media_embeddings"].route_key == "media-embeddings"
+    assert access_count == {
+        f"{module_name}.{attr_name}": 1
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -326,7 +326,9 @@ def test_append_imported_router_spec_skips_static_missing_attr_at_registration(
 
     assert len(specs) == 1
     assert register_router_specs(FastAPI(), specs) == 0
-    assert debug_messages == ["Skipping missing-router-attr router: router"]
+    assert debug_messages == [
+        f"Skipping missing-router-attr router: {module_name}.router"
+    ]
 
 
 def test_append_imported_router_spec_logs_missing_lazy_attr_once(
@@ -363,7 +365,9 @@ def test_append_imported_router_spec_logs_missing_lazy_attr_once(
 
     assert len(specs) == 1
     assert register_router_specs(FastAPI(), specs) == 0
-    assert debug_messages == ["Skipping missing-lazy-router-attr router: router"]
+    assert debug_messages == [
+        f"Skipping missing-lazy-router-attr router: {module_name}.router"
+    ]
 
 
 def test_iter_core_router_specs_defers_chat_router_attr_lookup(


### PR DESCRIPTION
## Change summary

Human-authored summary required before merge per AI-generated PR policy.

## What changed

- Rebased on latest `dev` after #1251 merged the chunking/vector/prompts processing tranche.
- Narrowed this PR to the remaining content embedding routers: `embeddings_v5_production_enhanced` and `media_embeddings`.
- Added router-group contract coverage proving those embedding specs defer router attribute lookup until resolution.
- Addressed the Qodo review finding by making missing `ImportedRouterSpec` attributes log as `import_path.attr_name` instead of only the attribute name.
- Recorded the narrowed embedding tranche in Backlog `TASK-28` and the review fix in `TASK-26`.

## Verification

- Red: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "missing_attr" -q`
- Focused: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "embedding_router_attr_lookup or processing_router_attr_lookup or workflow_router_attr_lookup or missing_attr or append_imported_router_spec" -q`
- Full router contracts: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q`
- Main router contracts: `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q`
- OpenAPI contracts: `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q`
- Bandit: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/conditional.py tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_pr1250_final.json`
- `git diff --check`

## References

- Tracks part of #1116
- Addresses Qodo review thread: https://github.com/rmusser01/tldw_server/pull/1250#discussion_r3179156006
