### PR TITLE
Phase 2.2: defer processing router imports

### DIFF
--- a/backlog/tasks/task-25 - Phase-2.2-processing-router-conditional-cleanup-G.md
+++ b/backlog/tasks/task-25 - Phase-2.2-processing-router-conditional-cleanup-G.md
@@ -1,0 +1,67 @@
+---
+id: TASK-25
+title: Phase 2.2 processing router conditional cleanup G
+status: Done
+assignee: []
+created_date: '2026-05-04 02:37'
+labels:
+  - phase-2
+  - router-groups
+  - refactor
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/issues/1116'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move only the covered processing and prompt router specs onto the shared lazy ImportedRouterSpec helper. Preserve public route metadata, route ordering, and the existing nonstandard `chunking_router` attribute binding.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chunking, vector stores, chunking templates, and prompts RouterSpec metadata is preserved.
+- [x] #2 Router attribute lookup for moved processing/prompt specs is lazy through RouterSpec resolution.
+- [x] #3 Full router group contract and adjacent main/OpenAPI contract tests pass.
+- [x] #4 Bandit touched-source scope and git diff --check pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test proving processing/prompt router attribute lookup is deferred until RouterSpec resolution.
+2. Run the focused selection red on current code.
+3. Replace only the processing/prompt import block with ImportedRouterSpec plus append_imported_router_spec while preserving metadata and `chunking_router`.
+4. Run focused and full router contract tests plus adjacent main/OpenAPI contract tests.
+5. Run Bandit on touched router source and git diff --check.
+6. Commit the narrow tranche and update the issue.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Red check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "processing_router_attr_lookup" -q` failed before implementation because the selected processing/prompt router attributes were resolved during spec construction.
+- Green focused check: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "processing_router_attr_lookup" -q` passed with `1 passed`.
+- Green full/adjacent checks: `python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q` passed with `48 passed`; `python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q` passed with `6 passed`; `python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q` passed with `69 passed`.
+- Security and hygiene: `python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_processing_router_conditionals_g.json` reported `0 results` and `0 errors`; `git diff --check` passed.
+- Documentation: no user-facing docs required for this internal router registration refactor.
+- Known skips or blockers: none.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the covered `chunking`, `vector-stores`, `chunking-templates`, and `prompts` registrations to the shared lazy `ImportedRouterSpec` helper while preserving route prefixes, tags, route keys, ordering, and the nonstandard `chunking_router` attr binding. Added regression coverage proving selected processing/prompt router attributes are not resolved until the selected `RouterSpec` objects are used, then verified the full router group contract, adjacent main/OpenAPI contract tests, Bandit touched-source scope, and whitespace checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_Server_API/app/api/v1/router_groups/content.py
+++ b/tldw_Server_API/app/api/v1/router_groups/content.py
@@ -170,57 +170,39 @@ def iter_content_router_specs() -> Iterable[RouterSpec]:
     else:
         logger.info("Skipping audio router imports in pytest (set MINIMAL_TEST_INCLUDE_AUDIO=1 to enable)")
 
-    # Chunking operations
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chunking import chunking_router
-
-        specs.append(RouterSpec(
-            router=chunking_router,
+    # Chunking, vector stores, and prompt operations
+    for processing_spec in (
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chunking",
+            log_name="chunking",
             prefix=f"{API_V1_PREFIX}/chunking",
             tags=("chunking",),
             route_key="chunking",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping chunking router: {e}")
-
-    # Vector stores (OpenAI-compatible)
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.vector_stores_openai import router as vector_stores_router
-
-        specs.append(RouterSpec(
-            router=vector_stores_router,
+            attr_name="chunking_router",
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.vector_stores_openai",
+            log_name="vector_stores",
             prefix=f"{API_V1_PREFIX}",
             tags=("vector-stores",),
             route_key="vector-stores",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping vector-stores router: {e}")
-
-    # Chunking templates
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.chunking_templates import router as chunking_templates_router
-
-        specs.append(RouterSpec(
-            router=chunking_templates_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.chunking_templates",
+            log_name="chunking_templates",
             prefix=f"{API_V1_PREFIX}",
             tags=("chunking-templates",),
             route_key="chunking-templates",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping chunking_templates router: {e}")
-
-    # Prompts
-    try:
-        from tldw_Server_API.app.api.v1.endpoints.prompts import router as prompt_router
-
-        specs.append(RouterSpec(
-            router=prompt_router,
+        ),
+        ImportedRouterSpec(
+            import_path="tldw_Server_API.app.api.v1.endpoints.prompts",
+            log_name="prompts",
             prefix=f"{API_V1_PREFIX}/prompts",
             tags=("prompts",),
             route_key="prompts",
-        ))
-    except Exception as e:  # noqa: BLE001
-        logger.debug(f"Skipping prompts router: {e}")
+        ),
+    ):
+        append_imported_router_spec(specs, processing_spec)
 
     # Workflow routers are force-included in explicit pytest runtime for unit coverage.
     for workflow_spec in (

--- a/tldw_Server_API/tests/Services/test_router_groups_contract.py
+++ b/tldw_Server_API/tests/Services/test_router_groups_contract.py
@@ -1171,6 +1171,83 @@ def test_iter_content_router_specs_defers_workflow_router_attr_lookup(
     assert access_count == {module_name: 1 for module_name in module_paths}
 
 
+def test_iter_content_router_specs_defers_processing_router_attr_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify covered processing/prompt specs keep router attr lookup lazy."""
+    module_paths = {
+        "tldw_Server_API.app.api.v1.endpoints.chunking": {
+            "chunking_router": "/chunk",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.vector_stores_openai": {
+            "router": "/vector_stores",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.chunking_templates": {
+            "router": "/chunking/templates",
+        },
+        "tldw_Server_API.app.api.v1.endpoints.prompts": {
+            "router": "/prompts",
+        },
+    }
+    access_count = {
+        f"{module_name}.{attr_name}": 0
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+    for module_name, attr_paths in module_paths.items():
+        fake_module = ModuleType(module_name)
+        routers: dict[str, APIRouter] = {}
+        for attr_name, path in attr_paths.items():
+            router = APIRouter()
+
+            @router.get(path)
+            def _endpoint() -> dict[str, str]:
+                return {"status": "ok"}
+
+            routers[attr_name] = router
+
+        def _module_getattr(
+            name: str,
+            *,
+            module_name: str = module_name,
+            routers: dict[str, APIRouter] = routers,
+        ) -> APIRouter:
+            if name not in routers:
+                raise AttributeError(name)
+            access_count[f"{module_name}.{name}"] += 1
+            return routers[name]
+
+        fake_module.__getattr__ = _module_getattr  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    specs = list(iter_content_router_specs())
+    assert access_count == {
+        f"{module_name}.{attr_name}": 0
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+    by_first_path = {_first_router_path(spec.router): spec for spec in specs}
+    assert by_first_path["/chunk"].prefix == "/api/v1/chunking"
+    assert by_first_path["/chunk"].tags == ("chunking",)
+    assert by_first_path["/chunk"].route_key == "chunking"
+    assert by_first_path["/vector_stores"].prefix == "/api/v1"
+    assert by_first_path["/vector_stores"].tags == ("vector-stores",)
+    assert by_first_path["/vector_stores"].route_key == "vector-stores"
+    assert by_first_path["/chunking/templates"].prefix == "/api/v1"
+    assert by_first_path["/chunking/templates"].tags == ("chunking-templates",)
+    assert by_first_path["/chunking/templates"].route_key == "chunking-templates"
+    assert by_first_path["/prompts"].prefix == "/api/v1/prompts"
+    assert by_first_path["/prompts"].tags == ("prompts",)
+    assert by_first_path["/prompts"].route_key == "prompts"
+    assert access_count == {
+        f"{module_name}.{attr_name}": 1
+        for module_name, attrs in module_paths.items()
+        for attr_name in attrs
+    }
+
+
 def test_qodo_reviewed_router_policy_regressions(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_router_module(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Moves chunking, vector stores, chunking templates, and prompts router registrations onto the shared lazy ImportedRouterSpec helper.
- Preserves prefixes, tags, route keys, ordering, and the nonstandard chunking_router attr binding.
- Adds regression coverage proving selected processing/prompt router attrs are not resolved during spec construction.

## Change summary
TODO: human-authored summary required before merge under Docs/superpowers/AI_GENERATED_PR_CHANGE_SUMMARY_POLICY_2026_04_17.md.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -k "processing_router_attr_lookup" -q (red before implementation, green after)
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_router_groups_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_main_router_contract.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m pytest tldw_Server_API/tests/Services/test_openapi_contracts.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -r tldw_Server_API/app/api/v1/router_groups/content.py -f json -o /tmp/bandit_phase2_2_processing_router_conditionals_g.json
- [x] git diff --check HEAD~1..HEAD