### PR TITLE
Normalize sandbox run status reasons

### DIFF
--- a/Docs/Sandbox/sandbox-runtime-capability-inventory.md
+++ b/Docs/Sandbox/sandbox-runtime-capability-inventory.md
@@ -78,6 +78,31 @@ centralized in `runtime_capabilities.py`.
 | `image_store_unavailable` | Image-store configuration or probing failed. |
 | `unknown` | A raw reason has no stable normalized mapping yet. |
 
+## Normalized Run Status Reason Codes
+
+Sandbox run status responses preserve raw `phase`, `message`, and `exit_code`
+while adding a derived `status_reason_code` for client grouping. The code is
+computed from existing status data and aggregate limit counters; it is not a
+separate persisted state machine.
+
+| Status reason code | Meaning |
+| --- | --- |
+| `queued` | The run is queued and has not started. |
+| `starting` | The run has been admitted and is starting. |
+| `running` | The runtime is executing the run. |
+| `completed` | The run completed without a non-zero exit or known limit signal. |
+| `limits_applied` | The run completed but output or artifact limits were applied. |
+| `nonzero_exit` | The runtime process completed with a non-zero exit code. |
+| `policy_failed` | Runtime or network/trust policy admission failed. |
+| `runtime_unavailable` | A runtime prerequisite was unavailable or missing. |
+| `startup_timeout` | Provisioning/startup timed out before execution completed. |
+| `execution_timeout` | Command execution exceeded the configured timeout. |
+| `canceled_by_user` | A cancellation request moved the run to killed state. |
+| `killed` | The run was killed without a more specific cancellation reason. |
+| `queue_ttl_expired` | The run expired while queued. |
+| `runtime_error` | The runtime failed without a more specific normalized reason. |
+| `unknown` | Existing status data does not map to a known reason code. |
+
 ## Trust-Level Support
 
 | Runtime | `trusted` | `standard` | `untrusted` | Notes |
@@ -142,7 +167,7 @@ an equally clear ownership model.
 | --- | --- | --- |
 | Host-local runtimes need clearer docs/API warnings that they are not VM-grade. | `seatbelt`, `worktree` | Phase 2 |
 | Allowlist support is inconsistent and often scaffold-only. | all except host-local unsupported paths | Phase 2 |
-| Common run status/error taxonomy is not normalized across runtimes. | all | Phase 3 |
+| Detailed runner-internal error strings still vary by runtime behind `runtime_error`. | all | Phase 3 |
 | Session semantics are not normalized across warm VM, container, and host-local reuse. | all | Phase 4 |
 | Recovery/repair ownership exists only for `vz_linux`. | all except `vz_linux` | Phase 4 |
 | CI has no single cross-runtime capability gate. | all | Phase 5 |

--- a/backlog/tasks/task-15 - Normalize-sandbox-run-status-reason-codes.md
+++ b/backlog/tasks/task-15 - Normalize-sandbox-run-status-reason-codes.md
@@ -1,0 +1,56 @@
+---
+id: TASK-15
+title: Normalize sandbox run status reason codes
+status: In Progress
+assignee: []
+created_date: '2026-05-03 20:38'
+labels:
+  - sandbox
+  - runtime
+  - api
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add an additive normalized run status reason-code layer for sandbox run status responses while preserving existing phase/message fields and avoiding storage migrations.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sandbox run status responses include a derived normalized status reason code without changing existing phase/message behavior.
+- [x] #2 Admin run summaries include the same derived code for list views.
+- [x] #3 The reason-code vocabulary is centralized and documented in sandbox runtime capability inventory/README.
+- [x] #4 Focused tests cover queued runs, timeouts, cancellations, policy failures, and artifact/output limit signals where existing status data permits derivation.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Notes
+
+- Added `run_status_taxonomy.py` as the centralized additive taxonomy for stable run status reason codes.
+- Wired `status_reason_code` into public run status responses and admin run summaries while preserving raw `phase`, `message`, and `exit_code`.
+- Kept the code derived from existing status data to avoid DB migrations; list internals now carry `resource_usage` so admin summaries can classify limit-applied runs.
+
+## Final Summary
+
+Implemented additive sandbox run status reason codes for public and admin status surfaces, documented the vocabulary, and added focused tests for taxonomy mapping, schema exposure, SQLite list preservation, and queued POST/GET durability.
+
+Verification:
+
+- `python -m pytest tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q --timeout=60`
+- `python -m py_compile tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/core/Sandbox/store.py`
+- `python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/core/Sandbox/store.py -f json -o /tmp/bandit_run_status_reasons.json`
+- `git diff --check`
+
+Known caveat: a selected admin TestClient integration path timed out in existing app shutdown/background Jobs worker teardown; the status reason-code coverage was kept to deterministic taxonomy, schema, SQLite-store, and minimal sandbox API tests.

--- a/backlog/tasks/task-30 - Address-PR-1252-sandbox-run-status-review-comments.md
+++ b/backlog/tasks/task-30 - Address-PR-1252-sandbox-run-status-review-comments.md
@@ -1,0 +1,71 @@
+---
+id: TASK-30
+title: Address PR 1252 sandbox run status review comments
+status: Done
+assignee:
+  - Codex
+created_date: '2026-05-04 03:01'
+labels:
+  - sandbox
+  - runtime
+  - api
+  - review-fix
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_server/pull/1252'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix verified review comments on PR #1252 for sandbox run status reason-code normalization.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Taxonomy classifies limit signals before phase-specific completed/failed/timed_out outcomes where existing usage data permits derivation.
+- [x] #2 Runtime-unavailable matching is narrow and explicitly covers VZ RuntimeUnavailable-derived messages without treating ordinary missing/not-found command errors as runtime availability issues.
+- [x] #3 New helper/module maintainability comments are addressed with type hints and module docstring.
+- [x] #4 Malformed resource_usage JSON in store list paths is logged without breaking resilient list responses.
+- [x] #5 Focused sandbox tests and security/format checks pass for the touched scope.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant
+- [x] #4 Bandit run for touched code when applicable or document non-code/environment skip
+- [x] #5 Final summary added
+- [x] #6 Known skips or blockers documented
+<!-- DOD:END -->
+
+## Implementation Plan
+
+1. Tighten `normalize_run_status_reason()` so limit signals take precedence for completed, failed, and timed-out runs.
+2. Narrow runtime-unavailable matching so explicit runtime/provisioning messages classify as `runtime_unavailable`, but ordinary command `missing`/`not found` failures do not.
+3. Add focused regression tests for the taxonomy changes, including the VZ RuntimeUnavailable-derived messages.
+4. Add the missing endpoint helper type hints and taxonomy module docstring.
+5. Log malformed `resource_usage` JSON in SQLite/Postgres list paths while keeping list responses resilient.
+6. Re-run focused tests, compile checks, `git diff --check`, and Bandit before pushing the PR update.
+
+## Implementation Notes
+
+- Moved limit-signal detection ahead of completed/failed/timed-out phase classification so output/artifact ceilings produce `limits_applied` consistently.
+- Added explicit VZ RuntimeUnavailable-derived message handling and narrowed the generic runtime-unavailable matcher to structured runtime/provisioning context.
+- Added endpoint helper parameter types and a module docstring for the new taxonomy module.
+- Logged malformed SQLite/Postgres `resource_usage` JSON at debug level while preserving resilient list behavior.
+
+## Final Summary
+
+Addressed the open PR #1252 review comments by tightening taxonomy classification, adding focused regression coverage, documenting the taxonomy module contract, typing the endpoint helper, and making malformed `resource_usage` decoding observable without breaking list responses.
+
+Verification:
+
+- `python -m pytest tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q --timeout=60`
+- `python -m py_compile tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/core/Sandbox/store.py`
+- `python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/core/Sandbox/store.py -f json -o /tmp/bandit_run_status_reasons_review_fix.json`
+- `git diff --check`
+
+Known caveat: GitHub Actions were still queued when this local review-fix pass was prepared.

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -10,6 +10,8 @@ import os
 import tempfile
 import threading
 import time
+from collections.abc import Mapping
+from typing import Any
 
 from fastapi import (
     APIRouter,
@@ -28,21 +30,21 @@ from fastapi import (
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.routing import APIRoute
 from loguru import logger
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_request_user, RequireRole, User
 
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import RequireRole, User, get_request_user
 from tldw_Server_API.app.api.v1.endpoints._pagination_utils import build_offset_pagination_meta
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
-    SandboxAdminMacOSDiagnosticsResponse,
-    SandboxAdminMacOSImageStoreCleanupRequest,
-    SandboxAdminMacOSImageStoreCleanupResponse,
-    SandboxAdminMacOSImageStoreCleanupPlanResponse,
-    SandboxAdminMacOSReconciliationRepairRequest,
-    SandboxAdminMacOSReconciliationRepairResponse,
     ArtifactListResponse,
     CancelResponse,
     SandboxAdminIdempotencyItem,
     SandboxAdminIdempotencyListResponse,
+    SandboxAdminMacOSDiagnosticsResponse,
+    SandboxAdminMacOSImageStoreCleanupPlanResponse,
+    SandboxAdminMacOSImageStoreCleanupRequest,
+    SandboxAdminMacOSImageStoreCleanupResponse,
+    SandboxAdminMacOSReconciliationRepairRequest,
+    SandboxAdminMacOSReconciliationRepairResponse,
     SandboxAdminRunDetails,
     SandboxAdminRunListResponse,
     SandboxAdminRunSummary,
@@ -74,16 +76,16 @@ from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.Metrics import increment_counter, observe_histogram
-from tldw_Server_API.app.core.Sandbox.models import RunSpec, SessionSpec
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, SessionSpec
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType as CoreRuntimeType
 from tldw_Server_API.app.core.Sandbox.models import TrustLevel as CoreTrustLevel
-from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import normalize_run_status_reason
 from tldw_Server_API.app.core.Sandbox.orchestrator import (
     IdempotencyConflict,
     QueueFull,
     SessionActiveRunsConflict,
 )
 from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
+from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import normalize_run_status_reason
 from tldw_Server_API.app.core.Sandbox.service import (
     SandboxImageStoreCleanupError,
     SandboxReconciliationRepairError,
@@ -169,10 +171,10 @@ _service = SandboxService(enable_background_tasks=False)
 
 def _status_reason_code(
     *,
-    phase,
+    phase: RunPhase | str | None,
     message: str | None,
     exit_code: int | str | None,
-    resource_usage,
+    resource_usage: Mapping[str, Any] | None,
 ) -> str:
     return normalize_run_status_reason(
         phase=phase,

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -77,6 +77,7 @@ from tldw_Server_API.app.core.Metrics import increment_counter, observe_histogra
 from tldw_Server_API.app.core.Sandbox.models import RunSpec, SessionSpec
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType as CoreRuntimeType
 from tldw_Server_API.app.core.Sandbox.models import TrustLevel as CoreTrustLevel
+from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import normalize_run_status_reason
 from tldw_Server_API.app.core.Sandbox.orchestrator import (
     IdempotencyConflict,
     QueueFull,
@@ -164,6 +165,21 @@ class SandboxArtifactGuardRoute(APIRoute):
 router = APIRouter(prefix="/sandbox", tags=["sandbox"], route_class=SandboxArtifactGuardRoute)
 
 _service = SandboxService(enable_background_tasks=False)
+
+
+def _status_reason_code(
+    *,
+    phase,
+    message: str | None,
+    exit_code: int | str | None,
+    resource_usage,
+) -> str:
+    return normalize_run_status_reason(
+        phase=phase,
+        message=message,
+        exit_code=exit_code,
+        resource_usage=resource_usage if isinstance(resource_usage, dict) else None,
+    )
 
 
 @router.on_event("startup")
@@ -1576,6 +1592,12 @@ async def start_run(
         image_digest=status.image_digest,
         policy_hash=status.policy_hash,
         phase=status.phase.value,
+        status_reason_code=_status_reason_code(
+            phase=status.phase,
+            message=status.message,
+            exit_code=status.exit_code,
+            resource_usage=status.resource_usage,
+        ),
         exit_code=status.exit_code,
         started_at=status.started_at,
         finished_at=status.finished_at,
@@ -1609,6 +1631,12 @@ async def get_run_status(
         image_digest=st.image_digest,
         policy_hash=st.policy_hash,
         phase=st.phase.value,
+        status_reason_code=_status_reason_code(
+            phase=st.phase,
+            message=st.message,
+            exit_code=st.exit_code,
+            resource_usage=st.resource_usage,
+        ),
         exit_code=st.exit_code,
         started_at=st.started_at,
         finished_at=st.finished_at,
@@ -2349,6 +2377,12 @@ async def admin_list_runs(
                 image_digest=r.get("image_digest"),
                 policy_hash=r.get("policy_hash"),
                 phase=r.get("phase"),
+                status_reason_code=_status_reason_code(
+                    phase=r.get("phase"),
+                    message=r.get("message"),
+                    exit_code=r.get("exit_code"),
+                    resource_usage=r.get("resource_usage"),
+                ),
                 exit_code=r.get("exit_code"),
                 started_at=(r.get("started_at") if isinstance(r.get("started_at"), str) else r.get("started_at")),
                 finished_at=(r.get("finished_at") if isinstance(r.get("finished_at"), str) else r.get("finished_at")),

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -15,6 +15,7 @@ from tldw_Server_API.app.core.Sandbox.runtime_capabilities import (
     RuntimeImplementationState,
     RuntimeReasonCode,
 )
+from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import RunStatusReasonCode
 
 RuntimeType = Literal[
     "docker",
@@ -200,6 +201,13 @@ class SandboxRunStatus(BaseModel):
         "killed",
         "timed_out",
     ]
+    status_reason_code: RunStatusReasonCode | None = Field(
+        default=None,
+        description=(
+            "Stable client-facing reason code derived from phase, message, exit_code, "
+            "and aggregate limit counters. Existing phase/message fields remain raw."
+        ),
+    )
     exit_code: int | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None
@@ -249,6 +257,10 @@ class SandboxAdminRunSummary(BaseModel):
         "killed",
         "timed_out",
     ]
+    status_reason_code: RunStatusReasonCode | None = Field(
+        default=None,
+        description="Stable client-facing reason code derived from the run status summary",
+    )
     exit_code: int | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -178,6 +178,10 @@ or maturity guarantees from availability alone.
 Runtime entries also preserve raw preflight `reasons` for operator diagnostics
 and expose additive `normalized_reasons` for stable client grouping across
 runtime-specific failures.
+Run status responses preserve raw `phase`, `message`, and `exit_code` while
+adding additive `status_reason_code` for stable client grouping of queued,
+completed, timeout, cancellation, policy, runtime-unavailable, nonzero-exit, and
+limit-applied outcomes.
 `/api/v1/sandbox/admin/macos-diagnostics` is an admin-only diagnostics surface for
 operator troubleshooting and exposes helper/template readiness details that are not
 included in the public discovery payload, plus reconciliation data for persisted

--- a/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+++ b/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Mapping
+
+from .models import RunPhase
+
+RunStatusReasonCode = Literal[
+    "queued",
+    "starting",
+    "running",
+    "completed",
+    "limits_applied",
+    "nonzero_exit",
+    "policy_failed",
+    "runtime_unavailable",
+    "startup_timeout",
+    "execution_timeout",
+    "canceled_by_user",
+    "killed",
+    "queue_ttl_expired",
+    "runtime_error",
+    "unknown",
+]
+
+_LIMIT_COUNTER_KEYS = (
+    "stdout_truncated",
+    "stderr_truncated",
+    "guest_output_limit_exceeded",
+    "artifact_files_skipped",
+    "artifact_skip_file_limit",
+    "artifact_skip_total_limit",
+    "artifact_skip_symlink",
+    "artifact_skip_invalid",
+    "artifact_skip_read_error",
+)
+
+
+def _phase_text(phase: RunPhase | str | None) -> str:
+    if isinstance(phase, RunPhase):
+        return phase.value
+    return str(phase or "").strip().lower()
+
+
+def _message_text(message: str | None) -> str:
+    return str(message or "").strip().lower()
+
+
+def _has_limit_signal(resource_usage: Mapping[str, Any] | None) -> bool:
+    if not isinstance(resource_usage, Mapping):
+        return False
+    for key in _LIMIT_COUNTER_KEYS:
+        try:
+            if int(resource_usage.get(key) or 0) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _is_nonzero_exit(exit_code: int | str | None) -> bool:
+    if exit_code is None:
+        return False
+    try:
+        return int(exit_code) != 0
+    except (TypeError, ValueError):
+        return False
+
+
+def normalize_run_status_reason(
+    *,
+    phase: RunPhase | str | None,
+    message: str | None,
+    exit_code: int | str | None,
+    resource_usage: Mapping[str, Any] | None,
+) -> RunStatusReasonCode:
+    """Derive a stable client-facing run reason code from existing status data."""
+
+    phase_value = _phase_text(phase)
+    message_value = _message_text(message)
+
+    if phase_value in {"queued", "starting", "running"}:
+        return phase_value  # type: ignore[return-value]
+
+    if phase_value == "completed":
+        if _has_limit_signal(resource_usage):
+            return "limits_applied"
+        return "completed"
+
+    if phase_value == "timed_out":
+        if "startup" in message_value:
+            return "startup_timeout"
+        return "execution_timeout"
+
+    if phase_value == "killed":
+        if "cancel" in message_value:
+            return "canceled_by_user"
+        return "killed"
+
+    if phase_value == "failed":
+        if message_value == "queue_ttl_expired":
+            return "queue_ttl_expired"
+        if "policy_failed" in message_value or (
+            "policy" in message_value and "failed" in message_value
+        ):
+            return "policy_failed"
+        if (
+            "runtime_unavailable" in message_value
+            or "unavailable" in message_value
+            or "not found" in message_value
+            or "missing" in message_value
+        ):
+            return "runtime_unavailable"
+        if "startup_timeout" in message_value:
+            return "startup_timeout"
+        if "execution_timeout" in message_value or message_value == "timeout":
+            return "execution_timeout"
+        if _is_nonzero_exit(exit_code):
+            return "nonzero_exit"
+        return "runtime_error"
+
+    return "unknown"

--- a/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
+++ b/tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py
@@ -1,6 +1,14 @@
+"""Normalize sandbox run status details into stable client-facing reason codes.
+
+This module derives an additive `status_reason_code` from existing run status
+fields. The vocabulary is intentionally small and stable for API clients, while
+the raw phase, message, and exit code remain available for operator debugging.
+"""
+
 from __future__ import annotations
 
-from typing import Any, Literal, Mapping
+from collections.abc import Mapping
+from typing import Any, Literal
 
 from .models import RunPhase
 
@@ -34,6 +42,22 @@ _LIMIT_COUNTER_KEYS = (
     "artifact_skip_read_error",
 )
 
+_RUNTIME_UNAVAILABLE_MESSAGES = frozenset({
+    "runtime_unavailable",
+    "runtime unavailable",
+    "docker_unavailable",
+    "firecracker_unavailable",
+    "vz_linux_unavailable",
+    "vz_macos_unavailable",
+    "seatbelt_unavailable",
+    "worktree_unavailable",
+    "vz_linux_policy_failed",
+    "vz_macos_policy_failed",
+})
+
+_RUNTIME_CONTEXT_TERMS = ("runtime", "provision")
+_RUNTIME_UNAVAILABLE_TERMS = ("unavailable", "not found", "missing")
+
 
 def _phase_text(phase: RunPhase | str | None) -> str:
     if isinstance(phase, RunPhase):
@@ -66,6 +90,18 @@ def _is_nonzero_exit(exit_code: int | str | None) -> bool:
         return False
 
 
+def _is_runtime_unavailable_message(message_value: str) -> bool:
+    if message_value in _RUNTIME_UNAVAILABLE_MESSAGES:
+        return True
+    if "runtime_unavailable" in message_value:
+        return True
+    if message_value.startswith("runtime_provisioning"):
+        return True
+    has_runtime_context = any(term in message_value for term in _RUNTIME_CONTEXT_TERMS)
+    has_unavailable_signal = any(term in message_value for term in _RUNTIME_UNAVAILABLE_TERMS)
+    return has_runtime_context and has_unavailable_signal
+
+
 def normalize_run_status_reason(
     *,
     phase: RunPhase | str | None,
@@ -81,9 +117,12 @@ def normalize_run_status_reason(
     if phase_value in {"queued", "starting", "running"}:
         return phase_value  # type: ignore[return-value]
 
+    if phase_value in {"completed", "failed", "timed_out"} and _has_limit_signal(
+        resource_usage
+    ):
+        return "limits_applied"
+
     if phase_value == "completed":
-        if _has_limit_signal(resource_usage):
-            return "limits_applied"
         return "completed"
 
     if phase_value == "timed_out":
@@ -99,17 +138,12 @@ def normalize_run_status_reason(
     if phase_value == "failed":
         if message_value == "queue_ttl_expired":
             return "queue_ttl_expired"
+        if _is_runtime_unavailable_message(message_value):
+            return "runtime_unavailable"
         if "policy_failed" in message_value or (
             "policy" in message_value and "failed" in message_value
         ):
             return "policy_failed"
-        if (
-            "runtime_unavailable" in message_value
-            or "unavailable" in message_value
-            or "not found" in message_value
-            or "missing" in message_value
-        ):
-            return "runtime_unavailable"
         if "startup_timeout" in message_value:
             return "startup_timeout"
         if "execution_timeout" in message_value or message_value == "timeout":

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -844,6 +844,7 @@ class InMemoryStore(SandboxStore):
                     "message": st.message,
                     "image_digest": st.image_digest,
                     "policy_hash": st.policy_hash,
+                    "resource_usage": st.resource_usage,
                 })
         def _key(r: dict):
             return r.get("started_at") or ""
@@ -2020,7 +2021,7 @@ class SQLiteStore(SandboxStore):
             where.append("started_at <= ?")
             params.append(started_at_to)
         sql = (
-            "SELECT id,user_id,spec_version,runtime,runtime_version,base_image,session_id,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,phase,exit_code,started_at,finished_at,message,image_digest,policy_hash "  # nosec B608
+            "SELECT id,user_id,spec_version,runtime,runtime_version,base_image,session_id,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,phase,exit_code,started_at,finished_at,message,image_digest,policy_hash,resource_usage "  # nosec B608
             f"FROM sandbox_runs WHERE {' AND '.join(where)} ORDER BY started_at {order} LIMIT ? OFFSET ?"
         )
         params.extend([int(limit), int(offset)])
@@ -2029,6 +2030,13 @@ class SQLiteStore(SandboxStore):
             items: list[dict] = []
             for row in cur.fetchall():
                 row_dict = dict(row)
+                resource_usage = None
+                if row_dict.get("resource_usage"):
+                    try:
+                        loaded = json.loads(row_dict.get("resource_usage"))
+                        resource_usage = loaded if isinstance(loaded, dict) else None
+                    except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS:
+                        resource_usage = None
                 items.append({
                     "id": row_dict.get("id"),
                     "user_id": row_dict.get("user_id"),
@@ -2048,6 +2056,7 @@ class SQLiteStore(SandboxStore):
                     "message": row_dict.get("message"),
                     "image_digest": row_dict.get("image_digest"),
                     "policy_hash": row_dict.get("policy_hash"),
+                    "resource_usage": resource_usage,
                 })
             return items
 
@@ -3300,7 +3309,7 @@ class PostgresStore(SandboxStore):
             where.append("started_at <= %s")
             params.append(started_at_to)
         sql = (
-            "SELECT id,user_id,spec_version,runtime,runtime_version,base_image,session_id,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,phase,exit_code,started_at,finished_at,message,image_digest,policy_hash "  # nosec B608
+            "SELECT id,user_id,spec_version,runtime,runtime_version,base_image,session_id,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,phase,exit_code,started_at,finished_at,message,image_digest,policy_hash,resource_usage "  # nosec B608
             f"FROM sandbox_runs WHERE {' AND '.join(where)} ORDER BY started_at {order} LIMIT %s OFFSET %s"
         )
         params.extend([int(limit), int(offset)])
@@ -3308,6 +3317,15 @@ class PostgresStore(SandboxStore):
             cur.execute(sql, tuple(params))
             items: list[dict] = []
             for row in cur.fetchall() or []:
+                resource_usage = row.get("resource_usage")
+                if isinstance(resource_usage, str):
+                    try:
+                        loaded = json.loads(resource_usage)
+                        resource_usage = loaded if isinstance(loaded, dict) else None
+                    except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS:
+                        resource_usage = None
+                elif not isinstance(resource_usage, dict):
+                    resource_usage = None
                 items.append({
                     "id": row.get("id"),
                     "user_id": row.get("user_id"),
@@ -3327,6 +3345,7 @@ class PostgresStore(SandboxStore):
                     "message": row.get("message"),
                     "image_digest": row.get("image_digest"),
                     "policy_hash": row.get("policy_hash"),
+                    "resource_usage": resource_usage,
                 })
             return items
 

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -2035,7 +2035,12 @@ class SQLiteStore(SandboxStore):
                     try:
                         loaded = json.loads(row_dict.get("resource_usage"))
                         resource_usage = loaded if isinstance(loaded, dict) else None
-                    except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS:
+                    except (TypeError, ValueError) as exc:
+                        logger.debug(
+                            "SQLiteStore.list_runs ignored malformed resource_usage for run_id={}: {}",
+                            row_dict.get("id"),
+                            exc,
+                        )
                         resource_usage = None
                 items.append({
                     "id": row_dict.get("id"),
@@ -3322,7 +3327,12 @@ class PostgresStore(SandboxStore):
                     try:
                         loaded = json.loads(resource_usage)
                         resource_usage = loaded if isinstance(loaded, dict) else None
-                    except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS:
+                    except (TypeError, ValueError) as exc:
+                        logger.debug(
+                            "PostgresStore.list_runs ignored malformed resource_usage for run_id={}: {}",
+                            row.get("id"),
+                            exc,
+                        )
                         resource_usage = None
                 elif not isinstance(resource_usage, dict):
                     resource_usage = None

--- a/tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py
@@ -44,6 +44,8 @@ def test_queued_post_run_status_has_no_started_or_finished_markers(monkeypatch) 
             pytest.fail(f"Queued run should not include finished_at marker, got {data['finished_at']!r}")
         if data["exit_code"] is not None:
             pytest.fail(f"Queued run should not include exit_code, got {data['exit_code']!r}")
+        if data.get("status_reason_code") != "queued":
+            pytest.fail(f"Queued run should expose status_reason_code='queued', got {data.get('status_reason_code')!r}")
 
 
 def test_post_run_response_fields_are_persisted_consistently_for_get(monkeypatch) -> None:
@@ -74,6 +76,7 @@ def test_post_run_response_fields_are_persisted_consistently_for_get(monkeypatch
             "spec_version",
             "runtime",
             "phase",
+            "status_reason_code",
             "exit_code",
             "started_at",
             "finished_at",

--- a/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
+from tldw_Server_API.app.core.Sandbox.store import SQLiteStore
+from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
+    SandboxAdminRunSummary,
+    SandboxRunStatus,
+)
+from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import (
+    normalize_run_status_reason,
+)
+
+
+def test_run_status_reason_taxonomy_maps_common_status_shapes() -> None:
+    assert normalize_run_status_reason(
+        phase=RunPhase.queued,
+        message=None,
+        exit_code=None,
+        resource_usage=None,
+    ) == "queued"
+    assert normalize_run_status_reason(
+        phase=RunPhase.completed,
+        message="Docker execution finished",
+        exit_code=0,
+        resource_usage=None,
+    ) == "completed"
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="Docker execution failed (exit=2)",
+        exit_code=2,
+        resource_usage=None,
+    ) == "nonzero_exit"
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="lima_policy_failed",
+        exit_code=None,
+        resource_usage=None,
+    ) == "policy_failed"
+    assert normalize_run_status_reason(
+        phase=RunPhase.timed_out,
+        message="startup_timeout",
+        exit_code=None,
+        resource_usage=None,
+    ) == "startup_timeout"
+    assert normalize_run_status_reason(
+        phase=RunPhase.timed_out,
+        message="execution_timeout",
+        exit_code=None,
+        resource_usage=None,
+    ) == "execution_timeout"
+    assert normalize_run_status_reason(
+        phase=RunPhase.killed,
+        message="canceled_by_user",
+        exit_code=None,
+        resource_usage=None,
+    ) == "canceled_by_user"
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="queue_ttl_expired",
+        exit_code=None,
+        resource_usage=None,
+    ) == "queue_ttl_expired"
+
+
+def test_run_status_reason_taxonomy_reports_limit_signals() -> None:
+    assert normalize_run_status_reason(
+        phase=RunPhase.completed,
+        message="Docker execution finished",
+        exit_code=0,
+        resource_usage={"stdout_truncated": 1, "artifact_files_skipped": 0},
+    ) == "limits_applied"
+    assert normalize_run_status_reason(
+        phase=RunPhase.completed,
+        message="Docker execution finished",
+        exit_code=0,
+        resource_usage={"artifact_files_skipped": 2},
+    ) == "limits_applied"
+
+
+def test_run_status_reason_taxonomy_accepts_string_phase_values() -> None:
+    assert normalize_run_status_reason(
+        phase="running",
+        message=None,
+        exit_code=None,
+        resource_usage=None,
+    ) == "running"
+    assert normalize_run_status_reason(
+        phase="failed",
+        message=f"runtime error at {datetime.now(timezone.utc).isoformat()}",
+        exit_code=None,
+        resource_usage=None,
+    ) == "runtime_error"
+    assert normalize_run_status_reason(
+        phase="failed",
+        message="bad exit code row",
+        exit_code="not-an-int",
+        resource_usage=None,
+    ) == "runtime_error"
+
+
+def test_public_and_admin_status_schemas_expose_reason_code() -> None:
+    public_schema = SandboxRunStatus.model_json_schema()
+    admin_schema = SandboxAdminRunSummary.model_json_schema()
+
+    assert "status_reason_code" in public_schema["properties"]
+    assert "status_reason_code" in admin_schema["properties"]
+
+
+def test_sqlite_run_listing_preserves_resource_usage_for_admin_reason_codes(tmp_path) -> None:
+    store = SQLiteStore(str(tmp_path / "sandbox.db"))
+    status = RunStatus(
+        id="limited-run",
+        phase=RunPhase.completed,
+        runtime=RuntimeType.docker,
+        exit_code=0,
+        message="Docker execution finished",
+        resource_usage={"stdout_truncated": 1, "artifact_files_skipped": 0},
+    )
+
+    store.put_run("user-1", status)
+    rows = store.list_runs(limit=10, offset=0)
+
+    assert rows[0]["resource_usage"] == {"stdout_truncated": 1, "artifact_files_skipped": 0}
+    assert normalize_run_status_reason(
+        phase=rows[0]["phase"],
+        message=rows[0]["message"],
+        exit_code=rows[0]["exit_code"],
+        resource_usage=rows[0]["resource_usage"],
+    ) == "limits_applied"

--- a/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
+++ b/tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
-from tldw_Server_API.app.core.Sandbox.store import SQLiteStore
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
     SandboxAdminRunSummary,
     SandboxRunStatus,
 )
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
 from tldw_Server_API.app.core.Sandbox.run_status_taxonomy import (
     normalize_run_status_reason,
 )
+from tldw_Server_API.app.core.Sandbox.store import SQLiteStore
 
 
 def test_run_status_reason_taxonomy_maps_common_status_shapes() -> None:
@@ -77,6 +77,51 @@ def test_run_status_reason_taxonomy_reports_limit_signals() -> None:
         exit_code=0,
         resource_usage={"artifact_files_skipped": 2},
     ) == "limits_applied"
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="Docker execution failed (exit=2)",
+        exit_code=2,
+        resource_usage={"stdout_truncated": 1},
+    ) == "limits_applied"
+    assert normalize_run_status_reason(
+        phase=RunPhase.timed_out,
+        message="execution_timeout",
+        exit_code=None,
+        resource_usage={"artifact_skip_total_limit": 1},
+    ) == "limits_applied"
+
+
+def test_run_status_reason_taxonomy_distinguishes_runtime_unavailable() -> None:
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="vz_linux_policy_failed",
+        exit_code=None,
+        resource_usage=None,
+    ) == "runtime_unavailable"
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="vz_macos_policy_failed",
+        exit_code=None,
+        resource_usage=None,
+    ) == "runtime_unavailable"
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="runtime provisioning template missing",
+        exit_code=None,
+        resource_usage=None,
+    ) == "runtime_unavailable"
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="command not found in PATH: python",
+        exit_code=None,
+        resource_usage=None,
+    ) == "runtime_error"
+    assert normalize_run_status_reason(
+        phase=RunPhase.failed,
+        message="artifact manifest missing",
+        exit_code=None,
+        resource_usage=None,
+    ) == "runtime_error"
 
 
 def test_run_status_reason_taxonomy_accepts_string_phase_values() -> None:


### PR DESCRIPTION
## Summary
- Add additive `status_reason_code` to public sandbox run status and admin run summary responses while preserving raw `phase`, `message`, and `exit_code`.
- Centralize run status reason normalization in `run_status_taxonomy.py`, including queued/running/completed, timeout, cancellation, policy, runtime-unavailable, nonzero-exit, limit-applied, and fallback runtime-error outcomes.
- Preserve `resource_usage` inside run listing internals so admin summaries can derive `limits_applied` without exposing new raw usage fields.
- Document the status reason-code vocabulary and track the slice in Backlog.md.

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_run_status_contract_durability.py tldw_Server_API/tests/sandbox/test_run_status_reason_codes.py -q --timeout=60`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m py_compile tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/core/Sandbox/store.py`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Sandbox/run_status_taxonomy.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/app/core/Sandbox/store.py -f json -o /tmp/bandit_run_status_reasons.json`
- [x] `git diff --check origin/dev..HEAD`

## Known Verification Caveat
- A selected admin TestClient integration path timed out in existing app shutdown/background Jobs worker teardown; this PR keeps focused coverage to deterministic taxonomy, schema, SQLite-store, and minimal sandbox API checks.

## Human Change summary
TODO: human maintainer must add the merge-gate change summary explaining what changed and why these implementation choices were made.